### PR TITLE
Add IO.Packaging test to check non-unicode value in ZipArchiveEntry general purpose bit flag

### DIFF
--- a/src/libraries/System.IO.Packaging/tests/ReflectionTests.cs
+++ b/src/libraries/System.IO.Packaging/tests/ReflectionTests.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using System.Reflection;
+using Xunit;
+
+namespace System.IO.Packaging.Tests;
+
+public class ReflectionTests
+{
+    [Fact]
+    public void Verify_GeneralPurposeBitFlag_NotSetTo_Unicode()
+    {
+        using MemoryStream ms = new();
+
+        using (ZipPackage package = (ZipPackage)Package.Open(ms, FileMode.Create, FileAccess.Write))
+        {
+            Uri uri = PackUriHelper.CreatePartUri(new Uri("document.xml", UriKind.Relative));
+            ZipPackagePart part = (ZipPackagePart)package.CreatePart(uri, Tests.Mime_MediaTypeNames_Text_Xml, CompressionOption.NotCompressed);
+            using (Stream partStream = part.GetStream())
+            {
+                using StreamWriter sw = new(partStream);
+                sw.Write(Tests.s_DocumentXml);
+            }
+            package.CreateRelationship(part.Uri, TargetMode.Internal, "http://packageRelType", "rId1234");
+        }
+
+        ms.Position = 0;
+        using (ZipArchive archive = new ZipArchive(ms, ZipArchiveMode.Read, leaveOpen: false))
+        {
+            foreach (ZipArchiveEntry entry in archive.Entries)
+            {
+                FieldInfo fieldInfo = typeof(ZipArchiveEntry).GetField("_generalPurposeBitFlag", BindingFlags.Instance | BindingFlags.NonPublic);
+                object fieldObject = fieldInfo.GetValue(entry);
+                ushort shortField = (ushort)fieldObject;
+                Assert.Equal(0, shortField); // If it was UTF8, we would set the general purpose bit flag to 0x800 (UnicodeFileNameAndComment)
+                CheckCharacters(entry.Name);
+                CheckCharacters(entry.Comment); // Unavailable in .NET Framework
+            }
+        }
+
+        void CheckCharacters(string value)
+        {
+            for (int i = 0; i < value.Length; i++)
+            {
+                char c = value[i];
+                Assert.True(c >= 32 && c <= 126, $"ZipArchiveEntry name character {c} requires UTF8");
+            }
+        }
+    }
+
+}

--- a/src/libraries/System.IO.Packaging/tests/System.IO.Packaging.Tests.csproj
+++ b/src/libraries/System.IO.Packaging/tests/System.IO.Packaging.Tests.csproj
@@ -5,6 +5,9 @@
   <ItemGroup>
     <Compile Include="Tests.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <Compile Include="ReflectionTests.cs" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.IO.Packaging.TestData" Version="$(SystemIOPackagingTestDataVersion)" />
     <ProjectReference Include="..\src\System.IO.Packaging.csproj" />

--- a/src/libraries/System.IO.Packaging/tests/Tests.cs
+++ b/src/libraries/System.IO.Packaging/tests/Tests.cs
@@ -12,9 +12,9 @@ namespace System.IO.Packaging.Tests
 {
     public class Tests : FileCleanupTestBase
     {
-        private const string Mime_MediaTypeNames_Text_Xml = "text/xml";
+        internal const string Mime_MediaTypeNames_Text_Xml = "text/xml";
         private const string Mime_MediaTypeNames_Image_Jpeg = "image/jpeg"; // System.Net.Mime.MediaTypeNames.Image.Jpeg
-        private const string s_DocumentXml = @"<Hello>Test</Hello>";
+        internal const string s_DocumentXml = @"<Hello>Test</Hello>";
         private const string s_ResourceXml = @"<Resource>Test</Resource>";
 
         private FileInfo GetTempFileInfoFromExistingFile(string existingFileName, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)


### PR DESCRIPTION
Continuation of https://github.com/dotnet/runtime/pull/87883
Fixes https://github.com/dotnet/runtime/issues/87882
