### PR TITLE
Move the IsLeft/IsRight decision out of the loop and use computed substring set

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
@@ -203,7 +203,7 @@ namespace System.Collections.Frozen
 #endif
         }
 
-        private static bool HasSufficientUniquenessFactor(HashSet<string> set, IEnumerable<string> uniqueStrings, int acceptableNonUniqueCount)
+        private static bool HasSufficientUniquenessFactor(HashSet<string> set, string[] uniqueStrings, int acceptableNonUniqueCount)
         {
             set.Clear();
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
@@ -109,7 +109,7 @@ namespace System.Collections.Frozen
                 foreach (string s in uniqueStrings)
                 {
                     // Get the span for the substring.
-                    ReadOnlySpan<char> substring = s.AsSpan();
+                    ReadOnlySpan<char> substring = count == 0 ? s.AsSpan() : Slicer(s, index, count);
 
                     // If the substring isn't ASCII, bail out to return the results.
                     if (!IsAllAscii(substring))

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
@@ -27,7 +27,7 @@ namespace System.Collections.Frozen
         /// operations, then we can select an ASCII-specific case-insensitive comparer which yields faster overall performance.
         /// </remarks>
         public static AnalysisResults Analyze(
-            string[] uniqueStrings, bool ignoreCase, int minLength, int maxLength)
+            ReadOnlySpan<string> uniqueStrings, bool ignoreCase, int minLength, int maxLength)
         {
             Debug.Assert(uniqueStrings.Length > 0);
 
@@ -62,7 +62,7 @@ namespace System.Collections.Frozen
 
                         if (HasSufficientUniquenessFactor(set, uniqueStrings, acceptableNonUniqueCount))
                         {
-                            return CreateAnalysisResults(set, ignoreCase, minLength, maxLength, index, count);
+                            return CreateAnalysisResults(uniqueStrings, ignoreCase, minLength, maxLength, index, count);
                         }
                     }
 
@@ -82,7 +82,7 @@ namespace System.Collections.Frozen
                         {
                             if (HasSufficientUniquenessFactor(set, uniqueStrings, acceptableNonUniqueCount))
                             {
-                                return CreateAnalysisResults(set, ignoreCase, minLength, maxLength, comparer.Index, count);
+                                return CreateAnalysisResults(uniqueStrings, ignoreCase, minLength, maxLength, comparer.Index, count);
                             }
                         }
                     }
@@ -94,7 +94,7 @@ namespace System.Collections.Frozen
         }
 
         private static AnalysisResults CreateAnalysisResults(
-            IEnumerable<string> uniqueStrings, bool ignoreCase, int minLength, int maxLength, int index, int count)
+            ReadOnlySpan<string> uniqueStrings, bool ignoreCase, int minLength, int maxLength, int index, int count)
         {
             // Start off by assuming all strings are ASCII
             bool allAsciiIfIgnoreCase = true;
@@ -203,13 +203,13 @@ namespace System.Collections.Frozen
 #endif
         }
 
-        private static bool HasSufficientUniquenessFactor(HashSet<string> set, string[] uniqueStrings, int acceptableNonUniqueCount)
+        private static bool HasSufficientUniquenessFactor(HashSet<string> set, ReadOnlySpan<string> uniqueStrings, int acceptableNonUniqueCount)
         {
             set.Clear();
 
             foreach (string s in uniqueStrings)
             {
-                if (!set.Add(s) && --acceptableNonUniqueCount < 0)
+                if (!set.Add(s) && acceptableNonUniqueCount-- <= 0)
                 {
                     return false;
                 }


### PR DESCRIPTION
While reviewing https://github.com/dotnet/runtime/pull/87510, I noticed the inline code in the comparers seems like since it's in the hot-loop path, might be faster to move the `IsLeft` conditionalized code out of the loop by adding a `static Slicer` to the comparator. The `Slicer` is the same logic as was originally in the bodies of the `Equals` and `GetHashCode` methods, and also matches the `delegate`s that were being passed to the internal `CreateAnalysisResults` method.

The slicing is really only changed once per Count, so move the `IsLeft`-dependent logic into aggressively inlined `Slicer` extension method because that makes things a bit faster and slightly reduces allocations.

~Builds on https://github.com/dotnet/runtime/pull/88709/ as that's a trivially true change.~ Has been merged now.

The summary of changes:
* Eliminate the the inner `TryUseSubstring` because we can just early return the calculated results as we build them
* Hoist the calculation of `acceptableNonUniqueCount` out to the top level since it never changes (which means we pass that into the `HasSufficientUniquenessFactor` method for it to "use up" internally (passed by value, so unchanged at call-site)
* Eliminated the `delegate ReadOnlySpan<char> GetSpan` and use, which helps reduce dynamic dispatch overhead in the `CreateAnalysisResults` method
* Eliminated the `IsLeft` field of the `SubstringComparer` since we can tell by the Index being negative that we're doing right-justified slicing (and documented that on the class)
* Changed the logic managing the `Index` and `Count` on the comparer for right-justified substrings.
* Added `[MethodImpl(MethodImplOptions.AggressiveInlining)]` to the `Equals` and `GetHashCode` overrides.