### PR TITLE
Avoid unnecessary string allocations in Get/SetMsQuicParameter

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
@@ -67,7 +67,11 @@ internal static class MsQuicHelpers
             &length,
             (byte*)&value);
 
-        ThrowHelper.ThrowIfMsQuicError(status, $"GetParam({handle}, {parameter}) failed");
+        if (StatusFailed(status))
+        {
+            ThrowHelper.ThrowMsQuicException(status, $"GetParam({handle}, {parameter}) failed");
+        }
+
         return value;
     }
 
@@ -80,6 +84,9 @@ internal static class MsQuicHelpers
             (uint)sizeof(T),
             (byte*)&value);
 
-        ThrowHelper.ThrowIfMsQuicError(status, $"SetParam({handle}, {parameter}) failed");
+        if (StatusFailed(status))
+        {
+            ThrowHelper.ThrowMsQuicException(status, $"SetParam({handle}, {parameter}) failed");
+        }
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ThrowHelper.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ThrowHelper.cs
@@ -130,8 +130,13 @@ internal static class ThrowHelper
     {
         if (StatusFailed(status))
         {
-            throw GetExceptionForMsQuicStatus(status, message: message);
+            ThrowMsQuicException(status, message);
         }
+    }
+
+    internal static void ThrowMsQuicException(int status, string? message = null)
+    {
+        throw GetExceptionForMsQuicStatus(status, message: message);
     }
 
     internal static string GetErrorMessageForStatus(int status, string? message)


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/88550#discussion_r1265468565