### PR TITLE
[wasm][debugger]Fix hotreload tests

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
@@ -52,7 +52,6 @@ namespace DebuggerTests
         }
 
         [ConditionalTheory(nameof(RunningOnChrome))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88528")]
         [InlineData("ApplyUpdateReferencedAssembly")]
         [InlineData("ApplyUpdateReferencedAssemblyChineseCharInPath\u3128")]
         public async Task DebugHotReloadMethodAddBreakpoint(string assembly_name)
@@ -221,7 +220,6 @@ namespace DebuggerTests
         }
 
         [ConditionalTheory(nameof(RunningOnChrome))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88528")]
         [InlineData("ApplyUpdateReferencedAssembly")]
         [InlineData("ApplyUpdateReferencedAssemblyChineseCharInPath\u3128")]
         public async Task DebugHotReloadMethodAddBreakpointUsingSDB(string assembly_name)
@@ -418,7 +416,6 @@ namespace DebuggerTests
         }
 
         [ConditionalFact(nameof(RunningOnChrome))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88528")]
         public async Task DebugHotReloadMethod_AddingNewMethod()
         {
             string asm_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.dll");
@@ -449,7 +446,6 @@ namespace DebuggerTests
         }
 
         [ConditionalFact(nameof(RunningOnChrome))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88528")]
         public async Task DebugHotReloadMethod_AddingNewStaticField()
         {
             string asm_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.dll");


### PR DESCRIPTION
It was throwing an exception while trying to read a CustomAttributeName.
Then hotreload was broken.