### PR TITLE
[release/7.0-staging][wasm][debugger] Improve debugger performance

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -1475,62 +1475,55 @@ namespace Microsoft.WebAssembly.Diagnostics
             }
         }
 
-        public async IAsyncEnumerable<SourceFile> Load(SessionId id, string[] loaded_files, ExecutionContext context, bool useDebuggerProtocol, [EnumeratorCancellation] CancellationToken token)
+        public async IAsyncEnumerable<SourceFile> Load(SessionId id, string[] loaded_files, ExecutionContext context, bool tryUseDebuggerProtocol, [EnumeratorCancellation] CancellationToken token)
         {
             var asm_files = new List<string>();
             List<DebugItem> steps = new List<DebugItem>();
 
-            if (!useDebuggerProtocol)
+            var pdb_files = new List<string>();
+            foreach (string file_name in loaded_files)
             {
-                var pdb_files = new List<string>();
-                foreach (string file_name in loaded_files)
+                if (file_name.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase))
+                    pdb_files.Add(file_name);
+                else
+                    asm_files.Add(file_name);
+            }
+
+            foreach (string url in asm_files)
+            {
+                try
                 {
-                    if (file_name.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase))
-                        pdb_files.Add(file_name);
-                    else
-                        asm_files.Add(file_name);
+                    string candidate_pdb = Path.ChangeExtension(url, "pdb");
+                    string pdb = pdb_files.FirstOrDefault(n => n == candidate_pdb);
+
+                    steps.Add(
+                        new DebugItem
+                        {
+                            Url = url,
+                            Data = Task.WhenAll(MonoProxy.HttpClient.GetByteArrayAsync(url, token), pdb != null ? MonoProxy.HttpClient.GetByteArrayAsync(pdb, token) : Task.FromResult<byte[]>(null))
+                        });
                 }
-
-                foreach (string url in asm_files)
+                catch (Exception e)
                 {
-                    try
+                    if (tryUseDebuggerProtocol)
                     {
-                        string candidate_pdb = Path.ChangeExtension(url, "pdb");
-                        string pdb = pdb_files.FirstOrDefault(n => n == candidate_pdb);
-
-                        steps.Add(
+                        try
+                        {
+                            string unescapedFileName = Uri.UnescapeDataString(url);
+                            steps.Add(
                             new DebugItem
                             {
                                 Url = url,
-                                Data = Task.WhenAll(MonoProxy.HttpClient.GetByteArrayAsync(url, token), pdb != null ? MonoProxy.HttpClient.GetByteArrayAsync(pdb, token) : Task.FromResult<byte[]>(null))
-                            });
-                    }
-                    catch (Exception e)
-                    {
-                        logger.LogDebug($"Failed to read {url} ({e.Message})");
-                    }
-                }
-            }
-            else
-            {
-                foreach (string file_name in loaded_files)
-                {
-                    if (file_name.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase))
-                        continue;
-                    try
-                    {
-                        string unescapedFileName = Uri.UnescapeDataString(file_name);
-                        steps.Add(
-                            new DebugItem
-                            {
-                                Url = file_name,
                                 Data = context.SdbAgent.GetBytesFromAssemblyAndPdb(Path.GetFileName(unescapedFileName), token)
                             });
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogDebug($"Failed to read {url} ({ex.Message})");
+                        }
                     }
-                    catch (Exception e)
-                    {
-                        logger.LogDebug($"Failed to read {file_name} ({e.Message})");
-                    }
+                    else
+                        logger.LogDebug($"Failed to read {url} ({e.Message})");
                 }
             }
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -1519,7 +1519,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         }
                         catch (Exception ex)
                         {
-                            logger.LogDebug($"Failed to read {url} ({ex.Message})");
+                            logger.LogDebug($"Failed to get bytes using debugger protocol {url} ({ex.Message})");
                         }
                     }
                     else

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -1523,7 +1523,9 @@ namespace Microsoft.WebAssembly.Diagnostics
                         }
                     }
                     else
+                    {
                         logger.LogDebug($"Failed to read {url} ({e.Message})");
+                    }
                 }
             }
 


### PR DESCRIPTION
Only try to use the debugger protocol if HttpClient.GetByteArrayAsync does not work.

Customer Impact:
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1772588
When the customer has a lot of assemblies in its solution the debugger takes a long time to attach.

Testing:
Launching the app and trying to debug. It reduces the attachment time by 2x, like from 4 seconds to 2 seconds.

Risk:
Low, only using the HttpClient.GetByteArrayAsync as it was used before, and retry with the debugger protocol if it fails.

