### PR TITLE
Improve default cross compiler state

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -649,6 +649,12 @@
   <!-- Build AOT cross compiler (if available) -->
   <Target Name="BuildMonoCross" Condition="'$(BuildMonoAOTCrossCompiler)' == 'true'" DependsOnTargets="BuildMonoRuntime">
 
+    <!-- If you don't specify the AOT host, assume it's the build machine -->
+    <PropertyGroup>
+      <AotHostArchitecture Condition="'$(AotHostArchitecture)' == ''">$(BuildArchitecture)</AotHostArchitecture>
+      <AotHostOS Condition="'$(AotHostOS)' == ''">$(_portableHostOS)</AotHostOS>
+    </PropertyGroup>
+
     <!-- iOS/tvOS specific options -->
     <PropertyGroup Condition="'$(TargetstvOS)' == 'true' or '$(TargetsiOS)' == 'true'">
       <!-- FIXME: Disable for simulator -->
@@ -681,7 +687,7 @@
     </PropertyGroup>
 
     <!-- Linux specific options -->
-    <ItemGroup Condition="'$(AotHostOS)' == 'linux' or $([MSBuild]::IsOSPlatform('Linux'))">
+    <ItemGroup Condition="'$(AotHostOS)' == 'linux'">
       <_LibClang Include="$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(MonoToolchainPrebuiltOS)/lib64/libclang.so.*"/>
     </ItemGroup>
     <PropertyGroup Condition="'$(TargetsLinux)' == 'true' and '$(Platform)' == 'arm64'">
@@ -694,7 +700,7 @@
 
     <PropertyGroup>
       <_MonoLLVMTargetArchitecture Condition="'$(MonoUseLLVMPackage)' == 'true'">$(BuildArchitecture)</_MonoLLVMTargetArchitecture>
-      <_MonoLLVMTargetArchitecture Condition="'$(AotHostArchitecture)' != '' and '$(MonoUseLLVMPackage)' == 'true'">$(AotHostArchitecture)</_MonoLLVMTargetArchitecture>
+      <_MonoLLVMTargetArchitecture Condition="'$(MonoUseLLVMPackage)' == 'true'">$(AotHostArchitecture)</_MonoLLVMTargetArchitecture>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(HostOS)' == 'Linux' and (('$(MonoAOTEnableLLVM)' == 'true' and '$(MonoUseLibCxx)' == 'true') or '$(TargetArchitecture)' == 'wasm')">
@@ -711,11 +717,11 @@
     </ItemGroup>
 
     <!-- macOS host specific options -->
-    <ItemGroup Condition="'$(AotHostOS)' == 'osx' or $([MSBuild]::IsOSPlatform('OSX'))">
-      <MonoAOTCMakeArgs Condition="'$(AotHostArchitecture)' == 'x64' or ('$(AotHostArchitecture)' == '' and '$(BuildArchitecture)' == 'x64')" Include="-DCMAKE_OSX_ARCHITECTURES=x86_64" />
-      <MonoAOTCMakeArgs Condition="'$(AotHostArchitecture)' == 'x86' or ('$(AotHostArchitecture)' == '' and '$(BuildArchitecture)' == 'x86')" Include="-DCMAKE_OSX_ARCHITECTURES=i386" />
-      <MonoAOTCMakeArgs Condition="'$(AotHostArchitecture)' == 'arm64' or ('$(AotHostArchitecture)' == '' and '$(BuildArchitecture)' == 'arm64')" Include="-DCMAKE_OSX_ARCHITECTURES=arm64" />
-      <MonoAOTCMakeArgs Condition="'$(AotHostArchitecture)' == 'arm' or ('$(AotHostArchitecture)' == '' and '$(BuildArchitecture)' == 'arm')" Include="&quot;-DCMAKE_OSX_ARCHITECTURES=armv7%3Barmv7s&quot;" />
+    <ItemGroup Condition="'$(AotHostOS)' == 'osx'">
+      <MonoAOTCMakeArgs Condition="'$(AotHostArchitecture)' == 'x64'" Include="-DCMAKE_OSX_ARCHITECTURES=x86_64" />
+      <MonoAOTCMakeArgs Condition="'$(AotHostArchitecture)' == 'x86'" Include="-DCMAKE_OSX_ARCHITECTURES=i386" />
+      <MonoAOTCMakeArgs Condition="'$(AotHostArchitecture)' == 'arm64'" Include="-DCMAKE_OSX_ARCHITECTURES=arm64" />
+      <MonoAOTCMakeArgs Condition="'$(AotHostArchitecture)' == 'arm'" Include="&quot;-DCMAKE_OSX_ARCHITECTURES=armv7%3Barmv7s&quot;" />
       <MonoAOTCMakeArgs Include="-DCMAKE_OSX_DEPLOYMENT_TARGET=$(macOSVersionMin)" />
       <MonoAOTCMakeArgs Include="-DENABLE_ICALL_EXPORT=1"/>
       <_MonoAOTCFLAGS Condition="'$(AotHostArchitecture)' == 'arm64'" Include="-arch arm64" />
@@ -737,7 +743,7 @@
     </PropertyGroup>
 
     <!-- Windows specific options -->
-    <ItemGroup Condition="'$(AotHostOS)' == 'windows' or $([MSBuild]::IsOSPlatform('Windows'))">
+    <ItemGroup Condition="'$(AotHostOS)' == 'windows'">
       <_MonoAOTCPPFLAGS Include="-DHOST_WIN32" />
       <_MonoAOTCPPFLAGS Include="-D__WIN32__" />
       <_MonoAOTCPPFLAGS Include="-DWIN32" />
@@ -805,7 +811,7 @@
     </ItemGroup>
 
     <!-- AOT compiler cross-build options  -->
-    <ItemGroup Condition="'$(AotHostArchitecture)' != '' and '$(MonoCrossDir)' != ''">
+    <ItemGroup Condition="'$(MonoCrossDir)' != ''">
       <MonoAOTCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
       <_MonoAotBuildEnv Include="TARGET_BUILD_ARCH=$(AotHostArchitecture)" />
     </ItemGroup>
@@ -849,7 +855,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_MonoSkipInitCompiler Condition="'$(AotHostArchitecture)' != '' and '$(AotHostArchitecture)' != '$(BuildArchitecture)'">false</_MonoSkipInitCompiler>
+      <_MonoSkipInitCompiler Condition="'$(AotHostArchitecture)' != '$(BuildArchitecture)'">false</_MonoSkipInitCompiler>
       <_MonoSkipInitCompiler Condition="'$(CrossBuild)' == 'true'">false</_MonoSkipInitCompiler>
       <_MonoAotCrossOffsetsCommand Condition="'$(MonoUseCrossTool)' == 'true'">$(PythonCmd) $(MonoProjectRoot)mono/tools/offsets-tool/offsets-tool.py @(MonoAotCrossOffsetsToolParams, ' ')</_MonoAotCrossOffsetsCommand>
       <_MonoAotCMakeConfigureCommand>cmake @(MonoAOTCMakeArgs, ' ') $(MonoCMakeExtraArgs) &quot;$(MonoProjectRoot.TrimEnd('\/'))&quot;</_MonoAotCMakeConfigureCommand>
@@ -910,6 +916,13 @@
 
   <!-- General targets -->
   <Target Name="BuildMono" AfterTargets="Build" DependsOnTargets="$(MonoDependsOnTargets)">
+
+    <!-- If you don't specify the AOT host, assume it's the build machine -->
+    <PropertyGroup>
+      <AotHostArchitecture Condition="'$(AotHostArchitecture)' == ''">$(BuildArchitecture)</AotHostArchitecture>
+      <AotHostOS Condition="'$(AotHostOS)' == ''">$(OS)</AotHostOS>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(BuildMonoAOTCrossCompilerOnly)' != 'true'">
       <_MonoRuntimeFilePath>$(MonoObjDir)out\lib\$(MonoFileName)</_MonoRuntimeFilePath>
       <_MonoRuntimeStaticFilePath Condition="'$(TargetsMacCatalyst)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsAndroid)' == 'true' or '$(TargetsLinuxBionic)' == 'true'">$(MonoObjDir)out\lib\$(MonoStaticLibFileName)</_MonoRuntimeStaticFilePath>
@@ -921,7 +934,7 @@
     </PropertyGroup>
     <PropertyGroup>
       <_MonoLLVMTargetArchitecture>$(BuildArchitecture)</_MonoLLVMTargetArchitecture>
-      <_MonoLLVMTargetArchitecture Condition="'$(TargetArchitecture)' != 'wasm' and '$(AotHostArchitecture)' != ''">$(AotHostArchitecture)</_MonoLLVMTargetArchitecture>
+      <_MonoLLVMTargetArchitecture Condition="'$(TargetArchitecture)' != 'wasm'">$(AotHostArchitecture)</_MonoLLVMTargetArchitecture>
     </PropertyGroup>
 
     <!-- Copy Mono runtime files to artifacts directory -->

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -652,7 +652,7 @@
     <!-- If you don't specify the AOT host, assume it's the build machine -->
     <PropertyGroup>
       <AotHostArchitecture Condition="'$(AotHostArchitecture)' == ''">$(BuildArchitecture)</AotHostArchitecture>
-      <AotHostOS Condition="'$(AotHostOS)' == ''">$(_portableHostOS)</AotHostOS>
+      <AotHostOS Condition="'$(AotHostOS)' == ''">$(HostOS)</AotHostOS>
     </PropertyGroup>
 
     <!-- iOS/tvOS specific options -->
@@ -920,7 +920,7 @@
     <!-- If you don't specify the AOT host, assume it's the build machine -->
     <PropertyGroup>
       <AotHostArchitecture Condition="'$(AotHostArchitecture)' == ''">$(BuildArchitecture)</AotHostArchitecture>
-      <AotHostOS Condition="'$(AotHostOS)' == ''">$(OS)</AotHostOS>
+      <AotHostOS Condition="'$(AotHostOS)' == ''">$(HostOS)</AotHostOS>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(BuildMonoAOTCrossCompilerOnly)' != 'true'">

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -553,12 +553,6 @@
       <_MonoCXXFLAGS Include="-Wl,--build-id=sha1" />
       <_MonoCXXFLAGS Condition="'$(Platform)' == 'arm'" Include="-march=armv7-a" />
     </ItemGroup>
-    <ItemGroup Condition="'$(AotHostOS)' == 'linux'">
-      <_MonoAOTCFLAGS Include="-Wl,--build-id=sha1" />
-      <_MonoAOTCFLAGS Condition="'$(AotHostArchitecture)' == 'arm'" Include="-march=armv7-a" />
-      <_MonoAOTCXXFLAGS Include="-Wl,--build-id=sha1" />
-      <_MonoAOTCXXFLAGS Condition="'$(AotHostArchitecture)' == 'arm'" Include="-march=armv7-a" />
-    </ItemGroup>
 
     <!-- Devloop features -->
     <ItemGroup Condition="'$(MonoMsCorDbi)' == 'true'">
@@ -708,6 +702,12 @@
       <_MonoAOTCXXFLAGS Include="-L$(MonoLLVMDir)\$(_MonoLLVMTargetArchitecture)\lib" />
       <_MonoAOTCXXFLAGS Include="-stdlib=libc++" />
       <MonoAOTCMakeArgs Include="-DMONO_SET_RPATH_ORIGIN=true" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(AotHostOS)' == 'linux'">
+      <_MonoAOTCFLAGS Include="-Wl,--build-id=sha1" />
+      <_MonoAOTCFLAGS Condition="'$(AotHostArchitecture)' == 'arm'" Include="-march=armv7-a" />
+      <_MonoAOTCXXFLAGS Include="-Wl,--build-id=sha1" />
+      <_MonoAOTCXXFLAGS Condition="'$(AotHostArchitecture)' == 'arm'" Include="-march=armv7-a" />
     </ItemGroup>
 
     <!-- macOS host specific options -->


### PR DESCRIPTION
There are several cases where a "basic" build with Mono results in an inscrutable error:

```
  CMake Error at /usr/share/cmake-3.21/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
    Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR)
```

Counter-intuitively, this is typically triggered by missing compiler flags in the `BuildMonoAOT` build target - caused by poor handling of cases where these variables are not specified on the command line. We also had some incorrect conditionals in variable setting based on `or` sometimes evaluating the wrong groups.

This PR fixes e.g.:

`docker run -e ROOTFS_DIR=/crossrootfs/x64 -it -w $(pwd) --platform linux/amd64 -v $(pwd):$(pwd) mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64 ./build.sh -ci -arch x64 --cross -os linux -s mono+libs+host+packs -c Release /p:MonoAOTEnableLLVM=true /p:MonoBundleLLVMOptimizer=true /p:BuildMonoAOTCrossCompiler=true /p:MonoLibClang="/usr/local/lib/libclang.so.16"`

But we do not yet have a solution to:

`docker run -e ROOTFS_DIR=/crossrootfs/arm64 -it -w $(pwd) --platform linux/amd64 -v $(pwd):$(pwd) mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64 ./build.sh -ci -arch arm64 --cross -os linux -s mono+libs+host+packs -c Release /p:MonoAOTEnableLLVM=true /p:MonoBundleLLVMOptimizer=true /p:BuildMonoAOTCrossCompiler=true /p:MonoLibClang="/usr/local/lib/libclang.so.16"`

The second case fails because we need a different ROOTFS_DIR value for `BuildMonoRuntime` and `BuildMonoCross` targets (we can't build a cross-compiler to cross-compile for arm64 on an x64 host unless we have an x64 crossrootfs for an x64 `mono-aot-cross` binary)