### PR TITLE
Print variable types when dumping the output

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -7641,7 +7641,16 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
 
     if (varDsc->lvClassHnd != NO_CLASS_HANDLE)
     {
-        printf(" %s", eeGetClassName(varDsc->lvClassHnd));
+        printf(" <%s>", eeGetClassName(varDsc->lvClassHnd));
+    }
+    else if (varTypeIsStruct(varDsc->TypeGet()))
+    {
+        ClassLayout* layout = varDsc->GetLayout();
+        if (layout != nullptr)
+        {
+            printf(" ");
+            gtDispClassLayout(layout, varDsc->TypeGet());
+        }
     }
 
     printf("\n");

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -7646,7 +7646,7 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
     else if (varTypeIsStruct(varDsc->TypeGet()))
     {
         ClassLayout* layout = varDsc->GetLayout();
-        if (layout != nullptr && layout->GetClassName() != nullptr)
+        if (layout != nullptr && !layout->IsBlockLayout())
         {
             printf(" <%s>", layout->GetClassName());
         }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -7639,6 +7639,11 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
         }
     }
 
+    if (varDsc->lvClassHnd != NO_CLASS_HANDLE)
+    {
+        printf(" %s", eeGetClassName(varDsc->lvClassHnd));
+    }
+
     printf("\n");
 }
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -7646,10 +7646,9 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
     else if (varTypeIsStruct(varDsc->TypeGet()))
     {
         ClassLayout* layout = varDsc->GetLayout();
-        if (layout != nullptr)
+        if (layout != nullptr && layout->GetClassName() != nullptr)
         {
-            printf(" ");
-            gtDispClassLayout(layout, varDsc->TypeGet());
+            printf(" <%s>", layout->GetClassName());
         }
     }
 


### PR DESCRIPTION
This makes reasoning about local types easier.

Would help with checking the diffs for #88163, #88277 and #88006.