### PR TITLE
Improve `crossgen2 --help` layout

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -319,9 +319,6 @@ namespace ILCompiler
 
                 foreach (string arch in ValidArchitectures)
                 {
-                    Console.Write(arch);
-                    Console.Write(": ");
-
                     TargetArchitecture targetArch = Helpers.GetTargetArchitecture(arch);
                     bool first = true;
                     foreach (var instructionSet in Internal.JitInterface.InstructionSetFlags.ArchitectureToValidInstructionSets(targetArch))
@@ -331,6 +328,8 @@ namespace ILCompiler
                         {
                             if (first)
                             {
+                                Console.Write(arch);
+                                Console.Write(": ");
                                 first = false;
                             }
                             else
@@ -340,6 +339,8 @@ namespace ILCompiler
                             Console.Write(instructionSet.Name);
                         }
                     }
+
+                    if (first) continue; // no instruction-set found for this architecture
 
                     Console.WriteLine();
                 }

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -40,7 +40,7 @@ namespace ILCompiler
         public CliOption<bool> OptimizeTime { get; } =
             new("--optimize-time", "--Ot") { Description = SR.OptimizeSpeedOption };
         public CliOption<TypeValidationRule> TypeValidation { get; } =
-            new("--type-validation") { DefaultValueFactory = _ => TypeValidationRule.Automatic, Description = SR.TypeValidation };
+            new("--type-validation") { DefaultValueFactory = _ => TypeValidationRule.Automatic, Description = SR.TypeValidation, HelpName = "arg" };
         public CliOption<bool> InputBubble { get; } =
             new("--inputbubble") { Description = SR.InputBubbleOption };
         public CliOption<Dictionary<string, string>> InputBubbleReferenceFilePaths { get; } =
@@ -126,9 +126,9 @@ namespace ILCompiler
         public CliOption<string> NonLocalGenericsModule { get; } =
             new("--non-local-generics-module") { DefaultValueFactory = _ => string.Empty, Description = SR.NonLocalGenericsModule };
         public CliOption<ReadyToRunMethodLayoutAlgorithm> MethodLayout { get; } =
-            new("--method-layout") { CustomParser = MakeReadyToRunMethodLayoutAlgorithm, DefaultValueFactory = MakeReadyToRunMethodLayoutAlgorithm, Description = SR.MethodLayoutOption };
+            new("--method-layout") { CustomParser = MakeReadyToRunMethodLayoutAlgorithm, DefaultValueFactory = MakeReadyToRunMethodLayoutAlgorithm, Description = SR.MethodLayoutOption, HelpName = "arg" };
         public CliOption<ReadyToRunFileLayoutAlgorithm> FileLayout { get; } =
-            new("--file-layout") { CustomParser = MakeReadyToRunFileLayoutAlgorithm, DefaultValueFactory = MakeReadyToRunFileLayoutAlgorithm, Description = SR.FileLayoutOption };
+            new("--file-layout") { CustomParser = MakeReadyToRunFileLayoutAlgorithm, DefaultValueFactory = MakeReadyToRunFileLayoutAlgorithm, Description = SR.FileLayoutOption, HelpName = "arg" };
         public CliOption<bool> VerifyTypeAndFieldLayout { get; } =
             new("--verify-type-and-field-layout") { Description = SR.VerifyTypeAndFieldLayoutOption };
         public CliOption<string> CallChainProfileFile { get; } =
@@ -301,13 +301,19 @@ namespace ILCompiler
                 Console.WriteLine();
                 Console.WriteLine(String.Format(SR.SwitchWithDefaultHelp, "--targetarch", String.Join("', '", ValidArchitectures), Helpers.GetTargetArchitecture(null).ToString().ToLowerInvariant()));
                 Console.WriteLine();
+                Console.WriteLine(String.Format(SR.SwitchWithDefaultHelp, "--type-validation", String.Join("', '", Enum.GetNames<TypeValidationRule>()), nameof(TypeValidationRule.Automatic)));
+                Console.WriteLine();
+
+                Console.WriteLine(SR.CrossModuleInliningExtraHelp);
+                Console.WriteLine();
+                Console.WriteLine(String.Format(SR.LayoutOptionExtraHelp, "--method-layout", String.Join("', '", Enum.GetNames<ReadyToRunMethodLayoutAlgorithm>())));
+                Console.WriteLine();
+                Console.WriteLine(String.Format(SR.LayoutOptionExtraHelp, "--file-layout", String.Join("', '", Enum.GetNames<ReadyToRunFileLayoutAlgorithm>())));
+                Console.WriteLine();
 
                 Console.WriteLine(SR.InstructionSetHelp);
                 foreach (string arch in ValidArchitectures)
                 {
-                    Console.Write(arch);
-                    Console.Write(": ");
-
                     TargetArchitecture targetArch = Helpers.GetTargetArchitecture(arch);
                     bool first = true;
                     foreach (var instructionSet in Internal.JitInterface.InstructionSetFlags.ArchitectureToValidInstructionSets(targetArch))
@@ -317,6 +323,8 @@ namespace ILCompiler
                         {
                             if (first)
                             {
+                                Console.Write(arch);
+                                Console.Write(": ");
                                 first = false;
                             }
                             else
@@ -326,6 +334,8 @@ namespace ILCompiler
                             Console.Write(instructionSet.Name);
                         }
                     }
+
+                    if (first) continue; // no instruction-set found for this architecture
 
                     Console.WriteLine();
                 }

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -313,10 +313,13 @@
     <value>Error: multiple input files are only supported in composite build mode: {0}</value>
   </data>
   <data name="MethodLayoutOption" xml:space="preserve">
-    <value>Layout algorithm used by profile-driven optimization for arranging methods in a file: DefaultSort, ExclusiveWeight, HotCold, or HotWarmCold). The default value is DefaultSort, which indicates that complex layout is disabled.</value>
+    <value>Layout algorithm used by profile-driven optimization for arranging methods in a file.</value>
   </data>
   <data name="FileLayoutOption" xml:space="preserve">
-    <value>Layout algorithm used by profile-driven optimization for arranging non-method contents in a file: DefaultSort or MethodOrder. The default value is DefaultSort, which indicates that complex layout is disabled.</value>
+    <value>Layout algorithm used by profile-driven optimization for arranging non-method contents in a file.</value>
+  </data>
+  <data name="LayoutOptionExtraHelp" xml:space="preserve">
+    <value>Note for {0}: Valid options are {1}. The default value is DefaultSort, which indicates that complex layout is disabled.</value>
   </data>
   <data name="CompositeRootPath" xml:space="preserve">
     <value>Logical root folder for composite builds; defaults to directory of 1st input file.</value>
@@ -382,13 +385,19 @@
     <value>Hexadecimal value to set target PE-file ImageBase field</value>
   </data>
   <data name="CrossModuleInlining" xml:space="preserve">
-    <value>Allow inclusion of code from the specified module into the module being compiled. In addition to specifying an assembly by name, the special value of "*" is recognized as indicating that code from all modules may be included. Any module specified in this way MUST be loadable from the first moment the R2R module is loaded, as loads of these modules may be triggered unpredictably.</value>
+    <value>Allow inclusion of code from the specified module into the module being compiled.</value>
+  </data>
+  <data name="CrossModuleInliningExtraHelp" xml:space="preserve">
+    <value>Note for --opt-cross-module: In addition to specifying an assembly by name, the special value of "*" is recognized as indicating that code from all modules may be included. Any module specified in this way MUST be loadable from the first moment the R2R module is loaded, as loads of these modules may be triggered unpredictably.</value>
   </data>
   <data name="AsyncModuleOptimization" xml:space="preserve">
     <value>Attempt to compile as much async infrastructure as possible for async methods. Defaults to enabled. To disable, specify false to this flag explicitly.</value>
   </data>
   <data name="NonLocalGenericsModule" xml:space="preserve">
-    <value>Specify the module which is permitted to contain generics defined or instantiated in any other module. Specify "*" to indicate that any module may hold arbitrary generics.</value>
+    <value>Specify "*" to indicate that any module may hold arbitrary generics.</value>
+  </data>
+  <data name="NonLocalGenericsModuleExtraHelp" xml:space="preserve">
+    <value>Note for --non-local-generics-module: Specify "*" to indicate that any module may hold arbitrary generics.</value>
   </data>
   <data name="ErrorNonLocalGenericsModule" xml:space="preserve">
     <value>"{0}" was specified to the --non-local-generics-module switch, but was not in the set of modules associated with the compile</value>


### PR DESCRIPTION
Following the same layout as ILCompiler:

```
--<option>    <short-description>
--<option>    <short-description>
...
...
--<option>    <short-description>

<Notes, examples etc. paragraphs go here>
```

Also skipped arch in notes section with no instruction-sets.

Was:
<img width="1728" alt="image" src="https://github.com/dotnet/runtime/assets/3840695/0ad1ea84-9bf6-4b8a-ad5b-36d4280cf5b0">
Now:
<img width="1728" alt="image" src="https://github.com/dotnet/runtime/assets/3840695/ae5f8d88-3716-4839-936d-5b60cb6680d5">
