### PR TITLE
Register a callback that tries to load other versions Open LDAP library if the default is failed

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Linux/Interop.Libraries.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
         internal const string Liblog = "liblog";
 
         internal const string Odbc32 = "libodbc.so.2";
-        internal const string OpenLdap = "libldap-2.4.so.2";
+        internal const string OpenLdap = "libldap-2.5.so.0";
         internal const string MsQuic = "libmsquic.so";
     }
 }

--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
@@ -74,21 +74,19 @@ internal static partial class Interop
             // Register callback that tries to load other libraries when the default library "libldap-2.5.so.0" not found
             AssemblyLoadContext.GetLoadContext(currentAssembly).ResolvingUnmanagedDll += (assembly, ldapName) =>
             {
-                IntPtr handle = IntPtr.Zero;
-
                 if (assembly != currentAssembly || ldapName != Libraries.OpenLdap)
                 {
-                    return handle;
+                    return IntPtr.Zero;
                 }
 
                 // Try loading previous (libldap-2.4.so.2) and next (libldap-2.6.so.0) versions
-                if (NativeLibrary.TryLoad("libldap-2.4.so.2", out handle) ||
+                if (NativeLibrary.TryLoad("libldap-2.4.so.2", out IntPtr handle) ||
                     NativeLibrary.TryLoad("libldap-2.6.so.0", out handle))
                 {
                     return handle;
                 }
 
-                throw new DllNotFoundException(SR.Format(SR.LDAP_LIBRARY_NOT_FOUND, ldapName));
+                return IntPtr.Zero;
             };
 
             // OpenLdap must be initialized on a single thread, once this is done it allows concurrent calls

--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
@@ -79,9 +79,9 @@ internal static partial class Interop
                     return IntPtr.Zero;
                 }
 
-                // Try loading previous (libldap-2.4.so.2) and next (libldap-2.6.so.0) versions
-                if (NativeLibrary.TryLoad("libldap-2.4.so.2", out IntPtr handle) ||
-                    NativeLibrary.TryLoad("libldap-2.6.so.0", out handle))
+                // Try load next (libldap-2.6.so.0) or previous (libldap-2.4.so.2) versions
+                if (NativeLibrary.TryLoad("libldap-2.6.so.0", out IntPtr handle) ||
+                    NativeLibrary.TryLoad("libldap-2.4.so.2", out handle))
                 {
                     return handle;
                 }

--- a/src/libraries/System.DirectoryServices.Protocols/src/Resources/Strings.resx
+++ b/src/libraries/System.DirectoryServices.Protocols/src/Resources/Strings.resx
@@ -426,7 +426,4 @@
   <data name="ReferralChasingOptionsNotSupported" xml:space="preserve">
     <value>Only ReferralChasingOptions.None and ReferralChasingOptions.All are supported on Linux.</value>
   </data>
-  <data name="LDAP_LIBRARY_NOT_FOUND" xml:space="preserve">
-    <value>The OpenLDAP library with version {0} was not found.</value>
-  </data>
 </root>

--- a/src/libraries/System.DirectoryServices.Protocols/src/Resources/Strings.resx
+++ b/src/libraries/System.DirectoryServices.Protocols/src/Resources/Strings.resx
@@ -426,4 +426,7 @@
   <data name="ReferralChasingOptionsNotSupported" xml:space="preserve">
     <value>Only ReferralChasingOptions.None and ReferralChasingOptions.All are supported on Linux.</value>
   </data>
+  <data name="LDAP_LIBRARY_NOT_FOUND" xml:space="preserve">
+    <value>The OpenLDAP library {0} not found.</value>
+  </data>
 </root>

--- a/src/libraries/System.DirectoryServices.Protocols/src/Resources/Strings.resx
+++ b/src/libraries/System.DirectoryServices.Protocols/src/Resources/Strings.resx
@@ -427,6 +427,6 @@
     <value>Only ReferralChasingOptions.None and ReferralChasingOptions.All are supported on Linux.</value>
   </data>
   <data name="LDAP_LIBRARY_NOT_FOUND" xml:space="preserve">
-    <value>The OpenLDAP library {0} not found.</value>
+    <value>The OpenLDAP library with version {0} was not found.</value>
   </data>
 </root>


### PR DESCRIPTION
### Register a callback that tries to load other versions of Open LDAP library if the default is failed

Open LDAP library version is hardcoded in runtime and used for native calls
https://github.com/dotnet/runtime/blob/b12e288a143c2986f81aa7c025beac9f5a4c7c29/src/libraries/Common/src/Interop/Linux/Interop.Libraries.cs#L9
From Ubuntu 22.04 only the new version of the library (libldap-2.5.so.0) is included in OS, so [System.DirectoryServices.Protocols.LdapConnection fails to find the new version of the LDAP library](https://github.com/dotnet/runtime/issues/69456) as mentioned in the issue.

@AaronRobinsonMSFT pointed out that we can register a callback to AssemblyLoadContext.Default.ResolvingUnmanagedll event. This event is raised if the native library could not be resolved via the default resolution logic.

The PR doesn't include a specific test, I don't think I can test the logic added here specifically, let me know if you have a testing idea. Though all existing tests that connects to LDAP server would test this, run the tests locally on Ubuntu 22.04, after the fix all tests that require LDAP server passed. (No CI test runs LDAP server so they are skipped in CI)

Fixes https://github.com/dotnet/runtime/issues/69456