### PR TITLE
Fix Int128 truncating conversion discarding significant bits

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -4976,7 +4976,7 @@ namespace System.Numerics
 
                     if (value._bits.Length >= 3)
                     {
-                        upperBits = value._bits[2];
+                        upperBits |= value._bits[2];
                     }
 
                     if (value._bits.Length >= 2)

--- a/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigIntegerTests.GenericMath.cs
@@ -2499,11 +2499,11 @@ namespace System.Numerics.Tests
         [Fact]
         public static void TryConvertToTruncatingInt128Test()
         {
-            Assert.Equal(Zero, NumberBaseHelper<Int128>.CreateTruncating<Int128>(Int128.Zero));
-            Assert.Equal(One, NumberBaseHelper<Int128>.CreateTruncating<Int128>(Int128.One));
-            Assert.Equal(Int128MaxValue, NumberBaseHelper<Int128>.CreateTruncating<Int128>(Int128.MaxValue));
-            Assert.Equal(Int128MinValue, NumberBaseHelper<Int128>.CreateTruncating<Int128>(Int128.MinValue));
-            Assert.Equal(NegativeOne, NumberBaseHelper<Int128>.CreateTruncating<Int128>(Int128.NegativeOne));
+            Assert.Equal(Int128.Zero, NumberBaseHelper<Int128>.CreateTruncating<BigInteger>(Zero));
+            Assert.Equal(Int128.One, NumberBaseHelper<Int128>.CreateTruncating<BigInteger>(One));
+            Assert.Equal(Int128.MaxValue, NumberBaseHelper<Int128>.CreateTruncating<BigInteger>(Int128MaxValue));
+            Assert.Equal(Int128.MinValue, NumberBaseHelper<Int128>.CreateTruncating<BigInteger>(Int128MinValue));
+            Assert.Equal(Int128.NegativeOne, NumberBaseHelper<Int128>.CreateTruncating<BigInteger>(NegativeOne));
         }
 
         [Fact]


### PR DESCRIPTION
Also fixes test that would have caught this bug.

Fixes #88389