### PR TITLE
[wasm][debugger] Fix regex for helix retries when chrome fails to launch

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -5,6 +5,6 @@
   "retryOnRules": [
     { "testAssembly": { "wildcard": "System.Net.*" } },
     { "failureMessage": { "regex": ".*Timed out after .* waiting for the browser to be ready.*" } },
-    { "failureMessage": { "regex": "System.IO.IOException : Process for .*chrome .* unexpectedly exited.* during startup" } }
+    { "failureMessage": { "regex": "System.IO.IOException : Process for .*chrome.*unexpectedly exited.* during startup" } }
   ]
 }


### PR DESCRIPTION
The regex was slightly off, and expected at least two spaces between `chrome` and `unexpected`.

Fixes https://github.com/dotnet/runtime/issues/87053 .