### PR TITLE
Improve text for OpenSsl primitives when OpenSSL is not available

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -811,7 +811,7 @@
     <value>OpenSSL is not supported on this platform.</value>
   </data>
   <data name="PlatformNotSupported_CryptographyOpenSSLNotFound" xml:space="preserve">
-    <value>Algorithm '{0}' requires OpenSSL however OpenSSL could not be found or loaded.</value>
+    <value>OpenSSL is required for algorithm '{0}' but could not be found or loaded.</value>
   </data>
   <data name="Security_AccessDenied" xml:space="preserve">
     <value>Access is denied.</value>

--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -810,6 +810,9 @@
   <data name="PlatformNotSupported_CryptographyOpenSSL" xml:space="preserve">
     <value>OpenSSL is not supported on this platform.</value>
   </data>
+  <data name="PlatformNotSupported_CryptographyOpenSSLNotFound" xml:space="preserve">
+    <value>Algorithm '{0}' requires OpenSSL however OpenSSL could not be found or loaded.</value>
+  </data>
   <data name="Security_AccessDenied" xml:space="preserve">
     <value>Access is denied.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -113,7 +113,7 @@ namespace System.Security.Cryptography
         {
             if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
             {
-                throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(DSAOpenSsl)));
+                throw new PlatformNotSupportedException(SR.Format(SR.PlatformNotSupported_CryptographyOpenSSLNotFound, nameof(DSAOpenSsl)));
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
@@ -101,7 +101,7 @@ namespace System.Security.Cryptography
         {
             if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
             {
-                throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(ECDiffieHellmanOpenSsl)));
+                throw new PlatformNotSupportedException(SR.Format(SR.PlatformNotSupported_CryptographyOpenSSLNotFound, nameof(ECDiffieHellmanOpenSsl)));
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -102,7 +102,7 @@ namespace System.Security.Cryptography
         {
             if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
             {
-                throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(ECDsaOpenSsl)));
+                throw new PlatformNotSupportedException(SR.Format(SR.PlatformNotSupported_CryptographyOpenSSLNotFound, nameof(ECDsaOpenSsl)));
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -94,7 +94,7 @@ namespace System.Security.Cryptography
         {
             if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
             {
-                throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(RSAOpenSsl)));
+                throw new PlatformNotSupportedException(SR.Format(SR.PlatformNotSupported_CryptographyOpenSSLNotFound, nameof(RSAOpenSsl)));
             }
         }
     }


### PR DESCRIPTION
When using any of the *OpenSsl primitives on macOS, the current exception text is somewhat confusing. Before, it would be

> Algorithm 'ECDiffieHellmanOpenSsl' is not supported on this platform.

After this change, it will be:

> Algorithm 'ECDiffieHellmanOpenSsl' requires OpenSSL however OpenSSL could not be found or loaded.

This only affects using the *OpenSsl primitives on macOS since it is the only platform where we "support" OpenSSL but don't outright require it. Windows, Android etc. will continue to use the OpenSsl.NotSupported.cs in their complication targets:

https://github.com/dotnet/runtime/blob/ae4d6987824188f6d051b77a89cd5c297cd70b79/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/OpenSsl.NotSupported.cs#L74-L77

So those platforms will continue to receive the former exception message.

cc @mvoss84 

Contributes to https://github.com/dotnet/runtime/issues/89006