### PR TITLE
Clean up usings in test cases assembly

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Advanced/TypeCheckRemovalDisabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Advanced/TypeCheckRemovalDisabled.cs
@@ -1,4 +1,3 @@
-using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnGenerics.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes.Debugger/KeepDebugMembers/DebuggerDisplayAttributeOnGenerics.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/AutoClass.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/AutoClass.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Attributes.StructLayout

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/ExplicitClass.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/ExplicitClass.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Attributes.StructLayout

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/UnusedTypeWithSequentialLayoutIsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes.StructLayout/UnusedTypeWithSequentialLayoutIsRemoved.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.InteropServices;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Attributes.StructLayout
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/AssemblyAttributeIsRemovedIfOnlyTypesUsedInAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/AssemblyAttributeIsRemovedIfOnlyTypesUsedInAssembly.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Attributes.Dependencies;
+﻿using Mono.Linker.Tests.Cases.Attributes.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/AttributeOnAssemblyIsKeptIfDeclarationIsSkipped.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/AttributeOnAssemblyIsKeptIfDeclarationIsSkipped.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Attributes;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 #if REFERENCE_INCLUDED

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/FixedLengthArrayAttributesArePreserved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/FixedLengthArrayAttributesArePreserved.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-using System.Security;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/GenericAttributes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/GenericAttributes.cs
@@ -1,6 +1,5 @@
 using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/MarshalAsCustomMarshaler.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/MarshalAsCustomMarshaler.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
+﻿using System.Runtime.InteropServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Attributes

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/MarshalAsCustomMarshalerInterface.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/MarshalAsCustomMarshalerInterface.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using System.Runtime.Serialization;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/AttributeDefinedAndUsedInOtherAssemblyIsKept.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/AttributeDefinedAndUsedInOtherAssemblyIsKept.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies;
+﻿using Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CanLinkCoreLibrariesWithOnlyKeepUsedAttributes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/CanLinkCoreLibrariesWithOnlyKeepUsedAttributes.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Timers;
+﻿using System.Timers;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeWithTypeForwarderIsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeWithTypeForwarderIsRemoved.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies;
+﻿using Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/SecurityAttributesOnUsedMethodAreKept.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/SecurityAttributesOnUsedMethodAreKept.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Security.Permissions;
+﻿using System.Security.Permissions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/SecurityAttributesOnUsedTypeAreKept.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/SecurityAttributesOnUsedTypeAreKept.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Security.Permissions;
+﻿using System.Security.Permissions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/BaseRemovedEventSource.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/BaseRemovedEventSource.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.Tracing;
+﻿using System.Diagnostics.Tracing;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/Excluded.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/Excluded.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.Tracing;
+﻿using System.Diagnostics.Tracing;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/StubbedMethodWithExceptionHandlers.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/BCLFeatures/ETW/StubbedMethodWithExceptionHandlers.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.Tracing;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/DelegateBeginInvokeEndInvokePair.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/DelegateBeginInvokeEndInvokePair.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Basic

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/LinkerHandlesRefFields.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/LinkerHandlesRefFields.cs
@@ -2,12 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/MultiLevelNestedClassesAllRemovedWhenNonUsed.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/MultiLevelNestedClassesAllRemovedWhenNonUsed.cs
@@ -1,6 +1,4 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
-
-namespace Mono.Linker.Tests.Cases.Basic
+﻿namespace Mono.Linker.Tests.Cases.Basic
 {
 	class MultiLevelNestedClassesAllRemovedWhenNonUsed
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/UnusedDelegateGetsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/UnusedDelegateGetsRemoved.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Mono.Linker.Tests.Cases.Basic
+﻿namespace Mono.Linker.Tests.Cases.Basic
 {
 	class UnusedDelegateGetsRemoved
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/UnusedEnumGetsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/UnusedEnumGetsRemoved.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Mono.Linker.Tests.Cases.Basic
+﻿namespace Mono.Linker.Tests.Cases.Basic
 {
 	class UnusedEnumGetsRemoved
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/UnusedEventGetsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/UnusedEventGetsRemoved.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Basic
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/UsedEnumIsKept.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/UsedEnumIsKept.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Basic

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CodegenAnnotation/ReflectionBlockedTest.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CodegenAnnotation/ReflectionBlockedTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedMethods.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedMethods.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.IO;
+﻿using System.Collections;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CoreLink/LinkingOfCoreLibrariesRemovesUnusedTypes.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CppCLI/CppCLIAssemblyIsAnalyzed.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CppCLI/CppCLIAssemblyIsAnalyzed.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Runtime.InteropServices;
 using Mono.Linker.Tests.Cases.CppCLI.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CppCLI/NonCopyActionWarnOnCppCLI.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CppCLI/NonCopyActionWarnOnCppCLI.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Runtime.InteropServices;
 using Mono.Linker.Tests.Cases.CppCLI.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
@@ -2,13 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.DataFlow;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ApplyTypeAnnotations.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.DataFlow

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyQualifiedNameDataflow.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.DataFlow

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributeConstructorDataflow.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.DataFlow

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributeFieldDataflow.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.DataFlow

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.DataFlow

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeAccessedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeAccessedViaReflection.cs
@@ -4,12 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
-using Mono.Linker.Tests.Cases.DataFlow;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeInPreservedAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeInPreservedAssembly.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DataFlow

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeInPreservedAssemblyWithWarning.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeInPreservedAssemblyWithWarning.cs
@@ -1,11 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DataFlow

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedTypesRelease.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedTypesRelease.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.DataFlow

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/Library.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/Library.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Mono.Linker.Tests.Cases.DataFlow.Dependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/MemberTypesAllBaseTypeAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/MemberTypesAllBaseTypeAssembly.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Mono.Linker.Tests.Cases.DataFlow.Dependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/UnresolvedLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/Dependencies/UnresolvedLibrary.cs
@@ -1,12 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Mono.Linker.Tests.Cases.DataFlow.Dependencies
 {
 	public class UnresolvedType

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/DynamicDependencyDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/DynamicDependencyDataflow.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.DataFlow

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/EmptyArrayIntrinsicsDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/EmptyArrayIntrinsicsDataFlow.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.DataFlow

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/EventDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/EventDataFlow.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExponentialDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExponentialDataFlow.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using BindingFlags = System.Reflection.BindingFlags;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlowMarking.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlowMarking.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterWarningLocation.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterWarningLocation.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
-using System.Security.Policy;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GetInterfaceDataFlow.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GetNestedTypeOnAllAnnotatedType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GetNestedTypeOnAllAnnotatedType.cs
@@ -2,12 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GetTypeDataFlow.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataFlow.cs
@@ -2,8 +2,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using BindingFlags = System.Reflection.BindingFlags;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypesAllOnCopyAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypesAllOnCopyAssembly.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.DataFlow.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypesRelationships.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypesRelationships.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefParameterDataFlow.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefReturnDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodByRefReturnDataFlow.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodOutParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodOutParameterDataFlow.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Reflection;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/RefFieldDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/RefFieldDataFlow.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using DAM = System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute;
 using DAMT = System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes;
 
@@ -519,11 +516,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		ref struct RefFieldWithMethods
 		{
 			[Kept]
-			[DynamicallyAccessedMembers (DAMT.PublicMethods)]
+			[DAM (DAMT.PublicMethods)]
 			public ref Type T;
 
 			[Kept]
-			public RefFieldWithMethods ([DynamicallyAccessedMembers (DAMT.PublicMethods)] ref Type t)
+			public RefFieldWithMethods ([DAM (DAMT.PublicMethods)] ref Type t)
 			{
 				T = ref t;
 			}
@@ -533,11 +530,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		ref struct RefFieldWithFields
 		{
 			[Kept]
-			[DynamicallyAccessedMembers (DAMT.PublicFields)]
+			[DAM (DAMT.PublicFields)]
 			public ref Type T;
 
 			[Kept]
-			public RefFieldWithFields ([DynamicallyAccessedMembers (DAMT.PublicFields)] ref Type t)
+			public RefFieldWithFields ([DAM (DAMT.PublicFields)] ref Type t)
 			{
 				T = ref t;
 			}
@@ -547,11 +544,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		ref struct RefFieldWithMethodsAndFields
 		{
 			[Kept]
-			[DynamicallyAccessedMembers (DAMT.PublicFields | DAMT.PublicMethods)]
+			[DAM (DAMT.PublicFields | DAMT.PublicMethods)]
 			public ref Type T;
 
 			[Kept]
-			public RefFieldWithMethodsAndFields ([DynamicallyAccessedMembers (DAMT.PublicFields | DAMT.PublicMethods)] ref Type t)
+			public RefFieldWithMethodsAndFields ([DAM (DAMT.PublicFields | DAMT.PublicMethods)] ref Type t)
 			{
 				T = ref t;
 			}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/StaticInterfaceMethodDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/StaticInterfaceMethodDataflow.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.DataFlow

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/SuppressWarningWithLinkAttributes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/SuppressWarningWithLinkAttributes.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/TypeBaseTypeDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/TypeBaseTypeDataFlow.cs
@@ -2,12 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/TypeHandleDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/TypeHandleDataFlow.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/TypeInfoIntrinsics.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/TypeInfoIntrinsics.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/VirtualMethodHierarchyDataflowAnnotationValidation.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/VirtualMethodHierarchyDataflowAnnotationValidation.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.DataFlow.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/XmlAnnotations.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/XmlAnnotations.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/DynamicDependencyInCopyAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/DynamicDependencyInCopyAssembly.cs
@@ -1,6 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/DynamicDependencyMethodInAssemblyLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/DynamicDependencyMethodInAssemblyLibrary.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
+﻿namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
 {
 	public class DynamicDependencyMethodInAssemblyLibrary
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/DynamicDependencyMethodInNonReferencedAssemblyChainedLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/DynamicDependencyMethodInNonReferencedAssemblyChainedLibrary.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/ReferenceImplementationLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/Dependencies/ReferenceImplementationLibrary.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyField.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyField.cs
@@ -1,8 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXml.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyFromAttributeXml.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyKeptOption.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyKeptOption.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberSignatureWildcard.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberSignatureWildcard.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberTypes.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
@@ -1,8 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInNonReferencedAssemblyWithEmbeddedXml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnForwardedType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnForwardedType.cs
@@ -1,12 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnUnusedMethodInNonReferencedAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnUnusedMethodInNonReferencedAssembly.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnUnusedMethodInNonReferencedAssemblyWithEmbeddedXml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/NewConstraintOnClass.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Generics/NewConstraintOnClass.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Generics

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/Dependencies/OverrideOfAbstractIsKeptNonEmptyLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/Dependencies/OverrideOfAbstractIsKeptNonEmptyLibrary.cs
@@ -1,12 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval.Dependencies
 {
 	public class OverrideOfAbstractIsKeptNonEmpty_UnusedType

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/Dependencies/OverrideOfAbstractIsKeptNonEmptyLibraryWithNonEmpty.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.AbstractClasses/NoKeptCtor/OverrideRemoval/Dependencies/OverrideOfAbstractIsKeptNonEmptyLibraryWithNonEmpty.cs
@@ -1,12 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Mono.Linker.Tests.Cases.Inheritance.AbstractClasses.NoKeptCtor.OverrideRemoval.Dependencies
 {
 	public class OverrideOfAbstractIsKeptNonEmptyLibraryWithNonEmpty :

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DefaultInterfaceMethodCallIntoClass.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DefaultInterfaceMethodCallIntoClass.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/GenericDefaultInterfaceMethods.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/GenericDefaultInterfaceMethods.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/InterfaceWithAttributeOnImplementation.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/InterfaceWithAttributeOnImplementation.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/SimpleDefaultInterfaceMethod.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/SimpleDefaultInterfaceMethod.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/UnusedDefaultInterfaceImplementation.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/UnusedDefaultInterfaceImplementation.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/InterfaceOnUninstantiatedTypeRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/InterfaceOnUninstantiatedTypeRemoved.cs
@@ -1,5 +1,4 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/BaseProvidesInterfaceMember/GenericInterfaceWithMethodComplex2.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/BaseProvidesInterfaceMember/GenericInterfaceWithMethodComplex2.cs
@@ -1,4 +1,3 @@
-using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/InterfaceNeededOnUnrelatedInterfaceList.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/InterfaceNeededOnUnrelatedInterfaceList.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/DynamicDependencyPreservesInterfaceMethod.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoKeptCtor/DynamicDependencyPreservesInterfaceMethod.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoKeptCtor
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/BaseProvidesInterfaceMethod.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/BaseProvidesInterfaceMethod.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Policy;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/Dependencies/Library.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/Dependencies/Library.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods.Dependencies
 {
 	public interface IStaticInterfaceWithDefaultImpls

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/OverrideInCopyAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/OverrideInCopyAssembly.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods.Dependencies;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/OverrideInSaveAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/OverrideInSaveAssembly.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods.Dependencies;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticAbstractInterfaceMethods.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticAbstractInterfaceMethods.cs
@@ -2,14 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticAbstractInterfaceMethodsLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticAbstractInterfaceMethodsLibrary.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticInterfaceMethodsInPreservedScope.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticInterfaceMethodsInPreservedScope.cs
@@ -1,13 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticVirtualInterfaceMethodsInPreservedScope.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticVirtualInterfaceMethodsInPreservedScope.cs
@@ -1,13 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticVirtualInterfaceMethodsInPreservedScopeLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticVirtualInterfaceMethodsInPreservedScopeLibrary.cs
@@ -1,13 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticVirtualInterfaceMethodsLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/StaticVirtualInterfaceMethodsLibrary.cs
@@ -1,13 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/UnusedInterfacesInPreservedScope.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/UnusedInterfacesInPreservedScope.cs
@@ -1,20 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Mono;
-using Mono.Linker;
-using Mono.Linker.Tests;
-using Mono.Linker.Tests.Cases;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
-using Mono.Linker.Tests.Cases.Inheritance;
-using Mono.Linker.Tests.Cases.Inheritance.Interfaces;
-using Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods;
 using Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/UnusedStaticInterfaceMethods.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/UnusedStaticInterfaceMethods.cs
@@ -2,12 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/VarianceBasic.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/VarianceBasic.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/OverrideOfAbstractInUnmarkedClassIsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/OverrideOfAbstractInUnmarkedClassIsRemoved.cs
@@ -1,13 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/UsedTypeWithOverrideOfVirtualMethodHasOverrideKept.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.VirtualMethods/UsedTypeWithOverrideOfVirtualMethodHasOverrideKept.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.VirtualMethods
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Interop/ByteArrayCom.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Interop/ByteArrayCom.cs
@@ -1,12 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Interop

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Interop/PInvoke/UnusedPInvoke.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Interop/PInvoke/UnusedPInvoke.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace Mono.Linker.Tests.Cases.Interop.PInvoke
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Interop/PInvoke/Warnings/ComPInvokeWarning.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/RootLibraryVisibleForwarders_Lib.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/RootLibraryVisibleForwarders_Lib.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 public class ExternalPublic
 {
 	protected void ProtectedMethod ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/LibraryWithUnresolvedInterfaces.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/LibraryWithUnresolvedInterfaces.cs
@@ -1,10 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.Serialization;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Libraries.Dependencies;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/AssemblyLevelLinkerAttributeRemoval_Lib.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/AssemblyLevelLinkerAttributeRemoval_Lib.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Mono.Linker.Tests.Cases.TestAttributeLib;
 
 [assembly: MyAttribute]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/LinkerAttributeRemovalAttributeFromCopyAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/LinkerAttributeRemovalAttributeFromCopyAssembly.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Mono.Linker.Tests.Cases.LinkAttributes.Dependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/LinkerAttributeRemovalAttributeToRemove.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/LinkerAttributeRemovalAttributeToRemove.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Mono.Linker.Tests.Cases.LinkAttributes.Dependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/ReferencedAssemblyWithAttributes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/Dependencies/ReferencedAssemblyWithAttributes.cs
@@ -1,4 +1,3 @@
-using System;
 using Mono.Linker.Tests.Cases.LinkAttributes.Dependencies;
 
 [assembly: TestRemove]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/EmbeddedLinkAttributes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/EmbeddedLinkAttributes.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemovalConditional.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkerAttributeRemovalConditional.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/OverrideAttributeRemoval.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/OverrideAttributeRemoval.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveAnExportedType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveAnExportedType.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.LinkXml.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExcludedFeatureCom.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExcludedFeatureCom.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExportedTypesUsingRegex.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExportedTypesUsingRegex.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.LinkXml.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveTypesUsingRegex.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveTypesUsingRegex.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.LinkXml

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/CanPreserveAnExportedType_Library.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/CanPreserveAnExportedType_Library.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Mono.Linker.Tests.Cases.LinkXml.Dependencies
+﻿namespace Mono.Linker.Tests.Cases.LinkXml.Dependencies
 {
 	public class CanPreserveAnExportedType_Library
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/CopyLibrary.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlFromCopyAssemblyIsProcessed
 {
 	public class CopyLibrary

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/OtherLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/Dependencies/EmbeddedLinkXmlFromCopyAssemblyIsProcessed/OtherLibrary.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Mono.Linker.Tests.Cases.LinkXml.Dependencies.EmbeddedLinkXmlFromCopyAssemblyIsProcessed
 {
 	public class OtherLibrary

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlUnresolvedReferencesAreReported.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlUnresolvedReferencesAreReported.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/PreserveSecondLevelMethodsOfNonRequiredType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/PreserveSecondLevelMethodsOfNonRequiredType.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/UnusedTypeDeclarationPreservedByLinkXmlIsKept.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/UnusedTypeDeclarationPreservedByLinkXmlIsKept.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.LinkXml

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredTypeIsKeptWithSingleMethod.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredTypeIsKeptWithSingleMethod.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinqExpressions/CanPreserveCustomOperators.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinqExpressions/CanPreserveCustomOperators.cs
@@ -1,5 +1,4 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.LinqExpressions
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinqExpressions/CustomOperatorsWithUnusedArgumentTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinqExpressions/CustomOperatorsWithUnusedArgumentTypes.cs
@@ -1,5 +1,4 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.LinqExpressions
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Metadata/NamesAreRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Metadata/NamesAreRemoved.cs
@@ -1,5 +1,4 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Metadata
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyInCopyAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyInCopyAssembly.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/PreserveDependencies/Dependencies/PreserveDependencyMethodInAssemblyLibrary.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies
+﻿namespace Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies
 {
 	public class PreserveDependencyMethodInAssemblyLibrary
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingSaveAction.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingSaveAction.cs
@@ -1,5 +1,4 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.References.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingSaveActionWithSymbols.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingSaveActionWithSymbols.cs
@@ -1,5 +1,4 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.References.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithCsc.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/AssemblyOnlyUsedByUsingWithCsc.cs
@@ -1,5 +1,4 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.References.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Dependencies/UnusedReferencedFromCopyAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Dependencies/UnusedReferencedFromCopyAssembly.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Mono.Linker.Tests.Cases.References.Dependencies
 {
 	public class UnusedReferencedFromCopyAssembly

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Dependencies/UnusedReferencedFromDynamicCopyAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Dependencies/UnusedReferencedFromDynamicCopyAssembly.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Mono.Linker.Tests.Cases.References.Dependencies
 {
 	public class UnusedReferencedFromDynamicCopyAssembly

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Individual/CanSkipUnresolved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Individual/CanSkipUnresolved.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
+﻿using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.References.Individual.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.References.Individual

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Individual/Dependencies/CanSkipUnresolved_Library.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Individual/Dependencies/CanSkipUnresolved_Library.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Mono.Linker.Tests.Cases.References.Individual.Dependencies
+﻿namespace Mono.Linker.Tests.Cases.References.Individual.Dependencies
 {
 	public class CanSkipUnresolved_Library
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/UserAssembliesAreLinkedByDefault.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/UserAssembliesAreLinkedByDefault.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.References.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/AsType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/AsType.cs
@@ -1,12 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Reflection

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/AssemblyImportedViaReflection.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ExpressionCallString.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ExpressionNewType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ExpressionNewType.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyMethodInfo.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ExpressionPropertyMethodInfo.cs
@@ -2,13 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Reflection

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflectionWithDefaultBindingFlags.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/MethodUsedViaReflectionWithDefaultBindingFlags.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/NestedTypeUsedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/NestedTypeUsedViaReflection.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/NestedTypesUsedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/NestedTypesUsedViaReflection.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetType.cs
@@ -4,10 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetTypeLibraryMode.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ObjectGetTypeLibraryMode.cs
@@ -1,12 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ParametersUsedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/ParametersUsedViaReflection.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq.Expressions;
-using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/PropertiesUsedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/PropertiesUsedViaReflection.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/RunClassConstructorUsedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/RunClassConstructorUsedViaReflection.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeBaseTypeUseViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeBaseTypeUseViaReflection.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Reflection

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeDelegator.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeDelegator.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyLibraryModeSuppressions.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyLibraryModeSuppressions.cs
@@ -1,12 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
@@ -7,11 +7,9 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchySuppressions.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchySuppressions.cs
@@ -2,12 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -3,7 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionLdstrValidButChanged.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflectionLdstrValidButChanged.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Reflection
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/UnderlyingSystemType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/UnderlyingSystemType.cs
@@ -2,11 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Repro/Program.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Repro/Program.cs
@@ -2,18 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Repro
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/BasicRequires.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/BasicRequires.cs
@@ -2,18 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/Dependencies/ReferenceInterfaces.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/Dependencies/ReferenceInterfaces.cs
@@ -1,12 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability.Dependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/Dependencies/RequiresInCopyAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/Dependencies/RequiresInCopyAssembly.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability.Dependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresAccessedThrough.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresAccessedThrough.cs
@@ -2,14 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresAttributeMismatch.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresAttributeMismatch.cs
@@ -1,12 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapabilityReflectionAnalysisEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresCapabilityReflectionAnalysisEnabled.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCode.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCodeRelease.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresInCompilerGeneratedCodeRelease.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnAttribute.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
@@ -2,12 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnStaticConstructor.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnStaticConstructor.cs
@@ -2,13 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnVirtualsAndInterfaces.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnVirtualsAndInterfaces.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresViaDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresViaDataflow.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.RequiresCapability

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresViaXml.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresViaXml.cs
@@ -1,12 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresWithCopyAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresWithCopyAssembly.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.RequiresCapability.Dependencies;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/SuppressRequires.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/SuppressRequires.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsNotProcessedIfNameDoesNotMatchAnAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsNotProcessedIfNameDoesNotMatchAnAssembly.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Resources

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsNotProcessedWithIgnoreDescriptors.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsNotProcessedWithIgnoreDescriptors.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Resources

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsNotProcessedWithIgnoreDescriptorsAndRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsNotProcessedWithIgnoreDescriptorsAndRemoved.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Resources

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsProcessed.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsProcessed.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Resources

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsProcessedAndKept.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsProcessedAndKept.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Resources

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsProcessedIfNameMatchesAnAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/EmbeddedLinkXmlFileIsProcessedIfNameMatchesAnAssembly.cs
@@ -1,4 +1,3 @@
-using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/NonLinkerEmbeddedResourceHasNoImpact.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Resources/NonLinkerEmbeddedResourceHasNoImpact.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Resources

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Sealer/MethodsDevirtualization.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Sealer/MethodsDevirtualization.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Reflection;
-using System.Reflection.Emit;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Sealer/TypesCanBeSealed.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Sealer/TypesCanBeSealed.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Reflection;
-using System.Reflection.Emit;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Serialization/CanDisableSerializationDiscovery.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Serialization/CanDisableSerializationDiscovery.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Xml.Serialization;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/SingleFile/SingleFileIntrinsics.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/SingleFile/SingleFileIntrinsics.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Statics/ExplicitStaticCtor.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Statics/ExplicitStaticCtor.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Statics/UnusedStaticConstructorGetsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Statics/UnusedStaticConstructorGetsRemoved.cs
@@ -1,6 +1,4 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
-
-namespace Mono.Linker.Tests.Cases.Statics
+﻿namespace Mono.Linker.Tests.Cases.Statics
 {
 	class UnusedStaticConstructorGetsRemoved
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Statics/UnusedStaticMethodGetsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Statics/UnusedStaticMethodGetsRemoved.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Statics
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Substitutions/StubBodyWithStaticCtor.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Substitutions/StubBodyWithStaticCtor.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/Dependencies/LibraryWithEmbeddedPdbSymbols.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/Dependencies/LibraryWithEmbeddedPdbSymbols.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Mono.Linker.Tests.Cases.Symbols.Dependencies
+﻿namespace Mono.Linker.Tests.Cases.Symbols.Dependencies
 {
 	public class LibraryWithEmbeddedPdbSymbols
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/Dependencies/LibraryWithPortablePdbSymbols.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/Dependencies/LibraryWithPortablePdbSymbols.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Mono.Linker.Tests.Cases.Symbols.Dependencies
+﻿namespace Mono.Linker.Tests.Cases.Symbols.Dependencies
 {
 	public class LibraryWithPortablePdbSymbols
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithEmbeddedPdb.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithEmbeddedPdb.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithEmbeddedPdbAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithEmbeddedPdbAndSymbolLinkingEnabled.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdb.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdb.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbAndSymbolLinkingEnabled.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabled.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPortablePdb.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPortablePdb.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPortablePdbAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPortablePdbAndSymbolLinkingEnabled.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypes.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesAndSymbolLinkingEnabled.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithCsc.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithCsc.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TestFramework.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithDebugPdbs.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithDebugPdbs.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TestFramework

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithMcs.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileTestCaseWithMcs.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TestFramework.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanCompileTestCaseWithCsc_Lib.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanCompileTestCaseWithCsc_Lib.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Mono.Linker.Tests.Cases.TestFramework.Dependencies
+﻿namespace Mono.Linker.Tests.Cases.TestFramework.Dependencies
 {
 	public class CanCompileTestCaseWithCsc_Lib
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanCompileTestCaseWithMcs_Lib.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/Dependencies/CanCompileTestCaseWithMcs_Lib.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Mono.Linker.Tests.Cases.TestFramework.Dependencies
+﻿namespace Mono.Linker.Tests.Cases.TestFramework.Dependencies
 {
 	public class CanCompileTestCaseWithMcs_Lib
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyExpectModifiedAttributesWork.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyExpectModifiedAttributesWork.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.Tracing;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyResourceInAssemblyAttributesBehavior.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyResourceInAssemblyAttributesBehavior.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TestFramework

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Tracing/DependencyRecorder/BasicDependencies.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Tracing/DependencyRecorder/BasicDependencies.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
 namespace Mono.Linker.Tests.Cases.Tracing.DependencyRecorder
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Tracing/Individual/CanDumpDependenciesToUncompressedDgml.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Tracing/Individual/CanDumpDependenciesToUncompressedDgml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
+﻿using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Tracing.Individual
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Tracing/Individual/CanDumpDependenciesToUncompressedXml.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Tracing/Individual/CanDumpDependenciesToUncompressedXml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
+﻿using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Tracing.Individual
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Tracing/Individual/CanEnableDependenciesDump.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Tracing/Individual/CanEnableDependenciesDump.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
+﻿using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Tracing.Individual
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Tracing/Individual/CanEnableReducedTracing.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Tracing/Individual/CanEnableReducedTracing.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
+﻿using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Tracing.Individual
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/AnotherLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/AnotherLibrary.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Reflection;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
-
 namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
 {
 	public class AnotherLibrary<T>

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/ImplementationLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/ImplementationLibrary.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Reflection;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 //[assembly: AssemblyVersion ("2.0")]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/LibraryUsingForwarder.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/LibraryUsingForwarder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
+﻿using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/ReferenceImplementationLibrary_3.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/Dependencies/ReferenceImplementationLibrary_3.cs
@@ -1,6 +1,4 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Metadata;
-
-namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
+﻿namespace Mono.Linker.Tests.Cases.TypeForwarding.Dependencies
 {
 	public class ImplementationLibrary3B
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardedIsUpdatedForMissingType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardedIsUpdatedForMissingType.cs
@@ -1,4 +1,3 @@
-using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardersModifiers.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardersModifiers.cs
@@ -1,4 +1,3 @@
-using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderInCopyAssemblyKeptByUsedCustomAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderInCopyAssemblyKeptByUsedCustomAttribute.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderInCopyAssemblyKeptByUsedInterface.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderInCopyAssemblyKeptByUsedInterface.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderInCopyAssemblyKeptByUsedNestedType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderInCopyAssemblyKeptByUsedNestedType.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderInCopyAssemblyKeptByUsedProperty.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderInCopyAssemblyKeptByUsedProperty.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderWithAssemblyCopyUsedAndForwarderLibraryKept.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedForwarderWithAssemblyCopyUsedAndForwarderLibraryKept.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedTransitiveForwarderIsResolvedAndFacadeRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedTransitiveForwarderIsResolvedAndFacadeRemoved.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedTransitiveForwarderIsResolvedAndFacadeRemovedInCopyAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/UsedTransitiveForwarderIsResolvedAndFacadeRemovedInCopyAssembly.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.TypeForwarding.Dependencies;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/BodiesWithSubstitutions.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/BodiesWithSubstitutions.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditionsOptimized.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/ComplexConditionsOptimized.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Reflection.Emit;
 using System.Runtime.InteropServices;
-using System.Runtime.Serialization;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/DataFlowRelated.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/DataFlowRelated.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/Dependencies/ReferencedAssemblyWithUnreachableBlocks.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/Dependencies/ReferencedAssemblyWithUnreachableBlocks.cs
@@ -1,6 +1,3 @@
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
-
 namespace Mono.Linker.Tests.Cases.UnreachableBlock.Dependencies
 {
 	public class AssemblyWithUnreachableBlocks

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/EndScopeOnMethoEnd.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/EndScopeOnMethoEnd.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBlock

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/ReplacedJumpTarget.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/ReplacedJumpTarget.cs
@@ -1,4 +1,3 @@
-using System;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBody/WorksWithDynamicDependency.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBody/WorksWithDynamicDependency.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanDisableWarnAsError.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanDisableWarnAsError.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Warnings

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanNotSingleWarnPerAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanNotSingleWarnPerAssembly.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanSingleWarn.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanSingleWarn.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanSingleWarnPerAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanSingleWarnPerAssembly.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanSingleWarnWithIndividualWarnAsError.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanSingleWarnWithIndividualWarnAsError.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanSingleWarnWithNoWarn.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanSingleWarnWithNoWarn.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanSingleWarnWithWarnAsError.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanSingleWarnWithWarnAsError.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanWarnAsError.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanWarnAsError.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Mono.Linker.Tests.Cases.Expectations.Assertions;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Warnings

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/Individual/CanGenerateWarningSuppressionFileCSharp.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/Individual/CanGenerateWarningSuppressionFileCSharp.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Warnings.Dependencies;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/Individual/CustomStepWithWarnings.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/Individual/CustomStepWithWarnings.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/InvalidWarningVersion.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/InvalidWarningVersion.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/NoWarnRegardlessOfWarnAsError.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/NoWarnRegardlessOfWarnAsError.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsFromXML.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsFromXML.cs
@@ -1,11 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInAssembly.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [assembly: ExpectedWarning ("IL2121", "IL2071", ProducedBy = Tool.Trimmer)]
 [assembly: UnconditionalSuppressMessage ("Test", "IL2071:Redundant suppression, warning is not issued in this assembly")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInCompilerGeneratedCode.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInCompilerGeneratedCode.cs
@@ -4,11 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
-
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInMembersAndTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInMembersAndTypes.cs
@@ -5,8 +5,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
-
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInMembersAndTypesUsingTarget.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInMembersAndTypesUsingTarget.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [module: UnconditionalSuppressMessage ("Test", "IL2071", Scope = "type", Target = "T:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.DetectRedundantSuppressionsInMembersAndTypesUsingTarget.RedundantSuppressionOnType")]
 [module: UnconditionalSuppressMessage ("Test", "IL2071", Scope = "member", Target = "M:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.DetectRedundantSuppressionsInMembersAndTypesUsingTarget.RedundantSuppressionOnMethod.Test")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInModule.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsInModule.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [assembly: ExpectedWarning ("IL2121", "IL2071", ProducedBy = Tool.Trimmer)]
 [module: UnconditionalSuppressMessage ("Test", "IL2071:Redundant suppression, warning is not issued in this assembly")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsSingleWarn.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsSingleWarn.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsTrimmedMembersTarget.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/DetectRedundantSuppressionsTrimmedMembersTarget.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [assembly: UnconditionalSuppressMessage ("Test", "IL2071",
 	Scope = "type",

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/ModuleSuppressionWithMemberScopeNullTarget.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/ModuleSuppressionWithMemberScopeNullTarget.cs
@@ -2,13 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 // A module level suppression with a 'type' or 'member' scope must also specify the target, pointing
 // to the type or member where the suppression should be put.

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/ModuleSuppressionWithModuleScopeNullTarget.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/ModuleSuppressionWithModuleScopeNullTarget.cs
@@ -2,13 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [module: UnconditionalSuppressMessage ("Test", "IL2026", Scope = "module", Target = null)]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/ModuleSuppressionWithNullScopeNullTarget.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/ModuleSuppressionWithNullScopeNullTarget.cs
@@ -2,13 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 // A module level suppression with a null scope will be put on the current module.
 [module: UnconditionalSuppressMessage ("Test", "IL2026", Scope = null, Target = null)]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInAssembly.cs
@@ -2,14 +2,13 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [assembly: UnconditionalSuppressMessage ("Test", "IL2072:Suppress unrecognized reflection pattern warnings in this assembly")]
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
 #if !NETCOREAPP
-	[Reference ("System.Core.dll")]
+	[Mono.Linker.Tests.Cases.Expectations.Metadata.Reference ("System.Core.dll")]
 #endif
 	[SkipKeptItemsValidation]
 	[LogDoesNotContain ("TriggerUnrecognizedPattern()")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCopyAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCopyAssembly.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 using System.Reflection;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypes.cs
@@ -3,12 +3,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
 #if !NETCOREAPP
-	[Reference ("System.Core.dll")]
+	[Mono.Linker.Tests.Cases.Expectations.Metadata.Reference ("System.Core.dll")]
 #endif
 	[SkipKeptItemsValidation]
 	[LogDoesNotContain ("TriggerUnrecognizedPattern()")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypesUsingTarget.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInMembersAndTypesUsingTarget.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
-using System.Text;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [module: UnconditionalSuppressMessage ("Test", "IL2072", Scope = "type", Target = "T:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.WarningsInType")]
 [module: UnconditionalSuppressMessage ("Test", "IL2072", Scope = "member", Target = "M:Mono.Linker.Tests.Cases.Warnings.WarningSuppression.WarningsInMembers.Method")]
@@ -16,14 +13,14 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
 #if !NETCOREAPP
-	[Reference ("System.Core.dll")]
+	[Mono.Linker.Tests.Cases.Expectations.Metadata.Reference ("System.Core.dll")]
 #endif
 	[SkipKeptItemsValidation]
 	[LogDoesNotContain ("TriggerUnrecognizedPattern()")]
 	public class SuppressWarningsInMembersAndTypesUsingTarget
 	{
 		/// <summary>
-		/// This test case checks module level UnconditionalSuppressMessage, primarily using 
+		/// This test case checks module level UnconditionalSuppressMessage, primarily using
 		/// System.Linq.Expressions.Expression.(Type type, string methodName, Type[]? typeArguments, params System.Linq.Expressions.Expression[]? arguments)
 		/// which has a RUC attribute but is treated as an intrinsic by the trimmer. The test case also has some member level suppressions and its
 		/// own RUC method (the IL2026 suppression in the code is due to this)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInModule.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInModule.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 [module: UnconditionalSuppressMessage ("Test", "IL2072:Suppress unrecognized reflection pattern warnings in this module")]
 [module: UnconditionalSuppressMessage ("Test", "IL2026:Test that specifying an invalid scope will result in a global suppression being ignored.",
@@ -11,7 +10,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 {
 #if !NETCOREAPP
-	[Reference ("System.Core.dll")]
+	[Mono.Linker.Tests.Cases.Expectations.Metadata.Reference ("System.Core.dll")]
 #endif
 	[SkipKeptItemsValidation]
 	[LogDoesNotContain ("TriggerUnrecognizedPattern()")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsViaXml.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsViaXml.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Helpers;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/TargettedModuleSuppressionWithUnmatchedScope.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/TargettedModuleSuppressionWithUnmatchedScope.cs
@@ -2,14 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
-using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 // Module suppressions that have scope argument `type` or `member` will always cause the value of the target parameter
 // to be parsed using the DocumentationSignatureParser, this parser rules where will the suppression be put depending upon the

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningsFromTrimmableAssembliesCanSurviveSingleWarn.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/WarningsFromTrimmableAssembliesCanSurviveSingleWarn.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Warnings.Dependencies;


### PR DESCRIPTION
The main goal here is to get rid of the unused `System.Linq` usings.  These cause problems for our UnityLinker tests that run against mono class libraries as it requires an additional reference.  We could work around it by referencing everything in the mono class libraries, which is what illink does during it's tests.  That said, some of the files had a lot of unnecessary usings and I don't think it's a bad thing to clean them up anyways.

Rather than hunt down the 10-20 files that were problematic I ran Rider's namespace clean up functionality on `Mono.Linker.Tests.Cases`