### PR TITLE
Allow passing Int128 to p/invokes by reference

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -231,7 +231,8 @@ namespace Internal.TypeSystem.Interop
             if (marshalAs != null)
                 nativeType = marshalAs.Type;
 
-            if (type.IsByRef)
+            bool isByRef = type.IsByRef;
+            if (isByRef)
             {
                 type = type.GetParameterType();
 
@@ -416,7 +417,7 @@ namespace Internal.TypeSystem.Interop
                     return MarshallerKind.Invalid;
                 }
 
-                if (!isField && ((DefType)type).IsInt128OrHasInt128Fields)
+                if (!isField && ((DefType)type).IsInt128OrHasInt128Fields && !isByRef)
                 {
                     // Int128 types or structs that contain them cannot be passed by value
                     return MarshallerKind.Invalid;

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -763,9 +763,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Attributes/LCID/LCIDTest/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: LCID marshalling</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Int128/Int128TestFieldLayout/*">
-            <Issue>https://github.com/dotnet/runtime/issues/74549</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest/**">
             <Issue>https://github.com/dotnet/runtime/issues/81674</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes #74549.

Cc @dotnet/ilc-contrib 