### PR TITLE
[mono][tests] Enable dynamic linking for maccatalyst in sandbox environment

### DIFF
--- a/src/mono/sample/iOS/Makefile
+++ b/src/mono/sample/iOS/Makefile
@@ -53,6 +53,7 @@ run-sim: clean appbuilder
 	/p:TargetOS=iossimulator \
 	/p:TargetArchitecture=$(MONO_ARCH) \
 	/p:MonoEnableLLVM=$(USE_LLVM) \
+	/p:MonoForceInterpreter=false \
 	/p:DeployAndRun=$(DEPLOY_AND_RUN) \
 	/p:RuntimeComponents="$(RUNTIME_COMPONENTS)" \
 	/p:DiagnosticPorts="$(DIAGNOSTIC_PORTS)" \
@@ -76,6 +77,7 @@ run-catalyst: clean appbuilder
 	/p:TargetOS=maccatalyst \
 	/p:TargetArchitecture=$(MONO_ARCH) \
 	/p:MonoEnableLLVM=false \
+	/p:MonoForceInterpreter=false \
 	/p:DeployAndRun=$(DEPLOY_AND_RUN) \
 	/p:EnableAppSandbox=$(APP_SANDBOX) \
 	/bl
@@ -85,7 +87,7 @@ run-catalyst-interp: clean appbuilder
 	-c $(MONO_CONFIG) \
 	/p:TargetOS=maccatalyst \
 	/p:TargetArchitecture=$(MONO_ARCH) \
-	/p:MonoEnableLLVM=False \
+	/p:MonoEnableLLVM=false \
 	/p:MonoForceInterpreter=true \
 	/p:DeployAndRun=$(DEPLOY_AND_RUN) \
 	/p:EnableAppSandbox=$(APP_SANDBOX) \

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -223,7 +223,7 @@ public class AppleAppBuilderTask : Task
 
     public override bool Execute()
     {
-        bool shouldStaticLink = true;
+        bool shouldStaticLink = !EnableAppSandbox;
         bool isDevice = (TargetOS == TargetNames.iOS || TargetOS == TargetNames.tvOS);
 
         ValidateRuntimeSelection();


### PR DESCRIPTION
This PR should fix the failing maccatalyst jobs in the sandbox environment by enabling dynamic linking. Additionally, it explicitly sets `MonoForceInterpreter` to false in the sample app when running in the full AOT mode on iossimulator and maccatalyst.