### PR TITLE
Add missing sections in implicit machine.config

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ImplicitMachineConfigHost.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ImplicitMachineConfigHost.cs
@@ -82,6 +82,8 @@ namespace System.Configuration
         <section name='satelliteassemblies' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
         <section name='startup' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
         <section name='system.diagnostics' type='System.Diagnostics.SystemDiagnosticsSection, System.Configuration.ConfigurationManager' allowLocation='false' />
+        <section name='system.runtime.remoting' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
+        <section name='windows' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
     </configSections>
     <configProtectedData defaultProvider='RsaProtectedConfigurationProvider'>
         <providers>

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ImplicitMachineConfigTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ImplicitMachineConfigTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.Configuration;
 using System.Configuration.Internal;
 using System.IO;
+using Microsoft.DotNet.RemoteExecutor;
+
 using Xunit;
 
 namespace System.ConfigurationTests
@@ -16,6 +18,30 @@ namespace System.ConfigurationTests
         {
             var appSettings = ConfigurationManager.AppSettings;
             Assert.NotNull(appSettings);
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void RuntimeAppSettingsSystemRuntimeRemotingSectionIsSupported()
+        {
+            using (var temp = new TempConfig(TestData.SystemRuntimeRemotingSectionConfig))
+            {
+                RemoteExecutor.Invoke((string configFilePath) => {
+                    AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", configFilePath);
+                    Assert.NotNull(ConfigurationManager.GetSection("system.runtime.remoting"));
+                }, temp.ConfigPath).Dispose();
+            }
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void RuntimeAppSettingsWindowsSectionIsSupported()
+        {
+            using (var temp = new TempConfig(TestData.WindowsSectionConfig))
+            {
+                RemoteExecutor.Invoke((string configFilePath) => {
+                    AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", configFilePath);
+                    Assert.NotNull(ConfigurationManager.GetSection("windows"));
+                }, temp.ConfigPath).Dispose();
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/TestData.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/TestData.cs
@@ -25,5 +25,23 @@ namespace System.ConfigurationTests
     <add key='BarKey' value='BarValue' />
   </appSettings>
 </configuration>";
+
+        public static string SystemRuntimeRemotingSectionConfig =
+@"<?xml version='1.0' encoding='utf-8' ?>
+<configuration>
+  <system.runtime.remoting>
+    <application>
+      <channels>
+        <channel ref='tcp' port='1111' />
+      </channels>
+    </application>
+  </system.runtime.remoting>
+</configuration>";
+
+        public static string WindowsSectionConfig =
+@"<?xml version='1.0' encoding='utf-8' ?>
+<configuration>
+  <windows />
+</configuration>";
     }
 }


### PR DESCRIPTION
This will add the missing sections of type IgnoreSection to the implicitly generated machine.config.

Fix #930