### PR TITLE
JIT: Mark replacements as dirty after setting GTF_VAR_DEATH

### DIFF
--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -2404,6 +2404,14 @@ void ReplaceVisitor::ReplaceLocal(GenTree** use, GenTree* user)
         {
             lcl->gtFlags |= GTF_VAR_DEATH;
             CheckForwardSubForLastUse(lclNum);
+
+            // Relying on the values in the struct local after this struct use
+            // would effectively introduce another use of the struct, so
+            // indicate that no replacements are up to date.
+            for (Replacement& rep : replacements)
+            {
+                SetNeedsWriteBack(rep);
+            }
         }
         return;
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_88616/Runtime_88616.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_88616/Runtime_88616.cs
@@ -32,8 +32,6 @@ public class Runtime_88616
         return Check(foo);
     }
 
-    private static int s_numCalls;
-
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void Mutate(S s)
     {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_88616/Runtime_88616.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_88616/Runtime_88616.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_88616
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        S foo;
+        foo.A = 10;
+        foo.B = 20;
+        foo.C = 30;
+        foo.D = 40;
+        foo.E = 50;
+        foo.A += foo.A += foo.A += foo.A += foo.A;
+        foo.B += foo.B += foo.B += foo.B += foo.B;
+        foo.C += foo.C += foo.C += foo.C += foo.C;
+        foo.D += foo.D += foo.D += foo.D += foo.D;
+        foo.E += foo.E += foo.E += foo.E += foo.E;
+        // 'foo' is a last use here (it is fully promoted so all of its state
+        // is stored in separate field locals), so physical promotions marks
+        // this occurence as GTF_VAR_DEATH.
+        Mutate(foo);
+        // However, we cannot use the fact that we wrote the fields back into
+        // the struct local above to skip those same write backs here; if we
+        // skip those write backs then we effectively introduce new uses of the
+        // struct local.
+        return Check(foo);
+    }
+
+    private static int s_numCalls;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Mutate(S s)
+    {
+        s.A = -42;
+        Consume(ref s);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Consume(ref S s)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Check(S s)
+    {
+        if (s.A != 50)
+        {
+            Console.WriteLine("FAIL: s.A == {0}", s.A);
+            return -1;
+        }
+
+        return 100;
+    }
+
+    private struct S
+    {
+        public long A, B, C, D, E;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_88616/Runtime_88616.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_88616/Runtime_88616.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Physically promoted struct locals are marked as dying when their remainder dies since all other state is stored in other locals. However, when we do this we must also mark all replacements as stale; otherwise a future struct use could skip writebacks and effectively introduce new uses, invalidating the previously marked last use bit.

Fix #88616

Note that the regression test introduced here requires #88665 to actually fail.