### PR TITLE
Tar: use UtcDateTime when setting last write time.

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -555,7 +555,7 @@ namespace System.Formats.Tar
         {
             try
             {
-                File.SetLastWriteTime(destinationFileName, lastWriteTime.LocalDateTime); // SetLastWriteTime expects local time
+                File.SetLastWriteTime(destinationFileName, lastWriteTime.UtcDateTime);
             }
             catch
             {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -451,7 +451,7 @@ namespace System.Formats.Tar
         {
             try
             {
-                Directory.SetLastWriteTime(fullPath, lastWriteTime.LocalDateTime); // SetLastWriteTime expects local time
+                Directory.SetLastWriteTime(fullPath, lastWriteTime.UtcDateTime);
             }
             catch
             {


### PR DESCRIPTION
Using LocalDateTime converts the UTC time from the archive to a local time, which is then converted back to UTC for the file system.

This removes the local time round-trip.