### PR TITLE
[MONO] Incorrect timestamps for perf events

### DIFF
--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -957,6 +957,9 @@
 /* Enable WebCIL image loader */
 #cmakedefine ENABLE_WEBCIL 1
 
+/* define if clockgettime exists */
+#cmakedefine HAVE_CLOCK_GETTIME 1
+
 #if defined(ENABLE_LLVM) && defined(HOST_WIN32) && defined(TARGET_WIN32) && (!defined(TARGET_AMD64) || !defined(_MSC_VER))
 #error LLVM for host=Windows and target=Windows is only supported on x64 MSVC build.
 #endif

--- a/src/mono/cmake/configure.cmake
+++ b/src/mono/cmake/configure.cmake
@@ -115,6 +115,8 @@ ac_check_funcs(
   pthread_attr_setstacksize pthread_get_stackaddr_np
 )
 
+check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
+
 check_symbol_exists(madvise "sys/mman.h" HAVE_MADVISE)
 check_symbol_exists(pthread_mutexattr_setprotocol "pthread.h" HAVE_DECL_PTHREAD_MUTEXATTR_SETPROTOCOL)
 check_symbol_exists(CLOCK_MONOTONIC "time.h" HAVE_CLOCK_MONOTONIC)


### PR DESCRIPTION
when added support for the debug info records with #85107 ,The perf was not able to map to the jitted-so's on top of the BenchmarkDotNet library. 
 i.e
```
5.47%  dotnet           [unknown]              [.] 0x000003ffa1fdc7e6
```

hence the perf source code annotation fails. on deeper inspection with the perf script logs, we noticed that the fork events and the mmap2 events were out of order. it seems `HAVE_CLOCK_GETTIME` i.e in `configure.ac` was removed while cleaning up the older makefile build system. hence returning always 0.
reference commit:-  https://github.com/dotnet/runtime/pull/47758

 @vargaz  as mentioned in the previous PR I added the macro to the cmake
#88373 

