### PR TITLE
Don't generate Unmanaged-to-Managed stubs with diagnostics

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -580,7 +580,7 @@ namespace Microsoft.Interop
 
             var vtableSlotAssignments = VirtualMethodPointerStubGenerator.GenerateVirtualMethodTableSlotAssignments(
                 interfaceMethods.Methods
-                    .Where(context => context.GenerationContext.Diagnostics.Length == 0 && context.UnmanagedToManagedStub.Diagnostics.Length == 0)
+                    .Where(context => context.UnmanagedToManagedStub.Diagnostics.Length == 0)
                     .Select(context => context.GenerationContext),
                 vtableLocalName);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -417,6 +417,7 @@ namespace Microsoft.Interop
                         comInterfaceAndMethods.DeclaredMethods
                             .Select(m => m.UnmanagedToManagedStub)
                             .OfType<GeneratedStubCodeContext>()
+                            .Where(context => context.Diagnostics.Length == 0)
                             .Select(context => context.Stub.Node)));
         }
 
@@ -577,7 +578,11 @@ namespace Microsoft.Interop
                                         })))));
             }
 
-            var vtableSlotAssignments = VirtualMethodPointerStubGenerator.GenerateVirtualMethodTableSlotAssignments(interfaceMethodStubs, vtableLocalName);
+            var vtableSlotAssignments = VirtualMethodPointerStubGenerator.GenerateVirtualMethodTableSlotAssignments(
+                interfaceMethods.Methods
+                    .Where(context => context.GenerationContext.Diagnostics.Length == 0 && context.UnmanagedToManagedStub.Diagnostics.Length == 0)
+                    .Select(context => context.GenerationContext),
+                vtableLocalName);
 
             return ImplementationInterfaceTemplate
                 .AddMembers(

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -437,7 +437,6 @@ namespace Microsoft.Interop
 
             const string vtableLocalName = "vtable";
             var interfaceType = interfaceMethods.Interface.Info.Type;
-            var interfaceMethodStubs = interfaceMethods.DeclaredMethods.Select(m => m.GenerationContext);
 
             // void** vtable = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(<interfaceType>, sizeof(void*) * <max(vtableIndex) + 1>);
             var vtableDeclarationStatement =
@@ -579,7 +578,7 @@ namespace Microsoft.Interop
             }
 
             var vtableSlotAssignments = VirtualMethodPointerStubGenerator.GenerateVirtualMethodTableSlotAssignments(
-                interfaceMethods.Methods
+                interfaceMethods.DeclaredMethods
                     .Where(context => context.UnmanagedToManagedStub.Diagnostics.All(diag => diag.Descriptor.DefaultSeverity != DiagnosticSeverity.Error))
                     .Select(context => context.GenerationContext),
                 vtableLocalName);

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -417,7 +417,7 @@ namespace Microsoft.Interop
                         comInterfaceAndMethods.DeclaredMethods
                             .Select(m => m.UnmanagedToManagedStub)
                             .OfType<GeneratedStubCodeContext>()
-                            .Where(context => context.Diagnostics.Length == 0)
+                            .Where(context => context.Diagnostics.Any(diag => diag.Descriptor.DefaultSeverity == DiagnosticSeverity.Error))
                             .Select(context => context.Stub.Node)));
         }
 
@@ -580,7 +580,7 @@ namespace Microsoft.Interop
 
             var vtableSlotAssignments = VirtualMethodPointerStubGenerator.GenerateVirtualMethodTableSlotAssignments(
                 interfaceMethods.Methods
-                    .Where(context => context.UnmanagedToManagedStub.Diagnostics.Length == 0)
+                    .Where(context => context.UnmanagedToManagedStub.Diagnostics.Any(diag => diag.Descriptor.DefaultSeverity == DiagnosticSeverity.Error))
                     .Select(context => context.GenerationContext),
                 vtableLocalName);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -417,7 +417,7 @@ namespace Microsoft.Interop
                         comInterfaceAndMethods.DeclaredMethods
                             .Select(m => m.UnmanagedToManagedStub)
                             .OfType<GeneratedStubCodeContext>()
-                            .Where(context => context.Diagnostics.Any(diag => diag.Descriptor.DefaultSeverity == DiagnosticSeverity.Error))
+                            .Where(context => context.Diagnostics.All(diag => diag.Descriptor.DefaultSeverity != DiagnosticSeverity.Error))
                             .Select(context => context.Stub.Node)));
         }
 
@@ -580,7 +580,7 @@ namespace Microsoft.Interop
 
             var vtableSlotAssignments = VirtualMethodPointerStubGenerator.GenerateVirtualMethodTableSlotAssignments(
                 interfaceMethods.Methods
-                    .Where(context => context.UnmanagedToManagedStub.Diagnostics.Any(diag => diag.Descriptor.DefaultSeverity == DiagnosticSeverity.Error))
+                    .Where(context => context.UnmanagedToManagedStub.Diagnostics.All(diag => diag.Descriptor.DefaultSeverity != DiagnosticSeverity.Error))
                     .Select(context => context.GenerationContext),
                 vtableLocalName);
 

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/CompileFails.cs
@@ -355,8 +355,6 @@ namespace ComInterfaceGenerator.Unit.Tests
             {
                 TestCode = source,
                 TestBehaviors = TestBehaviors.SkipGeneratedSourcesCheck,
-                // Our fallback mechanism for invalid code for unmanaged->managed stubs sometimes generates invalid code.
-                CompilerDiagnostics = CompilerDiagnostics.None,
             };
             test.ExpectedDiagnostics.AddRange(expectedDiagnostics);
             await test.RunAsync();


### PR DESCRIPTION
This PR disables our "partial generation" feature for the unmanaged->managed stubs. The partial generation generates many invalid `[UnmanagedCallersOnly]` method signatures, which causes compiler errors. By disabling the generation, we ensure that the source-generated code doesn't produce any compiler errors itself.

Fixes #82581
