### PR TITLE
fix processing of TLS renegotiation

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
@@ -865,17 +865,16 @@ namespace System.Net.Security
                                 throw new IOException(SR.net_ssl_io_renego);
                             }
                             await ReplyOnReAuthenticationAsync<TIOAdapter>(extraBuffer, cancellationToken).ConfigureAwait(false);
-                            // Loop on read.
-                            continue;
                         }
-
-                        if (status.ErrorCode == SecurityStatusPalErrorCode.ContextExpired)
+                        else if (status.ErrorCode == SecurityStatusPalErrorCode.ContextExpired)
                         {
                             _receivedEOF = true;
                             break;
                         }
-
-                        throw new IOException(SR.net_io_decrypt, SslStreamPal.GetException(status));
+                        else
+                        {
+                            throw new IOException(SR.net_io_decrypt, SslStreamPal.GetException(status));
+                        }
                     }
 
                     if (_buffer.DecryptedLength > 0)


### PR DESCRIPTION
fixes #88495

in the scenario described in  #88495 SslStream receives two TLS frame - encrypted data and frame that triggers renegotiation. (most likely to get updated encryption keys) The problem is that we have decrypted data written to user's buffer but after the renegotiation is finished we loop back to read loop - waiting for another TLS frame that may not come. That makes the Read call stuck depending if peer sends more data or not. 

The fix is to simply fall-through and hot regular processing that would either loop back if `processedLength` is zero, we can process more data _if_ available or we would return data already decrypted. 

There is no new test, the code I have to demonstrate this runs for several hour  before triggering this. 
