### PR TITLE
Light up Ascii.Equality.Equals and Ascii.Equality.EqualsIgnoreCase with Vector512 code path

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -536,8 +536,7 @@ namespace System.Text
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static Vector512<ushort> Load512(ref byte ptr)
             {
-                (Vector512<ushort> lower, Vector512<ushort> _) = Vector512.Widen(Vector256.LoadUnsafe(ref ptr).ToVector512());
-                return lower;
+                return Vector512.WidenLower(Vector256.LoadUnsafe(ref ptr).ToVector512());
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -536,17 +536,6 @@ namespace System.Text
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static Vector512<ushort> Load512(ref byte ptr)
             {
-                // This is done here for performance gain.
-                // A similar implementation would be as below:
-                //
-                //      (Vector256<ushort> lower, Vector256<ushort> upper) = Vector256.Widen(Vector256.LoadUnsafe(ref ptr));
-                //      return Vector512.Create(lower, upper);
-                //
-                // This is similar to what is done for Load256 here. But
-                // for Vector512, this implementation is low performance
-                // since a load and widen on Vector256 followed by a
-                // create on Vector512 is leading to a performance lower
-                // than that of similar implementationfor Vector256.
                 (Vector512<ushort> lower, Vector512<ushort> _) = Vector512.Widen(Vector256.LoadUnsafe(ref ptr).ToVector512());
                 return lower;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -99,7 +99,7 @@ namespace System.Text
                     }
                 }
             }
-            else if (Avx.IsSupported && length >= (uint)Vector256<TRight>.Count)
+            else if (Avx.IsSupported && length >= (uint)Vector256<TLeft>.Count)
             {
                 ref TLeft currentLeftSearchSpace = ref left;
                 ref TRight currentRightSearchSpace = ref right;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -61,42 +61,34 @@ namespace System.Text
                     }
                 }
             }
-            else if (Vector512.IsHardwareAccelerated && length >= (uint)Vector512<TRight>.Count)
+            else if (Vector512.IsHardwareAccelerated && length >= (uint)Vector512<TLeft>.Count)
             {
                 ref TLeft currentLeftSearchSpace = ref left;
-                ref TLeft oneVectorAwayFromLeftEnd = ref Unsafe.Add(ref currentLeftSearchSpace, length - TLoader.Count512);
                 ref TRight currentRightSearchSpace = ref right;
-                ref TRight oneVectorAwayFromRightEnd = ref Unsafe.Add(ref currentRightSearchSpace, length - (uint)Vector512<TRight>.Count);
-
-                Vector512<TRight> leftValues;
-                Vector512<TRight> rightValues;
+                // Add Vector512<TLeft>.Count because TLeft == TRight
+                // Or we are in the Widen case where we iterate 2 * TRight.Count which is the same as TLeft.Count
+                Debug.Assert(Vector512<TLeft>.Count == Vector512<TRight>.Count
+                    || (typeof(TLoader) == typeof(WideningLoader) && Vector512<TLeft>.Count == Vector512<TRight>.Count * 2));
+                ref TRight oneVectorAwayFromRightEnd = ref Unsafe.Add(ref currentRightSearchSpace, length - (uint)Vector512<TLeft>.Count);
 
                 // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
                 do
                 {
-                    leftValues = TLoader.Load512(ref currentLeftSearchSpace);
-                    rightValues = Vector512.LoadUnsafe(ref currentRightSearchSpace);
-
-                    if (leftValues != rightValues || !AllCharsInVectorAreAscii(leftValues | rightValues))
+                    if (!TLoader.EqualAndAscii512(ref currentLeftSearchSpace, ref currentRightSearchSpace))
                     {
                         return false;
                     }
 
-                    currentRightSearchSpace = ref Unsafe.Add(ref currentRightSearchSpace, Vector512<TRight>.Count);
-                    currentLeftSearchSpace = ref Unsafe.Add(ref currentLeftSearchSpace, TLoader.Count512);
+                    currentRightSearchSpace = ref Unsafe.Add(ref currentRightSearchSpace, Vector512<TLeft>.Count);
+                    currentLeftSearchSpace = ref Unsafe.Add(ref currentLeftSearchSpace, Vector512<TLeft>.Count);
                 }
                 while (!Unsafe.IsAddressGreaterThan(ref currentRightSearchSpace, ref oneVectorAwayFromRightEnd));
 
                 // If any elements remain, process the last vector in the search space.
-                if (length % (uint)Vector512<TRight>.Count != 0)
+                if (length % (uint)Vector512<TLeft>.Count != 0)
                 {
-                    leftValues = TLoader.Load512(ref oneVectorAwayFromLeftEnd);
-                    rightValues = Vector512.LoadUnsafe(ref oneVectorAwayFromRightEnd);
-
-                    if (leftValues != rightValues || !AllCharsInVectorAreAscii(leftValues | rightValues))
-                    {
-                        return false;
-                    }
+                    ref TLeft oneVectorAwayFromLeftEnd = ref Unsafe.Add(ref left, length - (uint)Vector512<TLeft>.Count);
+                    return TLoader.EqualAndAscii512(ref oneVectorAwayFromLeftEnd, ref oneVectorAwayFromRightEnd);
                 }
             }
             else if (Avx.IsSupported && length >= (uint)Vector256<TLeft>.Count)
@@ -112,7 +104,7 @@ namespace System.Text
                 // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
                 do
                 {
-                    if (!TLoader.EqualAndAscii(ref currentLeftSearchSpace, ref currentRightSearchSpace))
+                    if (!TLoader.EqualAndAscii256(ref currentLeftSearchSpace, ref currentRightSearchSpace))
                     {
                         return false;
                     }
@@ -126,7 +118,7 @@ namespace System.Text
                 if (length % (uint)Vector256<TLeft>.Count != 0)
                 {
                     ref TLeft oneVectorAwayFromLeftEnd = ref Unsafe.Add(ref left, length - (uint)Vector256<TLeft>.Count);
-                    return TLoader.EqualAndAscii(ref oneVectorAwayFromLeftEnd, ref oneVectorAwayFromRightEnd);
+                    return TLoader.EqualAndAscii256(ref oneVectorAwayFromLeftEnd, ref oneVectorAwayFromRightEnd);
                 }
             }
             else
@@ -255,7 +247,6 @@ namespace System.Text
                 {
                     leftValues = TLoader.Load512(ref currentLeftSearchSpace);
                     rightValues = Vector512.LoadUnsafe(ref currentRightSearchSpace);
-
                     if (!AllCharsInVectorAreAscii(leftValues | rightValues))
                     {
                         return false;
@@ -467,7 +458,8 @@ namespace System.Text
             static abstract Vector128<TRight> Load128(ref TLeft ptr);
             static abstract Vector256<TRight> Load256(ref TLeft ptr);
             static abstract Vector512<TRight> Load512(ref TLeft ptr);
-            static abstract bool EqualAndAscii(ref TLeft left, ref TRight right);
+            static abstract bool EqualAndAscii256(ref TLeft left, ref TRight right);
+            static abstract bool EqualAndAscii512(ref TLeft left, ref TRight right);
         }
 
         private readonly struct PlainLoader<T> : ILoader<T, T> where T : unmanaged, INumberBase<T>
@@ -477,10 +469,11 @@ namespace System.Text
             public static nuint Count512 => (uint)Vector512<T>.Count;
             public static Vector128<T> Load128(ref T ptr) => Vector128.LoadUnsafe(ref ptr);
             public static Vector256<T> Load256(ref T ptr) => Vector256.LoadUnsafe(ref ptr);
+            public static Vector512<T> Load512(ref T ptr) => Vector512.LoadUnsafe(ref ptr);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(Avx))]
-            public static bool EqualAndAscii(ref T left, ref T right)
+            public static bool EqualAndAscii256(ref T left, ref T right)
             {
                 Vector256<T> leftValues = Vector256.LoadUnsafe(ref left);
                 Vector256<T> rightValues = Vector256.LoadUnsafe(ref right);
@@ -493,7 +486,19 @@ namespace System.Text
                 return true;
             }
 
-            public static Vector512<T> Load512(ref T ptr) => Vector512.LoadUnsafe(ref ptr);
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool EqualAndAscii512(ref T left, ref T right)
+            {
+                Vector512<T> leftValues = Vector512.LoadUnsafe(ref left);
+                Vector512<T> rightValues = Vector512.LoadUnsafe(ref right);
+
+                if (leftValues != rightValues || !AllCharsInVectorAreAscii(leftValues))
+                {
+                    return false;
+                }
+
+                return true;
+            }
         }
 
         private readonly struct WideningLoader : ILoader<byte, ushort>
@@ -529,8 +534,15 @@ namespace System.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static Vector512<ushort> Load512(ref byte ptr)
+            {
+                (Vector256<ushort> lower, Vector256<ushort> upper) = Vector256.Widen(Vector256.LoadUnsafe(ref ptr));
+                return Vector512.Create(lower, upper);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(Avx))]
-            public static bool EqualAndAscii(ref byte utf8, ref ushort utf16)
+            public static bool EqualAndAscii256(ref byte utf8, ref ushort utf16)
             {
                 // We widen the utf8 param so we can compare it to utf16, this doubles how much of the utf16 vector we search
                 Debug.Assert(Vector256<byte>.Count == Vector256<ushort>.Count * 2);
@@ -554,10 +566,29 @@ namespace System.Text
                 return true;
             }
 
-            public static Vector512<ushort> Load512(ref byte ptr)
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool EqualAndAscii512(ref byte utf8, ref ushort utf16)
             {
-                (Vector256<ushort> lower, Vector256<ushort> upper) = Vector256.Widen(Vector256.LoadUnsafe(ref ptr));
-                return Vector512.Create(lower, upper);
+                // We widen the utf8 param so we can compare it to utf16, this doubles how much of the utf16 vector we search
+                Debug.Assert(Vector512<byte>.Count == Vector512<ushort>.Count * 2);
+
+                Vector512<byte> leftNotWidened = Vector512.LoadUnsafe(ref utf8);
+                if (!AllCharsInVectorAreAscii(leftNotWidened))
+                {
+                    return false;
+                }
+
+                (Vector512<ushort> leftLower, Vector512<ushort> leftUpper) = Vector512.Widen(leftNotWidened);
+                Vector512<ushort> right = Vector512.LoadUnsafe(ref utf16);
+                Vector512<ushort> rightNext = Vector512.LoadUnsafe(ref utf16, (uint)Vector512<ushort>.Count);
+
+                // A branchless version of "leftLower != right || leftUpper != rightNext"
+                if (((leftLower ^ right) | (leftUpper ^ rightNext)) != Vector512<ushort>.Zero)
+                {
+                    return false;
+                }
+
+                return true;
             }
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -82,8 +82,8 @@ namespace System.Text
                         return false;
                     }
 
-                    currentRightSearchSpace = ref Unsafe.Add(ref currentRightSearchSpace, Vector256<TRight>.Count);
-                    currentLeftSearchSpace = ref Unsafe.Add(ref currentLeftSearchSpace, TLoader.Count256);
+                    currentRightSearchSpace = ref Unsafe.Add(ref currentRightSearchSpace, Vector512<TRight>.Count);
+                    currentLeftSearchSpace = ref Unsafe.Add(ref currentLeftSearchSpace, TLoader.Count512);
                 }
                 while (!Unsafe.IsAddressGreaterThan(ref currentRightSearchSpace, ref oneVectorAwayFromRightEnd));
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -61,7 +61,7 @@ namespace System.Text
                     }
                 }
             }
-            else if (Avx512F.IsSupported && length >= (uint)Vector512<TRight>.Count)
+            else if (Vector512.IsHardwareAccelerated && length >= (uint)Vector512<TRight>.Count)
             {
                 ref TLeft currentLeftSearchSpace = ref left;
                 ref TLeft oneVectorAwayFromLeftEnd = ref Unsafe.Add(ref currentLeftSearchSpace, length - TLoader.Count512);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -536,8 +536,19 @@ namespace System.Text
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static Vector512<ushort> Load512(ref byte ptr)
             {
-                (Vector256<ushort> lower, Vector256<ushort> upper) = Vector256.Widen(Vector256.LoadUnsafe(ref ptr));
-                return Vector512.Create(lower, upper);
+                // This is done here for performance gain.
+                // A similar implementation would be as below:
+                //
+                //      (Vector256<ushort> lower, Vector256<ushort> upper) = Vector256.Widen(Vector256.LoadUnsafe(ref ptr));
+                //      return Vector512.Create(lower, upper);
+                //
+                // This is similar to what is done for Load256 here. But
+                // for Vector512, this implementation is low performance
+                // since a load and widen on Vector256 followed by a
+                // create on Vector512 is leading to a performance lower
+                // than that of similar implementationfor Vector256.
+                (Vector512<ushort> lower, Vector512<ushort> _) = Vector512.Widen(Vector256.LoadUnsafe(ref ptr).ToVector512());
+                return lower;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -236,7 +236,7 @@ namespace System.Text
                     }
                 }
             }
-            else if (Avx512F.IsSupported && length >= (uint)Vector512<TRight>.Count)
+            else if (Vector512.IsHardwareAccelerated && length >= (uint)Vector512<TRight>.Count)
             {
                 ref TLeft currentLeftSearchSpace = ref left;
                 ref TLeft oneVectorAwayFromLeftEnd = ref Unsafe.Add(ref currentLeftSearchSpace, length - TLoader.Count512);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -88,7 +88,7 @@ namespace System.Text
                 while (!Unsafe.IsAddressGreaterThan(ref currentRightSearchSpace, ref oneVectorAwayFromRightEnd));
 
                 // If any elements remain, process the last vector in the search space.
-                if (length % (uint)Vector256<TRight>.Count != 0)
+                if (length % (uint)Vector512<TRight>.Count != 0)
                 {
                     leftValues = TLoader.Load512(ref oneVectorAwayFromLeftEnd);
                     rightValues = Vector512.LoadUnsafe(ref oneVectorAwayFromRightEnd);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -500,7 +500,7 @@ namespace System.Text
         {
             public static nuint Count128 => sizeof(long);
             public static nuint Count256 => (uint)Vector128<byte>.Count;
-            public static nuint Count512 => (uint)Vector512<byte>.Count;
+            public static nuint Count512 => (uint)Vector256<byte>.Count;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static Vector128<ushort> Load128(ref byte ptr)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1508,11 +1508,15 @@ namespace System.Text
 
             if (typeof(T) == typeof(byte))
             {
-                return vector.AsByte().ExtractMostSignificantBits() == 0;
+                return
+                    Avx512F.IsSupported ? Vector512.EqualsAll(Vector512.BitwiseAnd(vector.AsByte(), Vector512.Create((byte)0x80)), Vector512<byte>.Zero) :
+                    vector.AsByte().ExtractMostSignificantBits() == 0;
             }
             else
             {
-                return ((vector.AsUInt16() & Vector512.Create((ushort)0xFF80)) == Vector512<ushort>.Zero);
+                return
+                    Avx512F.IsSupported ? Vector512.EqualsAll(Vector512.BitwiseAnd(vector.AsUInt16(), Vector512.Create((ushort)0xFF80)), Vector512<ushort>.Zero) :
+                    ((vector.AsUInt16() & Vector512.Create((ushort)0xFF80)) == Vector512<ushort>.Zero);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1500,7 +1500,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [CompExactlyDependsOn(typeof(Avx512F))]
         private static bool AllCharsInVectorAreAscii<T>(Vector512<T> vector)
             where T : unmanaged
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1500,6 +1500,23 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(Avx512F))]
+        private static bool AllCharsInVectorAreAscii<T>(Vector512<T> vector)
+            where T : unmanaged
+        {
+            Debug.Assert(typeof(T) == typeof(byte) || typeof(T) == typeof(ushort));
+
+            if (typeof(T) == typeof(byte))
+            {
+                return vector.AsByte().ExtractMostSignificantBits() == 0;
+            }
+            else
+            {
+                return ((vector.AsUInt16() & Vector512.Create((ushort)0xFF80)) == Vector512<ushort>.Zero);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector128<byte> ExtractAsciiVector(Vector128<ushort> vectorFirst, Vector128<ushort> vectorSecond)
         {
             // Narrows two vectors of words [ w7 w6 w5 w4 w3 w2 w1 w0 ] and [ w7' w6' w5' w4' w3' w2' w1' w0' ]

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1508,15 +1508,11 @@ namespace System.Text
 
             if (typeof(T) == typeof(byte))
             {
-                return
-                    Avx512F.IsSupported ? Vector512.EqualsAll(Vector512.BitwiseAnd(vector.AsByte(), Vector512.Create((byte)0x80)), Vector512<byte>.Zero) :
-                    vector.AsByte().ExtractMostSignificantBits() == 0;
+                return vector.AsByte().ExtractMostSignificantBits() == 0;
             }
             else
             {
-                return
-                    Avx512F.IsSupported ? Vector512.EqualsAll(Vector512.BitwiseAnd(vector.AsUInt16(), Vector512.Create((ushort)0xFF80)), Vector512<ushort>.Zero) :
-                    ((vector.AsUInt16() & Vector512.Create((ushort)0xFF80)) == Vector512<ushort>.Zero);
+                return (vector.AsUInt16() & Vector512.Create((ushort)0xFF80)) == Vector512<ushort>.Zero;
             }
         }
 


### PR DESCRIPTION
This PR is about adding Vector512 support to the existing ASCII.Equality.Equals and ASCIIEquality..EqualsIgnoreCase library APIs. The implementation remains very much similar to Vector256.

We have changed the implementation of ```public static Vector512<ushort> Load512``` to make sure we either retain the existing performance or see a performance gain. Please look the comments in the code for detailed explanation.

### PERF
---------
|                                      Method | Toolchain | Size |       Mean |     Error |    StdDev |     Median |        Min |        Max | Ratio | RatioSD |
|-------------------------------------------- |---------- |----- |-----------:|----------:|----------:|-----------:|-----------:|-----------:|------:|--------:|
|                                Equals_Bytes | Base_impl |    6 |   6.633 ns | 0.0262 ns | 0.0245 ns |   6.636 ns |   6.595 ns |   6.674 ns |  1.00 |    0.01 |
|                                Equals_Bytes | Diff_impl |    6 |   6.658 ns | 0.0351 ns | 0.0328 ns |   6.658 ns |   6.604 ns |   6.708 ns |  1.00 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                                Equals_Chars | Base_impl |    6 |   5.341 ns | 0.0375 ns | 0.0351 ns |   5.338 ns |   5.272 ns |   5.403 ns |  1.00 |    0.01 |
|                                Equals_Chars | Diff_impl |    6 |   5.379 ns | 0.0308 ns | 0.0288 ns |   5.379 ns |   5.327 ns |   5.421 ns |  1.00 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                          Equals_Bytes_Chars | Base_impl |    6 |   5.944 ns | 0.0635 ns | 0.0530 ns |   5.960 ns |   5.861 ns |   6.061 ns |  0.99 |    0.02 |
|                          Equals_Bytes_Chars | Diff_impl |    6 |   6.016 ns | 0.0836 ns | 0.0782 ns |   5.996 ns |   5.859 ns |   6.161 ns |  1.00 |    0.02 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|       EqualsIgnoreCase_ExactlyTheSame_Bytes | Base_impl |    6 |   6.451 ns | 0.0460 ns | 0.0430 ns |   6.444 ns |   6.394 ns |   6.530 ns |  0.99 |    0.01 |
|       EqualsIgnoreCase_ExactlyTheSame_Bytes | Diff_impl |    6 |   6.154 ns | 0.0247 ns | 0.0219 ns |   6.165 ns |   6.101 ns |   6.171 ns |  0.95 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|       EqualsIgnoreCase_ExactlyTheSame_Chars | Base_impl |    6 |   6.584 ns | 0.0801 ns | 0.0749 ns |   6.586 ns |   6.484 ns |   6.716 ns |  1.01 |    0.01 |
|       EqualsIgnoreCase_ExactlyTheSame_Chars | Diff_impl |    6 |   5.428 ns | 0.0189 ns | 0.0177 ns |   5.436 ns |   5.401 ns |   5.452 ns |  0.83 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
| EqualsIgnoreCase_ExactlyTheSame_Bytes_Chars | Base_impl |    6 |   6.443 ns | 0.0551 ns | 0.0516 ns |   6.455 ns |   6.346 ns |   6.519 ns |  1.00 |    0.01 |
| EqualsIgnoreCase_ExactlyTheSame_Bytes_Chars | Diff_impl |    6 |   6.113 ns | 0.0356 ns | 0.0315 ns |   6.118 ns |   6.062 ns |   6.177 ns |  0.95 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|        EqualsIgnoreCase_DifferentCase_Bytes | Base_impl |    6 |   6.513 ns | 0.0393 ns | 0.0367 ns |   6.510 ns |   6.460 ns |   6.577 ns |  0.98 |    0.01 |
|        EqualsIgnoreCase_DifferentCase_Bytes | Diff_impl |    6 |   7.089 ns | 0.0481 ns | 0.0450 ns |   7.079 ns |   7.033 ns |   7.174 ns |  1.07 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|        EqualsIgnoreCase_DifferentCase_Chars | Base_impl |    6 |   6.752 ns | 0.0468 ns | 0.0415 ns |   6.750 ns |   6.659 ns |   6.813 ns |  1.00 |    0.01 |
|        EqualsIgnoreCase_DifferentCase_Chars | Diff_impl |    6 |   7.174 ns | 0.0413 ns | 0.0387 ns |   7.177 ns |   7.110 ns |   7.246 ns |  1.06 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|  EqualsIgnoreCase_DifferentCase_Bytes_Chars | Base_impl |    6 |   6.465 ns | 0.0518 ns | 0.0484 ns |   6.461 ns |   6.410 ns |   6.563 ns |  0.93 |    0.01 |
|  EqualsIgnoreCase_DifferentCase_Bytes_Chars | Diff_impl |    6 |   7.111 ns | 0.0239 ns | 0.0212 ns |   7.111 ns |   7.063 ns |   7.151 ns |  1.03 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                                Equals_Bytes | Base_impl |   32 |   2.546 ns | 0.0305 ns | 0.0255 ns |   2.545 ns |   2.507 ns |   2.603 ns |  1.01 |    0.02 |
|                                Equals_Bytes | Diff_impl |   32 |   2.522 ns | 0.0257 ns | 0.0241 ns |   2.515 ns |   2.490 ns |   2.562 ns |  1.00 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                                Equals_Chars | Base_impl |   32 |   2.820 ns | 0.0118 ns | 0.0111 ns |   2.815 ns |   2.810 ns |   2.840 ns |  1.00 |    0.01 |
|                                Equals_Chars | Diff_impl |   32 |   2.833 ns | 0.0030 ns | 0.0024 ns |   2.834 ns |   2.828 ns |   2.836 ns |  1.00 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                          Equals_Bytes_Chars | Base_impl |   32 |   2.607 ns | 0.0089 ns | 0.0075 ns |   2.608 ns |   2.590 ns |   2.622 ns |  1.00 |    0.00 |
|                          Equals_Bytes_Chars | Diff_impl |   32 |   2.603 ns | 0.0102 ns | 0.0085 ns |   2.605 ns |   2.585 ns |   2.616 ns |  1.00 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|       EqualsIgnoreCase_ExactlyTheSame_Bytes | Base_impl |   32 |   2.954 ns | 0.0045 ns | 0.0035 ns |   2.954 ns |   2.950 ns |   2.963 ns |  0.85 |    0.00 |
|       EqualsIgnoreCase_ExactlyTheSame_Bytes | Diff_impl |   32 |   3.059 ns | 0.0086 ns | 0.0076 ns |   3.061 ns |   3.037 ns |   3.069 ns |  0.88 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|       EqualsIgnoreCase_ExactlyTheSame_Chars | Base_impl |   32 |   4.079 ns | 0.0258 ns | 0.0215 ns |   4.082 ns |   4.042 ns |   4.118 ns |  0.76 |    0.01 |
|       EqualsIgnoreCase_ExactlyTheSame_Chars | Diff_impl |   32 |   3.562 ns | 0.0175 ns | 0.0155 ns |   3.561 ns |   3.538 ns |   3.596 ns |  0.67 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
| EqualsIgnoreCase_ExactlyTheSame_Bytes_Chars | Base_impl |   32 |   4.299 ns | 0.0193 ns | 0.0181 ns |   4.301 ns |   4.266 ns |   4.333 ns |  0.76 |    0.00 |
| EqualsIgnoreCase_ExactlyTheSame_Bytes_Chars | Diff_impl |   32 |   3.662 ns | 0.0486 ns | 0.0455 ns |   3.667 ns |   3.559 ns |   3.717 ns |  0.65 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|        EqualsIgnoreCase_DifferentCase_Bytes | Base_impl |   32 |   3.844 ns | 0.0236 ns | 0.0221 ns |   3.844 ns |   3.809 ns |   3.882 ns |  0.65 |    0.00 |
|        EqualsIgnoreCase_DifferentCase_Bytes | Diff_impl |   32 |   4.240 ns | 0.0414 ns | 0.0387 ns |   4.226 ns |   4.197 ns |   4.315 ns |  0.72 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|        EqualsIgnoreCase_DifferentCase_Chars | Base_impl |   32 |   6.577 ns | 0.0263 ns | 0.0233 ns |   6.579 ns |   6.537 ns |   6.623 ns |  0.60 |    0.00 |
|        EqualsIgnoreCase_DifferentCase_Chars | Diff_impl |   32 |   4.536 ns | 0.0203 ns | 0.0190 ns |   4.542 ns |   4.509 ns |   4.563 ns |  0.42 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|  EqualsIgnoreCase_DifferentCase_Bytes_Chars | Base_impl |   32 |   7.672 ns | 0.0320 ns | 0.0284 ns |   7.681 ns |   7.624 ns |   7.710 ns |  0.71 |    0.00 |
|  EqualsIgnoreCase_DifferentCase_Bytes_Chars | Diff_impl |   32 |   5.625 ns | 0.0228 ns | 0.0190 ns |   5.631 ns |   5.580 ns |   5.655 ns |  0.52 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                                Equals_Bytes | Base_impl |  128 |   3.177 ns | 0.0010 ns | 0.0008 ns |   3.177 ns |   3.176 ns |   3.179 ns |  1.00 |    0.00 |
|                                Equals_Bytes | Diff_impl |  128 |   3.178 ns | 0.0013 ns | 0.0012 ns |   3.178 ns |   3.176 ns |   3.180 ns |  1.00 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                                Equals_Chars | Base_impl |  128 |   5.643 ns | 0.0237 ns | 0.0210 ns |   5.647 ns |   5.578 ns |   5.666 ns |  0.99 |    0.00 |
|                                Equals_Chars | Diff_impl |  128 |   5.317 ns | 0.0048 ns | 0.0040 ns |   5.317 ns |   5.308 ns |   5.324 ns |  0.94 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                          Equals_Bytes_Chars | Base_impl |  128 |   4.633 ns | 0.0292 ns | 0.0259 ns |   4.631 ns |   4.595 ns |   4.688 ns |  1.00 |    0.01 |
|                          Equals_Bytes_Chars | Diff_impl |  128 |   4.625 ns | 0.0234 ns | 0.0196 ns |   4.627 ns |   4.588 ns |   4.650 ns |  1.00 |    0.01 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|       EqualsIgnoreCase_ExactlyTheSame_Bytes | Base_impl |  128 |   6.018 ns | 0.0185 ns | 0.0164 ns |   6.011 ns |   6.001 ns |   6.047 ns |  0.63 |    0.00 |
|       EqualsIgnoreCase_ExactlyTheSame_Bytes | Diff_impl |  128 |   4.519 ns | 0.0334 ns | 0.0312 ns |   4.534 ns |   4.463 ns |   4.550 ns |  0.47 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|       EqualsIgnoreCase_ExactlyTheSame_Chars | Base_impl |  128 |  11.243 ns | 0.0057 ns | 0.0053 ns |  11.244 ns |  11.234 ns |  11.251 ns |  0.58 |    0.00 |
|       EqualsIgnoreCase_ExactlyTheSame_Chars | Diff_impl |  128 |   8.042 ns | 0.0035 ns | 0.0029 ns |   8.041 ns |   8.037 ns |   8.046 ns |  0.42 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
| EqualsIgnoreCase_ExactlyTheSame_Bytes_Chars | Base_impl |  128 |  14.060 ns | 0.0333 ns | 0.0295 ns |  14.053 ns |  14.019 ns |  14.131 ns |  0.68 |    0.00 |
| EqualsIgnoreCase_ExactlyTheSame_Bytes_Chars | Diff_impl |  128 |   8.859 ns | 0.0030 ns | 0.0027 ns |   8.858 ns |   8.855 ns |   8.864 ns |  0.43 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|        EqualsIgnoreCase_DifferentCase_Bytes | Base_impl |  128 |  11.694 ns | 0.0036 ns | 0.0030 ns |  11.695 ns |  11.690 ns |  11.701 ns |  0.60 |    0.00 |
|        EqualsIgnoreCase_DifferentCase_Bytes | Diff_impl |  128 |   7.287 ns | 0.0126 ns | 0.0105 ns |   7.287 ns |   7.267 ns |   7.303 ns |  0.38 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|        EqualsIgnoreCase_DifferentCase_Chars | Base_impl |  128 |  20.930 ns | 0.0275 ns | 0.0230 ns |  20.923 ns |  20.903 ns |  20.989 ns |  0.55 |    0.00 |
|        EqualsIgnoreCase_DifferentCase_Chars | Diff_impl |  128 |  14.724 ns | 0.0124 ns | 0.0116 ns |  14.725 ns |  14.690 ns |  14.738 ns |  0.38 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|  EqualsIgnoreCase_DifferentCase_Bytes_Chars | Base_impl |  128 |  24.800 ns | 0.0270 ns | 0.0252 ns |  24.802 ns |  24.760 ns |  24.840 ns |  0.61 |    0.00 |
|  EqualsIgnoreCase_DifferentCase_Bytes_Chars | Diff_impl |  128 |  14.666 ns | 0.0077 ns | 0.0072 ns |  14.664 ns |  14.656 ns |  14.682 ns |  0.36 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                                Equals_Bytes | Base_impl |  512 |   8.693 ns | 0.0057 ns | 0.0044 ns |   8.693 ns |   8.687 ns |   8.699 ns |  1.00 |    0.00 |
|                                Equals_Bytes | Diff_impl |  512 |  10.694 ns | 0.0031 ns | 0.0029 ns |  10.693 ns |  10.690 ns |  10.700 ns |  1.23 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                                Equals_Chars | Base_impl |  512 |  17.528 ns | 0.0065 ns | 0.0058 ns |  17.526 ns |  17.520 ns |  17.542 ns |  0.99 |    0.00 |
|                                Equals_Chars | Diff_impl |  512 |  16.729 ns | 0.0044 ns | 0.0041 ns |  16.727 ns |  16.722 ns |  16.737 ns |  0.95 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                          Equals_Bytes_Chars | Base_impl |  512 |  14.422 ns | 0.0048 ns | 0.0045 ns |  14.423 ns |  14.416 ns |  14.429 ns |  1.01 |    0.00 |
|                          Equals_Bytes_Chars | Diff_impl |  512 |  14.005 ns | 0.0065 ns | 0.0061 ns |  14.003 ns |  13.993 ns |  14.018 ns |  0.98 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|       EqualsIgnoreCase_ExactlyTheSame_Bytes | Base_impl |  512 |  19.734 ns | 0.0095 ns | 0.0089 ns |  19.733 ns |  19.721 ns |  19.750 ns |  0.44 |    0.00 |
|       EqualsIgnoreCase_ExactlyTheSame_Bytes | Diff_impl |  512 |  13.132 ns | 0.0036 ns | 0.0033 ns |  13.132 ns |  13.127 ns |  13.138 ns |  0.29 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|       EqualsIgnoreCase_ExactlyTheSame_Chars | Base_impl |  512 |  51.981 ns | 0.0377 ns | 0.0352 ns |  51.985 ns |  51.908 ns |  52.039 ns |  0.62 |    0.00 |
|       EqualsIgnoreCase_ExactlyTheSame_Chars | Diff_impl |  512 |  27.112 ns | 0.0064 ns | 0.0060 ns |  27.110 ns |  27.104 ns |  27.123 ns |  0.32 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
| EqualsIgnoreCase_ExactlyTheSame_Bytes_Chars | Base_impl |  512 |  57.214 ns | 0.0301 ns | 0.0282 ns |  57.213 ns |  57.170 ns |  57.273 ns |  0.61 |    0.00 |
| EqualsIgnoreCase_ExactlyTheSame_Bytes_Chars | Diff_impl |  512 |  31.673 ns | 0.0095 ns | 0.0074 ns |  31.673 ns |  31.661 ns |  31.682 ns |  0.34 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|        EqualsIgnoreCase_DifferentCase_Bytes | Base_impl |  512 |  43.033 ns | 0.0091 ns | 0.0080 ns |  43.034 ns |  43.020 ns |  43.047 ns |  0.50 |    0.00 |
|        EqualsIgnoreCase_DifferentCase_Bytes | Diff_impl |  512 |  27.040 ns | 0.1025 ns | 0.0856 ns |  27.064 ns |  26.756 ns |  27.070 ns |  0.32 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|        EqualsIgnoreCase_DifferentCase_Chars | Base_impl |  512 |  89.066 ns | 0.0922 ns | 0.0770 ns |  89.070 ns |  88.975 ns |  89.238 ns |  0.56 |    0.00 |
|        EqualsIgnoreCase_DifferentCase_Chars | Diff_impl |  512 |  52.448 ns | 0.0152 ns | 0.0135 ns |  52.448 ns |  52.429 ns |  52.477 ns |  0.33 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|  EqualsIgnoreCase_DifferentCase_Bytes_Chars | Base_impl |  512 | 102.465 ns | 0.0737 ns | 0.0653 ns | 102.459 ns | 102.327 ns | 102.600 ns |  0.60 |    0.00 |
|  EqualsIgnoreCase_DifferentCase_Bytes_Chars | Diff_impl |  512 |  56.994 ns | 0.1687 ns | 0.1409 ns |  56.940 ns |  56.871 ns |  57.312 ns |  0.34 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                                Equals_Bytes | Base_impl | 1024 |  15.430 ns | 0.0044 ns | 0.0041 ns |  15.430 ns |  15.421 ns |  15.435 ns |  0.98 |    0.00 |
|                                Equals_Bytes | Diff_impl | 1024 |  16.261 ns | 0.0044 ns | 0.0034 ns |  16.262 ns |  16.254 ns |  16.265 ns |  1.03 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                                Equals_Chars | Base_impl | 1024 |  38.232 ns | 0.7836 ns | 0.8710 ns |  38.331 ns |  36.608 ns |  39.653 ns |  0.95 |    0.02 |
|                                Equals_Chars | Diff_impl | 1024 |  39.503 ns | 0.0855 ns | 0.0799 ns |  39.520 ns |  39.219 ns |  39.548 ns |  0.98 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|                          Equals_Bytes_Chars | Base_impl | 1024 |  27.625 ns | 0.0398 ns | 0.0353 ns |  27.630 ns |  27.507 ns |  27.652 ns |  1.00 |    0.00 |
|                          Equals_Bytes_Chars | Diff_impl | 1024 |  27.242 ns | 0.0138 ns | 0.0129 ns |  27.243 ns |  27.213 ns |  27.259 ns |  0.99 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|       EqualsIgnoreCase_ExactlyTheSame_Bytes | Base_impl | 1024 |  49.150 ns | 0.1114 ns | 0.1042 ns |  49.189 ns |  48.969 ns |  49.267 ns |  0.63 |    0.00 |
|       EqualsIgnoreCase_ExactlyTheSame_Bytes | Diff_impl | 1024 |  24.301 ns | 0.0097 ns | 0.0091 ns |  24.299 ns |  24.288 ns |  24.319 ns |  0.31 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|       EqualsIgnoreCase_ExactlyTheSame_Chars | Base_impl | 1024 |  94.396 ns | 0.0399 ns | 0.0374 ns |  94.397 ns |  94.327 ns |  94.459 ns |  0.60 |    0.00 |
|       EqualsIgnoreCase_ExactlyTheSame_Chars | Diff_impl | 1024 |  60.306 ns | 0.0189 ns | 0.0167 ns |  60.304 ns |  60.274 ns |  60.342 ns |  0.38 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
| EqualsIgnoreCase_ExactlyTheSame_Bytes_Chars | Base_impl | 1024 | 102.150 ns | 0.2300 ns | 0.1920 ns | 102.080 ns | 101.973 ns | 102.638 ns |  0.61 |    0.00 |
| EqualsIgnoreCase_ExactlyTheSame_Bytes_Chars | Diff_impl | 1024 |  72.305 ns | 0.0378 ns | 0.0335 ns |  72.303 ns |  72.239 ns |  72.378 ns |  0.44 |    0.00 |
|                                             |           |      |            |           |           |            |            |            |       |         |
|        EqualsIgnoreCase_DifferentCase_Bytes | Base_impl | 1024 |  92.898 ns | 0.1827 ns | 0.1525 ns |  92.848 ns |  92.676 ns |  93.261 ns |  0.58 |    0.00 |
|        EqualsIgnoreCase_DifferentCase_Bytes | Diff_impl | 1024 |  48.550 ns | 0.0189 ns | 0.0177 ns |  48.544 ns |  48.531 ns |  48.585 ns |  0.30 |    0.00 |