### PR TITLE
[wasm] Use latest chrome for testing

### DIFF
--- a/eng/testing/ProvisioningVersions.props
+++ b/eng/testing/ProvisioningVersions.props
@@ -44,7 +44,7 @@
   <PropertyGroup>
     <!-- To use a specific version, set ChromeFindLatestAvailableVersion=false,
          and set the version, and revisions in the propertygroup below -->
-    <ChromeFindLatestAvailableVersion>false</ChromeFindLatestAvailableVersion>
+    <!--<ChromeFindLatestAvailableVersion>false</ChromeFindLatestAvailableVersion>-->
   </PropertyGroup>
 
   <PropertyGroup Label="Use specific version of chrome" Condition="'$(ChromeFindLatestAvailableVersion)' != 'true' and $([MSBuild]::IsOSPlatform('linux'))">


### PR DESCRIPTION
This was fixed to a specific version (`113.0.5672.63`) because of https://github.com/dotnet/runtime/issues/86919 . But trying to use latest again now.