### PR TITLE
Fix missing using statement

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
@@ -1,6 +1,10 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
+#if NATIVEAOT
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+#endif
+
 namespace Mono.Linker.Tests.Cases.DynamicDependencies
 {
 	class DynamicDependencyMethod


### PR DESCRIPTION
Add a using which was incorrectly removed because it's only necessary in NativeAOT configuration

@mrvoorhe fyi

Fixes https://github.com/dotnet/runtime/issues/88870