### PR TITLE
Adding Vector paths to ASCII GetIndexOfFirstNonAscii* Paths

### DIFF
--- a/src/libraries/System.Text.Encoding/tests/Ascii/FromUtf16Tests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Ascii/FromUtf16Tests.cs
@@ -19,15 +19,15 @@ namespace System.Text.Tests
         [Fact]
         public static void AllAsciiInput()
         {
-            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(128);
-            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(128);
+            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(256);
+            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(256);
 
             // Fill source with 00 .. 7F.
 
             Span<char> utf16Span = utf16Mem.Span;
             for (int i = 0; i < utf16Span.Length; i++)
             {
-                utf16Span[i] = (char)i;
+                utf16Span[i] = (char)(i % 128);
             }
             utf16Mem.MakeReadonly();
 
@@ -42,11 +42,11 @@ namespace System.Text.Tests
 
                 // First, validate that the workhorse saw the incoming data as all-ASCII.
                 Assert.Equal(OperationStatus.Done, Ascii.FromUtf16(utf16Span.Slice(i), asciiSpan.Slice(i), out int bytesWritten));
-                Assert.Equal(128 - i, bytesWritten);
+                Assert.Equal(256 - i, bytesWritten);
 
                 // Then, validate that the data was transcoded properly.
 
-                for (int j = i; j < 128; j++)
+                for (int j = i; j < 256; j++)
                 {
                     Assert.Equal((ushort)utf16Span[i], (ushort)asciiSpan[i]);
                 }
@@ -56,15 +56,15 @@ namespace System.Text.Tests
         [Fact]
         public static void SomeNonAsciiInput()
         {
-            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(128);
-            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(128);
+            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(256);
+            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(256);
 
             // Fill source with 00 .. 7F.
 
             Span<char> utf16Span = utf16Mem.Span;
             for (int i = 0; i < utf16Span.Length; i++)
             {
-                utf16Span[i] = (char)i;
+                utf16Span[i] = (char)(i % 128);
             }
 
             // We'll write to the ASCII span.

--- a/src/libraries/System.Text.Encoding/tests/Ascii/ToUtf16Tests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Ascii/ToUtf16Tests.cs
@@ -20,15 +20,15 @@ namespace System.Text.Tests
         [Fact]
         public static void AllAsciiInput()
         {
-            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(128);
-            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(128);
+            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(256);
+            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(256);
 
             // Fill source with 00 .. 7F, then trap future writes.
 
             Span<byte> asciiSpan = asciiMem.Span;
             for (int i = 0; i < asciiSpan.Length; i++)
             {
-                asciiSpan[i] = (byte)i;
+                asciiSpan[i] = (byte)(i % 128);
             }
             asciiMem.MakeReadonly();
 
@@ -44,11 +44,11 @@ namespace System.Text.Tests
                 // First, validate that the workhorse saw the incoming data as all-ASCII.
 
                 Assert.Equal(OperationStatus.Done, Ascii.ToUtf16(asciiSpan.Slice(i), utf16Span.Slice(i), out int charsWritten));
-                Assert.Equal(128 - i, charsWritten);
+                Assert.Equal(256 - i, charsWritten);
 
                 // Then, validate that the data was transcoded properly.
 
-                for (int j = i; j < 128; j++)
+                for (int j = i; j < 256; j++)
                 {
                     Assert.Equal((ushort)asciiSpan[i], (ushort)utf16Span[i]);
                 }
@@ -58,15 +58,15 @@ namespace System.Text.Tests
         [Fact]
         public static void SomeNonAsciiInput()
         {
-            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(128);
-            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(128);
+            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(256);
+            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(256);
 
             // Fill source with 00 .. 7F, then trap future writes.
 
             Span<byte> asciiSpan = asciiMem.Span;
             for (int i = 0; i < asciiSpan.Length; i++)
             {
-                asciiSpan[i] = (byte)i;
+                asciiSpan[i] = (byte)(i % 128);
             }
 
             // We'll write to the UTF-16 span.


### PR DESCRIPTION
The follow draft PR illustrates `Vector256` and `Vector512` SIMD upgrade paths for `GetIndexOfFirstNonAsciiChar` and `GetIndexOfFirstNonAsciiByte` using pure `VectorXX` xplat APIs, mostly to simplify implementation and prevent extra code bloat.

The following are some preliminary performance numbers taken on an IceLake machine that compare the default intrinsic SIMD implementation of `Vector128` with SSE intrinsics (`GetIndexOfFirstNonAsciiChar_Intrinsified`) with the pure `Vector512` and `Vector256` SIMD implementations (`GetIndexOfFirstNonAsciiChar_Vector`.

![image](https://github.com/dotnet/runtime/assets/91913526/f9dda974-8f68-45c0-b449-f34830bb33e5)

with `DOTNET_EnableAVX512F=0` (forces the Vector256 path)

![image](https://github.com/dotnet/runtime/assets/91913526/1827de22-c8ae-4f6f-8822-58394303594d)

There will be some performance left on the table with this approach for additional SIMD paths; however, I feel the xplat approach reaches a nice trade off between performance and complexity, and the `JIT` can handle generating more efficient code for the APIs in the future. I also expect greater performance improvements if we upgrade the associated narrowing and widening methods in `ASCII.Utility.cs` with similar approaches.

@dotnet/avx512-contrib 