### PR TITLE
Light up Ascii.IsValidCore with Vector512 code path

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1500,6 +1500,22 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool AllCharsInVectorAreAscii<T>(Vector512<T> vector)
+            where T : unmanaged
+        {
+            Debug.Assert(typeof(T) == typeof(byte) || typeof(T) == typeof(ushort));
+
+            if (typeof(T) == typeof(byte))
+            {
+                return vector.AsByte().ExtractMostSignificantBits() == 0;
+            }
+            else
+            {
+                return (vector.AsUInt16() & Vector512.Create((ushort)0xFF80)) == Vector512<ushort>.Zero;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector128<byte> ExtractAsciiVector(Vector128<ushort> vectorFirst, Vector128<ushort> vectorSecond)
         {
             // Narrows two vectors of words [ w7 w6 w5 w4 w3 w2 w1 w0 ] and [ w7' w6' w5' w4' w3' w2' w1' w0' ]

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
@@ -113,7 +113,7 @@ namespace System.Text
                     Vector128.LoadUnsafe(ref Unsafe.Subtract(ref searchSpaceEnd, Vector128<T>.Count)));
             }
 
-            if (Vector512.IsHardwareAccelerated)
+            if (Vector512.IsHardwareAccelerated && length >= Vector512<T>.Count)
             {
                 // Process inputs with lengths [33, 64] bytes.
                 if (length <= 2 * Vector512<T>.Count)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
@@ -174,7 +174,7 @@ namespace System.Text
                     Vector512.LoadUnsafe(ref Unsafe.Subtract(ref searchSpaceEnd, Vector512<T>.Count)));
             }
 
-            if (Avx.IsSupported)
+            else if (Avx.IsSupported)
             {
                 // Process inputs with lengths [33, 64] bytes.
                 if (length <= 2 * Vector256<T>.Count)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
@@ -115,7 +115,7 @@ namespace System.Text
 
             if (Vector512.IsHardwareAccelerated && length >= Vector512<T>.Count)
             {
-                // Process inputs with lengths [33, 64] bytes.
+                // Process inputs with lengths [65, 128] bytes.
                 if (length <= 2 * Vector512<T>.Count)
                 {
                     return AllCharsInVectorAreAscii(
@@ -123,10 +123,10 @@ namespace System.Text
                         Vector512.LoadUnsafe(ref Unsafe.Subtract(ref searchSpaceEnd, Vector512<T>.Count)));
                 }
 
-                // Process long inputs 128 bytes at a time.
+                // Process long inputs 256 bytes at a time.
                 if (length > 4 * Vector512<T>.Count)
                 {
-                    // Process the first 128 bytes.
+                    // Process the first 256 bytes.
                     if (!AllCharsInVectorAreAscii(
                         Vector512.LoadUnsafe(ref searchSpace) |
                         Vector512.LoadUnsafe(ref searchSpace, (nuint)Vector512<T>.Count) |
@@ -164,7 +164,7 @@ namespace System.Text
                     searchSpace = ref Unsafe.Add(ref searchSpace, finalStart);
                 }
 
-                // Process the last [1, 128] bytes.
+                // Process the last [1, 256] bytes.
                 // The search space has at least 2 * Vector512 bytes available to read.
                 // We process the first 2 and last 2 vectors, which may overlap.
                 return AllCharsInVectorAreAscii(

--- a/src/libraries/System.Text.Encoding/tests/Ascii/IsValidByteTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Ascii/IsValidByteTests.cs
@@ -28,7 +28,12 @@ namespace System.Text.Tests
             Vector128<byte>.Count + 1,
             Vector256<byte>.Count - 1,
             Vector256<byte>.Count,
-            Vector256<byte>.Count + 1 };
+            Vector256<byte>.Count + 1,
+            Vector512<byte>.Count - 1,
+            Vector512<byte>.Count,
+            Vector512<byte>.Count + 1,
+            4*Vector512<byte>.Count,
+            4*Vector512<byte>.Count + 1 };
 
         public static IEnumerable<object[]> AsciiOnlyBuffers
         {

--- a/src/libraries/System.Text.Encoding/tests/Ascii/IsValidCharTests.cs
+++ b/src/libraries/System.Text.Encoding/tests/Ascii/IsValidCharTests.cs
@@ -28,7 +28,12 @@ namespace System.Text.Tests
             Vector128<short>.Count + 1,
             Vector256<short>.Count - 1,
             Vector256<short>.Count,
-            Vector256<short>.Count + 1 };
+            Vector256<short>.Count + 1,
+            Vector512<short>.Count - 1,
+            Vector512<short>.Count,
+            Vector512<short>.Count + 1,
+            4*Vector512<short>.Count,
+            4*Vector512<short>.Count + 1 };
 
         public static IEnumerable<object[]> AsciiOnlyBuffers
         {


### PR DESCRIPTION
### NO NEED FOR REVIEW AT THIS TIME

This PR is about adding Vector512 support to the existing ASCII.IsValisCore library APIs. The implementation remains very much similar to Vector256.

### Perf
------