### PR TITLE
Standardize `AddBodySubstituterStep`

### DIFF
--- a/src/tools/illink/src/linker/Linker/Driver.cs
+++ b/src/tools/illink/src/linker/Linker/Driver.cs
@@ -894,7 +894,7 @@ namespace Mono.Linker
 			pipeline.AddStepBefore (typeof (MarkStep), new LinkAttributesStep (File.OpenRead (file), file));
 		}
 
-		static void AddBodySubstituterStep (Pipeline pipeline, string file)
+		protected virtual void AddBodySubstituterStep (Pipeline pipeline, string file)
 		{
 			pipeline.AddStepBefore (typeof (MarkStep), new BodySubstituterStep (File.OpenRead (file), file));
 		}


### PR DESCRIPTION
The other `Add*` methods for adding steps are `protected virtual`.  Do the same for `AddBodySubstituterStep`.

We do not currently leverage the ability to override but it would be nice to be able to call this to avoid duplicating the logic.  