### PR TITLE
[RISC-V] Missing defines in GC

### DIFF
--- a/src/coreclr/gc/env/gcenv.interlocked.inl
+++ b/src/coreclr/gc/env/gcenv.interlocked.inl
@@ -13,7 +13,7 @@
 #ifndef _MSC_VER
 __forceinline void Interlocked::InterlockedOperationBarrier()
 {
-#if defined(HOST_ARM64) || defined(HOST_LOONGARCH64)
+#if defined(HOST_ARM64) || defined(HOST_LOONGARCH64) || defined(HOST_RISCV64)
     // See PAL_InterlockedOperationBarrier() in the PAL
     __sync_synchronize();
 #endif

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -26240,7 +26240,7 @@ void gc_heap::save_post_plug_info (uint8_t* last_pinned_plug, uint8_t* last_obje
 }
 
 // enable on processors known to have a useful prefetch instruction
-#if defined(TARGET_AMD64) || defined(TARGET_X86) || defined(TARGET_ARM64)
+#if defined(TARGET_AMD64) || defined(TARGET_X86) || defined(TARGET_ARM64) || defined(TARGET_RISCV64)
 #define PREFETCH
 #endif
 

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -136,7 +136,7 @@ typedef cpuset_t cpu_set_t;
 #endif
 #endif // __APPLE__
 
-#if defined(HOST_ARM) || defined(HOST_ARM64) || defined(HOST_LOONGARCH64)
+#if defined(HOST_ARM) || defined(HOST_ARM64) || defined(HOST_LOONGARCH64) || defined(HOST_RISCV64)
 #define SYSCONF_GET_NUMPROCS _SC_NPROCESSORS_CONF
 #else
 #define SYSCONF_GET_NUMPROCS _SC_NPROCESSORS_ONLN


### PR DESCRIPTION
Some defines were not ported to RISC-V in GC. This PR fix it.

Part of https://github.com/dotnet/runtime/issues/84834

cc @jakobbotsch @wscho77 @HJLeee @JongHeonChoi @t-mustafin @clamp03 @gbalykov