### PR TITLE
JIT: Quirk a quirk in fgExpandVirtualVtableCallTarget

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7945,7 +7945,11 @@ GenTree* Compiler::fgExpandVirtualVtableCallTarget(GenTreeCall* call)
     // Dereference the this pointer to obtain the method table, it is called vtab below
     assert(VPTR_OFFS == 0); // We have to add this value to the thisPtr to get the methodTable
     GenTree* vtab = gtNewIndir(TYP_I_IMPL, thisPtr, GTF_IND_INVARIANT);
-    vtab->gtFlags &= ~GTF_EXCEPT; // TODO-Cleanup: delete this zero-diff quirk.
+
+    if (fgGlobalMorph)
+    {
+        vtab->gtFlags &= ~GTF_EXCEPT; // TODO-Cleanup: delete this zero-diff quirk.
+    }
 
     // Get the appropriate vtable chunk
     if (vtabOffsOfIndirection != CORINFO_VIRTUALCALL_NO_CHUNK)

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -2274,7 +2274,7 @@ GenTree** ReplaceVisitor::InsertMidTreeReadBacks(GenTree** use)
                 continue;
             }
 
-            JITDUMP("  V%02.[%03u..%03u) -> V%02u\n", agg->LclNum, rep.Offset, genTypeSize(rep.AccessType), rep.LclNum);
+            JITDUMP("  V%02u.[%03u..%03u) -> V%02u\n", agg->LclNum, rep.Offset, rep.Offset + genTypeSize(rep.AccessType), rep.LclNum);
 
             ClearNeedsReadBack(rep);
             GenTree* readBack = Promotion::CreateReadBack(m_compiler, agg->LclNum, rep);

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -2274,7 +2274,8 @@ GenTree** ReplaceVisitor::InsertMidTreeReadBacks(GenTree** use)
                 continue;
             }
 
-            JITDUMP("  V%02u.[%03u..%03u) -> V%02u\n", agg->LclNum, rep.Offset, rep.Offset + genTypeSize(rep.AccessType), rep.LclNum);
+            JITDUMP("  V%02u.[%03u..%03u) -> V%02u\n", agg->LclNum, rep.Offset,
+                    rep.Offset + genTypeSize(rep.AccessType), rep.LclNum);
 
             ClearNeedsReadBack(rep);
             GenTree* readBack = Promotion::CreateReadBack(m_compiler, agg->LclNum, rep);


### PR DESCRIPTION
Initially I just removed this, but that has somewhat impactful regressions (see https://github.com/dotnet/runtime/pull/88355#issuecomment-1619881729), which I'm not interested in taking on at this point of .NET 8. So this adds a further quirk on top of the quirk, which in this case ensures we have the right flags set after GDV call expansion.

Also fix a JITDUMP in physical promotion.

Fix #88349