### PR TITLE
[RISC-V][JIT] Fix NaN canonicalization issue

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1200,17 +1200,8 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                     }
                     else
                     {
-                        /* If we have an NaN value then don't record it */
                         noway_assert(op2->gtOper == GT_CNS_DBL);
-#ifdef TARGET_RISCV64
-                        if (op2->TypeGet() == TYP_FLOAT)
-                        {
-                            if (_isnan(FloatingPointUtils::convertDoubleToFloat(op2->AsDblCon()->DconValue())))
-                            {
-                                goto DONE_ASSERTION;
-                            }
-                        }
-#endif // TARGET_RISCV64
+                        /* If we have an NaN value then don't record it */
                         if (_isnan(op2->AsDblCon()->DconValue()))
                         {
                             goto DONE_ASSERTION; // Don't make an assertion
@@ -2596,17 +2587,7 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
             {
                 // Implicit conversion to float or double
                 assert(varTypeIsFloating(tree->TypeGet()));
-
-#ifdef TARGET_RISCV64
-                if (tree->TypeGet() == TYP_FLOAT)
-                {
-                    conValTree = gtNewDconNode(FloatingPointUtils::convertFloatToDouble(value), tree->TypeGet());
-                }
-                else
-#endif // TARGET_RISCV64
-                {
-                    conValTree = gtNewDconNode(value, tree->TypeGet());
-                }
+                conValTree = gtNewDconNode(FloatingPointUtils::convertToDouble(value), tree->TypeGet());
             }
             break;
         }
@@ -2717,7 +2698,7 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
                     case TYP_FLOAT:
                         // Same sized reinterpretation of bits to float
                         conValTree =
-                            gtNewDconNode(FloatingPointUtils::convertFloatToDouble(*reinterpret_cast<float*>(&value)),
+                            gtNewDconNode(FloatingPointUtils::convertToDouble(*reinterpret_cast<float*>(&value)),
                                           TYP_FLOAT);
                         break;
 

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2697,9 +2697,9 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
 
                     case TYP_FLOAT:
                         // Same sized reinterpretation of bits to float
-                        conValTree =
-                            gtNewDconNode(FloatingPointUtils::convertToDouble(*reinterpret_cast<float*>(&value)),
-                                          TYP_FLOAT);
+                        conValTree = gtNewDconNode(FloatingPointUtils::convertToDouble(
+                                                       BitOperations::UInt32BitsToSingle((uint32_t)value)),
+                                                   TYP_FLOAT);
                         break;
 
                     case TYP_DOUBLE:

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -8050,7 +8050,7 @@ CORINFO_FIELD_HANDLE emitter::emitFltOrDblConst(double constValue, emitAttr attr
 
     if (attr == EA_4BYTE)
     {
-        f        = FloatingPointUtils::convertDoubleToFloat(constValue);
+        f        = FloatingPointUtils::convertToSingle(constValue);
         cnsAddr  = &f;
         dataType = TYP_FLOAT;
     }

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -8050,7 +8050,15 @@ CORINFO_FIELD_HANDLE emitter::emitFltOrDblConst(double constValue, emitAttr attr
 
     if (attr == EA_4BYTE)
     {
-        f        = forceCastToFloat(constValue);
+#ifdef TARGET_RISCV64
+        f = *reinterpret_cast<float*>(&constValue);
+        if (!FloatingPointUtils::isNaN(f))
+        {
+            f = forceCastToFloat(constValue);
+        }
+#else
+        f = forceCastToFloat(constValue);
+#endif // TARGET_RISCV64
         cnsAddr  = &f;
         dataType = TYP_FLOAT;
     }

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -8050,15 +8050,7 @@ CORINFO_FIELD_HANDLE emitter::emitFltOrDblConst(double constValue, emitAttr attr
 
     if (attr == EA_4BYTE)
     {
-#ifdef TARGET_RISCV64
-        f = *reinterpret_cast<float*>(&constValue);
-        if (!FloatingPointUtils::isNaN(f))
-        {
-            f = forceCastToFloat(constValue);
-        }
-#else
-        f = forceCastToFloat(constValue);
-#endif // TARGET_RISCV64
+        f        = FloatingPointUtils::convertDoubleToFloat(constValue);
         cnsAddr  = &f;
         dataType = TYP_FLOAT;
     }

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3793,9 +3793,8 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 
                 if (op1->IsIntegralConst())
                 {
-                    int32_t i32Cns = (int32_t)op1->AsIntConCommon()->IconValue();
-                    float   f32Cns = *reinterpret_cast<float*>(&i32Cns);
-                    retNode        = gtNewDconNode(FloatingPointUtils::convertToDouble(f32Cns), TYP_FLOAT);
+                    float f32Cns = BitOperations::UInt32BitsToSingle((uint32_t)op1->AsIntConCommon()->IconValue());
+                    retNode      = gtNewDconNode(FloatingPointUtils::convertToDouble(f32Cns), TYP_FLOAT);
                 }
                 else
                 {
@@ -3836,7 +3835,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 if (op1->IsCnsFltOrDbl())
                 {
                     float f32Cns = FloatingPointUtils::convertToSingle(op1->AsDblCon()->DconValue());
-                    retNode      = gtNewIconNode(*reinterpret_cast<int32_t*>(&f32Cns));
+                    retNode      = gtNewIconNode((int32_t)BitOperations::SingleToUInt32Bits(f32Cns));
                 }
                 else
                 {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3795,7 +3795,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 {
                     int32_t i32Cns = (int32_t)op1->AsIntConCommon()->IconValue();
                     float   f32Cns = *reinterpret_cast<float*>(&i32Cns);
-                    retNode        = gtNewDconNode(FloatingPointUtils::convertFloatToDouble(f32Cns), TYP_FLOAT);
+                    retNode        = gtNewDconNode(FloatingPointUtils::convertToDouble(f32Cns), TYP_FLOAT);
                 }
                 else
                 {
@@ -3835,7 +3835,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 
                 if (op1->IsCnsFltOrDbl())
                 {
-                    float f32Cns = FloatingPointUtils::convertDoubleToFloat(op1->AsDblCon()->DconValue());
+                    float f32Cns = FloatingPointUtils::convertToSingle(op1->AsDblCon()->DconValue());
                     retNode      = gtNewIconNode(*reinterpret_cast<int32_t*>(&f32Cns));
                 }
                 else
@@ -4142,7 +4142,7 @@ GenTree* Compiler::impSRCSUnsafeIntrinsic(NamedIntrinsic          intrinsic,
                     else
                     {
                         assert(fromType == TYP_FLOAT);
-                        float f32Cns = FloatingPointUtils::convertDoubleToFloat(op1->AsDblCon()->DconValue());
+                        float f32Cns = FloatingPointUtils::convertToSingle(op1->AsDblCon()->DconValue());
                         return gtNewIconNode(static_cast<int32_t>(BitOperations::SingleToUInt32Bits(f32Cns)));
                     }
                 }
@@ -4183,7 +4183,7 @@ GenTree* Compiler::impSRCSUnsafeIntrinsic(NamedIntrinsic          intrinsic,
 
                         uint32_t u32Cns = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
                         float    f32Cns = BitOperations::UInt32BitsToSingle(u32Cns);
-                        return gtNewDconNode(FloatingPointUtils::convertFloatToDouble(f32Cns), TYP_FLOAT);
+                        return gtNewDconNode(FloatingPointUtils::convertToDouble(f32Cns), TYP_FLOAT);
                     }
                 }
                 else

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1556,7 +1556,7 @@ GenTree* Compiler::impFixupCallStructReturn(GenTreeCall* call, CORINFO_CLASS_HAN
     const ReturnTypeDesc* retTypeDesc = call->GetReturnTypeDesc();
     const unsigned        retRegCount = retTypeDesc->GetReturnRegCount();
 #else  // !FEATURE_MULTIREG_RET
-    const unsigned            retRegCount = 1;
+    const unsigned retRegCount = 1;
 #endif // !FEATURE_MULTIREG_RET
 
     structPassingKind howToReturnStruct;
@@ -3794,17 +3794,8 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 if (op1->IsIntegralConst())
                 {
                     int32_t i32Cns = (int32_t)op1->AsIntConCommon()->IconValue();
-#ifdef TARGET_RISCV64
-                    float f32Cns = *reinterpret_cast<float*>(&i32Cns);
-                    if (FloatingPointUtils::isNaN(f32Cns))
-                    {
-                        retNode = gtNewDconNode(*reinterpret_cast<double*>(&i32Cns), TYP_FLOAT);
-                    }
-                    else
-#endif // TARGET_RISCV64
-                    {
-                        retNode = gtNewDconNode(*reinterpret_cast<float*>(&i32Cns), TYP_FLOAT);
-                    }
+                    float   f32Cns = *reinterpret_cast<float*>(&i32Cns);
+                    retNode        = gtNewDconNode(FloatingPointUtils::convertFloatToDouble(f32Cns), TYP_FLOAT);
                 }
                 else
                 {
@@ -3844,17 +3835,8 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 
                 if (op1->IsCnsFltOrDbl())
                 {
-#ifdef TARGET_RISCV64
-                    double f64Cns = op1->AsDblCon()->DconValue();
-                    float  f32Cns = *reinterpret_cast<float*>(&f64Cns);
-                    if (!FloatingPointUtils::isNaN(f32Cns))
-                    {
-                        f32Cns = (float)op1->AsDblCon()->DconValue();
-                    }
-#else
-                    float     f32Cns      = (float)op1->AsDblCon()->DconValue();
-#endif // TARGET_RISCV64
-                    retNode = gtNewIconNode(*reinterpret_cast<int32_t*>(&f32Cns));
+                    float f32Cns = FloatingPointUtils::convertDoubleToFloat(op1->AsDblCon()->DconValue());
+                    retNode      = gtNewIconNode(*reinterpret_cast<int32_t*>(&f32Cns));
                 }
                 else
                 {
@@ -4160,16 +4142,7 @@ GenTree* Compiler::impSRCSUnsafeIntrinsic(NamedIntrinsic          intrinsic,
                     else
                     {
                         assert(fromType == TYP_FLOAT);
-#ifdef TARGET_RISCV64
-                        double f64Cns = op1->AsDblCon()->DconValue();
-                        float  f32Cns = *reinterpret_cast<float*>(&f64Cns);
-                        if (!FloatingPointUtils::isNaN(f32Cns))
-                        {
-                            f32Cns = static_cast<float>(op1->AsDblCon()->DconValue());
-                        }
-#else
-                        float f32Cns      = static_cast<float>(op1->AsDblCon()->DconValue());
-#endif // TARGET_RISCV64
+                        float f32Cns = FloatingPointUtils::convertDoubleToFloat(op1->AsDblCon()->DconValue());
                         return gtNewIconNode(static_cast<int32_t>(BitOperations::SingleToUInt32Bits(f32Cns)));
                     }
                 }
@@ -4209,17 +4182,8 @@ GenTree* Compiler::impSRCSUnsafeIntrinsic(NamedIntrinsic          intrinsic,
                         assert(toType == TYP_FLOAT);
 
                         uint32_t u32Cns = static_cast<uint32_t>(op1->AsIntConCommon()->IconValue());
-#ifdef TARGET_RISCV64
-                        float f32Cns = BitOperations::UInt32BitsToSingle(u32Cns);
-                        if (FloatingPointUtils::isNaN(f32Cns))
-                        {
-                            return gtNewDconNode(*reinterpret_cast<double*>(&f32Cns), TYP_FLOAT);
-                        }
-                        else
-#endif // TARGET_RISCV64
-                        {
-                            return gtNewDconNode(BitOperations::UInt32BitsToSingle(u32Cns), TYP_FLOAT);
-                        }
+                        float    f32Cns = BitOperations::UInt32BitsToSingle(u32Cns);
+                        return gtNewDconNode(FloatingPointUtils::convertFloatToDouble(f32Cns), TYP_FLOAT);
                     }
                 }
                 else

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2051,27 +2051,68 @@ unsigned __int64 FloatingPointUtils::convertDoubleToUInt64(double d)
     return u64;
 }
 
-double FloatingPointUtils::convertFloatToDouble(float f32)
+//------------------------------------------------------------------------
+// convertToDouble: Convert a single to a double with platform independent
+// preservation of payload bits.
+//
+// Arguments:
+//   f - the single
+//
+// Return Value:
+//   A double.
+//
+// Remarks:
+//   All our host platforms except for RISCV-64 will preserve payload bits of
+//   NaNs. This function implements the conversion in software for RISCV-64 to
+//   mimic other platforms.
+//
+double FloatingPointUtils::convertToDouble(float f)
 {
-#ifdef TARGET_RISCV64
-    if (FloatingPointUtils::isNaN(f32))
+#ifdef HOST_RISCV64
+    if (f == f)
     {
-        return *reinterpret_cast<double*>(&f32);
+        return f;
     }
-#endif // TARGET_RISCV64
-    return (double)f32;
+
+    uint32_t bits    = BitOperations::SingleToUInt32Bits(f);
+    uint32_t payload = bits & ((1u << 23) - 1);
+    uint64_t newBits = ((uint64_t)(bits >> 31) << 63) | 0x7FF8000000000000ul | ((uint64_t)payload << 29);
+    return BitOperations::UInt64BitsToDouble(newBits);
+#else
+    return f;
+#endif
 }
 
-float FloatingPointUtils::convertDoubleToFloat(double f64)
+//------------------------------------------------------------------------
+// convertToSingle: Convert a double to a single with platform independent
+// preservation of payload bits.
+//
+// Arguments:
+//   d - the double
+//
+// Return Value:
+//   A float.
+//
+// Remarks:
+//   All our host platforms except for RISCV-64 will preserve payload bits of
+//   NaNs. This function implements the conversion in software for RISCV-64 to
+//   mimic other platforms.
+//
+float FloatingPointUtils::convertToSingle(double d)
 {
-#ifdef TARGET_RISCV64
-    float f32 = *reinterpret_cast<float*>(&f64);
-    if (FloatingPointUtils::isNaN(f32))
+#ifdef HOST_RISCV64
+    if (d == d)
     {
-        return f32;
+        return (float)d;
     }
-#endif // TARGET_RISCV64
-    return forceCastToFloat(f64);
+
+    uint64_t bits       = BitOperations::DoubleToUInt64Bits(d);
+    uint32_t newPayload = (uint32_t)((bits >> 29) & ((1u << 23) - 1));
+    uint32_t newBits    = ((uint32_t)(bits >> 63) << 31) | 0x7F800000u | newPayload;
+    return BitOperations::UInt32BitsToSingle(newBits);
+#else
+    return (float)d;
+#endif
 }
 
 // Rounds a double-precision floating-point value to the nearest integer,

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2051,6 +2051,29 @@ unsigned __int64 FloatingPointUtils::convertDoubleToUInt64(double d)
     return u64;
 }
 
+double FloatingPointUtils::convertFloatToDouble(float f32)
+{
+#ifdef TARGET_RISCV64
+    if (FloatingPointUtils::isNaN(f32))
+    {
+        return *reinterpret_cast<double*>(&f32);
+    }
+#endif // TARGET_RISCV64
+    return (double)f32;
+}
+
+float FloatingPointUtils::convertDoubleToFloat(double f64)
+{
+#ifdef TARGET_RISCV64
+    float f32 = *reinterpret_cast<float*>(&f64);
+    if (FloatingPointUtils::isNaN(f32))
+    {
+        return f32;
+    }
+#endif // TARGET_RISCV64
+    return forceCastToFloat(f64);
+}
+
 // Rounds a double-precision floating-point value to the nearest integer,
 // and rounds midpoint values to the nearest even number.
 double FloatingPointUtils::round(double x)

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -729,9 +729,9 @@ public:
 
     static unsigned __int64 convertDoubleToUInt64(double d);
 
-    static double convertFloatToDouble(float f32);
+    static double convertToDouble(float f);
 
-    static float convertDoubleToFloat(double f64);
+    static float convertToSingle(double d);
 
     static double round(double x);
 

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -729,6 +729,10 @@ public:
 
     static unsigned __int64 convertDoubleToUInt64(double d);
 
+    static double convertFloatToDouble(float f32);
+
+    static float convertDoubleToFloat(double f64);
+
     static double round(double x);
 
     static float round(float x);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10345,7 +10345,7 @@ void Compiler::fgValueNumberTreeConst(GenTree* tree)
 
         case TYP_FLOAT:
         {
-            float f32Cns = FloatingPointUtils::convertDoubleToFloat(tree->AsDblCon()->DconValue());
+            float f32Cns = FloatingPointUtils::convertToSingle(tree->AsDblCon()->DconValue());
             tree->gtVNPair.SetBoth(vnStore->VNForFloatCon(f32Cns));
             break;
         }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10345,7 +10345,17 @@ void Compiler::fgValueNumberTreeConst(GenTree* tree)
 
         case TYP_FLOAT:
         {
-            tree->gtVNPair.SetBoth(vnStore->VNForFloatCon((float)tree->AsDblCon()->DconValue()));
+#ifdef TARGET_RISCV64
+            double f64Cns = tree->AsDblCon()->DconValue();
+            float  f32Cns = *reinterpret_cast<float*>(&f64Cns);
+            if (!_isnan(f32Cns))
+            {
+                f32Cns = (float)f64Cns;
+            }
+#else
+            float f32Cns = (float)tree->AsDblCon()->DconValue();
+#endif // TARGET_RISCV64
+            tree->gtVNPair.SetBoth(vnStore->VNForFloatCon(f32Cns));
             break;
         }
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10345,16 +10345,7 @@ void Compiler::fgValueNumberTreeConst(GenTree* tree)
 
         case TYP_FLOAT:
         {
-#ifdef TARGET_RISCV64
-            double f64Cns = tree->AsDblCon()->DconValue();
-            float  f32Cns = *reinterpret_cast<float*>(&f64Cns);
-            if (!_isnan(f32Cns))
-            {
-                f32Cns = (float)f64Cns;
-            }
-#else
-            float f32Cns = (float)tree->AsDblCon()->DconValue();
-#endif // TARGET_RISCV64
+            float f32Cns = FloatingPointUtils::convertDoubleToFloat(tree->AsDblCon()->DconValue());
             tree->gtVNPair.SetBoth(vnStore->VNForFloatCon(f32Cns));
             break;
         }


### PR DESCRIPTION
Based on the comments in https://github.com/dotnet/runtime/pull/88311#issuecomment-1617594875 and https://github.com/dotnet/runtime/pull/88311#issuecomment-1618963621, update codes to pass below tests.
```
./JIT/HardwareIntrinsics/General/Vector128/Vector128_r/Vector128_r.sh
./JIT/HardwareIntrinsics/General/Vector256/Vector256_r/Vector256_r.sh
./JIT/HardwareIntrinsics/General/Vector512/Vector512_r/Vector512_r.sh
./JIT/HardwareIntrinsics/General/Vector256/Vector256_ro/Vector256_ro.sh
./JIT/HardwareIntrinsics/General/Vector128/Vector128_ro/Vector128_ro.sh
./JIT/HardwareIntrinsics/General/Vector512/Vector512_ro/Vector512_ro.sh
./JIT/HardwareIntrinsics/General/Vector64/Vector64_r/Vector64_r.sh
./JIT/HardwareIntrinsics/General/Vector64/Vector64_ro/Vector64_ro.sh
```

I fixed all codes what I found. Minimum changes to pass the tests are those in `emit.cpp`, `valuenum.cpp` and `NI_System_BitConverter_Int32BitsToSingle` and `NI_System_BitConverter_SingleToInt32Bits` in `importercalls.cpp`.

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov