### PR TITLE
Remove the ignore from `CustomStepCanResolveTypesAfterSweep`

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Extensibility/CustomStepCanResolveTypesAfterSweep.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Extensibility/CustomStepCanResolveTypesAfterSweep.cs
@@ -4,9 +4,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Extensibility
 {
 	// Repro for https://github.com/dotnet/linker/issues/2267.
-#if !NETCOREAPP
-	[IgnoreTestCase ("Specific to the illink build")]
-#endif
 	[SetupCompileBefore ("ResolveTypesSubStep.dll", new[] { "Dependencies/ResolveTypesSubStep.cs" }, new[] { "illink.dll", "Mono.Cecil.dll", "netstandard.dll" })]
 	[SetupLinkerArgument ("--custom-step", "+OutputStep:ResolveTypesSubStep,ResolveTypesSubStep.dll")]
 	[SetupLinkerAction ("copy", "test")]


### PR DESCRIPTION
There are a few reasons to remove this.

* The ignore is pointless. `#if` cannot be used to ignore a test. Tests are collected from whatever version of `Mono.Linker.Tests.Cases` is handy.  It could be a net7 build.  It could be net471.   Our NUnit tests run on net7 and so we collect which tests to run from a net7 build of `Mono.Linker.Tests.Cases`.  This means we collect and run this test.
* It passes with UnityLinker.  
* No other tests in the `Extensibility` folder do this and I don't see anything special about this one.