### PR TITLE
Reduce boxing in logging

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
@@ -263,8 +263,15 @@ namespace Microsoft.Extensions.Logging
             return TryFormatArgumentIfNullOrEnumerable(value, ref stringValue) ? stringValue : value!;
         }
 
-        private static bool TryFormatArgumentIfNullOrEnumerable(object? value, [NotNullWhen(true)] ref object? stringValue)
+        private static bool TryFormatArgumentIfNullOrEnumerable<T>(T? value, [NotNullWhen(true)] ref object? stringValue)
         {
+            // Avoiding boxing of known types
+            if (typeof(T).IsPrimitive || typeof(T).IsEnum)
+            {
+                stringValue = null;
+                return false;
+            }
+
             if (value == null)
             {
                 stringValue = NullValue;


### PR DESCRIPTION
- Logging got overhauled to use CompositeFormat in .NET 8, this allows for non-boxing string formatting via string.Format. There's one piece of code that boxing the generic argument before handing off to string.Format so remove it for primitive types and enums.

Fixes #50768 

(while this doesn't fully fix the problem, it's as improved as we would make it for now for < 4 arguments).

PS: Between 4 and 10 arguments, I think we can consider using the new inline array to avoid the object array allocation (probably not worth it, but fun nonetheless).