### PR TITLE
[mono][sgen] Log also size of reserved empty major blocks

### DIFF
--- a/src/mono/mono/sgen/sgen-gc.h
+++ b/src/mono/mono/sgen/sgen-gc.h
@@ -716,6 +716,7 @@ struct _SgenMajorCollector {
 	gboolean (*ptr_is_from_pinned_alloc) (char *ptr);
 	void (*report_pinned_memory_usage) (void);
 	size_t (*get_num_major_sections) (void);
+	size_t (*get_num_empty_blocks) (void);
 	size_t (*get_bytes_survived_last_sweep) (void);
 	gboolean (*handle_gc_param) (const char *opt);
 	void (*print_gc_param_usage) (void);

--- a/src/mono/mono/sgen/sgen-marksweep.c
+++ b/src/mono/mono/sgen/sgen-marksweep.c
@@ -2319,6 +2319,12 @@ get_num_major_sections (void)
 	return num_major_sections;
 }
 
+static size_t
+get_num_empty_blocks (void)
+{
+	return num_empty_blocks;
+}
+
 /*
  * Returns the number of bytes in blocks that were present when the last sweep was
  * initiated, and were not freed during the sweep.  They are the basis for calculating the
@@ -2880,6 +2886,7 @@ sgen_marksweep_init_internal (SgenMajorCollector *collector, gboolean is_concurr
 	collector->ptr_is_from_pinned_alloc = ptr_is_from_pinned_alloc;
 	collector->report_pinned_memory_usage = major_report_pinned_memory_usage;
 	collector->get_num_major_sections = get_num_major_sections;
+	collector->get_num_empty_blocks = get_num_empty_blocks;
 	collector->get_bytes_survived_last_sweep = get_bytes_survived_last_sweep;
 	collector->handle_gc_param = major_handle_gc_param;
 	collector->print_gc_param_usage = major_print_gc_param_usage;

--- a/src/mono/mono/sgen/sgen-memory-governor.h
+++ b/src/mono/mono/sgen/sgen-memory-governor.h
@@ -50,6 +50,7 @@ typedef struct {
 	mword promoted_size;
 	mword major_size;
 	mword major_size_in_use;
+	mword major_empty_reserved_size;
 	mword los_size;
 	mword los_size_in_use;
 } SgenLogEntry;


### PR DESCRIPTION
These are blocks that currently have no objects in them, they are part of the block freelist and are not freed immediately, or on some platform never at all.