### PR TITLE
[wasm][debugger] Check client version to send debugger message

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -7482,23 +7482,27 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 			const unsigned char* pdb_bytes = NULL;
 			unsigned int symfile_size = 0;
 			mono_bundled_resources_get_assembly_resource_symbol_values (assembly_name, &pdb_bytes, &symfile_size);
-			MonoAssembly* assembly = find_assembly_by_name (assembly_name);
-			assembly_size = assembly->image->image_info->cli_cli_header.ch_metadata.size;
-			assembly_bytes = (const unsigned char*) assembly->image->raw_metadata;
-			if (symfile_size == 0) //try to send embedded pdb data
-			{
-				guint8 pe_guid [16];
-				gint32 pe_age;
-				gint32 pe_timestamp;
-				guint8 *ppdb_data = NULL;
-				int ppdb_compressed_size = 0;
-				char *ppdb_path;
-				mono_get_pe_debug_info_full (assembly->image, pe_guid, &pe_age, &pe_timestamp, &ppdb_data, &ppdb_size, &ppdb_compressed_size, &ppdb_path, NULL, NULL);
-				if (ppdb_compressed_size > 0)
-				{
-					symfile_size = ppdb_compressed_size;
-					pdb_bytes = ppdb_data;
-				}
+			if (!CHECK_PROTOCOL_VERSION(2, 62))	{
+				mono_bundled_resources_get_assembly_resource_values (assembly_name, &assembly_bytes, &assembly_size);
+			}
+			else {
+				MonoAssembly* assembly = find_assembly_by_name (assembly_name);
+				assembly_size = assembly->image->image_info->cli_cli_header.ch_metadata.size;
+				assembly_bytes = (const unsigned char*) assembly->image->raw_metadata;
+				if (symfile_size == 0) { //try to send embedded pdb data
+					guint8 pe_guid [16];
+					gint32 pe_age;
+					gint32 pe_timestamp;
+					guint8 *ppdb_data = NULL;
+					int ppdb_compressed_size = 0;
+					char *ppdb_path;
+					mono_get_pe_debug_info_full (assembly->image, pe_guid, &pe_age, &pe_timestamp, &ppdb_data, &ppdb_size, &ppdb_compressed_size, &ppdb_path, NULL, NULL);
+					if (ppdb_compressed_size > 0)
+					{
+						symfile_size = ppdb_compressed_size;
+						pdb_bytes = ppdb_data;
+					}
+				}				
 			}
 			m_dbgprot_buffer_init (buf, assembly_size + symfile_size + 1024);
 			m_dbgprot_buffer_add_byte_array (buf, (uint8_t *) assembly_bytes, assembly_size);

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -7468,14 +7468,11 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 	case MDBGPROT_CMD_GET_ASSEMBLY_BYTES: { //only used by wasm
 #ifdef HOST_WASM
 		char* assembly_name = m_dbgprot_decode_string (p, &p, end);
-		if (assembly_name == NULL)
-		{
+		if (assembly_name == NULL) {
 			m_dbgprot_buffer_add_int (buf, 0);
 			m_dbgprot_buffer_add_int (buf, 0);
 			m_dbgprot_buffer_add_int (buf, 0);
-		}
-		else
-		{
+		} else {
 			int ppdb_size = 0;
 			const unsigned char* assembly_bytes = NULL;
 			unsigned int assembly_size = 0;
@@ -7485,8 +7482,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 			mono_bundled_resources_get_assembly_resource_symbol_values (assembly_name, &pdb_bytes, &symfile_size);
 			if (!CHECK_PROTOCOL_VERSION(2, 62)) {
 				mono_bundled_resources_get_assembly_resource_values (assembly_name, &assembly_bytes, &assembly_size);
-			}
-			else {
+			} else {
 				assembly = find_assembly_by_name (assembly_name);
 				assembly_size = assembly->image->image_info->cli_cli_header.ch_metadata.size;
 				assembly_bytes = (const unsigned char*) assembly->image->raw_metadata;
@@ -7498,8 +7494,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 					int ppdb_compressed_size = 0;
 					char *ppdb_path;
 					mono_get_pe_debug_info_full (assembly->image, pe_guid, &pe_age, &pe_timestamp, &ppdb_data, &ppdb_size, &ppdb_compressed_size, &ppdb_path, NULL, NULL);
-					if (ppdb_compressed_size > 0)
-					{
+					if (ppdb_compressed_size > 0) {
 						symfile_size = ppdb_compressed_size;
 						pdb_bytes = ppdb_data;
 					}

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -7481,12 +7481,13 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 			unsigned int assembly_size = 0;
 			const unsigned char* pdb_bytes = NULL;
 			unsigned int symfile_size = 0;
+			MonoAssembly* assembly = NULL;
 			mono_bundled_resources_get_assembly_resource_symbol_values (assembly_name, &pdb_bytes, &symfile_size);
 			if (!CHECK_PROTOCOL_VERSION(2, 62))	{
 				mono_bundled_resources_get_assembly_resource_values (assembly_name, &assembly_bytes, &assembly_size);
 			}
 			else {
-				MonoAssembly* assembly = find_assembly_by_name (assembly_name);
+				assembly = find_assembly_by_name (assembly_name);
 				assembly_size = assembly->image->image_info->cli_cli_header.ch_metadata.size;
 				assembly_bytes = (const unsigned char*) assembly->image->raw_metadata;
 				if (symfile_size == 0) { //try to send embedded pdb data

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -7483,7 +7483,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 			unsigned int symfile_size = 0;
 			MonoAssembly* assembly = NULL;
 			mono_bundled_resources_get_assembly_resource_symbol_values (assembly_name, &pdb_bytes, &symfile_size);
-			if (!CHECK_PROTOCOL_VERSION(2, 62))	{
+			if (!CHECK_PROTOCOL_VERSION(2, 62)) {
 				mono_bundled_resources_get_assembly_resource_values (assembly_name, &assembly_bytes, &assembly_size);
 			}
 			else {
@@ -7507,7 +7507,8 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 			}
 			m_dbgprot_buffer_init (buf, assembly_size + symfile_size + 1024);
 			m_dbgprot_buffer_add_byte_array (buf, (uint8_t *) assembly_bytes, assembly_size);
-			m_dbgprot_buffer_add_int (buf, ppdb_size);
+			if (CHECK_PROTOCOL_VERSION(2, 62))
+				m_dbgprot_buffer_add_int (buf, ppdb_size);
 			m_dbgprot_buffer_add_byte_array (buf, (uint8_t *) pdb_bytes, symfile_size);
 			if (assembly)
 				send_debug_information (assembly, buf);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -818,7 +818,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         private static int debuggerObjectId;
         private static int cmdId = 1; //cmdId == 0 is used by events which come from runtime
-        private const int MINOR_VERSION = 61;
+        private const int MINOR_VERSION = 62;
         private const int MAJOR_VERSION = 2;
 
         private int VmMinorVersion { get; set; }


### PR DESCRIPTION
PR #86982 changed the response format for the `MDBGPROT_CMD_GET_ASSEMBLY_BYTES` in the `debugger-agent`, to send only the asm metadata instead of the full assembly contents.

But the PR missed adding appropriate version checks for the new format to keep backward compatibility. And this broke when a older proxy which didn't understand the new format was used with the updated runtime.

```
      Failed to load https://localhost:7284/_framework/Microsoft.AspNetCore.Authorization.wasm (Stream does not contain a valid Webcil file) (stack=   at Microsoft.NET.WebAssembly.Webcil.WebcilReader..ctor(Stream stream)
         at Microsoft.WebAssembly.Diagnostics.AssemblyInfo.FromBytes(MonoProxy monoProxy, SessionId sessionId, Byte[] assembly, Byte[] pdb, ILogger logger, CancellationToken token)
         at Microsoft.WebAssembly.Diagnostics.DebugStore.Load(SessionId id, String[] loaded_files, ExecutionContext context, Boolean useDebuggerProtocol, CancellationToken token)+MoveNext())
```

With this change I'm adding the needed version guards when sending the response. And bumping the BrowserDebugProxy version, so it can correctly get the newer format response.

Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/2236