### PR TITLE
Fix which path is taken in Enumerable.Select for empty partition

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Enumerable.SizeOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Enumerable.SizeOpt.cs
@@ -10,7 +10,7 @@ namespace System.Linq
         public static IEnumerable<TResult> Empty<TResult>() => Array.Empty<TResult>();
 
         private static IEnumerable<TResult>? GetEmptyIfEmpty<TSource, TResult>(IEnumerable<TSource> source) =>
-            ReferenceEquals(source, Array.Empty<TSource>()) ?
+            source is TSource[] { Length: 0 } ?
                 Array.Empty<TResult>() :
                 null;
     }

--- a/src/libraries/System.Linq/src/System/Linq/Enumerable.SizeOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Enumerable.SizeOpt.cs
@@ -8,5 +8,10 @@ namespace System.Linq
     public static partial class Enumerable
     {
         public static IEnumerable<TResult> Empty<TResult>() => Array.Empty<TResult>();
+
+        private static IEnumerable<TResult>? GetEmptyIfEmpty<TSource, TResult>(IEnumerable<TSource> source) =>
+            ReferenceEquals(source, Array.Empty<TSource>()) ?
+                Array.Empty<TResult>() :
+                null;
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Enumerable.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Enumerable.SpeedOpt.cs
@@ -8,5 +8,10 @@ namespace System.Linq
     public static partial class Enumerable
     {
         public static IEnumerable<TResult> Empty<TResult>() => EmptyPartition<TResult>.Instance;
+
+        private static IEnumerable<TResult>? GetEmptyIfEmpty<TSource, TResult>(IEnumerable<TSource> source) =>
+            source is EmptyPartition<TSource> ?
+                EmptyPartition<TResult>.Instance :
+                null;
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
@@ -13,9 +13,7 @@ namespace System.Linq
         static partial void CreateSelectIPartitionIterator<TResult, TSource>(
             Func<TSource, TResult> selector, IPartition<TSource> partition, ref IEnumerable<TResult>? result)
         {
-            result = partition is EmptyPartition<TSource> ?
-                EmptyPartition<TResult>.Instance :
-                new SelectIPartitionIterator<TSource, TResult>(partition, selector);
+            result = new SelectIPartitionIterator<TSource, TResult>(partition, selector);
         }
 
         private sealed partial class SelectEnumerableIterator<TSource, TResult> : IIListProvider<TResult>

--- a/src/libraries/System.Linq/src/System/Linq/Select.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Select.cs
@@ -28,6 +28,11 @@ namespace System.Linq
                 return iterator.Select(selector);
             }
 
+            if (GetEmptyIfEmpty<TSource, TResult>(source) is IEnumerable<TResult> empty)
+            {
+                return empty;
+            }
+
             if (source is IList<TSource> ilist)
             {
                 if (source is TSource[] array)


### PR DESCRIPTION
My recent changes to improve perf of some LINQ iterators by implementing `IList<T>` caused Select on an empty partition to start preferring a path that wasn't optimized for empty.  This fixes it.  I searched and don't see any other operators that would be similarly negatively affected.

Fixes the one related benchmark from https://github.com/dotnet/runtime/issues/88376 (EmptyTakeSelectToArray).  None of the other benchmarks there are related to my previous change.