### PR TITLE
Enable finalizer events for EventPipe

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -304,7 +304,7 @@ namespace System.Runtime
         // Indicate that the current round of finalizations is complete.
         [DllImport(Redhawk.BaseName)]
         [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        internal static extern void RhpSignalFinalizationComplete();
+        internal static extern void RhpSignalFinalizationComplete(uint fCount);
 
         [DllImport(Redhawk.BaseName)]
         [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/__Finalizer.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/__Finalizer.cs
@@ -29,11 +29,11 @@ namespace System.Runtime
                 // otherwise memory is low and we should initiate a collection.
                 if (InternalCalls.RhpWaitForFinalizerRequest() != 0)
                 {
-                    DrainQueue();
+                    uint fCount = DrainQueue();
 
                     // Tell anybody that's interested that the finalization pass is complete (there is a race condition here
                     // where we might immediately signal a new request as complete, but this is acceptable).
-                    InternalCalls.RhpSignalFinalizationComplete();
+                    InternalCalls.RhpSignalFinalizationComplete(fCount);
                 }
                 else
                 {
@@ -48,14 +48,16 @@ namespace System.Runtime
         // objects that came off of the finalizer queue.  If such temps were reported across the duration of the
         // finalizer thread wait operation, it could cause unpredictable behavior with weak handles.
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static unsafe void DrainQueue()
+        private static unsafe uint DrainQueue()
         {
+            uint fCount = 0;
             // Drain the queue of finalizable objects.
             while (true)
             {
                 object target = InternalCalls.RhpGetNextFinalizableObject();
                 if (target == null)
-                    return;
+                    return fCount;
+                fCount++;
 
                 // Call the finalizer on the current target object. If the finalizer throws we'll fail
                 // fast via normal Redhawk exception semantics (since we don't attempt to catch

--- a/src/coreclr/nativeaot/Runtime/FinalizerHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/FinalizerHelpers.cpp
@@ -159,6 +159,7 @@ EXTERN_C NATIVEAOT_API UInt32_BOOL __cdecl RhpWaitForFinalizerRequest()
                     pWork = pNext;
                 }
             }
+            FireEtwGCFinalizersBegin_V1(GetClrInstanceId());
             return TRUE;
 
         case WAIT_OBJECT_0 + 1:
@@ -182,8 +183,9 @@ EXTERN_C NATIVEAOT_API UInt32_BOOL __cdecl RhpWaitForFinalizerRequest()
 }
 
 // Indicate that the current round of finalizations is complete.
-EXTERN_C NATIVEAOT_API void __cdecl RhpSignalFinalizationComplete()
+EXTERN_C NATIVEAOT_API void __cdecl RhpSignalFinalizationComplete(uint32_t fcount)
 {
+    FireEtwGCFinalizersEnd_V1(fcount, GetClrInstanceId());
     g_FinalizerDoneEvent.Set();
 }
 

--- a/src/tests/tracing/eventpipe/simpleruntimeeventvalidation/simpleruntimeeventvalidation.cs
+++ b/src/tests/tracing/eventpipe/simpleruntimeeventvalidation/simpleruntimeeventvalidation.cs
@@ -36,6 +36,15 @@ namespace Tracing.Tests.SimpleRuntimeEventValidation
                     //ExceptionKeyword (0x8000): 0b1000_0000_0000_0000
                     new List<EventPipeProvider>(){new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Warning, 0b1000_0000_0000_0000)}, 
                     1024, _DoesTraceContainExceptionEvents, enableRundownProvider:false);
+
+                if(ret == 100)
+                {
+                ret = IpcTraceTest.RunAndValidateEventCounts(
+                    new Dictionary<string, ExpectedEventCount>(){{ "Microsoft-Windows-DotNETRuntime", -1}}, 
+                    _eventGeneratingActionForFinalizers, 
+                    new List<EventPipeProvider>(){new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, 0b1)}, 
+                    1024, _DoesTraceContainFinazlierEvents, enableRundownProvider:false);
+                }
             }
 
             if (ret < 0)
@@ -71,6 +80,21 @@ namespace Tracing.Tests.SimpleRuntimeEventValidation
                     //Do nothing
                 }
             }
+        };
+
+        private static Action _eventGeneratingActionForFinalizers = () =>
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                if (i % 10 == 0)
+                    Logger.logger.Log($"Called GC.WaitForPendingFinalizers() {i} times...");
+                RuntimeEventValidation providerValidation = new RuntimeEventValidation();
+                providerValidation = null;
+                GC.WaitForPendingFinalizers();
+            }
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
         };
 
         private static Func<EventPipeEventSource, Func<int>> _DoesTraceContainGCEvents = (source) =>
@@ -127,6 +151,20 @@ namespace Tracing.Tests.SimpleRuntimeEventValidation
                 bool ExStartResult = ExStartEvents >= 10;
 
                 return ExStartResult ? 100 : -1;
+            };
+        };
+
+        private static Func<EventPipeEventSource, Func<int>> _DoesTraceContainFinazlierEvents = (source) =>
+        {
+            int GCFinalizersEndEvents = 0;
+            source.Clr.GCFinalizersStop += (eventData) => GCFinalizersEndEvents += 1;
+            int GCFinalizersStartEvents = 0;
+            source.Clr.GCFinalizersStart += (eventData) => GCFinalizersStartEvents += 1;
+            return () => {
+                Logger.logger.Log("Event counts validation");
+                Logger.logger.Log("GCFinalizersEndEvents: " + GCFinalizersEndEvents);
+                Logger.logger.Log("GCFinalizersStartEvents: " + GCFinalizersStartEvents);
+                return GCFinalizersEndEvents >= 50 && GCFinalizersStartEvents >= 50 ? 100 : -1;
             };
         };
     }

--- a/src/tests/tracing/eventpipe/simpleruntimeeventvalidation/simpleruntimeeventvalidation.cs
+++ b/src/tests/tracing/eventpipe/simpleruntimeeventvalidation/simpleruntimeeventvalidation.cs
@@ -43,7 +43,7 @@ namespace Tracing.Tests.SimpleRuntimeEventValidation
                     new Dictionary<string, ExpectedEventCount>(){{ "Microsoft-Windows-DotNETRuntime", -1}}, 
                     _eventGeneratingActionForFinalizers, 
                     new List<EventPipeProvider>(){new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, 0b1)}, 
-                    1024, _DoesTraceContainFinazlierEvents, enableRundownProvider:false);
+                    1024, _DoesTraceContainFinalizerEvents, enableRundownProvider:false);
                 }
             }
 
@@ -88,8 +88,6 @@ namespace Tracing.Tests.SimpleRuntimeEventValidation
             {
                 if (i % 10 == 0)
                     Logger.logger.Log($"Called GC.WaitForPendingFinalizers() {i} times...");
-                RuntimeEventValidation providerValidation = new RuntimeEventValidation();
-                providerValidation = null;
                 GC.WaitForPendingFinalizers();
             }
             GC.Collect();
@@ -154,7 +152,7 @@ namespace Tracing.Tests.SimpleRuntimeEventValidation
             };
         };
 
-        private static Func<EventPipeEventSource, Func<int>> _DoesTraceContainFinazlierEvents = (source) =>
+        private static Func<EventPipeEventSource, Func<int>> _DoesTraceContainFinalizerEvents = (source) =>
         {
             int GCFinalizersEndEvents = 0;
             source.Clr.GCFinalizersStop += (eventData) => GCFinalizersEndEvents += 1;


### PR DESCRIPTION
Enable `FireEtwGCFinalizersBegin_V1` and `FireEtwGCFinalizersEnd_V1 `events in `EventPipe`.

Fixes #88056