### PR TITLE
Ensure GCHeap related debugging still works even when we use newer CLRGC to target older runtimes

### DIFF
--- a/src/coreclr/gc/dac_gcheap_fields.h
+++ b/src/coreclr/gc/dac_gcheap_fields.h
@@ -1,4 +1,4 @@
-// Whenever we add field here, we need to bare in mind that we have a scenario for a new clrgc
+// Whenever we add field here, we need to bear in mind that we have a scenario for a new clrgc
 // is used in an old runtime. In that case, the old runtime's DAC will have to interpret the
 // fields the way it was. So fields should only be added at the end of the struct.
 

--- a/src/coreclr/gc/dac_gcheap_fields.h
+++ b/src/coreclr/gc/dac_gcheap_fields.h
@@ -1,3 +1,12 @@
+// Whenever we add field here, we need to bare in mind that we have a scenario for a new clrgc
+// is used in an old runtime. In that case, the old runtime's DAC will have to interpret the
+// fields the way it was. So fields should only be added at the end of the struct.
+
+#ifndef DEFINE_OFFSET_ONLY_FIELD
+#define DEFINE_OFFSET_ONLY_FIELD_IGNORED
+#define DEFINE_OFFSET_ONLY_FIELD(name)
+#endif
+
 DEFINE_FIELD       (alloc_allocated,                    uint8_t*)
 DEFINE_DPTR_FIELD  (ephemeral_heap_segment,             dac_heap_segment)
 DEFINE_DPTR_FIELD  (finalize_queue,                     dac_finalize_queue)
@@ -16,8 +25,6 @@ DEFINE_FIELD       (mark_array,                         uint32_t*)
 DEFINE_FIELD       (next_sweep_obj,                     uint8_t*)    
 DEFINE_FIELD       (background_saved_lowest_address,    uint8_t*)
 DEFINE_FIELD       (background_saved_highest_address,   uint8_t*)
-DEFINE_DPTR_FIELD  (freeable_soh_segment,               dac_heap_segment)
-DEFINE_DPTR_FIELD  (freeable_uoh_segment,               dac_heap_segment)
 #if defined(ALL_FIELDS) || !defined(USE_REGIONS)
 DEFINE_DPTR_FIELD  (saved_sweep_ephemeral_seg,          dac_heap_segment)
 DEFINE_FIELD       (saved_sweep_ephemeral_start,        uint8_t*)
@@ -30,10 +37,21 @@ DEFINE_MISSING_FIELD(mark_array)
 DEFINE_MISSING_FIELD(next_sweep_obj)
 DEFINE_MISSING_FIELD(background_saved_lowest_address)
 DEFINE_MISSING_FIELD(background_saved_highest_address)
-DEFINE_MISSING_FIELD(freeable_soh_segment)
-DEFINE_MISSING_FIELD(freeable_uoh_segment)
 DEFINE_MISSING_FIELD(saved_sweep_ephemeral_seg)
 DEFINE_MISSING_FIELD(saved_sweep_ephemeral_start)
+#endif // defined(ALL_FIELDS) || defined(BACKGROUND_GC)
+
+// generation_table is a special field, it is not included in dac_gcheap
+// but its offset need to be right at this spot in order to match the 
+// layout we had in .NET 6+
+DEFINE_OFFSET_ONLY_FIELD(generation_table)
+
+#if defined(ALL_FIELDS) || defined(BACKGROUND_GC)
+DEFINE_DPTR_FIELD  (freeable_soh_segment,               dac_heap_segment)
+DEFINE_DPTR_FIELD  (freeable_uoh_segment,               dac_heap_segment)
+#else
+DEFINE_MISSING_FIELD(freeable_soh_segment)
+DEFINE_MISSING_FIELD(freeable_uoh_segment)
 #endif // defined(ALL_FIELDS) || defined(BACKGROUND_GC)
 
 #if defined(ALL_FIELDS) ||  defined(USE_REGIONS)
@@ -41,3 +59,8 @@ DEFINE_ARRAY_FIELD (free_regions,                        dac_region_free_list, F
 #else
 DEFINE_MISSING_FIELD(free_regions)
 #endif // ALL_FIELDS
+
+#ifdef DEFINE_OFFSET_ONLY_FIELD_IGNORED
+#undef DEFINE_OFFSET_ONLY_FIELD_IGNORED
+#undef DEFINE_OFFSET_ONLY_FIELD
+#endif

--- a/src/coreclr/gc/dac_gcheap_fields.h
+++ b/src/coreclr/gc/dac_gcheap_fields.h
@@ -39,7 +39,8 @@ DEFINE_MISSING_FIELD(saved_sweep_ephemeral_start)
 // This field is unused
 DEFINE_FIELD(generation_table, void*)
 
-// Here is where v0.2 fields starts
+// Here is where v5.2 fields starts
+
 #if defined(ALL_FIELDS) || defined(BACKGROUND_GC)
 DEFINE_DPTR_FIELD  (freeable_soh_segment,               dac_heap_segment)
 DEFINE_DPTR_FIELD  (freeable_uoh_segment,               dac_heap_segment)

--- a/src/coreclr/gc/dac_gcheap_fields.h
+++ b/src/coreclr/gc/dac_gcheap_fields.h
@@ -2,11 +2,6 @@
 // is used in an old runtime. In that case, the old runtime's DAC will have to interpret the
 // fields the way it was. So fields should only be added at the end of the struct.
 
-#ifndef DEFINE_OFFSET_ONLY_FIELD
-#define DEFINE_OFFSET_ONLY_FIELD_IGNORED
-#define DEFINE_OFFSET_ONLY_FIELD(name)
-#endif
-
 DEFINE_FIELD       (alloc_allocated,                    uint8_t*)
 DEFINE_DPTR_FIELD  (ephemeral_heap_segment,             dac_heap_segment)
 DEFINE_DPTR_FIELD  (finalize_queue,                     dac_finalize_queue)
@@ -41,11 +36,10 @@ DEFINE_MISSING_FIELD(saved_sweep_ephemeral_seg)
 DEFINE_MISSING_FIELD(saved_sweep_ephemeral_start)
 #endif // defined(ALL_FIELDS) || defined(BACKGROUND_GC)
 
-// generation_table is a special field, it is not included in dac_gcheap
-// but its offset need to be right at this spot in order to match the 
-// layout we had in .NET 6+
-DEFINE_OFFSET_ONLY_FIELD(generation_table)
+// This field is unused
+DEFINE_FIELD(generation_table, void*)
 
+// Here is where v0.2 fields starts
 #if defined(ALL_FIELDS) || defined(BACKGROUND_GC)
 DEFINE_DPTR_FIELD  (freeable_soh_segment,               dac_heap_segment)
 DEFINE_DPTR_FIELD  (freeable_uoh_segment,               dac_heap_segment)
@@ -59,8 +53,3 @@ DEFINE_ARRAY_FIELD (free_regions,                        dac_region_free_list, F
 #else
 DEFINE_MISSING_FIELD(free_regions)
 #endif // ALL_FIELDS
-
-#ifdef DEFINE_OFFSET_ONLY_FIELD_IGNORED
-#undef DEFINE_OFFSET_ONLY_FIELD_IGNORED
-#undef DEFINE_OFFSET_ONLY_FIELD
-#endif

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -51943,7 +51943,6 @@ void PopulateDacVars(GcDacVars *gcDacVars)
     };
 
     assert(gcDacVars != nullptr);
-
     // Note: These version numbers do not need to be checked in the .Net dac/SOS because
     // we always match the compiled dac and GC to the version used.  NativeAOT's SOS may
     // work differently than .Net SOS.  When making breaking changes here you may need to

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -51922,7 +51922,6 @@ void PopulateDacVars(GcDacVars *gcDacVars)
 #define DEFINE_DPTR_FIELD(field_name, field_type) offsetof(CLASS_NAME, field_name),
 #define DEFINE_ARRAY_FIELD(field_name, field_type, array_length) offsetof(CLASS_NAME, field_name),
 #define DEFINE_MISSING_FIELD(field_name) -1,
-#define DEFINE_OFFSET_ONLY_FIELD(field_name) offsetof(CLASS_NAME, field_name),
 
 #ifdef MULTIPLE_HEAPS
     static int gc_heap_field_offsets[] = {
@@ -51937,7 +51936,6 @@ void PopulateDacVars(GcDacVars *gcDacVars)
 #include "dac_generation_fields.h"
 #undef CLASS_NAME
 
-#undef DEFINE_OFFSET_ONLY_FIELD
 #undef DEFINE_MISSING_FIELD
 #undef DEFINE_ARRAY_FIELD
 #undef DEFINE_DPTR_FIELD

--- a/src/coreclr/gc/gcinterface.dac.h
+++ b/src/coreclr/gc/gcinterface.dac.h
@@ -190,19 +190,6 @@ public:
 #undef DEFINE_DPTR_FIELD
 #undef DEFINE_FIELD
 #undef ALL_FIELDS
-
-    // The generation table must always be last, because the size of this array
-    // (stored inline in the gc_heap class) can vary.
-    //
-    // The size of the generation class is not part of the GC-DAC interface,
-    // despite being embedded by-value into the gc_heap class. The DAC variable
-    // "generation_size" stores the size of the generation class, so the DAC can
-    // use it and pointer arithmetic to calculate correct offsets into the generation
-    // table. (See "GenerationTableIndex" function in the DAC for details)
-    //
-    // Also note that this array has length 1 because the C++ standard doesn't allow
-    // for 0-length arrays, although every major compiler is willing to tolerate it.
-    dac_generation generation_table[1];
 };
 
 #define GENERATION_TABLE_FIELD_INDEX 18

--- a/src/coreclr/gc/gcinterface.dac.h
+++ b/src/coreclr/gc/gcinterface.dac.h
@@ -205,7 +205,7 @@ public:
     dac_generation generation_table[1];
 };
 
-#define GENERATION_TABLE_FIELD_INDEX 21
+#define GENERATION_TABLE_FIELD_INDEX 18
 
 // Unlike other DACized structures, these types are loaded manually in the debugger.
 // To avoid misuse, pointers to them are explicitly casted to these unused type.
@@ -242,13 +242,7 @@ struct unused_generation
 // this structure contains __DPtrs for every DAC variable that will marshal values
 // from the debugee process to the debugger process when dereferenced.
 struct GcDacVars {
-  uint8_t major_version_number;
-  uint8_t minor_version_number;
-  size_t generation_size;
-  size_t total_generation_count;
-  int total_bookkeeping_elements;
-  int count_free_region_kinds;
-  size_t card_table_info_size;
+#define GC_DAC_VAL(type, name)       type name;
 #ifdef DACCESS_COMPILE
  #define GC_DAC_VAR(type, name)       DPTR(type) name;
  #define GC_DAC_PTR_VAR(type, name)   DPTR(type*) name;
@@ -257,6 +251,7 @@ struct GcDacVars {
  #define GC_DAC_VAR(type, name) type *name;
 #endif
 #include "gcinterface.dacvars.def"
+#undef GC_DAC_VAL
 };
 
 #endif // _GC_INTERFACE_DAC_H_

--- a/src/coreclr/gc/gcinterface.dacvars.def
+++ b/src/coreclr/gc/gcinterface.dacvars.def
@@ -19,7 +19,7 @@
 // degraded debugging experience.
 // Major version mismatches are not tolerated by the DAC and will be rejected upon load.
 
-// Whenever we add field here, we need to bare in mind that we have a scenario for a new clrgc
+// Whenever we add field here, we need to bear in mind that we have a scenario for a new clrgc
 // is used in an old runtime. In that case, the old runtime's DAC will have to interpret the
 // fields the way it was. So fields should only be added at the end of the struct, and their 
 // loading in PopulateDacVars need to be version checked against a bumped up minor version.

--- a/src/coreclr/gc/gcinterface.dacvars.def
+++ b/src/coreclr/gc/gcinterface.dacvars.def
@@ -19,6 +19,15 @@
 // degraded debugging experience.
 // Major version mismatches are not tolerated by the DAC and will be rejected upon load.
 
+// Whenever we add field here, we need to bare in mind that we have a scenario for a new clrgc
+// is used in an old runtime. In that case, the old runtime's DAC will have to interpret the
+// fields the way it was. So fields should only be added at the end of the struct, and their 
+// loading in PopulateDacVars need to be version checked against a bumped up minor version.
+
+#ifndef GC_DAC_VAL
+ #define GC_DAC_VAL(type, name)
+#endif // GC_DAC_VAL
+
 #ifndef GC_DAC_VAR
  #define GC_DAC_VAR(type, name)
 #endif // GC_DAC_VAR
@@ -33,6 +42,10 @@
 
 // This sequence of macros defines the specific variables that are exposed by the
 // GC to the DAC.
+GC_DAC_VAL        (uint8_t,               major_version_number)
+GC_DAC_VAL        (uint8_t,               minor_version_number)
+GC_DAC_VAL        (size_t,                generation_size)
+GC_DAC_VAL        (size_t,                total_generation_count)
 GC_DAC_VAR        (uint8_t,               build_variant)
 GC_DAC_VAR        (bool,                  built_with_svr)
 GC_DAC_ARRAY_VAR  (size_t,                gc_global_mechanisms)
@@ -42,8 +55,6 @@ GC_DAC_PTR_VAR    (uint32_t,              mark_array)
 GC_DAC_VAR        (c_gc_state,            current_c_gc_state)
 GC_DAC_PTR_VAR    (dac_heap_segment,      ephemeral_heap_segment)
 GC_DAC_PTR_VAR    (dac_heap_segment,      saved_sweep_ephemeral_seg)
-GC_DAC_PTR_VAR    (dac_heap_segment,      freeable_soh_segment)
-GC_DAC_PTR_VAR    (dac_heap_segment,      freeable_uoh_segment)
 GC_DAC_PTR_VAR    (uint8_t,               saved_sweep_ephemeral_start)
 GC_DAC_PTR_VAR    (uint8_t,               background_saved_lowest_address)
 GC_DAC_PTR_VAR    (uint8_t,               background_saved_highest_address)
@@ -68,6 +79,11 @@ GC_DAC_PTR_VAR    (uint8_t,               bookkeeping_start)
 GC_DAC_ARRAY_VAR  (dac_region_free_list,  global_regions_to_decommit)
 GC_DAC_PTR_VAR    (dac_region_free_list,  global_free_huge_regions)
 GC_DAC_ARRAY_VAR  (dac_region_free_list,  free_regions)
+GC_DAC_PTR_VAR    (dac_heap_segment,      freeable_soh_segment)
+GC_DAC_PTR_VAR    (dac_heap_segment,      freeable_uoh_segment)
+GC_DAC_VAL        (int,                   total_bookkeeping_elements)
+GC_DAC_VAL        (int,                   count_free_region_kinds)
+GC_DAC_VAL        (size_t,                card_table_info_size)
 
 #undef GC_DAC_VAR
 #undef GC_DAC_ARRAY_VAR

--- a/src/coreclr/gc/gcinterface.dacvars.def
+++ b/src/coreclr/gc/gcinterface.dacvars.def
@@ -79,6 +79,9 @@ GC_DAC_PTR_VAR    (uint8_t,               bookkeeping_start)
 GC_DAC_ARRAY_VAR  (dac_region_free_list,  global_regions_to_decommit)
 GC_DAC_PTR_VAR    (dac_region_free_list,  global_free_huge_regions)
 GC_DAC_ARRAY_VAR  (dac_region_free_list,  free_regions)
+
+// Here is where v5.2 fields starts
+
 GC_DAC_PTR_VAR    (dac_heap_segment,      freeable_soh_segment)
 GC_DAC_PTR_VAR    (dac_heap_segment,      freeable_uoh_segment)
 GC_DAC_VAL        (int,                   total_bookkeeping_elements)

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -11,7 +11,7 @@
 // The minor version of the IGCHeap interface. Non-breaking changes are required
 // to bump the minor version number. GCs and EEs with minor version number
 // mismatches can still interoperate correctly, with some care.
-#define GC_INTERFACE_MINOR_VERSION 1
+#define GC_INTERFACE_MINOR_VERSION 2
 
 // The major version of the IGCToCLR interface. Breaking changes to this interface
 // require bumps in the major version number.

--- a/src/coreclr/vm/gcheaputilities.cpp
+++ b/src/coreclr/vm/gcheaputilities.cpp
@@ -344,6 +344,8 @@ HRESULT GCHeapUtilities::LoadAndInitialize()
     g_gc_load_status = GC_LOAD_STATUS_START;
 
     LPCWSTR standaloneGcLocation = Configuration::GetKnobStringValue(W("System.GC.Name"), CLRConfig::EXTERNAL_GCName);
+    g_gc_dac_vars.major_version_number = GC_INTERFACE_MAJOR_VERSION;
+    g_gc_dac_vars.minor_version_number = GC_INTERFACE_MINOR_VERSION;
     if (!standaloneGcLocation)
     {
         return InitializeDefaultGC();


### PR DESCRIPTION
This change makes sure GCHeap-related debugging still works even when we use newer CLRGC to target older runtimes by:

- Placing all the newer fields at the end of `GcDacVars` and `dac_gcheap`, and
- Making sure GC never populate fields that do not exist on older versions.