### PR TITLE
Simplify KeyAnalyzer

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
@@ -124,7 +124,7 @@ namespace System.Collections.Frozen
                 // actually perform the comparison as case-sensitive even if case-insensitive
                 // was requested, as there's nothing that would compare equally to the substring
                 // other than the substring itself.
-                bool canSwitchIgnoreCaseToCaseSensitive = ignoreCase;
+                bool canSwitchIgnoreCaseToCaseSensitive = true;
 
                 foreach (string s in uniqueStrings)
                 {


### PR DESCRIPTION
Just a trivial code-review item. The assignment `bool canSwitchIgnoreCaseToCaseSensitive = ignoreCase;` can just be `bool canSwitchIgnoreCaseToCaseSensitive = true;` since we're just tested that value a couple lines up with `if (ignoreCase)`. This DOES emit different code at the IL level.
