### PR TITLE
[mono][tests] Add support for mobile devices in processinfo3 test

### DIFF
--- a/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
+++ b/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
@@ -312,9 +312,13 @@ namespace Tracing.Tests.ProcessInfoValidation
                 }
                 Logger.logger.Log("Finished checking process modules.");
             }
-            else if (OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
+            else if (OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
             {
                 expectedPortableRidOs = "unix";
+            }
+            else if (OperatingSystem.IsAndroid())
+            {
+                expectedPortableRidOs = "linux-bionic";
             }
             
             Utils.Assert(!string.IsNullOrEmpty(expectedPortableRidOs), $"Unable to calculate expected portable RID OS.");

--- a/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
+++ b/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
@@ -312,6 +312,10 @@ namespace Tracing.Tests.ProcessInfoValidation
                 }
                 Logger.logger.Log("Finished checking process modules.");
             }
+            else if (OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
+            {
+                expectedPortableRidOs = "unix";
+            }
             
             Utils.Assert(!string.IsNullOrEmpty(expectedPortableRidOs), $"Unable to calculate expected portable RID OS.");
 


### PR DESCRIPTION
This PR adds `unix` as an expected portable runtime identifier for mobile devices.

Fixes https://github.com/dotnet/runtime/issues/88186