### PR TITLE
[LoongArch64] Fix the NotImplementedException within R2RDump.

### DIFF
--- a/src/coreclr/tools/r2rdump/Program.cs
+++ b/src/coreclr/tools/r2rdump/Program.cs
@@ -209,6 +209,7 @@ namespace R2RDump
                     Machine.Amd64 => TargetArchitecture.X64,
                     Machine.ArmThumb2 => TargetArchitecture.ARM,
                     Machine.Arm64 => TargetArchitecture.ARM64,
+                    Machine.LoongArch64 => TargetArchitecture.LoongArch64,
                     _ => throw new NotImplementedException(r2r.Machine.ToString()),
                 };
                 TargetOS os = r2r.OperatingSystem switch


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port. 

Fix the NotImplementedException within R2RDump for LoongArch64.