### PR TITLE
feat: PolymorphicTypeResolver support PropertyNameCaseInsensitive

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -76,7 +76,7 @@ namespace System.Text.Json.Serialization.Metadata
 
                 string propertyName = polymorphismOptions.TypeDiscriminatorPropertyName;
 
-                JsonEncodedText jsonEncodedName = propertyName == JsonSerializer.TypePropertyName
+                JsonEncodedText jsonEncodedName = string.Equals(propertyName, JsonSerializer.TypePropertyName, options.PropertyNameCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)
                     ? JsonSerializer.s_metadataType
                     : JsonEncodedText.Encode(propertyName, options.Encoder);
 


### PR DESCRIPTION
When using `JsonPolymorphicAttribute`, through `JsonSerializerOptions.PropertyNameCaseInsensitive` determine whether to enable property name case insensitive.