### PR TITLE
Fix SelectLocalIndirTransform to take offset into account

### DIFF
--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1133,7 +1133,7 @@ private:
             }
 #endif // FEATURE_HW_INTRINSICS
 
-            if (!isDef)
+            if ((!isDef) && (offset == 0))
             {
                 if (varTypeIsIntegral(indir) && varTypeIsIntegral(varDsc))
                 {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_88950/Runtime_88950.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_88950/Runtime_88950.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_88950
+{
+    internal readonly struct Example
+    {
+        public readonly object? Value;
+        public readonly ulong Inner;
+
+        struct ExampleInner
+        {
+            public int Offset;
+            public int Length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Example(object? value, int offset, int length)
+        {
+            var inner = new ExampleInner
+            {
+                Offset = offset,
+                Length = length
+            };
+
+            Value = value;
+            Inner = Unsafe.As<ExampleInner, ulong>(ref inner);
+        }
+        public int Offset
+        {
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+            get
+            {
+                var inner = Inner;
+                return Unsafe.As<ulong, ExampleInner>(ref inner).Offset;
+            }
+        }
+
+        public int Length
+        {
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+            get
+            {
+                ulong inner = Inner;
+                return Unsafe.As<ulong, ExampleInner>(ref inner).Length;
+            }
+        }
+    }
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        var repro = new Example(new object(), 1234, 5678);
+        if (repro.Offset != 1234)
+        {
+            Console.WriteLine($"Offset: {repro.Offset}");
+            return 1;
+        }
+        if (repro.Length != 5678)
+        {
+            Console.WriteLine($"Length: {repro.Length}");
+            return 2;
+        }
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_88950/Runtime_88950.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_88950/Runtime_88950.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/88950

We used to recognize "NarrowCast" for this tree:
```
[000007] -----------                         *  RETURN    int
[000006] n----------                         \--*  IND       int
[000005] -----------                            \--*  FIELD_ADDR byref  Example+ExampleInner:Length
[000004] -----------                               \--*  LCL_ADDR  byref  V01 loc0         [+0]
```
and then converted it to:
```
[000007] -----------                         *  RETURN    int
[000008] -----------                         \--*  CAST      int <- long
[000005] -----------                            \--*  LCL_VAR   long   V01 loc0
```
which is not correct because the offset of `Length` field is not 0. Presumably, introduced in https://github.com/dotnet/runtime/pull/81454 so net8.0 only