### PR TITLE
JIT: Always consider empty remainders to be dying in physical promotion

### DIFF
--- a/src/coreclr/jit/promotion.h
+++ b/src/coreclr/jit/promotion.h
@@ -208,13 +208,13 @@ public:
 // Class to represent liveness information for a struct local's fields and remainder.
 class StructDeaths
 {
-    BitVec   m_deaths;
-    unsigned m_numFields = 0;
+    BitVec         m_deaths;
+    AggregateInfo* m_aggregate = nullptr;
 
     friend class PromotionLiveness;
 
 private:
-    StructDeaths(BitVec deaths, unsigned numFields) : m_deaths(deaths), m_numFields(numFields)
+    StructDeaths(BitVec deaths, AggregateInfo* agg) : m_deaths(deaths), m_aggregate(agg)
     {
     }
 

--- a/src/coreclr/jit/promotionliveness.cpp
+++ b/src/coreclr/jit/promotionliveness.cpp
@@ -839,6 +839,8 @@ bool StructDeaths::IsRemainderDying() const
 //
 bool StructDeaths::IsReplacementDying(unsigned index) const
 {
+    assert(index < m_aggregate->Replacements.size());
+
     BitVecTraits traits(1 + (unsigned)m_aggregate->Replacements.size(), nullptr);
     return BitVecOps::IsMember(&traits, m_deaths, 1 + index);
 }

--- a/src/coreclr/jit/promotionliveness.cpp
+++ b/src/coreclr/jit/promotionliveness.cpp
@@ -808,7 +808,7 @@ StructDeaths PromotionLiveness::GetDeathsForStructLocal(GenTreeLclVarCommon* lcl
 
     unsigned       lclNum  = lcl->GetLclNum();
     AggregateInfo* aggInfo = m_aggregates.Lookup(lclNum);
-    return StructDeaths(aggDeaths, (unsigned)aggInfo->Replacements.size());
+    return StructDeaths(aggDeaths, aggInfo);
 }
 
 //------------------------------------------------------------------------
@@ -820,7 +820,13 @@ StructDeaths PromotionLiveness::GetDeathsForStructLocal(GenTreeLclVarCommon* lcl
 //
 bool StructDeaths::IsRemainderDying() const
 {
-    BitVecTraits traits(1 + m_numFields, nullptr);
+    if (m_aggregate->UnpromotedMax <= m_aggregate->UnpromotedMin)
+    {
+        // No remainder.
+        return true;
+    }
+
+    BitVecTraits traits(1 + (unsigned)m_aggregate->Replacements.size(), nullptr);
     return BitVecOps::IsMember(&traits, m_deaths, 0);
 }
 
@@ -833,7 +839,7 @@ bool StructDeaths::IsRemainderDying() const
 //
 bool StructDeaths::IsReplacementDying(unsigned index) const
 {
-    BitVecTraits traits(1 + m_numFields, nullptr);
+    BitVecTraits traits(1 + (unsigned)m_aggregate->Replacements.size(), nullptr);
     return BitVecOps::IsMember(&traits, m_deaths, 1 + index);
 }
 


### PR DESCRIPTION
Liveness takes a few shortcuts that means it doesn't always handle the case where there is no remainder as the remainder dying, so add a special case in StructDeaths::IsRemainderDying to take care of this case.

Some minor improvements from more last-use copy omission are expected.

Without this the bug in #88616 is hard to expose because it requires there to be a remainder that is fully defined between the two calls.