### PR TITLE
UTFn->UTF-n

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/SP800108HmacCounterKdf.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SP800108HmacCounterKdf.cs
@@ -194,10 +194,10 @@ namespace System.Security.Cryptography
         ///   <paramref name="hashAlgorithm"/> is not a known or supported hash algorithm.
         /// </exception>
         /// <exception cref="EncoderFallbackException">
-        ///   <paramref name="label" /> or <paramref name="context" /> contains text that cannot be converted to UTF8.
+        ///   <paramref name="label" /> or <paramref name="context" /> contains text that cannot be converted to UTF-8.
         /// </exception>
         /// <remarks>
-        ///   <paramref name="label" /> and <paramref name="context" /> will be converted to bytes using the UTF8 encoding.
+        ///   <paramref name="label" /> and <paramref name="context" /> will be converted to bytes using the UTF-8 encoding.
         ///   for other encodings, perform the conversion using the desired encoding and use an overload which accepts the
         ///   label and context as a sequence of bytes.
         /// </remarks>
@@ -310,13 +310,13 @@ namespace System.Security.Cryptography
         ///   <paramref name="hashAlgorithm"/> is not a known or supported hash algorithm.
         /// </exception>
         /// <exception cref="EncoderFallbackException">
-        ///   <paramref name="label" /> or <paramref name="context" /> contains text that cannot be converted to UTF8.
+        ///   <paramref name="label" /> or <paramref name="context" /> contains text that cannot be converted to UTF-8.
         /// </exception>
         /// <exception cref="PlatformNotSupportedException">
         ///   The current platform does not have a supported implementation of HMAC.
         /// </exception>
         /// <remarks>
-        ///   <paramref name="label" /> and <paramref name="context" /> will be converted to bytes using the UTF8 encoding.
+        ///   <paramref name="label" /> and <paramref name="context" /> will be converted to bytes using the UTF-8 encoding.
         ///   for other encodings, perform the conversion using the desired encoding and use an overload which accepts the
         ///   label and context as a sequence of bytes.
         /// </remarks>
@@ -350,13 +350,13 @@ namespace System.Security.Cryptography
         ///   <paramref name="hashAlgorithm"/> is not a known or supported hash algorithm.
         /// </exception>
         /// <exception cref="EncoderFallbackException">
-        ///   <paramref name="label" /> or <paramref name="context" /> contains text that cannot be converted to UTF8.
+        ///   <paramref name="label" /> or <paramref name="context" /> contains text that cannot be converted to UTF-8.
         /// </exception>
         /// <exception cref="PlatformNotSupportedException">
         ///   The current platform does not have a supported implementation of HMAC.
         /// </exception>
         /// <remarks>
-        ///   <paramref name="label" /> and <paramref name="context" /> will be converted to bytes using the UTF8 encoding.
+        ///   <paramref name="label" /> and <paramref name="context" /> will be converted to bytes using the UTF-8 encoding.
         ///   for other encodings, perform the conversion using the desired encoding and use an overload which accepts the
         ///   label and context as a sequence of bytes.
         /// </remarks>
@@ -458,10 +458,10 @@ namespace System.Security.Cryptography
         ///   that can be derived.
         /// </exception>
         /// <exception cref="EncoderFallbackException">
-        ///   <paramref name="label" /> or <paramref name="context" /> contains text that cannot be converted to UTF8.
+        ///   <paramref name="label" /> or <paramref name="context" /> contains text that cannot be converted to UTF-8.
         /// </exception>
         /// <remarks>
-        ///   <paramref name="label" /> and <paramref name="context" /> will be converted to bytes using the UTF8 encoding.
+        ///   <paramref name="label" /> and <paramref name="context" /> will be converted to bytes using the UTF-8 encoding.
         ///   for other encodings, perform the conversion using the desired encoding and use an overload which accepts the
         ///   label and context as a sequence of bytes.
         /// </remarks>
@@ -484,10 +484,10 @@ namespace System.Security.Cryptography
         ///   <paramref name="destination" /> is larger than the maximum number of bytes that can be derived.
         /// </exception>
         /// <exception cref="EncoderFallbackException">
-        ///   <paramref name="label" /> or <paramref name="context" /> contains text that cannot be converted to UTF8.
+        ///   <paramref name="label" /> or <paramref name="context" /> contains text that cannot be converted to UTF-8.
         /// </exception>
         /// <remarks>
-        ///   <paramref name="label" /> and <paramref name="context" /> will be converted to bytes using the UTF8 encoding.
+        ///   <paramref name="label" /> and <paramref name="context" /> will be converted to bytes using the UTF-8 encoding.
         ///   for other encodings, perform the conversion using the desired encoding and use an overload which accepts the
         ///   label and context as a sequence of bytes.
         /// </remarks>
@@ -518,10 +518,10 @@ namespace System.Security.Cryptography
         ///   that can be derived.
         /// </exception>
         /// <exception cref="EncoderFallbackException">
-        ///   <paramref name="label" /> or <paramref name="context" /> contains text that cannot be converted to UTF8.
+        ///   <paramref name="label" /> or <paramref name="context" /> contains text that cannot be converted to UTF-8.
         /// </exception>
         /// <remarks>
-        ///   <paramref name="label" /> and <paramref name="context" /> will be converted to bytes using the UTF8 encoding.
+        ///   <paramref name="label" /> and <paramref name="context" /> will be converted to bytes using the UTF-8 encoding.
         ///   for other encodings, perform the conversion using the desired encoding and use an overload which accepts the
         ///   label and context as a sequence of bytes.
         /// </remarks>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -829,7 +829,7 @@ namespace System.IO
             }
 
             /// <summary>
-            /// Reads a UTF8 string from _buffer starting at the specified position and up to
+            /// Reads a UTF-8 string from _buffer starting at the specified position and up to
             /// the specified length.  Null termination is trimmed off (the length may include
             /// many null bytes, not just one, or it may include none).
             /// </summary>

--- a/src/libraries/System.Net.HttpListener/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.HttpListener/src/Resources/Strings.resx
@@ -312,7 +312,7 @@
     <value>The close status code '{0}' is reserved for system use only and cannot be specified when calling this method.</value>
   </data>
   <data name="net_WebSockets_InvalidCloseStatusDescription" xml:space="preserve">
-    <value>The close status description '{0}' is too long. The UTF8-representation of the status description must not be longer than {1} bytes.</value>
+    <value>The close status description '{0}' is too long. The UTF-8 representation of the status description must not be longer than {1} bytes.</value>
   </data>
   <data name="net_WebSockets_UnsupportedPlatform" xml:space="preserve">
     <value>The WebSocket protocol is not supported on this platform.</value>

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -428,7 +428,7 @@ namespace System.Net
             TryFormatCore(destination, out charsWritten);
 
         /// <summary>Tries to format the current IP address into the provided span.</summary>
-        /// <param name="utf8Destination">When this method returns, the IP address as a span of UTF8 bytes.</param>
+        /// <param name="utf8Destination">When this method returns, the IP address as a span of UTF-8 bytes.</param>
         /// <param name="bytesWritten">When this method returns, the number of bytes written into the <paramref name="utf8Destination"/>.</param>
         /// <returns><see langword="true" /> if the formatting was successful; otherwise, <see langword="false" />.</returns>
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten) =>

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPNetwork.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPNetwork.cs
@@ -252,9 +252,9 @@ namespace System.Net
             destination.TryWrite(CultureInfo.InvariantCulture, $"{BaseAddress}/{(uint)PrefixLength}", out charsWritten);
 
         /// <summary>
-        /// Attempts to write the <see cref="IPNetwork"/>'s CIDR notation to the given <paramref name="utf8Destination"/> UTF8 span and returns a value indicating whether the operation succeeded.
+        /// Attempts to write the <see cref="IPNetwork"/>'s CIDR notation to the given <paramref name="utf8Destination"/> UTF-8 span and returns a value indicating whether the operation succeeded.
         /// </summary>
-        /// <param name="utf8Destination">The destination span of UTF8 bytes.</param>
+        /// <param name="utf8Destination">The destination span of UTF-8 bytes.</param>
         /// <param name="bytesWritten">When this method returns, contains the number of bytes that were written to <paramref name="utf8Destination"/>.</param>
         /// <returns><see langword="true"/> if the formatting was succesful; otherwise <see langword="false"/>.</returns>
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten) =>

--- a/src/libraries/System.Net.WebSockets.Client/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.WebSockets.Client/src/Resources/Strings.resx
@@ -100,7 +100,7 @@
     <value>The close status code '{0}' is reserved for system use only and cannot be specified when calling this method.</value>
   </data>
   <data name="net_WebSockets_InvalidCloseStatusDescription" xml:space="preserve">
-    <value>The close status description '{0}' is too long. The UTF8-representation of the status description must not be longer than {1} bytes.</value>
+    <value>The close status description '{0}' is too long. The UTF-8 representation of the status description must not be longer than {1} bytes.</value>
   </data>
   <data name="net_WebSockets_Scheme" xml:space="preserve">
     <value>Only Uris starting with 'ws://' or 'wss://' are supported.</value>

--- a/src/libraries/System.Net.WebSockets/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.WebSockets/src/Resources/Strings.resx
@@ -100,7 +100,7 @@
     <value>The close status code '{0}' is reserved for system use only and cannot be specified when calling this method.</value>
   </data>
   <data name="net_WebSockets_InvalidCloseStatusDescription" xml:space="preserve">
-    <value>The close status description '{0}' is too long. The UTF8-representation of the status description must not be longer than {1} bytes.</value>
+    <value>The close status description '{0}' is too long. The UTF-8 representation of the status description must not be longer than {1} bytes.</value>
   </data>
   <data name="net_WebSockets_UnsupportedPlatform" xml:space="preserve">
     <value>The WebSocket protocol is not supported on this platform.</value>

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -26,7 +26,7 @@ namespace System.Net.WebSockets
     /// </remarks>
     internal sealed partial class ManagedWebSocket : WebSocket
     {
-        /// <summary>Encoding for the payload of text messages: UTF8 encoding that throws if invalid bytes are discovered, per the RFC.</summary>
+        /// <summary>Encoding for the payload of text messages: UTF-8 encoding that throws if invalid bytes are discovered, per the RFC.</summary>
         private static readonly UTF8Encoding s_textEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
         /// <summary>Valid states to be in when calling SendAsync.</summary>
@@ -61,7 +61,7 @@ namespace System.Net.WebSockets
         /// <summary>Buffer used for reading data from the network.</summary>
         private readonly Memory<byte> _receiveBuffer;
         /// <summary>
-        /// Tracks the state of the validity of the UTF8 encoding of text payloads.  Text may be split across fragments.
+        /// Tracks the state of the validity of the UTF-8 encoding of text payloads.  Text may be split across fragments.
         /// </summary>
         private readonly Utf8MessageState _utf8TextState = new Utf8MessageState();
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -452,7 +452,7 @@
     <value>The signature Type array contains some invalid type (i.e. null, void)</value>
   </data>
   <data name="Arg_InvalidUTF8String" xml:space="preserve">
-    <value>The UTF8 string passed in could not be converted to Unicode.</value>
+    <value>The UTF-8 string passed in could not be converted to Unicode.</value>
   </data>
   <data name="Arg_IOException" xml:space="preserve">
     <value>I/O error occurred.</value>
@@ -1292,7 +1292,7 @@
     <value>The NativeDigits array must contain exactly ten members.</value>
   </data>
   <data name="Argument_InvalidNativeDigitValue" xml:space="preserve">
-    <value>Each member of the NativeDigits array must be a single text element (one or more UTF16 code points) with a Unicode Nd (Number, Decimal Digit) property indicating it is a digit.</value>
+    <value>Each member of the NativeDigits array must be a single text element (one or more UTF-16 code points) with a Unicode Nd (Number, Decimal Digit) property indicating it is a digit.</value>
   </data>
   <data name="Argument_InvalidNeutralRegionName" xml:space="preserve">
     <value>The region name {0} should not correspond to neutral culture; a specific culture name is required.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Validator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Validator.cs
@@ -30,8 +30,8 @@ namespace System.Buffers.Text
         public static bool IsValid(ReadOnlySpan<char> base64Text, out int decodedLength) =>
             IsValid<char, Base64CharValidatable>(base64Text, out decodedLength);
 
-        /// <summary>Validates that the specified span of UTF8 text is comprised of valid base-64 encoded data.</summary>
-        /// <param name="base64TextUtf8">A span of UTF8 text to validate.</param>
+        /// <summary>Validates that the specified span of UTF-8 text is comprised of valid base-64 encoded data.</summary>
+        /// <param name="base64TextUtf8">A span of UTF-8 text to validate.</param>
         /// <returns><see langword="true"/> if <paramref name="base64TextUtf8"/> contains a valid, decodable sequence of base-64 encoded data; otherwise, <see langword="false"/>.</returns>
         /// <remarks>
         /// If the method returns <see langword="true"/>, the same text passed to <see cref="DecodeFromUtf8"/> and
@@ -41,9 +41,9 @@ namespace System.Buffers.Text
         public static bool IsValid(ReadOnlySpan<byte> base64TextUtf8) =>
             IsValid<byte, Base64ByteValidatable>(base64TextUtf8, out _);
 
-        /// <summary>Validates that the specified span of UTF8 text is comprised of valid base-64 encoded data.</summary>
-        /// <param name="base64TextUtf8">A span of UTF8 text to validate.</param>
-        /// <param name="decodedLength">If the method returns true, the number of decoded bytes that will result from decoding the input UTF8 text.</param>
+        /// <summary>Validates that the specified span of UTF-8 text is comprised of valid base-64 encoded data.</summary>
+        /// <param name="base64TextUtf8">A span of UTF-8 text to validate.</param>
+        /// <param name="decodedLength">If the method returns true, the number of decoded bytes that will result from decoding the input UTF-8 text.</param>
         /// <returns><see langword="true"/> if <paramref name="base64TextUtf8"/> contains a valid, decodable sequence of base-64 encoded data; otherwise, <see langword="false"/>.</returns>
         /// <remarks>
         /// If the method returns <see langword="true"/>, the same text passed to <see cref="DecodeFromUtf8"/> and

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Boolean.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Boolean.cs
@@ -6,10 +6,10 @@ namespace System.Buffers.Text
     public static partial class Utf8Formatter
     {
         /// <summary>
-        /// Formats a Boolean as a UTF8 string.
+        /// Formats a Boolean as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.cs
@@ -9,10 +9,10 @@ namespace System.Buffers.Text
     public static partial class Utf8Formatter
     {
         /// <summary>
-        /// Formats a DateTimeOffset as a UTF8 string.
+        /// Formats a DateTimeOffset as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>
@@ -58,10 +58,10 @@ namespace System.Buffers.Text
         }
 
         /// <summary>
-        /// Formats a DateTime as a UTF8 string.
+        /// Formats a DateTime as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Decimal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Decimal.cs
@@ -6,10 +6,10 @@ namespace System.Buffers.Text
     public static partial class Utf8Formatter
     {
         /// <summary>
-        /// Formats a Decimal as a UTF8 string.
+        /// Formats a Decimal as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
@@ -6,10 +6,10 @@ namespace System.Buffers.Text
     public static partial class Utf8Formatter
     {
         /// <summary>
-        /// Formats a Double as a UTF8 string.
+        /// Formats a Double as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>
@@ -29,10 +29,10 @@ namespace System.Buffers.Text
             FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
 
         /// <summary>
-        /// Formats a Single as a UTF8 string.
+        /// Formats a Single as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Guid.cs
@@ -6,10 +6,10 @@ namespace System.Buffers.Text
     public static partial class Utf8Formatter
     {
         /// <summary>
-        /// Formats a Guid as a UTF8 string.
+        /// Formats a Guid as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.cs
@@ -11,10 +11,10 @@ namespace System.Buffers.Text
     public static partial class Utf8Formatter
     {
         /// <summary>
-        /// Formats a Byte as a UTF8 string.
+        /// Formats a Byte as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>
@@ -35,10 +35,10 @@ namespace System.Buffers.Text
             TryFormat((uint)value, destination, out bytesWritten, format);
 
         /// <summary>
-        /// Formats an SByte as a UTF8 string.
+        /// Formats an SByte as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>
@@ -60,10 +60,10 @@ namespace System.Buffers.Text
             TryFormat(value, 0xFF, destination, out bytesWritten, format);
 
         /// <summary>
-        /// Formats a Unt16 as a UTF8 string.
+        /// Formats a Unt16 as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>
@@ -85,10 +85,10 @@ namespace System.Buffers.Text
             TryFormat((uint)value, destination, out bytesWritten, format);
 
         /// <summary>
-        /// Formats an Int16 as a UTF8 string.
+        /// Formats an Int16 as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>
@@ -109,10 +109,10 @@ namespace System.Buffers.Text
             TryFormat(value, 0xFFFF, destination, out bytesWritten, format);
 
         /// <summary>
-        /// Formats a UInt32 as a UTF8 string.
+        /// Formats a UInt32 as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>
@@ -163,10 +163,10 @@ namespace System.Buffers.Text
         }
 
         /// <summary>
-        /// Formats an Int32 as a UTF8 string.
+        /// Formats an Int32 as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>
@@ -223,10 +223,10 @@ namespace System.Buffers.Text
         }
 
         /// <summary>
-        /// Formats a UInt64 as a UTF8 string.
+        /// Formats a UInt64 as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>
@@ -277,10 +277,10 @@ namespace System.Buffers.Text
         }
 
         /// <summary>
-        /// Formats an Int64 as a UTF8 string.
+        /// Formats an Int64 as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.TimeSpan.cs
@@ -8,10 +8,10 @@ namespace System.Buffers.Text
     public static partial class Utf8Formatter
     {
         /// <summary>
-        /// Formats a TimeSpan as a UTF8 string.
+        /// Formats a TimeSpan as a UTF-8 string.
         /// </summary>
         /// <param name="value">Value to format</param>
-        /// <param name="destination">Buffer to write the UTF8-formatted value to</param>
+        /// <param name="destination">Buffer to write the UTF-8 formatted value to</param>
         /// <param name="bytesWritten">Receives the length of the formatted text in bytes</param>
         /// <param name="format">The standard format to use</param>
         /// <returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Convert.Base64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.Base64.cs
@@ -25,7 +25,7 @@ namespace System
         ///           or a destination span that's too small. <paramref name="consumed"/> and <paramref name="written"/> are set so that
         ///           parsing can continue with a slower whitespace-tolerant algorithm.
         ///
-        /// Note: This is a cut down version of the implementation of Base64.DecodeFromUtf8(), modified the accept UTF16 chars and act as a fast-path
+        /// Note: This is a cut down version of the implementation of Base64.DecodeFromUtf8(), modified the accept UTF-16 chars and act as a fast-path
         /// helper for the Convert routines when the input string contains no whitespace.
         /// </returns>
         private static bool TryDecodeFromUtf16(ReadOnlySpan<char> utf16, Span<byte> bytes, out int consumed, out int written)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/FieldMetadata.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/FieldMetadata.cs
@@ -19,7 +19,7 @@ namespace System.Diagnostics.Tracing
         private readonly string name;
 
         /// <summary>
-        /// The number of bytes in the UTF8 Encoding of 'name' INCLUDING a null terminator.
+        /// The number of bytes in the UTF-8 Encoding of 'name' INCLUDING a null terminator.
         /// </summary>
         private readonly int nameSize;
         private readonly EventFieldTags tags;

--- a/src/libraries/System.Private.CoreLib/src/System/IUtf8SpanFormattable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IUtf8SpanFormattable.cs
@@ -3,10 +3,10 @@
 
 namespace System
 {
-    /// <summary>Provides functionality to format the string representation of an object into a span as UTF8.</summary>
+    /// <summary>Provides functionality to format the string representation of an object into a span as UTF-8.</summary>
     public interface IUtf8SpanFormattable
     {
-        /// <summary>Tries to format the value of the current instance as UTF8 into the provided span of bytes.</summary>
+        /// <summary>Tries to format the value of the current instance as UTF-8 into the provided span of bytes.</summary>
         /// <param name="utf8Destination">When this method returns, this instance's value formatted as a span of bytes.</param>
         /// <param name="bytesWritten">When this method returns, the number of bytes that were written in <paramref name="utf8Destination"/>.</param>
         /// <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format for <paramref name="utf8Destination"/>.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -3605,7 +3605,7 @@ namespace System
         }
 
         /// <summary>Appends a char to the builder when the char is not known to be ASCII.</summary>
-        /// <remarks>This requires a helper as if the character isn't ASCII, for UTF8 encoding it will result in multiple bytes added.</remarks>
+        /// <remarks>This requires a helper as if the character isn't ASCII, for UTF-8 encoding it will result in multiple bytes added.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void AppendUnknownChar<TChar>(ref ValueListBuilder<TChar> vlb, char ch) where TChar : unmanaged, IUtfChar<TChar>
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -257,10 +257,10 @@ namespace System.Runtime.InteropServices
             value != null ? new ReadOnlySpan<char>(value, string.wcslen(value)) :
             default;
 
-        /// <summary>Creates a new read-only span for a null-terminated UTF8 string.</summary>
+        /// <summary>Creates a new read-only span for a null-terminated UTF-8 string.</summary>
         /// <param name="value">The pointer to the null-terminated string of bytes.</param>
         /// <returns>A read-only span representing the specified null-terminated string, or an empty span if the pointer is null.</returns>
-        /// <remarks>The returned span does not include the null terminator, nor does it validate the well-formedness of the UTF8 data.</remarks>
+        /// <remarks>The returned span does not include the null terminator, nor does it validate the well-formedness of the UTF-8 data.</remarks>
         /// <exception cref="ArgumentException">The string is longer than <see cref="int.MaxValue"/>.</exception>
         [CLSCompliant(false)]
         public static unsafe ReadOnlySpan<byte> CreateReadOnlySpanFromNullTerminated(byte* value) =>

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8.cs
@@ -330,7 +330,7 @@ namespace System.Text.Unicode
             }
         }
 
-        /// <summary>Writes the specified interpolated string to the UTF8 byte span.</summary>
+        /// <summary>Writes the specified interpolated string to the UTF-8 byte span.</summary>
         /// <param name="destination">The span to which the interpolated string should be formatted.</param>
         /// <param name="handler">The interpolated string.</param>
         /// <param name="bytesWritten">The number of characters written to the span.</param>
@@ -349,7 +349,7 @@ namespace System.Text.Unicode
             return false;
         }
 
-        /// <summary>Writes the specified interpolated string to the UTF8 byte span.</summary>
+        /// <summary>Writes the specified interpolated string to the UTF-8 byte span.</summary>
         /// <param name="destination">The span to which the interpolated string should be formatted.</param>
         /// <param name="provider">An object that supplies culture-specific formatting information.</param>
         /// <param name="handler">The interpolated string.</param>
@@ -360,12 +360,12 @@ namespace System.Text.Unicode
             // is the same as the non-provider overload.
             TryWrite(destination, ref handler, out bytesWritten);
 
-        /// <summary>Provides a handler used by the language compiler to format interpolated strings into UTF8 byte spans.</summary>
+        /// <summary>Provides a handler used by the language compiler to format interpolated strings into UTF-8 byte spans.</summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [InterpolatedStringHandler]
         public ref struct TryWriteInterpolatedStringHandler
         {
-            /// <summary>The destination UTF8 buffer.</summary>
+            /// <summary>The destination UTF-8 buffer.</summary>
             private readonly Span<byte> _destination;
             /// <summary>Optional provider to pass to IFormattable.ToString, ISpanFormattable.TryFormat, and IUtf8SpanFormattable.TryFormat calls.</summary>
             private readonly IFormatProvider? _provider;
@@ -376,7 +376,7 @@ namespace System.Text.Unicode
             /// <summary>Whether <see cref="_provider"/> provides an ICustomFormatter.</summary>
             private readonly bool _hasCustomFormatter;
 
-            /// <summary>Creates a handler used to write an interpolated string into a UTF8 <see cref="Span{Byte}"/>.</summary>
+            /// <summary>Creates a handler used to write an interpolated string into a UTF-8 <see cref="Span{Byte}"/>.</summary>
             /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
             /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
             /// <param name="destination">The destination buffer.</param>
@@ -391,7 +391,7 @@ namespace System.Text.Unicode
                 _hasCustomFormatter = false;
             }
 
-            /// <summary>Creates a handler used to write an interpolated string into a UTF8 <see cref="Span{Byte}"/>.</summary>
+            /// <summary>Creates a handler used to write an interpolated string into a UTF-8 <see cref="Span{Byte}"/>.</summary>
             /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
             /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
             /// <param name="destination">The destination buffer.</param>
@@ -588,7 +588,7 @@ namespace System.Text.Unicode
                 return Fail();
             }
 
-            /// <summary>Writes the specified span of UTF8 bytes to the handler.</summary>
+            /// <summary>Writes the specified span of UTF-8 bytes to the handler.</summary>
             /// <param name="utf8Value">The span to write.</param>
             public bool AppendFormatted(scoped ReadOnlySpan<byte> utf8Value)
             {
@@ -601,7 +601,7 @@ namespace System.Text.Unicode
                 return Fail();
             }
 
-            /// <summary>Writes the specified span of UTF8 bytes to the handler.</summary>
+            /// <summary>Writes the specified span of UTF-8 bytes to the handler.</summary>
             /// <param name="utf8Value">The span to write.</param>
             /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
             /// <param name="format">The format string.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Version.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Version.cs
@@ -186,14 +186,14 @@ namespace System
             TryFormatCore(destination, fieldCount, out charsWritten);
 
         /// <summary>Tries to format this version instance into a span of bytes.</summary>
-        /// <param name="utf8Destination">The span in which to write this instance's value formatted as a span of UTF8 bytes.</param>
+        /// <param name="utf8Destination">The span in which to write this instance's value formatted as a span of UTF-8 bytes.</param>
         /// <param name="bytesWritten">When this method returns, contains the number of bytes that were written in <paramref name="utf8Destination"/>.</param>
         /// <returns><see langword="true"/> if the formatting was successful; otherwise, <see langword="false"/>.</returns>
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten) =>
             TryFormatCore(utf8Destination, DefaultFormatFieldCount, out bytesWritten);
 
         /// <summary>Tries to format this version instance into a span of bytes.</summary>
-        /// <param name="utf8Destination">The span in which to write this instance's value formatted as a span of UTF8 bytes.</param>
+        /// <param name="utf8Destination">The span in which to write this instance's value formatted as a span of UTF-8 bytes.</param>
         /// <param name="fieldCount">The number of components to return. This value ranges from 0 to 4.</param>
         /// <param name="bytesWritten">When this method returns, contains the number of bytes that were written in <paramref name="utf8Destination"/>.</param>
         /// <returns><see langword="true"/> if the formatting was successful; otherwise, <see langword="false"/>.</returns>

--- a/src/libraries/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -640,13 +640,13 @@
     <value>The value '{0}' cannot be represented with the type '{1}'.</value>
   </data>
   <data name="XmlDeclarationRequired" xml:space="preserve">
-    <value>An XML declaration with an encoding is required for all non-UTF8 documents.</value>
+    <value>An XML declaration with an encoding is required for all non UTF-8 documents.</value>
   </data>
   <data name="XmlDeclMissingVersion" xml:space="preserve">
     <value>Version not found in XML declaration.</value>
   </data>
   <data name="XmlDeclMissing" xml:space="preserve">
-    <value>An XML declaration is required for all non-UTF8 documents.</value>
+    <value>An XML declaration is required for all non UTF-8 documents.</value>
   </data>
   <data name="XmlDeclNotFirst" xml:space="preserve">
     <value>No characters can appear before the XML declaration.</value>
@@ -766,7 +766,7 @@
     <value>UniqueId cannot be zero length.</value>
   </data>
   <data name="XmlInvalidUTF8Bytes" xml:space="preserve">
-    <value>'{0}' contains invalid UTF8 bytes.</value>
+    <value>'{0}' contains invalid UTF-8 bytes.</value>
   </data>
   <data name="XmlInvalidVersion" xml:space="preserve">
     <value>XML version must be '1.0'.</value>

--- a/src/libraries/System.Reflection.Metadata/src/Resources/Strings.resx
+++ b/src/libraries/System.Reflection.Metadata/src/Resources/Strings.resx
@@ -226,7 +226,7 @@
     <value>Image is either too small or contains an invalid byte offset or count.</value>
   </data>
   <data name="MetadataStringDecoderEncodingMustBeUtf8" xml:space="preserve">
-    <value>The MetadataStringDecoder instance used to instantiate the Metadata reader must have a UTF8 encoding.</value>
+    <value>The MetadataStringDecoder instance used to instantiate the Metadata reader must have a UTF-8 encoding.</value>
   </data>
   <data name="InvalidConstantValue" xml:space="preserve">
     <value>Invalid constant value.</value>

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryBlock.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryBlock.cs
@@ -283,11 +283,11 @@ namespace System.Reflection.Internal
         }
 
         /// <summary>
-        /// Read UTF8 at the given offset up to the given terminator, null terminator, or end-of-block.
+        /// Read UTF-8 at the given offset up to the given terminator, null terminator, or end-of-block.
         /// </summary>
-        /// <param name="offset">Offset in to the block where the UTF8 bytes start.</param>
-        /// <param name="prefix">UTF8 encoded prefix to prepend to the bytes at the offset before decoding.</param>
-        /// <param name="utf8Decoder">The UTF8 decoder to use that allows user to adjust fallback and/or reuse existing strings without allocating a new one.</param>
+        /// <param name="offset">Offset in to the block where the UTF-8 bytes start.</param>
+        /// <param name="prefix">UTF-8 encoded prefix to prepend to the bytes at the offset before decoding.</param>
+        /// <param name="utf8Decoder">The UTF-8 decoder to use that allows user to adjust fallback and/or reuse existing strings without allocating a new one.</param>
         /// <param name="numberOfBytesRead">The number of bytes read, which includes the terminator if we did not hit the end of the block.</param>
         /// <param name="terminator">A character in the ASCII range that marks the end of the string.
         /// If a value other than '\0' is passed we still stop at the null terminator if encountered first.</param>
@@ -304,7 +304,7 @@ namespace System.Reflection.Internal
         /// Get number of bytes from offset to given terminator, null terminator, or end-of-block (whichever comes first).
         /// Returned length does not include the terminator, but numberOfBytesRead out parameter does.
         /// </summary>
-        /// <param name="offset">Offset in to the block where the UTF8 bytes start.</param>
+        /// <param name="offset">Offset in to the block where the UTF-8 bytes start.</param>
         /// <param name="terminator">A character in the ASCII range that marks the end of the string.
         /// If a value other than '\0' is passed we still stop at the null terminator if encountered first.</param>
         /// <param name="numberOfBytesRead">The number of bytes read, which includes the terminator if we did not hit the end of the block.</param>

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -951,7 +951,7 @@ namespace System.Reflection.Metadata
         }
 
         /// <summary>
-        /// Writes UTF16 (little-endian) encoded string at the current position.
+        /// Writes UTF-16 (little-endian) encoded string at the current position.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
@@ -971,7 +971,7 @@ namespace System.Reflection.Metadata
         }
 
         /// <summary>
-        /// Writes UTF16 (little-endian) encoded string at the current position.
+        /// Writes UTF-16 (little-endian) encoded string at the current position.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
@@ -1014,7 +1014,7 @@ namespace System.Reflection.Metadata
         /// Writes string in SerString format (see ECMA-335-II 23.3 Custom attributes).
         /// </summary>
         /// <remarks>
-        /// The string is UTF8 encoded and prefixed by the its size in bytes.
+        /// The string is UTF-8 encoded and prefixed by the its size in bytes.
         /// Null string is represented as a single byte 0xFF.
         /// </remarks>
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
@@ -1033,9 +1033,9 @@ namespace System.Reflection.Metadata
         /// Writes string in User String (#US) heap format (see ECMA-335-II 24.2.4 #US and #Blob heaps):
         /// </summary>
         /// <remarks>
-        /// The string is UTF16 encoded and prefixed by the its size in bytes.
+        /// The string is UTF-16 encoded and prefixed by the its size in bytes.
         ///
-        /// This final byte holds the value 1 if and only if any UTF16 character within the string has any bit set in its top byte,
+        /// This final byte holds the value 1 if and only if any UTF-16 character within the string has any bit set in its top byte,
         /// or its low byte is any of the following: 0x01-0x08, 0x0E-0x1F, 0x27, 0x2D, 0x7F. Otherwise, it holds 0.
         /// The 1 signifies Unicode characters that require handling beyond that normally provided for 8-bit encoding sets.
         /// </remarks>
@@ -1053,7 +1053,7 @@ namespace System.Reflection.Metadata
         }
 
         /// <summary>
-        /// Writes UTF8 encoded string at the current position.
+        /// Writes UTF-8 encoded string at the current position.
         /// </summary>
         /// <param name="value">Constant value.</param>
         /// <param name="allowUnpairedSurrogates">

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobReader.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobReader.cs
@@ -636,7 +636,7 @@ namespace System.Reflection.Metadata
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="typeCode"/> is not a valid <see cref="ConstantTypeCode"/>.</exception>
         /// <returns>
         /// Boxed constant value. To avoid allocating the object use Read* methods directly.
-        /// Constants of type <see cref="ConstantTypeCode.String"/> are encoded as UTF16 strings, use <see cref="ReadUTF-16(int)"/> to read them.
+        /// Constants of type <see cref="ConstantTypeCode.String"/> are encoded as UTF16 strings, use <see cref="ReadUTF16(int)"/> to read them.
         /// </returns>
         public object? ReadConstant(ConstantTypeCode typeCode)
         {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobReader.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobReader.cs
@@ -387,7 +387,7 @@ namespace System.Reflection.Metadata
         }
 
         /// <summary>
-        /// Reads UTF8 encoded string starting at the current position.
+        /// Reads UTF-8 encoded string starting at the current position.
         /// </summary>
         /// <param name="byteCount">The number of bytes to read.</param>
         /// <returns>The string.</returns>
@@ -400,7 +400,7 @@ namespace System.Reflection.Metadata
         }
 
         /// <summary>
-        /// Reads UTF16 (little-endian) encoded string starting at the current position.
+        /// Reads UTF-16 (little-endian) encoded string starting at the current position.
         /// </summary>
         /// <param name="byteCount">The number of bytes to read.</param>
         /// <returns>The string.</returns>
@@ -578,7 +578,7 @@ namespace System.Reflection.Metadata
 
         /// <summary>
         /// Reads a string encoded as a compressed integer containing its length followed by
-        /// its contents in UTF8. Null strings are encoded as a single 0xFF byte.
+        /// its contents in UTF-8. Null strings are encoded as a single 0xFF byte.
         /// </summary>
         /// <remarks>Defined as a 'SerString' in the ECMA CLI specification.</remarks>
         /// <returns>String value or null.</returns>
@@ -636,7 +636,7 @@ namespace System.Reflection.Metadata
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="typeCode"/> is not a valid <see cref="ConstantTypeCode"/>.</exception>
         /// <returns>
         /// Boxed constant value. To avoid allocating the object use Read* methods directly.
-        /// Constants of type <see cref="ConstantTypeCode.String"/> are encoded as UTF16 strings, use <see cref="ReadUTF16(int)"/> to read them.
+        /// Constants of type <see cref="ConstantTypeCode.String"/> are encoded as UTF16 strings, use <see cref="ReadUTF-16(int)"/> to read them.
         /// </returns>
         public object? ReadConstant(ConstantTypeCode typeCode)
         {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
@@ -366,7 +366,7 @@ namespace System.Reflection.Metadata
         }
 
         /// <summary>
-        /// Writes UTF16 (little-endian) encoded string at the current position.
+        /// Writes UTF-16 (little-endian) encoded string at the current position.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
         public void WriteUTF16(char[] value)
@@ -380,7 +380,7 @@ namespace System.Reflection.Metadata
         }
 
         /// <summary>
-        /// Writes UTF16 (little-endian) encoded string at the current position.
+        /// Writes UTF-16 (little-endian) encoded string at the current position.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
         public void WriteUTF16(string value)
@@ -412,7 +412,7 @@ namespace System.Reflection.Metadata
         /// Writes string in SerString format (see ECMA-335-II 23.3 Custom attributes).
         /// </summary>
         /// <remarks>
-        /// The string is UTF8 encoded and prefixed by the its size in bytes.
+        /// The string is UTF-8 encoded and prefixed by the its size in bytes.
         /// Null string is represented as a single byte 0xFF.
         /// </remarks>
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
@@ -431,9 +431,9 @@ namespace System.Reflection.Metadata
         /// Writes string in User String (#US) heap format (see ECMA-335-II 24.2.4 #US and #Blob heaps):
         /// </summary>
         /// <remarks>
-        /// The string is UTF16 encoded and prefixed by the its size in bytes.
+        /// The string is UTF-16 encoded and prefixed by the its size in bytes.
         ///
-        /// This final byte holds the value 1 if and only if any UTF16 character within the string has any bit set in its top byte,
+        /// This final byte holds the value 1 if and only if any UTF-16 character within the string has any bit set in its top byte,
         /// or its low byte is any of the following: 0x01-0x08, 0x0E-0x1F, 0x27, 0x2D, 0x7F. Otherwise, it holds 0.
         /// The 1 signifies Unicode characters that require handling beyond that normally provided for 8-bit encoding sets.
         /// </remarks>
@@ -451,7 +451,7 @@ namespace System.Reflection.Metadata
         }
 
         /// <summary>
-        /// Writes UTF8 encoded string at the current position.
+        /// Writes UTF-8 encoded string at the current position.
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
         public void WriteUTF8(string value, bool allowUnpairedSurrogates)

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
@@ -245,7 +245,7 @@ namespace System.Reflection.Metadata.Ecma335
 
         /// <summary>
         /// Encodes a constant value to a blob and adds it to the Blob heap, if it's not there already.
-        /// Uses UTF16 to encode string constants.
+        /// Uses UTF-16 to encode string constants.
         /// </summary>
         /// <param name="value">Constant value.</param>
         /// <returns>Handle to the added or existing blob.</returns>
@@ -264,7 +264,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
 
         /// <summary>
-        /// Encodes a string using UTF16 encoding to a blob and adds it to the Blob heap, if it's not there already.
+        /// Encodes a string using UTF-16 encoding to a blob and adds it to the Blob heap, if it's not there already.
         /// </summary>
         /// <param name="value">String.</param>
         /// <returns>Handle to the added or existing blob.</returns>
@@ -289,7 +289,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
 
         /// <summary>
-        /// Encodes a string using UTF8 encoding to a blob and adds it to the Blob heap, if it's not there already.
+        /// Encodes a string using UTF-8 encoding to a blob and adds it to the Blob heap, if it's not there already.
         /// </summary>
         /// <param name="value">Constant value.</param>
         /// <param name="allowUnpairedSurrogates">

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataRootBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataRootBuilder.cs
@@ -50,7 +50,7 @@ namespace System.Reflection.Metadata.Ecma335
         /// It does not enforce all specification requirements on metadata tables.
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="tablesAndHeaps"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="metadataVersion"/> is too long (the number of bytes when UTF8-encoded must be less than 255).</exception>
+        /// <exception cref="ArgumentException"><paramref name="metadataVersion"/> is too long (the number of bytes when UTF-8 encoded must be less than 255).</exception>
         public MetadataRootBuilder(MetadataBuilder tablesAndHeaps, string? metadataVersion = null, bool suppressValidation = false)
         {
             if (tablesAndHeaps is null)

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
@@ -1018,7 +1018,7 @@ namespace System.Reflection.Metadata
         public MetadataStringComparer StringComparer => new MetadataStringComparer(this);
 
         /// <summary>
-        /// The decoder used by the reader to produce <see cref="string"/> instances from UTF8 encoded byte sequences.
+        /// The decoder used by the reader to produce <see cref="string"/> instances from UTF-8 encoded byte sequences.
         /// </summary>
         public MetadataStringDecoder UTF8Decoder { get; }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBinaryReader.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBinaryReader.cs
@@ -86,10 +86,10 @@ namespace System.Reflection.PortableExecutable
         }
 
         /// <summary>
-        /// Reads a fixed-length byte block as a null-padded UTF8-encoded string.
+        /// Reads a fixed-length byte block as a null-padded UTF-8 encoded string.
         /// The padding is not included in the returned string.
         ///
-        /// Note that it is legal for UTF8 strings to contain NUL; if NUL occurs
+        /// Note that it is legal for UTF-8 strings to contain NUL; if NUL occurs
         /// between non-NUL codepoints, it is not considered to be padding and
         /// is included in the result.
         /// </summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Rfc2898DeriveBytes.OneShot.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Rfc2898DeriveBytes.OneShot.cs
@@ -149,10 +149,10 @@ namespace System.Security.Cryptography
         ///   <see cref="HashAlgorithmName.SHA384" />, and <see cref="HashAlgorithmName.SHA512" />.
         /// </exception>
         /// <exception cref="EncoderFallbackException">
-        /// <paramref name="password" /> contains text that cannot be converted to UTF8.
+        /// <paramref name="password" /> contains text that cannot be converted to UTF-8.
         /// </exception>
         /// <remarks>
-        /// The <paramref name="password" /> will be converted to bytes using the UTF8 encoding. For
+        /// The <paramref name="password" /> will be converted to bytes using the UTF-8 encoding. For
         /// other encodings, convert the password string to bytes using the appropriate <see cref="System.Text.Encoding" />
         /// and use <see cref="Pbkdf2(byte[], byte[], int, HashAlgorithmName, int)" />.
         /// </remarks>
@@ -192,10 +192,10 @@ namespace System.Security.Cryptography
         ///   <see cref="HashAlgorithmName.SHA384" />, and <see cref="HashAlgorithmName.SHA512" />.
         /// </exception>
         /// <exception cref="EncoderFallbackException">
-        /// <paramref name="password" /> contains text that cannot be converted to UTF8.
+        /// <paramref name="password" /> contains text that cannot be converted to UTF-8.
         /// </exception>
         /// <remarks>
-        /// The <paramref name="password" /> will be converted to bytes using the UTF8 encoding. For
+        /// The <paramref name="password" /> will be converted to bytes using the UTF-8 encoding. For
         /// other encodings, convert the password string to bytes using the appropriate <see cref="System.Text.Encoding" />
         /// and use <see cref="Pbkdf2(ReadOnlySpan{byte}, ReadOnlySpan{byte}, int, HashAlgorithmName, int)" />.
         /// </remarks>
@@ -237,10 +237,10 @@ namespace System.Security.Cryptography
         ///   <see cref="HashAlgorithmName.SHA384" />, and <see cref="HashAlgorithmName.SHA512" />.
         /// </exception>
         /// <exception cref="EncoderFallbackException">
-        /// <paramref name="password" /> contains text that cannot be converted to UTF8.
+        /// <paramref name="password" /> contains text that cannot be converted to UTF-8.
         /// </exception>
         /// <remarks>
-        /// The <paramref name="password" /> will be converted to bytes using the UTF8 encoding. For
+        /// The <paramref name="password" /> will be converted to bytes using the UTF-8 encoding. For
         /// other encodings, convert the password string to bytes using the appropriate <see cref="System.Text.Encoding" />
         /// and use <see cref="Pbkdf2(ReadOnlySpan{byte}, ReadOnlySpan{byte}, Span{byte}, int, HashAlgorithmName)" />.
         /// </remarks>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
@@ -20,7 +20,7 @@ namespace System.Text.Json
         private const int UnseekableStreamInitialRentSize = 4096;
 
         /// <summary>
-        ///   Parse memory as UTF-8-encoded text representing a single JSON value into a JsonDocument.
+        ///   Parse memory as UTF-8 encoded text representing a single JSON value into a JsonDocument.
         /// </summary>
         /// <remarks>
         ///   <para>
@@ -50,7 +50,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        ///   Parse a sequence as UTF-8-encoded text representing a single JSON value into a JsonDocument.
+        ///   Parse a sequence as UTF-8 encoded text representing a single JSON value into a JsonDocument.
         /// </summary>
         /// <remarks>
         ///   <para>
@@ -101,7 +101,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        ///   Parse a <see cref="Stream"/> as UTF-8-encoded data representing a single JSON value into a
+        ///   Parse a <see cref="Stream"/> as UTF-8 encoded data representing a single JSON value into a
         ///   JsonDocument.  The Stream will be read to completion.
         /// </summary>
         /// <param name="utf8Json">JSON data to parse.</param>
@@ -180,7 +180,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        ///   Parse a <see cref="Stream"/> as UTF-8-encoded data representing a single JSON value into a
+        ///   Parse a <see cref="Stream"/> as UTF-8 encoded data representing a single JSON value into a
         ///   JsonDocument.  The Stream will be read to completion.
         /// </summary>
         /// <param name="utf8Json">JSON data to parse.</param>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.Parse.cs
@@ -101,7 +101,7 @@ namespace System.Text.Json.Nodes
         }
 
         /// <summary>
-        ///   Parse a <see cref="Stream"/> as UTF-8-encoded data representing a single JSON value into a
+        ///   Parse a <see cref="Stream"/> as UTF-8 encoded data representing a single JSON value into a
         ///   <see cref="JsonNode"/>.  The Stream will be read to completion.
         /// </summary>
         /// <param name="utf8Json">JSON text to parse.</param>


### PR DESCRIPTION
It's my understanding from https://www.unicode.org/reports/tr17 that the hyphen form is correct. So make strings and doc comments consistent.