### PR TITLE
Add an option to not generate precise GC info

### DIFF
--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -1,5 +1,7 @@
 <Project>
   <PropertyGroup>
+    <IlcUseConservativeGc>true</IlcUseConservativeGc>
+
     <OutputType>Exe</OutputType>
 
     <BundleDir>$([MSBuild]::NormalizeDirectory('$(OutDir)', 'publish'))</BundleDir>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -272,6 +272,9 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="--resilient" />
       <IlcArg Include="@(UnmanagedEntryPointsAssembly->'--generateunmanagedentrypoints:%(Identity)')" />
 
+      <IlcArg Condition="'$(IlcUseConservativeGc)' == 'true'" Include="--runtimeopt:gcConservative=1" />
+      <IlcArg Condition="'$(IlcUseConservativeGc)' == 'true'" Include="--noprecisegc" />
+
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--feature:System.Reflection.IsReflectionExecutionAvailable=false" />
 
       <!-- Configure LINQ expressions - disable Emit everywhere -->

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -495,7 +495,15 @@ namespace Internal.JitInterface
             _methodCodeNode.InitializeColdFrameInfos(_coldFrameInfos);
 #endif
             _methodCodeNode.InitializeDebugEHClauseInfos(debugEHClauseInfos);
-            _methodCodeNode.InitializeGCInfo(_gcInfo);
+
+#if !READYTORUN
+            if ((_compilation._compilationOptions & RyuJitCompilationOptions.NoPreciseGc) == 0
+                // GC info is necessary to unwind reverse P/invokes and cannot be stripped
+                || _methodCodeNode.Method.IsUnmanagedCallersOnly)
+#endif
+            {
+                _methodCodeNode.InitializeGCInfo(_gcInfo);
+            }
             _methodCodeNode.InitializeEHInfo(ehInfo);
 
             _methodCodeNode.InitializeDebugLocInfos(_debugLocInfos);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
@@ -25,6 +25,7 @@ namespace ILCompiler
         protected SecurityMitigationOptions _mitigationOptions;
         protected bool _dehydrate;
         protected bool _useDwarf5;
+        protected bool _isPreciseGc = true;
 
         partial void InitializePartial()
         {
@@ -119,6 +120,12 @@ namespace ILCompiler
         public CompilationBuilder UseDwarf5(bool value)
         {
             _useDwarf5 = value;
+            return this;
+        }
+
+        public CompilationBuilder UseGCStackReporting(bool isPrecise)
+        {
+            _isPreciseGc = isPrecise;
             return this;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -244,5 +244,6 @@ namespace ILCompiler
         ControlFlowGuardAnnotations = 0x2,
         UseDwarf5 = 0x4,
         UseResilience = 0x8,
+        NoPreciseGc = 0x10,
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
@@ -123,6 +123,9 @@ namespace ILCompiler
             if (_resilient)
                 options |= RyuJitCompilationOptions.UseResilience;
 
+            if (!_isPreciseGc)
+                options |= RyuJitCompilationOptions.NoPreciseGc;
+
             var factory = new RyuJitNodeFactory(_context, _compilationGroup, _metadataManager, _interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider, _inlinedThreadStatics, GetPreinitializationManager());
 
             JitConfigProvider.Initialize(_context.Target, jitFlagBuilder.ToArray(), _ryujitOptions, _jitPath);

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -91,6 +91,8 @@ namespace ILCompiler
             new("--stacktracedata") { Description = "Emit data to support generating stack trace strings at runtime" };
         public CliOption<bool> MethodBodyFolding { get; } =
             new("--methodbodyfolding") { Description = "Fold identical method bodies" };
+        public CliOption<bool> NoPreciseGc { get; } =
+            new("--noprecisegc") { Description = "Do not generate precise stack GC information" };
         public CliOption<string[]> InitAssemblies { get; } =
             new("--initassembly") { DefaultValueFactory = _ => Array.Empty<string>(), Description = "Assembly(ies) with a library initializer" };
         public CliOption<string[]> FeatureSwitches { get; } =
@@ -202,6 +204,7 @@ namespace ILCompiler
             Options.Add(IlDump);
             Options.Add(EmitStackTraceData);
             Options.Add(MethodBodyFolding);
+            Options.Add(NoPreciseGc);
             Options.Add(InitAssemblies);
             Options.Add(FeatureSwitches);
             Options.Add(RuntimeOptions);

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -535,6 +535,7 @@ namespace ILCompiler
                 .UseInstructionSetSupport(instructionSetSupport)
                 .UseBackendOptions(Get(_command.CodegenOptions))
                 .UseMethodBodyFolding(enable: Get(_command.MethodBodyFolding))
+                .UseGCStackReporting(isPrecise: !Get(_command.NoPreciseGc))
                 .UseParallelism(parallelism)
                 .UseMetadataManager(metadataManager)
                 .UseInteropStubManager(interopStubManager)

--- a/src/libraries/System.Collections.Immutable/tests/Frozen/FrozenDictionaryTests.cs
+++ b/src/libraries/System.Collections.Immutable/tests/Frozen/FrozenDictionaryTests.cs
@@ -196,6 +196,7 @@ namespace System.Collections.Frozen.Tests
 
         [Theory]
         [MemberData(nameof(LookupItems_AllItemsFoundAsExpected_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88628", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void LookupItems_AllItemsFoundAsExpected(int size, IEqualityComparer<TKey> comparer, bool specifySameComparer)
         {
             Dictionary<TKey, TValue> original =

--- a/src/tests/nativeaot/Directory.Build.props
+++ b/src/tests/nativeaot/Directory.Build.props
@@ -9,5 +9,7 @@
 
     <!-- We expect trimming to be fully enabled in these tests -->
     <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
+
+    <IlcUseConservativeGc>true</IlcUseConservativeGc>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Revived https://github.com/dotnet/runtime/pull/75817 with a small change.

Follow up to https://github.com/dotnet/runtime/pull/75803.

If enabled, conservative GC stack scanning will be used and metadata related to GC stack reporting will not be generated. The generated executable file will be smaller, but the GC will be less efficient (garbage collection might take longer and keep objects alive for longer periods of time than usual).

Saves 4.4% in size on a Hello World. Saves 6.7% on Stage 1. I'll take that.

The main difference from the previous PR is that I'm no longer dropping GC info on `UnmanagedCallersOnly` methods and that seems to be enough to make Smoke tests pass. Let's see what the rest of the testing thinks.

Cc @dotnet/ilc-contrib 