### PR TITLE
[browser][mt] smoke test active issues

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -51,6 +51,7 @@
   <!-- Samples that require a multi-threaded runtime -->
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' != 'multithread'" >
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-threads\Wasm.Browser.Threads.Sample.csproj" />
+    <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-eventpipe\Wasm.Browser.EventPipe.Sample.csproj" />
   </ItemGroup>
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -51,7 +51,6 @@
   <!-- Samples that require a multi-threaded runtime -->
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' != 'multithread'" >
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-threads\Wasm.Browser.Threads.Sample.csproj" />
-    <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-eventpipe\Wasm.Browser.EventPipe.Sample.csproj" />
   </ItemGroup>
 
@@ -549,7 +548,10 @@
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'">
     <!-- Don't want the default smoke tests - just verify that threading works -->
     <SmokeTestProject Remove="@(SmokeTestProject)" />
+    <SmokeTestProject Include="$(MonoProjectRoot)sample\wasm\browser-threads\Wasm.Browser.Threads.Sample.csproj" />
+    <!-- this sample is messy sandbox right now 
     <SmokeTestProject Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
+    -->
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\System.Net.WebSockets.Client.Tests.csproj" />
     <!-- ActiveIssue https://github.com/dotnet/runtime/issues/88084
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />

--- a/src/mono/sample/wasm/browser-threads-minimal/main.js
+++ b/src/mono/sample/wasm/browser-threads-minimal/main.js
@@ -76,7 +76,7 @@ try {
     console.log("smoke: HttpClientThread(blurst.txt) done " + t4);
 
     console.log("smoke: running WsClientMain");
-    let w0 = await exports.Sample.Test.WsClientMain("wss://socketsbay.com/wss/v2/1/demo/");
+    let w0 = await exports.Sample.Test.WsClientMain("wss://corefx-net-http11.azurewebsites.net/WebSocket/EchoWebSocket.ashx");
     console.log("smoke: WsClientMain done " + w0);
 
     /* ActiveIssue https://github.com/dotnet/runtime/issues/88057
@@ -110,6 +110,7 @@ try {
     console.log("smoke: running StartAllocatorFromWorker");
     exports.Sample.Test.StartAllocatorFromWorker();
 
+    /* ActiveIssue https://github.com/dotnet/runtime/issues/88663
     await delay(5000);
 
     console.log("smoke: running GCCollect");
@@ -119,6 +120,8 @@ try {
 
     console.log("smoke: running GCCollect");
     exports.Sample.Test.GCCollect();
+    console.log("smoke: running GCCollect done");
+    */
 
     console.log("smoke: running StopTimerFromWorker");
     exports.Sample.Test.StopTimerFromWorker();


### PR DESCRIPTION
Active issues

`WebSocket opening handshake timed out` [Log](https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-heads-main-0493978f6cfa46aeb0/Wasm.Browser.Threads.Minimal.Sample/1/console.ca9a1561.log?helixlogtype=result)

and https://github.com/dotnet/runtime/issues/88663

Fixes https://github.com/dotnet/runtime/issues/88668