### PR TITLE
JIT: Fold more constant string comparisons

### DIFF
--- a/src/coreclr/jit/importervectorization.cpp
+++ b/src/coreclr/jit/importervectorization.cpp
@@ -616,11 +616,21 @@ GenTree* Compiler::impStringEqualsOrStartsWith(bool startsWith, CORINFO_SIG_INFO
         op2 = impStackTop(0).val;
     }
 
-    if (!(op1->OperIs(GT_CNS_STR) ^ op2->OperIs(GT_CNS_STR)))
+    if (!op1->OperIs(GT_CNS_STR) && !op2->OperIs(GT_CNS_STR))
     {
-        // either op1 or op2 has to be CNS_STR, but not both - that case is optimized
-        // just fine as is.
         return nullptr;
+    }
+
+    // If the input literals are the same nodes we can early return "true"
+    // for Equals/StartsWith and Ordinal/OrdinalIgnoreCase
+    if (op1->OperIs(GT_CNS_STR) && op2->OperIs(GT_CNS_STR) && GenTree::Compare(op1, op2))
+    {
+        for (int i = 0; i < argsCount; i++)
+        {
+            // All args are side-effect free constants
+            impPopStack();
+        }
+        return gtNewTrue();
     }
 
     GenTree*       varStr;


### PR DESCRIPTION
Looks like there are a few cases where we give up on folding constant string comparisons
```cs
bool Test() => "aaa" == Cns("bbb");

// Avoid Roslyn's constant folding via inlining
string Cns(string v) => v;
```
Codegen for `Test()`:
```diff
; Method P:Test():bool:this (FullOpts)
-      mov      rax, 0x2990020924C
-      mov      rcx, 0x2990020926C
-      mov      edx, dword ptr [rax]
-      mov      r8d, dword ptr [rcx]
-      mov      eax, dword ptr [rax+02H]
-      mov      ecx, dword ptr [rcx+02H]
-      xor      edx, r8d
-      xor      eax, ecx
-      or       eax, edx
-      sete     al
-      movzx    rax, al
+      xor      eax, eax
       ret      
-; Total bytes of code: 45
+; Total bytes of code: 3
```

A better (and more complicated) fix is to handle `SequenceEquals(ref,ref,int)` in VN for constant args