### PR TITLE
[RISC-V][JIT] Fix DevDiv_718151 test

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -4975,17 +4975,6 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
 
             unsigned srcSize = layout->GetSize();
 
-            // If we have an HFA we can't have any GC pointers,
-            // if not then the max size for the struct is 16 bytes
-            if (compiler->IsHfa(layout->GetClassHandle()))
-            {
-                noway_assert(!layout->HasGCPtr());
-            }
-            else
-            {
-                noway_assert(srcSize <= 2 * TARGET_POINTER_SIZE);
-            }
-
             noway_assert(srcSize <= MAX_PASS_MULTIREG_BYTES);
 
             unsigned dstSize = treeNode->GetStackByteSize();

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -998,7 +998,7 @@ int LinearScan::BuildPutArgSplit(GenTreePutArgSplit* argNode)
     int srcCount = 0;
     assert(argNode->gtOper == GT_PUTARG_SPLIT);
 
-    GenTree* putArgChild = argNode->gtGetOp1();
+    GenTree* src = argNode->gtGetOp1();
 
     // Registers for split argument corresponds to source
     int dstCount = argNode->gtNumRegs;
@@ -1012,7 +1012,7 @@ int LinearScan::BuildPutArgSplit(GenTreePutArgSplit* argNode)
         argNode->SetRegNumByIdx(thisArgReg, i);
     }
 
-    if (putArgChild->OperGet() == GT_FIELD_LIST)
+    if (src->OperGet() == GT_FIELD_LIST)
     {
         // Generated code:
         // 1. Consume all of the items in the GT_FIELD_LIST (source)
@@ -1023,47 +1023,53 @@ int LinearScan::BuildPutArgSplit(GenTreePutArgSplit* argNode)
         // To avoid redundant moves, have the argument operand computed in the
         // register in which the argument is passed to the call.
 
-        for (GenTreeFieldList::Use& use : putArgChild->AsFieldList()->Uses())
+        for (GenTreeFieldList::Use& use : src->AsFieldList()->Uses())
         {
             GenTree* node = use.GetNode();
             assert(!node->isContained());
             // The only multi-reg nodes we should see are OperIsMultiRegOp()
+            unsigned currentRegCount = 1;
             assert(!node->IsMultiRegNode());
 
             // Consume all the registers, setting the appropriate register mask for the ones that
             // go into registers.
-            regMaskTP sourceMask = RBM_NONE;
-            if (sourceRegCount < argNode->gtNumRegs)
+            for (unsigned regIndex = 0; regIndex < currentRegCount; regIndex++)
             {
-                sourceMask = genRegMask((regNumber)((unsigned)argReg + sourceRegCount));
+                regMaskTP sourceMask = RBM_NONE;
+                if (sourceRegCount < argNode->gtNumRegs)
+                {
+                    sourceMask = genRegMask((regNumber)((unsigned)argReg + sourceRegCount));
+                }
+                sourceRegCount++;
+                BuildUse(node, sourceMask, regIndex);
             }
-            sourceRegCount++;
-            BuildUse(node, sourceMask, 0);
         }
         srcCount += sourceRegCount;
-        assert(putArgChild->isContained());
+        assert(src->isContained());
     }
     else
     {
-        assert(putArgChild->TypeGet() == TYP_STRUCT);
-        assert(putArgChild->OperGet() == GT_BLK);
+        assert(src->TypeIs(TYP_STRUCT) && src->isContained());
 
-        // We can use a ld/st sequence so we need an internal register
-        buildInternalIntRegisterDefForNode(argNode, allRegs(TYP_INT) & ~argMask);
-
-        GenTree* objChild = putArgChild->gtGetOp1();
-        if (objChild->IsLclVarAddr())
+        if (src->OperIs(GT_BLK))
         {
-            // We will generate all of the code for the GT_PUTARG_SPLIT, the GT_BLK and the GT_LCL_ADDR<0>
-            // as one contained operation
-            //
-            assert(objChild->isContained());
+            // If the PUTARG_SPLIT clobbers only one register we may need an
+            // extra internal register in case there is a conflict between the
+            // source address register and target register.
+            if (argNode->gtNumRegs == 1)
+            {
+                // We can use a ldr/str sequence so we need an internal register
+                buildInternalIntRegisterDefForNode(argNode, allRegs(TYP_INT) & ~argMask);
+            }
+
+            // We will generate code that loads from the OBJ's address, which must be in a register.
+            srcCount = BuildOperandUses(src->AsBlk()->Addr());
         }
         else
         {
-            srcCount = BuildIndirUses(putArgChild->AsIndir());
+            // We will generate all of the code for the GT_PUTARG_SPLIT and LCL_VAR/LCL_FLD as one contained operation.
+            assert(src->OperIsLocalRead());
         }
-        assert(putArgChild->isContained());
     }
     buildInternalRegisterUses();
     BuildDefs(argNode, dstCount, argMask);

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_718151/DevDiv_718151.cs
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_718151/DevDiv_718151.cs
@@ -22,7 +22,7 @@ struct StructWithStructField
     public Struct16bytes structField;
 }
 
-public class DevDiv_714266
+public class DevDiv_718151
 {
     [MethodImpl(MethodImplOptions.NoInlining)]
     int foo(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, Struct16bytes s)
@@ -38,7 +38,7 @@ public class DevDiv_714266
         StructWithStructField s = new StructWithStructField();
         s.structField.a = 100;
 
-        DevDiv_714266 test = new DevDiv_714266();
+        DevDiv_718151 test = new DevDiv_718151();
         return test.foo(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, s.structField);
     }
 


### PR DESCRIPTION
- Update PutArgStk based on ARM64 implementation (#70861)
- Fixed `./JIT/Regression/JitBlue/DevDiv_718151/DevDiv_718151/DevDiv_718151.sh` test
```
FAILED   - [  22s]./JIT/Regression/JitBlue/DevDiv_718151/DevDiv_718151/DevDiv_718151.sh
               BEGIN EXECUTION
               /work/dotnet/bugfix/artifacts/tests/coreclr/linux.riscv64.Checked/Tests/Core_Root/corerun -p System.Reflection.Metadata.MetadataUpdater.IsSupported=false -p System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=true DevDiv_718151.dll ''

               Assert failure(PID 628969 [0x000998e9], Thread: 628969 [0x998e9]): Assertion failed 'objChild->isContained()' in 'DevDiv_714266:TestEntryPoint():int' during 'Linear scan register alloc' (IL size 51; hash 0xb6b43c6a; Tier0)

                   File: /home/clamp/Work/dotnet/bugfix/src/coreclr/jit/lsrariscv64.cpp Line: 971
                   Image: /work/dotnet/bugfix/artifacts/tests/coreclr/linux.riscv64.Checked/Tests/Core_Root/corerun

               ./DevDiv_718151.sh: line 448: 628969 Aborted                 (core dumped) $LAUNCHER $ExePath "${CLRTestExecutionArguments[@]}"
               Expected: 100
               Actual: 134
               END EXECUTION - FAILED
```

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov