### PR TITLE
Respect IsDynamicCodeSupported in more places in Linq.Expressions

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 
@@ -12,7 +13,7 @@ namespace System.Dynamic.Utils
     internal static class DelegateHelpers
     {
         // This can be flipped to true using feature switches at publishing time
-        internal static bool CanEmitObjectArrayDelegate => true;
+        internal static bool CanEmitObjectArrayDelegate => RuntimeFeature.IsDynamicCodeSupported;
 
         // Separate class so that the it can be trimmed away and doesn't get conflated
         // with the Reflection.Emit statics below.

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -16,7 +16,7 @@ namespace System.Linq.Expressions.Interpreter
         /// </summary>
         public abstract int ArgumentCount { get; }
 
-        private static bool CanCreateArbitraryDelegates => true;
+        private static bool CanCreateArbitraryDelegates => RuntimeFeature.IsDynamicCodeSupported;
 
         #region Construction
 

--- a/src/libraries/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/CompilerTests.cs
@@ -451,7 +451,21 @@ namespace System.Linq.Expressions.Tests
                 Delegate del =
                     Expression.Lambda(Expression.Add(param, Expression.Constant(5)), param).Compile();
                 Assert.Equal(305, del.DynamicInvoke(300));
+
+                // testing more than 2 parameters is important because because it follows a different code path in Compile.
+                Expression<Func<int, int, int, int, int, int>> fiveParameterExpression = (a, b, c, d, e) => a + b + c + d + e;
+                Func<int, int, int, int, int, int> fiveParameterFunc = fiveParameterExpression.Compile();
+                Assert.Equal(7, fiveParameterFunc(2, 2, 1, 1, 0));
+
+                Expression<Func<int, int, int>> callExpression = (a, b) => Add(a, b);
+                Func<int, int, int> callFunc = callExpression.Compile();
+                Assert.Equal(29, callFunc(20, 9));
             }, options);
+        }
+
+        private static int Add(int a, int b)
+        {
+            return a + b;
         }
     }
 

--- a/src/libraries/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/CompilerTests.cs
@@ -455,7 +455,7 @@ namespace System.Linq.Expressions.Tests
                 // testing more than 2 parameters is important because because it follows a different code path in Compile.
                 Expression<Func<int, int, int, int, int, int>> fiveParameterExpression = (a, b, c, d, e) => a + b + c + d + e;
                 Func<int, int, int, int, int, int> fiveParameterFunc = fiveParameterExpression.Compile();
-                Assert.Equal(7, fiveParameterFunc(2, 2, 1, 1, 0));
+                Assert.Equal(6, fiveParameterFunc(2, 2, 1, 1, 0));
 
                 Expression<Func<int, int, int>> callExpression = (a, b) => Add(a, b);
                 Func<int, int, int> callFunc = callExpression.Compile();

--- a/src/libraries/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/CompilerTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Microsoft.DotNet.RemoteExecutor;
@@ -442,30 +443,51 @@ namespace System.Linq.Expressions.Tests
 
             using RemoteInvokeHandle remoteHandle = RemoteExecutor.Invoke(static () =>
             {
-                ParameterExpression param = Expression.Parameter(typeof(int));
-
-                Func<int, int> typedDel =
-                    Expression.Lambda<Func<int, int>>(Expression.Add(param, Expression.Constant(4)), param).Compile();
-                Assert.Equal(304, typedDel(300));
-
-                Delegate del =
-                    Expression.Lambda(Expression.Add(param, Expression.Constant(5)), param).Compile();
-                Assert.Equal(305, del.DynamicInvoke(300));
-
-                // testing more than 2 parameters is important because because it follows a different code path in Compile.
-                Expression<Func<int, int, int, int, int, int>> fiveParameterExpression = (a, b, c, d, e) => a + b + c + d + e;
-                Func<int, int, int, int, int, int> fiveParameterFunc = fiveParameterExpression.Compile();
-                Assert.Equal(6, fiveParameterFunc(2, 2, 1, 1, 0));
-
-                Expression<Func<int, int, int>> callExpression = (a, b) => Add(a, b);
-                Func<int, int, int> callFunc = callExpression.Compile();
-                Assert.Equal(29, callFunc(20, 9));
+                CompileWorksWhenDynamicCodeNotSupportedInner();
             }, options);
+        }
+
+        // run the same test code as the above CompileWorksWhenDynamicCodeNotSupported test
+        // to ensure this test works correctly on all platforms - even if RemoteExecutor is not supported
+        [Fact]
+        public static void CompileWorksWhenDynamicCodeNotSupportedInner()
+        {
+            ParameterExpression param = Expression.Parameter(typeof(int));
+
+            Func<int, int> typedDel =
+                Expression.Lambda<Func<int, int>>(Expression.Add(param, Expression.Constant(4)), param).Compile();
+            Assert.Equal(304, typedDel(300));
+
+            Delegate del =
+                Expression.Lambda(Expression.Add(param, Expression.Constant(5)), param).Compile();
+            Assert.Equal(305, del.DynamicInvoke(300));
+
+            // testing more than 2 parameters is important because because it follows a different code path in Compile.
+            Expression<Func<int, int, int, int, int, int>> fiveParameterExpression = (a, b, c, d, e) => a + b + c + d + e;
+            Func<int, int, int, int, int, int> fiveParameterFunc = fiveParameterExpression.Compile();
+            Assert.Equal(6, fiveParameterFunc(2, 2, 1, 1, 0));
+
+            Expression<Func<int, int, int>> callExpression = (a, b) => Add(a, b);
+            Func<int, int, int> callFunc = callExpression.Compile();
+            Assert.Equal(29, callFunc(20, 9));
+
+            MethodCallExpression methodCallExpression = Expression.Call(
+                instance: null,
+                typeof(CompilerTests).GetMethod("Add4", BindingFlags.NonPublic | BindingFlags.Static),
+                Expression.Constant(5), Expression.Constant(6), Expression.Constant(7), Expression.Constant(8));
+
+            Func<int> methodCallDelegate = Expression.Lambda<Func<int>>(methodCallExpression).Compile();
+            Assert.Equal(26, methodCallDelegate());
         }
 
         private static int Add(int a, int b)
         {
             return a + b;
+        }
+
+        private static int Add4(int a, int b, int c, int d)
+        {
+            return a + b + c + d;
         }
     }
 

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
@@ -8,6 +8,10 @@
       <!-- Used by VS4Mac via reflection to symbolize stack traces -->
       <method name="GetMethodFromNativeIP" />
     </type>
+    <type fullname="System.Reflection.Emit.AssemblyBuilder">
+      <!-- Used by System.Linq.Expressions via reflection -->
+      <method name="ForceAllowDynamicCode" />
+    </type>
     <type fullname="System.Runtime.Serialization.SerializationInfo">
       <!-- Used by System.Runtime.Serialization.Formatters via reflection -->
       <method name="UpdateValue" />

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -9,6 +9,9 @@ namespace System.Reflection.Emit
 {
     public abstract partial class AssemblyBuilder : Assembly
     {
+        [ThreadStatic]
+        private static bool t_allowDynamicCode;
+
         protected AssemblyBuilder()
         {
         }
@@ -81,9 +84,37 @@ namespace System.Reflection.Emit
 
         internal static void EnsureDynamicCodeSupported()
         {
-            if (!RuntimeFeature.IsDynamicCodeSupported)
+            if (!RuntimeFeature.IsDynamicCodeSupported && !t_allowDynamicCode)
             {
                 ThrowDynamicCodeNotSupported();
+            }
+        }
+
+        /// <summary>
+        /// Allows dynamic code even though RuntimeFeature.IsDynamicCodeSupported is false.
+        /// </summary>
+        /// <returns>An object that, when disposed, will revert allowing dynamic code back to its initial state.</returns>
+        /// <remarks>
+        /// This is useful for cases where RuntimeFeature.IsDynamicCodeSupported returns false, but
+        /// the runtime is still capable of emitting dynamic code. For example, when generating delegates
+        /// in System.Linq.Expressions while PublishAot=true is set in the project. At debug time, the app
+        /// uses the non-AOT runtime with the IsDynamicCodeSupported feature switch set to false.
+        /// </remarks>
+        internal static IDisposable ForceAllowDynamicCode() => new ForceAllowDynamicCodeScope();
+
+        private sealed class ForceAllowDynamicCodeScope : IDisposable
+        {
+            private readonly bool _previous;
+
+            public ForceAllowDynamicCodeScope()
+            {
+                _previous = t_allowDynamicCode;
+                t_allowDynamicCode = true;
+            }
+
+            public void Dispose()
+            {
+                t_allowDynamicCode = _previous;
             }
         }
 


### PR DESCRIPTION
* CanEmitObjectArrayDelegate
* CanCreateArbitraryDelegates

These properties are all set to `false` when running on NativeAOT, so have them respect RuntimeFeature.IsDynamicCodeSupported when not running on NativeAOT.

However, CanEmitObjectArrayDelegate needs a work around because DynamicDelegateAugments.CreateObjectArrayDelegate does not exist in CoreClr's System.Private.CoreLib.

Allow System.Linq.Expressions to create an object[] delegate using Ref.Emit even though RuntimeFeature.IsDynamicCodeSupported is set to false (ex. using a feature switch). To enable this, add an internal method in CoreLib that temporarily allows the current thread to skip the RuntimeFeature check and allows DynamicMethod instances to be created. When System.Linq.Expressions needs to generate one of these delegates, it calls the internal method through Reflection and continues to use Ref.Emit to generate the delegate.

Fix https://github.com/dotnet/runtime/issues/81803