### PR TITLE
Remove `#if NETCOREAPP` from test

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs
@@ -9,22 +9,18 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 	[RemovedAssembly ("library.dll")]
 	public class DynamicDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction
 	{
-#if NETCOREAPP
 		[Kept (By = Tool.Trimmer)] // Native AOT doesn't really support copyused behavior
 		public DynamicDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction ()
 		{
 		}
-#endif
 
 		public static void Main ()
 		{
 		}
 
 		[DynamicDependency ("MethodPreservedViaDependencyAttribute()", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction_Lib", "library")]
-#if NETCOREAPP
 		[Kept (By = Tool.Trimmer)] // Native AOT doesn't really support copyused behavior
 		[KeptAttributeAttribute (typeof (DynamicDependencyAttribute))]
-#endif
 		static void Dependency ()
 		{
 		}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction.cs
@@ -10,9 +10,7 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies
 	[RemovedAssembly ("library.dll")]
 	public class PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction
 	{
-#if NETCOREAPP
 		[Kept]
-#endif
 		private PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction ()
 		{
 		}
@@ -22,10 +20,8 @@ namespace Mono.Linker.Tests.Cases.PreserveDependencies
 		}
 
 		[PreserveDependency ("MethodPreservedViaDependencyAttribute()", "Mono.Linker.Tests.Cases.PreserveDependencies.Dependencies.PreserveDependencyOnUnusedMethodInNonReferencedAssemblyWithCopyUsedAction_Lib", "library")]
-#if NETCOREAPP
 		[Kept]
 		[KeptAttributeAttribute (typeof (PreserveDependencyAttribute))]
-#endif
 		static void Dependency ()
 		{
 		}


### PR DESCRIPTION
There is nothing net core specific about the assertions in this test.  No other tests in the `PreserveDependencies` folder have kept attributes inside of `#if NETCOREAPP`