### PR TITLE
Add GC.KeepAlive to COM paths in WeakReference

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/WeakReference.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/WeakReference.T.cs
@@ -110,6 +110,10 @@ namespace System
             if ((th & ComAwareBit) != 0 || comInfo != null)
             {
                 ComAwareWeakReference.SetTarget(ref _taggedHandle, target, comInfo);
+
+                // must keep the instance alive as long as we use the handle.
+                GC.KeepAlive(this);
+
                 return;
             }
 #endif
@@ -133,13 +137,22 @@ namespace System
                 if (th == 0)
                     return default;
 
+                T? target;
+
 #if FEATURE_COMINTEROP || FEATURE_COMWRAPPERS
                 if ((th & ComAwareBit) != 0)
-                    return Unsafe.As<T?>(ComAwareWeakReference.GetTarget(th));
+                {
+                    target = Unsafe.As<T?>(ComAwareWeakReference.GetTarget(th));
+
+                    // must keep the instance alive as long as we use the handle.
+                    GC.KeepAlive(this);
+
+                    return target;
+                }
 #endif
 
                 // unsafe cast is ok as the handle cannot be destroyed and recycled while we keep the instance alive
-                T? target = Unsafe.As<T?>(GCHandle.InternalGet(th));
+                target = Unsafe.As<T?>(GCHandle.InternalGet(th));
 
                 // must keep the instance alive as long as we use the handle.
                 GC.KeepAlive(this);

--- a/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.csproj
+++ b/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.csproj
@@ -4,8 +4,6 @@
     <!-- Registers global instances of ComWrappers -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Temporarily disabled due to https://github.com/dotnet/runtime/issues/81362 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="WeakReferenceTest.cs" />


### PR DESCRIPTION
Omission was noticed by @AustinWise.  I reproed the failure and this fix for it on linux-x64.

Fixes #81362