### PR TITLE
Enable SxS workload manifests

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -148,6 +148,7 @@
     <CreateVisualStudioWorkload BaseIntermediateOutputPath="$(WorkloadIntermediateOutputPath)"
                                 AllowMissingPacks="True"
                                 BaseOutputPath="$(WorkloadOutputPath)"
+                                EnableSideBySideManifests="true"
                                 ComponentResources="@(ComponentResources)"
                                 PackageSource="$(PackageSource)"
                                 ShortNames="@(ShortNames)"


### PR DESCRIPTION
This turns on generation of SxS manifest MSI installers (instead of being upgradable) and part of the new workload version model in the SDK