### PR TITLE
[wasm][debugger] Using "rollForwardOnNoCandidateFx": 2 for BrowserDebugHost

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugHost/runtimeconfig.template.json
+++ b/src/mono/wasm/debugger/BrowserDebugHost/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+ {
+   "rollForwardOnNoCandidateFx": 2
+ }


### PR DESCRIPTION
I was able to reproduce the issue and check that this PR fixes the issue.

This is the same configuration used on Blazor.DevServer.
https://github.com/dotnet/aspnetcore/blob/579d547d708eb19f8b05b00f5386649d6dac7b6a/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in#L8C6-L8C32

Fixes: https://github.com/dotnet/runtime/issues/88391
