### PR TITLE
Fix SuperFileCheck from failing outerloop

### DIFF
--- a/src/coreclr/tools/SuperFileCheck/Program.cs
+++ b/src/coreclr/tools/SuperFileCheck/Program.cs
@@ -392,7 +392,6 @@ namespace SuperFileCheck
 
             // Create anchors from the first prefix.
             var startAnchorText = $"// {checkPrefixes[0]}-LABEL: for method {methodName}";
-            var startInstrsAnchorText = $"// {checkPrefixes[0]}: Lcl frame size =";
             var endAnchorText = $"// {checkPrefixes[0]}: for method {methodName}";
 
             // Create temp source file based on the source text of the method.
@@ -406,7 +405,6 @@ namespace SuperFileCheck
                 tmpSrc.AppendLine(String.Empty);
             }
             tmpSrc.AppendLine(startAnchorText);
-            tmpSrc.AppendLine(startInstrsAnchorText);
             tmpSrc.AppendLine(TransformMethod(methodDecl, checkPrefixes));
             tmpSrc.AppendLine(endAnchorText);
 


### PR DESCRIPTION
Resolves: https://github.com/dotnet/runtime/issues/88622

Will need to run outerloop to double check.