### PR TITLE
Combine writes in `WidenAsciiToUtf16`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.Helpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.Helpers.cs
@@ -104,8 +104,7 @@ namespace System.Text
                 num |= num << 8;
                 return num & 0x00FF00FF_00FF00FFuL;
 #else
-                return ReadUInt32WideningLower(ref Unsafe.As<uint, byte>(ref source))
-                    | ((ulong)ReadUInt32WideningUpper(ref Unsafe.As<uint, byte>(ref source)) << 32);
+                return ReadUInt32WideningLower(ref source) | ((ulong)ReadUInt32WideningUpper(ref source) << 32);
 #endif
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.Helpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.Helpers.cs
@@ -115,7 +115,7 @@ namespace System.Text
             uint num = Unsafe.ReadUnaligned<uint>(ref source);
             return ((byte)num | (num << 8)) & 0x00FF00FFu;
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static uint ReadUInt32WideningUpper(ref byte source)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.Helpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.Helpers.cs
@@ -103,7 +103,7 @@ namespace System.Text
                 return (temp | (temp << 8)) & 0x00FF00FF_00FF00FFuL;
 #else
                 return ReadUInt32WideningLower(ref Unsafe.As<uint, byte>(ref num))
-                    | (ulong)ReadUInt32WideningUpper(ref Unsafe.As<uint, byte>(ref num)) << 32;
+                    | ((ulong)ReadUInt32WideningUpper(ref Unsafe.As<uint, byte>(ref num)) << 32);
 #endif
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.Helpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.Helpers.cs
@@ -104,8 +104,8 @@ namespace System.Text
                 num |= num << 8;
                 return num & 0x00FF00FF_00FF00FFuL;
 #else
-                return ReadUInt32WideningLower(ref Unsafe.As<uint, byte>(ref num))
-                    | ((ulong)ReadUInt32WideningUpper(ref Unsafe.As<uint, byte>(ref num)) << 32);
+                return ReadUInt32WideningLower(ref Unsafe.As<uint, byte>(ref source))
+                    | ((ulong)ReadUInt32WideningUpper(ref Unsafe.As<uint, byte>(ref source)) << 32);
 #endif
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.Helpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.Helpers.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 
 namespace System.Text

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.Helpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.Helpers.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.Arm;
 
 namespace System.Text
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1745,7 +1745,7 @@ namespace System.Text
                         goto FoundNonAsciiData;
                     }
 
-                    WriteUnalignedWidening(ref Unsafe.As<char, byte>(ref pUtf16Buffer[currentOffset]), asciiData);
+                    WriteUnalignedWidening(ref Unsafe.As<char, ushort>(ref pUtf16Buffer[currentOffset]), asciiData);
                     currentOffset += 4;
                 } while (currentOffset <= finalOffsetWhereCanLoop);
             }
@@ -1822,7 +1822,7 @@ namespace System.Text
         internal static void WidenFourAsciiBytesToUtf16AndWriteToBuffer(ref char outputBuffer, uint value)
         {
             Debug.Assert(AllBytesInUInt32AreAscii(value));
-            
+
             WriteUnalignedWidening(ref Unsafe.As<char, ushort>(ref outputBuffer), value);
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1706,16 +1706,17 @@ namespace System.Text
                 // Only bother vectorizing if we have enough data to do so.
                 if (elementCount >= SizeOfVector)
                 {
-                    // Note use of SBYTE instead of BYTE below; we're using the two's-complement
-                    // representation of negative integers to act as a surrogate for "is ASCII?".
-
                     nuint finalOffsetWhereCanLoop = elementCount - SizeOfVector;
                     do
                     {
                         Vector<byte> asciiVector = Unsafe.ReadUnaligned<Vector<byte>>(pAsciiBuffer + currentOffset);
+
+                        // If the high bit of any byte is set, that byte is non-ASCII.
+                        // In two's-complement, the high bit represents the sign of binary number.
                         if (Vector.LessThanAny(Vector.AsVectorSByte(asciiVector), Vector<sbyte>.Zero))
                         {
-                            break; // found non-ASCII data
+                            // Found non-ASCII data.
+                            break;
                         }
 
                         Vector.Widen(asciiVector, out Vector<ushort> lower, out Vector<ushort> upper);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1719,7 +1719,7 @@ namespace System.Text
                         }
 
                         Vector.Widen(asciiVector, out Vector<ushort> lower, out Vector<ushort> upper);
-                        WritePairUnaligned(ref Unsafe.As<char, ushort>(ref pUtf16Buffer[currentOffset]), (lower, upper));
+                        WritePairUnaligned(ref Unsafe.As<char, byte>(ref pUtf16Buffer[currentOffset]), (lower, upper));
 
                         currentOffset += SizeOfVector;
                     } while (currentOffset <= finalOffsetWhereCanLoop);
@@ -1745,7 +1745,7 @@ namespace System.Text
                         goto FoundNonAsciiData;
                     }
 
-                    WriteUnalignedWidening(ref Unsafe.As<char, ushort>(ref outputBuffer), value);
+                    WriteUnalignedWidening(ref Unsafe.As<char, byte>(ref pUtf16Buffer[currentOffset]), asciiData);
                     currentOffset += 4;
                 } while (currentOffset <= finalOffsetWhereCanLoop);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1650,7 +1650,7 @@ namespace System.Text
             // Intrinsified in mono interpreter
             nuint currentOffset = 0;
 
-            if (BitConverter.IsLittleEndian && Vector128.IsHardwareAccelerated && elementCount >= (uint)Vector128<byte>.Count)
+            if (Vector128.IsHardwareAccelerated && elementCount >= (uint)Vector128<byte>.Count)
             {
                 ushort* pCurrentWriteAddress = (ushort*)pUtf16Buffer;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1771,16 +1771,8 @@ namespace System.Text
                     goto FoundNonAsciiData;
                 }
 
-                if (BitConverter.IsLittleEndian)
-                {
-                    pUtf16Buffer[currentOffset] = (char)(byte)asciiData;
-                    pUtf16Buffer[currentOffset + 1] = (char)(asciiData >> 8);
-                }
-                else
-                {
-                    pUtf16Buffer[currentOffset + 1] = (char)(byte)asciiData;
-                    pUtf16Buffer[currentOffset] = (char)(asciiData >> 8);
-                }
+                // Same logic works regardless of endianness.
+                *(uint*)(pUtf16Buffer + currentOffset) = (asciiData | (asciiData << 8)) & 0x00ff00ffu;
 
                 currentOffset += 2;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1771,8 +1771,15 @@ namespace System.Text
                     goto FoundNonAsciiData;
                 }
 
-                // Same logic works regardless of endianness.
-                *(uint*)(pUtf16Buffer + currentOffset) = (asciiData | (asciiData << 8)) & 0x00ff00ffu;
+                if (BitConverter.IsLittleEndian)
+                {
+                    *(uint*)(pUtf16Buffer + currentOffset) = (asciiData | (asciiData << 8)) & 0x00ff00ffu;
+                }
+                else
+                {
+                    // this should cause test failure
+                    throw new NotImplementedException();
+                }
 
                 currentOffset += 2;
             }


### PR DESCRIPTION
TODO: Check logic for big-endian.

Indicative codegen on `ARM64` when widening `ushort` to `uint`.

```asm
;bc76418
            orr     w0, w3, w3,  LSL #8
            and     w0, w0, #0xD1FFAB1E
            ubfiz   x2, x2, #1, #32
            str     w0, [x1, x2]
						;; size=16 bbWeight=1 PerfScore 3.50
```

```asm
;base
            lsl     x0, x2, #1
            uxtb    w2, w3
            strh    w2, [x1, x0]
            uxth    w2, w3
            asr     w2, w2, #8
            add     x0, x1, x0
            strh    w2, [x0, #0x02]
						;; size=28 bbWeight=1 PerfScore 5.50
```