### PR TITLE
Ensure that the CpuId tests set preferredVectorByteLength to a non-zero value

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2306,13 +2306,10 @@ void Compiler::compSetProcessor()
             // users can override this with `DOTNET_PreferredVectorBitWidth=512` to
             // allow using such instructions where hardware support is available.
             //
-            // Under stress, sometimes leave the preferred vector width at 512, even if that means
-            // throttling. This helps with test coverage on test machines that might be older.
+            // Do not condition this based on stress mode as it makes the support
+            // reported inconsistent across methods and breaks expectations/functionality
 
-            if (!compStressCompile(STRESS_GENERIC_VARN, 20))
-            {
-                preferredVectorByteLength = 256 / 8;
-            }
+            preferredVectorByteLength = 256 / 8;
         }
     }
 

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Base/CpuId.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Base/CpuId.cs
@@ -256,9 +256,13 @@ namespace XarchHardwareIntrinsicTest._CpuId
                     }
                 }
 
-                if (isVector512Throttling)
+                if (isAvx512HierarchyDisabled || isVector512Throttling)
                 {
                     preferredVectorByteLength = 256 / 8;
+                }
+                else
+                {
+                    preferredVectorByteLength = 512 / 8;
                 }
             }
 

--- a/src/tests/readytorun/HardwareIntrinsics/X86/CpuId.cs
+++ b/src/tests/readytorun/HardwareIntrinsics/X86/CpuId.cs
@@ -251,9 +251,13 @@ namespace XarchHardwareIntrinsicTest._CpuId
                     }
                 }
 
-                if (isVector512Throttling)
+                if (isAvx512HierarchyDisabled || isVector512Throttling)
                 {
                     preferredVectorByteLength = 256 / 8;
+                }
+                else
+                {
+                    preferredVectorByteLength = 512 / 8;
                 }
             }
 


### PR DESCRIPTION
This resolves https://github.com/dotnet/runtime/issues/88581 and resolves https://github.com/dotnet/runtime/issues/88582 and resolves https://github.com/dotnet/runtime/issues/88580