### PR TITLE
[release/6.0-staging] Enable loading COM component in default ALC via runtime config setting

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Windows.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Windows.xml
@@ -11,4 +11,13 @@
       <method name="UnregisterClassForTypeInternal" />
     </type>
   </assembly>
+
+  <assembly fullname="System.Private.CoreLib" feature="System.Runtime.InteropServices.BuiltInComInterop.IsSupported" featurevalue="true">
+    <!-- Enables the .NET COM host to load a COM component. -->
+    <type fullname="Internal.Runtime.InteropServices.ComActivator" >
+      <method name="GetClassFactoryForTypeInContext" />
+      <method name="RegisterClassForTypeInContext" />
+      <method name="UnregisterClassForTypeInContext" />
+    </type>
+  </assembly>
 </linker>

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivationContextInternal.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivationContextInternal.cs
@@ -32,6 +32,7 @@ namespace Internal.Runtime.InteropServices
         public string AssemblyPath;
         public string AssemblyName;
         public string TypeName;
+        public bool IsolatedContext;
     }
 
     [ComImport]

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
@@ -59,9 +59,8 @@ namespace Internal.Runtime.InteropServices
 
     public partial struct ComActivationContext
     {
-        [RequiresUnreferencedCode("Built-in COM support is not trim compatible", Url = "https://aka.ms/dotnet-illink/com")]
         [CLSCompliant(false)]
-        public static unsafe ComActivationContext Create(ref ComActivationContextInternal cxtInt)
+        public static unsafe ComActivationContext Create(ref ComActivationContextInternal cxtInt, bool isolatedContext)
         {
             if (!Marshal.IsBuiltInComSupported)
             {
@@ -74,7 +73,8 @@ namespace Internal.Runtime.InteropServices
                 InterfaceId = cxtInt.InterfaceId,
                 AssemblyPath = Marshal.PtrToStringUni(new IntPtr(cxtInt.AssemblyPathBuffer))!,
                 AssemblyName = Marshal.PtrToStringUni(new IntPtr(cxtInt.AssemblyNameBuffer))!,
-                TypeName = Marshal.PtrToStringUni(new IntPtr(cxtInt.TypeNameBuffer))!
+                TypeName = Marshal.PtrToStringUni(new IntPtr(cxtInt.TypeNameBuffer))!,
+                IsolatedContext = isolatedContext
             };
         }
     }
@@ -85,6 +85,9 @@ namespace Internal.Runtime.InteropServices
         // Collection of all ALCs used for COM activation. In the event we want to support
         // unloadable COM server ALCs, this will need to be changed.
         private static readonly Dictionary<string, AssemblyLoadContext> s_assemblyLoadContexts = new Dictionary<string, AssemblyLoadContext>(StringComparer.InvariantCultureIgnoreCase);
+
+        // COM component assembly paths loaded in the default ALC
+        private static readonly HashSet<string> s_loadedInDefaultContext = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
 
         /// <summary>
         /// Entry point for unmanaged COM activation API from managed code
@@ -109,7 +112,7 @@ namespace Internal.Runtime.InteropServices
                 throw new ArgumentException(null, nameof(cxt));
             }
 
-            Type classType = FindClassType(cxt.ClassId, cxt.AssemblyPath, cxt.AssemblyName, cxt.TypeName);
+            Type classType = FindClassType(cxt);
 
             if (LicenseInteropProxy.HasLicense(classType))
             {
@@ -147,7 +150,7 @@ namespace Internal.Runtime.InteropServices
                 throw new ArgumentException(null, nameof(cxt));
             }
 
-            Type classType = FindClassType(cxt.ClassId, cxt.AssemblyPath, cxt.AssemblyName, cxt.TypeName);
+            Type classType = FindClassType(cxt);
 
             Type? currentType = classType;
             bool calledFunction = false;
@@ -215,7 +218,7 @@ namespace Internal.Runtime.InteropServices
         }
 
         /// <summary>
-        /// Internal entry point for unmanaged COM activation API from native code
+        /// Gets a class factory for COM activation in an isolated load context
         /// </summary>
         /// <param name="pCxtInt">Pointer to a <see cref="ComActivationContextInternal"/> instance</param>
         [RequiresUnreferencedCode("Built-in COM support is not trim compatible", Url = "https://aka.ms/dotnet-illink/com")]
@@ -224,10 +227,38 @@ namespace Internal.Runtime.InteropServices
         public static unsafe int GetClassFactoryForTypeInternal(ComActivationContextInternal* pCxtInt)
         {
             if (!Marshal.IsBuiltInComSupported)
-            {
                 throw new NotSupportedException(SR.NotSupported_COM);
-            }
 
+#pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
+            return GetClassFactoryForTypeImpl(pCxtInt, isolatedContext: true);
+#pragma warning restore IL2026
+        }
+
+        /// <summary>
+        /// Gets a class factory for COM activation in the specified load context
+        /// </summary>
+        /// <param name="pCxtInt">Pointer to a <see cref="ComActivationContextInternal"/> instance</param>
+        /// <param name="loadContext">Load context - currently must be IntPtr.Zero (default context) or -1 (isolated context)</param>
+        [UnmanagedCallersOnly]
+        private static unsafe int GetClassFactoryForTypeInContext(ComActivationContextInternal* pCxtInt, IntPtr loadContext)
+        {
+            if (!Marshal.IsBuiltInComSupported)
+                throw new NotSupportedException(SR.NotSupported_COM);
+
+            if (loadContext != IntPtr.Zero && loadContext != (IntPtr)(-1))
+                throw new ArgumentOutOfRangeException(nameof(loadContext));
+
+            return GetClassFactoryForTypeLocal(pCxtInt, isolatedContext: loadContext != IntPtr.Zero);
+
+            // Use a local function for a targeted suppression of the requires unreferenced code warning
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                Justification = "The same feature switch applies to GetClassFactoryForTypeInternal and this function. We rely on the warning from GetClassFactoryForTypeInternal.")]
+            static int GetClassFactoryForTypeLocal(ComActivationContextInternal* pCxtInt, bool isolatedContext) => GetClassFactoryForTypeImpl(pCxtInt, isolatedContext);
+        }
+
+        [RequiresUnreferencedCode("Built-in COM support is not trim compatible", Url = "https://aka.ms/dotnet-illink/com")]
+        private static unsafe int GetClassFactoryForTypeImpl(ComActivationContextInternal* pCxtInt, bool isolatedContext)
+        {
             ref ComActivationContextInternal cxtInt = ref *pCxtInt;
 
             if (IsLoggingEnabled())
@@ -244,7 +275,7 @@ $@"{nameof(GetClassFactoryForTypeInternal)} arguments:
 
             try
             {
-                var cxt = ComActivationContext.Create(ref cxtInt);
+                var cxt = ComActivationContext.Create(ref cxtInt, isolatedContext);
                 object cf = GetClassFactoryForType(cxt);
                 IntPtr nativeIUnknown = Marshal.GetIUnknownForObject(cf);
                 Marshal.WriteIntPtr(cxtInt.ClassFactoryDest, nativeIUnknown);
@@ -258,7 +289,7 @@ $@"{nameof(GetClassFactoryForTypeInternal)} arguments:
         }
 
         /// <summary>
-        /// Internal entry point for registering a managed COM server API from native code
+        /// Registers a managed COM server in an isolated load context
         /// </summary>
         /// <param name="pCxtInt">Pointer to a <see cref="ComActivationContextInternal"/> instance</param>
         [RequiresUnreferencedCode("Built-in COM support is not trim compatible", Url = "https://aka.ms/dotnet-illink/com")]
@@ -267,10 +298,30 @@ $@"{nameof(GetClassFactoryForTypeInternal)} arguments:
         public static unsafe int RegisterClassForTypeInternal(ComActivationContextInternal* pCxtInt)
         {
             if (!Marshal.IsBuiltInComSupported)
-            {
                 throw new NotSupportedException(SR.NotSupported_COM);
-            }
 
+            return RegisterClassForTypeImpl(pCxtInt, isolatedContext: true);
+        }
+
+        /// <summary>
+        /// Registers a managed COM server in the specified load context
+        /// </summary>
+        /// <param name="pCxtInt">Pointer to a <see cref="ComActivationContextInternal"/> instance</param>
+        /// <param name="loadContext">Load context - currently must be IntPtr.Zero (default context) or -1 (isolated context)</param>
+        [UnmanagedCallersOnly]
+        private static unsafe int RegisterClassForTypeInContext(ComActivationContextInternal* pCxtInt, IntPtr loadContext)
+        {
+            if (!Marshal.IsBuiltInComSupported)
+                throw new NotSupportedException(SR.NotSupported_COM);
+
+            if (loadContext != IntPtr.Zero && loadContext != (IntPtr)(-1))
+                throw new ArgumentOutOfRangeException(nameof(loadContext));
+
+            return RegisterClassForTypeImpl(pCxtInt, isolatedContext: loadContext != IntPtr.Zero);
+        }
+
+        private static unsafe int RegisterClassForTypeImpl(ComActivationContextInternal* pCxtInt, bool isolatedContext)
+        {
             ref ComActivationContextInternal cxtInt = ref *pCxtInt;
 
             if (IsLoggingEnabled())
@@ -293,8 +344,8 @@ $@"{nameof(RegisterClassForTypeInternal)} arguments:
 
             try
             {
-                var cxt = ComActivationContext.Create(ref cxtInt);
-                ClassRegistrationScenarioForType(cxt, register: true);
+                var cxt = ComActivationContext.Create(ref cxtInt, isolatedContext);
+                ClassRegistrationScenarioForTypeLocal(cxt, register: true);
             }
             catch (Exception e)
             {
@@ -302,10 +353,15 @@ $@"{nameof(RegisterClassForTypeInternal)} arguments:
             }
 
             return 0;
+
+            // Use a local function for a targeted suppression of the requires unreferenced code warning
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                Justification = "The same feature switch applies to GetClassFactoryForTypeInternal and this function. We rely on the warning from GetClassFactoryForTypeInternal.")]
+            static void ClassRegistrationScenarioForTypeLocal(ComActivationContext cxt, bool register) => ClassRegistrationScenarioForType(cxt, register);
         }
 
         /// <summary>
-        /// Internal entry point for unregistering a managed COM server API from native code
+        /// Unregisters a managed COM server in an isolated load context
         /// </summary>
         [RequiresUnreferencedCode("Built-in COM support is not trim compatible", Url = "https://aka.ms/dotnet-illink/com")]
         [CLSCompliant(false)]
@@ -313,10 +369,30 @@ $@"{nameof(RegisterClassForTypeInternal)} arguments:
         public static unsafe int UnregisterClassForTypeInternal(ComActivationContextInternal* pCxtInt)
         {
             if (!Marshal.IsBuiltInComSupported)
-            {
                 throw new NotSupportedException(SR.NotSupported_COM);
-            }
 
+            return UnregisterClassForTypeImpl(pCxtInt, isolatedContext: true);
+        }
+
+        /// <summary>
+        /// Unregisters a managed COM server in the specified load context
+        /// </summary>
+        /// <param name="pCxtInt">Pointer to a <see cref="ComActivationContextInternal"/> instance</param>
+        /// <param name="loadContext">Load context - currently must be IntPtr.Zero (default context) or -1 (isolated context)</param>
+        [UnmanagedCallersOnly]
+        private static unsafe int UnregisterClassForTypeInContext(ComActivationContextInternal* pCxtInt, IntPtr loadContext)
+        {
+            if (!Marshal.IsBuiltInComSupported)
+                throw new NotSupportedException(SR.NotSupported_COM);
+
+            if (loadContext != IntPtr.Zero && loadContext != (IntPtr)(-1))
+                throw new ArgumentOutOfRangeException(nameof(loadContext));
+
+            return UnregisterClassForTypeImpl(pCxtInt, isolatedContext: loadContext != IntPtr.Zero);
+        }
+
+        private static unsafe int UnregisterClassForTypeImpl(ComActivationContextInternal* pCxtInt, bool isolatedContext)
+        {
             ref ComActivationContextInternal cxtInt = ref *pCxtInt;
 
             if (IsLoggingEnabled())
@@ -339,8 +415,8 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
 
             try
             {
-                var cxt = ComActivationContext.Create(ref cxtInt);
-                ClassRegistrationScenarioForType(cxt, register: false);
+                var cxt = ComActivationContext.Create(ref cxtInt, isolatedContext);
+                ClassRegistrationScenarioForTypeLocal(cxt, register: false);
             }
             catch (Exception e)
             {
@@ -348,6 +424,11 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
             }
 
             return 0;
+
+            // Use a local function for a targeted suppression of the requires unreferenced code warning
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                Justification = "The same feature switch applies to GetClassFactoryForTypeInternal and this function. We rely on the warning from GetClassFactoryForTypeInternal.")]
+            static void ClassRegistrationScenarioForTypeLocal(ComActivationContext cxt, bool register) => ClassRegistrationScenarioForType(cxt, register);
         }
 
         private static bool IsLoggingEnabled()
@@ -366,14 +447,14 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
         }
 
         [RequiresUnreferencedCode("Built-in COM support is not trim compatible", Url = "https://aka.ms/dotnet-illink/com")]
-        private static Type FindClassType(Guid clsid, string assemblyPath, string assemblyName, string typeName)
+        private static Type FindClassType(ComActivationContext cxt)
         {
             try
             {
-                AssemblyLoadContext alc = GetALC(assemblyPath);
-                var assemblyNameLocal = new AssemblyName(assemblyName);
+                AssemblyLoadContext alc = GetALC(cxt.AssemblyPath, cxt.IsolatedContext);
+                var assemblyNameLocal = new AssemblyName(cxt.AssemblyName);
                 Assembly assem = alc.LoadFromAssemblyName(assemblyNameLocal);
-                Type? t = assem.GetType(typeName);
+                Type? t = assem.GetType(cxt.TypeName);
                 if (t != null)
                 {
                     return t;
@@ -383,7 +464,7 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
             {
                 if (IsLoggingEnabled())
                 {
-                    Log($"COM Activation of {clsid} failed. {e}");
+                    Log($"COM Activation of {cxt.ClassId} failed. {e}");
                 }
             }
 
@@ -392,16 +473,40 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
         }
 
         [RequiresUnreferencedCode("The trimmer might remove types which are needed by the assemblies loaded in this method.")]
-        private static AssemblyLoadContext GetALC(string assemblyPath)
+        private static AssemblyLoadContext GetALC(string assemblyPath, bool isolatedContext)
         {
             AssemblyLoadContext? alc;
-
-            lock (s_assemblyLoadContexts)
+            if (isolatedContext)
             {
-                if (!s_assemblyLoadContexts.TryGetValue(assemblyPath, out alc))
+                lock (s_assemblyLoadContexts)
                 {
-                    alc = new IsolatedComponentLoadContext(assemblyPath);
-                    s_assemblyLoadContexts.Add(assemblyPath, alc);
+                    if (!s_assemblyLoadContexts.TryGetValue(assemblyPath, out alc))
+                    {
+                        alc = new IsolatedComponentLoadContext(assemblyPath);
+                        s_assemblyLoadContexts.Add(assemblyPath, alc);
+                    }
+                }
+            }
+            else
+            {
+                alc = AssemblyLoadContext.Default;
+                lock (s_loadedInDefaultContext)
+                {
+                    if (!s_loadedInDefaultContext.Contains(assemblyPath))
+                    {
+                        var resolver = new AssemblyDependencyResolver(assemblyPath);
+                        AssemblyLoadContext.Default.Resolving +=
+                            [RequiresUnreferencedCode("Built-in COM support is not trim compatible", Url = "https://aka.ms/dotnet-illink/com")]
+                            (context, assemblyName) =>
+                            {
+                                string? assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
+                                return assemblyPath != null
+                                    ? context.LoadFromAssemblyPath(assemblyPath)
+                                    : null;
+                            };
+
+                        s_loadedInDefaultContext.Add(assemblyPath);
+                    }
                 }
             }
 

--- a/src/installer/tests/Assets/TestProjects/ComLibrary/ComLibrary.cs
+++ b/src/installer/tests/Assets/TestProjects/ComLibrary/ComLibrary.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Loader;
 
 namespace ComLibrary
 {
@@ -25,6 +27,8 @@ namespace ComLibrary
     {
         public Server()
         {
+            Assembly asm = Assembly.GetExecutingAssembly();
+            Console.WriteLine($"{asm.GetName().Name}: AssemblyLoadContext = {AssemblyLoadContext.GetLoadContext(asm)}");
             Console.WriteLine($"New instance of {nameof(Server)} created");
         }
     }

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Comhost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Comhost.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 {
+    [PlatformSpecific(TestPlatforms.Windows)] // COM activation is only supported on Windows
     public class Comhost : IClassFixture<Comhost.SharedTestState>
     {
         private readonly SharedTestState sharedState;
@@ -23,7 +24,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Theory]
-        [PlatformSpecific(TestPlatforms.Windows)] // COM activation is only supported on Windows
         [InlineData(1, true)]
         [InlineData(10, true)]
         [InlineData(10, false)]
@@ -90,7 +90,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // COM activation is only supported on Windows
         public void ActivateClass_IgnoreAppLocalHostFxr()
         {
             using (var fixture = sharedState.ComLibraryFixture.Copy())
@@ -118,7 +117,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // COM activation is only supported on Windows
         public void ActivateClass_ValidateIErrorInfoResult()
         {
             using (var fixture = sharedState.ComLibraryFixture.Copy())
@@ -148,7 +146,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // COM activation is only supported on Windows
         public void LoadTypeLibraries()
         {
             using (var fixture = sharedState.ComLibraryFixture.Copy())
@@ -238,7 +235,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             }
         }
     }
-    
+
     internal static class ComhostResultExtensions
     {
         public static FluentAssertions.AndConstraint<CommandResultAssertions> ExecuteInIsolatedContext(this CommandResultAssertions assertion, string assemblyName)

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Comhost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Comhost.cs
@@ -40,11 +40,52 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 .Execute();
 
             result.Should().Pass()
-                .And.HaveStdOutContaining("New instance of Server created");
+                .And.HaveStdOutContaining("New instance of Server created")
+                .And.ExecuteInIsolatedContext(sharedState.ComLibraryFixture.TestProject.AssemblyName);
 
             for (var i = 1; i <= count; ++i)
             {
                 result.Should().HaveStdOutContaining($"Activation of {sharedState.ClsidString} succeeded. {i} of {count}");
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ActivateClass_ContextConfig(bool inDefaultContext)
+        {
+            using (var fixture = sharedState.ComLibraryFixture.Copy())
+            {
+                var comHost = Path.Combine(
+                    fixture.TestProject.BuiltApp.Location,
+                    $"{fixture.TestProject.AssemblyName}.comhost.dll");
+
+                RuntimeConfig.FromFile(fixture.TestProject.RuntimeConfigJson)
+                    .WithProperty("System.Runtime.InteropServices.COM.LoadComponentInDefaultContext", inDefaultContext.ToString())
+                    .Save();
+
+                string[] args = {
+                    "comhost",
+                    "synchronous",
+                    "1",
+                    comHost,
+                    sharedState.ClsidString
+                    };
+                CommandResult result = sharedState.CreateNativeHostCommand(args, fixture.BuiltDotnet.BinPath)
+                    .Execute();
+
+                result.Should().Pass()
+                    .And.HaveStdOutContaining("New instance of Server created")
+                    .And.HaveStdOutContaining($"Activation of {sharedState.ClsidString} succeeded.");
+
+                if (inDefaultContext)
+                {
+                    result.Should().ExecuteInDefaultContext(sharedState.ComLibraryFixture.TestProject.AssemblyName);
+                }
+                else
+                {
+                    result.Should().ExecuteInIsolatedContext(sharedState.ComLibraryFixture.TestProject.AssemblyName);
+                }
             }
         }
 
@@ -195,6 +236,19 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
                 base.Dispose(disposing);
             }
+        }
+    }
+    
+    internal static class ComhostResultExtensions
+    {
+        public static FluentAssertions.AndConstraint<CommandResultAssertions> ExecuteInIsolatedContext(this CommandResultAssertions assertion, string assemblyName)
+        {
+            return assertion.HaveStdOutContaining($"{assemblyName}: AssemblyLoadContext = \"IsolatedComponentLoadContext(");
+        }
+
+        public static FluentAssertions.AndConstraint<CommandResultAssertions> ExecuteInDefaultContext(this CommandResultAssertions assertion, string assemblyName)
+        {
+            return assertion.HaveStdOutContaining($"{assemblyName}: AssemblyLoadContext = \"Default\" System.Runtime.Loader.DefaultAssemblyLoadContext");
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
@@ -8,5 +8,14 @@
       <!-- Used by VS4Mac via reflection to symbolize stack traces -->
       <method name="GetMethodFromNativeIP" />
     </type>
+    <type fullname="Internal.Runtime.InteropServices.ComActivator">
+      <!-- Used by hostpolicy.cpp -->
+      <method name="GetClassFactoryForTypeInContext" />
+      <method name="GetClassFactoryForTypeInternal" />
+      <method name="RegisterClassForTypeInContext" />
+      <method name="RegisterClassForTypeInternal" />
+      <method name="UnregisterClassForTypeInContext" />
+      <method name="UnregisterClassForTypeInternal" />
+    </type>
   </assembly>
 </linker>

--- a/src/native/corehost/comhost/comhost.cpp
+++ b/src/native/corehost/comhost/comhost.cpp
@@ -10,6 +10,7 @@
 #include "error_codes.h"
 #include "utils.h"
 #include <type_traits>
+#include <coreclr_delegates.h>
 
 using comhost::clsid_map_entry;
 using comhost::clsid_map;
@@ -41,14 +42,59 @@ struct com_activation_context
     void **class_factory_dest;
 };
 
-using com_delegate_fn = int(STDMETHODCALLTYPE*)(com_activation_context*);
+#define ISOLATED_CONTEXT (void*)-1
+using com_delegate_fn = int(STDMETHODCALLTYPE*)(com_activation_context*, void*);
+using com_delegate_no_load_context_fn = int(STDMETHODCALLTYPE*)(com_activation_context*);
 
 namespace
 {
-    int get_com_delegate(hostfxr_delegate_type del_type, pal::string_t *app_path, com_delegate_fn *delegate)
+    struct com_delegates
     {
-        return load_fxr_and_get_delegate(
-            del_type,
+        com_delegate_fn delegate;
+
+        // Delegate that does not take a load context. This version has existed since COM support was
+        // added in .NET Core 3.0. It is used as a fallback when loading in an isolated load context
+        // in versions of .NET without the functions that take a load context.
+        com_delegate_no_load_context_fn delegate_no_load_cxt;
+    };
+
+    // Fallback for loading a COM server in an isolated context in versions of .NET that don't have the
+    // functions that take a load context.
+    int get_com_delegate_no_load_context(hostfxr_delegate_type del_type, get_function_pointer_fn get_function_pointer, com_delegate_no_load_context_fn *delegate)
+    {
+        const pal::char_t* method_name;
+        switch (del_type)
+        {
+        case hostfxr_delegate_type::hdt_com_activation:
+            method_name = _X("GetClassFactoryForTypeInternal");
+            break;
+        case hostfxr_delegate_type::hdt_com_register:
+            method_name = _X("RegisterClassForTypeInternal");
+            break;
+        case hostfxr_delegate_type::hdt_com_unregister:
+            method_name = _X("UnregisterClassForTypeInternal");
+            break;
+        default:
+            return StatusCode::InvalidArgFailure;
+        }
+
+        return get_function_pointer(
+            _X("Internal.Runtime.InteropServices.ComActivator, System.Private.CoreLib"),
+            method_name,
+            UNMANAGEDCALLERSONLY_METHOD,
+            nullptr, // load context
+            nullptr, // reserved
+            reinterpret_cast<void**>(delegate));
+    }
+
+    int get_com_delegate(hostfxr_delegate_type del_type, pal::string_t *app_path, com_delegates &delegates, void **load_context)
+    {
+        delegates.delegate = nullptr;
+        delegates.delegate_no_load_cxt = nullptr;
+
+        get_function_pointer_fn get_function_pointer;
+        int status = load_fxr_and_get_delegate(
+            hostfxr_delegate_type::hdt_get_function_pointer,
             [app_path](const pal::string_t& host_path, pal::string_t* config_path_out)
             {
                 // Strip the comhost suffix to get the 'app' and config
@@ -65,8 +111,61 @@ namespace
 
                 return StatusCode::Success;
             },
-            delegate
+            [load_context](pal::dll_t fxr, hostfxr_handle context)
+            {
+                *load_context = ISOLATED_CONTEXT;
+                auto get_runtime_property_value = reinterpret_cast<hostfxr_get_runtime_property_value_fn>(pal::get_symbol(fxr, "hostfxr_get_runtime_property_value"));
+                const pal::char_t* value;
+                if (get_runtime_property_value(context, _X("System.Runtime.InteropServices.COM.LoadComponentInDefaultContext"), &value) == StatusCode::Success
+                    && pal::strcasecmp(value, _X("true")) == 0)
+                {
+                    *load_context = nullptr; // Default context
+                }
+            },
+            reinterpret_cast<void**>(&get_function_pointer)
         );
+        if (status != StatusCode::Success)
+            return status;
+
+        const pal::char_t* method_name;
+        switch (del_type)
+        {
+        case hostfxr_delegate_type::hdt_com_activation:
+            method_name = _X("GetClassFactoryForTypeInContext");
+            break;
+        case hostfxr_delegate_type::hdt_com_register:
+            method_name = _X("RegisterClassForTypeInContext");
+            break;
+        case hostfxr_delegate_type::hdt_com_unregister:
+            method_name = _X("UnregisterClassForTypeInContext");
+            break;
+        default:
+            return StatusCode::InvalidArgFailure;
+        }
+
+        status = get_function_pointer(
+            _X("Internal.Runtime.InteropServices.ComActivator, System.Private.CoreLib"),
+            method_name,
+            UNMANAGEDCALLERSONLY_METHOD,
+            nullptr, // load context
+            nullptr, // reserved
+            (void**)&delegates.delegate);
+
+        if (status == StatusCode::Success)
+            return status;
+
+        // Newer methods with context not found and using isolated context.
+        // Fall back to methods without context.
+        // The runtime will throw MissingMethodException, so we check for the corresponding COR_E_MISSINGMETHOD HRESULT.
+        // We also need to check for COR_E_MISSINGMEMBER due to a pre-7.0 bug where the HRESULT was not correctly set on
+        // MissingMethodException and it ended up with the HRESULT for MissingMemberException
+        if ((status == 0x80131513 /*COR_E_MISSINGMETHOD*/ || status == 0x80131512 /*COR_E_MISSINGMEMBER*/)
+            && *load_context == ISOLATED_CONTEXT)
+        {
+            status = get_com_delegate_no_load_context(del_type, get_function_pointer, &delegates.delegate_no_load_cxt);
+        }
+
+        return status;
     }
 
     void report_com_error_info(const GUID& guid, pal::string_t errs)
@@ -107,20 +206,23 @@ COM_API HRESULT STDMETHODCALLTYPE DllGetClassObject(
 
     HRESULT hr;
     pal::string_t app_path;
-    com_delegate_fn act;
+    com_delegates act;
+    void* load_context;
     {
         trace::setup();
         reset_redirected_error_writer();
 
         error_writer_scope_t writer_scope(redirected_error_writer);
 
-        int ec = get_com_delegate(hostfxr_delegate_type::hdt_com_activation, &app_path, &act);
+        int ec = get_com_delegate(hostfxr_delegate_type::hdt_com_activation, &app_path, act, &load_context);
         if (ec != StatusCode::Success)
         {
             report_com_error_info(rclsid, std::move(get_redirected_error_string()));
             return __HRESULT_FROM_WIN32(ec);
         }
     }
+
+    assert(act.delegate != nullptr || load_context == ISOLATED_CONTEXT);
 
     // Query the CLR for the type
 
@@ -134,7 +236,14 @@ COM_API HRESULT STDMETHODCALLTYPE DllGetClassObject(
         iter->second.type.c_str(),
         (void**)&classFactory
     };
-    RETURN_IF_FAILED(act(&cxt));
+    if (act.delegate != nullptr)
+    {
+        RETURN_IF_FAILED(act.delegate(&cxt, load_context));
+    }
+    else
+    {
+        RETURN_IF_FAILED(act.delegate_no_load_cxt(&cxt));
+    }
     assert(classFactory != nullptr);
 
     hr = classFactory->QueryInterface(riid, ppv);
@@ -463,8 +572,10 @@ COM_API HRESULT STDMETHODCALLTYPE DllRegisterServer(void)
 
     HRESULT hr;
     pal::string_t app_path;
-    com_delegate_fn reg;
-    RETURN_IF_FAILED(get_com_delegate(hostfxr_delegate_type::hdt_com_register, &app_path, &reg));
+    com_delegates reg;
+    void* load_context;
+    RETURN_IF_FAILED(get_com_delegate(hostfxr_delegate_type::hdt_com_register, &app_path, reg, &load_context));
+    assert(reg.delegate != nullptr || load_context == ISOLATED_CONTEXT);
 
     com_activation_context cxt
     {
@@ -486,7 +597,14 @@ COM_API HRESULT STDMETHODCALLTYPE DllRegisterServer(void)
         cxt.class_id = p.first;
         cxt.assembly_name = p.second.assembly.c_str();
         cxt.type_name = p.second.type.c_str();
-        RETURN_IF_FAILED(reg(&cxt));
+        if (reg.delegate != nullptr)
+        {
+            RETURN_IF_FAILED(reg.delegate(&cxt, load_context));
+        }
+        else
+        {
+            RETURN_IF_FAILED(reg.delegate_no_load_cxt(&cxt));
+        }
     }
 
     return S_OK;
@@ -507,8 +625,10 @@ COM_API HRESULT STDMETHODCALLTYPE DllUnregisterServer(void)
 
     HRESULT hr;
     pal::string_t app_path;
-    com_delegate_fn unreg;
-    RETURN_IF_FAILED(get_com_delegate(hostfxr_delegate_type::hdt_com_unregister, &app_path, &unreg));
+    com_delegates unreg;
+    void* load_context;
+    RETURN_IF_FAILED(get_com_delegate(hostfxr_delegate_type::hdt_com_unregister, &app_path, unreg, &load_context));
+    assert(unreg.delegate != nullptr || load_context == ISOLATED_CONTEXT);
 
     com_activation_context cxt
     {
@@ -527,7 +647,14 @@ COM_API HRESULT STDMETHODCALLTYPE DllUnregisterServer(void)
         cxt.class_id = p.first;
         cxt.assembly_name = p.second.assembly.c_str();
         cxt.type_name = p.second.type.c_str();
-        RETURN_IF_FAILED(unreg(&cxt));
+        if (unreg.delegate != nullptr)
+        {
+            RETURN_IF_FAILED(unreg.delegate(&cxt, load_context));
+        }
+        else
+        {
+            RETURN_IF_FAILED(unreg.delegate_no_load_cxt(&cxt));
+        }
 
         // Unregister the CLSID from registry
         RETURN_IF_FAILED(RemoveClsid(p.second));

--- a/src/native/corehost/ijwhost/ijwhost.cpp
+++ b/src/native/corehost/ijwhost/ijwhost.cpp
@@ -39,7 +39,8 @@ pal::hresult_t get_load_in_memory_assembly_delegate(pal::dll_t handle, load_in_m
 
             return StatusCode::Success;
         },
-        delegate
+        [](pal::dll_t fxr, hostfxr_handle context){ },
+        reinterpret_cast<void**>(delegate)
     );
 }
 


### PR DESCRIPTION
Allow COM components to opt-in to being loaded in the default ALC:

- `comhost` checks for the `System.Runtime.InteropServices.COM.LoadComponentInDefaultContext` property and uses new functions on `ComActivator`, loading into the default context if the property is set to true
- Default behaviour remains loading into an isolated context
- Fall back to using `ComActivator` functions that always load into an isolated context if new functions aren't found and loading in an isolated context

Port of https://github.com/dotnet/runtime/pull/79026

## Customer impact

Forcing COM servers into isolated contexts results in many issues for any servers trying to share types. This has been a particular source of pain for customers migrating from .NET Framework and we have had a number of customers / companies indicate this has been a blocker for their migration from .NET Framework to .NET 6.

See https://github.com/dotnet/runtime/issues/66013

## Testing

Manual testing using the COMServerDemo in our samples repo. Automated tests are added for both runtime and host.

## Risk

Low. This is targeted to COM activation. There is the possibility that a user will try to use the new setting and newer comhost to run on an older runtime that does not have these changes, in which case activation of their server will fail.