### PR TITLE
Disable failing `simpleruntimeeventvalidation` test on mono.

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2027,7 +2027,7 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/opt/OSR/pinnedlocal/**">
             <Issue>https://github.com/dotnet/runtime/issues/70820</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/simpleprovidervalidation/**">
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/simpleruntimeeventvalidation/**">
             <Issue>https://github.com/dotnet/runtime/issues/88499</Issue>
         </ExcludeList>
     </ItemGroup>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2027,6 +2027,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/opt/OSR/pinnedlocal/**">
             <Issue>https://github.com/dotnet/runtime/issues/70820</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/simpleprovidervalidation/**">
+            <Issue>https://github.com/dotnet/runtime/issues/88499</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Known failures for mono runtime on Windows -->


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/88499

Failing with:
```
      Expected: True
      Actual:   False
      Stack Trace:
           at tracing_eventpipe._simpleruntimeeventvalidation_simpleruntimeeventvalidation_simpleruntimeeventvalidation_._simpleruntimeeventvalidation_simpleruntimeeventvalidation_simpleruntimeeventvalidation_sh()
           at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
           at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
      Output:

        Return code:      1
        Raw output file:      /root/helix/work/workitem/uploads/Reports/tracing.eventpipe/simpleruntimeeventvalidation/simpleruntimeeventvalidation/simpleruntimeeventvalidation.output.txt
        Raw output:
        BEGIN EXECUTION
        /root/helix/work/correlation/corerun -p System.Reflection.Metadata.MetadataUpdater.IsSupported=false -p System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=true simpleruntimeeventvalidation.dll ''
          0.0s: ==TEST STARTING==
          0.2s: Connecting to EventPipe...
          0.2s: Started sending sentinel events...
          0.4s: Creating EventPipeEventSource...
          0.4s: EventPipeEventSource created
          0.4s: Dynamic.All callback registered
          0.4s: Running optional trace validator
          0.4s: Finished running optional trace validator
          0.4s: Starting stream processing...
          0.6s: Saw sentinel event
          0.6s: Stopped sending sentinel events
          0.6s: Starting event generating action...
          0.6s: Called GC.Collect() 0 times...
          0.7s: Called GC.Collect() 10 times...
          0.7s: Called GC.Collect() 20 times...
          0.7s: Called GC.Collect() 30 times...
          0.7s: Called GC.Collect() 40 times...
          0.7s: Stopping event generating action
          0.7s: Sending StopTracing command...
          0.7s: Saw new provider 'Microsoft-DotNETCore-EventPipe'
          0.7s: Stopping stream processing
          0.7s: Dropped 0 events
          0.7s: Finished StopTracing command
          0.7s: Reader task finished
          0.8s: Test FAILED!
          0.8s: No events for provider "Microsoft-Windows-DotNETRuntime"
          0.8s: Configuration:
          0.8s: {
          0.8s: providers: [
          0.8s: ]
          0.8s: }

          0.8s: Expected:
          0.8s: {
          0.8s: "Microsoft-Windows-DotNETRuntime" = -1 +- -0
          0.8s: }

          0.8s: Actual:
          0.8s: {
          0.8s: "Microsoft-DotNETCore-EventPipe" = 1
          0.8s: }
          0.8s: ==TEST FINISHED: FAILED!==
        Expected: 100
        Actual: 255
        END EXECUTION - FAILED
        Test failed. Trying to see if dump file was created in /home/helixbot/dotnetbuild/dumps since 7/6/2023 11:55:21 PM
        Test Harness Exitcode is : 1
        To run the test:
        > set CORE_ROOT=/root/helix/work/correlation
        > /root/helix/work/workitem/e/tracing/eventpipe/simpleruntimeeventvalidation/simpleruntimeeventvalidation/simpleruntimeeventvalidation.sh
```
