### PR TITLE
fix pooled array leak

### DIFF
--- a/src/libraries/Common/tests/System/Net/Security/FakeNtlmServer.cs
+++ b/src/libraries/Common/tests/System/Net/Security/FakeNtlmServer.cs
@@ -404,11 +404,8 @@ namespace System.Net.Security
 
         public void ResetKeys()
         {
-            if (_clientSeal != null)
-                _clientSeal.Dispose();
-
-            if (_serverSeal != null)
-                _serverSeal.Dispose();
+            _clientSeal?.Dispose();
+            _serverSeal?.Dispose();
 
             _clientSeal = new RC4(_clientSealingKey);
             _serverSeal = new RC4(_serverSealingKey);

--- a/src/libraries/Common/tests/System/Net/Security/FakeNtlmServer.cs
+++ b/src/libraries/Common/tests/System/Net/Security/FakeNtlmServer.cs
@@ -396,6 +396,12 @@ namespace System.Net.Security
 
         public void ResetKeys()
         {
+            if (_clientSeal != null)
+                _clientSeal.Dispose();
+
+            if (_serverSeal != null)
+                _serverSeal.Dispose();
+
             _clientSeal = new RC4(_clientSealingKey);
             _serverSeal = new RC4(_serverSealingKey);
         }

--- a/src/libraries/Common/tests/System/Net/Security/FakeNtlmServer.cs
+++ b/src/libraries/Common/tests/System/Net/Security/FakeNtlmServer.cs
@@ -24,7 +24,7 @@ namespace System.Net.Security
     // and responses for unit test purposes. The validation checks the
     // structure of the messages, their integrity and use of specified
     // features (eg. MIC).
-    internal class FakeNtlmServer
+    internal class FakeNtlmServer : IDisposable
     {
         public FakeNtlmServer(NetworkCredential expectedCredential)
         {
@@ -140,6 +140,14 @@ namespace System.Net.Security
             ConstrainedAuthentication = 1,
             MICPresent = 2,
             UntrustedSPN = 4,
+        }
+
+        public void Dispose()
+        {
+            _clientSeal?.Dispose();
+            _clientSeal = null;
+            _serverSeal?.Dispose();
+            _serverSeal = null;
         }
 
         private static ReadOnlySpan<byte> GetField(ReadOnlySpan<byte> payload, int fieldOffset)

--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -201,34 +202,29 @@ namespace System.IO
 
                 if (!handle.IsInvalid)
                 {
-                    const int InitialBufferSize = 4096;
-                    char[]? buffer = ArrayPool<char>.Shared.Rent(InitialBufferSize);
-                    uint result = GetFinalPathNameByHandle(handle, buffer);
+                    char[] buffer = new char[4096];
+                    uint result;
+                    fixed (char* bufPtr = buffer)
+                    {
+                        result = Interop.Kernel32.GetFinalPathNameByHandle(handle, bufPtr, (uint)buffer.Length, Interop.Kernel32.FILE_NAME_NORMALIZED);
+                    }
+
+                    if (result == 0)
+                    {
+                        throw new Win32Exception();
+                    }
+
+                    Debug.Assert(result <= buffer.Length);
 
                     // Remove extended prefix
                     int skip = PathInternal.IsExtended(buffer) ? 4 : 0;
 
-                    string str = new string(
-                        buffer,
-                        skip,
-                        (int)result - skip);
-
-                    ArrayPool<char>.Shared.Return(buffer);
-
-                    return str;
+                    return new string(buffer, skip, (int)result - skip);
                 }
             }
             catch { }
 
             return TestDirectory;
-        }
-
-        private unsafe uint GetFinalPathNameByHandle(SafeFileHandle handle, char[] buffer)
-        {
-            fixed (char* bufPtr = buffer)
-            {
-                return Interop.Kernel32.GetFinalPathNameByHandle(handle, bufPtr, (uint)buffer.Length, Interop.Kernel32.FILE_NAME_NORMALIZED);
-            }
         }
 
         protected string CreateTestDirectory(params string[] paths)

--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -208,10 +208,14 @@ namespace System.IO
                     // Remove extended prefix
                     int skip = PathInternal.IsExtended(buffer) ? 4 : 0;
 
-                    return new string(
+                    string str = new string(
                         buffer,
                         skip,
                         (int)result - skip);
+
+                    ArrayPool<char>.Shared.Return(buffer);
+
+                    return str;
                 }
             }
             catch { }

--- a/src/libraries/Common/tests/Tests/System/Net/MultiArrayBufferTests.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/MultiArrayBufferTests.cs
@@ -16,7 +16,7 @@ namespace Tests.System.Net
         [Fact]
         public void BasicTest()
         {
-            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+            using MultiArrayBuffer buffer = new MultiArrayBuffer(0);
 
             Assert.True(buffer.IsEmpty);
             Assert.True(buffer.ActiveMemory.IsEmpty);
@@ -98,7 +98,7 @@ namespace Tests.System.Net
         {
             const int Size = 64 * 1024 + 1;
 
-            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+            using MultiArrayBuffer buffer = new MultiArrayBuffer(0);
 
             for (int i = 0; i < Size; i++)
             {
@@ -124,7 +124,7 @@ namespace Tests.System.Net
             const int ByteCount = 7;
             const int RepeatCount = 8 * 1024;       // enough to ensure we cross several block boundaries
 
-            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+            using MultiArrayBuffer buffer = new MultiArrayBuffer(0);
 
             for (int i = 0; i < RepeatCount; i++)
             {
@@ -156,7 +156,7 @@ namespace Tests.System.Net
             const int ByteCount = 7;
             const int RepeatCount = 8 * 1024;       // enough to ensure we cross several block boundaries
 
-            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+            using MultiArrayBuffer buffer = new MultiArrayBuffer(0);
 
             for (int i = 0; i < RepeatCount; i++)
             {
@@ -188,7 +188,7 @@ namespace Tests.System.Net
             const int ByteCount = 7;
             const int RepeatCount = 8 * 1024;       // enough to ensure we cross several block boundaries
 
-            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+            using MultiArrayBuffer buffer = new MultiArrayBuffer(0);
 
             for (int i = 0; i < RepeatCount; i++)
             {
@@ -221,7 +221,7 @@ namespace Tests.System.Net
 
             const int RepeatCount = 8 * 1024;       // enough to ensure we cross several block boundaries
 
-            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+            using MultiArrayBuffer buffer = new MultiArrayBuffer(0);
 
             for (int i = 0; i < RepeatCount; i++)
             {
@@ -250,7 +250,7 @@ namespace Tests.System.Net
 
             const int RepeatCount = 13;
 
-            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+            using MultiArrayBuffer buffer = new MultiArrayBuffer(0);
 
             for (int i = 0; i < RepeatCount; i++)
             {
@@ -291,7 +291,7 @@ namespace Tests.System.Net
         [Fact]
         public void EnsureAvailableSpaceTest()
         {
-            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+            using MultiArrayBuffer buffer = new MultiArrayBuffer(0);
 
             Assert.Equal(0, buffer.ActiveMemory.Length);
             Assert.Equal(0, buffer.AvailableMemory.Length);
@@ -423,7 +423,7 @@ namespace Tests.System.Net
         [Fact]
         public void EnsureAvailableSpaceUpToLimitTest()
         {
-            MultiArrayBuffer buffer = new MultiArrayBuffer(0);
+            using MultiArrayBuffer buffer = new MultiArrayBuffer(0);
 
             Assert.Equal(0, buffer.ActiveMemory.Length);
             Assert.Equal(0, buffer.AvailableMemory.Length);

--- a/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http3/QPackDecoderTest.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http3/QPackDecoderTest.cs
@@ -15,7 +15,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 namespace System.Net.Http.Unit.Tests.QPack
 {
-    public class QPackDecoderTests
+    public class QPackDecoderTests : IDisposable
     {
         private const int MaxHeaderFieldSize = 8192;
 
@@ -62,6 +62,11 @@ namespace System.Net.Http.Unit.Tests.QPack
         public QPackDecoderTests()
         {
             _decoder = new QPackDecoder(MaxHeaderFieldSize);
+        }
+
+        public void Dispose()
+        {
+            _decoder.Dispose();
         }
 
         [Fact]
@@ -318,7 +323,7 @@ namespace System.Net.Http.Unit.Tests.QPack
 
         private static void TestDecode(byte[] encoded, KeyValuePair<string, string>[] expectedValues, bool expectDynamicTableEntry, int? bytesAtATime)
         {
-            QPackDecoder decoder = new QPackDecoder(MaxHeaderFieldSize);
+            using QPackDecoder decoder = new QPackDecoder(MaxHeaderFieldSize);
             TestHttpHeadersHandler handler = new TestHttpHeadersHandler();
 
             // Read past header

--- a/src/libraries/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
+++ b/src/libraries/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
@@ -276,7 +276,7 @@ namespace System.Text.Tests
             Assert.Equal('b', vsb[3]);
             vsb[3] = 'c';
             Assert.Equal('c', vsb[3]);
-            vsb.ToString();
+            vsb.Dispose();
         }
 
         [Fact]
@@ -299,7 +299,7 @@ namespace System.Text.Tests
             builder.EnsureCapacity(33);
 
             Assert.Equal(64, builder.Capacity);
-            builder.ToString();
+            builder.Dispose();
         }
 
         [Fact]
@@ -312,7 +312,7 @@ namespace System.Text.Tests
             builder.EnsureCapacity(16);
 
             Assert.Equal(64, builder.Capacity);
-            builder.ToString();
+            builder.Dispose();
         }
     }
 }

--- a/src/libraries/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
+++ b/src/libraries/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
@@ -180,6 +180,7 @@ namespace System.Text.Tests
 
             Assert.NotEqual(0, sb.Length);
             Assert.Equal(sb.Length, vsb.Length);
+            Assert.Equal(sb.ToString(), vsb.ToString());
         }
 
         [Fact]

--- a/src/libraries/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
+++ b/src/libraries/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
@@ -276,6 +276,7 @@ namespace System.Text.Tests
             Assert.Equal('b', vsb[3]);
             vsb[3] = 'c';
             Assert.Equal('c', vsb[3]);
+            vsb.ToString();
         }
 
         [Fact]
@@ -298,6 +299,7 @@ namespace System.Text.Tests
             builder.EnsureCapacity(33);
 
             Assert.Equal(64, builder.Capacity);
+            builder.ToString();
         }
 
         [Fact]
@@ -310,6 +312,7 @@ namespace System.Text.Tests
             builder.EnsureCapacity(16);
 
             Assert.Equal(64, builder.Capacity);
+            builder.ToString();
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -340,7 +340,7 @@ namespace System.Formats.Tar.Tests
             AssertFileModeEquals(filePath, TestPermission1);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         public void LinkBeforeTarget()
         {
             using TempDirectory source = new TempDirectory();

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -362,7 +362,7 @@ namespace System.Formats.Tar.Tests
             AssertFileModeEquals(filePath, TestPermission1);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         public async Task LinkBeforeTargetAsync()
         {
             using TempDirectory source = new TempDirectory();

--- a/src/libraries/System.Memory/tests/MemoryPool/MemoryPool.cs
+++ b/src/libraries/System.Memory/tests/MemoryPool/MemoryPool.cs
@@ -231,7 +231,7 @@ namespace System.MemoryTests
         [Fact]
         public static void ExtraDisposesAreIgnored()
         {
-            using IMemoryOwner<int> block = MemoryPool<int>.Shared.Rent(42);
+            IMemoryOwner<int> block = MemoryPool<int>.Shared.Rent(42);
             block.Dispose();
             block.Dispose();
         }
@@ -239,7 +239,7 @@ namespace System.MemoryTests
         [Fact]
         public static void NoMemoryAfterDispose()
         {
-            using IMemoryOwner<int> block = MemoryPool<int>.Shared.Rent(42);
+            IMemoryOwner<int> block = MemoryPool<int>.Shared.Rent(42);
             block.Dispose();
             Assert.Throws<ObjectDisposedException>(() => block.Memory);
         }

--- a/src/libraries/System.Memory/tests/MemoryPool/MemoryPool.cs
+++ b/src/libraries/System.Memory/tests/MemoryPool/MemoryPool.cs
@@ -90,7 +90,7 @@ namespace System.MemoryTests
         public static void MemoryPoolPinBadOffset(int elementIndex)
         {
             MemoryPool<int> pool = MemoryPool<int>.Shared;
-            IMemoryOwner<int> block = pool.Rent(10);
+            using IMemoryOwner<int> block = pool.Rent(10);
             Memory<int> memory = block.Memory;
             Span<int> sp = memory.Span;
             Assert.Equal(memory.Length, sp.Length);
@@ -101,7 +101,7 @@ namespace System.MemoryTests
         public static void MemoryPoolPinOffsetAtEnd()
         {
             MemoryPool<int> pool = MemoryPool<int>.Shared;
-            IMemoryOwner<int> block = pool.Rent(10);
+            using IMemoryOwner<int> block = pool.Rent(10);
             Memory<int> memory = block.Memory;
             Span<int> sp = memory.Span;
             Assert.Equal(memory.Length, sp.Length);
@@ -122,7 +122,7 @@ namespace System.MemoryTests
         public static void MemoryPoolPinBadOffsetTooLarge()
         {
             MemoryPool<int> pool = MemoryPool<int>.Shared;
-            IMemoryOwner<int> block = pool.Rent(10);
+            using IMemoryOwner<int> block = pool.Rent(10);
             Memory<int> memory = block.Memory;
             Span<int> sp = memory.Span;
             Assert.Equal(memory.Length, sp.Length);
@@ -231,7 +231,7 @@ namespace System.MemoryTests
         [Fact]
         public static void ExtraDisposesAreIgnored()
         {
-            IMemoryOwner<int> block = MemoryPool<int>.Shared.Rent(42);
+            using IMemoryOwner<int> block = MemoryPool<int>.Shared.Rent(42);
             block.Dispose();
             block.Dispose();
         }
@@ -239,7 +239,7 @@ namespace System.MemoryTests
         [Fact]
         public static void NoMemoryAfterDispose()
         {
-            IMemoryOwner<int> block = MemoryPool<int>.Shared.Rent(42);
+            using IMemoryOwner<int> block = MemoryPool<int>.Shared.Rent(42);
             block.Dispose();
             Assert.Throws<ObjectDisposedException>(() => block.Memory);
         }

--- a/src/libraries/System.Net.Http.Json/tests/UnitTests/TranscodingWriteStreamTests.cs
+++ b/src/libraries/System.Net.Http.Json/tests/UnitTests/TranscodingWriteStreamTests.cs
@@ -67,7 +67,7 @@ namespace System.Net.Http.Json.Functional.Tests
             var model = new TestModel { Message = message };
             var stream = new MemoryStream();
 
-            var transcodingStream = new TranscodingWriteStream(stream, targetEncoding);
+            using var transcodingStream = new TranscodingWriteStream(stream, targetEncoding);
             await JsonSerializer.SerializeAsync(transcodingStream, model, model.GetType());
             // The transcoding streams use Encoders and Decoders that have internal buffers. We need to flush these
             // when there is no more data to be written. Stream.FlushAsync isn't suitable since it's

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.FakeServer.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.FakeServer.cs
@@ -107,6 +107,8 @@ namespace System.Net.Http.Functional.Tests
             }
             while (!isAuthenticated);
 
+            fakeNtlmServer?.Dispose();
+
             await connection.SendResponseAsync(HttpStatusCode.OK);
         }
 

--- a/src/libraries/System.Net.Mail/tests/Functional/LoopbackSmtpServer.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/LoopbackSmtpServer.cs
@@ -156,7 +156,7 @@ namespace Systen.Net.Mail.Tests
                         else if (parts[1].Equals("GSSAPI", StringComparison.OrdinalIgnoreCase))
                         {
                             Debug.Assert(ExpectedGssapiCredential != null);
-                            FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(ExpectedGssapiCredential) { ForceNegotiateVersion = true };
+                            using FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(ExpectedGssapiCredential) { ForceNegotiateVersion = true };
                             FakeNegotiateServer fakeNegotiateServer = new FakeNegotiateServer(fakeNtlmServer);
 
                             try

--- a/src/libraries/System.Net.Security/src/System/Net/NTAuthentication.Managed.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NTAuthentication.Managed.cs
@@ -773,6 +773,10 @@ namespace System.Net
 
         private void ResetKeys()
         {
+            // Release buffers to pool
+            _clientSeal?.Dispose();
+            _serverSeal?.Dispose();
+
             _clientSeal = new RC4(_clientSealingKey);
             _serverSeal = new RC4(_serverSealingKey);
         }

--- a/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
@@ -41,7 +41,7 @@ namespace System.Net.Security.Tests
         [ConditionalFact(nameof(IsNtlmAvailable))]
         public void RemoteIdentity_ThrowsOnDisposed()
         {
-            FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(s_testCredentialRight);
+            using FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(s_testCredentialRight);
             NegotiateAuthentication negotiateAuthentication = new NegotiateAuthentication(
                 new NegotiateAuthenticationClientOptions
                 {
@@ -98,7 +98,7 @@ namespace System.Net.Security.Tests
         {
             // Mirrors the NTLMv2 example in the NTLM specification:
             NetworkCredential credential = new NetworkCredential("User", "Password", "Domain");
-            FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(credential);
+            using FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(credential);
             fakeNtlmServer.SendTimestamp = false;
             fakeNtlmServer.TargetIsServer = true;
             fakeNtlmServer.PreferUnicode = false;
@@ -151,7 +151,7 @@ namespace System.Net.Security.Tests
         [ConditionalFact(nameof(IsNtlmAvailable))]
         public void NtlmCorrectExchangeTest()
         {
-            FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(s_testCredentialRight);
+            using FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(s_testCredentialRight);
             NegotiateAuthentication ntAuth = new NegotiateAuthentication(
                 new NegotiateAuthenticationClientOptions
                 {
@@ -175,7 +175,7 @@ namespace System.Net.Security.Tests
         [ConditionalFact(nameof(IsNtlmAvailable))]
         public void NtlmIncorrectExchangeTest()
         {
-            FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(s_testCredentialRight);
+            using FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(s_testCredentialRight);
             NegotiateAuthentication ntAuth = new NegotiateAuthentication(
                 new NegotiateAuthenticationClientOptions
                 {
@@ -194,7 +194,7 @@ namespace System.Net.Security.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/65678", TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst)]
         public void NtlmSignatureTest()
         {
-            FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(s_testCredentialRight);
+            using FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(s_testCredentialRight);
             NegotiateAuthentication ntAuth = new NegotiateAuthentication(
                 new NegotiateAuthenticationClientOptions
                 {
@@ -250,7 +250,7 @@ namespace System.Net.Security.Tests
         public void NegotiateCorrectExchangeTest(bool requestMIC, bool requestConfidentiality)
         {
             // Older versions of gss-ntlmssp on Linux generate MIC at incorrect offset unless ForceNegotiateVersion is specified
-            FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(s_testCredentialRight) { ForceNegotiateVersion = true };
+            using FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(s_testCredentialRight) { ForceNegotiateVersion = true };
             FakeNegotiateServer fakeNegotiateServer = new FakeNegotiateServer(fakeNtlmServer) { RequestMIC = requestMIC };
             NegotiateAuthentication ntAuth = new NegotiateAuthentication(
                 new NegotiateAuthenticationClientOptions

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemName.cs
@@ -51,7 +51,13 @@ namespace System.IO.Enumeration
                 }
             }
 
-            return modified ? sb.ToString() : expression;
+            if (!modified)
+            {
+                sb.Dispose();
+                return expression;
+            }
+
+            return sb.ToString();
         }
 
         /// <summary>Verifies whether the given Win32 expression matches the given name. Supports the following wildcards: '*', '?', '&lt;', '&gt;', '"'. The backslash character '\' escapes.</summary>

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/DefaultInterpolatedStringHandlerTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/DefaultInterpolatedStringHandlerTests.cs
@@ -18,17 +18,17 @@ namespace System.Runtime.CompilerServices.Tests
         [InlineData(-16, 1)]
         public void LengthAndHoleArguments_Valid(int literalLength, int formattedCount)
         {
-            new DefaultInterpolatedStringHandler(literalLength, formattedCount);
+            new DefaultInterpolatedStringHandler(literalLength, formattedCount).ToStringAndClear();
 
             Span<char> scratch1 = stackalloc char[1];
             foreach (IFormatProvider provider in new IFormatProvider[] { null, new ConcatFormatter(), CultureInfo.InvariantCulture, CultureInfo.CurrentCulture, new CultureInfo("en-US"), new CultureInfo("fr-FR") })
             {
-                new DefaultInterpolatedStringHandler(literalLength, formattedCount, provider);
+                new DefaultInterpolatedStringHandler(literalLength, formattedCount, provider).ToStringAndClear();
 
-                new DefaultInterpolatedStringHandler(literalLength, formattedCount, provider, default);
-                new DefaultInterpolatedStringHandler(literalLength, formattedCount, provider, scratch1);
-                new DefaultInterpolatedStringHandler(literalLength, formattedCount, provider, Array.Empty<char>());
-                new DefaultInterpolatedStringHandler(literalLength, formattedCount, provider, new char[256]);
+                new DefaultInterpolatedStringHandler(literalLength, formattedCount, provider, default).ToStringAndClear();
+                new DefaultInterpolatedStringHandler(literalLength, formattedCount, provider, scratch1).ToStringAndClear();
+                new DefaultInterpolatedStringHandler(literalLength, formattedCount, provider, Array.Empty<char>()).ToStringAndClear();
+                new DefaultInterpolatedStringHandler(literalLength, formattedCount, provider, new char[256]).ToStringAndClear();
             }
         }
 
@@ -244,6 +244,8 @@ namespace System.Runtime.CompilerServices.Tests
                 handler.AppendFormatted(tss, 1, "X2");
                 Assert.Same(provider, tss.ToStringState.LastProvider);
             }
+
+            handler.ToStringAndClear();
         }
 
         [Fact]
@@ -357,6 +359,8 @@ namespace System.Runtime.CompilerServices.Tests
 
                 handler.AppendFormatted(t, 1, "X2");
                 Assert.Same(provider, ((IHasToStringState)t).ToStringState.LastProvider);
+
+                handler.ToStringAndClear();
             }
 
             Test(new FormattableInt32Wrapper(42));

--- a/src/libraries/System.Security.Cryptography/tests/ZeroMemoryTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/ZeroMemoryTests.cs
@@ -57,6 +57,8 @@ namespace System.Security.Cryptography.Tests
             {
                 Assert.Equal(0, testSpan[i]);
             }
+
+            ArrayPool<byte>.Shared.Return(rented, clearArray: false);
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
@@ -135,7 +135,8 @@ namespace System.Text.Json.SourceGeneration.Tests
         [InlineData("{ \"key\" : \"value\" }")]
         public void RoundtripJsonElement(string json)
         {
-            JsonElement jsonElement = JsonDocument.Parse(json).RootElement;
+            using JsonDocument jsonDocument = JsonDocument.Parse(json);
+            JsonElement jsonElement = jsonDocument.RootElement;
 
             string actualJson = JsonSerializer.Serialize(jsonElement, DefaultContext.JsonElement);
             JsonTestHelper.AssertJsonEqual(json, actualJson);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
@@ -118,12 +118,12 @@ namespace System.Text.Json.SourceGeneration.Tests
         [InlineData("{ \"key\" : \"value\" }")]
         public void RoundtripJsonDocument(string json)
         {
-            JsonDocument jsonDocument = JsonDocument.Parse(json);
+            using JsonDocument jsonDocument = JsonDocument.Parse(json);
 
             string actualJson = JsonSerializer.Serialize(jsonDocument, DefaultContext.JsonDocument);
             JsonTestHelper.AssertJsonEqual(json, actualJson);
 
-            JsonDocument actualJsonDocument = JsonSerializer.Deserialize(actualJson, DefaultContext.JsonDocument);
+            using JsonDocument actualJsonDocument = JsonSerializer.Deserialize(actualJson, DefaultContext.JsonDocument);
             JsonTestHelper.AssertJsonEqual(jsonDocument.RootElement, actualJsonDocument.RootElement);
         }
 


### PR DESCRIPTION
I ran the tests with some rudimentary tracing on the array pool and found one leak.

1. fix leak in FileSystemName.cs
2. fix some of the leaks in tests that were particularly noisy in the logs. Happy to revert some or all of these.