### PR TITLE
Proposal: combine returning week and year in one

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/ISOWeek.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/ISOWeek.cs
@@ -34,9 +34,7 @@ namespace System.Globalization
             return week;
         }
 
-        public static int GetYear(DateTime date) => GetWeekAndYear(date).Year;
-
-        public static (int Week, int Year) GetWeekAndYear(DateTime date)
+        public static int GetYear(DateTime date)
         {
             int week = GetWeekNumber(date);
 
@@ -44,18 +42,21 @@ namespace System.Globalization
             {
                 // If the week number obtained equals 0, it means that the
                 // given date belongs to the preceding (week-based) year.
-                return (week, date.Year - 1);
+                return date.Year - 1;
             }
 
             if (week > GetWeeksInYear(date.Year))
             {
                 // If a week number of 53 is obtained, one must check that
                 // the date is not actually in week 1 of the following year.
-                return (week, date.Year + 1);
+                return date.Year + 1;
             }
 
-            return (week, date.Year);
+            return date.Year;
         }
+
+        public static (int Week, int Year) GetWeekAndYear(DateTime date)
+            => (GetWeekOfYear(date), GetYear(date));
 
         // The year parameter represents an ISO week-numbering year (also called ISO year informally).
         // Each week's year is the Gregorian year in which the Thursday falls.

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/ISOWeek.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/ISOWeek.cs
@@ -34,7 +34,9 @@ namespace System.Globalization
             return week;
         }
 
-        public static int GetYear(DateTime date)
+        public static int GetYear(DateTime date) => GetWeekAndYear(date).Year;
+
+        public static (int Week, int Year) GetWeekAndYear(DateTime date)
         {
             int week = GetWeekNumber(date);
 
@@ -52,7 +54,7 @@ namespace System.Globalization
                 return date.Year + 1;
             }
 
-            return date.Year;
+            return (week, date.Year);
         }
 
         // The year parameter represents an ISO week-numbering year (also called ISO year informally).

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/ISOWeek.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/ISOWeek.cs
@@ -44,14 +44,14 @@ namespace System.Globalization
             {
                 // If the week number obtained equals 0, it means that the
                 // given date belongs to the preceding (week-based) year.
-                return date.Year - 1;
+                return (week, date.Year - 1);
             }
 
             if (week > GetWeeksInYear(date.Year))
             {
                 // If a week number of 53 is obtained, one must check that
                 // the date is not actually in week 1 of the following year.
-                return date.Year + 1;
+                return (week, date.Year + 1);
             }
 
             return (week, date.Year);


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/29060 Proposal: Combine ISOWeek.GetWeekOfYear and GetYear methods

https://github.com/dotnet/runtime/issues/29060#issuecomment-486333875

"if it is really necessary we can expose extra APIs return a Tuple of the week and the year"