### PR TITLE
Disable default JSON reflection when PublishTrimmed == true

### DIFF
--- a/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -44,6 +44,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_EnableConsumingManagedCodeFromNativeHosting Condition="'$(EnableCppCLIHostActivation)' == 'true'">true</_EnableConsumingManagedCodeFromNativeHosting>
     <_EnableConsumingManagedCodeFromNativeHosting Condition="'$(_EnableConsumingManagedCodeFromNativeHosting)' == ''">false</_EnableConsumingManagedCodeFromNativeHosting>
     <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(VerifyDependencyInjectionOpenGenericServiceTrimmability)' == ''">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
+    <JsonSerializerIsReflectionEnabledByDefault Condition="'$(JsonSerializerIsReflectionEnabledByDefault)' == ''">false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
 


### PR DESCRIPTION
Following up on feedback from https://github.com/dotnet/sdk/pull/33757 this updates from Microsoft.NET.Sdk.targets in the sdk repo to Microsoft.NET.ILLink.targets.

I might need some guidance on the testing strategy here, my assumption is that we would need to test this from the sdk repo once the change has been merged.

Fix https://github.com/dotnet/runtime/issues/84378