### PR TITLE
ExtendedProtectionPolicy.OSSupportsExtendedProtection: return `false`

### DIFF
--- a/src/libraries/System.Net.Security/src/ExcludeApiList.PNSE.Browser.txt
+++ b/src/libraries/System.Net.Security/src/ExcludeApiList.PNSE.Browser.txt
@@ -1,0 +1,1 @@
+P:System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy.OSSupportsExtendedProtection

--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -15,7 +15,7 @@
     <UseAppleCrypto Condition="'$(TargetPlatformIdentifier)' == 'osx' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'tvos'">true</UseAppleCrypto>
     <UseManagedNtlm Condition="'$(TargetPlatformIdentifier)' == 'android' or '$(TargetPlatformIdentifier)' == 'tvos'">true</UseManagedNtlm>
     <DefineConstants Condition="'$(UseAndroidCrypto)' == 'true' or '$(UseAppleCrypto)' == 'true'">$(DefineConstants);SYSNETSECURITY_NO_OPENSSL</DefineConstants>
-    <GenAPIExcludeApiList>ReferenceAssemblyExclusions.txt</GenAPIExcludeApiList>
+    <ApiExclusionListPath>$(MSBuildThisFileDirectory)ExcludeApiList.PNSE.Browser.txt</ApiExclusionListPath>
   </PropertyGroup>
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition="'$(UseManagedNtlm)' == 'true'" />
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''">
@@ -429,6 +429,9 @@
     <Compile Include="System\Net\Security\SslStreamPal.OSX.cs" />
     <Compile Include="System\Net\Security\StreamSizes.OSX.cs" />
     <Compile Include="System\Net\Security\CipherSuitesPolicyPal.OSX.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="System\Security\Authentication\ExtendedProtection\ExtendedProtectionPolicy.APIOverride.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />

--- a/src/libraries/System.Net.Security/src/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicy.APIOverride.cs
+++ b/src/libraries/System.Net.Security/src/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicy.APIOverride.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace System.Security.Authentication.ExtendedProtection
+{
+    public partial class ExtendedProtectionPolicy
+    {
+        public static bool OSSupportsExtendedProtection
+        {
+            get
+            {
+                // .NET Core is supported only on Win7+ where ExtendedProtection is supported.
+                // and unsupported on the browser
+                return !OperatingSystem.IsBrowser();
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Security/src/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicy.cs
+++ b/src/libraries/System.Net.Security/src/System/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicy.cs
@@ -143,14 +143,5 @@ namespace System.Security.Authentication.ExtendedProtection
 
             return sb.ToString();
         }
-
-        public static bool OSSupportsExtendedProtection
-        {
-            get
-            {
-                // .NET Core is supported only on Win7+ where ExtendedProtection is supported.
-                return true;
-            }
-        }
     }
 }


### PR DESCRIPTION
.. for browser, instead of throwing PNSE.

Fixes https://github.com/dotnet/runtime/issues/77405
