### PR TITLE
[wasm][debugger] Fix reading metadata info after applying changes

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -370,7 +370,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             _asyncScopes = Array.Empty<AsyncScopeDebugInformation>();
         }
 
-        public MethodInfo(AssemblyInfo assembly, MethodDefinitionHandle methodDefHandle, int token, SourceFile source, TypeInfo type, MetadataReader asmMetadataReader, MetadataReader pdbMetadataReader, bool fromEnC = false)
+        public MethodInfo(AssemblyInfo assembly, MethodDefinitionHandle methodDefHandle, int token, SourceFile source, TypeInfo type, MetadataReader asmMetadataReader, MetadataReader pdbMetadataReader, bool fromEnC)
         {
             this.IsAsync = -1;
             this.Assembly = assembly;
@@ -849,7 +849,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         internal MetadataReader asmMetadataReader { get; }
         internal MetadataReader pdbMetadataReader { get; set; }
 
-        internal List<Tuple<MetadataReader, MetadataReader>> enCMetadataReader = new();
+        internal List<(MetadataReader asm, MetadataReader pdb)> enCMetadataReader = new();
         private int debugId;
         internal int PdbAge { get; }
         internal System.Guid PdbGuid { get; }
@@ -1039,7 +1039,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             while (typeIdx > asmMetadataReaderLocal.TypeReferences.Count)
             {
                 typeIdx -= asmMetadataReaderLocal.TypeReferences.Count;
-                asmMetadataReaderLocal = enCMetadataReader[i].Item1;
+                asmMetadataReaderLocal = enCMetadataReader[i].asm;
                 i += 1;
             }
             return asmMetadataReaderLocal.GetTypeReference(MetadataTokens.TypeReferenceHandle(typeIdx));
@@ -1053,7 +1053,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             while (typeIdx > asmMetadataReaderLocal.TypeDefinitions.Count)
             {
                 typeIdx -= asmMetadataReaderLocal.TypeDefinitions.Count;
-                asmMetadataReaderLocal = enCMetadataReader[i].Item1;
+                asmMetadataReaderLocal = enCMetadataReader[i].asm;
                 i += 1;
             }
             return asmMetadataReaderLocal.GetTypeDefinition(MetadataTokens.TypeDefinitionHandle(typeIdx));
@@ -1066,7 +1066,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             while (methodIdx > asmMetadataReaderLocal.MethodDefinitions.Count)
             {
                 methodIdx -= asmMetadataReaderLocal.MethodDefinitions.Count;
-                asmMetadataReaderLocal = enCMetadataReader[i].Item1;
+                asmMetadataReaderLocal = enCMetadataReader[i].asm;
                 i += 1;
             }
             return asmMetadataReaderLocal.GetMethodDefinition(MetadataTokens.MethodDefinitionHandle(methodIdx));
@@ -1080,7 +1080,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             while (memberIdx > asmMetadataReaderLocal.MemberReferences.Count)
             {
                 memberIdx -= asmMetadataReaderLocal.MemberReferences.Count;
-                asmMetadataReaderLocal = enCMetadataReader[i].Item1;
+                asmMetadataReaderLocal = enCMetadataReader[i].asm;
                 i += 1;
             }
             return asmMetadataReaderLocal.GetMemberReference(MetadataTokens.MemberReferenceHandle(memberIdx));
@@ -1094,7 +1094,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             while (strIdx > asmMetadataReaderLocal.GetHeapSize(HeapIndex.String))
             {
                 strIdx -= asmMetadataReaderLocal.GetHeapSize(HeapIndex.String);
-                asmMetadataReaderLocal = enCMetadataReader[i].Item1;
+                asmMetadataReaderLocal = enCMetadataReader[i].asm;
                 i+=1;
             }
             return asmMetadataReaderLocal.GetString(MetadataTokens.StringHandle(strIdx));
@@ -1200,7 +1200,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                             source = GetOrAddSourceFile(methodDebugInformation.Document, documentName);
                         }
                     }
-                    var methodInfo = new MethodInfo(this, method, asmMetadataReader.GetRowNumber(method), source, typeInfo, asmMetadataReader, pdbMetadataReader);
+                    var methodInfo = new MethodInfo(this, method, asmMetadataReader.GetRowNumber(method), source, typeInfo, asmMetadataReader, pdbMetadataReader, fromEnC: false);
                     methods[asmMetadataReader.GetRowNumber(method)] = methodInfo;
 
                     source?.AddMethod(methodInfo);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -938,7 +938,6 @@ namespace Microsoft.WebAssembly.Diagnostics
             this.pdbMetadataReader = summary.PdbMetadataReader;
             Populate();
         }
-        //public MemberReference
         public bool TryGetCustomAttributeName(CustomAttributeHandle customAttribute, MetadataReader metadataReader, out string name)
         {
             name = "";

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -394,7 +394,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             foreach (CustomAttributeHandle cattr in customAttributes)
             {
                 var ca = asmMetadataReader.GetCustomAttribute(cattr);
-                if (fromEnC && (ca.Parent.Kind != HandleKind.MethodDefinition || (ca.Parent.Kind == HandleKind.MethodDefinition && ca.Parent.GetHashCode() != (token | (int)TokenType.MdtMethodDef))))
+                if (fromEnC && (ca.Parent.Kind != HandleKind.MethodDefinition || ca.Parent.GetHashCode() != (token | (int)TokenType.MdtMethodDef)))
                     continue;
                 if (!assembly.TryGetCustomAttributeName(cattr, asmMetadataReader, out string name))
                     continue;
@@ -849,7 +849,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         internal MetadataReader asmMetadataReader { get; }
         internal MetadataReader pdbMetadataReader { get; set; }
 
-        internal List<Tuple<MetadataReader, MetadataReader>> enCMetadataReader = new List<Tuple<MetadataReader, MetadataReader>>();
+        internal List<Tuple<MetadataReader, MetadataReader>> enCMetadataReader = new();
         private int debugId;
         internal int PdbAge { get; }
         internal System.Guid PdbGuid { get; }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
@@ -600,6 +600,32 @@ namespace DebuggerTests
                                        });
         }
 
+        [ConditionalFact(nameof(RunningOnChrome))]
+        public async Task DebugHotReloadMethod_AddingNewClassUsingDebugAttribute()
+        {
+            await SetJustMyCode(true);
+            string asm_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.dll");
+            string pdb_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.pdb");
+            string asm_file_hot_reload = Path.Combine(DebuggerTestAppPath, "../wasm/ApplyUpdateReferencedAssembly.dll");
+
+            var bp_notchanged = await SetBreakpoint(".*/MethodBody1.cs$", 55, 12, use_regex: true);
+            var bp_invalid = await SetBreakpoint(".*/MethodBody1.cs$", 118, 12, use_regex: true);
+
+            var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
+                    asm_file, pdb_file, "MethodBody6", "StaticMethod1", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
+
+            CheckLocation("dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 55, 12, scripts, pause_location["callFrames"]?[0]["location"]);
+            //apply first update
+            pause_location = await LoadAssemblyAndTestHotReloadUsingSDB(
+                    asm_file_hot_reload, "MethodBody10", "StaticMethod1", 1);
+
+            JToken top_frame = pause_location["callFrames"]?[0];
+            AssertEqual("ApplyUpdateReferencedAssembly.MethodBody10.StaticMethod1", top_frame?["functionName"]?.Value<string>(), top_frame?.ToString());
+            CheckLocation("dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 118, 12, scripts, top_frame["location"]);
+
+            await StepAndCheck(StepKind.Into, $"dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 119, 12, "ApplyUpdateReferencedAssembly.MethodBody10.StaticMethod1");
+        }
+
         // Enable this test when https://github.com/dotnet/hotreload-utils/pull/264 flows into dotnet/runtime repo
         // [ConditionalFact(nameof(RunningOnChrome))]
         // public async Task DebugHotReloadMethod_ChangeParameterName()

--- a/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
@@ -609,12 +609,12 @@ namespace DebuggerTests
             string asm_file_hot_reload = Path.Combine(DebuggerTestAppPath, "../wasm/ApplyUpdateReferencedAssembly.dll");
 
             await SetBreakpoint(".*/MethodBody1.cs$", 55, 12, use_regex: true);
-            await SetBreakpoint(".*/MethodBody1.cs$", 118, 12, use_regex: true);
 
             var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
                     asm_file, pdb_file, "MethodBody6", "StaticMethod1", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             CheckLocation("dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 55, 12, scripts, pause_location["callFrames"]?[0]["location"]);
+            await SetBreakpoint(".*/MethodBody1.cs$", 118, 12, use_regex: true);            
             //apply first update
             pause_location = await LoadAssemblyAndTestHotReloadUsingSDB(
                     asm_file_hot_reload, "MethodBody10", "StaticMethod1", 1);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
@@ -608,8 +608,8 @@ namespace DebuggerTests
             string pdb_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.pdb");
             string asm_file_hot_reload = Path.Combine(DebuggerTestAppPath, "../wasm/ApplyUpdateReferencedAssembly.dll");
 
-            var bp_notchanged = await SetBreakpoint(".*/MethodBody1.cs$", 55, 12, use_regex: true);
-            var bp_invalid = await SetBreakpoint(".*/MethodBody1.cs$", 118, 12, use_regex: true);
+            await SetBreakpoint(".*/MethodBody1.cs$", 55, 12, use_regex: true);
+            await SetBreakpoint(".*/MethodBody1.cs$", 118, 12, use_regex: true);
 
             var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
                     asm_file, pdb_file, "MethodBody6", "StaticMethod1", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1.cs
@@ -85,6 +85,24 @@ namespace ApplyUpdateReferencedAssembly
     
     
     
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
     // public class MethodBody9 {
     //     public static int M1(int a, int b) {
     //         return a + b;

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1.cs
@@ -38,12 +38,12 @@ namespace ApplyUpdateReferencedAssembly
         public static void StaticMethod4 () {
         }
     }
-
-
-
-
-
-
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
     public class MethodBody5 {
         public static void StaticMethod1 () {
             Console.WriteLine("breakpoint in a line that will not be changed");
@@ -57,52 +57,52 @@ namespace ApplyUpdateReferencedAssembly
             Console.WriteLine("original");
         }
     }
-
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
     // public class MethodBody9 {
     //     public static int M1(int a, int b) {
     //         return a + b;

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v1.cs
@@ -85,6 +85,24 @@ namespace ApplyUpdateReferencedAssembly
         }
     }
 
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
     // public class MethodBody9 {
     //     public static int M1(int x, int y) {
     //         return x + y;
@@ -94,4 +112,16 @@ namespace ApplyUpdateReferencedAssembly
     //         return M1(1, 2);
     //     }
     // }
+
+    public class MethodBody10 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a method in a new class");
+            StaticMethod2();
+            Console.WriteLine("do not step into StaticMethod2");
+        }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public static void StaticMethod2 () {
+            Console.WriteLine($"do not step into here");
+        }
+    }
 }

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v1.cs
@@ -84,25 +84,25 @@ namespace ApplyUpdateReferencedAssembly
             Console.WriteLine($"add a breakpoint the instance method of the new class");
         }
     }
-
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
     // public class MethodBody9 {
     //     public static int M1(int x, int y) {
     //         return x + y;

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v2.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v2.cs
@@ -103,4 +103,25 @@ namespace ApplyUpdateReferencedAssembly
             Console.WriteLine($"add a breakpoint the instance method of the new class");
         }
     }
+
+
+
+
+
+
+
+
+
+
+    public class MethodBody10 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a method in a new class");
+            StaticMethod2();
+            Console.WriteLine("do not step into StaticMethod2");
+        }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public static void StaticMethod2 () {
+            Console.WriteLine($"do not step into here");
+        }
+    }
 }

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v2.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v2.cs
@@ -38,12 +38,12 @@ namespace ApplyUpdateReferencedAssembly
         public static void StaticMethod4 () {
         }
     }
-
-
-
-
-
-
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
     public class MethodBody5 {
         public static void StaticMethod1 () {
             Console.WriteLine("beforeoriginal");
@@ -103,16 +103,16 @@ namespace ApplyUpdateReferencedAssembly
             Console.WriteLine($"add a breakpoint the instance method of the new class");
         }
     }
-
-
-
-
-
-
-
-
-
-
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
+// DO NOT CHANGE
     public class MethodBody10 {
         public static void StaticMethod1 () {
             Console.WriteLine("breakpoint in a method in a new class");


### PR DESCRIPTION
Doing the same thing that is done for GetString from metadatareader for:
GetTypeDefinition
GetTypeReference
GetMethodDefinition
GetMemberReference

It was also needed another change because methodDef.GetCustomAttributes() does not work on EnC metadatas.

The parent rowid used on CustomAttributes is the accumulated one(methodId from assembly + methodId from EnC), while the one used to get the MethodDef is the EnC rowid. 
So when we do this: methodDef.GetCustomAttributes() it doesn't find any CustomAttribute as it's using rowId 3 for example, and it should use rowId 19 which is the accumulated one.

