### PR TITLE
Disable System.Diagnostics.Tests.EventLogMessagesTests.CanReadAndWriteMessages on Windows 11

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogMessagesTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogMessagesTests.cs
@@ -53,6 +53,7 @@ namespace System.Diagnostics.Tests
         public static bool HasAssemblyFilesIsElevatedAndSupportsEventLogs => PlatformDetection.HasAssemblyFiles && Helpers.IsElevatedAndSupportsEventLogs;
 
         [ConditionalFact(nameof(HasAssemblyFilesIsElevatedAndSupportsEventLogs))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88224", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version22000OrGreater))]
         public void CanReadAndWriteMessages()
         {
             string messageDllPath = Path.Combine(Path.GetDirectoryName(typeof(EventLog).Assembly.Location), "System.Diagnostics.EventLog.Messages.dll");


### PR DESCRIPTION
Fixes blocking status for #88224