### PR TITLE
Add SocketsHttpHandler connection metrics

### DIFF
--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -211,6 +211,8 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SocksHelper.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SocksException.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Metrics\ConnectionMetricsInfo.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Metrics\SocketsHttpHandlerMetrics.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\SslClientAuthenticationOptionsExtensions.cs"
              Link="Common\System\Net\Security\SslClientAuthenticationOptionsExtensions.cs" />
     <Compile Include="$(CommonPath)System\Net\ExceptionCheck.cs"

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -211,7 +211,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SocksHelper.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SocksException.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\Metrics\ConnectionMetricsInfo.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Metrics\ConnectionMetrics.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Metrics\SocketsHttpHandlerMetrics.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\SslClientAuthenticationOptionsExtensions.cs"
              Link="Common\System\Net\Security\SslClientAuthenticationOptionsExtensions.cs" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
@@ -744,7 +744,7 @@ namespace System.Net.Http
             {
                 handler = new DiagnosticsHandler(handler, DistributedContextPropagator.Current);
             }
-            MetricsHandler metricsHandler = new MetricsHandler(handler, _meterFactory);
+            MetricsHandler metricsHandler = new MetricsHandler(handler, _meterFactory, out _);
 
             // Ensure a single handler is used for all requests.
             if (Interlocked.CompareExchange(ref _metricsHandler, metricsHandler, null) != null)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -42,7 +42,7 @@ namespace System.Net.Http
                 {
                     handler = new DiagnosticsHandler(handler, DistributedContextPropagator.Current);
                 }
-                MetricsHandler metricsHandler = new MetricsHandler(handler, _meterFactory);
+                MetricsHandler metricsHandler = new MetricsHandler(handler, _meterFactory, out _);
 
                 // Ensure a single handler is used for all requests.
                 if (Interlocked.CompareExchange(ref _metricsHandler, metricsHandler, null) != null)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
@@ -15,11 +15,11 @@ namespace System.Net.Http.Metrics
         private readonly Counter<long> _failedRequests;
         private readonly Histogram<double> _requestsDuration;
 
-        public MetricsHandler(HttpMessageHandler innerHandler, IMeterFactory? meterFactory)
+        public MetricsHandler(HttpMessageHandler innerHandler, IMeterFactory? meterFactory, out Meter meter)
         {
             _innerHandler = innerHandler;
 
-            Meter meter = meterFactory?.Create("System.Net.Http") ?? SharedMeter.Instance;
+            meter = meterFactory?.Create("System.Net.Http") ?? SharedMeter.Instance;
 
             // Meter has a cache for the instruments it owns
             _currentRequests = meter.CreateUpDownCounter<long>(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -48,7 +48,6 @@ namespace System.Net.Http
         private bool _receivedSettingsAck;
         private int _initialServerStreamWindowSize;
         private int _pendingWindowUpdate;
-        private long _idleSinceTickCount;
 
         private uint _maxConcurrentStreams;
         private uint _streamsInUse;
@@ -76,10 +75,6 @@ namespace System.Net.Http
         // Requests currently in flight will continue to be processed.
         // When all requests have completed, the connection will be torn down.
         private bool _disposed;
-
-        private const int TelemetryStatus_Opened = 1;
-        private const int TelemetryStatus_Closed = 2;
-        private int _markedByTelemetryStatus;
 
         private const int MaxStreamId = int.MaxValue;
 
@@ -138,6 +133,7 @@ namespace System.Net.Http
         private volatile KeepAliveState _keepAliveState;
 
         public Http2Connection(HttpConnectionPool pool, Stream stream)
+            : base(pool)
         {
             _pool = pool;
             _stream = stream;
@@ -162,7 +158,6 @@ namespace System.Net.Http
             _streamsInUse = 0;
 
             _pendingWindowUpdate = 0;
-            _idleSinceTickCount = Environment.TickCount64;
 
             _keepAlivePingDelay = TimeSpanToMs(_pool.Settings._keepAlivePingDelay);
             _keepAlivePingTimeout = TimeSpanToMs(_pool.Settings._keepAlivePingTimeout);
@@ -175,12 +170,6 @@ namespace System.Net.Http
                 // Previous connections to the same host advertised a limit.
                 // Use this as an initial value before we receive the SETTINGS frame.
                 _maxHeaderListSize = maxHeaderListSize;
-            }
-
-            if (HttpTelemetry.Log.IsEnabled())
-            {
-                HttpTelemetry.Log.Http20ConnectionEstablished();
-                _markedByTelemetryStatus = TelemetryStatus_Opened;
             }
 
             if (NetEventSource.Log.IsEnabled()) TraceConnection(_stream);
@@ -327,6 +316,11 @@ namespace System.Net.Http
 
                 if (_streamsInUse < _maxConcurrentStreams)
                 {
+                    if (_streamsInUse == 0)
+                    {
+                        MarkConnectionAsNotIdle();
+                    }
+
                     _streamsInUse++;
                     return true;
                 }
@@ -356,7 +350,7 @@ namespace System.Net.Http
 
                 if (_streamsInUse == 0)
                 {
-                    _idleSinceTickCount = Environment.TickCount64;
+                    MarkConnectionAsIdle();
 
                     if (_disposed)
                     {
@@ -1836,7 +1830,7 @@ namespace System.Net.Http
         {
             lock (SyncObject)
             {
-                return _streamsInUse == 0 ? nowTicks - _idleSinceTickCount : 0;
+                return _streamsInUse == 0 ? base.GetIdleTicks(nowTicks) : 0;
             }
         }
 
@@ -1894,13 +1888,7 @@ namespace System.Net.Http
             // ProcessIncomingFramesAsync and ProcessOutgoingFramesAsync respectively, and those methods are
             // responsible for returning the buffers.
 
-            if (HttpTelemetry.Log.IsEnabled())
-            {
-                if (Interlocked.Exchange(ref _markedByTelemetryStatus, TelemetryStatus_Closed) == TelemetryStatus_Opened)
-                {
-                    HttpTelemetry.Log.Http20ConnectionClosed();
-                }
-            }
+            MarkConnectionAsClosed();
         }
 
         public override void Dispose()

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Net.Http.Headers;
-using System.Net.Security;
 
 namespace System.Net.Http
 {
@@ -21,7 +20,6 @@ namespace System.Net.Http
     internal sealed class Http3Connection : HttpConnectionBase
     {
         private readonly HttpConnectionPool _pool;
-        private readonly HttpAuthority? _origin;
         private readonly HttpAuthority _authority;
         private readonly byte[]? _altUsedEncodedHeader;
         private QuicConnection? _connection;
@@ -48,10 +46,6 @@ namespace System.Net.Http
         // A connection-level error will abort any future operations.
         private Exception? _abortException;
 
-        private const int TelemetryStatus_Opened = 1;
-        private const int TelemetryStatus_Closed = 2;
-        private int _markedByTelemetryStatus;
-
         public HttpAuthority Authority => _authority;
         public HttpConnectionPool Pool => _pool;
         public uint MaxHeaderListSize => _maxHeaderListSize;
@@ -71,10 +65,10 @@ namespace System.Net.Http
             }
         }
 
-        public Http3Connection(HttpConnectionPool pool, HttpAuthority? origin, HttpAuthority authority, QuicConnection connection, bool includeAltUsedHeader)
+        public Http3Connection(HttpConnectionPool pool, HttpAuthority authority, QuicConnection connection, bool includeAltUsedHeader)
+            : base(pool)
         {
             _pool = pool;
-            _origin = origin;
             _authority = authority;
             _connection = connection;
 
@@ -91,12 +85,6 @@ namespace System.Net.Http
                 // Previous connections to the same host advertised a limit.
                 // Use this as an initial value before we receive the SETTINGS frame.
                 _maxHeaderListSize = maxHeaderListSize;
-            }
-
-            if (HttpTelemetry.Log.IsEnabled())
-            {
-                HttpTelemetry.Log.Http30ConnectionEstablished();
-                _markedByTelemetryStatus = TelemetryStatus_Opened;
             }
 
             // Errors are observed via Abort().
@@ -168,13 +156,7 @@ namespace System.Net.Http
 
                 }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
 
-                if (HttpTelemetry.Log.IsEnabled())
-                {
-                    if (Interlocked.Exchange(ref _markedByTelemetryStatus, TelemetryStatus_Closed) == TelemetryStatus_Opened)
-                    {
-                        HttpTelemetry.Log.Http30ConnectionClosed();
-                    }
-                }
+                MarkConnectionAsClosed();
             }
         }
 
@@ -201,6 +183,11 @@ namespace System.Net.Http
                         requestStream = new Http3RequestStream(request, this, quicStream);
                         lock (SyncObj)
                         {
+                            if (_activeRequests.Count == 0)
+                            {
+                                MarkConnectionAsNotIdle();
+                            }
+
                             _activeRequests.Add(quicStream, requestStream);
                         }
                     }
@@ -352,11 +339,17 @@ namespace System.Net.Http
         {
             lock (SyncObj)
             {
-                bool removed = _activeRequests.Remove(stream);
-
-                if (removed && ShuttingDown)
+                if (_activeRequests.Remove(stream))
                 {
-                    CheckForShutdown();
+                    if (ShuttingDown)
+                    {
+                        CheckForShutdown();
+                    }
+
+                    if (_activeRequests.Count == 0)
+                    {
+                        MarkConnectionAsIdle();
+                    }
                 }
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Http.Headers;
+using System.Net.Http.Metrics;
 using System.Net.Security;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -15,10 +16,78 @@ namespace System.Net.Http
 {
     internal abstract class HttpConnectionBase : IDisposable, IHttpTrace
     {
+        private readonly ConnectionMetricsInfo? _connectionMetricsInfo;
+        private readonly bool _httpTelemetryMarkedConnectionAsOpened;
+
+        private readonly long _creationTickCount = Environment.TickCount64;
+        private long _idleSinceTickCount;
+
         /// <summary>Cached string for the last Date header received on this connection.</summary>
         private string? _lastDateHeaderValue;
         /// <summary>Cached string for the last Server header received on this connection.</summary>
         private string? _lastServerHeaderValue;
+
+        public HttpConnectionBase(HttpConnectionPool pool)
+        {
+            Debug.Assert(this is HttpConnection or Http2Connection or Http3Connection);
+            Debug.Assert(pool.Settings._metrics is not null);
+
+            string protocol =
+                this is HttpConnection ? "HTTP/1.1" :
+                this is Http2Connection ? "HTTP/2" :
+                "HTTP/3";
+
+            int port = pool.OriginAuthority.Port;
+            int defaultPort = pool.IsSecure ? HttpConnectionPool.DefaultHttpsPort : HttpConnectionPool.DefaultHttpPort;
+
+            _connectionMetricsInfo = ConnectionMetricsInfo.TryCreate(
+                pool.Settings._metrics,
+                protocol,
+                pool.IsSecure ? "https" : "http",
+                pool.OriginAuthority.HostValue,
+                port == defaultPort ? null : port);
+
+            _connectionMetricsInfo?.ConnectionEstablished();
+
+            MarkConnectionAsIdle();
+
+            if (HttpTelemetry.Log.IsEnabled())
+            {
+                _httpTelemetryMarkedConnectionAsOpened = true;
+
+                if (this is HttpConnection) HttpTelemetry.Log.Http11ConnectionEstablished();
+                else if (this is Http2Connection) HttpTelemetry.Log.Http20ConnectionEstablished();
+                else HttpTelemetry.Log.Http30ConnectionEstablished();
+            }
+        }
+
+        public void MarkConnectionAsClosed()
+        {
+            _connectionMetricsInfo?.ConnectionClosed(durationMs: Environment.TickCount64 - _creationTickCount);
+
+            if (HttpTelemetry.Log.IsEnabled())
+            {
+                // Only decrement the connection count if we counted this connection
+                if (_httpTelemetryMarkedConnectionAsOpened)
+                {
+                    if (this is HttpConnection) HttpTelemetry.Log.Http11ConnectionClosed();
+                    else if (this is Http2Connection) HttpTelemetry.Log.Http20ConnectionClosed();
+                    else HttpTelemetry.Log.Http30ConnectionClosed();
+                }
+            }
+        }
+
+        public void MarkConnectionAsIdle()
+        {
+            _idleSinceTickCount = Environment.TickCount64;
+
+            _connectionMetricsInfo?.MarkAsIdle();
+        }
+
+        public void MarkConnectionAsNotIdle()
+        {
+            _connectionMetricsInfo?.MarkAsNotIdle();
+        }
 
         /// <summary>Uses <see cref="HeaderDescriptor.GetHeaderValue"/>, but first special-cases several known headers for which we can use caching.</summary>
         public string GetResponseHeaderValueWithCaching(HeaderDescriptor descriptor, ReadOnlySpan<byte> value, Encoding? valueEncoding)
@@ -60,11 +129,9 @@ namespace System.Net.Http
             }
         }
 
-        private readonly long _creationTickCount = Environment.TickCount64;
-
         public long GetLifetimeTicks(long nowTicks) => nowTicks - _creationTickCount;
 
-        public abstract long GetIdleTicks(long nowTicks);
+        public virtual long GetIdleTicks(long nowTicks) => nowTicks - _idleSinceTickCount;
 
         /// <summary>Check whether a connection is still usable, or should be scavenged.</summary>
         /// <returns>True if connection can be used.</returns>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -138,7 +138,8 @@ namespace System.Net.Http
             _proxyUri = proxyUri;
             _maxHttp11Connections = Settings._maxConnectionsPerServer;
 
-            Debug.Assert(host is not null || proxyUri is not null);
+            // The only case where 'host' will not be set if this is a Proxy connection pool.
+            Debug.Assert(host is not null || (kind == HttpConnectionKind.Proxy && proxyUri is not null));
             _originAuthority = new HttpAuthority(host ?? proxyUri!.IdnHost, port);
 
             _http2Enabled = _poolManager.Settings._maxHttpVersion >= HttpVersion.Version20;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -32,7 +32,7 @@ namespace System.Net.Http
         private readonly Uri? _proxyUri;
 
         /// <summary>The origin authority used to construct the <see cref="HttpConnectionPool"/>.</summary>
-        private readonly HttpAuthority? _originAuthority;
+        private readonly HttpAuthority _originAuthority;
 
         /// <summary>Initially set to null, this can be set to enable HTTP/3 based on Alt-Svc.</summary>
         private volatile HttpAuthority? _http3Authority;
@@ -138,10 +138,8 @@ namespace System.Net.Http
             _proxyUri = proxyUri;
             _maxHttp11Connections = Settings._maxConnectionsPerServer;
 
-            if (host != null)
-            {
-                _originAuthority = new HttpAuthority(host, port);
-            }
+            Debug.Assert(host is not null || proxyUri is not null);
+            _originAuthority = new HttpAuthority(host ?? proxyUri!.IdnHost, port);
 
             _http2Enabled = _poolManager.Settings._maxHttpVersion >= HttpVersion.Version20;
 
@@ -233,7 +231,7 @@ namespace System.Net.Http
             }
 
             string? hostHeader = null;
-            if (_originAuthority != null)
+            if (host is not null)
             {
                 // Precalculate ASCII bytes for Host header
                 // Note that if _host is null, this is a (non-tunneled) proxy connection, and we can't cache the hostname.
@@ -356,7 +354,7 @@ namespace System.Net.Http
             return sslOptions;
         }
 
-        public HttpAuthority? OriginAuthority => _originAuthority;
+        public HttpAuthority OriginAuthority => _originAuthority;
         public HttpConnectionSettings Settings => _poolManager.Settings;
         public HttpConnectionKind Kind => _kind;
         public bool IsSecure => _kind == HttpConnectionKind.Https || _kind == HttpConnectionKind.SslProxyTunnel || _kind == HttpConnectionKind.SslSocksTunnel;
@@ -379,7 +377,6 @@ namespace System.Net.Http
                 {
                     var sb = new StringBuilder();
 
-                    Debug.Assert(_originAuthority != null);
                     sb.Append(IsSecure ? "https://" : "http://")
                       .Append(_originAuthority.IdnHost);
 
@@ -956,7 +953,7 @@ namespace System.Net.Http
                 }
 #endif
                 // if the authority was sent as an option through alt-svc then include alt-used header
-                http3Connection = new Http3Connection(this, _originAuthority, authority, quicConnection, includeAltUsedHeader: _http3Authority == authority);
+                http3Connection = new Http3Connection(this, authority, quicConnection, includeAltUsedHeader: _http3Authority == authority);
                 _http3Connection = http3Connection;
 
                 if (NetEventSource.Log.IsEnabled())
@@ -1270,7 +1267,7 @@ namespace System.Net.Http
 
                     if (nextAuthority == null && value != null && value.AlpnProtocolName == "h3")
                     {
-                        var authority = new HttpAuthority(value.Host ?? _originAuthority!.IdnHost, value.Port);
+                        var authority = new HttpAuthority(value.Host ?? _originAuthority.IdnHost, value.Port);
                         if (IsAltSvcBlocked(authority, out _))
                         {
                             // Skip authorities in our blocklist.
@@ -1543,7 +1540,6 @@ namespace System.Net.Http
                 case HttpConnectionKind.Http:
                 case HttpConnectionKind.Https:
                 case HttpConnectionKind.ProxyConnect:
-                    Debug.Assert(_originAuthority != null);
                     stream = await ConnectToTcpHostAsync(_originAuthority.IdnHost, _originAuthority.Port, request, async, cancellationToken).ConfigureAwait(false);
                     if (_kind == HttpConnectionKind.ProxyConnect && _sslOptionsProxy != null)
                     {
@@ -1753,8 +1749,6 @@ namespace System.Net.Http
 
         private async ValueTask<Stream> EstablishProxyTunnelAsync(bool async, CancellationToken cancellationToken)
         {
-            Debug.Assert(_originAuthority != null);
-
             // Send a CONNECT request to the proxy server to establish a tunnel.
             HttpRequestMessage tunnelRequest = new HttpRequestMessage(HttpMethod.Connect, _proxyUri);
             tunnelRequest.Headers.Host = $"{_originAuthority.IdnHost}:{_originAuthority.Port}";    // This specifies destination host/port to connect to
@@ -1785,7 +1779,6 @@ namespace System.Net.Http
 
         private async ValueTask<Stream> EstablishSocksTunnel(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
-            Debug.Assert(_originAuthority != null);
             Debug.Assert(_proxyUri != null);
 
             Stream stream = await ConnectToTcpHostAsync(_proxyUri.IdnHost, _proxyUri.Port, request, async, cancellationToken).ConfigureAwait(false);
@@ -1958,6 +1951,7 @@ namespace System.Net.Http
                     {
                         // Add connection to the pool.
                         added = true;
+                        connection.MarkConnectionAsIdle();
                         _availableHttp11Connections.Add(connection);
                     }
 
@@ -2421,10 +2415,10 @@ namespace System.Net.Http
             (_proxyUri == null ?
                 (_sslOptionsHttp11 == null ?
                     $"http://{_originAuthority}" :
-                    $"https://{_originAuthority}" + (_sslOptionsHttp11.TargetHost != _originAuthority!.IdnHost ? $", SSL TargetHost={_sslOptionsHttp11.TargetHost}" : null)) :
+                    $"https://{_originAuthority}" + (_sslOptionsHttp11.TargetHost != _originAuthority.IdnHost ? $", SSL TargetHost={_sslOptionsHttp11.TargetHost}" : null)) :
                 (_sslOptionsHttp11 == null ?
                     $"Proxy {_proxyUri}" :
-                    $"https://{_originAuthority}/ tunnelled via Proxy {_proxyUri}" + (_sslOptionsHttp11.TargetHost != _originAuthority!.IdnHost ? $", SSL TargetHost={_sslOptionsHttp11.TargetHost}" : null)));
+                    $"https://{_originAuthority}/ tunnelled via Proxy {_proxyUri}" + (_sslOptionsHttp11.TargetHost != _originAuthority.IdnHost ? $", SSL TargetHost={_sslOptionsHttp11.TargetHost}" : null)));
 
         private void Trace(string? message, [CallerMemberName] string? memberName = null) =>
             NetEventSource.Log.HandlerMessage(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -138,7 +138,7 @@ namespace System.Net.Http
             _proxyUri = proxyUri;
             _maxHttp11Connections = Settings._maxConnectionsPerServer;
 
-            // The only case where 'host' will not be set if this is a Proxy connection pool.
+            // The only case where 'host' will not be set is if this is a Proxy connection pool.
             Debug.Assert(host is not null || (kind == HttpConnectionKind.Proxy && proxyUri is not null));
             _originAuthority = new HttpAuthority(host ?? proxyUri!.IdnHost, port);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Net.Http.Metrics;
 
 namespace System.Net.Http
 {
@@ -37,6 +38,7 @@ namespace System.Net.Http
         internal TimeSpan _maxResponseDrainTime = HttpHandlerDefaults.DefaultResponseDrainTimeout;
         internal int _maxResponseHeadersLength = HttpHandlerDefaults.DefaultMaxResponseHeadersLength;
         internal IMeterFactory? _meterFactory;
+        internal SocketsHttpHandlerMetrics? _metrics;
 
         internal TimeSpan _pooledConnectionLifetime = HttpHandlerDefaults.DefaultPooledConnectionLifetime;
         internal TimeSpan _pooledConnectionIdleTimeout = HttpHandlerDefaults.DefaultPooledConnectionIdleTimeout;
@@ -104,6 +106,7 @@ namespace System.Net.Http
                 _maxResponseDrainTime = _maxResponseDrainTime,
                 _maxResponseHeadersLength = _maxResponseHeadersLength,
                 _meterFactory = _meterFactory,
+                _metrics = _metrics,
                 _pooledConnectionLifetime = _pooledConnectionLifetime,
                 _pooledConnectionIdleTimeout = _pooledConnectionIdleTimeout,
                 _preAuthenticate = _preAuthenticate,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetrics.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 
 namespace System.Net.Http.Metrics
 {
-    internal sealed class ConnectionMetricsInfo
+    internal sealed class ConnectionMetrics
     {
         private readonly SocketsHttpHandlerMetrics _metrics;
         private readonly bool _currentConnectionsEnabled;
@@ -16,7 +16,7 @@ namespace System.Net.Http.Metrics
         private readonly object? _portTag;
         private bool _currentlyIdle;
 
-        public ConnectionMetricsInfo(SocketsHttpHandlerMetrics metrics, string protocol, string scheme, string host, int? port)
+        public ConnectionMetrics(SocketsHttpHandlerMetrics metrics, string protocol, string scheme, string host, int? port)
         {
             _metrics = metrics;
             _currentConnectionsEnabled = _metrics.CurrentConnections.Enabled;
@@ -27,6 +27,7 @@ namespace System.Net.Http.Metrics
             _portTag = port;
         }
 
+        // TagList is a huge struct, so we avoid storing it in a field to reduce the amount we allocate on the heap.
         private TagList GetTags()
         {
             TagList tags = default;
@@ -41,18 +42,6 @@ namespace System.Net.Http.Metrics
             }
 
             return tags;
-        }
-
-        public static ConnectionMetricsInfo? TryCreate(SocketsHttpHandlerMetrics metrics, string protocol, string scheme, string host, int? port)
-        {
-            if (metrics.CurrentConnections.Enabled ||
-                metrics.IdleConnections.Enabled ||
-                metrics.ConnectionDuration.Enabled)
-            {
-                return new ConnectionMetricsInfo(metrics, protocol, scheme, host, port);
-            }
-
-            return null;
         }
 
         public void ConnectionEstablished()

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetricsInfo.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetricsInfo.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace System.Net.Http.Metrics
+{
+    internal sealed class ConnectionMetricsInfo
+    {
+        private readonly SocketsHttpHandlerMetrics _metrics;
+        private readonly bool _currentConnectionsEnabled;
+        private readonly bool _idleConnectionsEnabled;
+        private readonly object _protocolTag;
+        private readonly object _schemeTag;
+        private readonly object _hostTag;
+        private readonly object? _portTag;
+        private bool _currentlyIdle;
+
+        public ConnectionMetricsInfo(SocketsHttpHandlerMetrics metrics, string protocol, string scheme, string host, int? port)
+        {
+            _metrics = metrics;
+            _currentConnectionsEnabled = _metrics.CurrentConnections.Enabled;
+            _idleConnectionsEnabled = _metrics.IdleConnections.Enabled;
+            _protocolTag = protocol;
+            _schemeTag = scheme;
+            _hostTag = host;
+            _portTag = port;
+        }
+
+        private TagList GetTags()
+        {
+            TagList tags = default;
+
+            tags.Add("protocol", _protocolTag);
+            tags.Add("scheme", _schemeTag);
+            tags.Add("host", _hostTag);
+
+            if (_portTag is not null)
+            {
+                tags.Add("port", _portTag);
+            }
+
+            return tags;
+        }
+
+        public static ConnectionMetricsInfo? TryCreate(SocketsHttpHandlerMetrics metrics, string protocol, string scheme, string host, int? port)
+        {
+            if (metrics.CurrentConnections.Enabled ||
+                metrics.IdleConnections.Enabled ||
+                metrics.ConnectionDuration.Enabled)
+            {
+                return new ConnectionMetricsInfo(metrics, protocol, scheme, host, port);
+            }
+
+            return null;
+        }
+
+        public void ConnectionEstablished()
+        {
+            if (_currentConnectionsEnabled)
+            {
+                _metrics.CurrentConnections.Add(1, GetTags());
+            }
+        }
+
+        public void ConnectionClosed(long durationMs)
+        {
+            MarkAsNotIdle();
+
+            if (_currentConnectionsEnabled)
+            {
+                _metrics.CurrentConnections.Add(-1, GetTags());
+            }
+
+            if (_metrics.ConnectionDuration.Enabled)
+            {
+                _metrics.ConnectionDuration.Record(durationMs / 1000d, GetTags());
+            }
+        }
+
+        public void MarkAsIdle()
+        {
+            if (_idleConnectionsEnabled && !_currentlyIdle)
+            {
+                _currentlyIdle = true;
+                _metrics.IdleConnections.Add(1, GetTags());
+            }
+        }
+
+        public void MarkAsNotIdle()
+        {
+            if (_idleConnectionsEnabled && _currentlyIdle)
+            {
+                _currentlyIdle = false;
+                _metrics.IdleConnections.Add(-1, GetTags());
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.Metrics;
+
+namespace System.Net.Http.Metrics
+{
+    internal sealed class SocketsHttpHandlerMetrics(Meter meter)
+    {
+        public readonly UpDownCounter<long> CurrentConnections = meter.CreateUpDownCounter<long>(
+            name: "http-client-current-connections",
+            description: "Number of outbound HTTP connections that are currently active on the client.");
+
+        public readonly UpDownCounter<long> IdleConnections = meter.CreateUpDownCounter<long>(
+            name: "http-client-current-idle-connections",
+            description: "Number of outbound HTTP connections that are currently idle on the client.");
+
+        public readonly Histogram<double> ConnectionDuration = meter.CreateHistogram<double>(
+            name: "http-client-connection-duration",
+            unit: "s",
+            description: "The duration of outbound HTTP connections.");
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -516,7 +516,9 @@ namespace System.Net.Http
                 handler = new DiagnosticsHandler(handler, propagator, settings._allowAutoRedirect);
             }
 
-            handler = new MetricsHandler(handler, _settings._meterFactory);
+            handler = new MetricsHandler(handler, settings._meterFactory, out Meter meter);
+
+            settings._metrics = new SocketsHttpHandlerMetrics(meter);
 
             if (settings._allowAutoRedirect)
             {


### PR DESCRIPTION
Closes #84978

Implements the following counters (final names TBD):
- `http-client-current-connections`
- `http-client-current-idle-connections`
- `http-client-connection-duration`

Unlike the description from #84978, I dropped the `reason` tag from `http-client-connection-duration` as it feels out of place on the duration counter, and it's not clear what values we'd want to report.

Merge conflicts with #88853 are expected.