### PR TITLE
Ignore suppressed diagnostics in code fix verifier

### DIFF
--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ILLink.Shared;
@@ -35,6 +37,15 @@ namespace ILLink.RoslynAnalyzer.Tests
 
 					return solution;
 				});
+			}
+
+			protected override ImmutableArray<(Project project, Diagnostic diagnostic)> SortDistinctDiagnostics (IEnumerable<(Project project, Diagnostic diagnostic)> diagnostics)
+			{
+				// Only include non-suppressed diagnostics in the result. Our tests suppress diagnostics
+				// with 'UnconditionalSuppressMessageAttribute', and expect them not to be reported.
+				return base.SortDistinctDiagnostics (diagnostics)
+					.Where (diagnostic => !diagnostic.diagnostic.IsSuppressed)
+					.ToImmutableArray ();
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/88278.

The failures started with https://github.com/dotnet/runtime/commit/299a8c9c178c38c6e7ca62b1bcce8f6e0d895ebe, which pulled in changes to the test SDK such that suppressed warnings are now included in the set of warnings checked by the code fix verifier.

The fix is based on similar changes in https://github.com/dotnet/roslyn-analyzers/pull/6711 which picks up the same version of the testing SDK.