### PR TITLE
Remove incorrect flag setting

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/SignatureVariable.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/SignatureVariable.cs
@@ -66,7 +66,16 @@ namespace Internal.TypeSystem
                 flags |= TypeFlags.SignatureTypeVariable;
             }
 
-            flags |= TypeFlags.AttributeCacheComputed;
+            // ******************************************************
+            // Do not add other flags here. If you're hitting asserts
+            // because a flag wasn't set, this is a bug in the
+            // calling code. The fix is not here.
+            //
+            // The calling code is asking questions that are not
+            // possible to answer for signature variables
+            // (like: is this ByRef-like? We won't know until
+            // a substitution happens. Any answer would be wrong.)
+            // ******************************************************
 
             return flags;
         }
@@ -104,6 +113,17 @@ namespace Internal.TypeSystem
             {
                 flags |= TypeFlags.SignatureMethodVariable;
             }
+
+            // ******************************************************
+            // Do not add other flags here. If you're hitting asserts
+            // because a flag wasn't set, this is a bug in the
+            // calling code. The fix is not here.
+            //
+            // The calling code is asking questions that are not
+            // possible to answer for signature variables
+            // (like: is this ByRef-like? We won't know until
+            // a substitution happens. Any answer would be wrong.)
+            // ******************************************************
 
             return flags;
         }


### PR DESCRIPTION
This was added in https://github.com/dotnet/runtime/pull/85743#discussion_r1215117945. Setting this flag is not the right thing to do. It sweeps issues under the carpet. Also, we're only doing it for signature type variables, not method variable. And since no tests seem to be failing, it might not even be necessary.