### PR TITLE
[JIT] Added BEGIN and END anchors for disasm output

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1966,6 +1966,11 @@ void CodeGen::genEmitMachineCode()
     trackedStackPtrsContig = !compiler->opts.compDbgEnC;
 #endif
 
+    if (compiler->opts.disAsm)
+    {
+        printf("; BEGIN METHOD ANCHOR %s\n", compiler->info.compFullName);
+    }
+
     codeSize = GetEmitter()->emitEndCodeGen(compiler, trackedStackPtrsContig, GetInterruptible(),
                                             IsFullPtrRegMapRequired(), compiler->compHndBBtabCount, &prologSize,
                                             &epilogSize, codePtr, &coldCodePtr, &consPtr DEBUGARG(&instrCount));
@@ -1984,6 +1989,11 @@ void CodeGen::genEmitMachineCode()
     compiler->info.compPerfScore +=
         ((double)compiler->info.compTotalColdCodeSize * (double)PERFSCORE_CODESIZE_COST_COLD);
 #endif // DEBUG || LATE_DISASM
+
+    if (compiler->opts.disAsm)
+    {
+        printf("; END METHOD ANCHOR %s\n", compiler->info.compFullName);
+    }
 
 #ifdef DEBUG
     if (compiler->opts.disAsm || verbose)

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1968,7 +1968,7 @@ void CodeGen::genEmitMachineCode()
 
     if (compiler->opts.disAsm)
     {
-        printf("; BEGIN METHOD ANCHOR %s\n", compiler->info.compFullName);
+        printf("; BEGIN METHOD ANCHOR %s\n", compiler->eeGetMethodFullName(compiler->info.compMethodHnd));
     }
 
     codeSize = GetEmitter()->emitEndCodeGen(compiler, trackedStackPtrsContig, GetInterruptible(),
@@ -1992,7 +1992,7 @@ void CodeGen::genEmitMachineCode()
 
     if (compiler->opts.disAsm)
     {
-        printf("; END METHOD ANCHOR %s\n", compiler->info.compFullName);
+        printf("; END METHOD ANCHOR %s\n", compiler->eeGetMethodFullName(compiler->info.compMethodHnd));
     }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1968,7 +1968,7 @@ void CodeGen::genEmitMachineCode()
 
     if (compiler->opts.disAsm)
     {
-        printf("; BEGIN METHOD ANCHOR %s\n", compiler->eeGetMethodFullName(compiler->info.compMethodHnd));
+        printf("; BEGIN METHOD %s\n", compiler->eeGetMethodFullName(compiler->info.compMethodHnd));
     }
 
     codeSize = GetEmitter()->emitEndCodeGen(compiler, trackedStackPtrsContig, GetInterruptible(),
@@ -1992,7 +1992,7 @@ void CodeGen::genEmitMachineCode()
 
     if (compiler->opts.disAsm)
     {
-        printf("; END METHOD ANCHOR %s\n", compiler->eeGetMethodFullName(compiler->info.compMethodHnd));
+        printf("; END METHOD %s\n", compiler->eeGetMethodFullName(compiler->info.compMethodHnd));
     }
 
 #ifdef DEBUG

--- a/src/coreclr/tools/SuperFileCheck/Program.cs
+++ b/src/coreclr/tools/SuperFileCheck/Program.cs
@@ -391,8 +391,8 @@ namespace SuperFileCheck
             var methodName = methodDeclInfo.FullyQualifiedName.Replace("*", "{{.*}}"); // Change wild-card to FileCheck wild-card syntax.
 
             // Create anchors from the first prefix.
-            var beginAnchorText = $"// {checkPrefixes[0]}-LABEL: BEGIN METHOD ANCHOR {methodName}";
-            var endAnchorText = $"// {checkPrefixes[0]}: END METHOD ANCHOR {methodName}";
+            var beginAnchorText = $"// {checkPrefixes[0]}-LABEL: BEGIN METHOD {methodName}";
+            var endAnchorText = $"// {checkPrefixes[0]}: END METHOD {methodName}";
 
             // Create temp source file based on the source text of the method.
             // Newlines are added to pad the text so FileCheck's error messages will correspond

--- a/src/coreclr/tools/SuperFileCheck/Program.cs
+++ b/src/coreclr/tools/SuperFileCheck/Program.cs
@@ -391,8 +391,8 @@ namespace SuperFileCheck
             var methodName = methodDeclInfo.FullyQualifiedName.Replace("*", "{{.*}}"); // Change wild-card to FileCheck wild-card syntax.
 
             // Create anchors from the first prefix.
-            var startAnchorText = $"// {checkPrefixes[0]}-LABEL: for method {methodName}";
-            var endAnchorText = $"// {checkPrefixes[0]}: for method {methodName}";
+            var beginAnchorText = $"// {checkPrefixes[0]}-LABEL: BEGIN METHOD ANCHOR {methodName}";
+            var endAnchorText = $"// {checkPrefixes[0]}: END METHOD ANCHOR {methodName}";
 
             // Create temp source file based on the source text of the method.
             // Newlines are added to pad the text so FileCheck's error messages will correspond
@@ -404,7 +404,7 @@ namespace SuperFileCheck
             {
                 tmpSrc.AppendLine(String.Empty);
             }
-            tmpSrc.AppendLine(startAnchorText);
+            tmpSrc.AppendLine(beginAnchorText);
             tmpSrc.AppendLine(TransformMethod(methodDecl, checkPrefixes));
             tmpSrc.AppendLine(endAnchorText);
 


### PR DESCRIPTION
This adds explicit BEGIN and END anchors so that FileCheck will only check the assembly body of the disasm output. Before, the anchors were ambiguous, so now it is explicit.

Example:
```
; Assembly listing for method BasicBenchmark.Program+BasicBenchmark:Virtual():this (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX512 - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; Final local variable assignments
;
;* V00 this         [V00    ] (  0,  0   )     ref  ->  zero-ref    this class-hnd single-def <BasicBenchmark.Program+BasicBenchmark>
;  V01 loc0         [V01,T01] (  2,  5   )     ref  ->  rbx         class-hnd single-def <System.IDisposable>
;  V02 loc1         [V02,T00] (  4, 13   )     int  ->  rsi        
;  V03 OutArgs      [V03    ] (  1,  1   )  struct (32) [rsp+00H]   do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
;
; Lcl frame size = 40
; BEGIN METHOD BasicBenchmark.Program+BasicBenchmark:Virtual():this

G_M37645_IG01:  ;; offset=0000H
       push     rsi
       push     rbx
       sub      rsp, 40
						;; size=6 bbWeight=1 PerfScore 2.25
G_M37645_IG02:  ;; offset=0006H
       test     byte  ptr [(reloc 0x7fff5936ec45)], 1      ; global ptr
       je       SHORT G_M37645_IG06
						;; size=9 bbWeight=1 PerfScore 4.00
G_M37645_IG03:  ;; offset=000FH
       mov      rcx, 0x1CF26001DC0      ; data for BasicBenchmark.Program:X
       mov      rbx, gword ptr [rcx]
       xor      esi, esi
						;; size=15 bbWeight=1 PerfScore 2.50
G_M37645_IG04:  ;; offset=001EH
       mov      rcx, rbx
       mov      r11, 0x7FFF58990090      ; code for System.IDisposable:Dispose():this
       call     [r11]System.IDisposable:Dispose():this
       inc      esi
       cmp      esi, 0x5F5E100
       jl       SHORT G_M37645_IG04
						;; size=26 bbWeight=4 PerfScore 20.00
G_M37645_IG05:  ;; offset=0038H
       add      rsp, 40
       pop      rbx
       pop      rsi
       ret      
						;; size=7 bbWeight=1 PerfScore 2.25
G_M37645_IG06:  ;; offset=003FH
       mov      rcx, 0x7FFF5936EC10
       mov      edx, 5
       call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE
       jmp      SHORT G_M37645_IG03
						;; size=22 bbWeight=0 PerfScore 0.00
; END METHOD BasicBenchmark.Program+BasicBenchmark:Virtual():this

; Total bytes of code 85, prolog size 6, PerfScore 39.50, instruction count 22, allocated bytes for code 85 (MethodHash=a3536cf2) for method BasicBenchmark.Program+BasicBenchmark:Virtual():this (FullOpts)
; ============================================================
```