### PR TITLE
Regex parser nits

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -513,33 +513,23 @@ namespace System.Text.RegularExpressions
         {
             _concatenation = new RegexNode(RegexNodeKind.Concatenate, _options);
 
-            while (true)
+            while (_pos < _pattern.Length)
             {
-                int c = _pattern.Length - _pos;
-                if (c == 0)
-                {
-                    break;
-                }
-
                 int startpos = _pos;
 
-                while (c > 0 && _pattern[_pos] != '$')
-                {
-                    _pos++;
-                    c--;
-                }
+                _pos = _pattern.IndexOf('$', _pos);
+                if (_pos == -1)
+                    _pos = _pattern.Length;
 
                 AddConcatenate(startpos, _pos - startpos, isReplacement: true);
 
-                if (c > 0)
+                if (_pos < _pattern.Length)
                 {
                     if (_pattern[_pos++] == '$')
                     {
-                        RegexNode node = ScanDollar();
-                        _unit = node;
+                        _unit = ScanDollar();
+                        AddConcatenate();
                     }
-
-                    AddConcatenate();
                 }
             }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -996,7 +996,7 @@ namespace System.Text.RegularExpressions
                         _pos = parenPos - 1;       // jump to the start of the parentheses
                         _ignoreNextParen = true;    // but make sure we don't try to capture the insides
 
-                        if (_pos + 3 < _pattern.Length && _pattern[_pos + 1] == '?')
+                        if (_pos + 2 < _pattern.Length && _pattern[_pos + 1] == '?')
                         {
                             // disallow comments in the condition
                             if (_pattern[_pos + 2] == '#')
@@ -1005,7 +1005,7 @@ namespace System.Text.RegularExpressions
                             }
 
                             // disallow named capture group (?<..>..) in the condition
-                            if (_pattern[_pos + 2] == '\'' || (_pos + 4 < _pattern.Length && _pattern[_pos + 2] == '<' && _pattern[_pos + 3] != '!' && _pattern[_pos + 3] != '='))
+                            if (_pattern[_pos + 2] == '\'' || (_pos + 3 < _pattern.Length && _pattern[_pos + 2] == '<' && _pattern[_pos + 3] != '!' && _pattern[_pos + 3] != '='))
                             {
                                 throw MakeException(RegexParseError.AlternationHasNamedCapture, SR.AlternationHasNamedCapture);
                             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1511,13 +1511,19 @@ namespace System.Text.RegularExpressions
         private char ScanHex(int c)
         {
             int i = 0;
-            int d;
 
             if (_pos + c <= _pattern.Length)
             {
-                for (; c > 0 && ((d = HexDigit(_pattern[_pos++])) >= 0); c -= 1)
+                for (; c > 0; c -= 1)
                 {
-                    i = (i * 0x10) + d;
+                    int d;
+                    char ch = _pattern[_pos++];
+                    if ((uint)(d = ch - '0') <= 9)
+                        i = (i * 0x10) + d;
+                    else if ((uint)(d = (ch | 0x20) - 'a') <= 5)
+                        i = (i * 0x10) + d + 0xa;
+                    else
+                        break;
                 }
             }
 
@@ -1527,23 +1533,6 @@ namespace System.Text.RegularExpressions
             }
 
             return (char)i;
-        }
-
-        /// <summary>Returns n &lt;= 0xF for a hex digit.</summary>
-        private static int HexDigit(char ch)
-        {
-            int d;
-
-            if ((uint)(d = ch - '0') <= 9)
-                return d;
-
-            if ((uint)(d = ch - 'a') <= 5)
-                return d + 0xa;
-
-            if ((uint)(d = ch - 'A') <= 5)
-                return d + 0xa;
-
-            return -1;
         }
 
         /// <summary>Grabs and converts an ASCII control character</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -659,20 +659,11 @@ namespace System.Text.RegularExpressions
                             break; // this break will only break out of the switch
                     }
                 }
-                else if (ch == '[')
+                else if (ch == '[' && _pos < _pattern.Length && _pattern[_pos] == ':' && !inRange && !_pattern.AsSpan(_pos).StartsWith(":]".AsSpan()))
                 {
                     // This is code for Posix style properties - [:Ll:] or [:IsTibetan:].
                     // It currently doesn't do anything other than skip the whole thing!
-                    if (_pos < _pattern.Length && _pattern[_pos] == ':' && !inRange)
-                    {
-                        int savePos = _pos;
-
-                        _pos++;
-                        if (_pos + 1 >= _pattern.Length || _pattern[_pos++] != ':' || _pattern[_pos++] != ']')
-                        {
-                            _pos = savePos;
-                        }
-                    }
+                    _pos++;
                 }
 
                 if (inRange)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1158,8 +1158,6 @@ namespace System.Text.RegularExpressions
         /// <summary>Scans \-style backreferences and character escapes</summary>
         private RegexNode? ScanBasicBackslash(bool scanOnly)
         {
-            Debug.Assert(_pos < _pattern.Length, "The current reading position must not be at the end of the pattern");
-
             int backpos = _pos;
             char close = '\0';
             bool angled = false;
@@ -1979,8 +1977,6 @@ namespace System.Text.RegularExpressions
 
         private readonly bool IsTrueQuantifier()
         {
-            Debug.Assert(_pos < _pattern.Length, "The current reading position must not be at the end of the pattern");
-
             int startpos = _pos;
             char ch = _pattern[startpos];
             if (ch != '{')

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -1675,7 +1674,7 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>Returns the node kind for zero-length assertions with a \ code.</summary>
-        private RegexNodeKind TypeFromCode(char ch) =>
+        private readonly RegexNodeKind TypeFromCode(char ch) =>
             ch switch
             {
                 'b' => (_options & RegexOptions.ECMAScript) != 0 ? RegexNodeKind.ECMABoundary : RegexNodeKind.Boundary,
@@ -1936,7 +1935,7 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>True if the capture slot was noted</summary>
-        private bool IsCaptureSlot(int i)
+        private readonly bool IsCaptureSlot(int i)
         {
             if (_caps != null)
             {
@@ -1958,7 +1957,7 @@ namespace System.Text.RegularExpressions
             capnum;
 
         /// <summary>Looks up the slot number for a given name</summary>
-        private bool IsCaptureName(string capname) => _capnames != null && _capnames.ContainsKey(capname);
+        private readonly bool IsCaptureName(string capname) => _capnames != null && _capnames.ContainsKey(capname);
 
         private const byte Q = 4;    // quantifier          * + ? {
         private const byte S = 3;    // stopper             $ ( ) . [ \ ^ |
@@ -2009,7 +2008,7 @@ namespace System.Text.RegularExpressions
         /// <summary>Returns true for whitespace.</summary>
         private static bool IsSpace(char ch) => ch <= ' ' && Category[ch] == W;
 
-        private bool IsTrueQuantifier()
+        private readonly bool IsTrueQuantifier()
         {
             Debug.Assert(_pos < _pattern.Length, "The current reading position must not be at the end of the pattern");
 
@@ -2162,7 +2161,7 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>Fills in a RegexParseException</summary>
-        private RegexParseException MakeException(RegexParseError error, string message) =>
+        private readonly RegexParseException MakeException(RegexParseError error, string message) =>
             new RegexParseException(error, _pos, SR.Format(SR.MakeException, _pattern, _pos, message));
 
         /// <summary>Gets group name from its number.</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -534,6 +534,7 @@ namespace System.Text.RegularExpressions
                     }
 
                     _concatenation.AddChild(_unit!);
+                    _unit = null;
                 }
             }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1576,7 +1576,15 @@ namespace System.Text.RegularExpressions
                 }
                 else
                 {
-                    RegexOptions options = OptionFromCode(ch);
+                    RegexOptions options = (char)(ch | 0x20) switch
+                    {
+                        'i' => RegexOptions.IgnoreCase,
+                        'm' => RegexOptions.Multiline,
+                        'n' => RegexOptions.ExplicitCapture,
+                        's' => RegexOptions.Singleline,
+                        'x' => RegexOptions.IgnorePatternWhitespace,
+                        _ => RegexOptions.None,
+                    };
                     if (options == 0)
                     {
                         return;
@@ -1684,18 +1692,6 @@ namespace System.Text.RegularExpressions
                 'Z' => RegexNodeKind.EndZ,
                 'z' => RegexNodeKind.End,
                 _ => RegexNodeKind.Nothing,
-            };
-
-        /// <summary>Returns option bit from single-char (?imnsx) code.</summary>
-        private static RegexOptions OptionFromCode(char ch) =>
-            (char)(ch | 0x20) switch
-            {
-                'i' => RegexOptions.IgnoreCase,
-                'm' => RegexOptions.Multiline,
-                'n' => RegexOptions.ExplicitCapture,
-                's' => RegexOptions.Singleline,
-                'x' => RegexOptions.IgnorePatternWhitespace,
-                _ => RegexOptions.None,
             };
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1085,8 +1085,6 @@ namespace System.Text.RegularExpressions
         /// <summary>Scans chars following a '\' (not counting the '\'), and returns a RegexNode for the type of atom scanned</summary>
         private RegexNode? ScanBackslash(bool scanOnly)
         {
-            Debug.Assert(_pos < _pattern.Length, "The current reading position must not be at the end of the pattern");
-
             char ch;
             switch (ch = _pattern[_pos])
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -759,7 +759,7 @@ namespace System.Text.RegularExpressions
             // 1. "(" followed by nothing
             // 2. "(x" where x != ?
             // 3. "(?)"
-            if (_pos == _pattern.Length || _pattern[_pos] != '?' || (_pattern[_pos] == '?' && _pos + 1 < _pattern.Length && _pattern[_pos + 1] == ')'))
+            if (_pos == _pattern.Length || _pattern[_pos] != '?' || (_pos + 1 < _pattern.Length && _pattern[_pos + 1] == ')'))
             {
                 if ((_options & RegexOptions.ExplicitCapture) != 0 || _ignoreNextParen)
                 {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -422,7 +422,8 @@ namespace System.Text.RegularExpressions
 
                 if (_pos == _pattern.Length || !(isQuantifier = IsTrueQuantifier()))
                 {
-                    AddUnitToConcatenate();
+                    _concatenation!.AddChild(_unit!);
+                    _unit = null;
                     goto ContinueOuterScan;
                 }
 
@@ -462,7 +463,8 @@ namespace System.Text.RegularExpressions
 
                             if (startpos == _pos || _pos == _pattern.Length || _pattern[_pos++] != '}')
                             {
-                                AddUnitToConcatenate();
+                                _concatenation!.AddChild(_unit!);
+                                _unit = null;
                                 _pos = startpos - 1;
                                 goto ContinueOuterScan;
                             }
@@ -488,8 +490,8 @@ namespace System.Text.RegularExpressions
                         throw MakeException(RegexParseError.ReversedQuantifierRange, SR.ReversedQuantifierRange);
                     }
 
-                    _unit = _unit!.MakeQuantifier(lazy, min, max);
-                    AddUnitToConcatenate();
+                    _concatenation!.AddChild(_unit!.MakeQuantifier(lazy, min, max));
+                    _unit = null;
                 }
 
             ContinueOuterScan:
@@ -2079,15 +2081,6 @@ namespace System.Text.RegularExpressions
             }
 
             _concatenation = new RegexNode(RegexNodeKind.Concatenate, _options);
-        }
-
-        /// <summary>Finish the current quantifiable (when a quantifier is not found or is not possible)</summary>
-        private void AddUnitToConcatenate()
-        {
-            // The first (| inside a Testgroup group goes directly to the group
-
-            _concatenation!.AddChild(_unit!);
-            _unit = null;
         }
 
         /// <summary>Finish the current group (in response to a ')' or end)</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -883,7 +883,7 @@ namespace System.Text.RegularExpressions
                                 {
                                     string capname = ScanCapname();
 
-                                    if (IsCaptureName(capname))
+                                    if (_capnames != null && _capnames.ContainsKey(capname))
                                     {
                                         capnum = (int)_capnames![capname]!;
                                     }
@@ -930,7 +930,7 @@ namespace System.Text.RegularExpressions
                                     {
                                         string uncapname = ScanCapname();
 
-                                        if (IsCaptureName(uncapname))
+                                        if (_capnames != null && _capnames.ContainsKey(uncapname))
                                         {
                                             uncapnum = (int)_capnames![uncapname]!;
                                         }
@@ -990,7 +990,7 @@ namespace System.Text.RegularExpressions
                             {
                                 string capname = ScanCapname();
 
-                                if (IsCaptureName(capname) && _pos < _pattern.Length && _pattern[_pos++] == ')')
+                                if (_capnames != null && _capnames.ContainsKey(capname) && _pos < _pattern.Length && _pattern[_pos++] == ')')
                                 {
                                     return new RegexNode(RegexNodeKind.BackreferenceConditional, _options, (int)_capnames![capname]!);
                                 }
@@ -1298,7 +1298,7 @@ namespace System.Text.RegularExpressions
                 {
                     return
                         scanOnly ? null :
-                        IsCaptureName(capname) ? new RegexNode(RegexNodeKind.Backreference, _options, (int)_capnames![capname]!) :
+                        _capnames != null && _capnames.ContainsKey(capname) ? new RegexNode(RegexNodeKind.Backreference, _options, (int)_capnames![capname]!) :
                         throw MakeException(RegexParseError.UndefinedNamedReference, SR.Format(SR.UndefinedNamedReference, capname));
                 }
             }
@@ -1394,7 +1394,7 @@ namespace System.Text.RegularExpressions
                 string capname = ScanCapname();
                 if (_pos < _pattern.Length && _pattern[_pos++] == '}')
                 {
-                    if (IsCaptureName(capname))
+                    if (_capnames != null && _capnames.ContainsKey(capname))
                     {
                         return new RegexNode(RegexNodeKind.Backreference, _options, (int)_capnames![capname]!);
                     }
@@ -1951,9 +1951,6 @@ namespace System.Text.RegularExpressions
             capnum == -1 ? -1 :
             caps != null ? (int)caps[capnum]! :
             capnum;
-
-        /// <summary>Looks up the slot number for a given name</summary>
-        private readonly bool IsCaptureName(string capname) => _capnames != null && _capnames.ContainsKey(capname);
 
         private const byte Q = 4;    // quantifier          * + ? {
         private const byte S = 3;    // stopper             $ ( ) . [ \ ^ |

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -886,7 +886,7 @@ namespace System.Text.RegularExpressions
 
                                     if (IsCaptureName(capname))
                                     {
-                                        capnum = CaptureSlotFromName(capname);
+                                        capnum = (int)_capnames![capname]!;
                                     }
 
                                     // check if we have bogus character after the name
@@ -933,7 +933,7 @@ namespace System.Text.RegularExpressions
 
                                         if (IsCaptureName(uncapname))
                                         {
-                                            uncapnum = CaptureSlotFromName(uncapname);
+                                            uncapnum = (int)_capnames![uncapname]!;
                                         }
                                         else
                                         {
@@ -993,7 +993,7 @@ namespace System.Text.RegularExpressions
 
                                 if (IsCaptureName(capname) && _pos < _pattern.Length && _pattern[_pos++] == ')')
                                 {
-                                    return new RegexNode(RegexNodeKind.BackreferenceConditional, _options, CaptureSlotFromName(capname));
+                                    return new RegexNode(RegexNodeKind.BackreferenceConditional, _options, (int)_capnames![capname]!);
                                 }
                             }
                         }
@@ -1299,7 +1299,7 @@ namespace System.Text.RegularExpressions
                 {
                     return
                         scanOnly ? null :
-                        IsCaptureName(capname) ? new RegexNode(RegexNodeKind.Backreference, _options, CaptureSlotFromName(capname)) :
+                        IsCaptureName(capname) ? new RegexNode(RegexNodeKind.Backreference, _options, (int)_capnames![capname]!) :
                         throw MakeException(RegexParseError.UndefinedNamedReference, SR.Format(SR.UndefinedNamedReference, capname));
                 }
             }
@@ -1397,7 +1397,7 @@ namespace System.Text.RegularExpressions
                 {
                     if (IsCaptureName(capname))
                     {
-                        return new RegexNode(RegexNodeKind.Backreference, _options, CaptureSlotFromName(capname));
+                        return new RegexNode(RegexNodeKind.Backreference, _options, (int)_capnames![capname]!);
                     }
                 }
             }
@@ -1945,9 +1945,6 @@ namespace System.Text.RegularExpressions
                 }
             }
         }
-
-        /// <summary>Looks up the slot number for a given name.</summary>
-        private int CaptureSlotFromName(string capname) => (int)_capnames![capname]!;
 
         /// <summary>True if the capture slot was noted</summary>
         private bool IsCaptureSlot(int i)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1070,19 +1070,14 @@ namespace System.Text.RegularExpressions
 
                 if ((_options & RegexOptions.IgnorePatternWhitespace) != 0 && _pos < _pattern.Length && _pattern[_pos] == '#')
                 {
-                    while (_pos < _pattern.Length && _pattern[_pos] != '\n')
-                    {
-                        _pos++;
-                    }
+                    _pos = _pattern.IndexOf('\n', _pos);
+                    if (_pos == -1)
+                        _pos = _pattern.Length;
                 }
                 else if (_pos + 2 < _pattern.Length && _pattern[_pos + 2] == '#' && _pattern[_pos + 1] == '?' && _pattern[_pos] == '(')
                 {
-                    while (_pos < _pattern.Length && _pattern[_pos] != ')')
-                    {
-                        _pos++;
-                    }
-
-                    if (_pos == _pattern.Length)
+                    _pos = _pattern.IndexOf(')', _pos);
+                    if (_pos == -1)
                     {
                         throw MakeException(RegexParseError.UnterminatedComment, SR.UnterminatedComment);
                     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -662,11 +662,20 @@ namespace System.Text.RegularExpressions
                             break; // this break will only break out of the switch
                     }
                 }
-                else if (ch == '[' && _pos < _pattern.Length && _pattern[_pos] == ':' && !inRange && !_pattern.AsSpan(_pos).StartsWith(":]".AsSpan()))
+                else if (ch == '[')
                 {
                     // This is code for Posix style properties - [:Ll:] or [:IsTibetan:].
                     // It currently doesn't do anything other than skip the whole thing!
-                    _pos++;
+                    if (_pos < _pattern.Length && _pattern[_pos] == ':' && !inRange)
+                    {
+                        int savePos = _pos;
+
+                        _pos++;
+                        if (_pos + 1 >= _pattern.Length || _pattern[_pos++] != ':' || _pattern[_pos++] != ']')
+                        {
+                            _pos = savePos;
+                        }
+                    }
                 }
 
                 if (inRange)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1074,6 +1074,7 @@ namespace System.Text.RegularExpressions
                     _pos = _pattern.IndexOf(')', _pos);
                     if (_pos == -1)
                     {
+                        _pos = _pattern.Length;
                         throw MakeException(RegexParseError.UnterminatedComment, SR.UnterminatedComment);
                     }
 


### PR DESCRIPTION
trivial changes.
1. I ran the real world patterns corpus through the parser and didn't notice anything that could be obviously improved except for one dictionary which was almost always resizing. Set size to eliminate resizing in 90% of cases.
2. Inlined some more low value helpers in RegexParser where I think it makes it clearer.
3. Marked methods readonly where our analyzer instructed it.
4. Some use of IndexOf() per feedback in #88392