### PR TITLE
Simplify condition to detect recursive inlining

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -42,7 +42,7 @@ unsigned Compiler::fgCheckInlineDepthAndRecursion(InlineInfo* inlineInfo)
         assert(inlineContext->GetCode() != nullptr);
         depth++;
 
-        if ((inlineContext->GetCode() == candidateCode) && (inlineContext->GetCallee() == inlineInfo->fncHandle) &&
+        if ((inlineContext->GetCallee() == inlineInfo->fncHandle) &&
             (inlineContext->GetRuntimeContext() == inlineInfo->inlineCandidateInfo->exactContextHnd))
         {
             // This is a recursive inline


### PR DESCRIPTION
This change simplifies the conditon and also makes it more robust. There are situation where the IL code pointer can differ for the same method.