### PR TITLE
[mono] Fix sorting custom attributes in ILStrip

### DIFF
--- a/src/tasks/MonoTargetsTasks/ILStrip/AssemblyStripper/AssemblyStripper.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/AssemblyStripper/AssemblyStripper.cs
@@ -18,7 +18,9 @@ namespace AssemblyStripper
         {
             CustomAttributeRow row_left = (CustomAttributeRow)left;
             CustomAttributeRow row_right = (CustomAttributeRow)right;
-            return row_left.Parent.RID.CompareTo(row_right.Parent.RID);
+            var leftParentCodedIdx = Utilities.CompressMetadataToken(CodedIndex.HasCustomAttribute, row_left.Parent);
+            var rightParentCodedIdx = Utilities.CompressMetadataToken(CodedIndex.HasCustomAttribute, row_right.Parent);
+            return leftParentCodedIdx.CompareTo(rightParentCodedIdx);
         }
     }
 


### PR DESCRIPTION
The change in https://github.com/dotnet/runtime/pull/87923 was subtly wrong, the problem is that RID on a Cecil metadata token masks out the token type. We actually have to reconstruct the custom attribute coded-index.

Credit to @lambdageek for the fix.