### PR TITLE
Trim RefSafetyRulesAttribute when trimming aggressively

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml
@@ -320,6 +320,9 @@
     <type fullname="System.Runtime.CompilerServices.ScopedRefAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
+    <type fullname="System.Runtime.CompilerServices.RefSafetyRulesAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
 
     <!-- Microsoft.CodeAnalysis -->
     <type fullname="Microsoft.CodeAnalysis.EmbeddedAttribute">


### PR DESCRIPTION
This is another attribute that Roslyn uses for its own purposes only.

Cc @dotnet/illink-contrib (btw what's the difference between this and @dotnet/illink?)