### PR TITLE
Fix minor documentation error for `IFloatingPoint<TSelf>.Round(TSelf, int, MidpointRounding)`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPoint.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IFloatingPoint.cs
@@ -38,7 +38,7 @@ namespace System.Numerics
         /// <returns>The result of rounding <paramref name="x" /> to the nearest integer using <paramref name="mode" />.</returns>
         static virtual TSelf Round(TSelf x, MidpointRounding mode) => TSelf.Round(x, digits: 0, mode);
 
-        /// <summary>Rounds a value to a specified number of fractional-digits using the default rounding mode (<see cref="MidpointRounding.ToEven" />).</summary>
+        /// <summary>Rounds a value to a specified number of fractional-digits using the specified rounding mode.</summary>
         /// <param name="x">The value to round.</param>
         /// <param name="digits">The number of fractional digits to which <paramref name="x" /> should be rounded.</param>
         /// <param name="mode">The mode under which <paramref name="x" /> should be rounded.</param>


### PR DESCRIPTION
## Summary

The method had a documentation error, where it said it uses the default midpoint rounding mode, as opposed to the specified one.

Fixes https://github.com/dotnet/runtime/issues/88401
Also see https://github.com/dotnet/dotnet-api-docs/pull/9122