### PR TITLE
[wasm] WBT: Fix breaking tests

### DIFF
--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -139,7 +139,7 @@
     <HelixCommandPrefixEnvVarItem Condition="'$(WindowsShell)' == 'true'" Include="DOTNET_CLI_HOME=%HELIX_WORKITEM_ROOT%\.dotnet" />
 
     <HelixCommandPrefixEnvVarItem Condition="'$(WindowsShell)' != 'true'" Include="DOTNET_ROOT=$HELIX_CORRELATION_PAYLOAD/$(SdkForWorkloadTestingDirName)" />
-    <!--<HelixCommandPrefixEnvVarItem Condition="'$(WindowsShell)' == 'true'" Include="DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\$(SdkForWorkloadTestingDirName)" />-->
+    <HelixCommandPrefixEnvVarItem Condition="'$(WindowsShell)' == 'true'" Include="DOTNET_ROOT=%HELIX_CORRELATION_PAYLOAD%\$(SdkForWorkloadTestingDirName)" />
 
     <HelixCommandPrefixEnvVarItem Condition="'$(WindowsShell)' != 'true'" Include="SDK_FOR_WORKLOAD_TESTING_PATH=%24{HELIX_CORRELATION_PAYLOAD}/$(SdkForWorkloadTestingDirName)" />
     <HelixCommandPrefixEnvVarItem Condition="'$(WindowsShell)' == 'true'" Include="SDK_FOR_WORKLOAD_TESTING_PATH=%HELIX_CORRELATION_PAYLOAD%\$(SdkForWorkloadTestingDirName)" />

--- a/src/mono/wasm/Wasm.Build.Tests/Common/BuildEnvironment.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Common/BuildEnvironment.cs
@@ -106,6 +106,7 @@ namespace Wasm.Build.Tests
             // `runtime` repo's build environment sets these, and they
             // mess up the build for the test project, which is using a different
             // dotnet
+            EnvVars["DOTNET_ROOT"] = sdkForWorkloadPath;
             EnvVars["DOTNET_INSTALL_DIR"] = sdkForWorkloadPath;
             EnvVars["DOTNET_MULTILEVEL_LOOKUP"] = "0";
             EnvVars["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1";

--- a/src/mono/wasm/Wasm.Build.Tests/Common/RunCommand.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Common/RunCommand.cs
@@ -11,7 +11,7 @@ public class RunCommand : DotNetCommand
     public RunCommand(BuildEnvironment buildEnv, ITestOutputHelper _testOutput, string label="") : base(buildEnv, _testOutput, false, label)
     {
         WithEnvironmentVariables(buildEnv.EnvVars);
-        WithEnvironmentVariable("DOTNET_ROOT", buildEnv.DotNet);
+        WithEnvironmentVariable("DOTNET_ROOT", Path.GetDirectoryName(buildEnv.DotNet)!);
         WithEnvironmentVariable("DOTNET_INSTALL_DIR", Path.GetDirectoryName(buildEnv.DotNet)!);
         WithEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0");
         WithEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1");


### PR DESCRIPTION
## `Wasm.Build.Tests.WasmTemplateTests.RunWithDifferentAppBundleLocations`
broke with the latest sdk:

`/root/helix/work/workitem/e/dotnet-latest/sdk/8.0.100-preview.7.23362.1/Roslyn/Microsoft.CSharp.Core.targets(80,5): error MSB6004: The specified task executable location "/root/helix/work/workitem/e/dotnet-latest/dotnet/dotnet" is invalid.`

This was because https://github.com/dotnet/roslyn/pull/68918 changed
to expect `DOTNET_ROOT` to be a directory instead of the exe path.

## [wasm] WBT: Set DOTNET_ROOT explicitly in the helix environment

The `NonWasmTemplateBuildTests` avoid using the default environment
variables used for all other tests, which includes `DOTNET_ROOT`. Set
`DOTNET_ROOT` explicitly in the helix setup script for windows, so we
always have a fallback.

```
    Wasm.Build.Tests.NonWasmTemplateBuildTests.NonWasmConsoleBuild_WithoutWorkload(config: "Debug", extraBuildArgs: "", targetFramework: "net6.0") [FAIL]
       Expected 0 exit code but got 1: C:\helix\work\workitem\e\dotnet-none\dotnet.exe build -restore -c Debug -bl:C:\helix\work\workitem\uploads\xharness-output\logs\nonwasm_net6.0_Debug_iyhtgmvj.uu4.binlog  -f net6.0
      Standard Output:
      [] MSBuild version 17.8.0-preview-23361-03+5ab64ed27 for .NET
      []   Determining projects to restore...
      []   Restored C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj (in 820 ms).
      []   Determining projects to restore...
      []   Restored C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj (in 11.21 sec).
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(314,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error : You must install or update .NET to run this application. [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error :  [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error : App: C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\bincore\csc.dll [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error : Architecture: x64 [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error : Framework: 'Microsoft.NETCore.App', version '8.0.0-preview.7.23361.9' (x64) [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error : .NET location: C:\helix\work\correlation\dotnet-cli\ [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error :  [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error : The following frameworks were found: [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error :   8.0.0-preview.5.23280.8 at [C:\helix\work\correlation\dotnet-cli\shared\Microsoft.NETCore.App] [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error :  [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error : Learn more: [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error : https://aka.ms/dotnet/app-launch-failed [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error :  [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error : To install missing framework, download: [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      [] C:\helix\work\workitem\e\dotnet-none\sdk\8.0.100-preview.7.23362.1\Roslyn\Microsoft.CSharp.Core.targets(80,5): error : https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=8.0.0-preview.7.23361.9&arch=x64&rid=win10-x64 [C:\helix\work\workitem\e\wbt\nonwasm_net6.0_Debug_iyhtgmvj.uu4\nonwasm_net6.0_Debug_iyhtgmvj.uu4.csproj]
      []
```

Fixes https://github.com/dotnet/runtime/issues/88752 .
Fixes https://github.com/dotnet/runtime/issues/88779 .