### PR TITLE
[mono][tests] Add support for tvOS in processinfo tests

### DIFF
--- a/src/native/eventpipe/ep-event-source.c
+++ b/src/native/eventpipe/ep-event-source.c
@@ -14,12 +14,12 @@
 
 #if defined(HOST_WINDOWS) || defined(HOST_WIN32)
 const ep_char8_t* _ep_os_info = "Windows";
+#elif defined(HOST_TVOS)
+const ep_char8_t* _ep_os_info = "tvOS";
 #elif defined(HOST_IOS)
 const ep_char8_t* _ep_os_info = "iOS";
 #elif defined(HOST_WATCHOS)
 const ep_char8_t* _ep_os_info = "WatchOS";
-#elif defined(HOST_TVOS)
-const ep_char8_t* _ep_os_info = "tvOS";
 #elif defined(__APPLE__)
 const ep_char8_t* _ep_os_info = "macOS";
 #elif defined(HOST_ANDROID)

--- a/src/tests/tracing/eventpipe/processinfo/processinfo.cs
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.cs
@@ -187,9 +187,13 @@ namespace Tracing.Tests.ProcessInfoValidation
             {
                 expectedOSValue = "Android";
             }
-            else if (OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
+            else if (OperatingSystem.IsIOS())
             {
                 expectedOSValue = "iOS";
+            }
+            else if (OperatingSystem.IsTvOS())
+            {
+                expectedOSValue = "tvOS";
             }
             else
             {

--- a/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
+++ b/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
@@ -188,9 +188,13 @@ namespace Tracing.Tests.ProcessInfoValidation
             {
                 expectedOSValue = "Android";
             }
-            else if (OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
+            else if (OperatingSystem.IsIOS())
             {
                 expectedOSValue = "iOS";
+            }
+            else if (OperatingSystem.IsTvOS())
+            {
+                expectedOSValue = "tvOS";
             }
             else
             {

--- a/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
+++ b/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
@@ -194,9 +194,13 @@ namespace Tracing.Tests.ProcessInfoValidation
             {
                 expectedOSValue = "Android";
             }
-            else if (OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
+            else if (OperatingSystem.IsIOS())
             {
                 expectedOSValue = "iOS";
+            }
+            else if (OperatingSystem.IsTvOS())
+            {
+                expectedOSValue = "tvOS";
             }
             else
             {


### PR DESCRIPTION
This PR adds support for tvOS in os detection in the processinfo tests. In Mono's build we currently also set `HOST_IOS` on tvOS.