### PR TITLE
Switch the order of AOT SDK and framework assemblies

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -149,8 +149,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <!-- Exclude unmanaged dlls -->
       <FrameworkAssemblies Include="$(IlcFrameworkPath)*.dll" Exclude="$(IlcFrameworkPath)*.Native.dll;$(IlcFrameworkPath)msquic.dll" />
 
-      <DefaultFrameworkAssemblies Include="@(FrameworkAssemblies)" />
       <DefaultFrameworkAssemblies Include="@(PrivateSdkAssemblies)" />
+      <DefaultFrameworkAssemblies Include="@(FrameworkAssemblies)" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
When you have built a CoreCLR CoreLib, it "poisons" the build s.t. running libraries tests with NAOT becomes impossible.

This is because `$(IlcFrameworkPath)` draws from a shared framework that contains the CoreCLR CoreLib, while it should use the  CoreLib from the AOT SDK.

This targeted change changes the order in which these two assemblies get passed to ILC and allows one to use "/p:TestNativeAot=true" without additional workarounds.

This may be a bit controversial as it has the potential to hide problems with bad build states, so I am putting this up more for discussion.