### PR TITLE
[aot] Build cross compilers targeting x64/x86 hosted on osx-arm64

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -222,6 +222,8 @@ extends:
           platforms:
           - linux_x64
           - linux_musl_x64
+          - linux_arm64
+          - linux_musl_arm64
           jobParameters:
             buildArgs: -s mono+packs -c $(_BuildConfig)
                       /p:MonoCrossAOTTargetOS=android+browser /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
@@ -232,28 +234,6 @@ extends:
             - mono_browser_offsets
             monoCrossAOTTargetOS:
             - android
-            - browser
-            isOfficialBuild: ${{ variables.isOfficialBuild }}
-            extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-            extraStepsParameters:
-              name: MonoRuntimePacks
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          runtimeFlavor: mono
-          buildConfig: release
-          platforms:
-          - linux_arm64
-          - linux_musl_arm64
-          jobParameters:
-            buildArgs: -s mono+packs -c $(_BuildConfig)
-                       /p:MonoCrossAOTTargetOS=browser /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
-            nameSuffix: CrossAOT_Mono
-            runtimeVariant: crossaot
-            dependsOn:
-            - mono_browser_offsets
-            monoCrossAOTTargetOS:
             - browser
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
@@ -290,6 +270,7 @@ extends:
           buildConfig: release
           platforms:
           - osx_x64
+          - osx_arm64
           jobParameters:
             buildArgs: -s mono+packs -c $(_BuildConfig)
                       /p:MonoCrossAOTTargetOS=android+browser+tvos+ios+maccatalyst /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
@@ -307,27 +288,6 @@ extends:
             - tvos
             - ios
             - maccatalyst
-            isOfficialBuild: ${{ variables.isOfficialBuild }}
-            extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-            extraStepsParameters:
-              name: MonoRuntimePacks
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          runtimeFlavor: mono
-          buildConfig: release
-          platforms:
-          - osx_arm64
-          jobParameters:
-            buildArgs: -s mono+packs -c $(_BuildConfig)
-                       /p:MonoCrossAOTTargetOS=browser /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
-            nameSuffix: CrossAOT_Mono
-            runtimeVariant: crossaot
-            dependsOn:
-            - mono_browser_offsets
-            monoCrossAOTTargetOS:
-            - browser
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
             extraStepsParameters:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -734,8 +734,8 @@ extends:
           platforms:
           - linux_x64
           - linux_musl_x64
-          # - linux_arm64
-          # - linux_musl_arm64
+          - linux_arm64
+          - linux_musl_arm64
           - windows_x64
           # - windows_x86
           # - windows_arm64
@@ -760,6 +760,7 @@ extends:
           buildConfig: release
           platforms:
           - osx_x64
+          - osx_arm64
           jobParameters:
             runtimeVariant: crossaot
             dependsOn:
@@ -774,27 +775,6 @@ extends:
             - tvos
             - ios
             - maccatalyst
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-          runtimeFlavor: mono
-          buildConfig: release
-          platforms:
-          - linux_arm64
-          - linux_musl_arm64
-          - osx_arm64
-          jobParameters:
-            runtimeVariant: crossaot
-            dependsOn:
-            - mono_browser_offsets
-            monoCrossAOTTargetOS:
-            - browser
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),

--- a/src/mono/mono/mini/exceptions-amd64.c
+++ b/src/mono/mono/mini/exceptions-amd64.c
@@ -904,7 +904,7 @@ altstack_handle_and_restore (MonoContext *ctx, MonoObject *obj, guint32 flags)
 void
 mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo, gpointer fault_addr, gboolean stack_ovf)
 {
-#if defined(MONO_ARCH_USE_SIGACTION)
+#if defined(MONO_ARCH_USE_SIGACTION) && defined(HOST_AMD64)
 	MonoException *exc = NULL;
 	gpointer *sp;
 	MonoJitTlsData *jit_tls = NULL;

--- a/src/mono/mono/mini/exceptions-amd64.c
+++ b/src/mono/mono/mini/exceptions-amd64.c
@@ -904,7 +904,7 @@ altstack_handle_and_restore (MonoContext *ctx, MonoObject *obj, guint32 flags)
 void
 mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo, gpointer fault_addr, gboolean stack_ovf)
 {
-#if defined(MONO_ARCH_USE_SIGACTION) && defined(HOST_AMD64)
+#if defined(MONO_ARCH_USE_SIGACTION) && !defined(MONO_CROSS_COMPILE)
 	MonoException *exc = NULL;
 	gpointer *sp;
 	MonoJitTlsData *jit_tls = NULL;

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -1429,6 +1429,7 @@ void
 mono_arch_cpu_init (void)
 {
 #ifndef _MSC_VER
+#if defined(HOST_AMD64)
 	guint16 fpcw;
 
 	/* spec compliance requires running with double precision */
@@ -1437,6 +1438,7 @@ mono_arch_cpu_init (void)
 	fpcw |= X86_FPCW_PREC_DOUBLE;
 	__asm__  __volatile__ ("fldcw %0\n": : "m" (fpcw));
 	__asm__  __volatile__ ("fnstcw %0\n": "=m" (fpcw));
+#endif
 #else
 	/* TODO: This is crashing on Win64 right now.
 	* _control87 (_PC_53, MCW_PC);

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -1429,7 +1429,7 @@ void
 mono_arch_cpu_init (void)
 {
 #ifndef _MSC_VER
-#if defined(HOST_AMD64)
+#if !defined(MONO_CROSS_COMPILE)
 	guint16 fpcw;
 
 	/* spec compliance requires running with double precision */

--- a/src/mono/mono/mini/mini-x86.c
+++ b/src/mono/mono/mini/mini-x86.c
@@ -841,6 +841,7 @@ exit:
 void
 mono_arch_cpu_init (void)
 {
+#if !defined(MONO_CROSS_COMPILE)
 	/* spec compliance requires running with double precision */
 #ifndef _MSC_VER
 	guint16 fpcw;
@@ -852,6 +853,7 @@ mono_arch_cpu_init (void)
 	__asm__  __volatile__ ("fnstcw %0\n": "=m" (fpcw));
 #else
 	_control87 (_PC_53, MCW_PC);
+#endif
 #endif
 }
 

--- a/src/mono/mono/utils/mono-context.h
+++ b/src/mono/mono/utils/mono-context.h
@@ -35,7 +35,7 @@ typedef struct __darwin_xmm_reg MonoContextSimdReg;
 #elif defined(TARGET_AMD64)
 #if defined(__APPLE__)
 #define MONO_HAVE_SIMD_REG
-#if defined(HOST_AMD64)
+#if !defined(MONO_CROSS_COMPILE)
 typedef struct __darwin_xmm_reg MonoContextSimdReg;
 #else
 /* if building for an arm64 host machine, a cross compiler that produces x64 modules, fake a MonoContextSimdReg */

--- a/src/mono/mono/utils/mono-context.h
+++ b/src/mono/mono/utils/mono-context.h
@@ -29,8 +29,12 @@
 
 #if defined(TARGET_X86)
 #if defined(__APPLE__)
-#define MONO_HAVE_SIMD_REG
+#if !defined(MONO_CROSS_COMPILE)
 typedef struct __darwin_xmm_reg MonoContextSimdReg;
+#else
+/* if building for an arm64 host machine, a cross compiler that produces x86 modules, fake a MonoContextSimdReg */
+typedef __uint128_t MonoContextSimdReg;
+#endif
 #endif
 #elif defined(TARGET_AMD64)
 #if defined(__APPLE__)

--- a/src/mono/mono/utils/mono-context.h
+++ b/src/mono/mono/utils/mono-context.h
@@ -63,8 +63,13 @@ typedef __m128d MonoContextSimdReg;
 typedef struct _libc_xmmreg MonoContextSimdReg;
 #elif defined(__linux__) || defined(__OpenBSD__)
 #define MONO_HAVE_SIMD_REG
+#if !defined(MONO_CROSS_COMPILE)
 #include <emmintrin.h>
 typedef __m128d MonoContextSimdReg;
+#else
+/* if building for an arm64 host machine, a cross compiler that produces x64 modules, fake a MonoContextSimdReg */
+typedef __uint128_t MonoContextSimdReg;
+#endif
 #endif
 #elif defined(TARGET_ARM64)
 /* We need a definition for MonoContextSimdReg even when cross-compiling

--- a/src/mono/mono/utils/mono-context.h
+++ b/src/mono/mono/utils/mono-context.h
@@ -35,7 +35,12 @@ typedef struct __darwin_xmm_reg MonoContextSimdReg;
 #elif defined(TARGET_AMD64)
 #if defined(__APPLE__)
 #define MONO_HAVE_SIMD_REG
+#if defined(HOST_AMD64)
 typedef struct __darwin_xmm_reg MonoContextSimdReg;
+#else
+/* if building for an arm64 host machine, a cross compiler that produces x64 modules, fake a MonoContextSimdReg */
+typedef __uint128_t MonoContextSimdReg;
+#endif
 #elif defined(__linux__) && defined(__GLIBC__)
 #define MONO_HAVE_SIMD_REG
 typedef struct _libc_xmmreg MonoContextSimdReg;

--- a/src/mono/mono/utils/mono-context.h
+++ b/src/mono/mono/utils/mono-context.h
@@ -47,7 +47,12 @@ typedef __uint128_t MonoContextSimdReg;
 #endif
 #elif defined(__linux__) && defined(__GLIBC__)
 #define MONO_HAVE_SIMD_REG
+#if !defined(MONO_CROSS_COMPILE)
 typedef struct _libc_xmmreg MonoContextSimdReg;
+#else
+/* if building for an arm64 host machine, a cross compiler that produces x64 modules, fake a MonoContextSimdReg */
+typedef __uint128_t MonoContextSimdReg;
+#endif
 #elif defined(HOST_WIN32)
 #define MONO_HAVE_SIMD_REG
 //#define MONO_HAVE_SIMD_REG_AVX

--- a/src/mono/mono/utils/mono-sigcontext.h
+++ b/src/mono/mono/utils/mono-sigcontext.h
@@ -111,7 +111,14 @@
 
 #elif defined(TARGET_AMD64)
 
-#if defined(__APPLE__)
+#if defined(MONO_CROSS_COMPILE)
+	#define UCONTEXT_REG_RDX(ctx) NULL
+	#define UCONTEXT_REG_RSP(ctx) NULL
+	#define UCONTEXT_REG_RSI(ctx) NULL
+	#define UCONTEXT_REG_RDI(ctx) NULL
+	#define UCONTEXT_REG_RIP(ctx) NULL
+
+#elif defined(__APPLE__)
 	#define UCONTEXT_REG_RAX(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__ss.__rax)
 	#define UCONTEXT_REG_RBX(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__ss.__rbx)
 	#define UCONTEXT_REG_RCX(ctx) (((ucontext_t*)(ctx))->uc_mcontext->__ss.__rcx)


### PR DESCRIPTION
This PR allows an `osx-arm64` or `osx-x64` machine to produce a `mono-aot-cross` compiler that will run on the following host and create AOT images for the following targets:

| Host | Target | Test App runs |
|--------|--------|--------|
| osx-arm64 | iossimulator-x64 | ✅  |
| osx-arm64 | android-x64 | ✅   |
| osx-arm64 | android-x86 | ✅  - depends on a hack for https://github.com/dotnet/runtime/issues/89039 | 

Additionally a `linux-x64` or `linux-arm64` machine can build a `mono-aot-cross` compiler for these host/target pairs:

| Host | Target | Test App runs |
|--------|--------|--------|
| linux-arm64 | android-x64 | :question: |
| linux-arm64 | linux_musl-x64 | :question: |
| linux-arm64 | android-x86 | :question: |

Related to https://github.com/dotnet/runtime/issues/82495