### PR TITLE
Update script to replace the BDN version being used in the PerfBDN app

### DIFF
--- a/eng/pipelines/coreclr/templates/build-perf-bdn-app.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-bdn-app.yml
@@ -28,7 +28,7 @@ steps:
       path: $(Build.SourcesDirectory)/ArtifactPacks
       patterns: |
         IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-!(*.symbols).nupkg
-      
+
   #    # Other artifacts to include once they are being built
   #    # EX. IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
 
@@ -56,9 +56,9 @@ steps:
       destinationFolder: $(Build.SourcesDirectory)/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-arm64
       overwriteExistingFiles: true
       cleanDestinationFolder: false
-  
+
   - script: |
-      echo '{ }' > ./global.json 
+      echo '{ }' > ./global.json
       curl -o NuGet.config 'https://raw.githubusercontent.com/dotnet/maui/${{parameters.framework}}/NuGet.config'
       curl -o dotnet-install.sh 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh'
       curl -Lo maui-supported-sdk-version.json 'https://aka.ms/dotnet/sdk/maui/${{parameters.framework}}.json'
@@ -86,22 +86,26 @@ steps:
       $perfLabExportLine = $instrumentationFileContent | Select-String -Pattern 'using BenchmarkDotNet.Toolchains.InProcess.Emit;'
       $lineNumber = $perfLabExportLine.LineNumber
       $instrumentationFileContent[$lineNumber-1] += "using BenchmarkDotNet.Extensions;"
-      
+
       $perfLabExportLine = $instrumentationFileContent | Select-String -Pattern 'var config = ManualConfig'
       $lineNumber = $perfLabExportLine.LineNumber
       $instrumentationFileContent[$lineNumber-1] += ".AddExporter(new PerfLabExporter()).WithArtifactsPath(`"/storage/emulated/0/Android/data/com.microsoft.maui.benchmarks/files`")"
       $instrumentationFileContent | Set-Content .\maui\src\Core\tests\Benchmarks.Droid\MainInstrumentation.cs
 
       $benchmarksDroidConfigFileContent = Get-Content .\maui\src\Core\tests\Benchmarks.Droid\Benchmarks.Droid.csproj
-     
+
       $propertyGroupLine = $benchmarksDroidConfigFileContent | Select-String -Pattern '<PropertyGroup>'
       $lineNumber = $propertyGroupLine.LineNumber
       $benchmarksDroidConfigFileContent[$lineNumber-1] += "<DefineConstants>`$(DefineConstants);PERFLAB_INLAB</DefineConstants>"
 
+      $packageReferenceLine = $benchmarksDroidConfigFileContent | Select-String -Pattern '<PackageReference Include="BenchmarkDotNet"'
+      $lineNumber = $packageReferenceLine.LineNumber
+      $benchmarksDroidConfigFileContent[$lineNumber-1] = "    <PackageReference Include=`"BenchmarkDotNet`" Version=`"`$(BenchmarkDotNetVersion)`" />"
+
       $projectReferenceLine = $benchmarksDroidConfigFileContent | Select-String -Pattern '<ProjectReference Include="..\\..\\src\\Core.csproj" />'
       $lineNumber = $projectReferenceLine.LineNumber
       $benchmarksDroidConfigFileContent[$lineNumber-1] += "<ProjectReference Include=`"..\..\..\..\..\performance\src\harness\BenchmarkDotnet.Extensions\BenchmarkDotnet.Extensions.csproj`" />"
-      
+
       $targetLine = $benchmarksDroidConfigFileContent | Select-String -Pattern '</Target>'
       $lineNumber = $targetLine.LineNumber
       $benchmarksDroidConfigFileContent[$lineNumber-1] += "
@@ -122,7 +126,7 @@ steps:
         </ItemGroup>
       </Target>
       "
-      
+
       $benchmarksDroidConfigFileContent | Set-Content .\maui\src\Core\tests\Benchmarks.Droid\Benchmarks.Droid.csproj
     displayName: Insert Target Replace, BDN config link, and PerfLabExporter
     workingDirectory: $(Build.SourcesDirectory)


### PR DESCRIPTION
PerfBDNApp builds are failing due to the BDN version passed to Benchmarks.Extensions and the Maui BDN version being different. Update script to replace the BDN version being used in the PerfBDN app to the same version we use in BDN extensions. 

Internal test run for perfBDNApp: https://dev.azure.com/dnceng/internal/_build/results?buildId=2223932&view=results