### PR TITLE
Remove extra checks for known types in log formatter

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
@@ -265,13 +265,6 @@ namespace Microsoft.Extensions.Logging
 
         private static bool TryFormatArgumentIfNullOrEnumerable<T>(T? value, [NotNullWhen(true)] ref object? stringValue)
         {
-            // Avoiding boxing of known types
-            if (typeof(T).IsPrimitive || typeof(T).IsEnum)
-            {
-                stringValue = null;
-                return false;
-            }
-
             if (value == null)
             {
                 stringValue = NullValue;


### PR DESCRIPTION
Turns out the JIT will not box in tier 1, this was trying to optimize tier 0 code.

Related to https://github.com/dotnet/runtime/issues/88987