### PR TITLE
[wasm] Stop importing function table when compiling wasm modules in jiterp

### DIFF
--- a/src/mono/wasm/runtime/jiterpreter-interp-entry.ts
+++ b/src/mono/wasm/runtime/jiterpreter-interp-entry.ts
@@ -298,7 +298,7 @@ function flush_wasm_entry_trampoline_jit_queue() {
         for (let i = 0; i < trampImports.length; i++)
             builder.markImportAsUsed(trampImports[i][0]);
 
-        builder._generateImportSection();
+        builder._generateImportSection(false);
 
         // Function section
         builder.beginSection(3);

--- a/src/mono/wasm/runtime/jiterpreter-jit-call.ts
+++ b/src/mono/wasm/runtime/jiterpreter-jit-call.ts
@@ -404,7 +404,7 @@ export function mono_interp_flush_jitcall_queue(): void {
         for (let i = 0; i < trampImports.length; i++)
             builder.markImportAsUsed(trampImports[i][0]);
 
-        builder._generateImportSection();
+        builder._generateImportSection(false);
 
         // Function section
         builder.beginSection(3);

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -242,7 +242,7 @@ export class WasmBuilder {
         const result: any = {
             c: <any>this.getConstants(),
             m: { h: (<any>Module).asm.memory },
-            f: { f: getWasmFunctionTable() },
+            // f: { f: getWasmFunctionTable() },
         };
 
         const importsToEmit = this.getImportsToEmit();
@@ -520,6 +520,9 @@ export class WasmBuilder {
         const importsToEmit = this.getImportsToEmit();
         this.lockImports = true;
 
+        if (includeFunctionTable !== false)
+            throw new Error("function table imports are disabled");
+
         // Import section
         this.beginSection(2);
         this.appendULeb(
@@ -687,7 +690,9 @@ export class WasmBuilder {
         this.endSection();
     }
 
-    call_indirect(functionTypeName: string, tableIndex: number) {
+    call_indirect(/* functionTypeName: string, tableIndex: number */) {
+        throw new Error("call_indirect unavailable");
+        /*
         const type = this.functionTypes[functionTypeName];
         if (!type)
             throw new Error("No function type named " + functionTypeName);
@@ -695,6 +700,7 @@ export class WasmBuilder {
         this.appendU8(WasmOpcode.call_indirect);
         this.appendULeb(typeIndex);
         this.appendULeb(tableIndex);
+        */
     }
 
     callImport(name: string) {

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -837,7 +837,7 @@ function generate_wasm(
             }
         );
 
-        builder.emitImportsAndFunctions();
+        builder.emitImportsAndFunctions(false);
 
         if (!keep) {
             if (ti && (ti.abortReason === "end-of-body"))


### PR DESCRIPTION
Importing the dotnet runtime's function table into a trace appears to cause v8 to allocate 1-3mb of memory each time. Right now we no longer use call_indirect in jitted code, so it's safe to stop importing it, which seems to remove the allocation and reduce our memory usage significantly.

cc @vargaz @radical 