### PR TITLE
[mono] Fix the formatting of field types FieldInfo.ToString () so it …

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -237,6 +237,7 @@
     <Compile Include="System\Reflection\InvokeRefReturn.cs" />
     <Compile Include="System\Reflection\InvokeWithRefLikeArgs.cs" />
     <Compile Include="System\Reflection\IsCollectibleTests.cs" />
+    <Compile Include="System\Reflection\FieldInfoTests.cs" />
     <Compile Include="System\Reflection\MethodBaseTests.cs" />
     <Compile Include="System\Reflection\MethodBodyTests.cs" />
     <Compile Include="System\Reflection\ModuleTests.cs" />

--- a/src/libraries/System.Runtime/tests/System/Reflection/FieldInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/FieldInfoTests.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+using TestAttributes;
+
+namespace System.Reflection.Tests
+{
+    public class FieldInfoTests
+    {
+        public int int_field;
+
+        [Fact]
+        public void ToStringFieldType()
+        {
+            Assert.Equal("Int32 int_field", typeof(FieldInfoTests).GetField("int_field").ToString());
+        }
+    }
+}

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -218,7 +218,7 @@ namespace System.Reflection
 
         public override string ToString()
         {
-            return $"{FieldType} {name}";
+            return $"{FieldType.FormatTypeName ()} {name}";
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
…matches clr.

Fixes https://github.com/dotnet/runtime/issues/88637.