### PR TITLE
Revert "[wasm][debugger] Remove usage of GeneratedRegex"

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -1352,9 +1352,8 @@ namespace Microsoft.WebAssembly.Diagnostics
 
     internal sealed partial class SourceFile
     {
-#pragma warning disable SYSLIB1045
-        private static readonly Regex regexForEscapeFileName = new (@"([:/])");
-#pragma warning restore SYSLIB1045
+        [GeneratedRegex(@"([:/])")]
+        private static partial Regex RegexForEscapeFileName();
 
         private readonly Dictionary<int, MethodInfo> methods;
         private readonly AssemblyInfo assembly;
@@ -1456,7 +1455,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         private static string EscapePathForUri(string path)
         {
             var builder = new StringBuilder();
-            foreach (var part in regexForEscapeFileName.Split(path))
+            foreach (var part in RegexForEscapeFileName().Split(path))
             {
                 if (part == ":" || part == "/")
                     builder.Append(part);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/EvaluateExpression.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/EvaluateExpression.cs
@@ -35,9 +35,9 @@ namespace Microsoft.WebAssembly.Diagnostics
                 ));
         private sealed partial class ExpressionSyntaxReplacer : CSharpSyntaxWalker
         {
-#pragma warning disable SYSLIB1045
-            private static Regex regexForReplaceVarName = new (@"[^A-Za-z0-9_]", RegexOptions.Singleline);
-#pragma warning restore SYSLIB1045
+            [GeneratedRegex(@"[^A-Za-z0-9_]", RegexOptions.Singleline)]
+            private static partial Regex RegexForReplaceVarName();
+
             public List<IdentifierNameSyntax> identifiers = new List<IdentifierNameSyntax>();
             public List<InvocationExpressionSyntax> methodCalls = new List<InvocationExpressionSyntax>();
             public List<MemberAccessExpressionSyntax> memberAccesses = new List<MemberAccessExpressionSyntax>();
@@ -113,7 +113,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     {
                         // Generate a random suffix
                         string suffix = Guid.NewGuid().ToString().Substring(0, 5);
-                        string prefix = regexForReplaceVarName.Replace(ma_str, "_");
+                        string prefix = RegexForReplaceVarName().Replace(ma_str, "_");
                         id_name = $"{prefix}_{suffix}";
 
                         memberAccessToParamName[ma_str] = id_name;
@@ -130,7 +130,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     {
                         // Generate a random suffix
                         string suffix = Guid.NewGuid().ToString().Substring(0, 5);
-                        string prefix = regexForReplaceVarName.Replace(iesStr, "_");
+                        string prefix = RegexForReplaceVarName().Replace(iesStr, "_");
                         id_name = $"{prefix}_{suffix}";
                         methodCallToParamName[iesStr] = id_name;
                     }
@@ -146,7 +146,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     {
                         // Generate a random suffix
                         string suffix = Guid.NewGuid().ToString().Substring(0, 5);
-                        string prefix = regexForReplaceVarName.Replace(eaStr, "_");
+                        string prefix = RegexForReplaceVarName().Replace(eaStr, "_");
                         id_name = $"{prefix}_{suffix}";
                         elementAccessToParamName[eaStr] = id_name;
                     }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -834,19 +834,23 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         internal readonly ILogger logger;
 
-#pragma warning disable SYSLIB1045
-        private static Regex regexForAsyncLocals = new (@"\<(?<varName>[^)]*)\>(?<varId>[^)]*)(__)(?<scopeId>\d+)", RegexOptions.Singleline);
+        [GeneratedRegex(@"\<(?<varName>[^)]*)\>(?<varId>[^)]*)(__)(?<scopeId>\d+)", RegexOptions.Singleline)]
+        private static partial Regex RegexForAsyncLocals(); //<testCSharpScope>5__1 // works
 
-        private static Regex regexForVBAsyncLocals = new (@"\$VB\$ResumableLocal_(?<varName>[^\$]*)\$(?<scopeId>\d+)", RegexOptions.Singleline); //$VB$ResumableLocal_testVbScope$2
+        [GeneratedRegex(@"\$VB\$ResumableLocal_(?<varName>[^\$]*)\$(?<scopeId>\d+)", RegexOptions.Singleline)]
+        private static partial Regex RegexForVBAsyncLocals(); //$VB$ResumableLocal_testVbScope$2
 
-        private static Regex regexForVBAsyncMethodName = new (@"VB\$StateMachine_(\d+)_(?<methodName>.*)", RegexOptions.Singleline); //VB$StateMachine_2_RunVBScope
+        [GeneratedRegex(@"VB\$StateMachine_(\d+)_(?<methodName>.*)", RegexOptions.Singleline)]
+        private static partial Regex RegexForVBAsyncMethodName(); //VB$StateMachine_2_RunVBScope
 
-        private static Regex regexForAsyncMethodName = new (@"\<([^>]*)\>([d][_][_])([0-9]*)");
+        [GeneratedRegex(@"\<([^>]*)\>([d][_][_])([0-9]*)")]
+        private static partial Regex RegexForAsyncMethodName();
 
-        private static Regex regexForGenericArgs = new (@"[`][0-9]+");
+        [GeneratedRegex(@"[`][0-9]+")]
+        private static partial Regex RegexForGenericArgs();
 
-        private static Regex regexForNestedLeftRightAngleBrackets = new ("^(((?'Open'<)[^<>]*)+((?'Close-Open'>)[^<>]*)+)*(?(Open)(?!))[^<>]*"); // <ContinueWithStaticAsync>b__3_0
-#pragma warning restore SYSLIB1045
+        [GeneratedRegex("^(((?'Open'<)[^<>]*)+((?'Close-Open'>)[^<>]*)+)*(?(Open)(?!))[^<>]*")]
+        private static partial Regex RegexForNestedLeftRightAngleBrackets(); // <ContinueWithStaticAsync>b__3_0
 
         public JObjectValueCreator ValueCreator { get; init; }
 
@@ -922,7 +926,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         {
             methodName = methodName.Replace(':', '.');
             methodName = methodName.Replace('/', '.');
-            methodName = regexForGenericArgs.Replace(methodName, "");
+            methodName = RegexForGenericArgs().Replace(methodName, "");
             return methodName;
         }
 
@@ -1304,7 +1308,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     var ret = retDebuggerCmdReader.ReadString();
                     if (ret.IndexOf(':') is int index && index > 0)
                         ret = ret.Substring(0, index);
-                    ret = regexForAsyncMethodName.Replace(ret, "$1");
+                    ret = RegexForAsyncMethodName().Replace(ret, "$1");
                     var numGenericTypeArgs = retDebuggerCmdReader.ReadInt32();
                     var numGenericMethodArgs = retDebuggerCmdReader.ReadInt32();
                     int numTotalGenericArgs = numGenericTypeArgs + numGenericMethodArgs;
@@ -1312,17 +1316,17 @@ namespace Microsoft.WebAssembly.Diagnostics
                     for (int i = 0; i < numTotalGenericArgs; i++)
                     {
                         var typeArgC = retDebuggerCmdReader.ReadString();
-                        typeArgC = regexForGenericArgs.Replace(typeArgC, "");
+                        typeArgC = RegexForGenericArgs().Replace(typeArgC, "");
                         genericArgs.Add(typeArgC);
                     }
-                    var match = regexForGenericArgs.Match(ret);
+                    var match = RegexForGenericArgs().Match(ret);
                     while (match.Success)
                     {
                         var countArgs = Convert.ToInt32(match.Value.Remove(0, 1));
                         ret = ret.Remove(match.Index, match.Value.Length);
                         ret = ret.Insert(match.Index, $"<{string.Join(", ", genericArgs.Take(countArgs))}>");
                         genericArgs.RemoveRange(0, countArgs);
-                        match = regexForGenericArgs.Match(ret);
+                        match = RegexForGenericArgs().Match(ret);
                     }
                     ret = ret.Replace('/', '.');
                     return ret;
@@ -1342,7 +1346,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         }
                         else if (klassName.StartsWith("VB$"))
                         {
-                            var match = regexForVBAsyncMethodName.Match(klassName);
+                            var match = RegexForVBAsyncMethodName().Match(klassName);
                             if (match.Success)
                                 ret = ret.Insert(0, match.Groups["methodName"].Value);
                             else
@@ -1350,7 +1354,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         }
                         else
                         {
-                            var matchOnClassName = regexForNestedLeftRightAngleBrackets.Match(klassName);
+                            var matchOnClassName = RegexForNestedLeftRightAngleBrackets().Match(klassName);
                             if (matchOnClassName.Success && matchOnClassName.Groups["Close"].Captures.Count > 0)
                                 klassName = matchOnClassName.Groups["Close"].Captures[0].Value;
                             if (ret.Length > 0)
@@ -1359,7 +1363,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         }
                     }
                     var methodName = retDebuggerCmdReader.ReadString();
-                    var matchOnMethodName = regexForNestedLeftRightAngleBrackets.Match(methodName);
+                    var matchOnMethodName = RegexForNestedLeftRightAngleBrackets().Match(methodName);
                     if (matchOnMethodName.Success && matchOnMethodName.Groups["Close"].Captures.Count > 0)
                     {
                         if (isAnonymous && anonymousMethodId.Length == 0 && methodName.Contains("__"))
@@ -1712,17 +1716,19 @@ namespace Microsoft.WebAssembly.Diagnostics
             }
             return null;
         }
-#pragma warning disable SYSLIB1045
-        private static Regex regexForGenericArity = new (@"`\d+");
-        private static Regex regexForSquareBrackets = new (@"[[, ]+]");
-#pragma warning restore SYSLIB1045
+
+        [GeneratedRegex(@"`\d+")]
+        private static partial Regex RegexForGenericArity();
+
+        [GeneratedRegex(@"[[, ]+]")]
+        private static partial Regex RegexForSquareBrackets();
 
         public async Task<string> GetTypeName(int typeId, CancellationToken token)
         {
             string className = await GetTypeNameOriginal(typeId, token);
             className = className.Replace("+", ".");
-            className = regexForGenericArity.Replace(className, "");
-            className = regexForSquareBrackets.Replace(className, "__SQUARED_BRACKETS__");
+            className = RegexForGenericArity().Replace(className, "");
+            className = RegexForSquareBrackets().Replace(className, "__SQUARED_BRACKETS__");
             //className = className.Replace("[]", "__SQUARED_BRACKETS__");
             className = className.Replace("[", "<");
             className = className.Replace("]", ">");
@@ -2065,7 +2071,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 }
                 else if (fieldName.StartsWith('<')) //examples: <code>5__2
                 {
-                    var match = regexForAsyncLocals.Match(fieldName);
+                    var match = RegexForAsyncLocals().Match(fieldName);
                     if (match.Success)
                     {
                         if (!method.Info.ContainsAsyncScope(Convert.ToInt32(match.Groups["scopeId"].Value), offset))
@@ -2080,7 +2086,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 }
                 else if (fieldName.StartsWith("$VB$ResumableLocal_", StringComparison.Ordinal))
                 {
-                    var match = regexForVBAsyncLocals.Match(fieldName);
+                    var match = RegexForVBAsyncLocals().Match(fieldName);
                     if (match.Success)
                     {
                         if (!method.Info.ContainsAsyncScope(Convert.ToInt32(match.Groups["scopeId"].Value) + 1, offset))


### PR DESCRIPTION
I think that now we are already using sdk preview 5, so we can rollback this one.

Reverts dotnet/runtime#86911