### PR TITLE
Add SocketsHttpHandler requests-queue-duration metrics

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.AnyOS.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.AnyOS.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Threading;
 
@@ -21,24 +22,22 @@ namespace System.Net.Http
         private EventCounter? _http30RequestsQueueDurationCounter;
 
         [NonEvent]
-        public void Http11RequestLeftQueue(double timeOnQueueMilliseconds)
+        public void RequestLeftQueue(int versionMajor, TimeSpan duration)
         {
-            _http11RequestsQueueDurationCounter?.WriteMetric(timeOnQueueMilliseconds);
-            RequestLeftQueue(timeOnQueueMilliseconds, versionMajor: 1, versionMinor: 1);
-        }
+            Debug.Assert(versionMajor is 1 or 2 or 3);
 
-        [NonEvent]
-        public void Http20RequestLeftQueue(double timeOnQueueMilliseconds)
-        {
-            _http20RequestsQueueDurationCounter?.WriteMetric(timeOnQueueMilliseconds);
-            RequestLeftQueue(timeOnQueueMilliseconds, versionMajor: 2, versionMinor: 0);
-        }
+            EventCounter? counter = versionMajor switch
+            {
+                1 => _http11RequestsQueueDurationCounter,
+                2 => _http20RequestsQueueDurationCounter,
+                _ => _http30RequestsQueueDurationCounter
+            };
 
-        [NonEvent]
-        public void Http30RequestLeftQueue(double timeOnQueueMilliseconds)
-        {
-            _http30RequestsQueueDurationCounter?.WriteMetric(timeOnQueueMilliseconds);
-            RequestLeftQueue(timeOnQueueMilliseconds, versionMajor: 3, versionMinor: 0);
+            double timeOnQueueMs = duration.TotalMilliseconds;
+
+            counter?.WriteMetric(timeOnQueueMs);
+
+            RequestLeftQueue(timeOnQueueMs, (byte)versionMajor, versionMinor: versionMajor == 1 ? (byte)1 : (byte)0);
         }
 
         protected override void OnEventCommand(EventCommandEventArgs command)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -160,7 +160,7 @@ namespace System.Net.Http
             }
         }
 
-        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, long queueStartingTimestamp, CancellationToken cancellationToken)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool requestsQueueDurationEnabled, long queueStartingTimestamp, CancellationToken cancellationToken)
         {
             // Allocate an active request
             QuicStream? quicStream = null;
@@ -173,7 +173,7 @@ namespace System.Net.Http
                     QuicConnection? conn = _connection;
                     if (conn != null)
                     {
-                        if (HttpTelemetry.Log.IsEnabled() && queueStartingTimestamp == 0)
+                        if (requestsQueueDurationEnabled && queueStartingTimestamp == 0)
                         {
                             queueStartingTimestamp = Stopwatch.GetTimestamp();
                         }
@@ -198,9 +198,9 @@ namespace System.Net.Http
                 catch (QuicException e) when (e.QuicError != QuicError.OperationAborted) { }
                 finally
                 {
-                    if (HttpTelemetry.Log.IsEnabled() && queueStartingTimestamp != 0)
+                    if (requestsQueueDurationEnabled && queueStartingTimestamp != 0)
                     {
-                        HttpTelemetry.Log.Http30RequestLeftQueue(Stopwatch.GetElapsedTime(queueStartingTimestamp).TotalMilliseconds);
+                        _pool.Settings._metrics!.RequestLeftQueue(Pool, Stopwatch.GetElapsedTime(queueStartingTimestamp), versionMajor: 3);
                     }
                 }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -47,15 +47,12 @@ namespace System.Net.Http
                     this is Http2Connection ? "HTTP/2" :
                     "HTTP/3";
 
-                int port = pool.OriginAuthority.Port;
-                int defaultPort = pool.IsSecure ? HttpConnectionPool.DefaultHttpsPort : HttpConnectionPool.DefaultHttpPort;
-
                 _connectionMetrics = new ConnectionMetrics(
                     metrics,
                     protocol,
                     pool.IsSecure ? "https" : "http",
                     pool.OriginAuthority.HostValue,
-                    port == defaultPort ? null : port);
+                    pool.IsDefaultPort ? null : pool.OriginAuthority.Port);
 
                 _connectionMetrics.ConnectionEstablished();
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -42,6 +42,7 @@ namespace System.Net.Http
                 metrics.IdleConnections.Enabled ||
                 metrics.ConnectionDuration.Enabled)
             {
+                // While requests may report HTTP/1.0 as the protocol, we treat all HTTP/1.X connections as HTTP/1.1.
                 string protocol =
                     this is HttpConnection ? "HTTP/1.1" :
                     this is Http2Connection ? "HTTP/2" :

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -998,15 +998,9 @@ namespace System.Net.Http
                     ThrowGetVersionException(request, 3, reasonException);
                 }
 
-                long? queueStartingTimestamp = HttpTelemetry.Log.IsEnabled() || Settings._metrics!.RequestsQueueDuration.Enabled ? Stopwatch.GetTimestamp() : null;
+                long queueStartingTimestamp = HttpTelemetry.Log.IsEnabled() || Settings._metrics!.RequestsQueueDuration.Enabled ? Stopwatch.GetTimestamp() : 0;
 
                 ValueTask<Http3Connection> connectionTask = GetHttp3ConnectionAsync(request, authority, cancellationToken);
-
-                if (queueStartingTimestamp.HasValue && connectionTask.IsCompleted)
-                {
-                    // We avoid logging RequestLeftQueue if a stream was available immediately (synchronously)
-                    queueStartingTimestamp = 0;
-                }
 
                 Http3Connection connection = await connectionTask.ConfigureAwait(false);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -236,10 +236,9 @@ namespace System.Net.Http
             {
                 // Precalculate ASCII bytes for Host header
                 // Note that if _host is null, this is a (non-tunneled) proxy connection, and we can't cache the hostname.
-                hostHeader =
-                    (_originAuthority.Port != (sslHostName == null ? DefaultHttpPort : DefaultHttpsPort)) ?
-                    $"{_originAuthority.HostValue}:{_originAuthority.Port}" :
-                    _originAuthority.HostValue;
+                hostHeader = IsDefaultPort
+                    ? _originAuthority.HostValue
+                    : $"{_originAuthority.HostValue}:{_originAuthority.Port}";
 
                 // Note the IDN hostname should always be ASCII, since it's already been IDNA encoded.
                 byte[] hostHeaderLine = new byte[6 + hostHeader.Length + 2]; // Host: foo\r\n
@@ -363,7 +362,7 @@ namespace System.Net.Http
         public ICredentials? ProxyCredentials => _poolManager.ProxyCredentials;
         public byte[]? HostHeaderLineBytes => _hostHeaderLineBytes;
         public CredentialCache? PreAuthCredentials { get; }
-        public bool IsDefaultPort => OriginAuthority.Port == (IsSecure ? DefaultHttpsPort : DefaultHttpsPort);
+        public bool IsDefaultPort => OriginAuthority.Port == (IsSecure ? DefaultHttpsPort : DefaultHttpPort);
 
         /// <summary>
         /// An ASCII origin string per RFC 6454 Section 6.2, in format &lt;scheme&gt;://&lt;host&gt;[:&lt;port&gt;]
@@ -382,7 +381,7 @@ namespace System.Net.Http
                     sb.Append(IsSecure ? "https://" : "http://")
                       .Append(_originAuthority.IdnHost);
 
-                    if (_originAuthority.Port != (IsSecure ? DefaultHttpsPort : DefaultHttpPort))
+                    if (!IsDefaultPort)
                     {
                         sb.Append(CultureInfo.InvariantCulture, $":{_originAuthority.Port}");
                     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 
 namespace System.Net.Http.Metrics
@@ -19,5 +20,42 @@ namespace System.Net.Http.Metrics
             name: "http-client-connection-duration",
             unit: "s",
             description: "The duration of outbound HTTP connections.");
+
+        public readonly Histogram<double> RequestsQueueDuration = meter.CreateHistogram<double>(
+            name: "http-client-requests-queue-duration",
+            unit: "s",
+            description: "The amount of time requests spent on a queue waiting for an available connection.");
+
+        public void RequestLeftQueue(HttpConnectionPool pool, TimeSpan duration, int versionMajor)
+        {
+            Debug.Assert(versionMajor is 1 or 2 or 3);
+
+            if (RequestsQueueDuration.Enabled)
+            {
+                TagList tags = default;
+
+                tags.Add("protocol", versionMajor switch
+                {
+                    1 => "HTTP/1.1",
+                    2 => "HTTP/2",
+                    _ => "HTTP/3"
+                });
+
+                tags.Add("scheme", pool.IsSecure ? "https" : "http");
+                tags.Add("host", pool.OriginAuthority.HostValue);
+
+                if (!pool.IsDefaultPort)
+                {
+                    tags.Add("port", pool.OriginAuthority.Port);
+                }
+
+                RequestsQueueDuration.Record(duration.TotalSeconds, tags);
+            }
+
+            if (HttpTelemetry.Log.IsEnabled())
+            {
+                HttpTelemetry.Log.RequestLeftQueue(versionMajor, duration);
+            }
+        }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
@@ -34,6 +34,7 @@ namespace System.Net.Http.Metrics
             {
                 TagList tags = default;
 
+                // While requests may report HTTP/1.0 as the protocol, we treat all HTTP/1.X connections as HTTP/1.1.
                 tags.Add("protocol", versionMajor switch
                 {
                     1 => "HTTP/1.1",
@@ -50,11 +51,6 @@ namespace System.Net.Http.Metrics
                 }
 
                 RequestsQueueDuration.Record(duration.TotalSeconds, tags);
-            }
-
-            if (HttpTelemetry.Log.IsEnabled())
-            {
-                HttpTelemetry.Log.RequestLeftQueue(versionMajor, duration);
             }
         }
     }


### PR DESCRIPTION
Contributes to #88384

Following #88893, this PR adds the `http-client-requests-queue-duration` counter (final name TBD).
Includes the same tags as other connection counters: `protocol`, `scheme`, `host`, and `port`.