### PR TITLE
Fix TimeZoneInfoTests.cs on iOS/tvOS

### DIFF
--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2335,7 +2335,7 @@ namespace System.Tests
                     }
                 }
 
-                if (!PlatformDetection.IsBrowser)
+                if (!PlatformDetection.IsBrowser && !PlatformDetection.IsiOS && !PlatformDetection.IstvOS)
                 {
                     foreach (string alias in s_UtcAliases)
                     {


### PR DESCRIPTION
The UTC alias test cases failed there after https://github.com/dotnet/runtime/pull/88641