### PR TITLE
Add package readme for obsolete .NET Standard 1.x packages

### DIFF
--- a/docs/project/obsolete-package-readme.md
+++ b/docs/project/obsolete-package-readme.md
@@ -1,3 +1,7 @@
+This file contains the readme for obsolete .NET Standard 1.x packages. The readme for these packages should be added manually using NuGet gallery website.
+
+-------------------------
+
 ## About
 
 The package is obsolete and not necessary. It should **not** be used. If you use it anyway (e.g. due to dependencies out of your control), it won't cause you any harm. This package is forwarded to in-box implementation both on .NET and on .NET Framework.

--- a/src/libraries/System.Net.Http/src/PACKAGE.md
+++ b/src/libraries/System.Net.Http/src/PACKAGE.md
@@ -1,7 +1,6 @@
 ## About
 
-Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.
+The package is obsolete and not necessary. It should NOT be used. If you use it anyway (e.g. due to dependencies out of your control), it won't cause you any harm.
 
-**NOTE:** System.Net.Http package is obsolete. You don't need to reference this package in your projects, because HTTP API is included in the shared framework. It is only provided for backwards compatibility.
-
-For more information about HTTP API, see [System.Net.Http namespace](https://learn.microsoft.com/en-us/dotnet/api/system.net.http).
+It is a result of failed attempt from 2016 to deliver value to .NET Framework customers outside of official .NET Framework updates. Later we realized it causes more troubles we didn't foresee, therefore we stopped shipping it for .NET Core entirely (the package will just forward to the in-box implementation) and on .NET Framework we made it exact copy of in-box code. As a result, using it does not bring any value, but does not cause any harm either.
+For more details, see [comment on GitHub issue dotnet/runtime#20777](https://github.com/dotnet/runtime/issues/20777#issuecomment-338418610)

--- a/src/libraries/System.Net.Http/src/PACKAGE.md
+++ b/src/libraries/System.Net.Http/src/PACKAGE.md
@@ -1,6 +1,3 @@
 ## About
 
-The package is obsolete and not necessary. It should NOT be used. If you use it anyway (e.g. due to dependencies out of your control), it won't cause you any harm.
-
-It is a result of failed attempt from 2016 to deliver value to .NET Framework customers outside of official .NET Framework updates. Later we realized it causes more troubles we didn't foresee, therefore we stopped shipping it for .NET Core entirely (the package will just forward to the in-box implementation) and on .NET Framework we made it exact copy of in-box code. As a result, using it does not bring any value, but does not cause any harm either.
-For more details, see [comment on GitHub issue dotnet/runtime#20777](https://github.com/dotnet/runtime/issues/20777#issuecomment-338418610)
+The package is obsolete and not necessary. It should **not** be used. If you use it anyway (e.g. due to dependencies out of your control), it won't cause you any harm. This package is forwarded to in-box implementation both on .NET and on .NET Framework.

--- a/src/libraries/System.Net.Http/src/PACKAGE.md
+++ b/src/libraries/System.Net.Http/src/PACKAGE.md
@@ -1,0 +1,7 @@
+## About
+
+Provides a programming interface for modern HTTP applications, including HTTP client components that allow applications to consume web services over HTTP and HTTP components that can be used by both clients and servers for parsing HTTP headers.
+
+**NOTE:** System.Net.Http package is obsolete. You don't need to reference this package in your projects, because HTTP API is included in the shared framework. It is only provided for backwards compatibility.
+
+For more information about HTTP API, see [System.Net.Http namespace](https://learn.microsoft.com/en-us/dotnet/api/system.net.http).


### PR DESCRIPTION
There're a lot of .NET Standard 1.x packages that are no longer updated and just forward to inbox implementation both on .NET and .NET Framework ([System.Runtime](https://www.nuget.org/packages/System.Runtime), [System.Runtime.Extensions](https://www.nuget.org/packages/System.Runtime.Extensions), [System.Net.Http](https://www.nuget.org/packages/System.Net.Http) and others). They still show up high in NuGet search results, because they have lots of downloads, which creates some confusion for users. 

This PR adds text for a generic package readme for these packages, to clarify that they should not be used. This readme should be added manually to them using NuGet gallery website. It can't be added automatically, because these packages are not published any more.

Fixes #86667

Related to #59630
