### PR TITLE
[RISC-V] Increase instruction group size

### DIFF
--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2368,9 +2368,9 @@ private:
     //
     CLANG_FORMAT_COMMENT_ANCHOR;
 
-#if defined(TARGET_ARMARCH) || defined(TARGET_LOONGARCH64)
-// ARM32 and ARM64 both can require a bigger prolog instruction group. One scenario is where
-// a function uses all the incoming integer and single-precision floating-point arguments,
+#if defined(TARGET_ARMARCH) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
+// ARM32/64, LoongArch and RISC-V can require a bigger prolog instruction group. One scenario
+// is where a function uses all the incoming integer and single-precision floating-point arguments,
 // and must store them all to the frame on entry. If the frame is very large, we generate
 // ugly code like:
 //     movw r10, 0x488
@@ -2387,7 +2387,7 @@ private:
 #else
 #define SC_IG_BUFFER_NUM_SMALL_DESCS 14
 #define SC_IG_BUFFER_NUM_LARGE_DESCS 50
-#endif // !(TARGET_ARMARCH || TARGET_LOONGARCH64)
+#endif // !(TARGET_ARMARCH || TARGET_LOONGARCH64 || TARGET_RISCV64)
 
     size_t emitIGbuffSize;
 


### PR DESCRIPTION
Similar to ARM default IG size is not enough for prolog generation.
Fixes:
```
JIT/jit64/hfa/main/testG/hfa_nd2G_d/hfa_nd2G_d.sh
JIT/jit64/hfa/main/testG/hfa_nd2G_r/hfa_nd2G_r.sh
JIT/jit64/hfa/main/testG/hfa_sd2G_d/hfa_sd2G_d.sh
JIT/jit64/hfa/main/testG/hfa_sd2G_r/hfa_sd2G_r.sh
```

Part of https://github.com/dotnet/runtime/issues/84834

cc @jakobbotsch @wscho77 @HJLeee @JongHeonChoi @t-mustafin @clamp03 @gbalykov