### PR TITLE
[7.0] Backport "Fix MSBuild integration for the host build with CMake 3.26"

### DIFF
--- a/eng/native/ijw/IJW.cmake
+++ b/eng/native/ijw/IJW.cmake
@@ -36,16 +36,16 @@ if (CLR_CMAKE_HOST_WIN32)
     # in case CMake has decided to use the SDK support.
     # We're dogfooding things, so we need to set settings in ways that the product doesn't quite support.
     # We don't actually need an installed/available target framework version here
-    # since we are disabling implicit framework references. We just need a valid value, and net8.0 is valid.
+    # since we are disabling implicit framework references. We just need a valid value, and net7.0 is valid.
     set_target_properties(${targetName} PROPERTIES
-      DOTNET_TARGET_FRAMEWORK net8.0
+      DOTNET_TARGET_FRAMEWORK net7.0
       VS_GLOBAL_DisableImplicitFrameworkReferences true
       VS_GLOBAL_GenerateRuntimeConfigurationFiles false
       VS_PROJECT_IMPORT "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/SetIJWProperties.props")
   endfunction()
 
   # 4365 - signed/unsigned mismatch
-  # 4679 - Could not import member. This is an issue with IJW and static abstract methods in interfaces. 
+  # 4679 - Could not import member. This is an issue with IJW and static abstract methods in interfaces.
   add_compile_options(/wd4365 /wd4679)
 
   # IJW

--- a/eng/native/ijw/IJW.cmake
+++ b/eng/native/ijw/IJW.cmake
@@ -31,6 +31,19 @@ if (CLR_CMAKE_HOST_WIN32)
     set_target_properties(${targetName} PROPERTIES COMPILE_OPTIONS "${compileOptions}")
   endfunction()
 
+  function(add_ijw_msbuild_project_properties targetName ijwhost_target)
+    # When we're building with MSBuild, we need to set some project properties
+    # in case CMake has decided to use the SDK support.
+    # We're dogfooding things, so we need to set settings in ways that the product doesn't quite support.
+    # We don't actually need an installed/available target framework version here
+    # since we are disabling implicit framework references. We just need a valid value, and net8.0 is valid.
+    set_target_properties(${targetName} PROPERTIES
+      DOTNET_TARGET_FRAMEWORK net8.0
+      VS_GLOBAL_DisableImplicitFrameworkReferences true
+      VS_GLOBAL_GenerateRuntimeConfigurationFiles false
+      VS_PROJECT_IMPORT "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/SetIJWProperties.props")
+  endfunction()
+
   # 4365 - signed/unsigned mismatch
   # 4679 - Could not import member. This is an issue with IJW and static abstract methods in interfaces. 
   add_compile_options(/wd4365 /wd4679)

--- a/eng/native/ijw/SetIJWProperties.props
+++ b/eng/native/ijw/SetIJWProperties.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- The C++/CLI targets don't let us set this in the project file where CMake lets us set project properties, so we set it in an imported project file where it will work. -->
+    <UseIJWHost>false</UseIJWHost>
+  </PropertyGroup>
+</Project>

--- a/src/native/corehost/test/ijw/CMakeLists.txt
+++ b/src/native/corehost/test/ijw/CMakeLists.txt
@@ -12,5 +12,6 @@ add_library(ijw SHARED ${SOURCES})
 target_link_libraries(ijw ${LINK_LIBRARIES_ADDITIONAL})
 
 remove_ijw_incompatible_target_options(ijw)
+add_ijw_msbuild_project_properties(ijw ijwhost)
 
 install_with_stripped_symbols(ijw TARGETS corehost_test)

--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/CMakeLists.txt
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES IjwCopyConstructorMarshaler.cpp)
 # add the shared library
 add_library (IjwCopyConstructorMarshaler SHARED ${SOURCES})
 target_link_libraries(IjwCopyConstructorMarshaler ${LINK_LIBRARIES_ADDITIONAL})
+add_ijw_msbuild_project_properties(IjwCopyConstructorMarshaler ijwhost)
 
 # add the install targets
 install (TARGETS IjwCopyConstructorMarshaler DESTINATION bin)

--- a/src/tests/Interop/IJW/IjwNativeDll/CMakeLists.txt
+++ b/src/tests/Interop/IJW/IjwNativeDll/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES IjwNativeDll.cpp)
 # add the shared library
 add_library (IjwNativeDll SHARED ${SOURCES})
 target_link_libraries(IjwNativeDll ${LINK_LIBRARIES_ADDITIONAL})
+add_ijw_msbuild_project_properties(IjwNativeDll ijwhost)
 
 # add the install targets
 install (TARGETS IjwNativeDll DESTINATION bin)

--- a/src/tests/Interop/IJW/NativeVarargs/CMakeLists.txt
+++ b/src/tests/Interop/IJW/NativeVarargs/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES IjwNativeVarargs.cpp)
 # add the shared library
 add_library (IjwNativeVarargs SHARED ${SOURCES})
 target_link_libraries(IjwNativeVarargs ${LINK_LIBRARIES_ADDITIONAL})
+add_ijw_msbuild_project_properties(IjwNativeVarargs ijwhost)
 
 # add the install targets
 install (TARGETS IjwNativeVarargs DESTINATION bin)


### PR DESCRIPTION
Backporting commit 2f208128f257b2390a8edefa0a19e0eaad6bd419 from this PR: https://github.com/dotnet/runtime/pull/88208

From a conversation with @hoyosjs, this should fix https://github.com/dotnet/runtime/issues/88806

There was other commit in the PR, but it just added a comment. Do we need it?