### PR TITLE
Fix alloc-dealloc mismatch

### DIFF
--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -160,7 +160,7 @@ void ThreadLocalBlock::EnsureModuleIndex(ModuleIndex index)
     }
 
     if (pOldModuleSlots != NULL)
-        delete pOldModuleSlots;
+        delete[] pOldModuleSlots;
 }
 
 #endif


### PR DESCRIPTION
This only started showing up in the ASAN PR once we had larger runtime tests after test consolidation.

Extracted from #74623