### PR TITLE
[libs][Unix][perf] Lazily initialize TimeZoneInfo names and order GetSystemTimeZones by Ids

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.Unix.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Threading;
+using System.Diagnostics;
 
 namespace System
 {
@@ -57,6 +58,7 @@ namespace System
             {
                 if (_uiCulture == null)
                 {
+                    Debug.Assert(!GlobalizationMode.Invariant);
                     // Determine the culture to use
                     CultureInfo uiCulture = CultureInfo.CurrentUICulture;
                     if (uiCulture.Name.Length == 0)

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.Unix.cs
@@ -48,6 +48,26 @@ namespace System
         }
 #pragma warning restore IDE0060
 
+        private static void GetStandardDisplayName(string timeZoneId, ref string? displayName)
+        {
+            // Determine the culture to use
+            CultureInfo uiCulture = CultureInfo.CurrentUICulture;
+            if (uiCulture.Name.Length == 0)
+                uiCulture = CultureInfo.GetCultureInfo(FallbackCultureName); // ICU doesn't work nicely with InvariantCulture
+
+            GetDisplayName(timeZoneId, Interop.Globalization.TimeZoneDisplayNameType.Standard, uiCulture.Name, ref displayName);
+        }
+
+        private static void GetDaylightDisplayName(string timeZoneId, ref string? displayName)
+        {
+            // Determine the culture to use
+            CultureInfo uiCulture = CultureInfo.CurrentUICulture;
+            if (uiCulture.Name.Length == 0)
+                uiCulture = CultureInfo.GetCultureInfo(FallbackCultureName); // ICU doesn't work nicely with InvariantCulture
+
+            GetDisplayName(timeZoneId, Interop.Globalization.TimeZoneDisplayNameType.DaylightSavings, uiCulture.Name, ref displayName);
+        }
+
         // Helper function that retrieves various forms of time zone display names from ICU
         private static unsafe void GetDisplayName(string timeZoneId, Interop.Globalization.TimeZoneDisplayNameType nameType, string uiCulture, ref string? displayName)
         {
@@ -96,8 +116,13 @@ namespace System
         }
 
         // Helper function that builds the value backing the DisplayName field from globalization data.
-        private static void GetFullValueForDisplayNameField(string timeZoneId, TimeSpan baseUtcOffset, CultureInfo uiCulture, ref string? displayName)
+        private static void GetFullValueForDisplayNameField(string timeZoneId, TimeSpan baseUtcOffset, ref string? displayName)
         {
+            // Determine the culture to use
+            CultureInfo uiCulture = CultureInfo.CurrentUICulture;
+            if (uiCulture.Name.Length == 0)
+                uiCulture = CultureInfo.GetCultureInfo(FallbackCultureName); // ICU doesn't work nicely with InvariantCulture
+
             // There are a few diffent ways we might show the display name depending on the data.
             // The algorithm used below should avoid duplicating the same words while still achieving the
             // goal of providing a unique, discoverable, and intuitive name.

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.Unix.cs
@@ -21,25 +21,6 @@ namespace System
             "Pacific/Pitcairn"    // Prefer "Pitcairn Islands Time" over "Pitcairn Time"
         };
 
-        // Main function that is called during construction to populate the three display names
-        private static void TryPopulateTimeZoneDisplayNamesFromGlobalizationData(string timeZoneId, TimeSpan baseUtcOffset, ref string? standardDisplayName, ref string? daylightDisplayName, ref string? displayName)
-        {
-            if (GlobalizationMode.Invariant)
-            {
-                return;
-            }
-
-            // Determine the culture to use
-            CultureInfo uiCulture = CultureInfo.CurrentUICulture;
-            if (uiCulture.Name.Length == 0)
-                uiCulture = CultureInfo.GetCultureInfo(FallbackCultureName); // ICU doesn't work nicely with InvariantCulture
-
-            // Attempt to populate the fields backing the StandardName, DaylightName, and DisplayName from globalization data.
-            GetDisplayName(timeZoneId, Interop.Globalization.TimeZoneDisplayNameType.Standard, uiCulture.Name, ref standardDisplayName);
-            GetDisplayName(timeZoneId, Interop.Globalization.TimeZoneDisplayNameType.DaylightSavings, uiCulture.Name, ref daylightDisplayName);
-            GetFullValueForDisplayNameField(timeZoneId, baseUtcOffset, uiCulture, ref displayName);
-        }
-
         // Helper function to get the standard display name for the UTC static time zone instance
         private static string GetUtcStandardDisplayName()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.MinimalGlobalizationData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.MinimalGlobalizationData.cs
@@ -6,6 +6,12 @@ namespace System
     public sealed partial class TimeZoneInfo
     {
 #pragma warning disable IDE0060
+        static partial void GetFullValueForDisplayNameField(string timeZoneId, TimeSpan baseUtcOffset, ref string? displayName);
+
+        static partial void GetStandardDisplayName(string timeZoneId, ref string? displayName);
+
+        static partial void GetDaylightDisplayName(string timeZoneId, ref string? displayName);
+
         private static string GetUtcStandardDisplayName()
         {
             // For this target, be consistent with other time zone display names that use an abbreviation.

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.MinimalGlobalizationData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.MinimalGlobalizationData.cs
@@ -6,8 +6,6 @@ namespace System
     public sealed partial class TimeZoneInfo
     {
 #pragma warning disable IDE0060
-        static partial void TryPopulateTimeZoneDisplayNamesFromGlobalizationData(string timeZoneId, TimeSpan baseUtcOffset, ref string? standardDisplayName, ref string? daylightDisplayName, ref string? displayName);
-
         private static string GetUtcStandardDisplayName()
         {
             // For this target, be consistent with other time zone display names that use an abbreviation.

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -49,7 +49,6 @@ namespace System
                 return;
             }
 
-            TZifHead t;
             DateTime[] dts;
             byte[] typeOfLocalTime;
             TZifType[] transitionType;
@@ -59,7 +58,7 @@ namespace System
             string? daylightAbbrevName = null;
 
             // parse the raw TZif bytes; this method can throw ArgumentException when the data is malformed.
-            TZif_ParseRaw(data, out t, out dts, out typeOfLocalTime, out transitionType, out zoneAbbreviations, out futureTransitionsPosixFormat);
+            TZif_ParseRaw(data, out dts, out typeOfLocalTime, out transitionType, out zoneAbbreviations, out futureTransitionsPosixFormat);
 
             // find the best matching baseUtcOffset and display strings based on the current utcNow value.
             // NOTE: read the Standard and Daylight display strings from the tzfile now in case they can't be loaded later
@@ -1065,7 +1064,7 @@ namespace System
             unixTime > DateTimeOffset.UnixMaxSeconds ? DateTime.MaxValue :
             DateTimeOffset.FromUnixTimeSeconds(unixTime).UtcDateTime;
 
-        private static void TZif_ParseRaw(byte[] data, out TZifHead t, out DateTime[] dts, out byte[] typeOfLocalTime, out TZifType[] transitionType,
+        private static void TZif_ParseRaw(byte[] data, out DateTime[] dts, out byte[] typeOfLocalTime, out TZifType[] transitionType,
                                           out string zoneAbbreviations, out string? futureTransitionsPosixFormat)
         {
             futureTransitionsPosixFormat = null;
@@ -1073,7 +1072,7 @@ namespace System
             // read in the 44-byte TZ header containing the count/length fields
             //
             int index = 0;
-            t = new TZifHead(data, index);
+            TZifHead t = new TZifHead(data, index);
             index += TZifHead.Length;
 
             int timeValuesLength = 4; // the first version uses 4-bytes to specify times

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -28,18 +28,21 @@ namespace System
         // (This list is not likely to change.)
         private static bool IsUtcAlias (string id)
         {
-            switch (char.ToLowerInvariant(id[0]))
+            switch ((ushort)id[0])
             {
-                case 'e':
+                case 69: // e
+                case 101: // E
                     return string.Equals(id, "Etc/UTC", StringComparison.OrdinalIgnoreCase) ||
                            string.Equals(id, "Etc/Universal", StringComparison.OrdinalIgnoreCase) ||
                            string.Equals(id, "Etc/UTC", StringComparison.OrdinalIgnoreCase) ||
                            string.Equals(id, "Etc/Zulu", StringComparison.OrdinalIgnoreCase);
-                case 'u':
+                case 85: // u
+                case 117: // U
                     return string.Equals(id, "UCT", StringComparison.OrdinalIgnoreCase) ||
                            string.Equals(id, "UTC", StringComparison.OrdinalIgnoreCase) ||
                            string.Equals(id, "Universal", StringComparison.OrdinalIgnoreCase);
-                case 'z':
+                case 90: // z
+                case 122: // Z
                     return string.Equals(id, "Zulu", StringComparison.OrdinalIgnoreCase);
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -231,12 +231,7 @@ namespace System
             if (GlobalizationMode.Invariant)
                 return displayName;
 
-            // Determine the culture to use
-            CultureInfo uiCulture = CultureInfo.CurrentUICulture;
-            if (uiCulture.Name.Length == 0)
-                uiCulture = CultureInfo.GetCultureInfo(FallbackCultureName); // ICU doesn't work nicely with InvariantCulture
-
-            GetFullValueForDisplayNameField(Id, BaseUtcOffset, uiCulture, ref displayName);
+            GetFullValueForDisplayNameField(Id, BaseUtcOffset, ref displayName);
 
             return displayName;
         }
@@ -250,11 +245,7 @@ namespace System
             if (GlobalizationMode.Invariant)
                 return standardDisplayName;
 
-            CultureInfo uiCulture = CultureInfo.CurrentUICulture;
-            if (uiCulture.Name.Length == 0)
-                uiCulture = CultureInfo.GetCultureInfo(FallbackCultureName); // ICU doesn't work nicely with InvariantCulture
-
-            GetDisplayName(Id, Interop.Globalization.TimeZoneDisplayNameType.Standard, uiCulture.Name, ref standardDisplayName);
+            GetStandardDisplayName(Id, ref standardDisplayName);
 
             return standardDisplayName;
         }
@@ -268,12 +259,7 @@ namespace System
             if (GlobalizationMode.Invariant)
                 return daylightDisplayName;
 
-            // Determine the culture to use
-            CultureInfo uiCulture = CultureInfo.CurrentUICulture;
-            if (uiCulture.Name.Length == 0)
-                uiCulture = CultureInfo.GetCultureInfo(FallbackCultureName); // ICU doesn't work nicely with InvariantCulture
-
-            GetDisplayName(Id, Interop.Globalization.TimeZoneDisplayNameType.DaylightSavings, uiCulture.Name, ref daylightDisplayName);
+            GetDaylightDisplayName(Id, ref daylightDisplayName);
 
             return daylightDisplayName;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -20,8 +20,8 @@ namespace System
 
         // Set fallback values using abbreviations, base offset, and id
         // These are expected in environments without time zone globalization data
-        private string? s_standardAbbrevName;
-        private string? s_daylightAbbrevName;
+        private string? _standardAbbrevName;
+        private string? _daylightAbbrevName;
 
         // Handle UTC and its aliases per https://github.com/unicode-org/cldr/blob/master/common/bcp47/timezone.xml
         // Hard-coded because we need to treat all aliases of UTC the same even when globalization data is not available.
@@ -81,11 +81,11 @@ namespace System
                 if (!transitionType[type].IsDst)
                 {
                     _baseUtcOffset = transitionType[type].UtcOffset;
-                    s_standardAbbrevName = TZif_GetZoneAbbreviation(zoneAbbreviations, transitionType[type].AbbreviationIndex);
+                    _standardAbbrevName = TZif_GetZoneAbbreviation(zoneAbbreviations, transitionType[type].AbbreviationIndex);
                 }
                 else
                 {
-                    s_daylightAbbrevName = TZif_GetZoneAbbreviation(zoneAbbreviations, transitionType[type].AbbreviationIndex);
+                    _daylightAbbrevName = TZif_GetZoneAbbreviation(zoneAbbreviations, transitionType[type].AbbreviationIndex);
                 }
             }
 
@@ -98,11 +98,11 @@ namespace System
                     if (!transitionType[i].IsDst)
                     {
                         _baseUtcOffset = transitionType[i].UtcOffset;
-                        s_standardAbbrevName = TZif_GetZoneAbbreviation(zoneAbbreviations, transitionType[i].AbbreviationIndex);
+                        _standardAbbrevName = TZif_GetZoneAbbreviation(zoneAbbreviations, transitionType[i].AbbreviationIndex);
                     }
                     else
                     {
-                        s_daylightAbbrevName = TZif_GetZoneAbbreviation(zoneAbbreviations, transitionType[i].AbbreviationIndex);
+                        _daylightAbbrevName = TZif_GetZoneAbbreviation(zoneAbbreviations, transitionType[i].AbbreviationIndex);
                     }
                 }
             }
@@ -246,7 +246,7 @@ namespace System
             if (IsUtcAlias(Id))
                 return GetUtcStandardDisplayName();
 
-            string? standardDisplayName = s_standardAbbrevName;
+            string? standardDisplayName = _standardAbbrevName;
             if (GlobalizationMode.Invariant)
                 return standardDisplayName;
 
@@ -264,7 +264,7 @@ namespace System
             if (IsUtcAlias(Id))
                 return StandardName;
 
-            string? daylightDisplayName = s_daylightAbbrevName ?? s_standardAbbrevName;
+            string? daylightDisplayName = _daylightAbbrevName ?? _standardAbbrevName;
             if (GlobalizationMode.Invariant)
                 return daylightDisplayName;
 

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -54,9 +54,6 @@ namespace System
 
             if (IsUtcAlias(id))
             {
-                _standardDisplayName = GetUtcStandardDisplayName();
-                _daylightDisplayName = _standardDisplayName;
-                _displayName = GetUtcFullDisplayName(_id, _standardDisplayName);
                 _baseUtcOffset = TimeSpan.Zero;
                 _adjustmentRules = Array.Empty<AdjustmentRule>();
                 return;
@@ -222,6 +219,9 @@ namespace System
 
         private string? PopulateDisplayName()
         {
+            if (IsUtcAlias(Id))
+                return GetUtcFullDisplayName(Id, StandardName);
+
             // Set fallback value using abbreviations, base offset, and id
             // These are expected in environments without time zone globalization data
             string? displayName = string.Create(null, stackalloc char[256], $"(UTC{(_baseUtcOffset >= TimeSpan.Zero ? '+' : '-')}{_baseUtcOffset:hh\\:mm}) {_id}");
@@ -240,6 +240,9 @@ namespace System
 
         private string? PopulateStandardDisplayName()
         {
+            if (IsUtcAlias(Id))
+                return GetUtcStandardDisplayName();
+
             string? standardDisplayName = s_standardAbbrevName;
             if (GlobalizationMode.Invariant)
                 return standardDisplayName;
@@ -255,6 +258,9 @@ namespace System
 
         private string? PopulateDaylightDisplayName()
         {
+            if (IsUtcAlias(Id))
+                return StandardName;
+
             string? daylightDisplayName = s_daylightAbbrevName ?? s_standardAbbrevName;
             if (GlobalizationMode.Invariant)
                 return daylightDisplayName;

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -154,8 +154,11 @@ namespace System
 
             ValidateTimeZoneInfo(_id, _baseUtcOffset, _adjustmentRules, out _supportsDaylightSavingTime);
             _displayName = standardName;
+            _displayNameSet = true;
             _standardDisplayName = standardName;
+            _standardDisplayNameSet = true;
             _daylightDisplayName = zone.GetDaylightName();
+            _daylightDisplayNameSet = true;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -88,6 +88,24 @@ namespace System
             return (AdjustmentRule[])_adjustmentRules.Clone();
         }
 
+        private string? PopulateDisplayName()
+        {
+            // Keep window's implementation to populate via constructor
+            return null;
+        }
+
+        private string? PopulateStandardDisplayName()
+        {
+            // Keep window's implementation to populate via constructor
+            return null;
+        }
+
+        private string? PopulateDaylightDisplayName()
+        {
+            // Keep window's implementation to populate via constructor
+            return null;
+        }
+
         private static void PopulateAllSystemTimeZones(CachedData cachedData)
         {
             Debug.Assert(Monitor.IsEntered(cachedData));

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -91,18 +91,24 @@ namespace System
         private static string? PopulateDisplayName()
         {
             // Keep window's implementation to populate via constructor
+            // This should not be reached
+            Debug.Assert(false);
             return null;
         }
 
         private static string? PopulateStandardDisplayName()
         {
             // Keep window's implementation to populate via constructor
+            // This should not be reached
+            Debug.Assert(false);
             return null;
         }
 
         private static string? PopulateDaylightDisplayName()
         {
             // Keep window's implementation to populate via constructor
+            // This should not be reached
+            Debug.Assert(false);
             return null;
         }
 
@@ -918,9 +924,9 @@ namespace System
                     value = new TimeZoneInfo(
                         id,
                         new TimeSpan(0, -(defaultTimeZoneInformation.Bias), 0),
-                        displayName,
-                        standardName,
-                        daylightName,
+                        displayName ?? string.Empty,
+                        standardName ?? string.Empty,
+                        daylightName ?? string.Empty,
                         adjustmentRules,
                         disableDaylightSavingTime: false);
 

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -88,19 +88,19 @@ namespace System
             return (AdjustmentRule[])_adjustmentRules.Clone();
         }
 
-        private string? PopulateDisplayName()
+        private static string? PopulateDisplayName()
         {
             // Keep window's implementation to populate via constructor
             return null;
         }
 
-        private string? PopulateStandardDisplayName()
+        private static string? PopulateStandardDisplayName()
         {
             // Keep window's implementation to populate via constructor
             return null;
         }
 
-        private string? PopulateDaylightDisplayName()
+        private static string? PopulateDaylightDisplayName()
         {
             // Keep window's implementation to populate via constructor
             return null;

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -154,11 +154,8 @@ namespace System
 
             ValidateTimeZoneInfo(_id, _baseUtcOffset, _adjustmentRules, out _supportsDaylightSavingTime);
             _displayName = standardName;
-            _displayNameSet = true;
             _standardDisplayName = standardName;
-            _standardDisplayNameSet = true;
             _daylightDisplayName = zone.GetDaylightName();
-            _daylightDisplayNameSet = true;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -989,9 +989,9 @@ namespace System
 
             _id = id;
             _baseUtcOffset = baseUtcOffset;
-            _displayName = displayName;
-            _standardDisplayName = standardDisplayName;
-            _daylightDisplayName = disableDaylightSavingTime ? null : daylightDisplayName;
+            _displayName = displayName ?? string.Empty;
+            _standardDisplayName = standardDisplayName ?? string.Empty;
+            _daylightDisplayName = disableDaylightSavingTime ? string.Empty : daylightDisplayName ?? string.Empty;
             _supportsDaylightSavingTime = adjustmentRulesSupportDst && !disableDaylightSavingTime;
             _adjustmentRules = adjustmentRules;
 
@@ -1012,9 +1012,9 @@ namespace System
             return new TimeZoneInfo(
                 id,
                 baseUtcOffset,
-                displayName ?? string.Empty,
-                standardDisplayName ?? string.Empty,
-                standardDisplayName ?? string.Empty,
+                displayName,
+                standardDisplayName,
+                standardDisplayName,
                 adjustmentRules: null,
                 disableDaylightSavingTime: false,
                 hasIanaId);
@@ -1034,9 +1034,9 @@ namespace System
             return CreateCustomTimeZone(
                 id,
                 baseUtcOffset,
-                displayName ?? string.Empty,
-                standardDisplayName ?? string.Empty,
-                daylightDisplayName ?? string.Empty,
+                displayName,
+                standardDisplayName,
+                daylightDisplayName,
                 adjustmentRules,
                 disableDaylightSavingTime: false);
         }
@@ -1063,9 +1063,9 @@ namespace System
             return new TimeZoneInfo(
                 id,
                 baseUtcOffset,
-                displayName ?? string.Empty,
-                standardDisplayName ?? string.Empty,
-                daylightDisplayName ?? string.Empty,
+                displayName,
+                standardDisplayName,
+                daylightDisplayName,
                 adjustmentRules,
                 disableDaylightSavingTime,
                 hasIanaId);

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -902,7 +902,7 @@ namespace System
                         {
                             // sort by BaseUtcOffset first and by DisplayName second - this is similar to the Windows Date/Time control panel
                             int comparison = x.BaseUtcOffset.CompareTo(y.BaseUtcOffset);
-                            return comparison == 0 ? string.CompareOrdinal(x.DisplayName, y.DisplayName) : comparison;
+                            return comparison == 0 ? string.CompareOrdinal(x.Id, y.Id) : comparison;
                         });
 
                         cachedData._readOnlySystemTimeZones = new ReadOnlyCollection<TimeZoneInfo>(array);

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -902,7 +902,7 @@ namespace System
                         {
                             // sort by BaseUtcOffset first and by DisplayName second - this is similar to the Windows Date/Time control panel
                             int comparison = x.BaseUtcOffset.CompareTo(y.BaseUtcOffset);
-                            return comparison == 0 ? string.CompareOrdinal(x.Id, y.Id) : comparison;
+                            return comparison == 0 ? string.CompareOrdinal(x.DisplayName, y.DisplayName) : comparison;
                         });
 
                         cachedData._readOnlySystemTimeZones = new ReadOnlyCollection<TimeZoneInfo>(array);

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -44,9 +44,9 @@ namespace System
         private const int MaxKeyLength = 255;
 
         private readonly string _id;
-        private readonly string? _displayName;
-        private readonly string? _standardDisplayName;
-        private readonly string? _daylightDisplayName;
+        private string? _displayName;
+        private string? _standardDisplayName;
+        private string? _daylightDisplayName;
         private readonly TimeSpan _baseUtcOffset;
         private readonly bool _supportsDaylightSavingTime;
         private readonly AdjustmentRule[]? _adjustmentRules;
@@ -146,11 +146,38 @@ namespace System
         /// </summary>
         public bool HasIanaId { get; }
 
-        public string DisplayName => _displayName ?? string.Empty;
+        public string DisplayName
+        {
+            get
+            {
+                if (_displayName == null)
+                    Interlocked.CompareExchange(ref _displayName, PopulateDisplayName(), null);
 
-        public string StandardName => _standardDisplayName ?? string.Empty;
+                return _displayName ?? string.Empty;
+            }
+        }
 
-        public string DaylightName => _daylightDisplayName ?? string.Empty;
+        public string StandardName
+        {
+            get
+            {
+                if (_standardDisplayName == null)
+                    Interlocked.CompareExchange(ref _standardDisplayName, PopulateStandardDisplayName(), null);
+
+                return _standardDisplayName ?? string.Empty;
+            }
+        }
+
+        public string DaylightName
+        {
+            get
+            {
+                if (_daylightDisplayName == null)
+                    Interlocked.CompareExchange(ref _daylightDisplayName, PopulateDaylightDisplayName(), null);
+
+                return _daylightDisplayName ?? string.Empty;
+            }
+        }
 
         public TimeSpan BaseUtcOffset => _baseUtcOffset;
 

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -44,11 +44,8 @@ namespace System
         private const int MaxKeyLength = 255;
 
         private readonly string _id;
-        private bool _displayNameSet;
         private string? _displayName;
-        private bool _standardDisplayNameSet;
         private string? _standardDisplayName;
-        private bool _daylightDisplayNameSet;
         private string? _daylightDisplayName;
         private readonly TimeSpan _baseUtcOffset;
         private readonly bool _supportsDaylightSavingTime;
@@ -153,11 +150,8 @@ namespace System
         {
             get
             {
-                if (_displayName == null && !_displayNameSet)
-                {
+                if (_displayName == null)
                     Interlocked.CompareExchange(ref _displayName, PopulateDisplayName(), null);
-                    _displayNameSet = true;
-                }
 
                 return _displayName ?? string.Empty;
             }
@@ -167,11 +161,8 @@ namespace System
         {
             get
             {
-                if (_standardDisplayName == null && !_standardDisplayNameSet)
-                {
+                if (_standardDisplayName == null)
                     Interlocked.CompareExchange(ref _standardDisplayName, PopulateStandardDisplayName(), null);
-                    _standardDisplayNameSet = true;
-                }
 
                 return _standardDisplayName ?? string.Empty;
             }
@@ -181,11 +172,8 @@ namespace System
         {
             get
             {
-                if (_daylightDisplayName == null && !_daylightDisplayNameSet)
-                {
+                if (_daylightDisplayName == null)
                     Interlocked.CompareExchange(ref _daylightDisplayName, PopulateDaylightDisplayName(), null);
-                    _daylightDisplayNameSet = true;
-                }
 
                 return _daylightDisplayName ?? string.Empty;
             }
@@ -1002,11 +990,8 @@ namespace System
             _id = id;
             _baseUtcOffset = baseUtcOffset;
             _displayName = displayName;
-            _displayNameSet = true;
             _standardDisplayName = standardDisplayName;
-            _standardDisplayNameSet = true;
             _daylightDisplayName = disableDaylightSavingTime ? null : daylightDisplayName;
-            _daylightDisplayNameSet = true;
             _supportsDaylightSavingTime = adjustmentRulesSupportDst && !disableDaylightSavingTime;
             _adjustmentRules = adjustmentRules;
 
@@ -1027,9 +1012,9 @@ namespace System
             return new TimeZoneInfo(
                 id,
                 baseUtcOffset,
-                displayName,
-                standardDisplayName,
-                standardDisplayName,
+                displayName ?? string.Empty,
+                standardDisplayName ?? string.Empty,
+                standardDisplayName ?? string.Empty,
                 adjustmentRules: null,
                 disableDaylightSavingTime: false,
                 hasIanaId);
@@ -1049,9 +1034,9 @@ namespace System
             return CreateCustomTimeZone(
                 id,
                 baseUtcOffset,
-                displayName,
-                standardDisplayName,
-                daylightDisplayName,
+                displayName ?? string.Empty,
+                standardDisplayName ?? string.Empty,
+                daylightDisplayName ?? string.Empty,
                 adjustmentRules,
                 disableDaylightSavingTime: false);
         }
@@ -1078,9 +1063,9 @@ namespace System
             return new TimeZoneInfo(
                 id,
                 baseUtcOffset,
-                displayName,
-                standardDisplayName,
-                daylightDisplayName,
+                displayName ?? string.Empty,
+                standardDisplayName ?? string.Empty,
+                daylightDisplayName ?? string.Empty,
                 adjustmentRules,
                 disableDaylightSavingTime,
                 hasIanaId);
@@ -1151,11 +1136,8 @@ namespace System
 
             _id = (string)info.GetValue("Id", typeof(string))!; // Do not rename (binary serialization)
             _displayName = (string?)info.GetValue("DisplayName", typeof(string)); // Do not rename (binary serialization)
-            _displayNameSet = true;
             _standardDisplayName = (string?)info.GetValue("StandardName", typeof(string)); // Do not rename (binary serialization)
-            _standardDisplayNameSet = true;
             _daylightDisplayName = (string?)info.GetValue("DaylightName", typeof(string)); // Do not rename (binary serialization)
-            _daylightDisplayNameSet = true;
             _baseUtcOffset = (TimeSpan)info.GetValue("BaseUtcOffset", typeof(TimeSpan))!; // Do not rename (binary serialization)
             _adjustmentRules = (AdjustmentRule[]?)info.GetValue("AdjustmentRules", typeof(AdjustmentRule[])); // Do not rename (binary serialization)
             _supportsDaylightSavingTime = (bool)info.GetValue("SupportsDaylightSavingTime", typeof(bool))!; // Do not rename (binary serialization)

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -44,8 +44,11 @@ namespace System
         private const int MaxKeyLength = 255;
 
         private readonly string _id;
+        private bool _displayNameSet;
         private string? _displayName;
+        private bool _standardDisplayNameSet;
         private string? _standardDisplayName;
+        private bool _daylightDisplayNameSet;
         private string? _daylightDisplayName;
         private readonly TimeSpan _baseUtcOffset;
         private readonly bool _supportsDaylightSavingTime;
@@ -150,8 +153,11 @@ namespace System
         {
             get
             {
-                if (_displayName == null)
+                if (_displayName == null && !_displayNameSet)
+                {
                     Interlocked.CompareExchange(ref _displayName, PopulateDisplayName(), null);
+                    _displayNameSet = true;
+                }
 
                 return _displayName ?? string.Empty;
             }
@@ -161,8 +167,11 @@ namespace System
         {
             get
             {
-                if (_standardDisplayName == null)
+                if (_standardDisplayName == null && !_standardDisplayNameSet)
+                {
                     Interlocked.CompareExchange(ref _standardDisplayName, PopulateStandardDisplayName(), null);
+                    _standardDisplayNameSet = true;
+                }
 
                 return _standardDisplayName ?? string.Empty;
             }
@@ -172,8 +181,11 @@ namespace System
         {
             get
             {
-                if (_daylightDisplayName == null)
+                if (_daylightDisplayName == null && !_daylightDisplayNameSet)
+                {
                     Interlocked.CompareExchange(ref _daylightDisplayName, PopulateDaylightDisplayName(), null);
+                    _daylightDisplayNameSet = true;
+                }
 
                 return _daylightDisplayName ?? string.Empty;
             }
@@ -990,8 +1002,11 @@ namespace System
             _id = id;
             _baseUtcOffset = baseUtcOffset;
             _displayName = displayName;
+            _displayNameSet = true;
             _standardDisplayName = standardDisplayName;
+            _standardDisplayNameSet = true;
             _daylightDisplayName = disableDaylightSavingTime ? null : daylightDisplayName;
+            _daylightDisplayNameSet = true;
             _supportsDaylightSavingTime = adjustmentRulesSupportDst && !disableDaylightSavingTime;
             _adjustmentRules = adjustmentRules;
 
@@ -1136,8 +1151,11 @@ namespace System
 
             _id = (string)info.GetValue("Id", typeof(string))!; // Do not rename (binary serialization)
             _displayName = (string?)info.GetValue("DisplayName", typeof(string)); // Do not rename (binary serialization)
+            _displayNameSet = true;
             _standardDisplayName = (string?)info.GetValue("StandardName", typeof(string)); // Do not rename (binary serialization)
+            _standardDisplayNameSet = true;
             _daylightDisplayName = (string?)info.GetValue("DaylightName", typeof(string)); // Do not rename (binary serialization)
+            _daylightDisplayNameSet = true;
             _baseUtcOffset = (TimeSpan)info.GetValue("BaseUtcOffset", typeof(TimeSpan))!; // Do not rename (binary serialization)
             _adjustmentRules = (AdjustmentRule[]?)info.GetValue("AdjustmentRules", typeof(AdjustmentRule[])); // Do not rename (binary serialization)
             _supportsDaylightSavingTime = (bool)info.GetValue("SupportsDaylightSavingTime", typeof(bool))!; // Do not rename (binary serialization)

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -88,9 +88,9 @@ namespace System
                         timeZone = new TimeZoneInfo(
                                             timeZone._id,
                                             timeZone._baseUtcOffset,
-                                            timeZone._displayName,
-                                            timeZone._standardDisplayName,
-                                            timeZone._daylightDisplayName,
+                                            timeZone.DisplayName,
+                                            timeZone.StandardName,
+                                            timeZone.DaylightName,
                                             timeZone._adjustmentRules,
                                             disableDaylightSavingTime: false,
                                             timeZone.HasIanaId);


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/8050

The [`TimeZoneInfo(byte[] data, string id, bool dstDisabled)`](https://github.com/dotnet/runtime/blob/2fbb7eb1ba014de7200e39f048d1ea74a39f0b61/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs#L35) constructor on Unix sets internal fields used in `DisplayName`, `StandardName`, and `DaylightName` by querying the timezone database via [`TryPopulateTimeZoneDisplayNamesFromGlobalizationData`](https://github.com/dotnet/runtime/blob/5a24757eab72279dcc28f2359ef5771b279efc59/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.Unix.cs#L25). For APIs that invoke that constructor for every timezone (>400 timezones on Android) like [`GetSystemTimeZones()`](https://github.com/dotnet/runtime/blob/2fbb7eb1ba014de7200e39f048d1ea74a39f0b61/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs#L856) this operation is costly. 
On average (on my machine, Mac mini M1, 2020 with 16GB memory running on OS 13.4 using Android Studio Emulator), `TryPopulateTimeZoneDisplayNamesFromGlobalizationData` takes ~66% (719.31ms) of the time `GetSystemTimeZones` takes (~1.091s). More specifically, [`GetFullValueForDisplayNameField`](https://github.com/dotnet/runtime/blob/5a24757eab72279dcc28f2359ef5771b279efc59/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.Unix.cs#L118) takes ~93% (669ms) of the time of `TryPopulateTimeZoneDisplayNamesFromGlobalizationData`, with the Interop `GetDisplayName`.

Example timing breakdown
```
A breakdown of the `630.37ms` it took to get `GetFullValueForDisplayNameField` is
`336.975ms` `GetDisplayName(timeZoneId, Interop.Globalization.TimeZoneDisplayNameType.Generic, uiCulture.Name, ref genericName);` 
`107.929ms` `GetDisplayName(timeZoneId, Interop.Globalization.TimeZoneDisplayNameType.GenericLocation, uiCulture.Name, ref genericLocationName);`
`1.6074ms`  `GetDisplayName(GmtId, Interop.Globalization.TimeZoneDisplayNameType.GenericLocation, uiCulture.Name, ref gmtLocationName);`
`54.2908ms` `GetDisplayName(GmtId, Interop.Globalization.TimeZoneDisplayNameType.Generic, uiCulture.Name, ref gmtGenericName);`
`1.1826ms` `StringArrayContains(timeZoneId, s_ZonesThatUseLocationName, StringComparison.OrdinalIgnoreCase)`
`17.178ms` `GetExemplarCityName(timeZoneId, uiCulture.Name);`
`75.2069ms` `uiCulture.CompareInfo.IndexOf(genericName, exemplarCityName, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace) >= 0 && genericLocationName != null`
```

This PR looks to improve the performance of APIs invoking a large number of `TimeZoneInfo` constructors by:
1) Lazily loading the values for `DisplayName`, `StandardName`, and `DaylightName`
2) <s>Ordering timezones by Id in `GetSystemTimeZones()` to avoid perf hit from `DisplayName` call.</s>
3) Direct numerical comparison for known UTC alias to reduce number of calls to String.Equals

--------------

On average (on my machine, Mac mini M1, 2020 with 16GB memory running on OS 13.4 using Android Studio Emulator),
Timing `TimeZoneInfo.GetSystemTimeZones()` with the changes in this PR when sorting based on `DisplayName`:
`GetSystemTimeZones`: ~677ms
`TimeZoneInfo(byte[] data, string id, bool dstDisabled)`: ~115.92ms
