### PR TITLE
Implement HttpRequestError

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -275,7 +275,9 @@ namespace System.Net.Http.Functional.Tests
         {
             await StartTransferTypeAndErrorServer(transferType, transferError, async uri =>
             {
-                await Assert.ThrowsAsync<IOException>(() => ReadAsStreamHelper(uri));
+                HttpIOException exception = await Assert.ThrowsAsync<HttpIOException>(() => ReadAsStreamHelper(uri));
+                _output.WriteLine(exception.Message);
+                Assert.Equal(HttpRequestError.ResponseEnded, exception.HttpRequestError);
             });
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -275,9 +275,16 @@ namespace System.Net.Http.Functional.Tests
         {
             await StartTransferTypeAndErrorServer(transferType, transferError, async uri =>
             {
-                HttpIOException exception = await Assert.ThrowsAsync<HttpIOException>(() => ReadAsStreamHelper(uri));
-                _output.WriteLine(exception.Message);
-                Assert.Equal(HttpRequestError.ResponseEnded, exception.HttpRequestError);
+                if (IsWinHttpHandler)
+                {
+                    await Assert.ThrowsAsync<IOException>(() => ReadAsStreamHelper(uri));
+                }
+                else
+                {
+                    HttpIOException exception = await Assert.ThrowsAsync<HttpIOException>(() => ReadAsStreamHelper(uri));
+                    Assert.Equal(HttpRequestError.ResponseEnded, exception.HttpRequestError);
+                }
+                
             });
         }
 

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -246,7 +246,7 @@ namespace System.Net.Http
         public static bool operator !=(System.Net.Http.HttpMethod? left, System.Net.Http.HttpMethod? right) { throw null; }
         public override string ToString() { throw null; }
     }
-    public sealed class HttpProtocolException : HttpIOException
+    public sealed class HttpProtocolException : System.Net.Http.HttpIOException
     {
         public HttpProtocolException(long errorCode, string? message, System.Exception? innerException) : base (default(System.Net.Http.HttpRequestError), default(string?), default(System.Exception?)) { }
         public long ErrorCode { get { throw null; } }
@@ -272,7 +272,7 @@ namespace System.Net.Http
         public HttpRequestException(string? message) { }
         public HttpRequestException(string? message, System.Exception? inner) { }
         public HttpRequestException(string? message, System.Exception? inner, System.Net.HttpStatusCode? statusCode) { }
-        public HttpRequestException(string? message, Exception? inner = null, HttpStatusCode? statusCode = null, HttpRequestError? httpRequestError = null) { }
+        public HttpRequestException(string? message, System.Exception? inner = null, System.Net.HttpStatusCode? statusCode = null, System.Net.Http.HttpRequestError? httpRequestError = null) { }
         public System.Net.Http.HttpRequestError? HttpRequestError { get { throw null; } }
         public System.Net.HttpStatusCode? StatusCode { get { throw null; } }
     }

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -203,6 +203,11 @@ namespace System.Net.Http
         protected virtual System.Threading.Tasks.Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext? context, System.Threading.CancellationToken cancellationToken) { throw null; }
         protected internal abstract bool TryComputeLength(out long length);
     }
+    public class HttpIOException : System.IO.IOException
+    {
+        public System.Net.Http.HttpRequestError HttpRequestError { get { throw null; } }
+        public HttpIOException(System.Net.Http.HttpRequestError httpRequestError, string? message = null, System.Exception? innerException = null) { }
+    }
     public abstract partial class HttpMessageHandler : System.IDisposable
     {
         protected HttpMessageHandler() { }
@@ -241,10 +246,25 @@ namespace System.Net.Http
         public static bool operator !=(System.Net.Http.HttpMethod? left, System.Net.Http.HttpMethod? right) { throw null; }
         public override string ToString() { throw null; }
     }
-    public sealed class HttpProtocolException : System.IO.IOException
+    public sealed class HttpProtocolException : HttpIOException
     {
-        public HttpProtocolException(long errorCode, string? message, System.Exception? innerException) { }
+        public HttpProtocolException(long errorCode, string? message, System.Exception? innerException) : base (default(System.Net.Http.HttpRequestError), default(string?), default(System.Exception?)) { }
         public long ErrorCode { get { throw null; } }
+    }
+    public enum HttpRequestError
+    {
+        Unknown = 0,
+        NameResolutionError,
+        ConnectionError,
+        SecureConnectionError,
+        HttpProtocolError,
+        ExtendedConnectNotSupported,
+        VersionNegotiationError,
+        UserAuthenticationError,
+        ProxyTunnelError,
+        InvalidResponse,
+        ResponseEnded,
+        ConfigurationLimitExceeded,
     }
     public partial class HttpRequestException : System.Exception
     {
@@ -252,6 +272,8 @@ namespace System.Net.Http
         public HttpRequestException(string? message) { }
         public HttpRequestException(string? message, System.Exception? inner) { }
         public HttpRequestException(string? message, System.Exception? inner, System.Net.HttpStatusCode? statusCode) { }
+        public HttpRequestException(string? message, Exception? inner = null, HttpStatusCode? statusCode = null, HttpRequestError? httpRequestError = null) { }
+        public System.Net.Http.HttpRequestError? HttpRequestError { get { throw null; } }
         public System.Net.HttpStatusCode? StatusCode { get { throw null; } }
     }
     public partial class HttpRequestMessage : System.IDisposable

--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -564,6 +564,9 @@
   <data name="net_http_proxy_tunnel_returned_failure_status_code" xml:space="preserve">
     <value>The proxy tunnel request to proxy '{0}' failed with status code '{1}'."</value>
   </data>
+  <data name="net_http_proxy_tunnel_error" xml:space="preserve">
+    <value>An error occured while establishing a connection to the proxy tunnel.</value>
+  </data>
   <data name="PlatformNotSupported_NetHttp" xml:space="preserve">
     <value>System.Net.Http is not supported on this platform.</value>
   </data>

--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -565,7 +565,7 @@
     <value>The proxy tunnel request to proxy '{0}' failed with status code '{1}'."</value>
   </data>
   <data name="net_http_proxy_tunnel_error" xml:space="preserve">
-    <value>An error occured while establishing a connection to the proxy tunnel.</value>
+    <value>An error occurred while establishing a connection to the proxy tunnel.</value>
   </data>
   <data name="PlatformNotSupported_NetHttp" xml:space="preserve">
     <value>System.Net.Http is not supported on this platform.</value>

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -58,10 +58,12 @@
     <Compile Include="System\Net\Http\HttpParseResult.cs" />
     <Compile Include="System\Net\Http\HttpProtocolException.cs" />
     <Compile Include="System\Net\Http\HttpRequestException.cs" />
+    <Compile Include="System\Net\Http\HttpRequestError.cs" />
     <Compile Include="System\Net\Http\HttpRequestMessage.cs" />
     <Compile Include="System\Net\Http\HttpRequestOptions.cs" />
     <Compile Include="System\Net\Http\HttpRequestOptionsKey.cs" />
     <Compile Include="System\Net\Http\HttpResponseMessage.cs" />
+    <Compile Include="System\Net\Http\HttpIOException.cs" />
     <Compile Include="System\Net\Http\HttpRuleParser.cs" />
     <Compile Include="System\Net\Http\HttpTelemetry.cs" />
     <Compile Include="System\Net\Http\HttpVersionPolicy.cs" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -638,7 +638,7 @@ namespace System.Net.Http
 
                 if (contentLength > maxBufferSize)
                 {
-                    error = new HttpRequestException(SR.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_content_buffersize_exceeded, maxBufferSize));
+                    error = CreateOverCapacityException(maxBufferSize);
                     return null;
                 }
 
@@ -719,7 +719,8 @@ namespace System.Net.Http
         internal static Exception WrapStreamCopyException(Exception e)
         {
             Debug.Assert(StreamCopyExceptionNeedsWrapping(e));
-            return new HttpRequestException(SR.net_http_content_stream_copy_error, e);
+            HttpRequestError error = e is HttpIOException ioEx ? ioEx.HttpRequestError : HttpRequestError.Unknown;
+            return new HttpRequestException(SR.net_http_content_stream_copy_error, e, httpRequestError: error);
         }
 
         private static int GetPreambleLength(ArraySegment<byte> buffer, Encoding encoding)
@@ -832,9 +833,9 @@ namespace System.Net.Http
             return returnFunc(state);
         }
 
-        private static HttpRequestException CreateOverCapacityException(int maxBufferSize)
+        private static HttpRequestException CreateOverCapacityException(long maxBufferSize)
         {
-            return new HttpRequestException(SR.Format(SR.net_http_content_buffersize_exceeded, maxBufferSize));
+            return new HttpRequestException(SR.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_content_buffersize_exceeded, maxBufferSize), httpRequestError: HttpRequestError.ConfigurationLimitExceeded);
         }
 
         internal sealed class LimitMemoryStream : MemoryStream

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpIOException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpIOException.cs
@@ -6,15 +6,10 @@ using System.IO;
 namespace System.Net.Http
 {
     /// <summary>
-    /// An exception thrown when an error occurs while reading the response content stream.
+    /// An exception thrown when an error occurs while reading the response.
     /// </summary>
     public class HttpIOException : IOException
     {
-        /// <summary>
-        /// Gets the <see cref="Http.HttpRequestError"/> that caused the exception.
-        /// </summary>
-        public HttpRequestError HttpRequestError { get; }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpIOException"/> class.
         /// </summary>
@@ -26,5 +21,10 @@ namespace System.Net.Http
         {
             HttpRequestError = httpRequestError;
         }
+
+        /// <summary>
+        /// Gets the <see cref="Http.HttpRequestError"/> that caused the exception.
+        /// </summary>
+        public HttpRequestError HttpRequestError { get; }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpIOException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpIOException.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// An exception thrown when an error occurs while reading the response content stream.
+    /// </summary>
+    public class HttpIOException : IOException
+    {
+        /// <summary>
+        /// Gets the <see cref="Http.HttpRequestError"/> that caused the exception.
+        /// </summary>
+        public HttpRequestError HttpRequestError { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpIOException"/> class.
+        /// </summary>
+        /// <param name="httpRequestError">The <see cref="Http.HttpRequestError"/> that caused the exception.</param>
+        /// <param name="message">The message string describing the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
+        public HttpIOException(HttpRequestError httpRequestError, string? message = null, Exception? innerException = null)
+            : base(message, innerException)
+        {
+            HttpRequestError = httpRequestError;
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpIOException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpIOException.cs
@@ -26,5 +26,8 @@ namespace System.Net.Http
         /// Gets the <see cref="Http.HttpRequestError"/> that caused the exception.
         /// </summary>
         public HttpRequestError HttpRequestError { get; }
+
+        /// <inheritdoc />
+        public override string Message => $"{base.Message} ({HttpRequestError})";
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpProtocolException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpProtocolException.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Net.Quic;
 
 namespace System.Net.Http
 {
@@ -47,10 +48,10 @@ namespace System.Net.Http
             return new HttpProtocolException((long)protocolError, message, null);
         }
 
-        internal static HttpProtocolException CreateHttp3StreamException(Http3ErrorCode protocolError)
+        internal static HttpProtocolException CreateHttp3StreamException(Http3ErrorCode protocolError, QuicException innerException)
         {
             string message = SR.Format(SR.net_http_http3_stream_error, GetName(protocolError), ((int)protocolError).ToString("x"));
-            return new HttpProtocolException((long)protocolError, message, null);
+            return new HttpProtocolException((long)protocolError, message, innerException);
         }
 
         internal static HttpProtocolException CreateHttp3ConnectionException(Http3ErrorCode protocolError, string? message = null)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpProtocolException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpProtocolException.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http
     /// When calling <see cref="Stream"/> methods on the stream returned by <see cref="HttpContent.ReadAsStream()"/> or
     /// <see cref="HttpContent.ReadAsStreamAsync(Threading.CancellationToken)"/>, <see cref="HttpProtocolException"/> can be thrown directly.
     /// </remarks>
-    public sealed class HttpProtocolException : IOException
+    public sealed class HttpProtocolException : HttpIOException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpProtocolException"/> class with the specified error code,
@@ -24,7 +24,7 @@ namespace System.Net.Http
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public HttpProtocolException(long errorCode, string message, Exception? innerException)
-            : base(message, innerException)
+            : base(Http.HttpRequestError.HttpProtocolError, message, innerException)
         {
             ErrorCode = errorCode;
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestError.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestError.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// Defines error categories representing the reason for <see cref="HttpRequestException"/> or <see cref="HttpIOException"/>.
+    /// </summary>
+    public enum HttpRequestError
+    {
+        /// <summary>
+        /// A generic or unknown error occured.
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// The DNS name resolution failed.
+        /// </summary>
+        NameResolutionError,                    // DNS request failed
+
+        /// <summary>
+        /// A transport-level failure occured while connecting to the remote endpoint.
+        /// </summary>
+        ConnectionError,
+
+        /// <summary>
+        /// An error occured during the TLS handshake.
+        /// </summary>
+        SecureConnectionError,
+
+        /// <summary>
+        /// An HTTP/2 or HTTP/3 protocol error occured.
+        /// </summary>
+        HttpProtocolError,                      // HTTP 2.0/3.0 protocol error occurred
+
+        /// <summary>
+        /// Extended CONNECT for WebSockets over HTTP/2 is not supported by the peer.
+        /// </summary>
+        ExtendedConnectNotSupported,
+
+        /// <summary>
+        /// Cannot negotiate the HTTP Version requested.
+        /// </summary>
+        VersionNegotiationError,
+
+        /// <summary>
+        /// The authentication failed with the provided credentials.
+        /// </summary>
+        UserAuthenticationError,
+
+        /// <summary>
+        /// An error occured while establishing a connection to the proxy tunnel.
+        /// </summary>
+        ProxyTunnelError,
+
+        /// <summary>
+        /// An invalid or malformed response has been received.
+        /// </summary>
+        InvalidResponse,                        // General error in response/malformed response
+
+        /// <summary>
+        /// The response ended prematurely.
+        /// </summary>
+        ResponseEnded,
+
+        /// <summary>
+        /// The response exceeded a pre-configured limit such as <see cref="HttpClient.MaxResponseContentBufferSize"/> or <see cref="HttpClientHandler.MaxResponseHeadersLength"/>.
+        /// </summary>
+        ConfigurationLimitExceeded,
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestError.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestError.cs
@@ -9,7 +9,7 @@ namespace System.Net.Http
     public enum HttpRequestError
     {
         /// <summary>
-        /// A generic or unknown error occured.
+        /// A generic or unknown error occurred.
         /// </summary>
         Unknown = 0,
 
@@ -19,17 +19,17 @@ namespace System.Net.Http
         NameResolutionError,
 
         /// <summary>
-        /// A transport-level failure occured while connecting to the remote endpoint.
+        /// A transport-level failure occurred while connecting to the remote endpoint.
         /// </summary>
         ConnectionError,
 
         /// <summary>
-        /// An error occured during the TLS handshake.
+        /// An error occurred during the TLS handshake.
         /// </summary>
         SecureConnectionError,
 
         /// <summary>
-        /// An HTTP/2 or HTTP/3 protocol error occured.
+        /// An HTTP/2 or HTTP/3 protocol error occurred.
         /// </summary>
         HttpProtocolError,
 
@@ -44,12 +44,12 @@ namespace System.Net.Http
         VersionNegotiationError,
 
         /// <summary>
-        /// The authentication failed with the provided credentials.
+        /// The authentication failed.
         /// </summary>
         UserAuthenticationError,
 
         /// <summary>
-        /// An error occured while establishing a connection to the proxy tunnel.
+        /// An error occurred while establishing a connection to the proxy tunnel.
         /// </summary>
         ProxyTunnelError,
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestError.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestError.cs
@@ -16,7 +16,7 @@ namespace System.Net.Http
         /// <summary>
         /// The DNS name resolution failed.
         /// </summary>
-        NameResolutionError,                    // DNS request failed
+        NameResolutionError,
 
         /// <summary>
         /// A transport-level failure occured while connecting to the remote endpoint.
@@ -31,7 +31,7 @@ namespace System.Net.Http
         /// <summary>
         /// An HTTP/2 or HTTP/3 protocol error occured.
         /// </summary>
-        HttpProtocolError,                      // HTTP 2.0/3.0 protocol error occurred
+        HttpProtocolError,
 
         /// <summary>
         /// Extended CONNECT for WebSockets over HTTP/2 is not supported by the peer.
@@ -56,7 +56,7 @@ namespace System.Net.Http
         /// <summary>
         /// An invalid or malformed response has been received.
         /// </summary>
-        InvalidResponse,                        // General error in response/malformed response
+        InvalidResponse,
 
         /// <summary>
         /// The response ended prematurely.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestException.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestException.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-
 namespace System.Net.Http
 {
     public class HttpRequestException : Exception
@@ -11,11 +8,10 @@ namespace System.Net.Http
         internal RequestRetryType AllowRetry { get; } = RequestRetryType.NoRetry;
 
         public HttpRequestException()
-            : this(null, null)
         { }
 
         public HttpRequestException(string? message)
-            : this(message, null)
+            : base(message)
         { }
 
         public HttpRequestException(string? message, Exception? inner)
@@ -40,6 +36,27 @@ namespace System.Net.Http
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestException" /> class with a specific message an inner exception, and an HTTP status code and an <see cref="HttpRequestError"/>.
+        /// </summary>
+        /// <param name="message">A message that describes the current exception.</param>
+        /// <param name="inner">The inner exception.</param>
+        /// <param name="statusCode">The HTTP status code.</param>
+        /// <param name="httpRequestError">The <see cref="HttpRequestError"/> that caused the exception.</param>
+        public HttpRequestException(string? message, Exception? inner = null, HttpStatusCode? statusCode = null, HttpRequestError? httpRequestError = null)
+            : this(message, inner, statusCode)
+        {
+            HttpRequestError = httpRequestError;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Http.HttpRequestError"/> that caused the exception.
+        /// </summary>
+        /// <value>
+        /// The <see cref="Http.HttpRequestError"/> or <see langword="null"/> if the underlying <see cref="HttpMessageHandler"/> did not provide it.
+        /// </value>
+        public HttpRequestError? HttpRequestError { get; }
+
+        /// <summary>
         /// Gets the HTTP status code to be returned with the exception.
         /// </summary>
         /// <value>
@@ -49,8 +66,8 @@ namespace System.Net.Http
 
         // This constructor is used internally to indicate that a request was not successfully sent due to an IOException,
         // and the exception occurred early enough so that the request may be retried on another connection.
-        internal HttpRequestException(string? message, Exception? inner, RequestRetryType allowRetry)
-            : this(message, inner)
+        internal HttpRequestException(string? message, Exception? inner, RequestRetryType allowRetry, HttpRequestError? httpRequestError = null)
+            : this(message, inner, httpRequestError: httpRequestError)
         {
             AllowRetry = allowRetry;
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/HttpMetricsEnrichmentContext.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/HttpMetricsEnrichmentContext.cs
@@ -53,7 +53,7 @@ namespace System.Net.Http.Metrics
         public HttpResponseMessage? Response => _response;
 
         /// <summary>
-        /// Gets the exception that occured or <see langword="null"/> if there was no error.
+        /// Gets the exception that occurred or <see langword="null"/> if there was no error.
         /// </summary>
         /// <remarks>
         /// This property must not be used from outside of the enrichment callbacks.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -209,7 +209,7 @@ namespace System.Net.Http
                                 {
                                     isNewConnection = false;
                                     connection.Dispose();
-                                    throw new HttpRequestException(SR.Format(SR.net_http_authvalidationfailure, statusCode), null, HttpStatusCode.Unauthorized);
+                                    throw new HttpRequestException(SR.Format(SR.net_http_authvalidationfailure, statusCode), null, HttpStatusCode.Unauthorized, HttpRequestError.UserAuthenticationError);
                                 }
                                 break;
                             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -73,7 +73,7 @@ namespace System.Net.Http
                         int bytesRead = _connection.Read(buffer.Slice(0, (int)Math.Min((ulong)buffer.Length, _chunkBytesRemaining)));
                         if (bytesRead == 0)
                         {
-                            throw new IOException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _chunkBytesRemaining));
+                            throw new HttpIOException(HttpRequestError.ResponseEnded, SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _chunkBytesRemaining));
                         }
                         _chunkBytesRemaining -= (ulong)bytesRead;
                         if (_chunkBytesRemaining == 0)
@@ -189,7 +189,7 @@ namespace System.Net.Http
                             int bytesRead = await _connection.ReadAsync(buffer.Slice(0, (int)Math.Min((ulong)buffer.Length, _chunkBytesRemaining))).ConfigureAwait(false);
                             if (bytesRead == 0)
                             {
-                                throw new IOException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _chunkBytesRemaining));
+                                throw new HttpIOException(HttpRequestError.ResponseEnded, SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _chunkBytesRemaining));
                             }
                             _chunkBytesRemaining -= (ulong)bytesRead;
                             if (_chunkBytesRemaining == 0)
@@ -332,7 +332,7 @@ namespace System.Net.Http
                             // Parse the hex value from it.
                             if (!Utf8Parser.TryParse(currentLine, out ulong chunkSize, out int bytesConsumed, 'X'))
                             {
-                                throw new IOException(SR.Format(SR.net_http_invalid_response_chunk_header_invalid, BitConverter.ToString(currentLine.ToArray())));
+                                throw new HttpIOException(HttpRequestError.InvalidResponse, SR.Format(SR.net_http_invalid_response_chunk_header_invalid, BitConverter.ToString(currentLine.ToArray())));
                             }
                             _chunkBytesRemaining = chunkSize;
 
@@ -386,7 +386,7 @@ namespace System.Net.Http
 
                             if (currentLine.Length != 0)
                             {
-                                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_chunk_terminator_invalid, Encoding.ASCII.GetString(currentLine)));
+                                throw new HttpIOException(HttpRequestError.InvalidResponse, SR.Format(SR.net_http_invalid_response_chunk_terminator_invalid, Encoding.ASCII.GetString(currentLine)));
                             }
 
                             _state = ParsingState.ExpectChunkHeader;
@@ -449,7 +449,7 @@ namespace System.Net.Http
                     }
                     else if (c != ' ' && c != '\t') // not called out in the RFC, but WinHTTP allows it
                     {
-                        throw new IOException(SR.Format(SR.net_http_invalid_response_chunk_extension_invalid, BitConverter.ToString(lineAfterChunkSize.ToArray())));
+                        throw new HttpIOException(HttpRequestError.InvalidResponse, SR.Format(SR.net_http_invalid_response_chunk_extension_invalid, BitConverter.ToString(lineAfterChunkSize.ToArray())));
                     }
                 }
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -7,6 +7,7 @@ using System.Net.Quic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.Versioning;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -88,13 +89,7 @@ namespace System.Net.Http
                     throw CancellationHelper.CreateOperationCanceledException(e, cancellationToken);
                 }
 
-                HttpRequestException ex = new HttpRequestException(SR.net_http_ssl_connection_failed, e);
-                if (request.IsExtendedConnectRequest)
-                {
-                    // Extended connect request is negotiating strictly for ALPN = "h2" because HttpClient is unaware of a possible downgrade.
-                    // At this point, SSL connection for HTTP / 2 failed, and the exception should indicate the reason for the external client / user.
-                    ex.Data["HTTP2_ENABLED"] = false;
-                }
+                HttpRequestException ex = new HttpRequestException(SR.net_http_ssl_connection_failed, e, httpRequestError: HttpRequestError.SecureConnectionError);
                 throw ex;
             }
 
@@ -134,11 +129,27 @@ namespace System.Net.Http
             }
         }
 
-        internal static Exception CreateWrappedException(Exception error, string host, int port, CancellationToken cancellationToken)
+        internal static Exception CreateWrappedException(Exception exception, string host, int port, CancellationToken cancellationToken)
         {
-            return CancellationHelper.ShouldWrapInOperationCanceledException(error, cancellationToken) ?
-                CancellationHelper.CreateOperationCanceledException(error, cancellationToken) :
-                new HttpRequestException($"{error.Message} ({host}:{port})", error, RequestRetryType.RetryOnNextProxy);
+            return CancellationHelper.ShouldWrapInOperationCanceledException(exception, cancellationToken) ?
+                CancellationHelper.CreateOperationCanceledException(exception, cancellationToken) :
+                new HttpRequestException($"{exception.Message} ({host}:{port})", exception, RequestRetryType.RetryOnNextProxy, DeduceError(exception));
+
+            static HttpRequestError DeduceError(Exception exception)
+            {
+                // TODO: Deduce quic errors from QuicException.TransportErrorCode once https://github.com/dotnet/runtime/issues/87262 is implemented.
+                if (exception is AuthenticationException)
+                {
+                    return HttpRequestError.SecureConnectionError;
+                }
+
+                if (exception is SocketException socketException && socketException.SocketErrorCode == SocketError.HostNotFound)
+                {
+                    return HttpRequestError.NameResolutionError;
+                }
+
+                return HttpRequestError.ConnectionError;
+            }
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -90,6 +90,12 @@ namespace System.Net.Http
                 }
 
                 HttpRequestException ex = new HttpRequestException(SR.net_http_ssl_connection_failed, e, httpRequestError: HttpRequestError.SecureConnectionError);
+                if (request.IsExtendedConnectRequest)
+                {
+                    // Extended connect request is negotiating strictly for ALPN = "h2" because HttpClient is unaware of a possible downgrade.
+                    // At this point, SSL connection for HTTP / 2 failed, and the exception should indicate the reason for the external client / user.
+                    ex.Data["HTTP2_ENABLED"] = false;
+                }
                 throw ex;
             }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -38,7 +38,7 @@ namespace System.Net.Http
                 if (bytesRead <= 0 && buffer.Length != 0)
                 {
                     // Unexpected end of response stream.
-                    throw new IOException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _contentBytesRemaining));
+                    throw new HttpIOException(HttpRequestError.ResponseEnded, SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _contentBytesRemaining));
                 }
 
                 Debug.Assert((ulong)bytesRead <= _contentBytesRemaining);
@@ -100,7 +100,7 @@ namespace System.Net.Http
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // Unexpected end of response stream.
-                    throw new IOException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _contentBytesRemaining));
+                    throw new HttpIOException(HttpRequestError.ResponseEnded, SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _contentBytesRemaining));
                 }
 
                 Debug.Assert((ulong)bytesRead <= _contentBytesRemaining);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -248,6 +248,7 @@ namespace System.Net.Http
                     throw;
                 }
 
+                // TODO: Review this case!
                 throw new IOException(SR.net_http_http2_connection_not_established, e);
             }
 
@@ -488,10 +489,10 @@ namespace System.Net.Http
             return frameHeader;
 
             void ThrowPrematureEOF(int requiredBytes) =>
-                throw new IOException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, requiredBytes - _incomingBuffer.ActiveLength));
+                throw new HttpIOException(HttpRequestError.ResponseEnded, SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, requiredBytes - _incomingBuffer.ActiveLength));
 
             void ThrowMissingFrame() =>
-                throw new IOException(SR.net_http_invalid_response_missing_frame);
+                throw new HttpIOException(HttpRequestError.ResponseEnded, SR.net_http_invalid_response_missing_frame);
         }
 
         private async Task ProcessIncomingFramesAsync()
@@ -523,10 +524,16 @@ namespace System.Net.Http
 
                     Debug.Assert(InitialSettingsReceived.Task.IsCompleted);
                 }
+                catch (HttpProtocolException e)
+                {
+                    InitialSettingsReceived.TrySetException(e);
+                    throw;
+                }
                 catch (Exception e)
                 {
-                    InitialSettingsReceived.TrySetException(new IOException(SR.net_http_http2_connection_not_established, e));
-                    throw new IOException(SR.net_http_http2_connection_not_established, e);
+                    var ex = new HttpIOException(HttpRequestError.InvalidResponse, SR.net_http_http2_connection_not_established, e);
+                    InitialSettingsReceived.TrySetException(ex);
+                    throw ex;
                 }
 
                 // Keep processing frames as they arrive.
@@ -2096,17 +2103,13 @@ namespace System.Net.Http
 
                 return http2Stream.GetAndClearResponse();
             }
-            catch (Exception e)
+            catch (HttpIOException e)
             {
-                if (e is IOException ||
-                    e is ObjectDisposedException ||
-                    e is HttpProtocolException ||
-                    e is InvalidOperationException)
-                {
-                    throw new HttpRequestException(SR.net_http_client_execution_error, e);
-                }
-
-                throw;
+                throw new HttpRequestException(e.Message, e, httpRequestError: e.HttpRequestError);
+            }
+            catch (Exception e) when (e is IOException || e is ObjectDisposedException || e is InvalidOperationException)
+            {
+                throw new HttpRequestException(SR.net_http_client_execution_error, e, httpRequestError: HttpRequestError.Unknown);
             }
         }
 
@@ -2206,7 +2209,7 @@ namespace System.Net.Http
             throw new HttpRequestException(message, innerException, allowRetry: RequestRetryType.RetryOnConnectionFailure);
 
         private static Exception GetRequestAbortedException(Exception? innerException = null) =>
-            innerException as HttpProtocolException ?? new IOException(SR.net_http_request_aborted, innerException);
+            innerException as HttpIOException ?? new IOException(SR.net_http_request_aborted, innerException);
 
         [DoesNotReturn]
         private static void ThrowRequestAborted(Exception? innerException = null) =>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -531,9 +531,8 @@ namespace System.Net.Http
                 }
                 catch (Exception e)
                 {
-                    var ex = new HttpIOException(HttpRequestError.InvalidResponse, SR.net_http_http2_connection_not_established, e);
-                    InitialSettingsReceived.TrySetException(ex);
-                    throw ex;
+                    InitialSettingsReceived.TrySetException(new HttpIOException(HttpRequestError.InvalidResponse, SR.net_http_http2_connection_not_established, e));
+                    throw new HttpIOException(HttpRequestError.InvalidResponse, SR.net_http_http2_connection_not_established, e);
                 }
 
                 // Keep processing frames as they arrive.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -540,7 +540,7 @@ namespace System.Net.Http
                 if (index <= LastHPackRequestPseudoHeaderId)
                 {
                     if (NetEventSource.Log.IsEnabled()) Trace($"Invalid request pseudo-header ID {index}.");
-                    throw new HttpRequestException(SR.net_http_invalid_response);
+                    throw new HttpRequestException(SR.net_http_invalid_response, httpRequestError: HttpRequestError.InvalidResponse);
                 }
                 else if (index <= LastHPackStatusPseudoHeaderId)
                 {
@@ -563,7 +563,7 @@ namespace System.Net.Http
                 if (index <= LastHPackRequestPseudoHeaderId)
                 {
                     if (NetEventSource.Log.IsEnabled()) Trace($"Invalid request pseudo-header ID {index}.");
-                    throw new HttpRequestException(SR.net_http_invalid_response);
+                    throw new HttpRequestException(SR.net_http_invalid_response, httpRequestError: HttpRequestError.InvalidResponse);
                 }
                 else if (index <= LastHPackStatusPseudoHeaderId)
                 {
@@ -589,7 +589,7 @@ namespace System.Net.Http
                 _headerBudgetRemaining -= amount;
                 if (_headerBudgetRemaining < 0)
                 {
-                    throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _connection._pool.Settings.MaxResponseHeadersByteLength));
+                    throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _connection._pool.Settings.MaxResponseHeadersByteLength), httpRequestError: HttpRequestError.ConfigurationLimitExceeded);
                 }
             }
 
@@ -611,14 +611,14 @@ namespace System.Net.Http
                     if (_responseProtocolState == ResponseProtocolState.ExpectingHeaders)
                     {
                         if (NetEventSource.Log.IsEnabled()) Trace("Received extra status header.");
-                        throw new HttpRequestException(SR.net_http_invalid_response_multiple_status_codes);
+                        throw new HttpRequestException(SR.net_http_invalid_response_multiple_status_codes, httpRequestError: HttpRequestError.ConfigurationLimitExceeded);
                     }
 
                     if (_responseProtocolState != ResponseProtocolState.ExpectingStatus)
                     {
                         // Pseudo-headers are allowed only in header block
                         if (NetEventSource.Log.IsEnabled()) Trace($"Status pseudo-header received in {_responseProtocolState} state.");
-                        throw new HttpRequestException(SR.net_http_invalid_response_pseudo_header_in_trailer);
+                        throw new HttpRequestException(SR.net_http_invalid_response_pseudo_header_in_trailer, httpRequestError: HttpRequestError.InvalidResponse);
                     }
 
                     Debug.Assert(_response != null);
@@ -681,7 +681,7 @@ namespace System.Net.Http
                     if (_responseProtocolState != ResponseProtocolState.ExpectingHeaders && _responseProtocolState != ResponseProtocolState.ExpectingTrailingHeaders)
                     {
                         if (NetEventSource.Log.IsEnabled()) Trace("Received header before status.");
-                        throw new HttpRequestException(SR.net_http_invalid_response);
+                        throw new HttpRequestException(SR.net_http_invalid_response, httpRequestError: HttpRequestError.InvalidResponse);
                     }
 
                     Encoding? valueEncoding = _connection._pool.Settings._responseHeaderEncodingSelector?.Invoke(descriptor.Name, _request);
@@ -725,7 +725,7 @@ namespace System.Net.Http
                     else
                     {
                         if (NetEventSource.Log.IsEnabled()) Trace($"Invalid response pseudo-header '{Encoding.ASCII.GetString(name)}'.");
-                        throw new HttpRequestException(SR.net_http_invalid_response);
+                        throw new HttpRequestException(SR.net_http_invalid_response, httpRequestError: HttpRequestError.InvalidResponse);
                     }
                 }
                 else
@@ -734,7 +734,7 @@ namespace System.Net.Http
                     if (!HeaderDescriptor.TryGet(name, out HeaderDescriptor descriptor))
                     {
                         // Invalid header name
-                        throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)));
+                        throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)), httpRequestError: HttpRequestError.InvalidResponse);
                     }
 
                     OnHeader(descriptor, value);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -252,15 +252,27 @@ namespace System.Net.Http
                 {
                     case Http3ErrorCode.VersionFallback:
                         // The server is requesting us fall back to an older HTTP version.
-                        throw new HttpRequestException(SR.net_http_retry_on_older_version, ex, RequestRetryType.RetryOnLowerHttpVersion);
+                        throw new HttpRequestException(SR.net_http_retry_on_older_version, ex, RequestRetryType.RetryOnLowerHttpVersion, httpRequestError: HttpRequestError.VersionNegotiationError);
 
                     case Http3ErrorCode.RequestRejected:
                         // The server is rejecting the request without processing it, retry it on a different connection.
-                        throw new HttpRequestException(SR.net_http_request_aborted, ex, RequestRetryType.RetryOnConnectionFailure);
+                        throw new HttpRequestException(SR.net_http_request_aborted, ex, RequestRetryType.RetryOnConnectionFailure, httpRequestError: HttpRequestError.Unknown);
 
                     default:
                         // Our stream was reset.
-                        throw new HttpRequestException(SR.net_http_client_execution_error, _connection.AbortException ?? HttpProtocolException.CreateHttp3StreamException(code));
+                        HttpRequestError httpRequestError;
+                        Exception innerException;
+                        if (_connection.AbortException != null)
+                        {
+                            httpRequestError = HttpRequestError.Unknown;
+                            innerException = _connection.AbortException;
+                        }
+                        else
+                        {
+                            httpRequestError = HttpRequestError.HttpProtocolError;
+                            innerException = HttpProtocolException.CreateHttp3StreamException(code);
+                        }
+                        throw new HttpRequestException(SR.net_http_client_execution_error, innerException, httpRequestError: httpRequestError);
                 }
             }
             catch (QuicException ex) when (ex.QuicError == QuicError.ConnectionAborted)
@@ -270,12 +282,12 @@ namespace System.Net.Http
                 Http3ErrorCode code = (Http3ErrorCode)ex.ApplicationErrorCode.Value;
 
                 Exception abortException = _connection.Abort(HttpProtocolException.CreateHttp3ConnectionException(code, SR.net_http_http3_connection_close));
-                throw new HttpRequestException(SR.net_http_client_execution_error, abortException);
+                throw new HttpRequestException(SR.net_http_client_execution_error, abortException, httpRequestError: HttpRequestError.HttpProtocolError);
             }
             catch (QuicException ex) when (ex.QuicError == QuicError.OperationAborted && _connection.AbortException != null)
             {
                 // we close the connection, propagate the AbortException
-                throw new HttpRequestException(SR.net_http_client_execution_error, _connection.AbortException);
+                throw new HttpRequestException(SR.net_http_client_execution_error, _connection.AbortException, httpRequestError: HttpRequestError.Unknown);
             }
             // It is possible for user's Content code to throw an unexpected OperationCanceledException.
             catch (OperationCanceledException ex) when (ex.CancellationToken == _requestBodyCancellationSource.Token || ex.CancellationToken == cancellationToken)
@@ -289,14 +301,13 @@ namespace System.Net.Http
                 else
                 {
                     Debug.Assert(_requestBodyCancellationSource.IsCancellationRequested);
-                    throw new HttpRequestException(SR.net_http_request_aborted, ex, RequestRetryType.RetryOnConnectionFailure);
+                    throw new HttpRequestException(SR.net_http_request_aborted, ex, RequestRetryType.RetryOnConnectionFailure, httpRequestError: HttpRequestError.Unknown);
                 }
             }
-            catch (HttpProtocolException ex)
+            catch (HttpIOException ex)
             {
-                // A connection-level protocol error has occurred on our stream.
                 _connection.Abort(ex);
-                throw new HttpRequestException(SR.net_http_client_execution_error, ex);
+                throw new HttpRequestException(SR.net_http_client_execution_error, ex, httpRequestError: ex.HttpRequestError);
             }
             catch (Exception ex)
             {
@@ -305,7 +316,7 @@ namespace System.Net.Http
                 {
                     throw;
                 }
-                throw new HttpRequestException(SR.net_http_client_execution_error, ex);
+                throw new HttpRequestException(SR.net_http_client_execution_error, ex, httpRequestError: HttpRequestError.Unknown);
             }
             finally
             {
@@ -342,7 +353,7 @@ namespace System.Net.Http
                     {
                         Trace($"Expected HEADERS as first response frame; received {frameType}.");
                     }
-                    throw new HttpRequestException(SR.net_http_invalid_response);
+                    throw new HttpIOException(HttpRequestError.InvalidResponse, SR.net_http_invalid_response);
                 }
 
                 await ReadHeadersAsync(payloadLength, cancellationToken).ConfigureAwait(false);
@@ -528,7 +539,7 @@ namespace System.Net.Http
                             {
                                 Trace("Response content exceeded Content-Length.");
                             }
-                            throw new HttpRequestException(SR.net_http_invalid_response);
+                            throw new HttpIOException(HttpRequestError.InvalidResponse, SR.net_http_invalid_response);
                         }
                         break;
                     default:
@@ -824,7 +835,7 @@ namespace System.Net.Http
                     else
                     {
                         // Our buffer has partial frame data in it but not enough to complete the read: bail out.
-                        throw new HttpRequestException(SR.net_http_invalid_response_premature_eof);
+                        throw new HttpIOException(HttpRequestError.ResponseEnded, SR.net_http_invalid_response_premature_eof);
                     }
                 }
 
@@ -868,7 +879,7 @@ namespace System.Net.Http
             if (headersLength > _headerBudgetRemaining)
             {
                 _stream.Abort(QuicAbortDirection.Read, (long)Http3ErrorCode.ExcessiveLoad);
-                throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _connection.Pool.Settings.MaxResponseHeadersByteLength));
+                throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _connection.Pool.Settings.MaxResponseHeadersByteLength), httpRequestError: HttpRequestError.ConfigurationLimitExceeded);
             }
 
             _headerBudgetRemaining -= (int)headersLength;
@@ -887,7 +898,7 @@ namespace System.Net.Http
                     else
                     {
                         if (NetEventSource.Log.IsEnabled()) Trace($"Server closed response stream before entire header payload could be read. {headersLength:N0} bytes remaining.");
-                        throw new HttpRequestException(SR.net_http_invalid_response_premature_eof);
+                        throw new HttpIOException(HttpRequestError.ResponseEnded, SR.net_http_invalid_response_premature_eof);
                     }
                 }
 
@@ -909,7 +920,7 @@ namespace System.Net.Http
             if (!HeaderDescriptor.TryGet(name, out HeaderDescriptor descriptor))
             {
                 // Invalid header name
-                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)));
+                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)), httpRequestError: HttpRequestError.InvalidResponse);
             }
             OnHeader(staticIndex: null, descriptor, staticValue: default, literalValue: value);
         }
@@ -1147,7 +1158,8 @@ namespace System.Net.Http
 
                         if (bytesRead == 0 && buffer.Length != 0)
                         {
-                            throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _responseDataPayloadRemaining));
+                            throw new HttpIOException(HttpRequestError.ResponseEnded, SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _responseDataPayloadRemaining));
+                            //throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _responseDataPayloadRemaining));
                         }
 
                         totalBytesRead += bytesRead;
@@ -1219,7 +1231,8 @@ namespace System.Net.Http
 
                         if (bytesRead == 0 && buffer.Length != 0)
                         {
-                            throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _responseDataPayloadRemaining));
+                            //throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _responseDataPayloadRemaining));
+                            throw new HttpIOException(HttpRequestError.ResponseEnded, SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _responseDataPayloadRemaining));
                         }
 
                         totalBytesRead += bytesRead;
@@ -1263,8 +1276,7 @@ namespace System.Net.Http
                     _connection.Abort(exception);
                     throw exception;
 
-                case HttpProtocolException:
-                    // A connection-level protocol error has occurred on our stream.
+                case HttpIOException:
                     _connection.Abort(ex);
                     ExceptionDispatchInfo.Throw(ex); // Rethrow.
                     return; // Never reached.
@@ -1276,7 +1288,7 @@ namespace System.Net.Http
             }
 
             _stream.Abort(QuicAbortDirection.Read, (long)Http3ErrorCode.InternalError);
-            throw new IOException(SR.net_http_client_execution_error, new HttpRequestException(SR.net_http_client_execution_error, ex));
+            throw new HttpIOException(HttpRequestError.Unknown, SR.net_http_client_execution_error, new HttpRequestException(SR.net_http_client_execution_error, ex));
         }
 
         private async ValueTask<bool> ReadNextDataFrameAsync(HttpResponseMessage response, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -1159,7 +1159,6 @@ namespace System.Net.Http
                         if (bytesRead == 0 && buffer.Length != 0)
                         {
                             throw new HttpIOException(HttpRequestError.ResponseEnded, SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _responseDataPayloadRemaining));
-                            //throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _responseDataPayloadRemaining));
                         }
 
                         totalBytesRead += bytesRead;
@@ -1231,7 +1230,6 @@ namespace System.Net.Http
 
                         if (bytesRead == 0 && buffer.Length != 0)
                         {
-                            //throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _responseDataPayloadRemaining));
                             throw new HttpIOException(HttpRequestError.ResponseEnded, SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _responseDataPayloadRemaining));
                         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -261,8 +261,9 @@ namespace System.Net.Http
 
                     default:
                         // Our stream was reset.
-                        var innerException = HttpProtocolException.CreateHttp3StreamException(code, ex);
-                        throw new HttpRequestException(SR.net_http_client_execution_error, innerException, httpRequestError: HttpRequestError.HttpProtocolError);
+                        Exception innerException = _connection.AbortException ?? HttpProtocolException.CreateHttp3StreamException(code, ex);
+                        HttpRequestError httpRequestError = innerException is HttpProtocolException ? HttpRequestError.HttpProtocolError : HttpRequestError.Unknown;
+                        throw new HttpRequestException(SR.net_http_client_execution_error, innerException, httpRequestError: httpRequestError);
                 }
             }
             catch (QuicException ex) when (ex.QuicError == QuicError.ConnectionAborted)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -621,7 +621,7 @@ namespace System.Net.Http
                         _canRetry = true;
                     }
 
-                    throw new IOException(SR.net_http_invalid_response_premature_eof);
+                    throw new HttpIOException(HttpRequestError.ResponseEnded, SR.net_http_invalid_response_premature_eof);
                 }
 
 
@@ -1023,7 +1023,7 @@ namespace System.Net.Http
             const int MinStatusLineLength = 12; // "HTTP/1.x 123"
             if (line.Length < MinStatusLineLength || line[8] != ' ')
             {
-                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_line, Encoding.ASCII.GetString(line)));
+                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_line, Encoding.ASCII.GetString(line)), httpRequestError: HttpRequestError.InvalidResponse);
             }
 
             ulong first8Bytes = BitConverter.ToUInt64(line);
@@ -1044,7 +1044,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_line, Encoding.ASCII.GetString(line)));
+                    throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_line, Encoding.ASCII.GetString(line)), httpRequestError: HttpRequestError.InvalidResponse);
                 }
             }
 
@@ -1052,7 +1052,7 @@ namespace System.Net.Http
             byte status1 = line[9], status2 = line[10], status3 = line[11];
             if (!IsDigit(status1) || !IsDigit(status2) || !IsDigit(status3))
             {
-                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_code, Encoding.ASCII.GetString(line.Slice(9, 3))));
+                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_code, Encoding.ASCII.GetString(line.Slice(9, 3))), httpRequestError: HttpRequestError.InvalidResponse);
             }
             response.SetStatusCodeWithoutValidation((HttpStatusCode)(100 * (status1 - '0') + 10 * (status2 - '0') + (status3 - '0')));
 
@@ -1075,15 +1075,15 @@ namespace System.Net.Http
                     {
                         response.ReasonPhrase = HttpRuleParser.DefaultHttpEncoding.GetString(reasonBytes);
                     }
-                    catch (FormatException error)
+                    catch (FormatException formatEx)
                     {
-                        throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_reason, Encoding.ASCII.GetString(reasonBytes.ToArray())), error);
+                        throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_reason, Encoding.ASCII.GetString(reasonBytes.ToArray())), formatEx, httpRequestError: HttpRequestError.InvalidResponse);
                     }
                 }
             }
             else
             {
-                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_line, Encoding.ASCII.GetString(line)));
+                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_line, Encoding.ASCII.GetString(line)), httpRequestError: HttpRequestError.InvalidResponse);
             }
         }
 
@@ -1182,7 +1182,7 @@ namespace System.Net.Http
             }
 
             static void ThrowForInvalidHeaderLine(ReadOnlySpan<byte> buffer, int newLineIndex) =>
-                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_line, Encoding.ASCII.GetString(buffer.Slice(0, newLineIndex))));
+                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_line, Encoding.ASCII.GetString(buffer.Slice(0, newLineIndex))), httpRequestError: HttpRequestError.InvalidResponse);
         }
 
         private void AddResponseHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, HttpResponseMessage response, bool isFromTrailer)
@@ -1281,14 +1281,14 @@ namespace System.Net.Http
             Debug.Assert(added);
 
             static void ThrowForEmptyHeaderName() =>
-                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, ""));
+                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, ""), httpRequestError: HttpRequestError.InvalidResponse);
 
             static void ThrowForInvalidHeaderName(ReadOnlySpan<byte> name) =>
-                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)));
+                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)), httpRequestError: HttpRequestError.InvalidResponse);
         }
 
         private void ThrowExceededAllowedReadLineBytes() =>
-            throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _pool.Settings.MaxResponseHeadersByteLength));
+            throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _pool.Settings.MaxResponseHeadersByteLength), httpRequestError: HttpRequestError.ConfigurationLimitExceeded);
 
         private void ProcessKeepAliveHeader(string keepAlive)
         {
@@ -1611,7 +1611,7 @@ namespace System.Net.Http
             if (NetEventSource.Log.IsEnabled()) Trace($"Received {bytesRead} bytes.");
             if (bytesRead == 0)
             {
-                throw new IOException(SR.net_http_invalid_response_premature_eof);
+                throw new HttpIOException(HttpRequestError.ResponseEnded, SR.net_http_invalid_response_premature_eof);
             }
         }
 
@@ -2023,7 +2023,7 @@ namespace System.Net.Http
 
             if (_connectionClose)
             {
-                throw new HttpRequestException(SR.net_http_authconnectionfailure);
+                throw new HttpRequestException(SR.net_http_authconnectionfailure, httpRequestError: HttpRequestError.UserAuthenticationError);
             }
 
             Debug.Assert(response.Content != null);
@@ -2039,7 +2039,7 @@ namespace System.Net.Http
                 if (!await responseStream.DrainAsync(_pool.Settings._maxResponseDrainSize).ConfigureAwait(false) ||
                     _connectionClose)       // Draining may have set this
                 {
-                    throw new HttpRequestException(SR.net_http_authconnectionfailure);
+                    throw new HttpRequestException(SR.net_http_authconnectionfailure, httpRequestError: HttpRequestError.UserAuthenticationError);
                 }
             }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -158,7 +158,7 @@ namespace System.Net.Http
                 !IsDigit(status2 = value[1]) ||
                 !IsDigit(status3 = value[2]))
             {
-                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_code, System.Text.Encoding.ASCII.GetString(value)));
+                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_code, System.Text.Encoding.ASCII.GetString(value)), httpRequestError: HttpRequestError.InvalidResponse);
             }
 
             return 100 * (status1 - '0') + 10 * (status2 - '0') + (status3 - '0');

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -447,7 +447,13 @@ namespace System.Net.Http
         {
             Debug.Assert(desiredVersion == 2 || desiredVersion == 3);
 
-            throw new HttpRequestException(SR.Format(SR.net_http_requested_version_cannot_establish, request.Version, request.VersionPolicy, desiredVersion), inner, httpRequestError: HttpRequestError.VersionNegotiationError);
+            HttpRequestException ex = new(SR.Format(SR.net_http_requested_version_cannot_establish, request.Version, request.VersionPolicy, desiredVersion), inner, httpRequestError: HttpRequestError.VersionNegotiationError);
+            if (request.IsExtendedConnectRequest && desiredVersion == 2)
+            {
+                ex.Data["HTTP2_ENABLED"] = false;
+            }
+
+            throw ex;
         }
 
         private bool CheckExpirationOnGet(HttpConnectionBase connection)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1165,7 +1165,7 @@ namespace System.Net.Http
                     // Throw if fallback is not allowed by the version policy.
                     if (request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
                     {
-                        throw new HttpRequestException(SR.Format(SR.net_http_requested_version_server_refused, request.Version, request.VersionPolicy), e);
+                        throw new HttpRequestException(SR.Format(SR.net_http_requested_version_server_refused, request.Version, request.VersionPolicy), e, httpRequestError: HttpRequestError.VersionNegotiationError);
                     }
 
                     if (NetEventSource.Log.IsEnabled())

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1100,7 +1100,9 @@ namespace System.Net.Http
                                     await connection.InitialSettingsReceived.WaitWithCancellationAsync(cancellationToken).ConfigureAwait(false);
                                     if (!connection.IsConnectEnabled)
                                     {
-                                        throw new HttpRequestException(SR.net_unsupported_extended_connect, httpRequestError: HttpRequestError.ExtendedConnectNotSupported);
+                                        HttpRequestException exception = new(SR.net_unsupported_extended_connect, httpRequestError: HttpRequestError.ExtendedConnectNotSupported);
+                                        exception.Data["SETTINGS_ENABLE_CONNECT_PROTOCOL"] = false;
+                                        throw exception;
                                     }
                                 }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1783,7 +1783,7 @@ namespace System.Net.Http
             catch (Exception e) when (!(e is OperationCanceledException))
             {
                 Debug.Assert(!(e is HttpRequestException));
-                throw new HttpRequestException(SR.net_http_request_aborted, e, httpRequestError: HttpRequestError.ProxyTunnelError);
+                throw new HttpRequestException(SR.net_http_proxy_tunnel_error, e, httpRequestError: HttpRequestError.ProxyTunnelError);
             }
 
             return stream;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocksHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocksHelper.cs
@@ -359,6 +359,7 @@ namespace System.Net.Http
 
             if (bytesRead < buffer.Length)
             {
+                // TODO: How should we categorize this? Seems more like a connection establishment than than InvalidResponse
                 throw new IOException(SR.net_http_invalid_response_premature_eof);
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocksHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocksHelper.cs
@@ -359,7 +359,6 @@ namespace System.Net.Http
 
             if (bytesRead < buffer.Length)
             {
-                // TODO: How should we categorize this? Seems more like a connection establishment than than InvalidResponse
                 throw new IOException(SR.net_http_invalid_response_premature_eof);
             }
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -32,13 +32,16 @@ namespace System.Net.Http.Functional.Tests
         {
             HttpRequestException outerEx = await Assert.ThrowsAsync<HttpRequestException>(() => task);
             _output.WriteLine(outerEx.InnerException.Message);
+            Assert.Equal(HttpRequestError.HttpProtocolError, outerEx.HttpRequestError);
             HttpProtocolException protocolEx = Assert.IsType<HttpProtocolException>(outerEx.InnerException);
+            Assert.Equal(HttpRequestError.HttpProtocolError, protocolEx.HttpRequestError);
             Assert.Equal(errorCode, (ProtocolErrors)protocolEx.ErrorCode);
         }
 
         private async Task AssertHttpProtocolException(Task task, ProtocolErrors errorCode)
         {
             HttpProtocolException protocolEx = await Assert.ThrowsAsync<HttpProtocolException>(() => task);
+            Assert.Equal(HttpRequestError.HttpProtocolError, protocolEx.HttpRequestError);
             Assert.Equal(errorCode, (ProtocolErrors)protocolEx.ErrorCode);
         }
 
@@ -301,6 +304,22 @@ namespace System.Net.Http.Functional.Tests
                 // Send a reset stream frame so that the stream moves to a terminal state.
                 RstStreamFrame resetStream = new RstStreamFrame(FrameFlags.None, (int)ProtocolErrors.INTERNAL_ERROR, streamId);
                 await connection.WriteFrameAsync(resetStream);
+
+                await AssertProtocolErrorAsync(sendTask, ProtocolErrors.INTERNAL_ERROR);
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsAlpn))]
+        public async Task Http2_IncorrectServerPreface_RequestFailsWithAppropriateHttpProtocolException()
+        {
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
+
+                Http2LoopbackConnection connection = await server.AcceptConnectionAsync();
+                await connection.ReadSettingsAsync();
+                await connection.SendGoAway(0, ProtocolErrors.INTERNAL_ERROR);
 
                 await AssertProtocolErrorAsync(sendTask, ProtocolErrors.INTERNAL_ERROR);
             }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -901,7 +901,7 @@ namespace System.Net.Http.Functional.Tests
                 }
                 else
                 {
-                    var ioe = Assert.IsType<IOException>(ex);
+                    var ioe = Assert.IsType<HttpIOException>(ex);
                     var hre = Assert.IsType<HttpRequestException>(ioe.InnerException);
                     var qex = Assert.IsType<QuicException>(hre.InnerException);
                     Assert.Equal(QuicError.OperationAborted, qex.QuicError);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2ExtendedConnect.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2ExtendedConnect.cs
@@ -90,8 +90,7 @@ namespace System.Net.Http.Functional.Tests
                 request.Headers.Protocol = "foo";
 
                 HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request));
-
-                Assert.Equal(false, ex.Data["SETTINGS_ENABLE_CONNECT_PROTOCOL"]);
+                Assert.Equal(HttpRequestError.ExtendedConnectNotSupported, ex.HttpRequestError);
 
                 clientCompleted.SetResult();
             },
@@ -154,12 +153,12 @@ namespace System.Net.Http.Functional.Tests
                 HttpRequestMessage request = CreateRequest(HttpMethod.Connect, server.Address, UseVersion, exactVersion: true);
                 request.Headers.Protocol = "foo";
 
-                Exception ex = await Assert.ThrowsAnyAsync<Exception>(() => client.SendAsync(request));
+                HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request));
                 clientCompleted.SetResult();
 
                 if (useSsl)
                 {
-                    Assert.Equal(false, ex.Data["HTTP2_ENABLED"]);
+                    Assert.Equal(HttpRequestError.VersionNegotiationError, ex.HttpRequestError);
                 }
             });
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2ExtendedConnect.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2ExtendedConnect.cs
@@ -159,6 +159,7 @@ namespace System.Net.Http.Functional.Tests
                 if (useSsl)
                 {
                     Assert.Equal(HttpRequestError.VersionNegotiationError, ex.HttpRequestError);
+                    Assert.Equal(false, ex.Data["HTTP2_ENABLED"]);
                 }
             });
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2ExtendedConnect.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2ExtendedConnect.cs
@@ -153,12 +153,10 @@ namespace System.Net.Http.Functional.Tests
                 HttpRequestMessage request = CreateRequest(HttpMethod.Connect, server.Address, UseVersion, exactVersion: true);
                 request.Headers.Protocol = "foo";
 
-                HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request));
+                Exception ex = await Assert.ThrowsAnyAsync<Exception>(() => client.SendAsync(request));
                 clientCompleted.SetResult();
-
                 if (useSsl)
                 {
-                    Assert.Equal(HttpRequestError.VersionNegotiationError, ex.HttpRequestError);
                     Assert.Equal(false, ex.Data["HTTP2_ENABLED"]);
                 }
             });

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -4350,6 +4350,7 @@ namespace System.Net.Http.Functional.Tests
         protected override Version UseVersion => HttpVersion.Version30;
     }
 
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
     public abstract class SocketsHttpHandler_HttpRequestErrorTest : HttpClientHandlerTestBase
     {
         protected SocketsHttpHandler_HttpRequestErrorTest(ITestOutputHelper output) : base(output)
@@ -4368,15 +4369,9 @@ namespace System.Net.Http.Functional.Tests
 
             HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(message));
 
-            if (UseVersion.Major < 3)
-            {
-                Assert.Equal(HttpRequestError.NameResolutionError, ex.HttpRequestError);
-            }
-            else
-            {
-                // System.Net.Quic does not report DNS resolution errors yet
-                Assert.Equal(HttpRequestError.ConnectionError, ex.HttpRequestError);
-            }
+            // TODO: Some platforms fail to detect NameResolutionError reliably, we should investigate this.
+            // Also, System.Net.Quic does not report DNS resolution errors yet.
+            Assert.True(ex.HttpRequestError is HttpRequestError.NameResolutionError or HttpRequestError.ConnectionError);
         }
 
         [Fact]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -4477,6 +4477,7 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
+    [Collection(nameof(DisableParallelization))]
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsQuicSupported))]
     public sealed class SocketsHttpHandler_HttpRequestErrorTest_Http30 : SocketsHttpHandler_HttpRequestErrorTest
     {

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -192,6 +192,8 @@
              Link="ProductionCode\System\Net\Http\HttpCompletionOption.cs" />
     <Compile Include="..\..\src\System\Net\Http\HttpContent.cs"
              Link="ProductionCode\System\Net\Http\HttpContent.cs" />
+    <Compile Include="..\..\src\System\Net\Http\HttpIOException.cs"
+                 Link="ProductionCode\System\Net\Http\HttpIOException.cs" />
     <Compile Include="..\..\src\System\Net\Http\HttpMessageHandler.cs"
              Link="ProductionCode\System\Net\Http\HttpMessageHandler.cs" />
     <Compile Include="..\..\src\System\Net\Http\HttpMessageInvoker.cs"
@@ -200,6 +202,8 @@
              Link="ProductionCode\System\Net\Http\HttpMethod.cs" />
     <Compile Include="..\..\src\System\Net\Http\HttpParseResult.cs"
              Link="ProductionCode\System\Net\Http\HttpParseResult.cs" />
+    <Compile Include="..\..\src\System\Net\Http\HttpRequestError.cs"
+                 Link="ProductionCode\System\Net\Http\HttpRequestError.cs" />
     <Compile Include="..\..\src\System\Net\Http\HttpRequestException.cs"
              Link="ProductionCode\System\Net\Http\HttpRequestException.cs" />
     <Compile Include="..\..\src\System\Net\Http\RequestRetryType.cs"

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -135,7 +135,7 @@ namespace System.Net.WebSockets
                         break;
                     }
                     catch (HttpRequestException ex) when
-                        ((ex.Data.Contains("SETTINGS_ENABLE_CONNECT_PROTOCOL") || ex.Data.Contains("HTTP2_ENABLED"))
+                        ((ex.HttpRequestError is HttpRequestError.ExtendedConnectNotSupported or HttpRequestError.VersionNegotiationError or HttpRequestError.SecureConnectionError)
                         && tryDowngrade
                         && (options.HttpVersion == HttpVersion.Version11 || options.HttpVersionPolicy == HttpVersionPolicy.RequestVersionOrLower))
                     {

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -135,7 +135,7 @@ namespace System.Net.WebSockets
                         break;
                     }
                     catch (HttpRequestException ex) when
-                        ((ex.HttpRequestError is HttpRequestError.ExtendedConnectNotSupported or HttpRequestError.VersionNegotiationError or HttpRequestError.SecureConnectionError)
+                        ((ex.HttpRequestError == HttpRequestError.ExtendedConnectNotSupported || ex.Data.Contains("HTTP2_ENABLED"))
                         && tryDowngrade
                         && (options.HttpVersion == HttpVersion.Version11 || options.HttpVersionPolicy == HttpVersionPolicy.RequestVersionOrLower))
                     {

--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
@@ -77,6 +77,7 @@ namespace System.Net.WebSockets.Client.Tests
                     var ex = await Assert.ThrowsAnyAsync<WebSocketException>(() => t);
                     HttpRequestException inner = Assert.IsType<HttpRequestException>(ex.InnerException);
                     Assert.Equal(HttpRequestError.ExtendedConnectNotSupported, inner.HttpRequestError);
+                    Assert.True(ex.InnerException.Data.Contains("SETTINGS_ENABLE_CONNECT_PROTOCOL"));
                 }
             },
             async server =>
@@ -102,6 +103,7 @@ namespace System.Net.WebSockets.Client.Tests
                     var ex = await Assert.ThrowsAnyAsync<WebSocketException>(() => t);
                     HttpRequestException inner = Assert.IsType<HttpRequestException>(ex.InnerException);
                     Assert.Equal(HttpRequestError.ExtendedConnectNotSupported, inner.HttpRequestError);
+                    Assert.True(ex.InnerException.Data.Contains("SETTINGS_ENABLE_CONNECT_PROTOCOL"));
                 }
             },
             async server =>

--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
@@ -124,6 +124,7 @@ namespace System.Net.WebSockets.Client.Tests
                 Task t = cws.ConnectAsync(Test.Common.Configuration.WebSockets.SecureRemoteEchoServer, GetInvoker(), cts.Token);
 
                 var ex = await Assert.ThrowsAnyAsync<WebSocketException>(() => t);
+                Assert.True(ex.InnerException.Data.Contains("HTTP2_ENABLED"));
                 HttpRequestException inner = Assert.IsType<HttpRequestException>(ex.InnerException);
                 Assert.Equal(HttpRequestError.SecureConnectionError, inner.HttpRequestError);
                 Assert.Equal(WebSocketState.Closed, cws.State);

--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
@@ -75,8 +75,8 @@ namespace System.Net.WebSockets.Client.Tests
                     Task t = cws.ConnectAsync(uri, GetInvoker(), cts.Token);
 
                     var ex = await Assert.ThrowsAnyAsync<WebSocketException>(() => t);
-                    Assert.IsType<HttpRequestException>(ex.InnerException);
-                    Assert.True(ex.InnerException.Data.Contains("SETTINGS_ENABLE_CONNECT_PROTOCOL"));
+                    HttpRequestException inner = Assert.IsType<HttpRequestException>(ex.InnerException);
+                    Assert.Equal(HttpRequestError.ExtendedConnectNotSupported, inner.HttpRequestError);
                 }
             },
             async server =>
@@ -100,8 +100,8 @@ namespace System.Net.WebSockets.Client.Tests
                     Task t = cws.ConnectAsync(uri, GetInvoker(), cts.Token);
 
                     var ex = await Assert.ThrowsAnyAsync<WebSocketException>(() => t);
-                    Assert.IsType<HttpRequestException>(ex.InnerException);
-                    Assert.True(ex.InnerException.Data.Contains("SETTINGS_ENABLE_CONNECT_PROTOCOL"));
+                    HttpRequestException inner = Assert.IsType<HttpRequestException>(ex.InnerException);
+                    Assert.Equal(HttpRequestError.ExtendedConnectNotSupported, inner.HttpRequestError);
                 }
             },
             async server =>
@@ -124,8 +124,8 @@ namespace System.Net.WebSockets.Client.Tests
                 Task t = cws.ConnectAsync(Test.Common.Configuration.WebSockets.SecureRemoteEchoServer, GetInvoker(), cts.Token);
 
                 var ex = await Assert.ThrowsAnyAsync<WebSocketException>(() => t);
-                Assert.IsType<HttpRequestException>(ex.InnerException);
-                Assert.True(ex.InnerException.Data.Contains("HTTP2_ENABLED"));
+                HttpRequestException inner = Assert.IsType<HttpRequestException>(ex.InnerException);
+                Assert.Equal(HttpRequestError.SecureConnectionError, inner.HttpRequestError);
                 Assert.Equal(WebSocketState.Closed, cws.State);
             }
         }

--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
@@ -126,7 +126,10 @@ namespace System.Net.WebSockets.Client.Tests
                 var ex = await Assert.ThrowsAnyAsync<WebSocketException>(() => t);
                 Assert.True(ex.InnerException.Data.Contains("HTTP2_ENABLED"));
                 HttpRequestException inner = Assert.IsType<HttpRequestException>(ex.InnerException);
-                Assert.Equal(HttpRequestError.SecureConnectionError, inner.HttpRequestError);
+                HttpRequestError expectedError = PlatformDetection.SupportsAlpn ?
+                    HttpRequestError.SecureConnectionError :
+                    HttpRequestError.VersionNegotiationError;
+                Assert.Equal(expectedError, inner.HttpRequestError);
                 Assert.Equal(WebSocketState.Closed, cws.State);
             }
         }


### PR DESCRIPTION
Implements the proposal from https://github.com/dotnet/runtime/issues/76644#issuecomment-1624144878. I left out `TransportError`, since it would be a new error case with little value, requiring new error logic.

Fixes #76644, fixes #82168.