### PR TITLE
[libs][Unix] Fix UTC alias lookup

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -33,8 +33,8 @@ namespace System
                 case 69: // e
                 case 101: // E
                     return string.Equals(id, "Etc/UTC", StringComparison.OrdinalIgnoreCase) ||
+                           string.Equals(id, "Etc/UCT", StringComparison.OrdinalIgnoreCase) ||
                            string.Equals(id, "Etc/Universal", StringComparison.OrdinalIgnoreCase) ||
-                           string.Equals(id, "Etc/UTC", StringComparison.OrdinalIgnoreCase) ||
                            string.Equals(id, "Etc/Zulu", StringComparison.OrdinalIgnoreCase);
                 case 85: // u
                 case 117: // U

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2428,9 +2428,14 @@ namespace System.Tests
         [PlatformSpecific(~TestPlatforms.Windows)]
         public static void UtcAliases_MapToUtc()
         {
+            TimeZoneInfo.AdjustmentRule[] expectedAdjustmentRules = TimeZoneInfo.Utc.GetAdjustmentRules();
+
             foreach (string utcAlias in s_UtcAliases)
             {
-                Assert.Equal(TimeZoneInfo.Utc, TimeZoneInfo.FindSystemTimeZoneById(utcAlias));
+                TimeZoneInfo actualUtc = TimeZoneInfo.FindSystemTimeZoneById(utcAlias);
+                Assert.Equal(TimeZoneInfo.Utc.BaseUtcOffset, actualUtc.BaseUtcOffset);
+                Assert.Equal(TimeZoneInfo.Utc.SupportsDaylightSavingTime, actualUtc.SupportsDaylightSavingTime);
+                Assert.Equal(expectedAdjustmentRules, actualUtc.GetAdjustmentRules());
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2428,14 +2428,10 @@ namespace System.Tests
         [PlatformSpecific(~TestPlatforms.Windows)]
         public static void UtcAliases_MapToUtc()
         {
-            TimeZoneInfo.AdjustmentRule[] expectedAdjustmentRules = TimeZoneInfo.Utc.GetAdjustmentRules();
-
             foreach (string utcAlias in s_UtcAliases)
             {
                 TimeZoneInfo actualUtc = TimeZoneInfo.FindSystemTimeZoneById(utcAlias);
-                Assert.Equal(TimeZoneInfo.Utc.BaseUtcOffset, actualUtc.BaseUtcOffset);
-                Assert.Equal(TimeZoneInfo.Utc.SupportsDaylightSavingTime, actualUtc.SupportsDaylightSavingTime);
-                Assert.Equal(expectedAdjustmentRules, actualUtc.GetAdjustmentRules());
+                Assert.True(TimeZoneInfo.Utc.HasSameRules(actualUtc));
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2424,6 +2424,16 @@ namespace System.Tests
             }
         }
 
+        [Fact]
+        [PlatformSpecific(~TestPlatforms.Windows)]
+        public static void UtcAliases_MapToUtc()
+        {
+            foreach (string utcAlias in s_UtcAliases)
+            {
+                Assert.Equal(TimeZoneInfo.Utc, TimeZoneInfo.FindSystemTimeZoneById(utcAlias));
+            }
+        }
+
         [ActiveIssue("https://github.com/dotnet/runtime/issues/19794", TestPlatforms.AnyUnix)]
         [Theory]
         [MemberData(nameof(SystemTimeZonesTestData))]

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2335,9 +2335,12 @@ namespace System.Tests
                     }
                 }
 
-                foreach (string alias in s_UtcAliases)
+                if (!PlatformDetection.IsBrowser)
                 {
-                    yield return new object[] { TimeZoneInfo.FindSystemTimeZoneById(alias) };
+                    foreach (string alias in s_UtcAliases)
+                    {
+                        yield return new object[] { TimeZoneInfo.FindSystemTimeZoneById(alias) };
+                    }
                 }
             }
         }

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2425,7 +2425,7 @@ namespace System.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.Windows)]
+        [PlatformSpecific(~TestPlatforms.Windows & ~TestPlatforms.Browser)]
         public static void UtcAliases_MapToUtc()
         {
             TimeZoneInfo.AdjustmentRule[] expectedAdjustmentRules = TimeZoneInfo.Utc.GetAdjustmentRules();

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2429,6 +2429,20 @@ namespace System.Tests
             }
         }
 
+        [Fact]
+        [PlatformSpecific(~TestPlatforms.Windows & ~TestPlatforms.Browser)]
+        public static void UtcAliases_MapToUtc()
+        {
+            TimeZoneInfo.AdjustmentRule[] expectedAdjustmentRules = TimeZoneInfo.Utc.GetAdjustmentRules();
+
+            foreach (var alias in s_UtcAliases)
+            {
+                TimeZoneInfo actualUtc = TimeZoneInfo.FindSystemTimeZoneById(alias);
+                Assert.Equal(TimeZoneInfo.Utc.BaseUtcOffset, actualUtc.BaseUtcOffset);
+                Assert.Equal(expectedAdjustmentRules, actualUtc.GetAdjustmentRules());
+            }
+        }
+
         [ActiveIssue("https://github.com/dotnet/runtime/issues/19794", TestPlatforms.AnyUnix)]
         [Theory]
         [MemberData(nameof(SystemTimeZonesTestData))]

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2428,10 +2428,13 @@ namespace System.Tests
         [PlatformSpecific(~TestPlatforms.Windows)]
         public static void UtcAliases_MapToUtc()
         {
-            foreach (string utcAlias in s_UtcAliases)
+            TimeZoneInfo.AdjustmentRule[] expectedAdjustmentRules = TimeZoneInfo.Utc.GetAdjustmentRules();
+
+            foreach (var alias in s_UtcAliases)
             {
-                TimeZoneInfo actualUtc = TimeZoneInfo.FindSystemTimeZoneById(utcAlias);
-                Assert.True(TimeZoneInfo.Utc.HasSameRules(actualUtc));
+                TimeZoneInfo actualUtc = TimeZoneInfo.FindSystemTimeZoneById(alias);
+                Assert.Equal(TimeZoneInfo.Utc.BaseUtcOffset, actualUtc.BaseUtcOffset);
+                Assert.Equal(expectedAdjustmentRules, actualUtc.GetAdjustmentRules());
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2334,6 +2334,11 @@ namespace System.Tests
                         yield return new object[] { tz };
                     }
                 }
+
+                foreach (string alias in s_UtcAliases)
+                {
+                    yield return new object[] { TimeZoneInfo.FindSystemTimeZoneById(alias) };
+                }
             }
         }
 
@@ -2421,20 +2426,6 @@ namespace System.Tests
                 {
                     Assert.False(string.IsNullOrWhiteSpace(timeZone.DaylightName), $"Id: \"{timeZone.Id}\", DaylightName should not have been empty.");
                 }
-            }
-        }
-
-        [Fact]
-        [PlatformSpecific(~TestPlatforms.Windows & ~TestPlatforms.Browser)]
-        public static void UtcAliases_MapToUtc()
-        {
-            TimeZoneInfo.AdjustmentRule[] expectedAdjustmentRules = TimeZoneInfo.Utc.GetAdjustmentRules();
-
-            foreach (var alias in s_UtcAliases)
-            {
-                TimeZoneInfo actualUtc = TimeZoneInfo.FindSystemTimeZoneById(alias);
-                Assert.Equal(TimeZoneInfo.Utc.BaseUtcOffset, actualUtc.BaseUtcOffset);
-                Assert.Equal(expectedAdjustmentRules, actualUtc.GetAdjustmentRules());
             }
         }
 


### PR DESCRIPTION
* Fix UTC -> UCT typo
* Re-order lookup to match source in the comment linked above

I noticed #88368 introduced this bug.

Not sure if this should have a regression test, or where such a test would go.