### PR TITLE
[wasm] Disable runtime test dependent on creating a process

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3502,6 +3502,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/simpleprovidervalidation/**">
             <Issue>System.Diagnostics.Process is not supported on wasm</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/simpleruntimeeventvalidation/**">
+            <Issue>System.Diagnostics.Process is not supported on wasm</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetOS)' == 'android'" >


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/88499

`tracing/eventpipe/simpleruntimeeventvalidation`:

```
          Generated app bundle at /root/helix/work/workitem/e/tracing/eventpipe/simpleruntimeeventvalidation/simpleruntimeeventvalidation/WasmApp/
        Incoming arguments: --run simpleruntimeeventvalidation.dll
        Application arguments: --run simpleruntimeeventvalidation.dll
        console.info: Initializing dotnet version 8.0.0-ci commit hash f47b553f129cfa7f006cb1a2f2088112c5ca0112
          0.0s: ==TEST STARTING==
          0.1s: System.PlatformNotSupportedException: System.Diagnostics.Process is not supported on this platform.
           at System.Diagnostics.Process.GetCurrentProcess()
           at Tracing.Tests.Common.IpcTraceTest.Validate(Boolean enableRundownProvider)
           at Tracing.Tests.Common.IpcTraceTest.RunAndValidateEventCounts(Dictionary`2 expectedEventCounts, Action eventGeneratingAction, List`1 providers, Int32 circularBufferMB, Func`2 optionalTraceValidator, Boolean enableRundownProvider)
          0.1s: ==TEST FINISHED: FAILED!==
        test-main.js exiting simpleruntimeeventvalidation.dll with result -1
        console.info: WASM EXIT -1
```

This was added in https://github.com/dotnet/runtime/pull/87785, but got merged on red.
