### PR TITLE
Add Driver.Context setter

### DIFF
--- a/src/tools/illink/src/linker/Linker/Driver.cs
+++ b/src/tools/illink/src/linker/Linker/Driver.cs
@@ -83,6 +83,10 @@ namespace Mono.Linker
 				Debug.Assert (context != null);
 				return context;
 			}
+			set {
+				Debug.Assert (context == null);
+				context = value;
+			}
 		}
 
 		private static readonly char[] s_separators = new char[] { ',', ';', ' ' };


### PR DESCRIPTION
We implement our own `Driver.SetupContext`.  Our command line parsing logic is different and we have additional command line options.

In our very old revision of the upstream linker there was
```
protected LinkContext context;
```

Which we would set.  This would ensure that if one of the helper methods that uses the context were called that things would all work. The most common scenario seems to be for error logging.  There are many helper methods that will call `Context.LogError` and if we haven't set the `context` field by then we have a problem.

We are syncing up and now the `context` field is private and there is a protected property getter, but no setter.

Adding a setter was the easiest way to get our context stored in the `context` field.