### PR TITLE
Rewrite DbBuffer Read/Write methods with stackalloc

### DIFF
--- a/src/libraries/System.Data.Odbc/src/Common/System/Data/ProviderBase/DbBuffer.cs
+++ b/src/libraries/System.Data.Odbc/src/Common/System/Data/ProviderBase/DbBuffer.cs
@@ -172,7 +172,6 @@ namespace System.Data.ProviderBase
             offset += BaseOffset;
             Validate(offset, destination.Length);
             Debug.Assert(0 == offset % ADP.PtrSize, "invalid alignment");
-            Debug.Assert(null != destination, "null destination");
 
             bool mustRelease = false;
 

--- a/src/libraries/System.Data.Odbc/src/Common/System/Data/ProviderBase/DbBuffer.cs
+++ b/src/libraries/System.Data.Odbc/src/Common/System/Data/ProviderBase/DbBuffer.cs
@@ -290,7 +290,6 @@ namespace System.Data.ProviderBase
             offset += BaseOffset;
             Validate(offset, 2 * destination.Length);
             Debug.Assert(0 == offset % ADP.PtrSize, "invalid alignment");
-            Debug.Assert(null != destination, "null destination");
 
             bool mustRelease = false;
 
@@ -515,7 +514,6 @@ namespace System.Data.ProviderBase
             offset += BaseOffset;
             Validate(offset, source.Length);
             Debug.Assert(0 == offset % ADP.PtrSize, "invalid alignment");
-            Debug.Assert(null != source, "null source");
 
             bool mustRelease = false;
 
@@ -624,7 +622,6 @@ namespace System.Data.ProviderBase
             offset += BaseOffset;
             Validate(offset, 2 * source.Length);
             Debug.Assert(0 == offset % ADP.PtrSize, "invalid alignment");
-            Debug.Assert(null != source, "null source");
 
             bool mustRelease = false;
 
@@ -770,26 +767,22 @@ namespace System.Data.ProviderBase
             }
         }
 
-        internal Guid ReadGuid(int offset)
+        internal unsafe Guid ReadGuid(int offset)
         {
             offset += BaseOffset;
 
-            unsafe
-            {
-                Validate(offset, sizeof(Guid));
-            }
+            Validate(offset, sizeof(Guid));
 
-            Debug.Assert(0 == offset % ADP.PtrSize, "invalid alignment");
+            Debug.Assert(0 == offset % /* alignof(Guid) */ sizeof(int), "invalid alignment");
 
             bool mustRelease = false;
             try
             {
                 DangerousAddRef(ref mustRelease);
-                unsafe
-                {
-                    byte* addrGuid = (byte*)DangerousGetHandle() + (uint)offset;
-                    return new Guid(new ReadOnlySpan<byte>(addrGuid, sizeof(Guid)));
-                }
+
+                byte* addrGuid = (byte*)DangerousGetHandle() + (uint)offset;
+
+                return new Guid(new ReadOnlySpan<byte>(addrGuid, sizeof(Guid)));
             }
             finally
             {
@@ -799,24 +792,18 @@ namespace System.Data.ProviderBase
                 }
             }
         }
-        internal void WriteGuid(int offset, Guid value)
+        internal unsafe void WriteGuid(int offset, Guid value)
         {
             offset += BaseOffset;
 
-            unsafe
-            {
-                Validate(offset, sizeof(Guid));
-            }
+            Validate(offset, sizeof(Guid));
 
-            Debug.Assert(0 == offset % ADP.PtrSize, "invalid alignment");
+            Debug.Assert(0 == offset % /* alignof(Guid) */ sizeof(int), "invalid alignment");
             bool mustRelease = false;
             try
             {
                 DangerousAddRef(ref mustRelease);
-                unsafe
-                {
-                    *((Guid*)DangerousGetHandle() + (uint)offset) = value;
-                }
+                *((Guid*)DangerousGetHandle() + (uint)offset) = value;
             }
             finally
             {

--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcUtils.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcUtils.cs
@@ -332,7 +332,7 @@ namespace System.Data.Odbc
 
         internal void WriteODBCDateTime(int offset, DateTime value)
         {
-            short[] buffer = new short[6] {
+            Span<short> spanBuffer = stackalloc short[6] {
                 unchecked((short)value.Year),
                 unchecked((short)value.Month),
                 unchecked((short)value.Day),
@@ -340,7 +340,7 @@ namespace System.Data.Odbc
                 unchecked((short)value.Minute),
                 unchecked((short)value.Second),
             };
-            WriteInt16Array(offset, buffer, 0, 6);
+            WriteInt16Array(offset, spanBuffer.Slice(0, 6));
             WriteInt32(offset + 12, value.Millisecond * 1000000); //fraction
         }
     }


### PR DESCRIPTION
A memory optimisation for DbBuffer class, avoid GC allocation when possible 