### PR TITLE
Fix Codespaces prebuild after CMake upgrade and set policy in Mono

### DIFF
--- a/.devcontainer/libraries/Dockerfile
+++ b/.devcontainer/libraries/Dockerfile
@@ -1,22 +1,22 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.192.0/containers/dotnet/.devcontainer/base.Dockerfile
 # For details on dotnet specific container, see: https://github.com/microsoft/vscode-dev-containers/tree/main/containers/dotnet
 
-# [Choice] .NET version: 6.0, 3.1
-ARG VARIANT="6.0-focal"
+# [Choice] .NET version: 6.0, 7.0
+ARG VARIANT="6.0-jammy"
 FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
 
 # Set up machine requirements to build the repo and the gh CLI
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         cmake \
-        llvm-10 \
-        clang-10 \
+        llvm \
+        clang \
         build-essential \
-        python \
+        python3 \
         curl \
         git \
-        lldb-6.0 \
-        liblldb-6.0-dev \
+        lldb \
+        liblldb-dev \
         libunwind8 \
         libunwind8-dev \
         gettext \

--- a/.devcontainer/libraries/devcontainer.json
+++ b/.devcontainer/libraries/devcontainer.json
@@ -4,9 +4,8 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update 'VARIANT' to pick a .NET Core version: 3.1, 6.0
-			// Append -bullseye or -focal to pin to an OS version.
-			"VARIANT": "6.0-focal"
+			// Update 'VARIANT' to pick a .NET Core version: 6.0, 7.0
+			"VARIANT": "6.0-jammy"
 		}
 	},
 	"hostRequirements": {

--- a/.devcontainer/wasm/Dockerfile
+++ b/.devcontainer/wasm/Dockerfile
@@ -1,22 +1,22 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.192.0/containers/dotnet/.devcontainer/base.Dockerfile
 # For details on dotnet specific container, see: https://github.com/microsoft/vscode-dev-containers/tree/main/containers/dotnet
 
-# [Choice] .NET version: 6.0, 3.1
-ARG VARIANT="6.0-focal"
+# [Choice] .NET version: 6.0, 7.0
+ARG VARIANT="6.0-jammy"
 FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
 
 # Set up machine requirements to build the repo and the gh CLI
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         cmake \
-        llvm-10 \
-        clang-10 \
+        llvm \
+        clang \
         build-essential \
-        python \
+        python3 \
         curl \
         git \
-        lldb-6.0 \
-        liblldb-6.0-dev \
+        lldb \
+        liblldb-dev \
         libunwind8 \
         libunwind8-dev \
         gettext \

--- a/.devcontainer/wasm/devcontainer.json
+++ b/.devcontainer/wasm/devcontainer.json
@@ -4,9 +4,8 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update 'VARIANT' to pick a .NET Core version: 3.1, 6.0
-			// Append -bullseye or -focal to pin to an OS version.
-			"VARIANT": "6.0-focal"
+			// Update 'VARIANT' to pick a .NET Core version: 6.0, 7.0
+			"VARIANT": "6.0-jammy"
 		}
 	},
 	"hostRequirements": {

--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 
+cmake_policy(SET CMP0091 NEW)
+
 project(mono)
 
 include(../../eng/native/configurepaths.cmake)


### PR DESCRIPTION
The prebuild on Codespaces broke after the minimum CMake version was bumped in https://github.com/dotnet/runtime/pull/86530 because the container was still using Ubuntu 20.04 (Focal) which only has CMake 3.16.1.

Upgrade to Ubuntu 22.04 (Jammy) so we have a new enough CMake.

Also fix a missing policy in the Mono CMakeLists.txt that was accidentally removed.