### PR TITLE
[release/7.0] Unblock WASM CI failures in Firefox debugger tests

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -1042,7 +1042,7 @@ namespace DebuggerTests
             );
         }
 
-        [ConditionalTheory(nameof(RunningOnChrome))]
+        [ConditionalTheory]
         [InlineData("ClassInheritsFromClassWithoutDebugSymbols", 1287, true)]
         [InlineData("ClassInheritsFromClassWithoutDebugSymbols", 1287, false)]
         [InlineData("ClassInheritsFromNonUserCodeClass", 1335, true)]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/75018. Tests passed locally, so they should be fine on CI as well.