### PR TITLE
[RISC-V] Fix GitHub_* tests

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -6510,8 +6510,6 @@ void CodeGen::genJmpMethod(GenTree* jmp)
         {
             var_types loadType = TYP_UNDEF;
 
-            // NOTE for RISCV64: not supports the HFA.
-            assert(!varDsc->lvIsHfaRegArg());
             if (varTypeIsStruct(varDsc))
             {
                 // Must be <= 16 bytes or else it wouldn't be passed in registers, except for HFA,

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -6520,7 +6520,9 @@ void CodeGen::genJmpMethod(GenTree* jmp)
                     loadType = varDsc->lvIs4Field1 ? TYP_FLOAT : TYP_DOUBLE;
                 }
                 else
+                {
                     loadType = varDsc->GetLayout()->GetGCPtrType(0);
+                }
             }
             else
             {
@@ -6547,7 +6549,9 @@ void CodeGen::genJmpMethod(GenTree* jmp)
                     loadType = varDsc->lvIs4Field2 ? TYP_FLOAT : TYP_DOUBLE;
                 }
                 else
+                {
                     loadType = varDsc->GetLayout()->GetGCPtrType(1);
+                }
 
                 loadSize = emitActualTypeSize(loadType);
                 int offs = loadSize == EA_4BYTE ? 4 : 8;

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -6510,12 +6510,19 @@ void CodeGen::genJmpMethod(GenTree* jmp)
         {
             var_types loadType = TYP_UNDEF;
 
+            // NOTE for RISCV64: not supports the HFA.
+            assert(!varDsc->lvIsHfaRegArg());
             if (varTypeIsStruct(varDsc))
             {
                 // Must be <= 16 bytes or else it wouldn't be passed in registers, except for HFA,
                 // which can be bigger (and is handled above).
                 noway_assert(EA_SIZE_IN_BYTES(varDsc->lvSize()) <= 16);
-                loadType = varDsc->GetLayout()->GetGCPtrType(0);
+                if (emitter::isFloatReg(argReg))
+                {
+                    loadType = varDsc->lvIs4Field1 ? TYP_FLOAT : TYP_DOUBLE;
+                }
+                else
+                    loadType = varDsc->GetLayout()->GetGCPtrType(0);
             }
             else
             {
@@ -6532,14 +6539,21 @@ void CodeGen::genJmpMethod(GenTree* jmp)
             regSet.AddMaskVars(genRegMask(argReg));
             gcInfo.gcMarkRegPtrVal(argReg, loadType);
 
-            if (compiler->lvaIsMultiregStruct(varDsc, compiler->info.compIsVarArgs))
+            if (varDsc->GetOtherArgReg() < REG_STK)
             {
                 // Restore the second register.
-                argRegNext = genRegArgNext(argReg);
+                argRegNext = varDsc->GetOtherArgReg();
 
-                loadType = varDsc->GetLayout()->GetGCPtrType(1);
+                if (emitter::isFloatReg(argRegNext))
+                {
+                    loadType = varDsc->lvIs4Field2 ? TYP_FLOAT : TYP_DOUBLE;
+                }
+                else
+                    loadType = varDsc->GetLayout()->GetGCPtrType(1);
+
                 loadSize = emitActualTypeSize(loadType);
-                GetEmitter()->emitIns_R_S(ins_Load(loadType), loadSize, argRegNext, varNum, TARGET_POINTER_SIZE);
+                int offs = loadSize == EA_4BYTE ? 4 : 8;
+                GetEmitter()->emitIns_R_S(ins_Load(loadType), loadSize, argRegNext, varNum, offs);
 
                 regSet.AddMaskVars(genRegMask(argRegNext));
                 gcInfo.gcMarkRegPtrVal(argRegNext, loadType);

--- a/src/coreclr/vm/riscv64/virtualcallstubcpu.hpp
+++ b/src/coreclr/vm/riscv64/virtualcallstubcpu.hpp
@@ -82,8 +82,7 @@ struct DispatchStub
 private:
     friend struct DispatchHolder;
 
-    DWORD _entryPoint[9];
-    DWORD _pad;
+    DWORD _entryPoint[8];
     size_t  _expectedMT;
     PCODE _implTarget;
     PCODE _failTarget;
@@ -102,14 +101,13 @@ struct DispatchHolder
     void  Initialize(DispatchHolder* pDispatchHolderRX, PCODE implTarget, PCODE failTarget, size_t expectedMT)
     {
         // auipc t4,0
-        // addi  t4, t4, 36 
-        // ld  t0,0(a0) ; methodTable from object in $a0
-        // ld  t6,0(t4)    // t6 _expectedMT
-        // bne  t6, t0, failLabel
-        // ld  t4, 8(t4)    // t4 _implTarget
+        // ld    t0, 0(a0)     // methodTable from object in $a0
+        // ld    t6, 32(t4)    // t6 _expectedMT
+        // bne   t6, t0, failLabel
+        // ld    t4, 40(t4)    // t4 _implTarget
         // jalr  x0, t4, 0
         // failLabel:
-        // ld  t4, 16(t4)    // t4 _failTarget
+        // ld    t4, 48(t4)    // t4 _failTarget
         // jalr  x0, t4, 0
         //
         //
@@ -117,15 +115,14 @@ struct DispatchHolder
         // _implTarget
         // _failTarget
 
-        _stub._entryPoint[0] = DISPATCH_STUB_FIRST_DWORD; // auipc  t4,0 // 0x00000e97
-        _stub._entryPoint[1] = 0x028e8e93; // addi  t4, t4, 40
-        _stub._entryPoint[2] = 0x00053283; // ld  t0, 0(a0)    //; methodTable from object in $a0
-        _stub._entryPoint[3] = 0x000ebf83; // ld  r6, 0(t4)    // t6 _expectedMT
-        _stub._entryPoint[4] = 0x005f9663; // bne  t6, t0, failLabel
-        _stub._entryPoint[5] = 0x008ebe83; // ld  t4, 8(t4)    // t4 _implTarget
-        _stub._entryPoint[6] = 0x000e8067; // jalr x0, t4, 0
-        _stub._entryPoint[7] = 0x010ebe83; // ld  t4, 16(t4)    // t4 _failTarget
-        _stub._entryPoint[8] = 0x000e8067; // jalr x0, t4, 0
+        _stub._entryPoint[0] = DISPATCH_STUB_FIRST_DWORD; // auipc t4,0  // 0x00000e97
+        _stub._entryPoint[1] = 0x00053283; // ld    t0, 0(a0)     // methodTable from object in $a0
+        _stub._entryPoint[2] = 0x020ebf83; // ld    t6, 32(t4)    // t6 _expectedMT
+        _stub._entryPoint[3] = 0x005f9663; // bne   t6, t0, failLabel
+        _stub._entryPoint[4] = 0x028ebe83; // ld    t4, 40(t4)    // t4 _implTarget
+        _stub._entryPoint[5] = 0x000e8067; // jalr  x0, t4, 0
+        _stub._entryPoint[6] = 0x030ebe83; // ld    t4, 48(t4)    // t4 _failTarget
+        _stub._entryPoint[7] = 0x000e8067; // jalr  x0, t4, 0
 
         _stub._expectedMT = expectedMT;
         _stub._implTarget = implTarget;


### PR DESCRIPTION
- Fix an assertion in GitHub_17585 by updating DISPATCH STUB
- Fix a invalid result in GitHub_23147 by updating `genJmpMethod` in `codegenriscv64.cpp`
```
FAILED   - [  20s]./JIT/Regression/JitBlue/GitHub_17585/GitHub_17585/GitHub_17585.sh
               BEGIN EXECUTION
               /work/dotnet/riscv64/artifacts/tests/coreclr/linux.riscv64.Checked/Tests/Core_Root/corerun -p System.Reflection.Metadata.MetadataUpdater.IsSupported=false -p System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=true GitHub_17585.dll ''

               Assert failure(PID 637342 [0x0009b99e], Thread: 637342 [0x9b99e]): !"AV in DispatchStub at unknown instruction"
                   File: /home/clamp/Work/dotnet/riscv64/src/coreclr/vm/riscv64/stubs.cpp Line: 876
                   Image: /work/dotnet/riscv64/artifacts/tests/coreclr/linux.riscv64.Checked/Tests/Core_Root/corerun

               ./GitHub_17585.sh: line 448: 637342 Aborted                 (core dumped) $LAUNCHER $ExePath "${CLRTestExecutionArguments[@]}"
               Expected: 100
               Actual: 134
               END EXECUTION - FAILED


FAILED   - [  14s]./JIT/Regression/JitBlue/GitHub_23147/GitHub_23147/GitHub_23147.sh
               BEGIN EXECUTION
               /work/dotnet/jobs/riscv/bugfix/artifacts/tests/coreclr/linux.riscv64.Checked/Tests/Core_Root/corerun -p System.Reflection.Metadata.MetadataUpdater.IsSupported=false -p System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=true GitHub_23147.dll ''
               jmp_test_f2 FAIL
               jmp_test_f3 PASS
               jmp_test_f4 PASS
               jmp_test_d2 PASS
               jmp_test_d3 PASS
               jmp_test_d4 PASS
               Expected: 100
               Actual: 1
               END EXECUTION - FAILED
```

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov