### PR TITLE
Ensure that IsPow2 for floating-point numbers correctly take subnormal values into account

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -533,12 +533,28 @@ namespace System
         {
             ulong bits = BitConverter.DoubleToUInt64Bits(value);
 
-            ushort biasedExponent = ExtractBiasedExponentFromBits(bits);;
+            if ((long)bits <= 0)
+            {
+                // Zero and negative values cannot be powers of 2
+                return false;
+            }
+
+            ushort biasedExponent = ExtractBiasedExponentFromBits(bits);
             ulong trailingSignificand = ExtractTrailingSignificandFromBits(bits);
 
-            return (value > 0)
-                && (biasedExponent != MinBiasedExponent) && (biasedExponent != MaxBiasedExponent)
-                && (trailingSignificand == MinTrailingSignificand);
+            if (biasedExponent == MinBiasedExponent)
+            {
+                // Subnormal values have 1 bit set when they're powers of 2
+                return ulong.PopCount(trailingSignificand) == 1;
+            }
+            else if (biasedExponent == MaxBiasedExponent)
+            {
+                // NaN and Infinite values cannot be powers of 2
+                return false;
+            }
+
+            // Normal values have 0 bits set when they're powers of 2
+            return trailingSignificand == MinTrailingSignificand;
         }
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -1194,12 +1194,28 @@ namespace System
         {
             ushort bits = BitConverter.HalfToUInt16Bits(value);
 
+            if ((short)bits <= 0)
+            {
+                // Zero and negative values cannot be powers of 2
+                return false;
+            }
+
             byte biasedExponent = ExtractBiasedExponentFromBits(bits);
             ushort trailingSignificand = ExtractTrailingSignificandFromBits(bits);
 
-            return (value > Zero)
-                && (biasedExponent != MinBiasedExponent) && (biasedExponent != MaxBiasedExponent)
-                && (trailingSignificand == MinTrailingSignificand);
+            if (biasedExponent == MinBiasedExponent)
+            {
+                // Subnormal values have 1 bit set when they're powers of 2
+                return ushort.PopCount(trailingSignificand) == 1;
+            }
+            else if (biasedExponent == MaxBiasedExponent)
+            {
+                // NaN and Infinite values cannot be powers of 2
+                return false;
+            }
+
+            // Normal values have 0 bits set when they're powers of 2
+            return trailingSignificand == MinTrailingSignificand;
         }
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -529,12 +529,28 @@ namespace System
         {
             uint bits = BitConverter.SingleToUInt32Bits(value);
 
+            if ((int)bits <= 0)
+            {
+                // Zero and negative values cannot be powers of 2
+                return false;
+            }
+
             byte biasedExponent = ExtractBiasedExponentFromBits(bits);
             uint trailingSignificand = ExtractTrailingSignificandFromBits(bits);
 
-            return (value > 0)
-                && (biasedExponent != MinBiasedExponent) && (biasedExponent != MaxBiasedExponent)
-                && (trailingSignificand == MinTrailingSignificand);
+            if (biasedExponent == MinBiasedExponent)
+            {
+                // Subnormal values have 1 bit set when they're powers of 2
+                return uint.PopCount(trailingSignificand) == 1;
+            }
+            else if (biasedExponent == MaxBiasedExponent)
+            {
+                // NaN and Infinite values cannot be powers of 2
+                return false;
+            }
+
+            // Normal values have 0 bits set when they're powers of 2
+            return trailingSignificand == MinTrailingSignificand;
         }
 
         /// <inheritdoc cref="IBinaryNumber{TSelf}.Log2(TSelf)" />

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.GenericMath.cs
@@ -244,7 +244,7 @@ namespace System.Runtime.InteropServices.Tests
             Assert.False(BinaryNumberHelper<NFloat>.IsPow2(NegativeZero));
             Assert.False(BinaryNumberHelper<NFloat>.IsPow2(NFloat.NaN));
             Assert.False(BinaryNumberHelper<NFloat>.IsPow2(Zero));
-            Assert.False(BinaryNumberHelper<NFloat>.IsPow2(NFloat.Epsilon));
+            Assert.True(BinaryNumberHelper<NFloat>.IsPow2(NFloat.Epsilon));
             Assert.False(BinaryNumberHelper<NFloat>.IsPow2(MaxSubnormal));
             Assert.True(BinaryNumberHelper<NFloat>.IsPow2(MinNormal));
             Assert.True(BinaryNumberHelper<NFloat>.IsPow2(One));

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.GenericMath.cs
@@ -108,7 +108,7 @@ namespace System.Tests
             Assert.False(BinaryNumberHelper<double>.IsPow2(-0.0));
             Assert.False(BinaryNumberHelper<double>.IsPow2(double.NaN));
             Assert.False(BinaryNumberHelper<double>.IsPow2(0.0));
-            Assert.False(BinaryNumberHelper<double>.IsPow2(double.Epsilon));
+            Assert.True(BinaryNumberHelper<double>.IsPow2(double.Epsilon));
             Assert.False(BinaryNumberHelper<double>.IsPow2(MaxSubnormal));
             Assert.True(BinaryNumberHelper<double>.IsPow2(MinNormal));
             Assert.True(BinaryNumberHelper<double>.IsPow2(1.0));

--- a/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.GenericMath.cs
@@ -120,7 +120,7 @@ namespace System.Tests
             Assert.False(BinaryNumberHelper<Half>.IsPow2(NegativeZero));
             Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.NaN));
             Assert.False(BinaryNumberHelper<Half>.IsPow2(Zero));
-            Assert.False(BinaryNumberHelper<Half>.IsPow2(Half.Epsilon));
+            Assert.True(BinaryNumberHelper<Half>.IsPow2(Half.Epsilon));
             Assert.False(BinaryNumberHelper<Half>.IsPow2(MaxSubnormal));
             Assert.True(BinaryNumberHelper<Half>.IsPow2(MinNormal));
             Assert.True(BinaryNumberHelper<Half>.IsPow2(One));

--- a/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.GenericMath.cs
@@ -108,7 +108,7 @@ namespace System.Tests
             Assert.False(BinaryNumberHelper<float>.IsPow2(-0.0f));
             Assert.False(BinaryNumberHelper<float>.IsPow2(float.NaN));
             Assert.False(BinaryNumberHelper<float>.IsPow2(0.0f));
-            Assert.False(BinaryNumberHelper<float>.IsPow2(float.Epsilon));
+            Assert.True(BinaryNumberHelper<float>.IsPow2(float.Epsilon));
             Assert.False(BinaryNumberHelper<float>.IsPow2(MaxSubnormal));
             Assert.True(BinaryNumberHelper<float>.IsPow2(MinNormal));
             Assert.True(BinaryNumberHelper<float>.IsPow2(1.0f));


### PR DESCRIPTION
This resolves #88023 by ensuring that subnormal values check for a trailing significand with 1 bit set.