### PR TITLE
add SendTo/ReceiveFrom with SocketAddress

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Socket.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Socket.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Net;
-using System.Net.Internals;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 
@@ -11,7 +10,11 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
+#if SYSTEM_NET_SOCKETS_DLL
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_Socket")]
         internal static unsafe partial Error Socket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, IntPtr* socket);
+#endif
+        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_Socket")]
+        internal static unsafe partial Error Socket(int addressFamily, int socketType, int protocolType, IntPtr* socket);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Socket.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Socket.cs
@@ -10,10 +10,6 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-#if SYSTEM_NET_SOCKETS_DLL
-        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_Socket")]
-        internal static unsafe partial Error Socket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, IntPtr* socket);
-#endif
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_Socket")]
         internal static unsafe partial Error Socket(int addressFamily, int socketType, int protocolType, IntPtr* socket);
     }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
@@ -9,9 +9,9 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPSocketAddressSizes")]
+        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSocketAddressSizes")]
         [SuppressGCTransition]
-        internal static unsafe partial Error GetIPSocketAddressSizes(int* ipv4SocketAddressSize, int* ipv6SocketAddressSize);
+        internal static partial Error GetSocketAddressSizes(ref int ipv4SocketAddressSize, ref int ipv6SocketAddressSize, ref int udsSocketAddressSize, ref int maxSocketAddressSize);
 
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetAddressFamily")]
         [SuppressGCTransition]

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSocketAddressSizes")]
         [SuppressGCTransition]
-        internal static partial Error GetSocketAddressSizes(ref int ipv4SocketAddressSize, ref int ipv6SocketAddressSize, ref int udsSocketAddressSize, ref int maxSocketAddressSize);
+        internal static unsafe partial Error GetSocketAddressSizes(int* ipv4SocketAddressSize, int* ipv6SocketAddressSize, int* udsSocketAddressSize, int* maxSocketAddressSize);
 
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetAddressFamily")]
         [SuppressGCTransition]

--- a/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.ICMP.cs
+++ b/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.ICMP.cs
@@ -104,6 +104,6 @@ internal static partial class Interop
 
         [LibraryImport(Interop.Libraries.IpHlpApi, SetLastError = true)]
         internal static unsafe partial uint Icmp6SendEcho2(SafeCloseIcmpHandle icmpHandle, SafeWaitHandle Event, IntPtr apcRoutine, IntPtr apcContext,
-            byte* sourceSocketAddress, byte[] destSocketAddress, SafeLocalAllocHandle data, ushort dataSize, ref IP_OPTION_INFORMATION options, SafeLocalAllocHandle replyBuffer, uint replySize, uint timeout);
+            Span<byte> sourceSocketAddress, Span<byte> destSocketAddress, SafeLocalAllocHandle data, ushort dataSize, ref IP_OPTION_INFORMATION options, SafeLocalAllocHandle replyBuffer, uint replySize, uint timeout);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.NetworkInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.NetworkInformation.cs
@@ -64,7 +64,7 @@ internal static partial class Interop
                 AddressFamily family = (addressLength > Internals.SocketAddress.IPv4AddressSize)
                     ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork;
                 Internals.SocketAddress sockAddress = new Internals.SocketAddress(family, addressLength);
-                Marshal.Copy(address, sockAddress.Buffer, 0, addressLength);
+                Marshal.Copy(address, sockAddress.InternalBuffer, 0, addressLength);
 
                 return sockAddress.GetIPAddress();
             }

--- a/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.NetworkInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.NetworkInformation.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
-using Internals = System.Net.Internals;
 
 internal static partial class Interop
 {
@@ -53,20 +52,14 @@ internal static partial class Interop
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal struct IpSocketAddress
+        internal unsafe struct IpSocketAddress
         {
             internal IntPtr address;
             internal int addressLength;
 
             internal IPAddress MarshalIPAddress()
             {
-                // Determine the address family used to create the IPAddress.
-                AddressFamily family = (addressLength > Internals.SocketAddress.IPv4AddressSize)
-                    ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork;
-                Internals.SocketAddress sockAddress = new Internals.SocketAddress(family, addressLength);
-                Marshal.Copy(address, sockAddress.InternalBuffer, 0, addressLength);
-
-                return sockAddress.GetIPAddress();
+                return IPEndPointExtensions.GetIPAddress(new Span<byte>((void*)address, addressLength));
             }
         }
 
@@ -511,7 +504,7 @@ internal static partial class Interop
             uint* outBufLen);
 
         [LibraryImport(Interop.Libraries.IpHlpApi)]
-        internal static unsafe partial uint GetBestInterfaceEx(byte* ipAddress, int* index);
+        internal static unsafe partial uint GetBestInterfaceEx(Span<byte> ipAddress, int* index);
 
         [LibraryImport(Interop.Libraries.IpHlpApi)]
         internal static partial uint GetIfEntry2(ref MibIfRow2 pIfRow);

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSAConnect.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSAConnect.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         [LibraryImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static partial SocketError WSAConnect(
             SafeSocketHandle socketHandle,
-            byte[] socketAddress,
+            Span<byte> socketAddress,
             int socketAddressSize,
             IntPtr inBuffer,
             IntPtr outBuffer,

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSAConnect.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSAConnect.cs
@@ -10,13 +10,22 @@ internal static partial class Interop
     internal static partial class Winsock
     {
         [LibraryImport(Interop.Libraries.Ws2_32, SetLastError = true)]
-        internal static partial SocketError WSAConnect(
+        private static partial SocketError WSAConnect(
             SafeSocketHandle socketHandle,
-            Span<byte> socketAddress,
+            ReadOnlySpan<byte> socketAddress,
             int socketAddressSize,
             IntPtr inBuffer,
             IntPtr outBuffer,
             IntPtr sQOS,
             IntPtr gQOS);
+
+        internal static SocketError WSAConnect(
+            SafeSocketHandle socketHandle,
+            ReadOnlySpan<byte> socketAddress,
+            IntPtr inBuffer,
+            IntPtr outBuffer,
+            IntPtr sQOS,
+            IntPtr gQOS) =>
+            WSAConnect(socketHandle, socketAddress, socketAddress.Length, inBuffer, outBuffer, sQOS, gQOS);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.accept.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.accept.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         [LibraryImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static partial IntPtr accept(
             SafeSocketHandle socketHandle,
-            byte[] socketAddress,
+            Span<byte> socketAddress,
             ref int socketAddressSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.recvfrom.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.recvfrom.cs
@@ -13,10 +13,10 @@ internal static partial class Interop
         [LibraryImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static unsafe partial int recvfrom(
             SafeSocketHandle socketHandle,
-            byte* pinnedBuffer,
+            Span<byte> pinnedBuffer,
             int len,
             SocketFlags socketFlags,
-            byte[] socketAddress,
+            Span<byte> socketAddress,
             ref int socketAddressSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.sendto.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.sendto.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
             byte* pinnedBuffer,
             int len,
             SocketFlags socketFlags,
-            byte[] socketAddress,
+            ReadOnlySpan<byte> socketAddress,
             int socketAddressSize);
     }
 }

--- a/src/libraries/Common/src/System/Net/IPEndPointExtensions.cs
+++ b/src/libraries/Common/src/System/Net/IPEndPointExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Net;
 
 namespace System.Net.Sockets

--- a/src/libraries/Common/src/System/Net/IPEndPointExtensions.cs
+++ b/src/libraries/Common/src/System/Net/IPEndPointExtensions.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+
+namespace System.Net.Sockets
+{
+    internal static class IPEndPointExtensions
+    {
+        public static IPAddress GetIPAddress(ReadOnlySpan<byte> socketAddressBuffer)
+        {
+            if (SocketAddressPal.GetAddressFamily(socketAddressBuffer) == AddressFamily.InterNetworkV6)
+            {
+                Span<byte> address = stackalloc byte[IPAddressParserStatics.IPv6AddressBytes];
+                uint scope;
+                SocketAddressPal.GetIPv6Address(socketAddressBuffer, address, out scope);
+                return new IPAddress(address, (long)scope);
+            }
+
+            return new IPAddress((long)SocketAddressPal.GetIPv4Address(socketAddressBuffer) & 0x0FFFFFFFF);
+        }
+
+        public static void SetIPAddress(Span<byte> socketAddressBuffer, IPAddress address)
+        {
+            SocketAddressPal.SetAddressFamily(socketAddressBuffer, address.AddressFamily);
+            SocketAddressPal.SetPort(socketAddressBuffer, 0);
+            if (address.AddressFamily == AddressFamily.InterNetwork)
+            {
+#pragma warning disable CS0618
+                SocketAddressPal.SetIPv4Address(socketAddressBuffer, (uint)address.Address);
+#pragma warning restore CS0618
+            }
+            else
+            {
+                Span<byte> addressBuffer = stackalloc byte[IPAddressParserStatics.IPv6AddressBytes];
+                address.TryWriteBytes(addressBuffer, out _);
+                SocketAddressPal.SetIPv6Address(socketAddressBuffer, addressBuffer, (uint)address.ScopeId);
+            }
+        }
+
+        public static IPEndPoint CreateIPEndPoint(ReadOnlySpan<byte> socketAddressBuffer)
+        {
+           return new IPEndPoint(GetIPAddress(socketAddressBuffer), SocketAddressPal.GetPort(socketAddressBuffer));
+        }
+
+        // https://github.com/dotnet/runtime/issues/78993
+        public static void Serialize(this IPEndPoint endPoint, Span<byte> destination)
+        {
+            SocketAddressPal.SetAddressFamily(destination, endPoint.AddressFamily);
+            SetIPAddress(destination, endPoint.Address);
+            SocketAddressPal.SetPort(destination, (ushort)endPoint.Port);
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -53,6 +53,7 @@ namespace System.Net.Internals
             set
             {
                 ArgumentOutOfRangeException.ThrowIfGreaterThan(value, Buffer.Length);
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, MinSize);
                 InternalSize = value;
             }
         }
@@ -145,6 +146,10 @@ namespace System.Net.Internals
             SocketAddressPal.SetAddressFamily(Buffer, addressFamily);
         }
 
+        /// <summary>This represents underlying memory that can be passed to native OS calls.</summary>
+        /// <remarks>
+        /// This memory can be invalidated if <see cref="Size"/> is changed or if the SocketAddress is used in another receive call.
+        /// </remarks>
         public Memory<byte> SocketBuffer
         {
             get

--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -65,7 +65,7 @@ namespace System.Net.Internals
         {
             get
             {
-                if (offset < 0 || offset >= Size)
+                if ((uint)offset >= (uint)Size)
                 {
                     throw new IndexOutOfRangeException();
                 }
@@ -73,7 +73,7 @@ namespace System.Net.Internals
             }
             set
             {
-                if (offset < 0 || offset >= Size)
+                if ((uint)offset >= (uint)Size)
                 {
                     throw new IndexOutOfRangeException();
                 }
@@ -152,7 +152,7 @@ namespace System.Net.Internals
 
         /// <summary>This represents underlying memory that can be passed to native OS calls.</summary>
         /// <remarks>
-        /// This memory can be invalidated if <see cref="Size"/> is changed or if the SocketAddress is used in another receive call.
+        /// Content of the memory can be invalidated if <see cref="Size"/> is changed or if the SocketAddress is used in another receive call.
         /// </remarks>
         public Memory<byte> Buffer
         {
@@ -223,7 +223,7 @@ namespace System.Net.Internals
         public override int GetHashCode()
         {
             HashCode hash = default;
-            hash.AddBytes(Buffer.Span);
+            hash.AddBytes(new ReadOnlySpan<byte>(InternalBuffer, 0, InternalSize));
             return hash.ToHashCode();
         }
 

--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -101,6 +101,7 @@ namespace System.Net.Internals
             size = (size + IntPtr.Size -  1) / IntPtr.Size * IntPtr.Size + IntPtr.Size;
 #endif
             Buffer = new byte[size];
+            Buffer[0] = (byte)InternalSize;
 
             SocketAddressPal.SetAddressFamily(Buffer, family);
         }

--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -111,6 +111,7 @@ namespace System.Net.Internals
             : this(ipAddress.AddressFamily,
                 ((ipAddress.AddressFamily == AddressFamily.InterNetwork) ? IPv4AddressSize : IPv6AddressSize))
         {
+
             // No Port.
             SocketAddressPal.SetPort(InternalBuffer, 0);
 
@@ -142,7 +143,7 @@ namespace System.Net.Internals
         internal SocketAddress(AddressFamily addressFamily, ReadOnlySpan<byte> buffer)
         {
             InternalBuffer = buffer.ToArray();
-            InternalSize = Buffer.Length;
+            InternalSize = InternalBuffer.Length;
             SocketAddressPal.SetAddressFamily(InternalBuffer, addressFamily);
         }
 

--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -50,6 +50,11 @@ namespace System.Net.Internals
             {
                 return InternalSize;
             }
+            set
+            {
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, Buffer.Length);
+                InternalSize = value;
+            }
         }
 
         // Access to unmanaged serialized data. This doesn't
@@ -137,6 +142,14 @@ namespace System.Net.Internals
             Buffer = buffer.ToArray();
             InternalSize = Buffer.Length;
             SocketAddressPal.SetAddressFamily(Buffer, addressFamily);
+        }
+
+        public Memory<byte> SocketBuffer
+        {
+            get
+            {
+                return new Memory<byte>(Buffer, 0, InternalSize);
+            }
         }
 
         internal IPAddress GetIPAddress()

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -11,16 +11,30 @@ namespace System.Net
 {
     internal static class SocketAddressPal
     {
-        public static readonly int IPv6AddressSize;
         public static readonly int IPv4AddressSize;
+        public static readonly int IPv6AddressSize;
         public static readonly int UdsAddressSize;
         public static readonly int MaxAddressSize;
 
-        static SocketAddressPal()
+#pragma warning disable CA1810
+        static unsafe SocketAddressPal()
         {
-            Interop.Error err = Interop.Sys.GetSocketAddressSizes(ref IPv4AddressSize, ref IPv6AddressSize, ref UdsAddressSize, ref MaxAddressSize);
+            int ipv4 = 0;
+            int ipv6 = 0;
+            int uds = 0;
+            int max = 0;
+            Interop.Error err = Interop.Sys.GetSocketAddressSizes(&ipv4, &ipv6, &uds, &max);
             Debug.Assert(err == Interop.Error.SUCCESS, $"Unexpected err: {err}");
+            Debug.Assert(ipv4 > 0);
+            Debug.Assert(ipv6 > 0);
+            Debug.Assert(uds > 0);
+            Debug.Assert(max >= ipv4 && max >= ipv6 && max >= uds);
+            IPv4AddressSize = ipv4;
+            IPv6AddressSize =ipv6;
+            UdsAddressSize = uds;
+            MaxAddressSize =max;
         }
+#pragma warning restore CA1810
 
         private static void ThrowOnFailure(Interop.Error err)
         {

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -177,7 +177,8 @@ namespace System.Net
         {
             AddressFamily family = GetAddressFamily(buffer);
             buffer.Clear();
-            buffer[0] = (byte)buffer.Length;
+            // platforms where this matters (OSXLike & BSD) use uint8 for SA length
+            buffer[0] = (byte)Math.Min(buffer.Length, 255);
             SetAddressFamily(buffer, family);
         }
     }

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -30,9 +30,9 @@ namespace System.Net
             Debug.Assert(uds > 0);
             Debug.Assert(max >= ipv4 && max >= ipv6 && max >= uds);
             IPv4AddressSize = ipv4;
-            IPv6AddressSize =ipv6;
+            IPv6AddressSize = ipv6;
             UdsAddressSize = uds;
-            MaxAddressSize =max;
+            MaxAddressSize = max;
         }
 #pragma warning restore CA1810
 

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -13,8 +13,6 @@ namespace System.Net
     {
         public static readonly int IPv6AddressSize = GetIPv6AddressSize();
         public static readonly int IPv4AddressSize = GetIPv4AddressSize();
-        //public static readonly int IPv4AddressSize = GetUdsAddressSize();
-        //public static readonly int IPv4AddressSize = GetMaxAddressSize();
 
         private static unsafe int GetIPv6AddressSize()
         {
@@ -66,7 +64,7 @@ namespace System.Net
             return family;
         }
 
-        public static unsafe void SetAddressFamily(byte[] buffer, AddressFamily family)
+        public static unsafe void SetAddressFamily(Span<byte> buffer, AddressFamily family)
         {
             Interop.Error err;
 
@@ -166,6 +164,14 @@ namespace System.Net
             }
 
             ThrowOnFailure(err);
+        }
+
+        public static unsafe void Clear(Span<byte> buffer)
+        {
+            AddressFamily family = GetAddressFamily(buffer);
+            buffer.Clear();
+            buffer[0] = (byte)buffer.Length;
+            SetAddressFamily(buffer, family);
         }
     }
 }

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -13,6 +13,8 @@ namespace System.Net
     {
         public static readonly int IPv6AddressSize = GetIPv6AddressSize();
         public static readonly int IPv4AddressSize = GetIPv4AddressSize();
+        //public static readonly int IPv4AddressSize = GetUdsAddressSize();
+        //public static readonly int IPv4AddressSize = GetMaxAddressSize();
 
         private static unsafe int GetIPv6AddressSize()
         {

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -11,23 +11,15 @@ namespace System.Net
 {
     internal static class SocketAddressPal
     {
-        public static readonly int IPv6AddressSize = GetIPv6AddressSize();
-        public static readonly int IPv4AddressSize = GetIPv4AddressSize();
+        public static readonly int IPv6AddressSize;
+        public static readonly int IPv4AddressSize;
+        public static readonly int UdsAddressSize;
+        public static readonly int MaxAddressSize;
 
-        private static unsafe int GetIPv6AddressSize()
+        static SocketAddressPal()
         {
-            int ipv6AddressSize, unused;
-            Interop.Error err = Interop.Sys.GetIPSocketAddressSizes(&unused, &ipv6AddressSize);
+            Interop.Error err = Interop.Sys.GetSocketAddressSizes(ref IPv4AddressSize, ref IPv6AddressSize, ref UdsAddressSize, ref MaxAddressSize);
             Debug.Assert(err == Interop.Error.SUCCESS, $"Unexpected err: {err}");
-            return ipv6AddressSize;
-        }
-
-        private static unsafe int GetIPv4AddressSize()
-        {
-            int ipv4AddressSize, unused;
-            Interop.Error err = Interop.Sys.GetIPSocketAddressSizes(&ipv4AddressSize, &unused);
-            Debug.Assert(err == Interop.Error.SUCCESS, $"Unexpected err: {err}");
-            return ipv4AddressSize;
         }
 
         private static void ThrowOnFailure(Interop.Error err)

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Unix.cs
@@ -92,7 +92,7 @@ namespace System.Net
             return port;
         }
 
-        public static unsafe void SetPort(byte[] buffer, ushort port)
+        public static unsafe void SetPort(Span<byte> buffer, ushort port)
         {
             Interop.Error err;
             fixed (byte* rawAddress = buffer)
@@ -130,7 +130,7 @@ namespace System.Net
             scope = localScope;
         }
 
-        public static unsafe void SetIPv4Address(byte[] buffer, uint address)
+        public static unsafe void SetIPv4Address(Span<byte> buffer, uint address)
         {
             Interop.Error err;
             fixed (byte* rawAddress = buffer)
@@ -141,21 +141,22 @@ namespace System.Net
             ThrowOnFailure(err);
         }
 
-        public static unsafe void SetIPv4Address(byte[] buffer, byte* address)
+        public static unsafe void SetIPv4Address(Span<byte> buffer, byte* address)
         {
             uint addr = (uint)System.Runtime.InteropServices.Marshal.ReadInt32((IntPtr)address);
             SetIPv4Address(buffer, addr);
         }
 
-        public static unsafe void SetIPv6Address(byte[] buffer, Span<byte> address, uint scope)
+        public static unsafe void SetIPv6Address(Span<byte> buffer, Span<byte> address, uint scope)
         {
+
             fixed (byte* rawInput = &MemoryMarshal.GetReference(address))
             {
                 SetIPv6Address(buffer, rawInput, address.Length, scope);
             }
         }
 
-        public static unsafe void SetIPv6Address(byte[] buffer, byte* address, int addressLength, uint scope)
+        public static unsafe void SetIPv6Address(Span<byte> buffer, byte* address, int addressLength, uint scope)
         {
             Interop.Error err;
             fixed (byte* rawAddress = buffer)

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -36,8 +36,8 @@ namespace System.Net
         public static ushort GetPort(ReadOnlySpan<byte> buffer)
             => BinaryPrimitives.ReadUInt16BigEndian(buffer.Slice(2));
 
-        public static void SetPort(byte[] buffer, ushort port)
-            => BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(2), port);
+        public static void SetPort(Span<byte> buffer, ushort port)
+            => BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(2), port);
 
         public static uint GetIPv4Address(ReadOnlySpan<byte> buffer)
             => BinaryPrimitives.ReadUInt32LittleEndian(buffer.Slice(4));
@@ -49,22 +49,22 @@ namespace System.Net
             scope = BinaryPrimitives.ReadUInt32LittleEndian(buffer.Slice(24));
         }
 
-        public static void SetIPv4Address(byte[] buffer, uint address)
+        public static void SetIPv4Address(Span<byte> buffer, uint address)
         {
             // IPv4 Address serialization
-            BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(4), address);
+            BinaryPrimitives.WriteUInt32LittleEndian(buffer.Slice(4), address);
         }
 
-        public static void SetIPv6Address(byte[] buffer, Span<byte> address, uint scope)
+        public static void SetIPv6Address(Span<byte> buffer, Span<byte> address, uint scope)
         {
             // No handling for Flow Information
-            BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(4), 0);
+            BinaryPrimitives.WriteUInt32LittleEndian(buffer.Slice(4), 0);
 
             // Scope serialization
-            BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(24), scope);
+            BinaryPrimitives.WriteUInt32LittleEndian(buffer.Slice(24), scope);
 
             // Address serialization
-            address.CopyTo(buffer.AsSpan(8));
+            address.CopyTo(buffer.Slice(8));
         }
 
         public static unsafe void Clear(Span<byte> buffer)

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -10,6 +10,8 @@ namespace System.Net
     {
         public const int IPv6AddressSize = 28;
         public const int IPv4AddressSize = 16;
+        public const int UdsAddressSize = 110;
+        public const int MaxAddressSize = 128;
 
         public static AddressFamily GetAddressFamily(ReadOnlySpan<byte> buffer)
         {

--- a/src/libraries/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -10,15 +10,13 @@ namespace System.Net
     {
         public const int IPv6AddressSize = 28;
         public const int IPv4AddressSize = 16;
-        public const int UdsAddressSize = 110;
-        public const int MaxAddressSize = 128;
 
         public static AddressFamily GetAddressFamily(ReadOnlySpan<byte> buffer)
         {
             return (AddressFamily)BitConverter.ToInt16(buffer);
         }
 
-        public static void SetAddressFamily(byte[] buffer, AddressFamily family)
+        public static void SetAddressFamily(Span<byte> buffer, AddressFamily family)
         {
             if ((int)(family) > ushort.MaxValue)
             {
@@ -67,6 +65,13 @@ namespace System.Net
 
             // Address serialization
             address.CopyTo(buffer.AsSpan(8));
+        }
+
+        public static unsafe void Clear(Span<byte> buffer)
+        {
+            AddressFamily family = GetAddressFamily(buffer);
+            buffer.Clear();
+            SetAddressFamily(buffer, family);
         }
     }
 }

--- a/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Internals;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 
@@ -21,7 +20,11 @@ namespace System.Net
             IntPtr socket = invalid;
             try
             {
+#if SYSTEM_NET_SOCKETS_DLL
                 Interop.Error result = Interop.Sys.Socket(af, SocketType.Dgram, 0, &socket);
+#else
+                Interop.Error result = Interop.Sys.Socket((int)af, (int)Internals.SocketType.Dgram, 0, &socket);
+#endif
                 // we get EAFNOSUPPORT when family is not supported by Kernel, EPROTONOSUPPORT may come from policy enforcement like FreeBSD jail()
                 return result != Interop.Error.EAFNOSUPPORT && result != Interop.Error.EPROTONOSUPPORT;
             }

--- a/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
@@ -8,6 +8,7 @@ namespace System.Net
 {
     internal static partial class SocketProtocolSupportPal
     {
+        private const int DgramSocketType = 2;
         private static unsafe bool IsSupported(AddressFamily af)
         {
             // Check for AF_UNIX on iOS/tvOS. The OS claims to support this, but returns EPERM on bind.
@@ -20,11 +21,7 @@ namespace System.Net
             IntPtr socket = invalid;
             try
             {
-#if SYSTEM_NET_SOCKETS_DLL
-                Interop.Error result = Interop.Sys.Socket(af, SocketType.Dgram, 0, &socket);
-#else
-                Interop.Error result = Interop.Sys.Socket((int)af, (int)Internals.SocketType.Dgram, 0, &socket);
-#endif
+                Interop.Error result = Interop.Sys.Socket((int)af, DgramSocketType, 0, &socket);
                 // we get EAFNOSUPPORT when family is not supported by Kernel, EPROTONOSUPPORT may come from policy enforcement like FreeBSD jail()
                 return result != Interop.Error.EAFNOSUPPORT && result != Interop.Error.EPROTONOSUPPORT;
             }

--- a/src/libraries/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
+++ b/src/libraries/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
@@ -19,9 +19,9 @@
     <Compile Include="Fakes\IPAddressFakeExtensions.cs" />
     <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs"
              Link="Common\System\Net\Logging\NetEventSource.cs" />
-    <Compile Include="$(CommonPath)System\Net\Sockets\ProtocolType.cs" Condition="'$(TargetPlatformIdentifier)' == 'windows'"
+    <Compile Include="$(CommonPath)System\Net\Sockets\ProtocolType.cs"
              Link="Common\System\Net\Sockets\ProtocolType.cs" />
-    <Compile Include="$(CommonPath)System\Net\Sockets\SocketType.cs" Condition="'$(TargetPlatformIdentifier)' == 'windows'"
+    <Compile Include="$(CommonPath)System\Net\Sockets\SocketType.cs"
              Link="Common\System\Net\Sockets\SocketType.cs" />
     <Compile Include="$(CommonPath)System\Net\Sockets\ProtocolFamily.cs"
               Link="Common\System\Net\Sockets\ProtocolFamily.cs" />

--- a/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -82,7 +82,7 @@
     <Compile Include="System\Net\NetworkInformation\TeredoHelper.cs" />
     <!-- System.Net common -->
     <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs" Link="Common\System\Net\IPAddressParserStatics.cs" />
-    <Compile Include="$(CommonPath)System\Net\SocketAddress.cs" Link="Common\System\Net\SocketAddress.cs" />
+    <Compile Include="$(CommonPath)System\Net\IPEndPointExtensions.cs" Link="Common\System\Net\IPEndPointExtensions.cs" />
     <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs" Link="Common\System\Net\SocketAddressPal.Windows.cs" />
     <Compile Include="$(CommonPath)System\Net\NetworkInformation\StartIPOptions.cs" Link="Common\System\Net\NetworkInformation\StartIPOptions.cs" />
     <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Windows.cs" Link="Common\System\Net\NetworkInformation\HostInformationPal.Windows.cs" />

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
@@ -44,14 +44,13 @@ namespace System.Net.NetworkInformation
         private static unsafe int GetBestInterfaceForAddress(IPAddress addr)
         {
             int index;
-            Internals.SocketAddress address = new Internals.SocketAddress(addr);
-            fixed (byte* buffer = address.InternalBuffer)
+            Span<byte> buffer= stackalloc byte[SocketAddressPal.IPv6AddressSize];
+            IPEndPointExtensions.SetIPAddress(buffer, addr);
+
+            int error = (int)Interop.IpHlpApi.GetBestInterfaceEx(buffer, &index);
+            if (error != 0)
             {
-                int error = (int)Interop.IpHlpApi.GetBestInterfaceEx(buffer, &index);
-                if (error != 0)
-                {
-                    throw new NetworkInformationException(error);
-                }
+                throw new NetworkInformationException(error);
             }
 
             return index;

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
@@ -45,7 +45,7 @@ namespace System.Net.NetworkInformation
         {
             int index;
             Internals.SocketAddress address = new Internals.SocketAddress(addr);
-            fixed (byte* buffer = address.Buffer)
+            fixed (byte* buffer = address.InternalBuffer)
             {
                 int error = (int)Interop.IpHlpApi.GetBestInterfaceEx(buffer, &index);
                 if (error != 0)

--- a/src/libraries/System.Net.Ping/src/System.Net.Ping.csproj
+++ b/src/libraries/System.Net.Ping/src/System.Net.Ping.csproj
@@ -24,17 +24,14 @@
     <!-- System.Net Common -->
     <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs"
              Link="Common\System\Net\IPAddressParserStatics.cs" />
-    <Compile Include="$(CommonPath)System\Net\SocketAddress.cs"
-             Link="Common\System\Net\SocketAddress.cs" />
     <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.cs"
              Link="Common\System\Net\SocketProtocolSupportPal.cs" />
     <Compile Include="$(CommonPath)System\Net\InternalException.cs"
              Link="Common\System\Net\InternalException.cs" />
-    <!-- System.Net.Internals -->
-    <Compile Include="$(CommonPath)System\Net\Internals\IPAddressExtensions.cs"
-             Link="Common\System\Net\Internals\IPAddressExtensions.cs" />
-    <Compile Include="$(CommonPath)System\Net\Internals\IPEndPointExtensions.cs"
-             Link="Common\System\Net\Internals\IPEndPointExtensions.cs" />
+    <Compile Include="$(CommonPath)System\Net\IPEndPointExtensions.cs"
+             Link="Common\System\Net\IPEndPointExtensions.cs" />
+    <Compile Include="$(CommonPath)System\Net\Sockets\SocketType.cs"
+             Link="Common\System\Net\Sockets\SocketType.cs" />
   </ItemGroup>
   <ItemGroup Condition="('$(TargetPlatformIdentifier)' != '' and '$(TargetPlatformIdentifier)' != 'windows')">
     <Compile Include="System\Net\NetworkInformation\IcmpV4MessageConstants.cs" />
@@ -96,9 +93,6 @@
              Link="Common\Interop\Windows\WinSock\Interop.WSAStartup.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs"
              Link="Common\Interop\Windows\WinSock\Interop.SocketConstructorFlags.cs" />
-    <!-- System.Net.Internals -->
-    <Compile Include="$(CommonPath)System\Net\Sockets\SocketType.cs"
-             Link="Common\System\Net\Sockets\SocketType.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
@@ -194,7 +194,7 @@ namespace System.Net.NetworkInformation
                 IntPtr.Zero,
                 IntPtr.Zero,
                 sourceAddr,
-                remoteAddr.Buffer,
+                remoteAddr.InternalBuffer,
                 _requestBuffer!,
                 (ushort)buffer.Length,
                 ref ipOptions,

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
@@ -183,10 +183,11 @@ namespace System.Net.NetworkInformation
                     (uint)timeout);
             }
 
-            IPEndPoint ep = new IPEndPoint(address, 0);
-            Internals.SocketAddress remoteAddr = IPEndPointExtensions.Serialize(ep);
-            byte* sourceAddr = stackalloc byte[28];
-            NativeMemory.Clear(sourceAddr, 28);
+            Span<byte> remoteAddr = stackalloc byte[SocketAddressPal.IPv6AddressSize];
+            IPEndPointExtensions.SetIPAddress(remoteAddr, address);
+
+            Span<byte> sourceAddr = stackalloc byte[SocketAddressPal.IPv6AddressSize];
+            sourceAddr.Clear();
 
             return (int)Interop.IpHlpApi.Icmp6SendEcho2(
                 _handlePingV6!,
@@ -194,7 +195,7 @@ namespace System.Net.NetworkInformation
                 IntPtr.Zero,
                 IntPtr.Zero,
                 sourceAddr,
-                remoteAddr.InternalBuffer,
+                remoteAddr,
                 _requestBuffer!,
                 (ushort)buffer.Length,
                 ref ipOptions,

--- a/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -356,7 +356,7 @@ namespace System.Net
         public System.Net.Sockets.AddressFamily Family { get { throw null; } }
         public byte this[int offset] { get { throw null; } set { } }
         public int Size { get { throw null; } set { } }
-        public System.Memory<byte> SocketBuffer { get { throw null; } }
+        public System.Memory<byte> Buffer { get { throw null; } }
         public override bool Equals(object? comparand) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }

--- a/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -349,15 +349,17 @@ namespace System.Net
         public System.Net.NetworkCredential GetCredential(string? host, int port, string? authenticationType) { throw null; }
         public System.Net.NetworkCredential GetCredential(System.Uri? uri, string? authenticationType) { throw null; }
     }
-    public partial class SocketAddress
+    public partial class SocketAddress : System.IEquatable<System.Net.SocketAddress>
     {
         public SocketAddress(System.Net.Sockets.AddressFamily family) { }
         public SocketAddress(System.Net.Sockets.AddressFamily family, int size) { }
         public System.Net.Sockets.AddressFamily Family { get { throw null; } }
         public byte this[int offset] { get { throw null; } set { } }
         public int Size { get { throw null; } set { } }
+        public static int GetMaximumAddressSize(System.Net.Sockets.AddressFamily addressFamily) { throw null; }
         public System.Memory<byte> Buffer { get { throw null; } }
         public override bool Equals(object? comparand) { throw null; }
+        public bool Equals(System.Net.SocketAddress? comparand) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
     }

--- a/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -355,7 +355,8 @@ namespace System.Net
         public SocketAddress(System.Net.Sockets.AddressFamily family, int size) { }
         public System.Net.Sockets.AddressFamily Family { get { throw null; } }
         public byte this[int offset] { get { throw null; } set { } }
-        public int Size { get { throw null; } }
+        public int Size { get { throw null; } set { } }
+        public System.Memory<byte> SocketBuffer { get { throw null; } }
         public override bool Equals(object? comparand) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -31,6 +31,28 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => new SocketAddress(AddressFamily.InterNetwork, 1)); //Size < MinSize (32)
         }
 
+        [Theory]
+        [InlineData(AddressFamily.InterNetwork)]
+        [InlineData(AddressFamily.InterNetworkV6)]
+        [InlineData(AddressFamily.Unix)]
+        public static void Ctor_AddressFamilySize_Correct(AddressFamily addressFamily)
+        {
+            SocketAddress sa = new SocketAddress(addressFamily);
+            Assert.Equal(SocketAddress.GetMaximumAddressSize(addressFamily), sa.Size);
+            Assert.Equal(SocketAddress.GetMaximumAddressSize(addressFamily), sa.Buffer.Length);
+            Assert.True(sa.Size <= SocketAddress.GetMaximumAddressSize(AddressFamily.Unknown));
+        }
+
+        [Fact]
+        public static void AddressFamily_Size_Correct()
+        {
+            SocketAddress sa = new SocketAddress(AddressFamily.InterNetwork);
+            Assert.Throws<ArgumentOutOfRangeException>(() => sa.Size = sa.Size + 1);
+
+            sa.Size = 4;
+            Assert.Equal(4, sa.Buffer.Length);
+        }
+
         [Fact]
         public static void Equals_Compare_Success()
         {

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -14,7 +14,7 @@ namespace System.Net.Primitives.Functional.Tests
         {
             SocketAddress sa = new SocketAddress(AddressFamily.InterNetwork);
             Assert.Equal(AddressFamily.InterNetwork, sa.Family);
-            Assert.Equal(32, sa.Size);
+            Assert.Equal(16, sa.Size);
         }
 
         [Fact]

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -28,9 +28,8 @@
     <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs" Link="Common\System\Net\Logging\NetEventSource.Common.cs" />
     <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="Common\System\Net\StreamBuffer.cs" />
-    <Compile Include="$(CommonPath)System\Net\SocketAddress.cs" Link="Common\System\Net\SocketAddress.cs" />
     <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs" Link="Common\System\Net\IPAddressParserStatics.cs" />
-    <Compile Include="$(CommonPath)System\Net\Internals\IPEndPointExtensions.cs" Link="Common\System\Net\Internals\IPEndPointExtensions.cs" />
+    <Compile Include="$(CommonPath)System\Net\IPEndPointExtensions.cs" Link="Common\System\Net\IPEndPointExtensions.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\TlsAlertMessage.cs" Link="Common\System\Net\Security\TlsAlertMessage.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs" Link="Common\System\HexConverter.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\TargetHostNameHelper.cs" Link="Common\System\Net\Security\TargetHostNameHelper.cs" />

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicExtensions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Quic;
 internal unsafe partial struct QUIC_NEW_CONNECTION_INFO
 {
     public override string ToString()
-        => $"{{ {nameof(QuicVersion)} = {QuicVersion}, {nameof(LocalAddress)} = {LocalAddress->ToIPEndPoint()}, {nameof(RemoteAddress)} = {RemoteAddress->ToIPEndPoint()} }}";
+        => $"{{ {nameof(QuicVersion)} = {QuicVersion}, {nameof(LocalAddress)} = {MsQuicHelpers.QuicAddrToIPEndPoint(LocalAddress)}, {nameof(RemoteAddress)} = {MsQuicHelpers.QuicAddrToIPEndPoint(RemoteAddress)} }}";
 }
 
 internal unsafe partial struct QUIC_LISTENER_EVENT
@@ -17,7 +17,7 @@ internal unsafe partial struct QUIC_LISTENER_EVENT
         => Type switch
         {
             QUIC_LISTENER_EVENT_TYPE.NEW_CONNECTION
-                => $"{{ {nameof(NEW_CONNECTION.Info)} = {{ {nameof(QUIC_NEW_CONNECTION_INFO.QuicVersion)} = {NEW_CONNECTION.Info->QuicVersion}, {nameof(QUIC_NEW_CONNECTION_INFO.LocalAddress)} = {NEW_CONNECTION.Info->LocalAddress->ToIPEndPoint()}, {nameof(QUIC_NEW_CONNECTION_INFO.RemoteAddress)} = {NEW_CONNECTION.Info->RemoteAddress->ToIPEndPoint()} }} }}",
+                => $"{{ {nameof(NEW_CONNECTION.Info)} = {{ {nameof(QUIC_NEW_CONNECTION_INFO.QuicVersion)} = {NEW_CONNECTION.Info->QuicVersion}, {nameof(QUIC_NEW_CONNECTION_INFO.LocalAddress)} = {MsQuicHelpers.QuicAddrToIPEndPoint(NEW_CONNECTION.Info->LocalAddress)}, {nameof(QUIC_NEW_CONNECTION_INFO.RemoteAddress)} = {MsQuicHelpers.QuicAddrToIPEndPoint(NEW_CONNECTION.Info->RemoteAddress)} }} }}",
             _ => string.Empty
         };
 }
@@ -36,9 +36,9 @@ internal unsafe partial struct QUIC_CONNECTION_EVENT
             QUIC_CONNECTION_EVENT_TYPE.SHUTDOWN_COMPLETE
                 => $"{{ {nameof(SHUTDOWN_COMPLETE.HandshakeCompleted)} = {SHUTDOWN_COMPLETE.HandshakeCompleted}, {nameof(SHUTDOWN_COMPLETE.PeerAcknowledgedShutdown)} = {SHUTDOWN_COMPLETE.PeerAcknowledgedShutdown}, {nameof(SHUTDOWN_COMPLETE.AppCloseInProgress)} = {SHUTDOWN_COMPLETE.AppCloseInProgress} }}",
             QUIC_CONNECTION_EVENT_TYPE.LOCAL_ADDRESS_CHANGED
-                => $"{{ {nameof(LOCAL_ADDRESS_CHANGED.Address)} = {LOCAL_ADDRESS_CHANGED.Address->ToIPEndPoint()} }}",
+                => $"{{ {nameof(LOCAL_ADDRESS_CHANGED.Address)} = {MsQuicHelpers.QuicAddrToIPEndPoint(LOCAL_ADDRESS_CHANGED.Address)} }}",
             QUIC_CONNECTION_EVENT_TYPE.PEER_ADDRESS_CHANGED
-                => $"{{ {nameof(PEER_ADDRESS_CHANGED.Address)} = {PEER_ADDRESS_CHANGED.Address->ToIPEndPoint()} }}",
+                => $"{{ {nameof(PEER_ADDRESS_CHANGED.Address)} = {MsQuicHelpers.QuicAddrToIPEndPoint(PEER_ADDRESS_CHANGED.Address)} }}",
             QUIC_CONNECTION_EVENT_TYPE.PEER_STREAM_STARTED
                 => $"{{ {nameof(PEER_STREAM_STARTED.Flags)} = {PEER_STREAM_STARTED.Flags} }}",
             QUIC_CONNECTION_EVENT_TYPE.PEER_CERTIFICATE_RECEIVED

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
@@ -38,20 +38,19 @@ internal static class MsQuicHelpers
     internal static unsafe IPEndPoint ToIPEndPoint(this ref QuicAddr quicAddress, AddressFamily? addressFamilyOverride = null)
     {
         // MsQuic always uses storage size as if IPv6 was used
-        Span<byte> addressBytes = new Span<byte>((byte*)Unsafe.AsPointer(ref quicAddress), Internals.SocketAddress.IPv6AddressSize);
-        return new Internals.SocketAddress(addressFamilyOverride ?? SocketAddressPal.GetAddressFamily(addressBytes), addressBytes).GetIPEndPoint();
+        Span<byte> addressBytes = new Span<byte>((byte*)Unsafe.AsPointer(ref quicAddress), SocketAddressPal.IPv6AddressSize);
+        if (addressFamilyOverride != null)
+        {
+            SocketAddressPal.SetAddressFamily(addressBytes, (AddressFamily)addressFamilyOverride!);
+        }
+        return IPEndPointExtensions.CreateIPEndPoint(addressBytes);
     }
 
     internal static unsafe QuicAddr ToQuicAddr(this IPEndPoint ipEndPoint)
     {
-        // TODO: is the layout same for SocketAddress.Buffer and QuicAddr on all platforms?
         QuicAddr result = default;
         Span<byte> rawAddress = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref result, 1));
-
-        Internals.SocketAddress address = IPEndPointExtensions.Serialize(ipEndPoint);
-        Debug.Assert(address.Size <= rawAddress.Length);
-
-        address.InternalBuffer.AsSpan(0, address.Size).CopyTo(rawAddress);
+        ipEndPoint.Serialize(rawAddress);
         return result;
     }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
@@ -35,10 +35,10 @@ internal static class MsQuicHelpers
         return false;
     }
 
-    internal static unsafe IPEndPoint ToIPEndPoint(this ref QuicAddr quicAddress, AddressFamily? addressFamilyOverride = null)
+    internal static unsafe IPEndPoint QuicAddrToIPEndPoint(QuicAddr* quicAddress, AddressFamily? addressFamilyOverride = null)
     {
         // MsQuic always uses storage size as if IPv6 was used
-        Span<byte> addressBytes = new Span<byte>((byte*)Unsafe.AsPointer(ref quicAddress), SocketAddressPal.IPv6AddressSize);
+        Span<byte> addressBytes = new Span<byte>(quicAddress, SocketAddressPal.IPv6AddressSize);
         if (addressFamilyOverride != null)
         {
             SocketAddressPal.SetAddressFamily(addressBytes, (AddressFamily)addressFamilyOverride!);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
@@ -51,7 +51,7 @@ internal static class MsQuicHelpers
         Internals.SocketAddress address = IPEndPointExtensions.Serialize(ipEndPoint);
         Debug.Assert(address.Size <= rawAddress.Length);
 
-        address.Buffer.AsSpan(0, address.Size).CopyTo(rawAddress);
+        address.InternalBuffer.AsSpan(0, address.Size).CopyTo(rawAddress);
         return result;
     }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -239,8 +239,8 @@ public sealed partial class QuicConnection : IAsyncDisposable
             throw;
         }
 
-        _remoteEndPoint = info->RemoteAddress->ToIPEndPoint();
-        _localEndPoint = info->LocalAddress->ToIPEndPoint();
+        _remoteEndPoint = MsQuicHelpers.QuicAddrToIPEndPoint(info->RemoteAddress);
+        _localEndPoint = MsQuicHelpers.QuicAddrToIPEndPoint(info->LocalAddress);
 #if DEBUG
         _tlsSecret = MsQuicTlsSecret.Create(_handle);
 #endif
@@ -478,10 +478,10 @@ public sealed partial class QuicConnection : IAsyncDisposable
         _negotiatedApplicationProtocol = new SslApplicationProtocol(new Span<byte>(data.NegotiatedAlpn, data.NegotiatedAlpnLength).ToArray());
 
         QuicAddr remoteAddress = MsQuicHelpers.GetMsQuicParameter<QuicAddr>(_handle, QUIC_PARAM_CONN_REMOTE_ADDRESS);
-        _remoteEndPoint = remoteAddress.ToIPEndPoint();
+        _remoteEndPoint = MsQuicHelpers.QuicAddrToIPEndPoint(&remoteAddress);
 
         QuicAddr localAddress = MsQuicHelpers.GetMsQuicParameter<QuicAddr>(_handle, QUIC_PARAM_CONN_LOCAL_ADDRESS);
-        _localEndPoint = localAddress.ToIPEndPoint();
+        _localEndPoint = MsQuicHelpers.QuicAddrToIPEndPoint(&localAddress);
 
         if (NetEventSource.Log.IsEnabled())
         {
@@ -514,12 +514,12 @@ public sealed partial class QuicConnection : IAsyncDisposable
     }
     private unsafe int HandleEventLocalAddressChanged(ref LOCAL_ADDRESS_CHANGED_DATA data)
     {
-        _localEndPoint = data.Address->ToIPEndPoint();
+        _localEndPoint = MsQuicHelpers.QuicAddrToIPEndPoint(data.Address);
         return QUIC_STATUS_SUCCESS;
     }
     private unsafe int HandleEventPeerAddressChanged(ref PEER_ADDRESS_CHANGED_DATA data)
     {
-        _remoteEndPoint = data.Address->ToIPEndPoint();
+        _remoteEndPoint = MsQuicHelpers.QuicAddrToIPEndPoint(data.Address);
         return QUIC_STATUS_SUCCESS;
     }
     private unsafe int HandleEventPeerStreamStarted(ref PEER_STREAM_STARTED_DATA data)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -157,7 +157,7 @@ public sealed partial class QuicListener : IAsyncDisposable
 
         // Get the actual listening endpoint.
         address = GetMsQuicParameter<QuicAddr>(_handle, QUIC_PARAM_LISTENER_LOCAL_ADDRESS);
-        LocalEndPoint = address.ToIPEndPoint(options.ListenEndPoint.AddressFamily);
+        LocalEndPoint = MsQuicHelpers.QuicAddrToIPEndPoint(&address, options.ListenEndPoint.AddressFamily);
     }
 
     /// <summary>
@@ -281,7 +281,7 @@ public sealed partial class QuicListener : IAsyncDisposable
         {
             if (NetEventSource.Log.IsEnabled())
             {
-                NetEventSource.Info(this, $"{this} Refusing connection from {data.Info->RemoteAddress->ToIPEndPoint()} due to backlog limit");
+                NetEventSource.Info(this, $"{this} Refusing connection from {MsQuicHelpers.QuicAddrToIPEndPoint(data.Info->RemoteAddress)} due to backlog limit");
             }
 
             Interlocked.Increment(ref _pendingConnectionsCapacity);

--- a/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -400,7 +400,7 @@ namespace System.Net.Sockets
         public int ReceiveFrom(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { throw null; }
         public int ReceiveFrom(System.Span<byte> buffer, ref System.Net.EndPoint remoteEP) { throw null; }
         public int ReceiveFrom(System.Span<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { throw null; }
-        public int ReceiveFrom(System.Span<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.SocketAddress remoteSA) { throw null; }
+        public int ReceiveFrom(System.Span<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.SocketAddress socketAddress) { throw null; }
         public System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(System.ArraySegment<byte> buffer, System.Net.EndPoint remoteEndPoint) { throw null; }
         public System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { throw null; }
         public System.Threading.Tasks.ValueTask<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(System.Memory<byte> buffer, System.Net.EndPoint remoteEndPoint, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -445,7 +445,7 @@ namespace System.Net.Sockets
         public int SendTo(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }
         public int SendTo(System.ReadOnlySpan<byte> buffer, System.Net.EndPoint remoteEP) { throw null; }
         public int SendTo(System.ReadOnlySpan<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }
-        public int SendTo(System.ReadOnlySpan<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.SocketAddress remoteSA) { throw null; }
+        public int SendTo(System.ReadOnlySpan<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.SocketAddress socketAddress) { throw null; }
         public System.Threading.Tasks.Task<int> SendToAsync(System.ArraySegment<byte> buffer, System.Net.EndPoint remoteEP) { throw null; }
         public System.Threading.Tasks.Task<int> SendToAsync(System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }
         public bool SendToAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }

--- a/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -400,7 +400,7 @@ namespace System.Net.Sockets
         public int ReceiveFrom(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { throw null; }
         public int ReceiveFrom(System.Span<byte> buffer, ref System.Net.EndPoint remoteEP) { throw null; }
         public int ReceiveFrom(System.Span<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { throw null; }
-        public int ReceiveFrom(System.Span<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.SocketAddress socketAddress) { throw null; }
+        public int ReceiveFrom(System.Span<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.SocketAddress receivedSocketAddress) { throw null; }
         public System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(System.ArraySegment<byte> buffer, System.Net.EndPoint remoteEndPoint) { throw null; }
         public System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { throw null; }
         public System.Threading.Tasks.ValueTask<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(System.Memory<byte> buffer, System.Net.EndPoint remoteEndPoint, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -105,6 +105,8 @@ namespace System.Net.Sockets
         public LingerOption(bool enable, int seconds) { }
         public bool Enabled { get { throw null; } set { } }
         public int LingerTime { get { throw null; } set { } }
+        public override bool Equals(object? comparand) { throw null; }
+        public override int GetHashCode() { throw null; }
     }
     public partial class MulticastOption
     {
@@ -223,7 +225,7 @@ namespace System.Net.Sockets
     public sealed partial class SafeSocketHandle : Microsoft.Win32.SafeHandles.SafeHandleMinusOneIsInvalid
     {
         public SafeSocketHandle() : base (default(bool)) { }
-        public SafeSocketHandle(System.IntPtr preexistingHandle, bool ownsHandle) : base (default(bool)) { }
+        public SafeSocketHandle(nint preexistingHandle, bool ownsHandle) : base (default(bool)) { }
         public override bool IsInvalid { get { throw null; } }
         protected override bool ReleaseHandle() { throw null; }
     }
@@ -272,7 +274,7 @@ namespace System.Net.Sockets
         public bool DualMode { get { throw null; } set { } }
         public bool EnableBroadcast { get { throw null; } set { } }
         public bool ExclusiveAddressUse { get { throw null; } set { } }
-        public System.IntPtr Handle { get { throw null; } }
+        public nint Handle { get { throw null; } }
         public bool IsBound { get { throw null; } }
         [System.Diagnostics.CodeAnalysis.DisallowNullAttribute]
         public System.Net.Sockets.LingerOption? LingerState { get { throw null; } set { } }
@@ -398,6 +400,7 @@ namespace System.Net.Sockets
         public int ReceiveFrom(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { throw null; }
         public int ReceiveFrom(System.Span<byte> buffer, ref System.Net.EndPoint remoteEP) { throw null; }
         public int ReceiveFrom(System.Span<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, ref System.Net.EndPoint remoteEP) { throw null; }
+        public int ReceiveFrom(System.Span<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.SocketAddress remoteSA) { throw null; }
         public System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(System.ArraySegment<byte> buffer, System.Net.EndPoint remoteEndPoint) { throw null; }
         public System.Threading.Tasks.Task<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEndPoint) { throw null; }
         public System.Threading.Tasks.ValueTask<System.Net.Sockets.SocketReceiveFromResult> ReceiveFromAsync(System.Memory<byte> buffer, System.Net.EndPoint remoteEndPoint, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -442,6 +445,7 @@ namespace System.Net.Sockets
         public int SendTo(byte[] buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }
         public int SendTo(System.ReadOnlySpan<byte> buffer, System.Net.EndPoint remoteEP) { throw null; }
         public int SendTo(System.ReadOnlySpan<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }
+        public int SendTo(System.ReadOnlySpan<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.SocketAddress remoteSA) { throw null; }
         public System.Threading.Tasks.Task<int> SendToAsync(System.ArraySegment<byte> buffer, System.Net.EndPoint remoteEP) { throw null; }
         public System.Threading.Tasks.Task<int> SendToAsync(System.ArraySegment<byte> buffer, System.Net.Sockets.SocketFlags socketFlags, System.Net.EndPoint remoteEP) { throw null; }
         public bool SendToAsync(System.Net.Sockets.SocketAsyncEventArgs e) { throw null; }
@@ -811,6 +815,8 @@ namespace System.Net.Sockets
         public UnixDomainSocketEndPoint(string path) { }
         public override System.Net.Sockets.AddressFamily AddressFamily { get { throw null; } }
         public override System.Net.EndPoint Create(System.Net.SocketAddress socketAddress) { throw null; }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
         public override System.Net.SocketAddress Serialize() { throw null; }
         public override string ToString() { throw null; }
     }

--- a/src/libraries/System.Net.Sockets/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Sockets/src/Resources/Strings.resx
@@ -315,4 +315,7 @@
   <data name="net_sockets_handle_already_used" xml:space="preserve">
     <value>Handle is already used by another Socket.</value>
   </data>
+  <data name="net_sockets_address_small" xml:space="preserve">
+    <value>Provided SocketAddress is too small for given AddressFamily.</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -73,7 +73,7 @@ namespace System.Net.Sockets
             Internals.SocketAddress socketAddress = IPEndPointExtensions.Serialize(ep);
             unsafe
             {
-                fixed (byte* bufferPtr = socketAddress.Buffer)
+                fixed (byte* bufferPtr = socketAddress.InternalBuffer)
                 fixed (int* sizePtr = &socketAddress.InternalSize)
                 {
                     errorCode = SocketPal.GetSockName(_handle, bufferPtr, sizePtr);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1382,7 +1382,7 @@ namespace System.Net.Sockets
         /// </summary>
         /// <param name="buffer">A span of bytes that contains the data to be sent.</param>
         /// <param name="socketFlags">A bitwise combination of the <see cref="SocketFlags"/> values.</param>
-        /// <param name="socketAddress">The <see cref="EndPoint"/> that represents the destination for the data.</param>
+        /// <param name="socketAddress">The <see cref="SocketAddress"/> that represents the destination for the data.</param>
         /// <returns>The number of bytes sent.</returns>
         /// <exception cref="ArgumentNullException"><c>remoteEP</c> is <see langword="null" />.</exception>
         /// <exception cref="SocketException">An error occurred when attempting to access the socket.</exception>

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1895,6 +1895,11 @@ namespace System.Net.Sockets
         {
             ThrowIfDisposed();
 
+            if (receivedSocketAddress.Size < SocketAddress.GetMaximumAddressSize(AddressFamily))
+            {
+                throw new ArgumentOutOfRangeException(nameof(receivedSocketAddress), SR.net_sockets_address_small);
+            }
+
             ValidateBlockingMode();
 
             int bytesTransferred;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -304,7 +304,7 @@ namespace System.Net.Sockets
 
                     unsafe
                     {
-                        fixed (byte* buffer = socketAddress.Buffer)
+                        fixed (byte* buffer = socketAddress.InternalBuffer)
                         fixed (int* bufferSize = &socketAddress.InternalSize)
                         {
                             // This may throw ObjectDisposedException.
@@ -346,7 +346,7 @@ namespace System.Net.Sockets
                     // This may throw ObjectDisposedException.
                     SocketError errorCode = SocketPal.GetPeerName(
                         _handle,
-                        socketAddress.Buffer,
+                        socketAddress.InternalBuffer,
                         ref socketAddress.InternalSize);
 
                     if (errorCode != SocketError.Success)
@@ -765,7 +765,7 @@ namespace System.Net.Sockets
             SocketError errorCode = SocketPal.Bind(
                 _handle,
                 _protocolType,
-                socketAddress.Buffer,
+                socketAddress.InternalBuffer,
                 socketAddress.Size);
 
             // Throw an appropriate SocketException if the native call fails.
@@ -1019,7 +1019,7 @@ namespace System.Net.Sockets
             {
                 errorCode = SocketPal.Accept(
                     _handle,
-                    socketAddress.SocketBuffer,
+                    socketAddress.Buffer,
                     out socketAddressLen,
                     out acceptedSocketHandle);
                 socketAddress.Size = socketAddressLen;
@@ -1284,7 +1284,7 @@ namespace System.Net.Sockets
             Internals.SocketAddress socketAddress = Serialize(ref remoteEP);
 
             int bytesTransferred;
-            SocketError errorCode = SocketPal.SendTo(_handle, buffer, offset, size, socketFlags, socketAddress.SocketBuffer, out bytesTransferred);
+            SocketError errorCode = SocketPal.SendTo(_handle, buffer, offset, size, socketFlags, socketAddress.Buffer, out bytesTransferred);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1356,7 +1356,7 @@ namespace System.Net.Sockets
             Internals.SocketAddress socketAddress = Serialize(ref remoteEP);
 
             int bytesTransferred;
-            SocketError errorCode = SocketPal.SendTo(_handle, buffer, socketFlags, socketAddress.SocketBuffer, out bytesTransferred);
+            SocketError errorCode = SocketPal.SendTo(_handle, buffer, socketFlags, socketAddress.Buffer, out bytesTransferred);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1395,7 +1395,7 @@ namespace System.Net.Sockets
             ValidateBlockingMode();
 
             int bytesTransferred;
-            SocketError errorCode = SocketPal.SendTo(_handle, buffer, socketFlags, socketAddress.SocketBuffer, out bytesTransferred);
+            SocketError errorCode = SocketPal.SendTo(_handle, buffer, socketFlags, socketAddress.Buffer, out bytesTransferred);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1886,19 +1886,19 @@ namespace System.Net.Sockets
         /// </summary>
         /// <param name="buffer">A span of bytes that is the storage location for received data.</param>
         /// <param name="socketFlags">A bitwise combination of the <see cref="SocketFlags"/> values.</param>
-        /// <param name="socketAddress">An <see cref="SocketAddress"/>, passed by reference, that represents the remote server.</param>
+        /// <param name="receivedSocketAddress">An <see cref="SocketAddress"/>, that will be updated with value of the remote peer.</param>
         /// <returns>The number of bytes received.</returns>
         /// <exception cref="ArgumentNullException"><c>remoteEP</c> is <see langword="null" />.</exception>
         /// <exception cref="SocketException">An error occurred when attempting to access the socket.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="Socket"/> has been closed.</exception>
-        public int ReceiveFrom(Span<byte> buffer, SocketFlags socketFlags, SocketAddress socketAddress)
+        public int ReceiveFrom(Span<byte> buffer, SocketFlags socketFlags, SocketAddress receivedSocketAddress)
         {
             ThrowIfDisposed();
 
             ValidateBlockingMode();
 
             int bytesTransferred;
-            SocketError errorCode = SocketPal.ReceiveFrom(_handle, buffer, socketFlags, socketAddress.SocketBuffer, out int socketAddressSize, out bytesTransferred);
+            SocketError errorCode = SocketPal.ReceiveFrom(_handle, buffer, socketFlags, receivedSocketAddress.Buffer, out int socketAddressSize, out bytesTransferred);
 
             UpdateReceiveSocketErrorForDisposed(ref errorCode, bytesTransferred);
             // If the native call fails we'll throw a SocketException.
@@ -1925,7 +1925,7 @@ namespace System.Net.Sockets
                 throw socketException;
             }
 
-            socketAddress.Size = socketAddressSize;
+            receivedSocketAddress.Size = socketAddressSize;
 
             return bytesTransferred;
         }
@@ -3172,7 +3172,7 @@ namespace System.Net.Sockets
             SocketError errorCode;
             try
             {
-                errorCode = SocketPal.Connect(_handle, socketAddress.SocketBuffer);
+                errorCode = SocketPal.Connect(_handle, socketAddress.Buffer);
             }
             catch (Exception ex)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3172,7 +3172,7 @@ namespace System.Net.Sockets
             SocketError errorCode;
             try
             {
-                errorCode = SocketPal.Connect(_handle, socketAddress.Buffer, socketAddress.Size);
+                errorCode = SocketPal.Connect(_handle, socketAddress.SocketBuffer);
             }
             catch (Exception ex)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1382,20 +1382,20 @@ namespace System.Net.Sockets
         /// </summary>
         /// <param name="buffer">A span of bytes that contains the data to be sent.</param>
         /// <param name="socketFlags">A bitwise combination of the <see cref="SocketFlags"/> values.</param>
-        /// <param name="remoteSA">The <see cref="EndPoint"/> that represents the destination for the data.</param>
+        /// <param name="socketAddress">The <see cref="EndPoint"/> that represents the destination for the data.</param>
         /// <returns>The number of bytes sent.</returns>
         /// <exception cref="ArgumentNullException"><c>remoteEP</c> is <see langword="null" />.</exception>
         /// <exception cref="SocketException">An error occurred when attempting to access the socket.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="Socket"/> has been closed.</exception>
-        public int SendTo(ReadOnlySpan<byte> buffer, SocketFlags socketFlags, SocketAddress remoteSA)
+        public int SendTo(ReadOnlySpan<byte> buffer, SocketFlags socketFlags, SocketAddress socketAddress)
         {
             ThrowIfDisposed();
-            ArgumentNullException.ThrowIfNull(remoteSA);
+            ArgumentNullException.ThrowIfNull(socketAddress);
 
             ValidateBlockingMode();
 
             int bytesTransferred;
-            SocketError errorCode = SocketPal.SendTo(_handle, buffer, socketFlags, remoteSA.SocketBuffer, out bytesTransferred);
+            SocketError errorCode = SocketPal.SendTo(_handle, buffer, socketFlags, socketAddress.SocketBuffer, out bytesTransferred);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1886,19 +1886,19 @@ namespace System.Net.Sockets
         /// </summary>
         /// <param name="buffer">A span of bytes that is the storage location for received data.</param>
         /// <param name="socketFlags">A bitwise combination of the <see cref="SocketFlags"/> values.</param>
-        /// <param name="remoteSA">An <see cref="SocketAddress"/>, passed by reference, that represents the remote server.</param>
+        /// <param name="socketAddress">An <see cref="SocketAddress"/>, passed by reference, that represents the remote server.</param>
         /// <returns>The number of bytes received.</returns>
         /// <exception cref="ArgumentNullException"><c>remoteEP</c> is <see langword="null" />.</exception>
         /// <exception cref="SocketException">An error occurred when attempting to access the socket.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="Socket"/> has been closed.</exception>
-        public int ReceiveFrom(Span<byte> buffer, SocketFlags socketFlags, SocketAddress remoteSA)
+        public int ReceiveFrom(Span<byte> buffer, SocketFlags socketFlags, SocketAddress socketAddress)
         {
             ThrowIfDisposed();
 
             ValidateBlockingMode();
 
             int bytesTransferred;
-            SocketError errorCode = SocketPal.ReceiveFrom(_handle, buffer, socketFlags, remoteSA.SocketBuffer, out int socketAddressSize, out bytesTransferred);
+            SocketError errorCode = SocketPal.ReceiveFrom(_handle, buffer, socketFlags, socketAddress.SocketBuffer, out int socketAddressSize, out bytesTransferred);
 
             UpdateReceiveSocketErrorForDisposed(ref errorCode, bytesTransferred);
             // If the native call fails we'll throw a SocketException.
@@ -1925,7 +1925,7 @@ namespace System.Net.Sockets
                 throw socketException;
             }
 
-            remoteSA.Size = socketAddressSize;
+            socketAddress.Size = socketAddressSize;
 
             return bytesTransferred;
         }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1535,7 +1535,6 @@ namespace System.Net.Sockets
 
         public SocketError Receive(Memory<byte> buffer, SocketFlags flags, int timeout, out int bytesReceived)
         {
-            //int socketAddressLen = 0;
             return ReceiveFrom(buffer, ref flags, Memory<byte>.Empty, out int _, timeout, out bytesReceived);
         }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -70,7 +70,7 @@ namespace System.Net.Sockets
 
         internal unsafe SocketError DoOperationConnect(SafeSocketHandle handle)
         {
-            SocketError socketError = handle.AsyncContext.ConnectAsync(_socketAddress!.SocketBuffer, ConnectCompletionCallback);
+            SocketError socketError = handle.AsyncContext.ConnectAsync(_socketAddress!.Buffer, ConnectCompletionCallback);
             if (socketError != SocketError.IOPending)
             {
                 FinishOperationSync(socketError, 0, SocketFlags.None);
@@ -148,11 +148,11 @@ namespace System.Net.Sockets
             int socketAddressLen;
             if (_bufferList == null)
             {
-                errorCode = handle.AsyncContext.ReceiveFromAsync(_buffer.Slice(_offset, _count), _socketFlags, _socketAddress!.SocketBuffer, out socketAddressLen, out bytesReceived, out flags, TransferCompletionCallback, cancellationToken);
+                errorCode = handle.AsyncContext.ReceiveFromAsync(_buffer.Slice(_offset, _count), _socketFlags, _socketAddress!.Buffer, out socketAddressLen, out bytesReceived, out flags, TransferCompletionCallback, cancellationToken);
             }
             else
             {
-                errorCode = handle.AsyncContext.ReceiveFromAsync(_bufferListInternal!, _socketFlags, _socketAddress!.SocketBuffer, out socketAddressLen, out bytesReceived, out flags, TransferCompletionCallback);
+                errorCode = handle.AsyncContext.ReceiveFromAsync(_bufferListInternal!, _socketFlags, _socketAddress!.Buffer, out socketAddressLen, out bytesReceived, out flags, TransferCompletionCallback);
             }
 
             if (errorCode != SocketError.IOPending)
@@ -197,7 +197,7 @@ namespace System.Net.Sockets
             if (socketError != SocketError.IOPending)
             {
                 _socketAddress.Size = socketAddressSize;
-                CompleteReceiveMessageFromOperation(_socketAddress.SocketBuffer, socketAddressSize, receivedFlags, ipPacketInformation);
+                CompleteReceiveMessageFromOperation(_socketAddress.Buffer, socketAddressSize, receivedFlags, ipPacketInformation);
                 FinishOperationSync(socketError, bytesReceived, receivedFlags);
             }
             return socketError;
@@ -296,16 +296,16 @@ namespace System.Net.Sockets
             SocketError errorCode;
             if (_bufferList == null)
             {
-                errorCode = handle.AsyncContext.SendToAsync(_buffer, _offset, _count, _socketFlags, _socketAddress!.SocketBuffer, out bytesSent, TransferCompletionCallback, cancellationToken);
+                errorCode = handle.AsyncContext.SendToAsync(_buffer, _offset, _count, _socketFlags, _socketAddress!.Buffer, out bytesSent, TransferCompletionCallback, cancellationToken);
             }
             else
             {
-                errorCode = handle.AsyncContext.SendToAsync(_bufferListInternal!, _socketFlags, _socketAddress!.SocketBuffer, out bytesSent, TransferCompletionCallback);
+                errorCode = handle.AsyncContext.SendToAsync(_bufferListInternal!, _socketFlags, _socketAddress!.Buffer, out bytesSent, TransferCompletionCallback);
             }
 
             if (errorCode != SocketError.IOPending)
             {
-                CompleteTransferOperation(_socketAddress.SocketBuffer, _socketAddress.Size, SocketFlags.None);
+                CompleteTransferOperation(_socketAddress.Buffer, _socketAddress.Size, SocketFlags.None);
                 FinishOperationSync(errorCode, bytesSent, SocketFlags.None);
             }
 
@@ -331,7 +331,7 @@ namespace System.Net.Sockets
 
         private SocketError FinishOperationAccept(Internals.SocketAddress remoteSocketAddress)
         {
-            System.Buffer.BlockCopy(_acceptBuffer!, 0, remoteSocketAddress.Buffer, 0, _acceptAddressBufferCount);
+            System.Buffer.BlockCopy(_acceptBuffer!, 0, remoteSocketAddress.InternalBuffer, 0, _acceptAddressBufferCount);
             Socket acceptedSocket = _currentSocket!.CreateAcceptSocket(
                 SocketPal.CreateSocket(_acceptedFileDescriptor),
                 _currentSocket._rightEndPoint!.Create(remoteSocketAddress));

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -49,7 +49,6 @@ namespace System.Net.Sockets
             Debug.Assert(acceptHandle == null, $"Unexpected acceptHandle: {acceptHandle}");
 
             IntPtr acceptedFd;
-            //int socketAddressLen = _acceptAddressBufferCount / 2;
             SocketError socketError = handle.AsyncContext.AcceptAsync(_acceptBuffer!, out int socketAddressLen, out acceptedFd, AcceptCompletionCallback, cancellationToken);
 
             if (socketError != SocketError.IOPending)
@@ -98,7 +97,6 @@ namespace System.Net.Sockets
 
         private void CompleteTransferOperation(Memory<byte> _, int socketAddressSize, SocketFlags receivedFlags)
         {
-            //Debug.Assert(socketAddress == null || socketAddress == _socketAddress!.Buffer, $"Unexpected socketAddress: {socketAddress}");
             _socketAddressSize = socketAddressSize;
             _receivedFlags = receivedFlags;
         }
@@ -147,7 +145,7 @@ namespace System.Net.Sockets
             SocketFlags flags;
             SocketError errorCode;
             int bytesReceived;
-            int socketAddressLen; // = _socketAddress!.Size;
+            int socketAddressLen;
             if (_bufferList == null)
             {
                 errorCode = handle.AsyncContext.ReceiveFromAsync(_buffer.Slice(_offset, _count), _socketFlags, _socketAddress!.SocketBuffer, out socketAddressLen, out bytesReceived, out flags, TransferCompletionCallback, cancellationToken);
@@ -175,8 +173,6 @@ namespace System.Net.Sockets
 
         private void CompleteReceiveMessageFromOperation(Memory<byte> socketAddress, int socketAddressSize, SocketFlags receivedFlags, IPPacketInformation ipPacketInformation)
         {
-            //Debug.Assert(_socketAddress != null, "Expected non-null _socketAddress");
-            //Debug.Assert(socketAddress == null || _socketAddress.Buffer == socketAddress, $"Unexpected socketAddress: {socketAddress}");
             Debug.Assert(socketAddress.Length == socketAddressSize);
 
             _socketAddressSize = socketAddress.Length;
@@ -297,7 +293,6 @@ namespace System.Net.Sockets
             _socketAddressSize = 0;
 
             int bytesSent;
-            //int socketAddressLen = _socketAddress!.Size;
             SocketError errorCode;
             if (_bufferList == null)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -71,7 +71,7 @@ namespace System.Net.Sockets
 
         internal unsafe SocketError DoOperationConnect(SafeSocketHandle handle)
         {
-            SocketError socketError = handle.AsyncContext.ConnectAsync(_socketAddress!.Buffer, _socketAddress.Size, ConnectCompletionCallback);
+            SocketError socketError = handle.AsyncContext.ConnectAsync(_socketAddress!.SocketBuffer, ConnectCompletionCallback);
             if (socketError != SocketError.IOPending)
             {
                 FinishOperationSync(socketError, 0, SocketFlags.None);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -13,7 +13,7 @@ namespace System.Net.Sockets
         private IntPtr _acceptedFileDescriptor;
         private int _socketAddressSize;
         private SocketFlags _receivedFlags;
-        private Action<int, byte[]?, int, SocketFlags, SocketError>? _transferCompletionCallback;
+        private Action<int, Memory<byte>, SocketFlags, SocketError>? _transferCompletionCallback;
 
         partial void InitializeInternals();
 
@@ -23,18 +23,18 @@ namespace System.Net.Sockets
 
         partial void CompleteCore();
 
-        private void AcceptCompletionCallback(IntPtr acceptedFileDescriptor, byte[] socketAddress, int socketAddressSize, SocketError socketError)
+        private void AcceptCompletionCallback(IntPtr acceptedFileDescriptor, Memory<byte> socketAddress, SocketError socketError)
         {
-            CompleteAcceptOperation(acceptedFileDescriptor, socketAddress, socketAddressSize);
+            CompleteAcceptOperation(acceptedFileDescriptor, socketAddress);
 
             CompletionCallback(0, SocketFlags.None, socketError);
         }
 
-        private void CompleteAcceptOperation(IntPtr acceptedFileDescriptor, byte[] socketAddress, int socketAddressSize)
+        private void CompleteAcceptOperation(IntPtr acceptedFileDescriptor, Memory<byte> socketAddress)
         {
             _acceptedFileDescriptor = acceptedFileDescriptor;
-            Debug.Assert(socketAddress == null || socketAddress == _acceptBuffer, $"Unexpected socketAddress: {socketAddress}");
-            _acceptAddressBufferCount = socketAddressSize;
+            Debug.Assert(socketAddress.Length > 0);
+            _acceptAddressBufferCount = socketAddress.Length;
         }
 
         internal unsafe SocketError DoOperationAccept(Socket _ /*socket*/, SafeSocketHandle handle, SafeSocketHandle? acceptHandle, CancellationToken cancellationToken)
@@ -49,12 +49,12 @@ namespace System.Net.Sockets
             Debug.Assert(acceptHandle == null, $"Unexpected acceptHandle: {acceptHandle}");
 
             IntPtr acceptedFd;
-            int socketAddressLen = _acceptAddressBufferCount / 2;
-            SocketError socketError = handle.AsyncContext.AcceptAsync(_acceptBuffer!, ref socketAddressLen, out acceptedFd, AcceptCompletionCallback, cancellationToken);
+            //int socketAddressLen = _acceptAddressBufferCount / 2;
+            SocketError socketError = handle.AsyncContext.AcceptAsync(_acceptBuffer!, out int socketAddressLen, out acceptedFd, AcceptCompletionCallback, cancellationToken);
 
             if (socketError != SocketError.IOPending)
             {
-                CompleteAcceptOperation(acceptedFd, _acceptBuffer!, socketAddressLen);
+                CompleteAcceptOperation(acceptedFd, new Memory<byte>(_acceptBuffer, 0, socketAddressLen));
                 FinishOperationSync(socketError, 0, SocketFlags.None);
             }
 
@@ -86,19 +86,19 @@ namespace System.Net.Sockets
             return socketError;
         }
 
-        private Action<int, byte[]?, int, SocketFlags, SocketError> TransferCompletionCallback =>
+        private Action<int, Memory<byte>, SocketFlags, SocketError> TransferCompletionCallback =>
             _transferCompletionCallback ??= TransferCompletionCallbackCore;
 
-        private void TransferCompletionCallbackCore(int bytesTransferred, byte[]? socketAddress, int socketAddressSize, SocketFlags receivedFlags, SocketError socketError)
+        private void TransferCompletionCallbackCore(int bytesTransferred, Memory<byte> socketAddress, SocketFlags receivedFlags, SocketError socketError)
         {
-            CompleteTransferOperation(socketAddress, socketAddressSize, receivedFlags);
+            CompleteTransferOperation(socketAddress, socketAddress.Length, receivedFlags);
 
             CompletionCallback(bytesTransferred, receivedFlags, socketError);
         }
 
-        private void CompleteTransferOperation(byte[]? socketAddress, int socketAddressSize, SocketFlags receivedFlags)
+        private void CompleteTransferOperation(Memory<byte> _, int socketAddressSize, SocketFlags receivedFlags)
         {
-            Debug.Assert(socketAddress == null || socketAddress == _socketAddress!.Buffer, $"Unexpected socketAddress: {socketAddress}");
+            //Debug.Assert(socketAddress == null || socketAddress == _socketAddress!.Buffer, $"Unexpected socketAddress: {socketAddress}");
             _socketAddressSize = socketAddressSize;
             _receivedFlags = receivedFlags;
         }
@@ -147,14 +147,14 @@ namespace System.Net.Sockets
             SocketFlags flags;
             SocketError errorCode;
             int bytesReceived;
-            int socketAddressLen = _socketAddress!.Size;
+            int socketAddressLen; // = _socketAddress!.Size;
             if (_bufferList == null)
             {
-                errorCode = handle.AsyncContext.ReceiveFromAsync(_buffer.Slice(_offset, _count), _socketFlags, _socketAddress.Buffer, ref socketAddressLen, out bytesReceived, out flags, TransferCompletionCallback, cancellationToken);
+                errorCode = handle.AsyncContext.ReceiveFromAsync(_buffer.Slice(_offset, _count), _socketFlags, _socketAddress!.SocketBuffer, out socketAddressLen, out bytesReceived, out flags, TransferCompletionCallback, cancellationToken);
             }
             else
             {
-                errorCode = handle.AsyncContext.ReceiveFromAsync(_bufferListInternal!, _socketFlags, _socketAddress.Buffer, ref socketAddressLen, out bytesReceived, out flags, TransferCompletionCallback);
+                errorCode = handle.AsyncContext.ReceiveFromAsync(_bufferListInternal!, _socketFlags, _socketAddress!.SocketBuffer, out socketAddressLen, out bytesReceived, out flags, TransferCompletionCallback);
             }
 
             if (errorCode != SocketError.IOPending)
@@ -166,19 +166,20 @@ namespace System.Net.Sockets
             return errorCode;
         }
 
-        private void ReceiveMessageFromCompletionCallback(int bytesTransferred, byte[] socketAddress, int socketAddressSize, SocketFlags receivedFlags, IPPacketInformation ipPacketInformation, SocketError errorCode)
+        private void ReceiveMessageFromCompletionCallback(int bytesTransferred, Memory<byte> socketAddress, SocketFlags receivedFlags, IPPacketInformation ipPacketInformation, SocketError errorCode)
         {
-            CompleteReceiveMessageFromOperation(socketAddress, socketAddressSize, receivedFlags, ipPacketInformation);
+            CompleteReceiveMessageFromOperation(socketAddress, socketAddress.Length, receivedFlags, ipPacketInformation);
 
             CompletionCallback(bytesTransferred, receivedFlags, errorCode);
         }
 
-        private void CompleteReceiveMessageFromOperation(byte[] socketAddress, int socketAddressSize, SocketFlags receivedFlags, IPPacketInformation ipPacketInformation)
+        private void CompleteReceiveMessageFromOperation(Memory<byte> socketAddress, int socketAddressSize, SocketFlags receivedFlags, IPPacketInformation ipPacketInformation)
         {
-            Debug.Assert(_socketAddress != null, "Expected non-null _socketAddress");
-            Debug.Assert(socketAddress == null || _socketAddress.Buffer == socketAddress, $"Unexpected socketAddress: {socketAddress}");
+            //Debug.Assert(_socketAddress != null, "Expected non-null _socketAddress");
+            //Debug.Assert(socketAddress == null || _socketAddress.Buffer == socketAddress, $"Unexpected socketAddress: {socketAddress}");
+            Debug.Assert(socketAddress.Length == socketAddressSize);
 
-            _socketAddressSize = socketAddressSize;
+            _socketAddressSize = socketAddress.Length;
             _receivedFlags = receivedFlags;
             _receiveMessageFromPacketInfo = ipPacketInformation;
         }
@@ -196,10 +197,11 @@ namespace System.Net.Sockets
             int bytesReceived;
             SocketFlags receivedFlags;
             IPPacketInformation ipPacketInformation;
-            SocketError socketError = handle.AsyncContext.ReceiveMessageFromAsync(_buffer.Slice(_offset, _count), _bufferListInternal, _socketFlags, _socketAddress.Buffer, ref socketAddressSize, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, ReceiveMessageFromCompletionCallback, cancellationToken);
+            SocketError socketError = handle.AsyncContext.ReceiveMessageFromAsync(_buffer.Slice(_offset, _count), _bufferListInternal, _socketFlags, _socketAddress.Buffer, out socketAddressSize, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, ReceiveMessageFromCompletionCallback, cancellationToken);
             if (socketError != SocketError.IOPending)
             {
-                CompleteReceiveMessageFromOperation(_socketAddress.Buffer, socketAddressSize, receivedFlags, ipPacketInformation);
+                _socketAddress.Size = socketAddressSize;
+                CompleteReceiveMessageFromOperation(_socketAddress.SocketBuffer, socketAddressSize, receivedFlags, ipPacketInformation);
                 FinishOperationSync(socketError, bytesReceived, receivedFlags);
             }
             return socketError;
@@ -295,20 +297,20 @@ namespace System.Net.Sockets
             _socketAddressSize = 0;
 
             int bytesSent;
-            int socketAddressLen = _socketAddress!.Size;
+            //int socketAddressLen = _socketAddress!.Size;
             SocketError errorCode;
             if (_bufferList == null)
             {
-                errorCode = handle.AsyncContext.SendToAsync(_buffer, _offset, _count, _socketFlags, _socketAddress.Buffer, ref socketAddressLen, out bytesSent, TransferCompletionCallback, cancellationToken);
+                errorCode = handle.AsyncContext.SendToAsync(_buffer, _offset, _count, _socketFlags, _socketAddress!.SocketBuffer, out bytesSent, TransferCompletionCallback, cancellationToken);
             }
             else
             {
-                errorCode = handle.AsyncContext.SendToAsync(_bufferListInternal!, _socketFlags, _socketAddress.Buffer, ref socketAddressLen, out bytesSent, TransferCompletionCallback);
+                errorCode = handle.AsyncContext.SendToAsync(_bufferListInternal!, _socketFlags, _socketAddress!.SocketBuffer, out bytesSent, TransferCompletionCallback);
             }
 
             if (errorCode != SocketError.IOPending)
             {
-                CompleteTransferOperation(_socketAddress.Buffer, socketAddressLen, SocketFlags.None);
+                CompleteTransferOperation(_socketAddress.SocketBuffer, _socketAddress.Size, SocketFlags.None);
                 FinishOperationSync(errorCode, bytesSent, SocketFlags.None);
             }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -284,7 +284,7 @@ namespace System.Net.Sockets
         internal SocketError DoOperationConnect(SafeSocketHandle handle)
         {
             // Called for connectionless protocols.
-            SocketError socketError = SocketPal.Connect(handle, _socketAddress!.SocketBuffer);
+            SocketError socketError = SocketPal.Connect(handle, _socketAddress!.Buffer);
             FinishOperationSync(socketError, 0, SocketFlags.None);
             return socketError;
         }
@@ -303,7 +303,7 @@ namespace System.Net.Sockets
                 {
                     bool success = socket.ConnectEx(
                         handle,
-                        _socketAddress!.Buffer.AsSpan(),
+                        _socketAddress!.InternalBuffer.AsSpan(),
                         (IntPtr)(bufferPtr + _offset),
                         _count,
                         out int bytesTransferred,
@@ -763,7 +763,7 @@ namespace System.Net.Sockets
                         1,
                         out int bytesTransferred,
                         _socketFlags,
-                        _socketAddress!.Buffer.AsSpan(),
+                        _socketAddress!.InternalBuffer.AsSpan(),
                         overlapped,
                         IntPtr.Zero);
 
@@ -790,7 +790,7 @@ namespace System.Net.Sockets
                     _bufferListInternal!.Count,
                     out int bytesTransferred,
                     _socketFlags,
-                    _socketAddress!.Buffer.AsSpan(),
+                    _socketAddress!.InternalBuffer.AsSpan(),
                     overlapped,
                     IntPtr.Zero);
 
@@ -883,11 +883,11 @@ namespace System.Net.Sockets
             get
             {
                 Debug.Assert(_pinnedSocketAddress != null);
-                Debug.Assert(_pinnedSocketAddress.Buffer != null);
-                Debug.Assert(_pinnedSocketAddress.Buffer.Length > 0);
+                Debug.Assert(_pinnedSocketAddress.InternalBuffer != null);
+                Debug.Assert(_pinnedSocketAddress.InternalBuffer.Length > 0);
                 Debug.Assert(_socketAddressGCHandle.IsAllocated);
-                Debug.Assert(_socketAddressGCHandle.Target == _pinnedSocketAddress.Buffer);
-                fixed (void* ptrSocketAddressBuffer = &_pinnedSocketAddress.Buffer[0])
+                Debug.Assert(_socketAddressGCHandle.Target == _pinnedSocketAddress.InternalBuffer);
+                fixed (void* ptrSocketAddressBuffer = &_pinnedSocketAddress.InternalBuffer[0])
                 {
                     return (IntPtr)ptrSocketAddressBuffer;
                 }
@@ -1075,7 +1075,7 @@ namespace System.Net.Sockets
                         out remoteSocketAddress.InternalSize
                     );
 
-                    Marshal.Copy(remoteAddr, remoteSocketAddress.Buffer, 0, remoteSocketAddress.Size);
+                    Marshal.Copy(remoteAddr, remoteSocketAddress.InternalBuffer, 0, remoteSocketAddress.Size);
                 }
 
                 socketError = Interop.Winsock.setsockopt(

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -284,7 +284,7 @@ namespace System.Net.Sockets
         internal SocketError DoOperationConnect(SafeSocketHandle handle)
         {
             // Called for connectionless protocols.
-            SocketError socketError = SocketPal.Connect(handle, _socketAddress!.Buffer, _socketAddress.Size);
+            SocketError socketError = SocketPal.Connect(handle, _socketAddress!.SocketBuffer);
             FinishOperationSync(socketError, 0, SocketFlags.None);
             return socketError;
         }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -873,7 +873,7 @@ namespace System.Net.Sockets
             }
 
             // Pin down the new one.
-            _socketAddressGCHandle = GCHandle.Alloc(_socketAddress!.Buffer, GCHandleType.Pinned);
+            _socketAddressGCHandle = GCHandle.Alloc(_socketAddress!.InternalBuffer, GCHandleType.Pinned);
             _socketAddress.CopyAddressSizeIntoBuffer();
             _pinnedSocketAddress = _socketAddress;
         }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1267,11 +1267,11 @@ namespace System.Net.Sockets
             SocketError errorCode;
             if (!handle.IsNonBlocking)
             {
-                errorCode = handle.AsyncContext.ReceiveMessageFrom(new Memory<byte>(buffer, offset, count), ref socketFlags, socketAddress.SocketBuffer, out socketAddressLen, isIPv4, isIPv6, handle.ReceiveTimeout, out ipPacketInformation, out bytesTransferred);
+                errorCode = handle.AsyncContext.ReceiveMessageFrom(new Memory<byte>(buffer, offset, count), ref socketFlags, socketAddress.Buffer, out socketAddressLen, isIPv4, isIPv6, handle.ReceiveTimeout, out ipPacketInformation, out bytesTransferred);
             }
             else
             {
-                if (!TryCompleteReceiveMessageFrom(handle, new Span<byte>(buffer, offset, count), null, socketFlags, socketAddress.SocketBuffer, out socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out socketFlags, out ipPacketInformation, out errorCode))
+                if (!TryCompleteReceiveMessageFrom(handle, new Span<byte>(buffer, offset, count), null, socketFlags, socketAddress.Buffer, out socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out socketFlags, out ipPacketInformation, out errorCode))
                 {
                     errorCode = SocketError.WouldBlock;
                 }
@@ -1285,7 +1285,7 @@ namespace System.Net.Sockets
 
         public static SocketError ReceiveMessageFrom(Socket socket, SafeSocketHandle handle, Span<byte> buffer, ref SocketFlags socketFlags, Internals.SocketAddress socketAddress, out Internals.SocketAddress receiveAddress, out IPPacketInformation ipPacketInformation, out int bytesTransferred)
         {
-            byte[] socketAddressBuffer = socketAddress.Buffer;
+            byte[] socketAddressBuffer = socketAddress.InternalBuffer;
             int socketAddressLen;
 
             bool isIPv4, isIPv6;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -397,11 +397,6 @@ namespace System.Net.Sockets
             Span<Interop.Sys.IOVector> iovecs = allocOnStack ? stackalloc Interop.Sys.IOVector[IovStackThreshold] : new Interop.Sys.IOVector[maxBuffers];
 
             int sockAddrLen = socketAddress.Length;
-            //if (socketAddress != null)
-            //{
-            //    sockAddrLen = socketAddressLen;
-            //}
-
             long received = 0;
             int toReceive = 0, iovCount = 0;
             try
@@ -1264,7 +1259,7 @@ namespace System.Net.Sockets
 
         public static SocketError ReceiveMessageFrom(Socket socket, SafeSocketHandle handle, byte[] buffer, int offset, int count, ref SocketFlags socketFlags, Internals.SocketAddress socketAddress, out Internals.SocketAddress receiveAddress, out IPPacketInformation ipPacketInformation, out int bytesTransferred)
         {
-            int socketAddressLen; // = socketAddress.Size;
+            int socketAddressLen;
 
             bool isIPv4, isIPv6;
             Socket.GetIPProtocolInformation(socket.AddressFamily, socketAddress, out isIPv4, out isIPv6);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -60,7 +60,7 @@ namespace System.Net.Sockets
 
             IntPtr fd;
             SocketError errorCode;
-            Interop.Error error = Interop.Sys.Socket(addressFamily, socketType, protocolType, &fd);
+            Interop.Error error = Interop.Sys.Socket((int)addressFamily, (int)socketType, (int)protocolType, &fd);
             if (error == Interop.Error.SUCCESS)
             {
                 Debug.Assert(fd != (IntPtr)(-1), "fd should not be -1");
@@ -579,7 +579,7 @@ namespace System.Net.Sockets
                         if (socketAddressLen == 0)
                         {
                             // We can fail to get peer address on TCP
-                            socketAddressLen =  socketAddress.Length;
+                            socketAddressLen = socketAddress.Length;
                             SocketAddressPal.Clear(socketAddress);
                         }
 
@@ -846,7 +846,7 @@ namespace System.Net.Sockets
                     if (socketAddress.Length > 0 && socketAddressLen == 0)
                     {
                         // We can fail to get peer address on TCP
-                        socketAddressLen =  socketAddress.Length;
+                        socketAddressLen = socketAddress.Length;
                         SocketAddressPal.Clear(socketAddress);
                     }
                     return true;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -138,16 +138,13 @@ namespace System.Net.Sockets
             return received;
         }
 
-        private static unsafe int SysReceive(SafeSocketHandle socket, SocketFlags flags, Span<byte> buffer, byte[]? socketAddress, ref int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
+        private static unsafe int SysReceive(SafeSocketHandle socket, SocketFlags flags, Span<byte> buffer, Span<byte> socketAddress, out int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
         {
             Debug.Assert(socket.IsSocket);
 
-            Debug.Assert(socketAddress != null || socketAddressLen == 0, $"Unexpected values: socketAddress={socketAddress}, socketAddressLen={socketAddressLen}");
-
             long received = 0;
-            int sockAddrLen = socketAddress != null ? socketAddressLen : 0;
 
-            fixed (byte* sockAddr = socketAddress)
+            fixed (byte* sockAddr = &MemoryMarshal.GetReference(socketAddress))
             fixed (byte* b = &MemoryMarshal.GetReference(buffer))
             {
                 var iov = new Interop.Sys.IOVector {
@@ -157,7 +154,7 @@ namespace System.Net.Sockets
 
                 var messageHeader = new Interop.Sys.MessageHeader {
                     SocketAddress = sockAddr,
-                    SocketAddressLen = sockAddrLen,
+                    SocketAddressLen = socketAddress.Length,
                     IOVectors = &iov,
                     IOVectorCount = 1
                 };
@@ -169,7 +166,7 @@ namespace System.Net.Sockets
                     &received);
 
                 receivedFlags = messageHeader.Flags;
-                sockAddrLen = messageHeader.SocketAddressLen;
+                socketAddressLen = messageHeader.SocketAddressLen;
             }
 
             if (errno != Interop.Error.SUCCESS)
@@ -177,7 +174,6 @@ namespace System.Net.Sockets
                 return -1;
             }
 
-            socketAddressLen = sockAddrLen;
             return checked((int)received);
         }
 
@@ -237,7 +233,7 @@ namespace System.Net.Sockets
             return sent;
         }
 
-        private static unsafe int SysSend(SafeSocketHandle socket, SocketFlags flags, ReadOnlySpan<byte> buffer, ref int offset, ref int count, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
+        private static unsafe int SysSend(SafeSocketHandle socket, SocketFlags flags, ReadOnlySpan<byte> buffer, ref int offset, ref int count, ReadOnlySpan<byte> socketAddress, out Interop.Error errno)
         {
             Debug.Assert(socket.IsSocket);
 
@@ -256,7 +252,7 @@ namespace System.Net.Sockets
                 var messageHeader = new Interop.Sys.MessageHeader
                 {
                     SocketAddress = sockAddr,
-                    SocketAddressLen = socketAddress != null ? socketAddressLen : 0,
+                    SocketAddressLen = socketAddress.Length,
                     IOVectors = &iov,
                     IOVectorCount = 1
                 };
@@ -281,18 +277,12 @@ namespace System.Net.Sockets
             return sent;
         }
 
-        private static unsafe int SysSend(SafeSocketHandle socket, SocketFlags flags, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, byte[]? socketAddress, int socketAddressLen, out Interop.Error errno)
+        private static unsafe int SysSend(SafeSocketHandle socket, SocketFlags flags, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, ReadOnlySpan<byte> socketAddress, out Interop.Error errno)
         {
             Debug.Assert(socket.IsSocket);
 
             // Pin buffers and set up iovecs.
             int startIndex = bufferIndex, startOffset = offset;
-
-            int sockAddrLen = 0;
-            if (socketAddress != null)
-            {
-                sockAddrLen = socketAddressLen;
-            }
 
             int maxBuffers = buffers.Count - startIndex;
             bool allocOnStack = maxBuffers <= IovStackThreshold;
@@ -320,7 +310,7 @@ namespace System.Net.Sockets
                 {
                     var messageHeader = new Interop.Sys.MessageHeader {
                         SocketAddress = sockAddr,
-                        SocketAddressLen = sockAddrLen,
+                        SocketAddressLen = socketAddress.Length,
                         IOVectors = iov,
                         IOVectorCount = iovCount
                     };
@@ -377,7 +367,7 @@ namespace System.Net.Sockets
             return bytesSent;
         }
 
-        private static unsafe int SysReceive(SafeSocketHandle socket, SocketFlags flags, IList<ArraySegment<byte>> buffers, byte[]? socketAddress, ref int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
+        private static unsafe int SysReceive(SafeSocketHandle socket, SocketFlags flags, IList<ArraySegment<byte>> buffers, Span<byte> socketAddress, out int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
         {
             Debug.Assert(socket.IsSocket);
 
@@ -392,6 +382,7 @@ namespace System.Net.Sockets
                 if (errno != Interop.Error.SUCCESS)
                 {
                     receivedFlags = 0;
+                    socketAddressLen = 0;
                     return -1;
                 }
                 if (available == 0)
@@ -405,11 +396,11 @@ namespace System.Net.Sockets
             Span<GCHandle> handles = allocOnStack ? stackalloc GCHandle[IovStackThreshold] : new GCHandle[maxBuffers];
             Span<Interop.Sys.IOVector> iovecs = allocOnStack ? stackalloc Interop.Sys.IOVector[IovStackThreshold] : new Interop.Sys.IOVector[maxBuffers];
 
-            int sockAddrLen = 0;
-            if (socketAddress != null)
-            {
-                sockAddrLen = socketAddressLen;
-            }
+            int sockAddrLen = socketAddress.Length;
+            //if (socketAddress != null)
+            //{
+            //    sockAddrLen = socketAddressLen;
+            //}
 
             long received = 0;
             int toReceive = 0, iovCount = 0;
@@ -469,16 +460,17 @@ namespace System.Net.Sockets
                 }
             }
 
+            socketAddressLen = sockAddrLen;
+
             if (errno != Interop.Error.SUCCESS)
             {
                 return -1;
             }
 
-            socketAddressLen = sockAddrLen;
             return checked((int)received);
         }
 
-        private static unsafe int SysReceiveMessageFrom(SafeSocketHandle socket, SocketFlags flags, Span<byte> buffer, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
+        private static unsafe int SysReceiveMessageFrom(SafeSocketHandle socket, SocketFlags flags, Span<byte> buffer, Span<byte> socketAddress, out int socketAddressLen, bool isIPv4, bool isIPv6, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
         {
             Debug.Assert(socket.IsSocket);
             Debug.Assert(socketAddress != null, "Expected non-null socketAddress");
@@ -486,7 +478,7 @@ namespace System.Net.Sockets
             int cmsgBufferLen = Interop.Sys.GetControlMessageBufferSize(Convert.ToInt32(isIPv4), Convert.ToInt32(isIPv6));
             byte* cmsgBuffer = stackalloc byte[cmsgBufferLen];
 
-            int sockAddrLen = socketAddressLen;
+            int sockAddrLen = socketAddress.Length;
 
             Interop.Sys.MessageHeader messageHeader;
 
@@ -518,6 +510,8 @@ namespace System.Net.Sockets
                 sockAddrLen = messageHeader.SocketAddressLen;
             }
 
+            socketAddressLen = sockAddrLen;
+
             if (errno != Interop.Error.SUCCESS)
             {
                 ipPacketInformation = default(IPPacketInformation);
@@ -525,13 +519,12 @@ namespace System.Net.Sockets
             }
 
             ipPacketInformation = GetIPPacketInformation(&messageHeader, isIPv4, isIPv6);
-            socketAddressLen = sockAddrLen;
             return checked((int)received);
         }
 
         private static unsafe int SysReceiveMessageFrom(
             SafeSocketHandle socket, SocketFlags flags, IList<ArraySegment<byte>> buffers,
-            byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6,
+            Span<byte> socketAddress, out int socketAddressLen, bool isIPv4, bool isIPv6,
             out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
         {
             Debug.Assert(socket.IsSocket);
@@ -566,7 +559,7 @@ namespace System.Net.Sockets
                     var messageHeader = new Interop.Sys.MessageHeader
                     {
                         SocketAddress = sockAddr,
-                        SocketAddressLen = socketAddressLen,
+                        SocketAddressLen = socketAddress.Length,
                         IOVectors = iov,
                         IOVectorCount = iovCount,
                         ControlBuffer = cmsgBuffer,
@@ -581,12 +574,11 @@ namespace System.Net.Sockets
                         &received);
 
                     receivedFlags = messageHeader.Flags;
-                    int sockAddrLen = messageHeader.SocketAddressLen;
+                    socketAddressLen = messageHeader.SocketAddressLen;
 
                     if (errno == Interop.Error.SUCCESS)
                     {
                         ipPacketInformation = GetIPPacketInformation(&messageHeader, isIPv4, isIPv6);
-                        socketAddressLen = sockAddrLen;
                         return checked((int)received);
                     }
                     else
@@ -606,22 +598,24 @@ namespace System.Net.Sockets
             }
         }
 
-        public static unsafe bool TryCompleteAccept(SafeSocketHandle socket, byte[] socketAddress, ref int socketAddressLen, out IntPtr acceptedFd, out SocketError errorCode)
+        public static unsafe bool TryCompleteAccept(SafeSocketHandle socket, Memory<byte> socketAddress, out int socketAddressLen, out IntPtr acceptedFd, out SocketError errorCode)
         {
             IntPtr fd = IntPtr.Zero;
             Interop.Error errno;
-            int sockAddrLen = socketAddressLen;
-            fixed (byte* rawSocketAddress = socketAddress)
+            int sockAddrLen = socketAddress.Length;
+            fixed (byte* rawSocketAddress = socketAddress.Span)
             {
                 try
                 {
                     errno = Interop.Sys.Accept(socket, rawSocketAddress, &sockAddrLen, &fd);
+                    socketAddressLen = sockAddrLen;
                 }
                 catch (ObjectDisposedException)
                 {
                     // The socket was closed, or is closing.
                     errorCode = SocketError.OperationAborted;
                     acceptedFd = (IntPtr)(-1);
+                    socketAddressLen = 0;
                     return true;
                 }
             }
@@ -630,7 +624,6 @@ namespace System.Net.Sockets
             {
                 Debug.Assert(fd != (IntPtr)(-1), "Expected fd != -1");
 
-                socketAddressLen = sockAddrLen;
                 errorCode = SocketError.Success;
                 acceptedFd = fd;
 
@@ -735,11 +728,11 @@ namespace System.Net.Sockets
             return true;
         }
 
-        public static bool TryCompleteReceiveFrom(SafeSocketHandle socket, Span<byte> buffer, SocketFlags flags, byte[]? socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode) =>
-            TryCompleteReceiveFrom(socket, buffer, null, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
+        public static bool TryCompleteReceiveFrom(SafeSocketHandle socket, Span<byte> buffer, SocketFlags flags, Span<byte> socketAddress, out int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode) =>
+            TryCompleteReceiveFrom(socket, buffer, null, flags, socketAddress, out socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
 
-        public static bool TryCompleteReceiveFrom(SafeSocketHandle socket, IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[]? socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode) =>
-            TryCompleteReceiveFrom(socket, default(Span<byte>), buffers, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
+        public static bool TryCompleteReceiveFrom(SafeSocketHandle socket, IList<ArraySegment<byte>> buffers, SocketFlags flags, Span<byte> socketAddress, out int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode) =>
+            TryCompleteReceiveFrom(socket, default(Span<byte>), buffers, flags, socketAddress, out socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
 
         public static unsafe bool TryCompleteReceive(SafeSocketHandle socket, Span<byte> buffer, SocketFlags flags, out int bytesReceived, out SocketError errorCode)
         {
@@ -800,12 +793,13 @@ namespace System.Net.Sockets
             }
         }
 
-        public static unsafe bool TryCompleteReceiveFrom(SafeSocketHandle socket, Span<byte> buffer, IList<ArraySegment<byte>>? buffers, SocketFlags flags, byte[]? socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
+        public static unsafe bool TryCompleteReceiveFrom(SafeSocketHandle socket, Span<byte> buffer, IList<ArraySegment<byte>>? buffers, SocketFlags flags, Span<byte> socketAddress, out int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
         {
             try
             {
                 Interop.Error errno;
                 int received;
+                int socketAddressLength = 0;
 
                 if (!socket.IsSocket)
                 {
@@ -819,7 +813,7 @@ namespace System.Net.Sockets
                 else if (buffers != null)
                 {
                     // Receive into a set of buffers
-                    received = SysReceive(socket, flags, buffers, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
+                    received = SysReceive(socket, flags, buffers, socketAddress, out socketAddressLength, out receivedFlags, out errno);
                 }
                 else if (buffer.Length == 0)
                 {
@@ -828,7 +822,7 @@ namespace System.Net.Sockets
                     // however complete a 0-byte read successfully when data isn't available, as the request can logically be satisfied
                     // synchronously. As such, we treat 0 specially, and perform a 1-byte peek.
                     byte oneBytePeekBuffer;
-                    received = SysReceive(socket, flags | SocketFlags.Peek, new Span<byte>(&oneBytePeekBuffer, 1), socketAddress, ref socketAddressLen, out receivedFlags, out errno);
+                    received = SysReceive(socket, flags | SocketFlags.Peek, new Span<byte>(&oneBytePeekBuffer, 1), socketAddress, out socketAddressLength, out receivedFlags, out errno);
                     if (received > 0)
                     {
                         // Peeked for 1-byte, but the actual request was for 0.
@@ -838,17 +832,19 @@ namespace System.Net.Sockets
                 else
                 {
                     // Receive > 0 bytes into a single buffer
-                    received = SysReceive(socket, flags, buffer, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
+                    received = SysReceive(socket, flags, buffer, socketAddress, out socketAddressLength, out receivedFlags, out errno);
                 }
 
                 if (received != -1)
                 {
                     bytesReceived = received;
                     errorCode = SocketError.Success;
+                    socketAddressLen = socketAddressLength;
                     return true;
                 }
 
                 bytesReceived = 0;
+                socketAddressLen = 0;
 
                 if (errno != Interop.Error.EAGAIN && errno != Interop.Error.EWOULDBLOCK)
                 {
@@ -864,20 +860,21 @@ namespace System.Net.Sockets
                 // The socket was closed, or is closing.
                 bytesReceived = 0;
                 receivedFlags = 0;
+                socketAddressLen = 0;
                 errorCode = SocketError.OperationAborted;
                 return true;
             }
         }
 
-        public static unsafe bool TryCompleteReceiveMessageFrom(SafeSocketHandle socket, Span<byte> buffer, IList<ArraySegment<byte>>? buffers, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out SocketError errorCode)
+        public static unsafe bool TryCompleteReceiveMessageFrom(SafeSocketHandle socket, Span<byte> buffer, IList<ArraySegment<byte>>? buffers, SocketFlags flags, Memory<byte> socketAddress, out int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out SocketError errorCode)
         {
             try
             {
                 Interop.Error errno;
 
                 int received = buffers == null ?
-                    SysReceiveMessageFrom(socket, flags, buffer, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno) :
-                    SysReceiveMessageFrom(socket, flags, buffers, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno);
+                    SysReceiveMessageFrom(socket, flags, buffer, socketAddress.Span, out socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno) :
+                    SysReceiveMessageFrom(socket, flags, buffers, socketAddress.Span, out socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno);
 
                 if (received != -1)
                 {
@@ -902,31 +899,32 @@ namespace System.Net.Sockets
                 // The socket was closed, or is closing.
                 bytesReceived = 0;
                 receivedFlags = 0;
+                socketAddressLen = 0;
                 ipPacketInformation = default(IPPacketInformation);
                 errorCode = SocketError.OperationAborted;
                 return true;
             }
         }
 
-        public static bool TryCompleteSendTo(SafeSocketHandle socket, Span<byte> buffer, ref int offset, ref int count, SocketFlags flags, byte[]? socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        public static bool TryCompleteSendTo(SafeSocketHandle socket, Span<byte> buffer, ref int offset, ref int count, SocketFlags flags, ReadOnlySpan<byte> socketAddress, ref int bytesSent, out SocketError errorCode)
         {
             int bufferIndex = 0;
-            return TryCompleteSendTo(socket, buffer, null, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
+            return TryCompleteSendTo(socket, buffer, null, ref bufferIndex, ref offset, ref count, flags, socketAddress, ref bytesSent, out errorCode);
         }
 
-        public static bool TryCompleteSendTo(SafeSocketHandle socket, ReadOnlySpan<byte> buffer, SocketFlags flags, byte[]? socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        public static bool TryCompleteSendTo(SafeSocketHandle socket, ReadOnlySpan<byte> buffer, SocketFlags flags, ReadOnlySpan<byte> socketAddress, ref int bytesSent, out SocketError errorCode)
         {
             int bufferIndex = 0, offset = 0, count = buffer.Length;
-            return TryCompleteSendTo(socket, buffer, null, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
+            return TryCompleteSendTo(socket, buffer, null, ref bufferIndex, ref offset, ref count, flags, socketAddress, ref bytesSent, out errorCode);
         }
 
-        public static bool TryCompleteSendTo(SafeSocketHandle socket, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, SocketFlags flags, byte[]? socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        public static bool TryCompleteSendTo(SafeSocketHandle socket, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, SocketFlags flags, ReadOnlySpan<byte> socketAddress, ref int bytesSent, out SocketError errorCode)
         {
             int count = 0;
-            return TryCompleteSendTo(socket, default(ReadOnlySpan<byte>), buffers, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
+            return TryCompleteSendTo(socket, default(ReadOnlySpan<byte>), buffers, ref bufferIndex, ref offset, ref count, flags, socketAddress, ref bytesSent, out errorCode);
         }
 
-        public static bool TryCompleteSendTo(SafeSocketHandle socket, ReadOnlySpan<byte> buffer, IList<ArraySegment<byte>>? buffers, ref int bufferIndex, ref int offset, ref int count, SocketFlags flags, byte[]? socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        public static bool TryCompleteSendTo(SafeSocketHandle socket, ReadOnlySpan<byte> buffer, IList<ArraySegment<byte>>? buffers, ref int bufferIndex, ref int offset, ref int count, SocketFlags flags, ReadOnlySpan<byte> socketAddress, ref int bytesSent, out SocketError errorCode)
         {
             bool successfulSend = false;
             long start = socket.IsUnderlyingHandleBlocking && socket.SendTimeout > 0 ? Environment.TickCount64 : 0; // Get ticks only if timeout is set and socket is blocking.
@@ -946,9 +944,9 @@ namespace System.Net.Sockets
                     else
                     {
                         sent = buffers != null ?
-                            SysSend(socket, flags, buffers, ref bufferIndex, ref offset, socketAddress, socketAddressLen, out errno) :
+                            SysSend(socket, flags, buffers, ref bufferIndex, ref offset, socketAddress, out errno) :
                             socketAddress == null ? SysSend(socket, flags, buffer, ref offset, ref count, out errno) :
-                                                    SysSend(socket, flags, buffer, ref offset, ref count, socketAddress, socketAddressLen, out errno);
+                                                    SysSend(socket, flags, buffer, ref offset, ref count, socketAddress, out errno);
                     }
                 }
                 catch (ObjectDisposedException)
@@ -1094,7 +1092,7 @@ namespace System.Net.Sockets
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
-        public static SocketError Accept(SafeSocketHandle listenSocket, byte[] socketAddress, ref int socketAddressLen, out SafeSocketHandle socket)
+        public static SocketError Accept(SafeSocketHandle listenSocket, Memory<byte> socketAddress, out int socketAddressLen, out SafeSocketHandle socket)
         {
             socket = new SafeSocketHandle();
 
@@ -1102,11 +1100,11 @@ namespace System.Net.Sockets
             SocketError errorCode;
             if (!listenSocket.IsNonBlocking)
             {
-                errorCode = listenSocket.AsyncContext.Accept(socketAddress, ref socketAddressLen, out acceptedFd);
+                errorCode = listenSocket.AsyncContext.Accept(socketAddress, out socketAddressLen, out acceptedFd);
             }
             else
             {
-                if (!TryCompleteAccept(listenSocket, socketAddress, ref socketAddressLen, out acceptedFd, out errorCode))
+                if (!TryCompleteAccept(listenSocket, socketAddress, out socketAddressLen, out acceptedFd, out errorCode))
                 {
                     errorCode = SocketError.WouldBlock;
                 }
@@ -1151,7 +1149,7 @@ namespace System.Net.Sockets
             int bufferIndex = 0;
             int offset = 0;
             SocketError errorCode;
-            TryCompleteSendTo(handle, bufferList, ref bufferIndex, ref offset, socketFlags, null, 0, ref bytesTransferred, out errorCode);
+            TryCompleteSendTo(handle, bufferList, ref bufferIndex, ref offset, socketFlags, ReadOnlySpan<byte>.Empty, ref bytesTransferred, out errorCode);
             return errorCode;
         }
 
@@ -1164,7 +1162,7 @@ namespace System.Net.Sockets
 
             bytesTransferred = 0;
             SocketError errorCode;
-            TryCompleteSendTo(handle, buffer, ref offset, ref count, socketFlags, null, 0, ref bytesTransferred, out errorCode);
+            TryCompleteSendTo(handle, buffer, ref offset, ref count, socketFlags, ReadOnlySpan<byte>.Empty, ref bytesTransferred, out errorCode);
             return errorCode;
         }
 
@@ -1177,7 +1175,7 @@ namespace System.Net.Sockets
 
             bytesTransferred = 0;
             SocketError errorCode;
-            TryCompleteSendTo(handle, buffer, socketFlags, null, 0, ref bytesTransferred, out errorCode);
+            TryCompleteSendTo(handle, buffer, socketFlags, ReadOnlySpan<byte>.Empty, ref bytesTransferred, out errorCode);
             return errorCode;
         }
 
@@ -1197,29 +1195,29 @@ namespace System.Net.Sockets
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
-        public static SocketError SendTo(SafeSocketHandle handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, byte[] socketAddress, int socketAddressLen, out int bytesTransferred)
+        public static SocketError SendTo(SafeSocketHandle handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, Memory<byte> socketAddress, out int bytesTransferred)
         {
             if (!handle.IsNonBlocking)
             {
-                return handle.AsyncContext.SendTo(buffer, offset, count, socketFlags, socketAddress, socketAddressLen, handle.SendTimeout, out bytesTransferred);
+                return handle.AsyncContext.SendTo(buffer, offset, count, socketFlags, socketAddress, handle.SendTimeout, out bytesTransferred);
             }
 
             bytesTransferred = 0;
             SocketError errorCode;
-            TryCompleteSendTo(handle, buffer, ref offset, ref count, socketFlags, socketAddress, socketAddressLen, ref bytesTransferred, out errorCode);
+            TryCompleteSendTo(handle, buffer, ref offset, ref count, socketFlags, socketAddress.Span, ref bytesTransferred, out errorCode);
             return errorCode;
         }
 
-        public static SocketError SendTo(SafeSocketHandle handle, ReadOnlySpan<byte> buffer, SocketFlags socketFlags, byte[] socketAddress, int socketAddressLen, out int bytesTransferred)
+        public static SocketError SendTo(SafeSocketHandle handle, ReadOnlySpan<byte> buffer, SocketFlags socketFlags, Memory<byte> socketAddress, out int bytesTransferred)
         {
             if (!handle.IsNonBlocking)
             {
-                return handle.AsyncContext.SendTo(buffer, socketFlags, socketAddress, socketAddressLen, handle.SendTimeout, out bytesTransferred);
+                return handle.AsyncContext.SendTo(buffer, socketFlags, socketAddress, handle.SendTimeout, out bytesTransferred);
             }
 
             bytesTransferred = 0;
             SocketError errorCode;
-            TryCompleteSendTo(handle, buffer, socketFlags, socketAddress, socketAddressLen, ref bytesTransferred, out errorCode);
+            TryCompleteSendTo(handle, buffer, socketFlags, socketAddress.Span, ref bytesTransferred, out errorCode);
             return errorCode;
         }
 
@@ -1232,8 +1230,7 @@ namespace System.Net.Sockets
             }
             else
             {
-                int socketAddressLen = 0;
-                if (!TryCompleteReceiveFrom(handle, buffers, socketFlags, null, ref socketAddressLen, out bytesTransferred, out _, out errorCode))
+                if (!TryCompleteReceiveFrom(handle, buffers, socketFlags, null, out int _, out bytesTransferred, out _, out errorCode))
                 {
                     errorCode = SocketError.WouldBlock;
                 }
@@ -1268,8 +1265,7 @@ namespace System.Net.Sockets
 
         public static SocketError ReceiveMessageFrom(Socket socket, SafeSocketHandle handle, byte[] buffer, int offset, int count, ref SocketFlags socketFlags, Internals.SocketAddress socketAddress, out Internals.SocketAddress receiveAddress, out IPPacketInformation ipPacketInformation, out int bytesTransferred)
         {
-            byte[] socketAddressBuffer = socketAddress.Buffer;
-            int socketAddressLen = socketAddress.Size;
+            int socketAddressLen; // = socketAddress.Size;
 
             bool isIPv4, isIPv6;
             Socket.GetIPProtocolInformation(socket.AddressFamily, socketAddress, out isIPv4, out isIPv6);
@@ -1277,11 +1273,11 @@ namespace System.Net.Sockets
             SocketError errorCode;
             if (!handle.IsNonBlocking)
             {
-                errorCode = handle.AsyncContext.ReceiveMessageFrom(new Memory<byte>(buffer, offset, count), ref socketFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, handle.ReceiveTimeout, out ipPacketInformation, out bytesTransferred);
+                errorCode = handle.AsyncContext.ReceiveMessageFrom(new Memory<byte>(buffer, offset, count), ref socketFlags, socketAddress.SocketBuffer, out socketAddressLen, isIPv4, isIPv6, handle.ReceiveTimeout, out ipPacketInformation, out bytesTransferred);
             }
             else
             {
-                if (!TryCompleteReceiveMessageFrom(handle, new Span<byte>(buffer, offset, count), null, socketFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out socketFlags, out ipPacketInformation, out errorCode))
+                if (!TryCompleteReceiveMessageFrom(handle, new Span<byte>(buffer, offset, count), null, socketFlags, socketAddress.SocketBuffer, out socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out socketFlags, out ipPacketInformation, out errorCode))
                 {
                     errorCode = SocketError.WouldBlock;
                 }
@@ -1296,7 +1292,7 @@ namespace System.Net.Sockets
         public static SocketError ReceiveMessageFrom(Socket socket, SafeSocketHandle handle, Span<byte> buffer, ref SocketFlags socketFlags, Internals.SocketAddress socketAddress, out Internals.SocketAddress receiveAddress, out IPPacketInformation ipPacketInformation, out int bytesTransferred)
         {
             byte[] socketAddressBuffer = socketAddress.Buffer;
-            int socketAddressLen = socketAddress.Size;
+            int socketAddressLen;
 
             bool isIPv4, isIPv6;
             Socket.GetIPProtocolInformation(socket.AddressFamily, socketAddress, out isIPv4, out isIPv6);
@@ -1304,11 +1300,11 @@ namespace System.Net.Sockets
             SocketError errorCode;
             if (!handle.IsNonBlocking)
             {
-                errorCode = handle.AsyncContext.ReceiveMessageFrom(buffer, ref socketFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, handle.ReceiveTimeout, out ipPacketInformation, out bytesTransferred);
+                errorCode = handle.AsyncContext.ReceiveMessageFrom(buffer, ref socketFlags, socketAddressBuffer, out socketAddressLen, isIPv4, isIPv6, handle.ReceiveTimeout, out ipPacketInformation, out bytesTransferred);
             }
             else
             {
-                if (!TryCompleteReceiveMessageFrom(handle, buffer, null, socketFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out socketFlags, out ipPacketInformation, out errorCode))
+                if (!TryCompleteReceiveMessageFrom(handle, buffer, null, socketFlags, socketAddressBuffer, out socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out socketFlags, out ipPacketInformation, out errorCode))
                 {
                     errorCode = SocketError.WouldBlock;
                 }
@@ -1319,27 +1315,27 @@ namespace System.Net.Sockets
             return errorCode;
         }
 
-        public static SocketError ReceiveFrom(SafeSocketHandle handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, byte[] socketAddress, ref int socketAddressLen, out int bytesTransferred)
+        public static SocketError ReceiveFrom(SafeSocketHandle handle, byte[] buffer, int offset, int count, SocketFlags socketFlags, Memory<byte> socketAddress, out int socketAddressLen, out int bytesTransferred)
         {
             if (!handle.IsNonBlocking)
             {
-                return handle.AsyncContext.ReceiveFrom(new Memory<byte>(buffer, offset, count), ref socketFlags, socketAddress, ref socketAddressLen, handle.ReceiveTimeout, out bytesTransferred);
+                return handle.AsyncContext.ReceiveFrom(new Memory<byte>(buffer, offset, count), ref socketFlags, socketAddress, out socketAddressLen, handle.ReceiveTimeout, out bytesTransferred);
             }
 
             SocketError errorCode;
-            bool completed = TryCompleteReceiveFrom(handle, new Span<byte>(buffer, offset, count), socketFlags, socketAddress, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
+            bool completed = TryCompleteReceiveFrom(handle, new Span<byte>(buffer, offset, count), socketFlags, socketAddress.Span, out socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
-        public static SocketError ReceiveFrom(SafeSocketHandle handle, Span<byte> buffer, SocketFlags socketFlags, byte[] socketAddress, ref int socketAddressLen, out int bytesTransferred)
+        public static SocketError ReceiveFrom(SafeSocketHandle handle, Span<byte> buffer, SocketFlags socketFlags, Memory<byte> socketAddress, out int socketAddressLen, out int bytesTransferred)
         {
             if (!handle.IsNonBlocking)
             {
-                return handle.AsyncContext.ReceiveFrom(buffer, ref socketFlags, socketAddress, ref socketAddressLen, handle.ReceiveTimeout, out bytesTransferred);
+                return handle.AsyncContext.ReceiveFrom(buffer, ref socketFlags, socketAddress, out socketAddressLen, handle.ReceiveTimeout, out bytesTransferred);
             }
 
             SocketError errorCode;
-            bool completed = TryCompleteReceiveFrom(handle, buffer, socketFlags, socketAddress, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
+            bool completed = TryCompleteReceiveFrom(handle, buffer, socketFlags, socketAddress.Span, out socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -448,7 +448,7 @@ namespace System.Net.Sockets
             receiveAddress = socketAddress;
             ipPacketInformation = default(IPPacketInformation);
             fixed (byte* bufferPtr = &MemoryMarshal.GetReference(buffer))
-            fixed (byte* ptrSocketAddress = socketAddress.Buffer)
+            fixed (byte* ptrSocketAddress = &MemoryMarshal.GetReference(socketAddress.Buffer.Span))
             {
                 Interop.Winsock.WSAMsg wsaMsg;
                 wsaMsg.socketAddress = (IntPtr)ptrSocketAddress;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -192,7 +192,6 @@ namespace System.Net.Sockets
             SocketError errorCode = Interop.Winsock.WSAConnect(
                 handle,
                 peerAddress.Span,
-                peerAddress.Length,
                 IntPtr.Zero,
                 IntPtr.Zero,
                 IntPtr.Zero,

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -187,12 +187,12 @@ namespace System.Net.Sockets
             return socket.IsInvalid ? GetLastSocketError() : SocketError.Success;
         }
 
-        public static SocketError Connect(SafeSocketHandle handle, byte[] peerAddress, int peerAddressLen)
+        public static SocketError Connect(SafeSocketHandle handle, Memory<byte> peerAddress)
         {
             SocketError errorCode = Interop.Winsock.WSAConnect(
                 handle,
-                peerAddress,
-                peerAddressLen,
+                peerAddress.Span,
+                peerAddress.Length,
                 IntPtr.Zero,
                 IntPtr.Zero,
                 IntPtr.Zero,

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -176,10 +176,11 @@ namespace System.Net.Sockets
             return errorCode == SocketError.SocketError ? GetLastSocketError() : SocketError.Success;
         }
 
-        public static SocketError Accept(SafeSocketHandle listenSocket, byte[] socketAddress, ref int socketAddressSize, out SafeSocketHandle socket)
+        public static SocketError Accept(SafeSocketHandle listenSocket, Memory<byte> socketAddress, out int socketAddressSize, out SafeSocketHandle socket)
         {
             socket = new SafeSocketHandle();
-            Marshal.InitHandle(socket, Interop.Winsock.accept(listenSocket, socketAddress, ref socketAddressSize));
+            socketAddressSize = socketAddress.Length;
+            Marshal.InitHandle(socket, Interop.Winsock.accept(listenSocket, socketAddress.Span, ref socketAddressSize));
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, socket);
 
@@ -300,15 +301,15 @@ namespace System.Net.Sockets
             }
         }
 
-        public static SocketError SendTo(SafeSocketHandle handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, byte[] peerAddress, int peerAddressSize, out int bytesTransferred) =>
-            SendTo(handle, buffer.AsSpan(offset, size), socketFlags, peerAddress, peerAddressSize, out bytesTransferred);
+        public static SocketError SendTo(SafeSocketHandle handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, ReadOnlyMemory<byte> peerAddress, out int bytesTransferred) =>
+            SendTo(handle, buffer.AsSpan(offset, size), socketFlags, peerAddress, out bytesTransferred);
 
-        public static unsafe SocketError SendTo(SafeSocketHandle handle, ReadOnlySpan<byte> buffer, SocketFlags socketFlags, byte[] peerAddress, int peerAddressSize, out int bytesTransferred)
+        public static unsafe SocketError SendTo(SafeSocketHandle handle, ReadOnlySpan<byte> buffer, SocketFlags socketFlags, ReadOnlyMemory<byte> peerAddress, out int bytesTransferred)
         {
             int bytesSent;
             fixed (byte* bufferPtr = &MemoryMarshal.GetReference(buffer))
             {
-                bytesSent = Interop.Winsock.sendto(handle, bufferPtr, buffer.Length, socketFlags, peerAddress, peerAddressSize);
+                bytesSent = Interop.Winsock.sendto(handle, bufferPtr, buffer.Length, socketFlags, peerAddress.Span, peerAddress.Length);
             }
 
             if (bytesSent == (int)SocketError.SocketError)
@@ -512,17 +513,15 @@ namespace System.Net.Sockets
             return SocketError.Success;
         }
 
-        public static unsafe SocketError ReceiveFrom(SafeSocketHandle handle, byte[] buffer, int offset, int size, SocketFlags _ /*socketFlags*/, byte[] socketAddress, ref int addressLength, out int bytesTransferred) =>
-            ReceiveFrom(handle, buffer.AsSpan(offset, size), SocketFlags.None, socketAddress, ref addressLength, out bytesTransferred);
+        public static unsafe SocketError ReceiveFrom(SafeSocketHandle handle, byte[] buffer, int offset, int size, SocketFlags _ /*socketFlags*/, Memory<byte> socketAddress, out int addressLength, out int bytesTransferred) =>
+            ReceiveFrom(handle, buffer.AsSpan(offset, size), SocketFlags.None, socketAddress, out addressLength, out bytesTransferred);
 
-        public static unsafe SocketError ReceiveFrom(SafeSocketHandle handle, Span<byte> buffer, SocketFlags socketFlags, byte[] socketAddress, ref int addressLength, out int bytesTransferred)
+        public static unsafe SocketError ReceiveFrom(SafeSocketHandle handle, Span<byte> buffer, SocketFlags socketFlags, Memory<byte> socketAddress, out int addressLength, out int bytesTransferred)
         {
             int bytesReceived;
 
-            fixed (byte* bufferPtr = &MemoryMarshal.GetReference(buffer))
-            {
-                bytesReceived = Interop.Winsock.recvfrom(handle, bufferPtr, buffer.Length, socketFlags, socketAddress, ref addressLength);
-            }
+            addressLength = socketAddress.Length;
+            bytesReceived = Interop.Winsock.recvfrom(handle, buffer, buffer.Length, socketFlags, socketAddress.Span, ref addressLength);
 
             if (bytesReceived == (int)SocketError.SocketError)
             {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
@@ -155,6 +155,52 @@ namespace System.Net.Sockets.Tests
         }
 
         [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ReceiveSent_SocketAddress_Success(bool ipv4)
+        {
+            //const int Offset = 10;
+            const int DatagramSize = 256;
+            const int DatagramsToSend = 16;
+
+            IPAddress address = ipv4 ? IPAddress.Loopback : IPAddress.IPv6Loopback;
+            using Socket server = new Socket(address.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
+            using Socket client = new Socket(address.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
+
+            client.BindToAnonymousPort(address);
+            server.BindToAnonymousPort(address);
+
+            byte[] sendBuffer = new byte[DatagramSize];
+            byte[] receiveBuffer = new byte[DatagramSize];
+
+            SocketAddress serverSA = server.LocalEndPoint.Serialize();
+            SocketAddress clientSA = client.LocalEndPoint.Serialize();
+            SocketAddress sa = new SocketAddress(address.AddressFamily);
+
+            Random rnd = new Random(0);
+
+            for (int i = 0; i < DatagramsToSend; i++)
+            {
+                rnd.NextBytes(sendBuffer);
+                client.SendTo(sendBuffer.AsSpan(), SocketFlags.None, serverSA);
+
+                int readBytes = server.ReceiveFrom(receiveBuffer, SocketFlags.None, sa);
+                Assert.Equal(sa, clientSA);
+                Assert.Equal(client.LocalEndPoint, client.LocalEndPoint.Create(sa));
+                Assert.True(new Span<byte>(receiveBuffer, 0, readBytes).SequenceEqual(sendBuffer));
+
+                // and send it back to make sure it works.
+                rnd.NextBytes(sendBuffer);
+                server.SendTo(sendBuffer, SocketFlags.None, sa);
+                readBytes = client.ReceiveFrom(receiveBuffer, SocketFlags.None, sa);
+                Assert.Equal(sa, serverSA);
+                Assert.Equal(server.LocalEndPoint, server.LocalEndPoint.Create(sa));
+                Assert.True(new Span<byte>(receiveBuffer, 0, readBytes).SequenceEqual(sendBuffer));
+
+            }
+        }
+
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task ClosedBeforeOperation_Throws_ObjectDisposedException(bool closeOrDispose)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
@@ -159,7 +159,6 @@ namespace System.Net.Sockets.Tests
         [InlineData(true)]
         public void ReceiveSent_SocketAddress_Success(bool ipv4)
         {
-            //const int Offset = 10;
             const int DatagramSize = 256;
             const int DatagramsToSend = 16;
 
@@ -198,6 +197,20 @@ namespace System.Net.Sockets.Tests
                 Assert.True(new Span<byte>(receiveBuffer, 0, readBytes).SequenceEqual(sendBuffer));
 
             }
+        }
+
+        [Fact]
+        public void ReceiveSent_SmallSocketAddress_Throws()
+        {
+            using Socket server = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            server.BindToAnonymousPort(IPAddress.Loopback);
+
+            byte[] receiveBuffer = new byte[1];
+
+            SocketAddress serverSA = server.LocalEndPoint.Serialize();
+
+            SocketAddress sa = new SocketAddress(AddressFamily.InterNetwork, 2);
+           Assert.Throws<ArgumentOutOfRangeException>(() => server.ReceiveFrom(receiveBuffer, SocketFlags.None, sa));
         }
 
         [Theory]

--- a/src/native/libs/System.Native/entrypoints.c
+++ b/src/native/libs/System.Native/entrypoints.c
@@ -137,7 +137,7 @@ static const Entry s_sysNative[] =
     DllImportEntry(SystemNative_GetNameInfo)
     DllImportEntry(SystemNative_GetDomainName)
     DllImportEntry(SystemNative_GetHostName)
-    DllImportEntry(SystemNative_GetIPSocketAddressSizes)
+    DllImportEntry(SystemNative_GetSocketAddressSizes)
     DllImportEntry(SystemNative_GetAddressFamily)
     DllImportEntry(SystemNative_SetAddressFamily)
     DllImportEntry(SystemNative_GetPort)

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -659,15 +659,17 @@ static bool IsInBounds(const void* void_baseAddr, size_t len, const void* void_v
     return valueAddr >= baseAddr && (valueAddr + valueSize) <= (baseAddr + len);
 }
 
-int32_t SystemNative_GetIPSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize)
+int32_t SystemNative_GetSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize, int32_t* udsSocketAddressSize, int32_t* maxSocketAddressSize)
 {
-    if (ipv4SocketAddressSize == NULL || ipv6SocketAddressSize == NULL)
+    if (ipv4SocketAddressSize == NULL || ipv6SocketAddressSize == NULL || udsSocketAddressSize == NULL || maxSocketAddressSize == NULL)
     {
         return Error_EFAULT;
     }
 
     *ipv4SocketAddressSize = sizeof(struct sockaddr_in);
     *ipv6SocketAddressSize = sizeof(struct sockaddr_in6);
+    *udsSocketAddressSize = sizeof(struct sockaddr_un);
+    *maxSocketAddressSize = sizeof(struct sockaddr_storage);
     return Error_SUCCESS;
 }
 

--- a/src/native/libs/System.Native/pal_networking.h
+++ b/src/native/libs/System.Native/pal_networking.h
@@ -312,7 +312,7 @@ PALEXPORT int32_t SystemNative_GetDomainName(uint8_t* name, int32_t nameLength);
 
 PALEXPORT int32_t SystemNative_GetHostName(uint8_t* name, int32_t nameLength);
 
-PALEXPORT int32_t SystemNative_GetIPSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize);
+PALEXPORT int32_t SystemNative_GetSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize, int32_t* udsSocketAddressSize, int32_t* maxSocketAddressSize);
 
 PALEXPORT int32_t SystemNative_GetAddressFamily(const uint8_t* socketAddress, int32_t socketAddressLen, int32_t* addressFamily);
 

--- a/src/native/libs/System.Native/pal_networking_wasi.c
+++ b/src/native/libs/System.Native/pal_networking_wasi.c
@@ -61,7 +61,7 @@ int32_t SystemNative_GetHostName(uint8_t* name, int32_t nameLength)
     return gethostname((char*)name, unsignedSize);
 }
 
-int32_t SystemNative_GetIPSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize)
+int32_t SystemNative_GetSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize, int32_t*udsSocketAddressSize, int* maxSocketAddressSize)
 {
     return Error_EFAULT;
 }


### PR DESCRIPTION
And uses new SocketAddress API. That spanifies some of the PAL code as prep for removal of Internal.SocketAddress. 

fixes  #86872 
contributes to  #87397
contributes to https://github.com/dotnet/runtime/issues/30797