### PR TITLE
Fix `TimeZoneInfo.Equals` and `TimeZoneInfo.HasSameRules`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -934,9 +934,9 @@ namespace System
             AdjustmentRule[]? currentRules = _adjustmentRules;
             AdjustmentRule[]? otherRules = other._adjustmentRules;
 
-            if (currentRules is null || otherRules is null)
+            if (currentRules is null && otherRules is null)
             {
-                return currentRules == otherRules;
+                return true;
             }
 
             return currentRules.AsSpan().SequenceEqual(otherRules);

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2433,7 +2433,7 @@ namespace System.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.Windows | ~TestPlatforms.Browser | ~TestPlatforms.iOS | ~TestPlatforms.tvOS)]
+        [PlatformSpecific(~TestPlatforms.Windows & ~TestPlatforms.Browser & ~TestPlatforms.iOS & ~TestPlatforms.tvOS)]
         public static void UtcAliases_MapToUtc()
         {
             foreach (string alias in s_UtcAliases)

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2432,8 +2432,9 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        [PlatformSpecific(~TestPlatforms.Windows & ~TestPlatforms.Browser & ~TestPlatforms.iOS & ~TestPlatforms.tvOS)]
+        private static bool SupportICUWithUtcAlias => PlatformDetection.IsIcuGlobalization && PlatformDetection.IsNotAppleMobile && PlatformDetection.IsNotBrowser;
+
+        [ConditionalFact(nameof(SupportICUWithUtcAlias))]
         public static void UtcAliases_MapToUtc()
         {
             foreach (string alias in s_UtcAliases)

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2433,6 +2433,7 @@ namespace System.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
+        [PlatformSpecific(~TestPlatforms.Browser | ~TestPlatforms.iOS | ~TestPlatforms.tvOS)]
         public static void UtcAliases_MapToUtc()
         {
             foreach (string alias in s_UtcAliases)

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2432,27 +2432,14 @@ namespace System.Tests
             }
         }
 
-        [Fact]
-        [PlatformSpecific(~TestPlatforms.Windows & ~TestPlatforms.Browser)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
         public static void UtcAliases_MapToUtc()
-        {
-            TimeZoneInfo.AdjustmentRule[] expectedAdjustmentRules = TimeZoneInfo.Utc.GetAdjustmentRules();
-
-            foreach (var alias in s_UtcAliases)
-            {
-                TimeZoneInfo actualUtc = TimeZoneInfo.FindSystemTimeZoneById(alias);
-                Assert.Equal(TimeZoneInfo.Utc.BaseUtcOffset, actualUtc.BaseUtcOffset);
-                Assert.Equal(expectedAdjustmentRules, actualUtc.GetAdjustmentRules());
-            }
-        }
-
-        [Fact]
-        public static void UtcAliases_AreEqualToUtc()
         {
             foreach (string alias in s_UtcAliases)
             {
                 TimeZoneInfo actualUtc = TimeZoneInfo.FindSystemTimeZoneById(alias);
-                Assert.Equal(TimeZoneInfo.Utc, actualUtc);
+                Assert.True(TimeZoneInfo.Utc.HasSameRules(actualUtc));
+                Assert.True(actualUtc.HasSameRules(TimeZoneInfo.Utc));
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2446,6 +2446,16 @@ namespace System.Tests
             }
         }
 
+        [Fact]
+        public static void UtcAliases_AreEqualToUtc()
+        {
+            foreach (string alias in s_UtcAliases)
+            {
+                TimeZoneInfo actualUtc = TimeZoneInfo.FindSystemTimeZoneById(alias);
+                Assert.Equal(TimeZoneInfo.Utc, actualUtc);
+            }
+        }
+
         [ActiveIssue("https://github.com/dotnet/runtime/issues/19794", TestPlatforms.AnyUnix)]
         [Theory]
         [MemberData(nameof(SystemTimeZonesTestData))]

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2432,8 +2432,8 @@ namespace System.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
-        [PlatformSpecific(~TestPlatforms.Browser | ~TestPlatforms.iOS | ~TestPlatforms.tvOS)]
+        [Fact]
+        [PlatformSpecific(~TestPlatforms.Windows | ~TestPlatforms.Browser | ~TestPlatforms.iOS | ~TestPlatforms.tvOS)]
         public static void UtcAliases_MapToUtc()
         {
             foreach (string alias in s_UtcAliases)


### PR DESCRIPTION
Based on https://github.com/dotnet/runtime/pull/88641#issuecomment-1632932583

On Linux, different UTC aliases for produce TimeZoneInfos which have all the same rules, but some have `_adjustmentRules == null` and others `_adjustmentRules == []`. The corresponding API `GetAdjustmentRules()` returns an empty array if the underlying value is null:
https://github.com/dotnet/runtime/blob/a3c21b95c91012df3e2572a1331ed7cc1f2679e6/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs#L140-L146
https://github.com/dotnet/runtime/blob/a3c21b95c91012df3e2572a1331ed7cc1f2679e6/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs#L81-L87
Which implies that these two values are equivalent.