### PR TITLE
[wasm] Fix WasmBase.IsSupported in AOT

### DIFF
--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -5336,6 +5336,7 @@ static SimdIntrinsic packedsimd_methods [] = {
 
 static const IntrinGroup supported_wasm_intrinsics [] = {
 	{ "PackedSimd", MONO_CPU_WASM_SIMD, packedsimd_methods, sizeof (packedsimd_methods) },
+	{ "WasmBase", MONO_CPU_WASM_BASE, wasmbase_methods, sizeof (wasmbase_methods) },
 };
 
 static const IntrinGroup supported_wasm_common_intrinsics [] = {


### PR DESCRIPTION
Add `WasmBase` to `supported_wasm_intrinsics group`. That way we handle the `WasmBase` correctly when SIMD is enabled (default case). Before this change the `emit_hardware_intrinsics` returned false for the `WasmBase.IsSupported`, because it wasn't in the group and we are using it for the whole `S.R.I.Wasm` namespace.

Example of the emitted code difference to confirm the fix:

    (func corlib_ulong_Log2_ulong(param i64, i32) (result i64)) code size difference: -30 bytes
    ...
       local.get $0
       i64.const
    -  i64.shr.u
    -  i32.wrap.i64
    -  local.tee $1
    -  i32.eqz
    +  i64.or
    +  i64.clz
    +  i64.const
    +  i64.xor
    -  if
    -   local.get $0
    -   i32.wrap.i64
    -   i32.const
    -   i32.or
    -   local.get $1
    -   call corlib_System_Numerics_BitOperations_Log2SoftwareFallback_uint
    -   i64.extend.i32.u
    -   return
    -
    -  local.get $1
    -  i32.const
    -  i32.or
    -  local.get $1
    -  call corlib_System_Numerics_BitOperations_Log2SoftwareFallback_uint
    -  i32.const
    -  i32.add
    -  i64.extend.i32.u