### PR TITLE
Improve non-SIMD block copy/init codegen

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3276,7 +3276,7 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
 
         // Round up to the closest power of two, but make sure it's not larger
         // than the register we used for the main loop
-        regSize = min(regSize, roundUpGPRSize(size));
+        regSize = min(regSize, compiler->roundUpGPRSize(size));
 
         unsigned shiftBack = regSize - size;
         assert(shiftBack <= regSize);
@@ -3560,7 +3560,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
             // Round up to the closest power of two, but make sure it's not larger
             // than the register we used for the main loop
-            regSize = min(regSize, roundUpGPRSize(size));
+            regSize = min(regSize, compiler->roundUpGPRSize(size));
 
             unsigned shiftBack = regSize - size;
             assert(shiftBack <= regSize);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3274,7 +3274,7 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
     {
         assert(size <= REGSIZE_BYTES);
 
-        // Round down to the closest power of two (1, 2 or 4)
+        // Round down to the closest power of two
         regSize = 1 << BitOperations::Log2(size);
 
         unsigned shiftBack = regSize - size;
@@ -3557,7 +3557,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
         {
             assert(size <= REGSIZE_BYTES);
 
-            // Round down to the closest power of two (1, 2 or 4)
+            // Round down to the closest power of two
             regSize = 1 << BitOperations::Log2(size);
 
             unsigned shiftBack = regSize - size;

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3274,8 +3274,9 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
     {
         assert(size <= REGSIZE_BYTES);
 
-        // Round down to the closest power of two
-        regSize = 1 << BitOperations::Log2(size);
+        // Round up to the closest power of two, but make sure it's not larger
+        // than the register we used for the main loop
+        regSize = min(regSize, roundUpGPRSize(size));
 
         unsigned shiftBack = regSize - size;
         assert(shiftBack <= regSize);
@@ -3557,8 +3558,9 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
         {
             assert(size <= REGSIZE_BYTES);
 
-            // Round down to the closest power of two
-            regSize = 1 << BitOperations::Log2(size);
+            // Round up to the closest power of two, but make sure it's not larger
+            // than the register we used for the main loop
+            regSize = min(regSize, roundUpGPRSize(size));
 
             unsigned shiftBack = regSize - size;
             assert(shiftBack <= regSize);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3272,7 +3272,7 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
     // Handle the non-SIMD remainder by overlapping with previously processed data if needed
     if (size > 0)
     {
-        assert(size < REGSIZE_BYTES);
+        assert(size <= REGSIZE_BYTES);
 
         // Round down to the closest power of two (1, 2 or 4)
         regSize = 1 << BitOperations::Log2(size);
@@ -3555,7 +3555,7 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
         // Handle the non-SIMD remainder by overlapping with previously processed data if needed
         if (size > 0)
         {
-            assert(size < REGSIZE_BYTES);
+            assert(size <= REGSIZE_BYTES);
 
             // Round down to the closest power of two (1, 2 or 4)
             regSize = 1 << BitOperations::Log2(size);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3269,8 +3269,14 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
         }
     }
 
+    // Handle the non-SIMD remainder by overlapping with previously processed data if needed
     if (size > 0)
     {
+        assert(size < REGSIZE_BYTES);
+
+        // Round down to the closest power of two (1, 2 or 4)
+        regSize = 1 << BitOperations::Log2(size);
+
         unsigned shiftBack = regSize - size;
         assert(shiftBack <= regSize);
         dstOffset -= shiftBack;
@@ -3546,8 +3552,14 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
             }
         }
 
+        // Handle the non-SIMD remainder by overlapping with previously processed data if needed
         if (size > 0)
         {
+            assert(size < REGSIZE_BYTES);
+
+            // Round down to the closest power of two (1, 2 or 4)
+            regSize = 1 << BitOperations::Log2(size);
+
             unsigned shiftBack = regSize - size;
             assert(shiftBack <= regSize);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8931,6 +8931,7 @@ private:
     }
 #endif // FEATURE_SIMD
 
+public:
     // Similiar to roundUpSIMDSize, but for General Purpose Registers (GPR)
     unsigned int roundUpGPRSize(unsigned size)
     {
@@ -8945,7 +8946,6 @@ private:
         return size; // 2, 1, 0
     }
 
-public:
     enum UnrollKind
     {
         Memset,

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8931,6 +8931,20 @@ private:
     }
 #endif // FEATURE_SIMD
 
+    // Similiar to roundUpSIMDSize, but for General Purpose Registers (GPR)
+    unsigned int roundUpGPRSize(unsigned size)
+    {
+        if (size > 4 && (REGSIZE_BYTES == 8))
+        {
+            return 8;
+        }
+        else if (size > 2)
+        {
+            return 4;
+        }
+        return size; // 2, 1, 0
+    }
+
 public:
     enum UnrollKind
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8932,7 +8932,7 @@ private:
 #endif // FEATURE_SIMD
 
 public:
-    // Similiar to roundUpSIMDSize, but for General Purpose Registers (GPR)
+    // Similar to roundUpSIMDSize, but for General Purpose Registers (GPR)
     unsigned int roundUpGPRSize(unsigned size)
     {
         if (size > 4 && (REGSIZE_BYTES == 8))


### PR DESCRIPTION
Quick fix for https://github.com/dotnet/runtime/pull/88367#issuecomment-1620727300
```cs
object Test() => new [] { 1, 2, 3 };
```
Codegen diff:
```diff
; Method P:Test():System.Object (FullOpts)
       sub      rsp, 40
       mov      rcx, 0x7FF9874FA2A8      ; int[]
       mov      edx, 3
       call     CORINFO_HELP_NEWARR_1_VC
       mov      rcx, 0x2D9C8452CE8      ; const ptr
       mov      rdx, qword ptr [rcx]
       mov      qword ptr [rax+10H], rdx
-      mov      rdx, qword ptr [rcx+04H]
-      mov      qword ptr [rax+14H], rdx
+      mov      edx, dword ptr [rcx+08H]
+      mov      dword ptr [rax+18H], edx
       add      rsp, 40
       ret      
-; Total bytes of code: 54
+; Total bytes of code: 52
```

Arm codegen is already doing the same.