### PR TITLE
Strip more attributes on NativeAOT publishing

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.xml
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.xml
@@ -14,8 +14,37 @@
   </assembly>
 
   <assembly fullname="*">
+
     <!-- Internal attributes shared as implementation, so they could be in any assembly -->
     <type fullname="System.Runtime.Versioning.NonVersionableAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+
+    <!-- [EditorBrowsable] is only relevant for IDE scenarios -->
+    <type fullname="System.ComponentModel.EditorBrowsableAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+
+    <!-- [CompilerGenerated] and [GeneratedCode] are often added by source generators, but don't really do anything -->
+    <type fullname="System.Runtime.CompilerServices.CompilerGeneratedAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.CodeDom.Compiler.GeneratedCodeAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+
+    <!-- [ExcludeFromCodeAnalysis] is only relevant when doing local development or running tests -->
+    <type fullname="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+  </assembly>
+
+  <!-- Debugger support attributes, not used when debug support is disabled -->
+  <assembly fullname="*" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="false">
+    <type fullname="System.Diagnostics.DebuggerNonUserCodeAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.DebuggerStepThroughAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
   </assembly>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.xml
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.xml
@@ -47,6 +47,12 @@
     <type fullname="System.Diagnostics.DebuggerStepThroughAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
+    <type fullname="System.Diagnostics.DebuggerDisplayAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Diagnostics.DebuggerTypeProxyAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
   </assembly>
 
   <!-- Public attributes that need to be interpreted by the compiler, fine to strip afterwards -->


### PR DESCRIPTION
> **Note**: follow up from a conversation with @MichalStrehovsky on the C# Discord.

This PR enables stripping of the following additional attributes on NativeAOT publishing:
- `[EditorBrowsable]`
- `[CompilerGenerated]`
- `[GeneratedCode]`
- `[ExcludeFromCodeCoverage]`
- `[DebuggerNonUserCode]`
- `[DebuggerStepThrough]`

These attributes are especially common for code generated by source generators.
The last two are gated behind `<DebuggerSupport>` being disabled.