### PR TITLE
Don't crash the trim analyzer if it finds unrecognized nodes in the input

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using ILLink.Shared.DataFlow;
 using Microsoft.CodeAnalysis;
 
@@ -29,7 +30,12 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 				// These will just be ignored when referenced later.
 				break;
 			default:
-				throw new NotImplementedException (operation.Kind.ToString ());
+				// Assert on anything else as it means we need to implement support for it
+				// but do not throw here as it means new Roslyn version could cause the analyzer to crash
+				// which is not fixable by the user. The analyzer is not going to be 100% correct no matter what we do
+				// so effectively ignoring constructs it doesn't understand is OK.
+				Debug.Fail ($"{operation.GetType ()}: {operation.Syntax.GetLocation ().GetLineSpan ()}");
+				break;
 			}
 			Reference = operation;
 		}

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -282,7 +282,13 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 				// (don't have specific I*Operation types), such as pointer dereferences.
 				if (targetOperation.Kind is OperationKind.None)
 					break;
-				throw new NotImplementedException ($"{targetOperation.GetType ()}: {targetOperation.Syntax.GetLocation ().GetLineSpan ()}");
+
+				// Assert on anything else as it means we need to implement support for it
+				// but do not throw here as it means new Roslyn version could cause the analyzer to crash
+				// which is not fixable by the user. The analyzer is not going to be 100% correct no matter what we do
+				// so effectively ignoring constructs it doesn't understand is OK.
+				Debug.Fail ($"{targetOperation.GetType ()}: {targetOperation.Syntax.GetLocation ().GetLineSpan ()}");
+				break;
 			}
 			return Visit (operation.Value, state);
 		}


### PR DESCRIPTION
New versions of the compiler will introduce new nodes and values. The analyzer can never be 100% in sync with the compiler, so it needs to be able to gracefully handle nodes it doesn't know anything about.

Change the several throws to just `Debug.Fail`. For end-users if we hit unrecognized node, we will effectively ignore that part of the code. So not 100% precise, but the analyzer will never be 100% regardless.

This is in response to #88684, but we can't add tests for it yet because the necessary compiler changes are in Preview 6, the repo is still on Preview 5.