### PR TITLE
Fix options source gen with non-accessible validation attributes

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -249,11 +249,11 @@ The diagnostic id values reserved for .NET Libraries analyzer warnings are `SYSL
 |  __`SYSLIB1212`__ | Options validation generator: Member potentially missing transitive validation. |
 |  __`SYSLIB1213`__ | Options validation generator: Member potentially missing enumerable validation. |
 |  __`SYSLIB1214`__ | Options validation generator: Can't validate constants, static fields or properties. |
-|  __`SYSLIB1215`__ | *_`SYSLIB1214`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
-|  __`SYSLIB1216`__ | *_`SYSLIB1214`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
-|  __`SYSLIB1217`__ | *_`SYSLIB1214`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
-|  __`SYSLIB1218`__ | *_`SYSLIB1214`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
-|  __`SYSLIB1219`__ | *_`SYSLIB1214`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
+|  __`SYSLIB1215`__ | Options validation generator: Validation attribute on the member is inaccessible from the validator type. |
+|  __`SYSLIB1216`__ | *_`SYSLIB1216`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
+|  __`SYSLIB1217`__ | *_`SYSLIB1217`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
+|  __`SYSLIB1218`__ | *_`SYSLIB1218`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
+|  __`SYSLIB1219`__ | *_`SYSLIB1219`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
 |  __`SYSLIB1220`__ | JsonSourceGenerator encountered a [JsonConverterAttribute] with an invalid type argument. |
 |  __`SYSLIB1221`__ | JsonSourceGenerator does not support this C# language version. |
 |  __`SYSLIB1222`__ | Constructor annotated with JsonConstructorAttribute is inaccessible. |

--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -250,10 +250,10 @@ The diagnostic id values reserved for .NET Libraries analyzer warnings are `SYSL
 |  __`SYSLIB1213`__ | Options validation generator: Member potentially missing enumerable validation. |
 |  __`SYSLIB1214`__ | Options validation generator: Can't validate constants, static fields or properties. |
 |  __`SYSLIB1215`__ | Options validation generator: Validation attribute on the member is inaccessible from the validator type. |
-|  __`SYSLIB1216`__ | *_`SYSLIB1216`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
-|  __`SYSLIB1217`__ | *_`SYSLIB1217`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
-|  __`SYSLIB1218`__ | *_`SYSLIB1218`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
-|  __`SYSLIB1219`__ | *_`SYSLIB1219`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
+|  __`SYSLIB1216`__ | *_`SYSLIB1201`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
+|  __`SYSLIB1217`__ | *_`SYSLIB1201`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
+|  __`SYSLIB1218`__ | *_`SYSLIB1201`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
+|  __`SYSLIB1219`__ | *_`SYSLIB1201`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
 |  __`SYSLIB1220`__ | JsonSourceGenerator encountered a [JsonConverterAttribute] with an invalid type argument. |
 |  __`SYSLIB1221`__ | JsonSourceGenerator does not support this C# language version. |
 |  __`SYSLIB1222`__ | Constructor annotated with JsonConstructorAttribute is inaccessible. |

--- a/src/libraries/Microsoft.Extensions.Options/gen/DiagDescriptors.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/DiagDescriptors.cs
@@ -98,5 +98,12 @@ namespace Microsoft.Extensions.Options.Generators
             messageFormat: SR.CantValidateStaticOrConstMemberMessage,
             category: Category,
             defaultSeverity: DiagnosticSeverity.Warning);
+
+        public static DiagnosticDescriptor InaccessibleValidationAttribute { get; } = Make(
+            id: "SYSLIB1215",
+            title: SR.InaccessibleValidationAttributeTitle,
+            messageFormat: SR.InaccessibleValidationAttribute,
+            category: Category,
+            defaultSeverity: DiagnosticSeverity.Info);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/gen/DiagDescriptors.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/DiagDescriptors.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Extensions.Options.Generators
         public static DiagnosticDescriptor InaccessibleValidationAttribute { get; } = Make(
             id: "SYSLIB1215",
             title: SR.InaccessibleValidationAttributeTitle,
-            messageFormat: SR.InaccessibleValidationAttribute,
+            messageFormat: SR.InaccessibleValidationAttributeMessage,
             category: Category,
             defaultSeverity: DiagnosticSeverity.Info);
     }

--- a/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
@@ -439,7 +439,8 @@ namespace Microsoft.Extensions.Options.Generators
                     // pop the stack
                     _ = _visitedModelTypes.Remove(enumeratedType.WithNullableAnnotation(NullableAnnotation.None));
                 }
-                else if (ConvertTo(attributeType, _symbolHolder.ValidationAttributeSymbol))
+                else if (ConvertTo(attributeType, _symbolHolder.ValidationAttributeSymbol) &&
+                        _compilation.IsSymbolAccessibleWithin(attributeType, _compilation.Assembly))
                 {
                     var validationAttr = new ValidationAttributeInfo(attributeType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
                     validationAttrs.Add(validationAttr);

--- a/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
@@ -439,9 +439,14 @@ namespace Microsoft.Extensions.Options.Generators
                     // pop the stack
                     _ = _visitedModelTypes.Remove(enumeratedType.WithNullableAnnotation(NullableAnnotation.None));
                 }
-                else if (ConvertTo(attributeType, _symbolHolder.ValidationAttributeSymbol) &&
-                        _compilation.IsSymbolAccessibleWithin(attributeType, validatorType))
+                else if (ConvertTo(attributeType, _symbolHolder.ValidationAttributeSymbol))
                 {
+                    if (!_compilation.IsSymbolAccessibleWithin(attributeType, validatorType))
+                    {
+                        Diag(DiagDescriptors.InaccessibleValidationAttribute, location, attributeType.Name, member.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat), validatorType.Name);
+                        continue;
+                    }
+
                     var validationAttr = new ValidationAttributeInfo(attributeType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
                     validationAttrs.Add(validationAttr);
 

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/Strings.resx
@@ -201,7 +201,7 @@
   <data name="ValidatorsNeedSimpleConstructorTitle" xml:space="preserve">
     <value>Validators used for transitive or enumerable validation must have a constructor with no parameters.</value>
   </data>
-  <data name="InaccessibleValidationAttribute" xml:space="preserve">
+  <data name="InaccessibleValidationAttributeMessage" xml:space="preserve">
     <value>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</value>
   </data>
   <data name="InaccessibleValidationAttributeTitle" xml:space="preserve">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/Strings.resx
@@ -201,4 +201,10 @@
   <data name="ValidatorsNeedSimpleConstructorTitle" xml:space="preserve">
     <value>Validators used for transitive or enumerable validation must have a constructor with no parameters.</value>
   </data>
+  <data name="InaccessibleValidationAttribute" xml:space="preserve">
+    <value>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</value>
+  </data>
+  <data name="InaccessibleValidationAttributeTitle" xml:space="preserve">
+    <value>Validation attribute on the member is inaccessible from the validator type..</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.cs.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Typ anotovaný třídou OptionsValidatorAttribute neimplementuje nezbytné rozhraní.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">Ověřovací atributy nelze použít u privátního pole nebo vlastnosti {0}.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.cs.xlf
@@ -62,7 +62,7 @@
         <target state="translated">Typ anotovaný třídou OptionsValidatorAttribute neimplementuje nezbytné rozhraní.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.de.xlf
@@ -62,7 +62,7 @@
         <target state="translated">Ein mit "OptionsValidatorAttribute" versehener Typ implementiert nicht die erforderliche Schnittstelle.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.de.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Ein mit "OptionsValidatorAttribute" versehener Typ implementiert nicht die erforderliche Schnittstelle.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">Validierungsattribute können nicht auf private Felder oder Eigenschaften {0} angewendet werden.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.es.xlf
@@ -62,7 +62,7 @@
         <target state="translated">Un tipo anotado con “OptionsValidatorAttribute” no implementa la interfaz necesaria.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.es.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Un tipo anotado con “OptionsValidatorAttribute” no implementa la interfaz necesaria.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">No se pueden aplicar atributos de validación a la propiedad o campo privado {0}.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.fr.xlf
@@ -62,7 +62,7 @@
         <target state="translated">Un type annoté avec 'OptionsValidatorAttribute' n’implémente pas l’interface nécessaire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.fr.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Un type annoté avec 'OptionsValidatorAttribute' n’implémente pas l’interface nécessaire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">Impossible d’appliquer les attributs de validation au champ privé ou à la propriété {0}.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.it.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Un tipo annotato con 'OptionsValidatorAttribute' non implementa l'interfaccia necessaria.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">Non è possibile applicare gli attributi di convalida al campo privato o alla proprietà {0}.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.it.xlf
@@ -62,7 +62,7 @@
         <target state="translated">Un tipo annotato con 'OptionsValidatorAttribute' non implementa l'interfaccia necessaria.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ja.xlf
@@ -62,6 +62,16 @@
         <target state="translated">'OptionsValidatorAttribute' の注釈が付けられた型が、必要とされるインターフェイスを実装していません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">プライベート フィールドまたはプロパティ {0} には検証属性を適用できません。</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ja.xlf
@@ -62,7 +62,7 @@
         <target state="translated">'OptionsValidatorAttribute' の注釈が付けられた型が、必要とされるインターフェイスを実装していません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ko.xlf
@@ -62,7 +62,7 @@
         <target state="translated">'OptionsValidatorAttribute'로 주석이 추가된 형식은 필요한 인터페이스를 구현하지 않습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ko.xlf
@@ -62,6 +62,16 @@
         <target state="translated">'OptionsValidatorAttribute'로 주석이 추가된 형식은 필요한 인터페이스를 구현하지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">프라이빗 필드 또는 속성 {0}에 유효성 검사 특성을 적용할 수 없습니다.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pl.xlf
@@ -62,7 +62,7 @@
         <target state="translated">Typ z adnotacją „OptionsValidatorAttribute” nie implementuje wymaganego interfejsu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pl.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Typ z adnotacją „OptionsValidatorAttribute” nie implementuje wymaganego interfejsu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">Nie można zastosować atrybutów weryfikacji do pola prywatnego lub właściwości {0}.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -62,7 +62,7 @@
         <target state="translated">Um tipo anotado com "OptionsValidatorAttribute" não implementa a interface necessária.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Um tipo anotado com "OptionsValidatorAttribute" não implementa a interface necessária.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">Não é possível aplicar atributos de validação a um campo privado ou propriedade {0}.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ru.xlf
@@ -62,7 +62,7 @@
         <target state="translated">Тип с аннотацией OptionsValidatorAttribute не реализует необходимый интерфейс.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ru.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Тип с аннотацией OptionsValidatorAttribute не реализует необходимый интерфейс.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">Не удается применить атрибуты проверки к закрытому полю или свойству {0}.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.tr.xlf
@@ -62,6 +62,16 @@
         <target state="translated">'OptionsValidatorAttribute' ile açıklama eklenmiş bir tür gerekli arabirimi uygulamıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">Doğrulama öznitelikleri, {0} özel alanına veya özelliğine uygulanamıyor.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.tr.xlf
@@ -62,7 +62,7 @@
         <target state="translated">'OptionsValidatorAttribute' ile açıklama eklenmiş bir tür gerekli arabirimi uygulamıyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -62,7 +62,7 @@
         <target state="translated">用 "OptionsValidatorAttribute" 批注的类型未实现必要的接口。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -62,6 +62,16 @@
         <target state="translated">用 "OptionsValidatorAttribute" 批注的类型未实现必要的接口。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">无法将验证属性应用于专用字段或属性 {0}。</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -62,6 +62,16 @@
         <target state="translated">以 'OptionsValidatorAttribute' 附註的類型未實作必要的介面。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleValidationAttribute">
+        <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleValidationAttributeTitle">
+        <source>Validation attribute on the member is inaccessible from the validator type..</source>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
         <target state="translated">無法將驗證屬性套用至私用欄位或屬性 {0}。</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -62,7 +62,7 @@
         <target state="translated">以 'OptionsValidatorAttribute' 附註的類型未實作必要的介面。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InaccessibleValidationAttribute">
+      <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
         <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
@@ -1267,7 +1267,7 @@ namespace __OptionValidationStaticInstances
     }
 
     [ConditionalFact(nameof(SupportRemoteExecutionAndNotInBrowser))]
-    public void IgnoreNotAccessibleValidationAttributesTest()
+    public void InaccessibleValidationAttributesTest()
     {
         string source = """
             using System;
@@ -1357,7 +1357,8 @@ namespace __OptionValidationStaticInstances
                 .ConfigureAwait(false);
 
             _ = Assert.Single(generatedSources);
-            Assert.Empty(diagnostics);
+            Assert.Single(diagnostics);
+            Assert.Equal(DiagDescriptors.InaccessibleValidationAttribute.Id, diagnostics[0].Id);
             string generatedSource = generatedSources[0].SourceText.ToString();
             Assert.Contains("global::System.ComponentModel.DataAnnotations.RangeAttribute", generatedSource);
             Assert.Contains("global::System.ComponentModel.DataAnnotations.RequiredAttribute", generatedSource);

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
@@ -1179,7 +1179,9 @@ namespace __OptionValidationStaticInstances
         Assert.Equal(DiagDescriptors.ValidatorsNeedSimpleConstructor.Id, diagnostics[0].Id);
     }
 
-    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+    private static bool SupportRemoteExecutionAndNotInBrowser => RemoteExecutor.IsSupported && !PlatformDetection.IsBrowser;
+
+    [ConditionalFact(nameof(SupportRemoteExecutionAndNotInBrowser))]
     public void ProduceDiagnosticFromOtherAssemblyTest()
     {
         string source = """
@@ -1259,6 +1261,123 @@ namespace __OptionValidationStaticInstances
 
             // validate the location is inside the MyOptions class and not outside the compilation which is in the referenced assembly
             Assert.StartsWith("src-0.cs: (12,", diag.Location.GetLineSpan().ToString());
+        }, assemblyPath).Dispose();
+
+        File.Delete(assemblyPath); // cleanup
+    }
+
+    [ConditionalFact(nameof(SupportRemoteExecutionAndNotInBrowser))]
+    public void IgnoreNotAccessibleValidationAttributesTest()
+    {
+        string source = """
+            using System;
+            using System.ComponentModel.DataAnnotations;
+
+            #nullable enable
+
+            namespace ValidationTest;
+
+            public class BaseOptions
+            {
+                [Timeout] // internal attribute not visible outside the assembly
+                public int Prop1 { get; set; }
+
+                [Required]
+                public string Prop2 { get; set; }
+            }
+
+            [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+            internal sealed class TimeoutAttribute : ValidationAttribute
+            {
+                protected override ValidationResult IsValid(object? value, ValidationContext? validationContext)
+                {
+                    return ValidationResult.Success!;
+                }
+            }
+        """;
+
+        string assemblyName = Path.GetRandomFileName();
+        string assemblyPath = Path.Combine(Path.GetTempPath(), assemblyName + ".dll");
+
+        var compilation = CSharpCompilation
+                .Create(assemblyName, options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                .AddReferences(MetadataReference.CreateFromFile(AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == "System.Runtime").Location))
+                .AddReferences(MetadataReference.CreateFromFile(typeof(string).Assembly.Location))
+                .AddReferences(MetadataReference.CreateFromFile(typeof(RequiredAttribute).Assembly.Location))
+                .AddReferences(MetadataReference.CreateFromFile(typeof(OptionsValidatorAttribute).Assembly.Location))
+                .AddReferences(MetadataReference.CreateFromFile(typeof(IValidateOptions<object>).Assembly.Location))
+                .AddSyntaxTrees(CSharpSyntaxTree.ParseText(source));
+
+        EmitResult emitResult = compilation.Emit(assemblyPath);
+        Assert.True(emitResult.Success);
+
+        RemoteExecutor.Invoke(async (assemblyFullPath) => {
+            string source0 = """
+                using Microsoft.Extensions.Options;
+                """;
+
+            string source1 = """
+                using System.ComponentModel.DataAnnotations;
+
+                #nullable enable
+                #pragma warning disable CS1591
+
+                namespace ValidationTest
+                {
+                    public class ExtOptions : BaseOptions
+                    {
+                        [Range(0, 10)]
+                        public int Prop3 { get; set; }
+                    }
+                }
+                """;
+
+            string source2 = """
+                namespace ValidationTest
+                {
+                    [OptionsValidator]
+                    internal sealed partial class ExtOptionsValidator : IValidateOptions<ExtOptions>
+                    {
+                    }
+                }
+                """;
+
+            Assembly assembly = Assembly.LoadFrom(assemblyFullPath);
+
+            var (diagnostics, generatedSources) = await RoslynTestUtils.RunGenerator(
+                    new Generator(),
+                    new[]
+                    {
+                        assembly,
+                        Assembly.GetAssembly(typeof(RequiredAttribute)),
+                        Assembly.GetAssembly(typeof(OptionsValidatorAttribute)),
+                        Assembly.GetAssembly(typeof(IValidateOptions<object>)),
+                    },
+                    new List<string> { source0 + source1 + source2 })
+                .ConfigureAwait(false);
+
+            _ = Assert.Single(generatedSources);
+            Assert.Empty(diagnostics);
+            string generatedSource = generatedSources[0].SourceText.ToString();
+            Assert.Contains("global::System.ComponentModel.DataAnnotations.RangeAttribute", generatedSource);
+            Assert.Contains("global::System.ComponentModel.DataAnnotations.RequiredAttribute", generatedSource);
+            Assert.DoesNotContain("Timeout", generatedSource);
+
+            // Ensure the generated source compiles
+            var compilation = CSharpCompilation
+                    .Create(Path.GetRandomFileName()+".dll", options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                    .AddReferences(MetadataReference.CreateFromFile(AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == "System.Runtime").Location))
+                    .AddReferences(MetadataReference.CreateFromFile(typeof(string).Assembly.Location))
+                    .AddReferences(MetadataReference.CreateFromFile(typeof(RequiredAttribute).Assembly.Location))
+                    .AddReferences(MetadataReference.CreateFromFile(typeof(OptionsValidatorAttribute).Assembly.Location))
+                    .AddReferences(MetadataReference.CreateFromFile(typeof(IValidateOptions<object>).Assembly.Location))
+                    .AddReferences(MetadataReference.CreateFromFile(typeof(System.CodeDom.Compiler.GeneratedCodeAttribute).Assembly.Location))
+                    .AddReferences(MetadataReference.CreateFromFile(assemblyFullPath))
+                    .AddSyntaxTrees(CSharpSyntaxTree.ParseText(source1 + Environment.NewLine + generatedSource));
+
+            MemoryStream ms = new();
+            EmitResult emitResult = compilation.Emit(ms);
+            Assert.True(emitResult.Success);
         }, assemblyPath).Dispose();
 
         File.Delete(assemblyPath); // cleanup

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Resources/Strings.resx
@@ -204,4 +204,10 @@
   <data name="CantValidateStaticOrConstMemberTitle" xml:space="preserve">
     <value>Can't validate constants, static fields or properties.</value>
   </data>
+  <data name="InaccessibleValidationAttribute" xml:space="preserve">
+    <value>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</value>
+  </data>
+  <data name="InaccessibleValidationAttributeTitle" xml:space="preserve">
+    <value>Validation attribute on the member is inaccessible from the validator type..</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Resources/Strings.resx
@@ -204,7 +204,7 @@
   <data name="CantValidateStaticOrConstMemberTitle" xml:space="preserve">
     <value>Can't validate constants, static fields or properties.</value>
   </data>
-  <data name="InaccessibleValidationAttribute" xml:space="preserve">
+  <data name="InaccessibleValidationAttributeMessage" xml:space="preserve">
     <value>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</value>
   </data>
   <data name="InaccessibleValidationAttributeTitle" xml:space="preserve">

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Resources/Strings.resx
@@ -204,4 +204,10 @@
   <data name="CantValidateStaticOrConstMemberTitle" xml:space="preserve">
     <value>Can't validate constants, static fields or properties.</value>
   </data>
+  <data name="InaccessibleValidationAttribute" xml:space="preserve">
+    <value>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</value>
+  </data>
+  <data name="InaccessibleValidationAttributeTitle" xml:space="preserve">
+    <value>Validation attribute on the member is inaccessible from the validator type..</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Resources/Strings.resx
@@ -204,7 +204,7 @@
   <data name="CantValidateStaticOrConstMemberTitle" xml:space="preserve">
     <value>Can't validate constants, static fields or properties.</value>
   </data>
-  <data name="InaccessibleValidationAttribute" xml:space="preserve">
+  <data name="InaccessibleValidationAttributeMessage" xml:space="preserve">
     <value>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</value>
   </data>
   <data name="InaccessibleValidationAttributeTitle" xml:space="preserve">


### PR DESCRIPTION
The Options source generator creates code for validating an options class. This options class may be inherited from a base class located in a different assembly. It is also possible for the base class to have properties marked with the **internal** validation attribute, which means they should not be accessible outside the base class assembly. In such situations, the source generator should exclude the validation of these properties since it cannot generate code to access internal properties. Here's an example code illustrating this problem:

### Assembly 1 
```C#
        using System;
        using System.ComponentModel.DataAnnotations;

        #nullable enable

        namespace ValidationTest;

        public class BaseOptions
        {
            [Timeout] // internal attribute not visible outside the assembly
            public int Prop1 { get; set; }

            [Required]
            public string Prop2 { get; set; }
        }

        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
        internal sealed class TimeoutAttribute : ValidationAttribute
        {
            protected override ValidationResult IsValid(object? value, ValidationContext? validationContext)
            {
                return ValidationResult.Success!;
            }
        }
``` 

### Assembly 2 reference Assembly 1 and uses the source gen 

```C#
        using Microsoft.Extensions.Options;
        using System.ComponentModel.DataAnnotations;

        #nullable enable
        #pragma warning disable CS1591

        namespace ValidationTest;
   
        public class ExtOptions : BaseOptions
        {
            [Range(0, 10)]
            public int Prop3 { get; set; }
         }

        [OptionsValidator]
        internal sealed partial class ExtOptionsValidator : IValidateOptions<ExtOptions>
        {
        }
    }
``` 
