### PR TITLE
Add JsonSourceGenerationOptions.UseStringEnumConverter

### DIFF
--- a/src/libraries/System.Text.Json/Common/JsonSourceGenerationOptionsAttribute.cs
+++ b/src/libraries/System.Text.Json/Common/JsonSourceGenerationOptionsAttribute.cs
@@ -132,5 +132,11 @@ namespace System.Text.Json.Serialization
         /// Specifies the source generation mode for types that don't explicitly set the mode with <see cref="JsonSerializableAttribute.GenerationMode"/>.
         /// </summary>
         public JsonSourceGenerationMode GenerationMode { get; set; }
+
+        /// <summary>
+        /// Instructs the source generator to default to <see cref="JsonStringEnumConverter"/>
+        /// instead of numeric serialization for all enum types encountered in its type graph.
+        /// </summary>
+        public bool UseStringEnumConverter { get; set; }
     }
 }

--- a/src/libraries/System.Text.Json/gen/Helpers/KnownTypeSymbols.cs
+++ b/src/libraries/System.Text.Json/gen/Helpers/KnownTypeSymbols.cs
@@ -218,6 +218,9 @@ namespace System.Text.Json.SourceGeneration
         public INamedTypeSymbol? JsonStringEnumConverterType => GetOrResolveType("System.Text.Json.Serialization.JsonStringEnumConverter", ref _JsonStringEnumConverterType);
         private Option<INamedTypeSymbol?> _JsonStringEnumConverterType;
 
+        public INamedTypeSymbol? JsonStringEnumConverterOfTType => GetOrResolveType("System.Text.Json.Serialization.JsonStringEnumConverter`1", ref _JsonStringEnumConverterOfTType);
+        private Option<INamedTypeSymbol?> _JsonStringEnumConverterOfTType;
+
         public INamedTypeSymbol? IJsonOnSerializingType => GetOrResolveType(JsonConstants.IJsonOnSerializingFullName, ref _IJsonOnSerializingType);
         private Option<INamedTypeSymbol?> _IJsonOnSerializingType;
 

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -270,6 +270,7 @@ namespace System.Text.Json.SourceGeneration
                 JsonCommentHandling? readCommentHandling = null;
                 JsonUnknownTypeHandling? unknownTypeHandling = null;
                 JsonUnmappedMemberHandling? unmappedMemberHandling = null;
+                bool? useStringEnumConverter = null;
                 bool? writeIndented = null;
 
                 if (attributeData.ConstructorArguments.Length > 0)
@@ -356,6 +357,10 @@ namespace System.Text.Json.SourceGeneration
                             unmappedMemberHandling = (JsonUnmappedMemberHandling)namedArg.Value.Value!;
                             break;
 
+                        case nameof(JsonSourceGenerationOptionsAttribute.UseStringEnumConverter):
+                            useStringEnumConverter = (bool)namedArg.Value.Value!;
+                            break;
+
                         case nameof(JsonSourceGenerationOptionsAttribute.WriteIndented):
                             writeIndented = (bool)namedArg.Value.Value!;
                             break;
@@ -389,6 +394,7 @@ namespace System.Text.Json.SourceGeneration
                     ReadCommentHandling = readCommentHandling,
                     UnknownTypeHandling = unknownTypeHandling,
                     UnmappedMemberHandling = unmappedMemberHandling,
+                    UseStringEnumConverter = useStringEnumConverter,
                     WriteIndented = writeIndented,
                 };
             }
@@ -491,7 +497,18 @@ namespace System.Text.Json.SourceGeneration
                 }
                 else if (type.TypeKind is TypeKind.Enum)
                 {
-                    classType = ClassType.Enum;
+                    if (options?.UseStringEnumConverter == true)
+                    {
+                        Debug.Assert(_knownSymbols.JsonStringEnumConverterOfTType != null);
+                        INamedTypeSymbol converterSymbol = _knownSymbols.JsonStringEnumConverterOfTType.Construct(type);
+
+                        customConverterType = new TypeRef(converterSymbol);
+                        classType = ClassType.TypeWithDesignTimeProvidedCustomConverter;
+                    }
+                    else
+                    {
+                        classType = ClassType.Enum;
+                    }
                 }
                 else if (TryResolveCollectionType(type,
                     out ITypeSymbol? valueType,

--- a/src/libraries/System.Text.Json/gen/Model/SourceGenerationOptionsSpec.cs
+++ b/src/libraries/System.Text.Json/gen/Model/SourceGenerationOptionsSpec.cs
@@ -47,6 +47,8 @@ namespace System.Text.Json.SourceGeneration
 
         public required JsonUnmappedMemberHandling? UnmappedMemberHandling { get; init; }
 
+        public required bool? UseStringEnumConverter { get; init; }
+
         public required bool? WriteIndented { get; init; }
 
         public JsonKnownNamingPolicy? GetEffectivePropertyNamingPolicy()

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -969,6 +969,12 @@ namespace System.Text.Json.Serialization
         KebabCaseLower = 4,
         KebabCaseUpper = 5,
     }
+    public sealed partial class JsonNumberEnumConverter<TEnum> : System.Text.Json.Serialization.JsonConverterFactory where TEnum : struct
+    {
+        public JsonNumberEnumConverter() { }
+        public override bool CanConvert(System.Type typeToConvert) { throw null; }
+        public override System.Text.Json.Serialization.JsonConverter? CreateConverter(System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
+    }
     [System.FlagsAttribute]
     public enum JsonNumberHandling
     {
@@ -1063,6 +1069,7 @@ namespace System.Text.Json.Serialization
         public System.Text.Json.JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
         public System.Text.Json.Serialization.JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
         public System.Text.Json.Serialization.JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } set { } }
+        public bool UseStringEnumConverter { get { throw null; } set { } }
         public bool WriteIndented { get { throw null; } set { } }
     }
     [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JsonStringEnumConverter cannot be statically analyzed and requires runtime code generation. Applications should use the generic JsonStringEnumConverter<TEnum> instead.")]

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -130,6 +130,7 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="System\Text\Json\Serialization\IJsonOnDeserializing.cs" />
     <Compile Include="System\Text\Json\Serialization\IJsonOnSerialized.cs" />
     <Compile Include="System\Text\Json\Serialization\IJsonOnSerializing.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonNumberEnumConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.Document.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.Element.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.Node.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonNumberEnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonNumberEnumConverter.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization.Converters;
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// Converter to convert enums to and from numeric values.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type that this converter targets.</typeparam>
+    /// <remarks>
+    /// This is the default converter for enums and can be used to override
+    /// <see cref="JsonSourceGenerationOptionsAttribute.UseStringEnumConverter"/>
+    /// on individual types or properties.
+    /// </remarks>
+    public sealed class JsonNumberEnumConverter<TEnum> : JsonConverterFactory
+        where TEnum : struct, Enum
+    {
+        /// <inheritdoc />
+        public override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(TEnum);
+
+        /// <inheritdoc />
+        public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (typeToConvert != typeof(TEnum))
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException_JsonConverterFactory_TypeNotSupported(typeToConvert);
+            }
+
+            return new EnumConverter<TEnum>(EnumConverterOptions.AllowNumbers, options);
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSourceGenerationOptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSourceGenerationOptionsTests.cs
@@ -121,5 +121,34 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(PersonStruct))]
         public partial class ContextWithInvalidSerializerDefaults : JsonSerializerContext
         { }
+
+        [Fact]
+        public static void UseStringEnumConverter_EnablesDefaultStringEnumSerialization()
+        {
+            var value = new ClassWithEnumProperty { StringValue = MyEnum.A, NumberValue = MyEnum.A };
+            string expectedJson = """{"StringValue":"A","NumberValue":0}""";
+
+            string json = JsonSerializer.Serialize(value, ContextWithStringEnumConverterEnabled.Default.ClassWithEnumProperty);
+            Assert.Equal(expectedJson, json);
+
+            value = JsonSerializer.Deserialize(json, ContextWithStringEnumConverterEnabled.Default.ClassWithEnumProperty);
+            Assert.Equal(MyEnum.A, value.StringValue);
+            Assert.Equal(MyEnum.A, value.NumberValue);
+        }
+
+        public class ClassWithEnumProperty
+        {
+            public MyEnum StringValue { get; set; }
+
+            [JsonConverter(typeof(JsonNumberEnumConverter<MyEnum>))]
+            public MyEnum NumberValue { get; set; }
+        }
+
+        public enum MyEnum { A = 0, B = 1, C = 2 }
+
+        [JsonSourceGenerationOptions(UseStringEnumConverter = true)]
+        [JsonSerializable(typeof(ClassWithEnumProperty))]
+        public partial class ContextWithStringEnumConverterEnabled : JsonSerializerContext
+        { }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/EnumConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/EnumConverterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -51,6 +52,7 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(JsonNumberEnumConverter<DayOfWeek>), typeof(DayOfWeek))]
         [InlineData(typeof(JsonNumberEnumConverter<MyCustomEnum>), typeof(MyCustomEnum))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(JsonNumberEnumConverter<>))]
         public static void JsonNumberEnumConverter_SupportedType_WorksAsExpected(Type converterType, Type supportedType)
         {
             var options = new JsonSerializerOptions();
@@ -68,6 +70,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(JsonNumberEnumConverter<DayOfWeek>), typeof(JsonStringEnumConverter<MyCustomEnum>))]
         [InlineData(typeof(JsonNumberEnumConverter<DayOfWeek>), typeof(MyCustomEnum))]
         [InlineData(typeof(JsonNumberEnumConverter<MyCustomEnum>), typeof(DayOfWeek))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(JsonNumberEnumConverter<>))]
         public static void JsonNumberEnumConverter_InvalidType_ThrowsArgumentOutOfRangeException(Type converterType, Type unsupportedType)
         {
             var options = new JsonSerializerOptions();


### PR DESCRIPTION
This PR:

* Implements the `JsonSourceGenerationOptionsAttribuet.UseStringEnumConverter` property.
* Implements the `JsonNumberEnumConverter<TEnum>` converter.

Fix #87195.