### PR TITLE
[libs][iOS] Unify `System.Linq.Expression.dll` build for all platforms

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.IsInterpreting.LibraryBuild.xml
+++ b/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.IsInterpreting.LibraryBuild.xml
@@ -1,7 +1,0 @@
-<linker>
-  <assembly fullname="System.Linq.Expressions">
-    <type fullname="System.Linq.Expressions.LambdaExpression">
-      <method signature="System.Boolean get_CanCompileToIL()" body="stub" value="false" />
-    </type>
-  </assembly>
-</linker>

--- a/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-ios;$(NetCoreAppCurrent)-tvos;$(NetCoreAppCurrent)-maccatalyst</TargetFrameworks>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <DefineConstants> $(DefineConstants);FEATURE_FAST_CREATE</DefineConstants>
     <NoWarn>$(NoWarn);CA1859</NoWarn>
     <EnableAOTAnalyzer>false</EnableAOTAnalyzer>

--- a/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -1,22 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-ios;$(NetCoreAppCurrent)-tvos;$(NetCoreAppCurrent)-maccatalyst</TargetFrameworks>
-    <IsInterpreting>false</IsInterpreting>
     <DefineConstants> $(DefineConstants);FEATURE_FAST_CREATE</DefineConstants>
     <NoWarn>$(NoWarn);CA1859</NoWarn>
     <EnableAOTAnalyzer>false</EnableAOTAnalyzer>
-  </PropertyGroup>
-  <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
-  <PropertyGroup>
-    <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
-    <IsInterpreting Condition="'$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'tvos' or '$(TargetPlatformIdentifier)' == 'maccatalyst'">true</IsInterpreting>
-    <ILLinkSubstitutionsLibraryBuildXml Condition="'$(IsInterpreting)' == 'true'">ILLink\ILLink.Substitutions.IsInterpreting.LibraryBuild.xml</ILLinkSubstitutionsLibraryBuildXml>
     <!--
       Disable constant propagation so that methods referenced from ILLink.Substitutions.xml don't get inlined
       with a wrong value at library build time and the substitution can still be selected at publish time.
-      For iOS/tvOS/Catalyst we prefer smaller size by default, so keep constprop enabled to get rid of the expression compiler.
     -->
-    <ILLinkDisableIPConstProp Condition="'$(TargetPlatformIdentifier)' != 'ios' and '$(TargetPlatformIdentifier)' != 'tvos' and '$(TargetPlatformIdentifier)' != 'maccatalyst'">true</ILLinkDisableIPConstProp>
+    <ILLinkDisableIPConstProp>true</ILLinkDisableIPConstProp>
   </PropertyGroup>
   <ItemGroup>
     <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.xml" />

--- a/src/mono/msbuild/apple/build/AppleBuild.targets
+++ b/src/mono/msbuild/apple/build/AppleBuild.targets
@@ -143,7 +143,7 @@
       <MonoAOTCompilerDefaultAotArguments Include="nrgctx-fetch-trampolines=256" />
       <MonoAOTCompilerDefaultAotArguments Include="ngsharedvt-trampolines=4400" />
       <MonoAOTCompilerDefaultAotArguments Include="nftnptr-arg-trampolines=4000" />
-      <MonoAOTCompilerDefaultAotArguments Include="nrgctx-trampolines=70000" />
+      <MonoAOTCompilerDefaultAotArguments Include="nrgctx-trampolines=110000" />
 
       <MonoAOTCompilerDefaultProcessArguments Include="-O=gsharedvt" />
     </ItemGroup>

--- a/src/mono/msbuild/apple/build/AppleBuild.targets
+++ b/src/mono/msbuild/apple/build/AppleBuild.targets
@@ -143,7 +143,7 @@
       <MonoAOTCompilerDefaultAotArguments Include="nrgctx-fetch-trampolines=256" />
       <MonoAOTCompilerDefaultAotArguments Include="ngsharedvt-trampolines=4400" />
       <MonoAOTCompilerDefaultAotArguments Include="nftnptr-arg-trampolines=4000" />
-      <MonoAOTCompilerDefaultAotArguments Include="nrgctx-trampolines=50000" />
+      <MonoAOTCompilerDefaultAotArguments Include="nrgctx-trampolines=60000" />
 
       <MonoAOTCompilerDefaultProcessArguments Include="-O=gsharedvt" />
     </ItemGroup>

--- a/src/mono/msbuild/apple/build/AppleBuild.targets
+++ b/src/mono/msbuild/apple/build/AppleBuild.targets
@@ -143,7 +143,7 @@
       <MonoAOTCompilerDefaultAotArguments Include="nrgctx-fetch-trampolines=256" />
       <MonoAOTCompilerDefaultAotArguments Include="ngsharedvt-trampolines=4400" />
       <MonoAOTCompilerDefaultAotArguments Include="nftnptr-arg-trampolines=4000" />
-      <MonoAOTCompilerDefaultAotArguments Include="nrgctx-trampolines=60000" />
+      <MonoAOTCompilerDefaultAotArguments Include="nrgctx-trampolines=70000" />
 
       <MonoAOTCompilerDefaultProcessArguments Include="-O=gsharedvt" />
     </ItemGroup>


### PR DESCRIPTION
### Description

This PR removes special builds of `System.Linq.Expression.dll` for iOS-like platforms enabling us to ship a single assembly for all platforms, and to have better compatibility between our AOT engines.

These changes contribute towards fixing how the library is built for iOS-like platforms preventing conditional variables like: `CanEmitObjectArrayDelegate` to be removed from the library during library build time, which are required to be present for AOT compilation (during app deployment) with NativeAOT, as discussed in: https://github.com/dotnet/runtime/issues/87924

### Changes

The following changes are introduced:
- Library build-time substitution: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.IsInterpreting.LibraryBuild.xml has been removed
- Library build-time constant propagation is disabled

### Measurements

Unifying how the library is built for all platforms affects the library size, which can be seen from the following measurements:

| System.Linq.Expressions.dll | Size (b) | diff (b) | diff (%) |
|-----------------------------|----------|----------|----------|
| main                        | 449024   | NaN      | NaN      |
| this PR                  | 562176   | 113152      | 25,2%    |

The increase in size of `25%` comes from the fact that `Ref.Emit` code paths are now included in the assembly. However, this does not cause any size regressions for applications built for iOS-like platforms, because during app deployment the unsupported code paths (like `Ref.Emit`) will be removed during trimming due to:
https://github.com/dotnet/runtime/blob/d361507d72ab11cfbe2863f118664f1a61a08315/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs#L29
as `IsDynamicCodeSupported=false` on these platforms.

### Summary 

This PR affects the following:

- the size of the shipped `System.Linq.Expression.dll` for iOS-like platforms is increased by `~113Kb` (`~25%`)
- the fullAOT + `UseInterpreter=true` configurations with Mono (when interpreter is used as a fallback on iOS-like platforms) are now interpreting `Ref.Emit` generated code instead of using Reflection
    - the size of deployed apps in this configuration is also increased by keeping `Ref.Emit` backend (which should not be a problem as we do not recommend this setup for app deployment in the first place)
 
The apps deployed with standard Mono fullAOT configurations for iOS-like platforms should not be affected by this change once: https://github.com/xamarin/xamarin-macios/pull/18555 gets merged in.   