### PR TITLE
Don't fallback to PNSE, and give a more descriptive error message.

### DIFF
--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -3426,6 +3426,9 @@ Usage: dotnet {0} [--assembly &lt;assembly file path&gt;] [--type &lt;type name&
   <data name="GenerateSerializerNotFound" xml:space="preserve">
     <value>Method 'System.Xml.Serialization.XmlSerializer.GenerateSerializer' was not found. This is likely because you are using an older version of the framework. Please update to .NET Core v2.1 or later.</value>
   </data>
+  <data name="CodeGenConvertError" xml:space="preserve">
+    <value>CodeGenError({0}): Cannot convert source type [{1}] to target type [{2}].</value>
+  </data>
   <data name="CompilingScriptsNotSupported" xml:space="preserve">
     <value>Compiling JScript/CSharp scripts is not supported</value>
   </data>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeGenerator.cs
@@ -1628,7 +1628,7 @@ namespace System.Xml.Serialization
         private readonly string _reason;
 
         public CodeGeneratorConversionException(Type sourceType, Type targetType, bool isAddress, string reason)
-            : base()
+            : base(SR.Format(SR.CodeGenConvertError, reason, sourceType.ToString(), targetType.ToString()))
         {
             _sourceType = sourceType;
             _targetType = targetType;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -59,11 +59,6 @@ namespace System.Xml.Serialization
                 }
             }
 
-#if FALLBACK_TO_CSHARP_GEN_COMPILE
-            // We will make best effort to use RefEmit for assembly generation
-            bool fallbackToCSharpAssemblyGeneration = false;
-#endif
-
             if (!containsSoapMapping && !TempAssembly.UseLegacySerializerGeneration)
             {
                 try
@@ -83,13 +78,6 @@ namespace System.Xml.Serialization
                 //
             }
             else
-#if FALLBACK_TO_CSHARP_GEN_COMPILE
-            {
-                fallbackToCSharpAssemblyGeneration = true;
-            }
-
-            if (fallbackToCSharpAssemblyGeneration)
-#endif
             {
                 throw new PlatformNotSupportedException(SR.CompilingScriptsNotSupported);
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -73,7 +73,7 @@ namespace System.Xml.Serialization
                 // Only catch and handle known failures with RefEmit
                 catch (CodeGeneratorConversionException ex)
                 {
-                    // There is no CSharp-generating/compiling fallback in .Net Core because compilers are not part of the SDK.
+                    // There is no CSharp-generating/compiling fallback in .Net Core because compilers are not part of the runtime.
                     // Instead of throwing a PNSE as a result of trying this "fallback" which doesn't exist, lets just let the
                     // original error bubble up.
                     //fallbackToCSharpAssemblyGeneration = true;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -59,29 +59,41 @@ namespace System.Xml.Serialization
                 }
             }
 
+#if FALLBACK_TO_CSHARP_GEN_COMPILE
             // We will make best effort to use RefEmit for assembly generation
             bool fallbackToCSharpAssemblyGeneration = false;
+#endif
 
             if (!containsSoapMapping && !TempAssembly.UseLegacySerializerGeneration)
             {
+#if FALLBACK_TO_CSHARP_GEN_COMPILE
                 try
                 {
+#endif
                     _assembly = GenerateRefEmitAssembly(xmlMappings, types);
+#if FALLBACK_TO_CSHARP_GEN_COMPILE
                 }
                 // Only catch and handle known failures with RefEmit
                 catch (CodeGeneratorConversionException)
                 {
-                    fallbackToCSharpAssemblyGeneration = true;
+                    // There is no CSharp-generating/compiling fallback in .Net Core because compilers are not part of the SDK.
+                    // Instead of throwing a PNSE as a result of trying this "fallback" which doesn't exist, lets just throw the
+                    // original exception.
+                    //fallbackToCSharpAssemblyGeneration = true;
+                    throw;
                 }
                 // Add other known exceptions here...
                 //
+#endif
             }
             else
+#if FALLBACK_TO_CSHARP_GEN_COMPILE
             {
                 fallbackToCSharpAssemblyGeneration = true;
             }
 
             if (fallbackToCSharpAssemblyGeneration)
+#endif
             {
                 throw new PlatformNotSupportedException(SR.CompilingScriptsNotSupported);
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -66,25 +66,21 @@ namespace System.Xml.Serialization
 
             if (!containsSoapMapping && !TempAssembly.UseLegacySerializerGeneration)
             {
-#if FALLBACK_TO_CSHARP_GEN_COMPILE
                 try
                 {
-#endif
                     _assembly = GenerateRefEmitAssembly(xmlMappings, types);
-#if FALLBACK_TO_CSHARP_GEN_COMPILE
                 }
                 // Only catch and handle known failures with RefEmit
-                catch (CodeGeneratorConversionException)
+                catch (CodeGeneratorConversionException ex)
                 {
                     // There is no CSharp-generating/compiling fallback in .Net Core because compilers are not part of the SDK.
-                    // Instead of throwing a PNSE as a result of trying this "fallback" which doesn't exist, lets just throw the
-                    // original exception.
+                    // Instead of throwing a PNSE as a result of trying this "fallback" which doesn't exist, lets just let the
+                    // original error bubble up.
                     //fallbackToCSharpAssemblyGeneration = true;
-                    throw;
+                    throw new InvalidOperationException(ex.Message, ex);
                 }
                 // Add other known exceptions here...
                 //
-#endif
             }
             else
 #if FALLBACK_TO_CSHARP_GEN_COMPILE


### PR DESCRIPTION
I decided that the best action here was to just rip out all the code that in all likelihood is never coming back. However, I did want to leave some trace as a visible reminder if this part of the code is re-visited during any future ILGen/Reflection transition. So instead of just ripping it out entirely, I used ugly #if statements. Feel free to nuke those if you think we should just check in the clean sweep.

Also, when throwing `CodeGeneratorConversionException`, I noticed that the exception message is just as useless as the PNSE exception. So I've added a new non-default exception message for that exception type.

Also, `CodeGeneratorConversion` is internal, so I wrapped it in an `InvalidOperationException` which seems to be the typical practice at this level of the stack. I'm open to suggestions on that.

Fixes: #81613 #87944