### PR TITLE
Run NativeAOT tests when ILLink changes

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -346,9 +346,11 @@ extends:
             buildArgs: -s clr.aot+clr.iltools+libs+clr.toolstests -c $(_BuildConfig) -test
             enablePublishTestResults: true
             testResultsFormat: 'xunit'
+            # We want to run AOT tests when illink changes because there's share code and tests from illink which are used by AOT
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
       # Build Mono AOT offset headers once, for consumption elsewhere

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
@@ -86,7 +86,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			Type[] arr = new Type[] { typeof (TestType), typeof (TProperties), typeAll };
 			arr[0].RequiresAll ();
 			arr[1].RequiresPublicProperties ();
-			arr[1].RequiresPublicFields (); // Should warn
+			arr[1].RequiresPublicFields (); // Should warn - member types mismatch
 			arr[2].RequiresAll ();
 			arr[3].RequiresPublicMethods (); // Should warn - unknown value at this index
 		}


### PR DESCRIPTION
NativeAOT uses code from ILLinker - specifically we share lot of tests. So if these change we want to make sure it didn't break their usage in NativeAOT.

The comment change in the tests is to trigger this new rule in the CI - but we can keep the comment regardless.

This was found by https://github.com/dotnet/runtime/pull/88678 which broke NativeAOT (https://github.com/dotnet/runtime/issues/88922) because the CI for https://github.com/dotnet/runtime/pull/88678 didn't run NativeAOT tests.