### PR TITLE
Bumping .net7 and .net6 version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <SdkBandVersion>8.0.100</SdkBandVersion>
-    <PackageVersionNet7>7.0.5</PackageVersionNet7>
+    <PackageVersionNet7>7.0.8</PackageVersionNet7>
     <PackageVersionNet6>6.0.$([MSBuild]::Add($([System.Version]::Parse('$(PackageVersionNet7)').Build),11))</PackageVersionNet6>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>7</PreReleaseVersionIteration>


### PR DESCRIPTION
Otherwise the installers generated from main on dotnet/installer will continue using:
VersionNet7 - 7.0.5 
VersionNet6 - 6.0.16
And there are some errors on WASM in 6.0.16 that are already fixed on newer versions.

Bumping to 7.0.8 because 7.0.9 is not public yet.

Fixes: https://github.com/aspnet/AspNetCore-ManualTests/issues/2219