### PR TITLE
[mono][mini] Fix conversion from STACK_PTR to R8

### DIFF
--- a/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
@@ -1291,7 +1291,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69795", TestRuntimes.Mono)]
         public static void CreateCheckedFromUIntPtrTest()
         {
             if (Environment.Is64BitProcess)
@@ -1580,7 +1579,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69795", TestRuntimes.Mono)]
         public static void CreateSaturatingFromUIntPtrTest()
         {
             if (Environment.Is64BitProcess)
@@ -1869,7 +1867,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69795", TestRuntimes.Mono)]
         public static void CreateTruncatingFromUIntPtrTest()
         {
             if (Environment.Is64BitProcess)

--- a/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/Int64Tests.GenericMath.cs
@@ -1292,7 +1292,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [SkipOnMono("https://github.com/dotnet/runtime/issues/69795")]
         public static void CreateCheckedFromDoubleTest()
         {
             Assert.Equal((long)0x0000_0000_0000_0000, NumberBaseHelper<long>.CreateChecked<double>(+0.0));
@@ -1398,7 +1397,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [SkipOnMono("https://github.com/dotnet/runtime/issues/69795")]
         public static void CreateCheckedFromNFloatTest()
         {
             Assert.Equal((long)0x0000_0000_0000_0000, NumberBaseHelper<long>.CreateChecked<NFloat>(+0.0f));
@@ -1445,7 +1443,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [SkipOnMono("https://github.com/dotnet/runtime/issues/69795")]
         public static void CreateCheckedFromSingleTest()
         {
             Assert.Equal((long)0x0000_0000_0000_0000, NumberBaseHelper<long>.CreateChecked<float>(+0.0f));

--- a/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
@@ -1913,7 +1913,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [SkipOnMono("https://github.com/dotnet/runtime/issues/69795")]
         public static void CreateCheckedFromDoubleTest()
         {
             Assert.Equal((nint)0x0000_0000, NumberBaseHelper<nint>.CreateChecked<double>(+0.0));
@@ -2063,7 +2062,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [SkipOnMono("https://github.com/dotnet/runtime/issues/69795")]
         public static void CreateCheckedFromNFloatTest()
         {
             Assert.Equal((nint)0x0000_0000, NumberBaseHelper<nint>.CreateChecked<NFloat>(+0.0f));
@@ -2113,7 +2111,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [SkipOnMono("https://github.com/dotnet/runtime/issues/69795")]
         public static void CreateCheckedFromSingleTest()
         {
             Assert.Equal((nint)0x0000_0000, NumberBaseHelper<nint>.CreateChecked<float>(+0.0f));

--- a/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
@@ -1293,7 +1293,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69795", TestRuntimes.Mono)]
         public static void CreateCheckedFromUIntPtrTest()
         {
             if (Environment.Is64BitProcess)
@@ -1584,7 +1583,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69795", TestRuntimes.Mono)]
         public static void CreateSaturatingFromUIntPtrTest()
         {
             if (Environment.Is64BitProcess)
@@ -1875,7 +1873,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/69795", TestRuntimes.Mono)]
         public static void CreateTruncatingFromUIntPtrTest()
         {
             if (Environment.Is64BitProcess)

--- a/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt64Tests.GenericMath.cs
@@ -1291,7 +1291,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [SkipOnMono("https://github.com/dotnet/runtime/issues/69795")]
         public static void CreateCheckedFromDoubleTest()
         {
             Assert.Equal((ulong)0x0000_0000_0000_0000, NumberBaseHelper<ulong>.CreateChecked<double>(+0.0));
@@ -1398,7 +1397,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [SkipOnMono("https://github.com/dotnet/runtime/issues/69795")]
         public static void CreateCheckedFromNFloatTest()
         {
             Assert.Equal((ulong)0x0000_0000_0000_0000, NumberBaseHelper<ulong>.CreateChecked<NFloat>(0.0f));
@@ -1444,7 +1442,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [SkipOnMono("https://github.com/dotnet/runtime/issues/69795")]
         public static void CreateCheckedFromSingleTest()
         {
             Assert.Equal((ulong)0x0000_0000_0000_0000, NumberBaseHelper<ulong>.CreateChecked<float>(+0.0f));

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -1070,10 +1070,15 @@ type_from_op (MonoCompile *cfg, MonoInst *ins, MonoInst *src1, MonoInst *src2)
 		ins->type = STACK_R8;
 		switch (src1->type) {
 		case STACK_I4:
+#if TARGET_SIZEOF_VOID_P == 4
 		case STACK_PTR:
+#endif
 			ins->opcode = OP_ICONV_TO_R_UN;
 			break;
 		case STACK_I8:
+#if TARGET_SIZEOF_VOID_P == 8
+		case STACK_PTR:
+#endif
 			ins->opcode = OP_LCONV_TO_R_UN;
 			break;
 		case STACK_R4:


### PR DESCRIPTION
It was hardcoded to int conversion instead of checking the arch ptr size.

Fixes https://github.com/dotnet/runtime/issues/69795