### PR TITLE
JIT: Propagate multi-reg-index for upper-vector-restore ref positions

### DIFF
--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1045,10 +1045,8 @@ private:
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     void buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation currentLoc, regMaskTP fpCalleeKillSet);
-    void buildUpperVectorRestoreRefPosition(Interval*    lclVarInterval,
-                                            LsraLocation currentLoc,
-                                            GenTree*     node,
-                                            bool         isUse);
+    void buildUpperVectorRestoreRefPosition(
+        Interval* lclVarInterval, LsraLocation currentLoc, GenTree* node, bool isUse, unsigned multiRegIdx);
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
 
 #if defined(UNIX_AMD64_ABI) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)


### PR DESCRIPTION
`LinearScan::resolveRegisters` will write the register back to the IR node for an upper-vector-restore RP, so without this propagation we would overwrite the register assignment for an unrelated field.

For example, for IR like
```scala
N001 (  9,  6) [000090] m------N---                   t90 =    LCL_VAR   struct<JIT.HardwareIntrinsics.Arm._AdvSimd.SimpleTernaryOpTest__AbsoluteDifferenceWideningUpperAndAdd_Vector128_UInt32+TestStruct, 48>(P) V00 loc0
                                                            ▌    simd16 field V00._fld1 (fldOffset=0x0) -> V14 tmp10         (last use)
                                                            ▌    simd16 field V00._fld2 (fldOffset=0x10) -> V15 tmp11         (last use)
                                                            ▌    simd16 field V00._fld3 (fldOffset=0x20) -> V16 tmp12         (last use) $540
                                                            ┌──▌  t90    struct
N002 ( 10,  7) [000091] -----------                         ▌  RETURN    struct $VN.Void
```
we could build ref positions such as

```
[000091] 449.#639 U14  UVRs   UVRes    NA   │    │    │    │    │    │    │    │    │    │    │    │    │V16a│    │    │    │
         449.#640 d0   Fixd   Keep     d0   │    │    │    │    │    │    │    │    │    │    │    │    │V16a│    │    │    │
         449.#641 V14  Use *  ReLod    d0   │    │    │    │    │    │    │    │    │    │    │V14a│    │V16a│    │    │    │
                              Keep     d0   │    │    │    │    │    │    │    │    │    │    │V14i│    │V16a│    │    │    │
         449.#642 U15  UVRs   UVRes    NA   │    │    │    │    │    │    │    │    │    │    │    │    │V16a│    │    │    │
         449.#643 d1   Fixd   Keep     d1   │    │    │    │    │    │    │    │    │    │    │    │    │V16a│    │    │    │
         449.#644 V15  Use *  ReLod    d1   │    │    │    │    │    │    │    │    │    │    │    │V15a│V16a│    │    │    │
                              Keep     d1   │    │    │    │    │    │    │    │    │    │    │    │V15i│V16a│    │    │    │
         449.#645 d2   Fixd   Keep     d2   │    │    │    │    │    │    │    │    │    │    │    │    │V16a│    │    │    │
         449.#646 V16  Use *  Keep     d2   │    │    │    │    │    │    │    │    │    │    │    │    │V16i│    │    │    │
```

When writing back register assignments the upper-vector-restore at `449.#642` ended up overwriting the assignment for the first field on [000090], resulting in

```scala
N447 (  9,  6) [000090] m------N--z                   t90 =    LCL_VAR   struct<JIT.HardwareIntrinsics.Arm._AdvSimd.SimpleTernaryOpTest__AbsoluteDifferenceWideningUpperAndAdd_Vector128_UInt32+TestStruct, 48>(P) V00 loc0          NA
                                                            ▌    simd16 field V00._fld1 (fldOffset=0x0) -> V14 tmp10         (last use)
                                                            ▌    simd16 field V00._fld2 (fldOffset=0x10) -> V15 tmp11         (last use)
                                                            ▌    simd16 field V00._fld3 (fldOffset=0x20) -> V16 tmp12         d2 (last use) REG NA,d1,d2 $540
                                                            ┌──▌  t90    struct
N449 ( 10,  7) [000091] -----------                         ▌  RETURN    struct REG NA $VN.Void
```
(note the REG NA instead of REG d0).