### PR TITLE
Bring back old array enumerator code

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -400,7 +400,8 @@ namespace System
             // ! Warning: "this" is an array, not an SZArrayHelper. See comments above
             // ! or you may introduce a security hole!
             T[] @this = Unsafe.As<T[]>(this);
-            return @this.Length == 0 ? SZGenericArrayEnumerator<T>.Empty : new SZGenericArrayEnumerator<T>(@this);
+            int length = @this.Length;
+            return length == 0 ? SZGenericArrayEnumerator<T>.Empty : new SZGenericArrayEnumerator<T>(@this, length);
         }
 
         private void CopyTo<T>(T[] array, int index)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
@@ -1199,68 +1199,6 @@ namespace System
         }
     }
 
-    internal class SZGenericArrayEnumeratorBase : IDisposable
-    {
-        protected int _index;
-        protected int _endIndex;
-
-        internal SZGenericArrayEnumeratorBase()
-        {
-            _index = -1;
-        }
-
-        public bool MoveNext()
-        {
-            if (_index < _endIndex)
-            {
-                _index++;
-                return (_index < _endIndex);
-            }
-            return false;
-        }
-
-        public void Dispose()
-        {
-        }
-    }
-
-    internal sealed class SZGenericArrayEnumerator<T> : SZGenericArrayEnumeratorBase, IEnumerator<T>
-    {
-        private readonly T[] _array;
-
-        // Passing -1 for endIndex so that MoveNext always returns false without mutating _index
-        internal static readonly SZGenericArrayEnumerator<T> Empty = new SZGenericArrayEnumerator<T>(null, -1);
-
-        internal SZGenericArrayEnumerator(T[] array, int endIndex)
-        {
-            _array = array;
-            _endIndex = endIndex;
-        }
-
-        public T Current
-        {
-            get
-            {
-                if ((uint)_index >= (uint)_endIndex)
-                    ThrowHelper.ThrowInvalidOperationException();
-                return _array[_index];
-            }
-        }
-
-        object IEnumerator.Current
-        {
-            get
-            {
-                return Current;
-            }
-        }
-
-        void IEnumerator.Reset()
-        {
-            _index = -1;
-        }
-    }
-
     public class MDArray
     {
         public const int MinRank = 1;

--- a/src/libraries/System.Private.CoreLib/src/System/Array.Enumerators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.Enumerators.cs
@@ -67,6 +67,8 @@ namespace System
         }
     }
 
+    // Native AOT doesn't use these for size on disk reasons
+#if !NATIVEAOT
     internal abstract class SZGenericArrayEnumeratorBase : IDisposable
     {
         protected readonly Array _array;
@@ -140,6 +142,7 @@ namespace System
 
         object? IEnumerator.Current => Current;
     }
+#endif
 
     internal abstract class GenericEmptyEnumeratorBase : IDisposable, IEnumerator
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Array.Enumerators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.Enumerators.cs
@@ -107,7 +107,7 @@ namespace System
         /// to be using T[] elsewhere, this singleton should be used.  Otherwise, GenericEmptyEnumerator's
         /// singleton should be used instead, as it doesn't reference T[] in order to reduce footprint.
         /// </remarks>
-        internal static readonly SZGenericArrayEnumerator<T> Empty = new SZGenericArrayEnumerator<T>(null, -1);
+        internal static readonly SZGenericArrayEnumerator<T> Empty = new SZGenericArrayEnumerator<T>(null, 0);
 
         internal SZGenericArrayEnumerator(T[]? array, int endIndex)
             : base(endIndex)
@@ -121,7 +121,7 @@ namespace System
             get
             {
                 if ((uint)_index >= (uint)_endIndex)
-                    ThrowHelper.ThrowInvalidOperationException();
+                    ThrowHelper.ThrowInvalidOperationException_EnumCurrent(_index);
                 return _array![_index];
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Array.Enumerators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.Enumerators.cs
@@ -80,11 +80,13 @@ namespace System
 
         public bool MoveNext()
         {
-            if (_index < _endIndex)
+            int index = _index + 1;
+            if ((uint)index < (uint)_endIndex)
             {
-                _index++;
-                return (_index < _endIndex);
+                _index = index;
+                return true;
             }
+            _index = _endIndex;
             return false;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Array.Enumerators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.Enumerators.cs
@@ -67,82 +67,65 @@ namespace System
         }
     }
 
-    // Native AOT doesn't use these for size on disk reasons
-#if !NATIVEAOT
     internal abstract class SZGenericArrayEnumeratorBase : IDisposable
     {
-        protected readonly Array _array;
         protected int _index;
+        protected readonly int _endIndex;
 
-        protected SZGenericArrayEnumeratorBase(Array array)
+        protected SZGenericArrayEnumeratorBase(int endIndex)
         {
-            Debug.Assert(array != null);
-
-            _array = array;
             _index = -1;
+            _endIndex = endIndex;
         }
 
         public bool MoveNext()
         {
-            int index = _index + 1;
-            uint length = (uint)_array.NativeLength;
-            if ((uint)index >= length)
+            if (_index < _endIndex)
             {
-                _index = (int)length;
-                return false;
+                _index++;
+                return (_index < _endIndex);
             }
-            _index = index;
-            return true;
+            return false;
         }
 
         public void Reset() => _index = -1;
 
-#pragma warning disable CA1822 // https://github.com/dotnet/roslyn-analyzers/issues/5911
         public void Dispose()
         {
         }
-#pragma warning restore CA1822
     }
 
     internal sealed class SZGenericArrayEnumerator<T> : SZGenericArrayEnumeratorBase, IEnumerator<T>
     {
+        private readonly T[]? _array;
+
         /// <summary>Provides an empty enumerator singleton.</summary>
         /// <remarks>
         /// If the consumer is using SZGenericArrayEnumerator elsewhere or is otherwise likely
         /// to be using T[] elsewhere, this singleton should be used.  Otherwise, GenericEmptyEnumerator's
         /// singleton should be used instead, as it doesn't reference T[] in order to reduce footprint.
         /// </remarks>
-#pragma warning disable CA1825
-        internal static readonly SZGenericArrayEnumerator<T> Empty =
-            // Array.Empty is intentionally omitted here, since we don't want to pay for generic instantiations
-            // that wouldn't have otherwise been used.
-            new SZGenericArrayEnumerator<T>(new T[0]);
-#pragma warning restore CA1825
+        internal static readonly SZGenericArrayEnumerator<T> Empty = new SZGenericArrayEnumerator<T>(null, -1);
 
-        public SZGenericArrayEnumerator(T[] array)
-            : base(array)
+        internal SZGenericArrayEnumerator(T[]? array, int endIndex)
+            : base(endIndex)
         {
+            Debug.Assert(array == null || endIndex == array.Length);
+            _array = array;
         }
 
         public T Current
         {
             get
             {
-                int index = _index;
-                T[] array = Unsafe.As<T[]>(_array);
-
-                if ((uint)index >= (uint)array.Length)
-                {
-                    ThrowHelper.ThrowInvalidOperationException_EnumCurrent(index);
-                }
-
-                return array[index];
+                if ((uint)_index >= (uint)_endIndex)
+                    ThrowHelper.ThrowInvalidOperationException();
+                return _array![_index];
             }
         }
 
         object? IEnumerator.Current => Current;
     }
-#endif
 
     internal abstract class GenericEmptyEnumeratorBase : IDisposable, IEnumerator
     {

--- a/src/mono/System.Private.CoreLib/src/System/Array.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Array.Mono.cs
@@ -468,7 +468,8 @@ namespace System
 
         internal IEnumerator<T> InternalArray__IEnumerable_GetEnumerator<T>()
         {
-            return Length == 0 ? SZGenericArrayEnumerator<T>.Empty : new SZGenericArrayEnumerator<T>(Unsafe.As<T[]>(this));
+            int length = Length;
+            return length == 0 ? SZGenericArrayEnumerator<T>.Empty : new SZGenericArrayEnumerator<T>(Unsafe.As<T[]>(this), length);
         }
 
         internal void InternalArray__ICollection_Clear()


### PR DESCRIPTION
This is a 0.3% size saving for Stage1. We not only allow array enumerators to be preinitialized again, but also avoid introducing many array `MethodTables` (looks like the new enumerators force array `MethodTable` for cases where we could have avoided them).

I shaped the old code to look like after the refactor in #82751, but reintroduced the old classes.

Fixes #82993.

Cc @dotnet/ilc-contrib 