### PR TITLE
Trim XmlSerializers codegen if unsupported

### DIFF
--- a/src/libraries/System.Private.Xml/src/ILLink/ILLink.Substitutions.xml
+++ b/src/libraries/System.Private.Xml/src/ILLink/ILLink.Substitutions.xml
@@ -4,5 +4,9 @@
       <method signature="System.Boolean get_IsNetworkingEnabledByDefault()" body="stub" value="false"
               feature="System.Xml.XmlResolver.IsNetworkingEnabledByDefault" featurevalue="false" />
     </type>
+    <type fullname="System.Xml.Serialization.XmlSerializer">
+      <method signature="System.Xml.Serialization.SerializationMode get_Mode()" body="stub" value="1"
+              feature="System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported" featurevalue="false" />
+    </type>
   </assembly>
 </linker>


### PR DESCRIPTION
The problem is that ILC is not smart enough to figure out that the Mode property evaluates to a constant which lead to ILC always compiling the never used codegen backends for XmlSerializer.

Adding a substitution to ensure that Mode is a constant on NativeAOT brings down the size of a `Hello XmlSerializer` sample app from 10MB to 5MB. On a more real world usecase, in a NativeAOT app that uses Newtonsoft (where the dependency graph is Newtonsoft -> System.Data -> XmlSerializer), this cuts down the size from 14.9MB to 14.2MB.