### PR TITLE
Improve StringValues, StringSegment and IChangeToken debugging

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/src/CancellationChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/CancellationChangeToken.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.Extensions.Internal;
 
@@ -10,6 +11,7 @@ namespace Microsoft.Extensions.Primitives
     /// <summary>
     /// A <see cref="IChangeToken"/> implementation using <see cref="CancellationToken"/>.
     /// </summary>
+    [DebuggerDisplay("HasChanged = {HasChanged}")]
     public class CancellationChangeToken : IChangeToken
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Primitives/src/CompositeChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/CompositeChangeToken.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.Primitives
     /// <summary>
     /// An <see cref="IChangeToken"/> which represents one or more <see cref="IChangeToken"/> instances.
     /// </summary>
+    [DebuggerDisplay("HasChanged = {HasChanged}")]
     public class CompositeChangeToken : IChangeToken
     {
         private static readonly Action<object?> _onChangeDelegate = OnChange;

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.Primitives
     /// <summary>
     /// An optimized representation of a substring.
     /// </summary>
+    [DebuggerDisplay("{Value}")]
     public readonly struct StringSegment : IEquatable<StringSegment>, IEquatable<string?>
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Extensions.Primitives
     /// <summary>
     /// Represents zero/null, one, or many strings in an efficient way.
     /// </summary>
+    [DebuggerDisplay("{ToString()}")]
+    [DebuggerTypeProxy(typeof(StringValuesDebugView))]
     public readonly struct StringValues : IList<string?>, IReadOnlyList<string?>, IEquatable<StringValues>, IEquatable<string?>, IEquatable<string?[]?>
     {
         /// <summary>
@@ -824,6 +826,12 @@ namespace Microsoft.Extensions.Primitives
             public void Dispose()
             {
             }
+        }
+
+        private sealed class StringValuesDebugView(StringValues values)
+        {
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public string?[] Items => values.ToArray();
         }
     }
 }


### PR DESCRIPTION
## StringValues

Before:

![image](https://github.com/dotnet/runtime/assets/303201/84a8ae87-03ff-41a5-a1f4-22da41901218)

After:

![image](https://github.com/dotnet/runtime/assets/303201/201969a8-d0d7-48bd-a576-b8780724a724)

## StringSegment

Before:

![image](https://github.com/dotnet/runtime/assets/303201/169cf5b2-e1ef-4b25-873b-aa8f4f4baf05)

After:

![image](https://github.com/dotnet/runtime/assets/303201/7072093f-a3fd-4f17-89cd-b372c27b8f07)