### PR TITLE
[RISC-V, LOONGARCH64] Fix FuncEvalHijack stack allocation

### DIFF
--- a/src/coreclr/debug/ee/loongarch64/dbghelpers.S
+++ b/src/coreclr/debug/ee/loongarch64/dbghelpers.S
@@ -8,7 +8,7 @@
 // hijacking stub used to perform a func-eval, see Debugger::FuncEvalSetup() for use.
 //
 // on entry:
-//   x0  : pointer to DebuggerEval object
+//   a0  : pointer to DebuggerEval object
 //
 
 // @dbgtodo- once we port Funceval, use the ExceptionHijack stub instead of this func-eval stub.
@@ -17,9 +17,9 @@ NESTED_ENTRY FuncEvalHijack, _TEXT, UnhandledExceptionHandlerUnix
     //       you change the prolog you will also need to update the personality routine.
 
     // push arg to the stack so our personality routine can find it
-    // push lr to get good stacktrace in debugger
+    // push ra to get good stacktrace in debugger
     //                            $fp,$ra
-    PROLOG_SAVE_REG_PAIR_INDEXED  22, 1, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED  22, 1, 32
     st.d  $a0, $sp, 16
 
     // FuncEvalHijackWorker returns the address we should jump to.

--- a/src/coreclr/debug/ee/riscv64/dbghelpers.S
+++ b/src/coreclr/debug/ee/riscv64/dbghelpers.S
@@ -17,8 +17,8 @@ NESTED_ENTRY FuncEvalHijack, _TEXT, UnhandledExceptionHandlerUnix
     //       you change the prolog you will also need to update the personality routine.
 
     // push arg to the stack so our personality routine can find it
-    // push lr to get good stacktrace in debugger
-    PROLOG_SAVE_REG_PAIR_INDEXED  fp, ra, -32
+    // push ra to get good stacktrace in debugger
+    PROLOG_SAVE_REG_PAIR_INDEXED  fp, ra, 32
     sd  a0, 16(sp)
 
     // FuncEvalHijackWorker returns the address we should jump to.

--- a/src/coreclr/pal/src/arch/loongarch64/activationhandlerwrapper.S
+++ b/src/coreclr/pal/src/arch/loongarch64/activationhandlerwrapper.S
@@ -11,7 +11,7 @@ C_FUNC(ActivationHandlerReturnOffset):
 
 NESTED_ENTRY ActivationHandlerWrapper, _TEXT, NoHandler
     //                           $fp,$ra
-    PROLOG_SAVE_REG_PAIR_INDEXED 22, 1, -(16 + CONTEXT_Size)
+    PROLOG_SAVE_REG_PAIR_INDEXED 22, 1, (16 + CONTEXT_Size)
     // Should never actually run
     EMIT_BREAKPOINT
     bl      EXTERNAL_C_FUNC(ActivationHandler)

--- a/src/coreclr/pal/src/arch/loongarch64/dispatchexceptionwrapper.S
+++ b/src/coreclr/pal/src/arch/loongarch64/dispatchexceptionwrapper.S
@@ -34,7 +34,7 @@ C_FUNC(PAL_DispatchExceptionReturnOffset):
 
 NESTED_ENTRY PAL_DispatchExceptionWrapper, _TEXT, NoHandler
     //                           $fp,$ra
-    PROLOG_SAVE_REG_PAIR_INDEXED 22, 1, -16
+    PROLOG_SAVE_REG_PAIR_INDEXED 22, 1, 16
     // Should never actually run
     EMIT_BREAKPOINT
     bl      EXTERNAL_C_FUNC(PAL_DispatchException)


### PR DESCRIPTION
Part of #84834
cc @shushanhf @clamp03 @alpencolt @gbalykov

Seems negative stack offset was copy-pasted from arm64 arch despites of arm64 don't change offset sign inside of `PROLOG_SAVE_REG_PAIR_INDEXED`.

RISC-V Stack alloc w/o patch:
```S
(gdb) disassemble FuncEvalHijack
Dump of assembler code for function FuncEvalHijack:
   0x0000003ff763e454 <+0>:     addi    sp,sp,32
   0x0000003ff763e456 <+2>:     sd      s0,0(sp)
   0x0000003ff763e458 <+4>:     sd      ra,8(sp)
   0x0000003ff763e45a <+6>:     mv      s0,sp
   0x0000003ff763e45c <+8>:     sd      a0,16(sp)
   0x0000003ff763e45e <+10>:    jal     ra,0x3ff76290ce <FuncEvalHijackWorker(DebuggerEval*)>
   0x0000003ff763e462 <+14>:    addi    sp,sp,32
   0x0000003ff763e464 <+16>:    jr      a0
```