### PR TITLE
[Mono] Add coreclr_shutdown to mono 

### DIFF
--- a/src/mono/mono/mini/main-core.c
+++ b/src/mono/mono/mini/main-core.c
@@ -19,6 +19,7 @@
 #pragma comment(linker, "/export:coreclr_initialize=_coreclr_initialize@28")
 #pragma comment(linker, "/export:coreclr_execute_assembly=_coreclr_execute_assembly@24")
 #pragma comment(linker, "/export:coreclr_shutdown_2=_coreclr_shutdown_2@12")
+#pragma comment(linker, "/export:coreclr_shutdown=_coreclr_shutdown@8")
 #pragma comment(linker, "/export:coreclr_create_delegate=_coreclr_create_delegate@24")
 #pragma comment(linker, "/export:coreclr_set_error_writer=_coreclr_set_error_writer@4")
 #undef MONO_API

--- a/src/mono/mono/mini/main-core.c
+++ b/src/mono/mono/mini/main-core.c
@@ -39,6 +39,7 @@ MONO_API int STDAPICALLTYPE coreclr_execute_assembly (void* hostHandle, unsigned
 	const char* managedAssemblyPath, unsigned int* exitCode);
 
 MONO_API int STDAPICALLTYPE coreclr_shutdown_2 (void* hostHandle, unsigned int domainId, int* latchedExitCode);
+MONO_API int STDAPICALLTYPE coreclr_shutdown (void* hostHandle, unsigned int domainId);
 
 MONO_API int STDAPICALLTYPE coreclr_create_delegate (void* hostHandle, unsigned int domainId,
 	const char* entryPointAssemblyName, const char* entryPointTypeName, const char* entryPointMethodName,
@@ -104,6 +105,24 @@ int STDAPICALLTYPE coreclr_shutdown_2 (void* hostHandle, unsigned int domainId, 
 {
 	return monovm_shutdown (latchedExitCode);
 }
+
+//
+// Shutdown CoreCLR. It unloads the app domain and stops the CoreCLR host.
+//
+// Parameters:
+//  hostHandle              - Handle of the host
+//  domainId                - Id of the domain
+//  latchedExitCode         - Latched exit code after domain unloaded
+//
+// Returns:
+//  HRESULT indicating status of the operation. S_OK if the assembly was successfully executed
+//
+int STDAPICALLTYPE coreclr_shutdown (void* hostHandle, unsigned int domainId)
+{
+       int latchedExitCode = 0 ;
+       return monovm_shutdown (&latchedExitCode);
+}
+
 
 //
 // Create a native callable delegate for a managed method.


### PR DESCRIPTION
There was a crash seen while working on netcordbg due to unavailability of coreclr_shutdown
for mono. Implemented the missing code for mono. 