### PR TITLE
Enable new analyzers CA1862, CA1864 in runtime and fix findings.

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -474,6 +474,12 @@ dotnet_diagnostic.CA1860.severity = warning
 # CA1861: Avoid constant arrays as arguments
 dotnet_diagnostic.CA1861.severity = warning
 
+# CA1862: Prefer using 'StringComparer'/'StringComparison' to perform case-insensitive string comparisons
+dotnet_diagnostic.CA1862.severity = warning
+
+# CA1864: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
+dotnet_diagnostic.CA1864.severity = warning
+
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none
 

--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -471,6 +471,12 @@ dotnet_diagnostic.CA1860.severity = none
 # CA1861: Avoid constant arrays as arguments
 dotnet_diagnostic.CA1861.severity = none
 
+# CA1862: Prefer using 'StringComparer'/'StringComparison' to perform case-insensitive string comparisons
+dotnet_diagnostic.CA1862.severity = none
+
+# CA1864: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
+dotnet_diagnostic.CA1864.severity = none
+
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none
 

--- a/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
+++ b/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
@@ -353,8 +353,7 @@ namespace ILCompiler
             lock (this)
             {
                 // Ensure that name is unique and update our tables accordingly.
-                if (!_mangledTypeNames.ContainsKey(type))
-                    _mangledTypeNames.Add(type, mangledName);
+                _mangledTypeNames.TryAdd(type, mangledName);
             }
 
             return mangledName;
@@ -386,8 +385,7 @@ namespace ILCompiler
 
                 lock (this)
                 {
-                    if (!_mangledMethodNames.ContainsKey(method))
-                        _mangledMethodNames.Add(method, utf8MangledName);
+                    _mangledMethodNames.TryAdd(method, utf8MangledName);
                 }
 
                 return utf8MangledName;
@@ -557,8 +555,7 @@ namespace ILCompiler
             {
                 lock (this)
                 {
-                    if (!_unqualifiedMangledMethodNames.ContainsKey(method))
-                        _unqualifiedMangledMethodNames.Add(method, utf8MangledName);
+                    _unqualifiedMangledMethodNames.TryAdd(method, utf8MangledName);
                 }
             }
 
@@ -622,8 +619,7 @@ namespace ILCompiler
 
             lock (this)
             {
-                if (!_mangledFieldNames.ContainsKey(field))
-                    _mangledFieldNames.Add(field, utf8MangledName);
+                _mangledFieldNames.TryAdd(field, utf8MangledName);
             }
 
             return utf8MangledName;
@@ -644,8 +640,7 @@ namespace ILCompiler
 
             lock (this)
             {
-                if (!_mangledStringLiterals.ContainsKey(literal))
-                    _mangledStringLiterals.Add(literal, mangledName);
+                _mangledStringLiterals.TryAdd(literal, mangledName);
             }
 
             return mangledName;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/IBCProfileData.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/IBCProfileData.cs
@@ -51,10 +51,7 @@ Arch:          {Arch}
             MethodProfileData[] dataArray = methodData.ToArray();
             foreach (MethodProfileData data in dataArray)
             {
-                if (!_methodData.ContainsKey(data.Method))
-                {
-                    _methodData.Add(data.Method, data);
-                }
+                _methodData.TryAdd(data.Method, data);
             }
             _partialNGen = partialNGen;
             _config = config;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
@@ -130,13 +130,12 @@ namespace System.Diagnostics.Metrics
             {
                 _beginInstrumentMeasurements(instrument);
 
-                if (!_instruments.ContainsKey(instrument))
+                if (_instruments.TryAdd(instrument, true))
                 {
                     // This has side effects that prompt MeasurementsCompleted
                     // to be called if this is called multiple times on an
                     // instrument in a shared MetricsEventSource.
                     _listener.EnableMeasurementEvents(instrument, state);
-                    _instruments.Add(instrument, true);
                 }
             }
         }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
@@ -129,13 +129,15 @@ namespace System.Diagnostics.Metrics
             if (state != null)
             {
                 _beginInstrumentMeasurements(instrument);
-
-                if (_instruments.TryAdd(instrument, true))
+#pragma warning disable CA1864 // Prefer the 'IDictionary.TryAdd(TKey, TValue)' method. IDictionary.TryAdd() is not available in one of the builds
+                if (!_instruments.ContainsKey(instrument))
+#pragma warning restore CA1864
                 {
                     // This has side effects that prompt MeasurementsCompleted
                     // to be called if this is called multiple times on an
                     // instrument in a shared MetricsEventSource.
                     _listener.EnableMeasurementEvents(instrument, state);
+                    _instruments.Add(instrument, true);
                 }
             }
         }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -522,7 +522,7 @@ namespace System.Diagnostics
                         }
                         else
                         {
-                            if (processInfos.ContainsKey(processInfo.ProcessId))
+                            if (!processInfos.TryAdd(processInfo.ProcessId, processInfo))
                             {
                                 // We've found two entries in the perfcounters that claim to be the
                                 // same process.  We throw an exception.  Is this really going to be
@@ -549,7 +549,6 @@ namespace System.Diagnostics
                                     }
                                 }
                                 processInfo.ProcessName = instanceName.ToString();
-                                processInfos.Add(processInfo.ProcessId, processInfo);
                             }
                         }
                     }

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADDNLinkedAttrSet.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADDNLinkedAttrSet.cs
@@ -667,11 +667,10 @@ namespace System.DirectoryServices.AccountManagement
                     if (null == foreignSid.sidIssuerName)
                     {
                         // create and return the unknown principal if it is not yet present in usersVisited
-                        if (!_usersVisited.ContainsKey(foreignSid.name))
+                        if (_usersVisited.TryAdd(foreignSid.name, true))
                         {
                             byte[] sid = Utils.ConvertNativeSidToByteArray(foreignSid.pSid);
                             UnknownPrincipal unknownPrincipal = UnknownPrincipal.CreateUnknownPrincipal(_storeCtx.OwningContext, sid, foreignSid.name);
-                            _usersVisited.Add(foreignSid.name, true);
                             this.current = null;
                             _currentForeignDE = null;
                             _currentForeignPrincipal = unknownPrincipal;

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Schema/XNodeValidator.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Schema/XNodeValidator.cs
@@ -157,10 +157,7 @@ namespace System.Xml.Schema
             XmlSchemaInfo? si = o.Annotation<XmlSchemaInfo>();
             if (si != null)
             {
-                if (!schemaInfos.ContainsKey(si))
-                {
-                    schemaInfos.Add(si, si);
-                }
+                schemaInfos.TryAdd(si, si);
                 o.RemoveAnnotations<XmlSchemaInfo>();
             }
             if (!schemaInfos.TryGetValue(schemaInfo, out si))

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/DtdParser.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/DtdParser.cs
@@ -1229,17 +1229,11 @@ namespace System.Xml
 
                     if (isParamEntity)
                     {
-                        if (!_schemaInfo.ParameterEntities.ContainsKey(entityName))
-                        {
-                            _schemaInfo.ParameterEntities.Add(entityName, entity);
-                        }
+                        _schemaInfo.ParameterEntities.TryAdd(entityName, entity);
                     }
                     else
                     {
-                        if (!_schemaInfo.GeneralEntities.ContainsKey(entityName))
-                        {
-                            _schemaInfo.GeneralEntities.Add(entityName, entity);
-                        }
+                        _schemaInfo.GeneralEntities.TryAdd(entityName, entity);
                     }
                     entity.DeclaredInExternal = !ParsingInternalSubset;
                     entity.ParsingInProgress = true;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/DtdParserAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/DtdParserAsync.cs
@@ -861,17 +861,11 @@ namespace System.Xml
 
                     if (isParamEntity)
                     {
-                        if (!_schemaInfo.ParameterEntities.ContainsKey(entityName))
-                        {
-                            _schemaInfo.ParameterEntities.Add(entityName, entity);
-                        }
+                        _schemaInfo.ParameterEntities.TryAdd(entityName, entity);
                     }
                     else
                     {
-                        if (!_schemaInfo.GeneralEntities.ContainsKey(entityName))
-                        {
-                            _schemaInfo.GeneralEntities.Add(entityName, entity);
-                        }
+                        _schemaInfo.GeneralEntities.TryAdd(entityName, entity);
                     }
                     entity.DeclaredInExternal = !ParsingInternalSubset;
                     entity.ParsingInProgress = true;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaCollectionCompiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaCollectionCompiler.cs
@@ -305,10 +305,7 @@ namespace System.Xml.Schema
                 SchemaNotation no = new SchemaNotation(notation.QualifiedName);
                 no.SystemLiteral = notation.System;
                 no.Pubid = notation.Public;
-                if (!schemaInfo.Notations.ContainsKey(no.Name.Name))
-                {
-                    schemaInfo.Notations.Add(no.Name.Name, no);
-                }
+                schemaInfo.Notations.TryAdd(no.Name.Name, no);
             }
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaInfo.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaInfo.cs
@@ -299,10 +299,7 @@ namespace System.Xml.Schema
 
             foreach (string tns in sinfo.TargetNamespaces.Keys)
             {
-                if (!_targetNamespaces.ContainsKey(tns))
-                {
-                    _targetNamespaces.Add(tns, true);
-                }
+                _targetNamespaces.TryAdd(tns, true);
             }
 
             foreach (KeyValuePair<XmlQualifiedName, SchemaElementDecl> entry in sinfo._elementDecls)
@@ -321,17 +318,11 @@ namespace System.Xml.Schema
             }
             foreach (SchemaAttDef attdef in sinfo.AttributeDecls.Values)
             {
-                if (!_attributeDecls.ContainsKey(attdef.Name))
-                {
-                    _attributeDecls.Add(attdef.Name, attdef);
-                }
+                _attributeDecls.TryAdd(attdef.Name, attdef);
             }
             foreach (SchemaNotation notation in sinfo.Notations.Values)
             {
-                if (!Notations.ContainsKey(notation.Name.Name))
-                {
-                    Notations.Add(notation.Name.Name, notation);
-                }
+                Notations.TryAdd(notation.Name.Name, notation);
             }
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaSetCompiler.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/SchemaSetCompiler.cs
@@ -167,10 +167,7 @@ namespace System.Xml.Schema
                 SchemaNotation no = new SchemaNotation(notation!.QualifiedName);
                 no.SystemLiteral = notation.System;
                 no.Pubid = notation.Public;
-                if (!schemaInfo.Notations.ContainsKey(no.Name.Name))
-                {
-                    schemaInfo.Notations.Add(no.Name.Name, no);
-                }
+                schemaInfo.Notations.TryAdd(no.Name.Name, no);
             }
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XdrBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XdrBuilder.cs
@@ -1051,11 +1051,7 @@ namespace System.Xml.Schema
                 // Global AttributeTypes are URN qualified so that we can look them up across schemas.
                 qname = new XmlQualifiedName(qname.Name, builder._TargetNamespace);
                 builder._AttributeDef._AttDef.Name = qname;
-                if (!builder._SchemaInfo.AttributeDecls.ContainsKey(qname))
-                {
-                    builder._SchemaInfo.AttributeDecls.Add(qname, builder._AttributeDef._AttDef);
-                }
-                else
+                if (!builder._SchemaInfo.AttributeDecls.TryAdd(qname, builder._AttributeDef._AttDef))
                 {
                     builder.SendValidationEvent(SR.Sch_DupAttribute, XmlQualifiedName.ToString(qname.Name, prefix));
                 }

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmPublishAssets.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ComputeWasmPublishAssets.cs
@@ -577,6 +577,7 @@ public class ComputeWasmPublishAssets : Task
 
         foreach (var candidate in resolvedFilesToPublish)
         {
+#pragma warning disable CA1864 // Prefer the 'IDictionary.TryAdd(TKey, TValue)' method. Dictionary.TryAdd() not available in .Net framework.
             if (AssetsComputingHelper.ShouldFilterCandidate(candidate, TimeZoneSupport, InvariantGlobalization, CopySymbols, customIcuCandidateFilename, EnableThreads, EmitSourceMap, out var reason))
             {
                 Log.LogMessage(MessageImportance.Low, "Skipping asset '{0}' because '{1}'", candidate.ItemSpec, reason);
@@ -654,6 +655,7 @@ public class ComputeWasmPublishAssets : Task
                 }
                 continue;
             }
+#pragma warning restore CA1864
         }
     }
 

--- a/src/tools/illink/src/tlens/TLens.Analyzers/UnnecessaryFieldsAssignmentAnalyzer.cs
+++ b/src/tools/illink/src/tlens/TLens.Analyzers/UnnecessaryFieldsAssignmentAnalyzer.cs
@@ -72,9 +72,7 @@ namespace TLens.Analyzers
 					methods.Add (method);
 				}
 
-				if (!fields.ContainsKey (field))
-					fields.Add (field, access);
-				else
+				if (!fields.TryAdd (field, access))
 					fields[field] |= access;
 			}
 		}


### PR DESCRIPTION
### Enable new analyzers CA1862, CA1864 in runtime and fix findings.

- Nothing flagged for CA1862: `Prefer using 'StringComparer'/'StringComparison' to perform case-insensitive string comparisons`
- All updates related to CA1864: `Prefer the 'IDictionary.TryAdd(TKey, TValue)' method`, thanks to @CollinAlpert