### PR TITLE
Skip internal tool restore on mac

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -142,8 +142,8 @@ jobs:
       clean: true
       fetchDepth: $(checkoutFetchDepth)
 
-    - ${{ if eq(parameters.isOfficialBuild, true) }}:
-      - template: /eng/pipelines/common/restore-internal-tools.yml
+    #- ${{ if eq(parameters.isOfficialBuild, true) }}:
+    #  - template: /eng/pipelines/common/restore-internal-tools.yml
 
     - ${{ each monoCrossAOTTargetOS in parameters.monoCrossAOTTargetOS }}:
       - task: DownloadPipelineArtifact@2

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -142,7 +142,7 @@ jobs:
       clean: true
       fetchDepth: $(checkoutFetchDepth)
 
-    - ${{ if and(eq(parameters.isOfficialBuild, true), in(parameters.osGroup, 'windows')) }}:
+    - ${{ if and(eq(parameters.isOfficialBuild, true), notin(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator')) }}:
       - template: /eng/pipelines/common/restore-internal-tools.yml
 
     - ${{ each monoCrossAOTTargetOS in parameters.monoCrossAOTTargetOS }}:

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -142,8 +142,8 @@ jobs:
       clean: true
       fetchDepth: $(checkoutFetchDepth)
 
-    #- ${{ if eq(parameters.isOfficialBuild, true) }}:
-    #  - template: /eng/pipelines/common/restore-internal-tools.yml
+    - ${{ if and(eq(parameters.isOfficialBuild, true), in(parameters.osGroup, 'windows')) }}:
+      - template: /eng/pipelines/common/restore-internal-tools.yml
 
     - ${{ each monoCrossAOTTargetOS in parameters.monoCrossAOTTargetOS }}:
       - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
Looks like the Mac internal builds don't consume anything from the internal tools. This looks to be the highest rate rate for build timing out