### PR TITLE
remove redundant OR

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -55,7 +55,7 @@ namespace System.Text
                     uint valueA = uint.CreateTruncating(Unsafe.Add(ref left, i));
                     uint valueB = uint.CreateTruncating(Unsafe.Add(ref right, i));
 
-                    if (valueA != valueB || !UnicodeUtility.IsAsciiCodePoint(valueA | valueB))
+                    if (valueA != valueB || !UnicodeUtility.IsAsciiCodePoint(valueA))
                     {
                         return false;
                     }
@@ -108,7 +108,7 @@ namespace System.Text
                     leftValues = TLoader.Load128(ref currentLeftSearchSpace);
                     rightValues = Vector128.LoadUnsafe(ref currentRightSearchSpace);
 
-                    if (leftValues != rightValues || !AllCharsInVectorAreAscii(leftValues | rightValues))
+                    if (leftValues != rightValues || !AllCharsInVectorAreAscii(leftValues))
                     {
                         return false;
                     }
@@ -124,7 +124,7 @@ namespace System.Text
                     leftValues = TLoader.Load128(ref oneVectorAwayFromLeftEnd);
                     rightValues = Vector128.LoadUnsafe(ref oneVectorAwayFromRightEnd);
 
-                    if (leftValues != rightValues || !AllCharsInVectorAreAscii(leftValues | rightValues))
+                    if (leftValues != rightValues || !AllCharsInVectorAreAscii(leftValues))
                     {
                         return false;
                     }


### PR DESCRIPTION
both inputs are equal here so if one of them is non ASCII, then the other one is too (idea taken from @BrennanConroy)

ASM diff: https://www.diffchecker.com/hdGIxueW

#87141 have not introduced the regression reported in #88670, but it has changed... the code alignment.

This PR improves the perf for the mentioned benchmark by 5%.

The other benchmark is back to it's previous state:

![image](https://github.com/dotnet/runtime/assets/6011991/08f7defb-4400-4708-9b8b-e43fdaa1bae5)

So it should be safe to assume that this PR is going to fix #88670

```cmd
dotnet run -c Release -f net8.0 -- --filter "*Perf_Ascii.Equals_*Chars*" --envVars DOTNET_EnableAVX2:0 --memoryRandomization --launchCount 6 --corerun $removedForBrevity
```

```ini
BenchmarkDotNet=v0.13.2.2052-nightly, OS=Windows 11 (10.0.22621.1848)
AMD Ryzen Threadripper PRO 3945WX 12-Cores, 1 CPU, 24 logical and 12 physical cores
.NET SDK=8.0.100-preview.4.23259.14
  [Host]     : .NET 8.0.0 (8.0.23.25905), X64 RyuJIT AVX2
  Job-VOGWHW : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX
  Job-AYOMRP : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX
```


|             Method |  Job | Size |      Mean | Ratio |
|------------------- |----- |----- |----------:|------:|
|       Equals_Chars |   PR |    6 |  5.121 ns |  0.93 |
|       Equals_Chars | main |    6 |  5.502 ns |  1.00 |
|                    |      |      |           |       |
| Equals_Bytes_Chars |   PR |    6 |  4.533 ns |  0.95 |
| Equals_Bytes_Chars | main |    6 |  4.778 ns |  1.00 |
|                    |      |      |           |       |
|       Equals_Chars |   PR |  128 | 15.179 ns |  1.00 |
|       Equals_Chars | main |  128 | 15.176 ns |  1.00 |
|                    |      |      |           |       |
| Equals_Bytes_Chars |   PR |  128 | 11.559 ns |  1.01 |
| Equals_Bytes_Chars | main |  128 | 11.413 ns |  1.00 |