### PR TITLE
Add NativeAOT runtime pack builds for osx x64/arm64

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -104,6 +104,8 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: release
           platforms:
+          - osx_x64
+          - osx_arm64
           - maccatalyst_x64
           - maccatalyst_arm64
           - tvossimulator_x64


### PR DESCRIPTION
This is necessary for the NativeAOT work in xamarin-macios