### PR TITLE
JIT: Ensure last-use copy omission candidates are marked with GTF_GLOB_REF

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3224,15 +3224,6 @@ GenTree* Compiler::optCopyAssertionProp(AssertionDsc*        curAssertion,
     tree->SetLclNum(copyLclNum);
     tree->SetSsaNum(copySsaNum);
 
-    // Copy prop and last-use copy elision happens at the same time in morph.
-    // This node may potentially not be a last use of the new local.
-    //
-    // TODO-CQ: It is probably better to avoid doing this propagation if we
-    // would otherwise omit an implicit byref copy since this propagation will
-    // force us to create another copy anyway.
-    //
-    tree->gtFlags &= ~GTF_VAR_DEATH;
-
 #ifdef DEBUG
     if (verbose)
     {

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3224,6 +3224,15 @@ GenTree* Compiler::optCopyAssertionProp(AssertionDsc*        curAssertion,
     tree->SetLclNum(copyLclNum);
     tree->SetSsaNum(copySsaNum);
 
+    // Copy prop and last-use copy elision happens at the same time in morph.
+    // This node may potentially not be a last use of the new local.
+    //
+    // TODO-CQ: It is probably better to avoid doing this propagation if we
+    // would otherwise omit an implicit byref copy since this propagation will
+    // force us to create another copy anyway.
+    //
+    tree->gtFlags &= ~GTF_VAR_DEATH;
+
 #ifdef DEBUG
     if (verbose)
     {

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4732,6 +4732,9 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     //
     DoPhase(this, PHASE_PHYSICAL_PROMOTION, &Compiler::PhysicalPromotion);
 
+    // Expose candidates for implicit byref last-use copy elision.
+    DoPhase(this, PHASE_IMPBYREF_COPY_OMISSION, &Compiler::fgMarkImplicitByRefCopyOmissionCandidates);
+
     // Locals tree list is no longer kept valid.
     fgNodeThreading = NodeThreading::None;
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -541,6 +541,7 @@ public:
 
 #if FEATURE_IMPLICIT_BYREFS
     unsigned char lvIsImplicitByRef : 1; // Set if the argument is an implicit byref.
+    unsigned char lvLastUseCopyOmissionCandidate : 1; // Set if the local appears as a last use that will be passed as an implicit byref.
 #endif                                   // FEATURE_IMPLICIT_BYREFS
 
 #if defined(TARGET_LOONGARCH64)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4616,7 +4616,6 @@ public:
 
     bool fgRemoveRestOfBlock; // true if we know that we will throw
     bool fgStmtRemoved;       // true if we remove statements -> need new DFA
-    bool fgRemarkGlobalUses;  // true if morph should remark global uses after processing a statement
 
     enum FlowGraphOrder
     {
@@ -5917,7 +5916,6 @@ private:
     GenTreeCall* fgMorphArgs(GenTreeCall* call);
 
     void fgMakeOutgoingStructArgCopy(GenTreeCall* call, CallArg* arg);
-    void fgMarkGlobalUses(Statement* stmt);
 
     GenTree* fgMorphLeafLocal(GenTreeLclVarCommon* lclNode);
 #ifdef TARGET_X86
@@ -6129,6 +6127,9 @@ private:
 
     // Reset the refCount for implicit byrefs.
     void fgResetImplicitByRefRefCount();
+
+    // Identify all candidates for last-use copy omission.
+    PhaseStatus fgMarkImplicitByRefCopyOmissionCandidates();
 
     // Change implicit byrefs' types from struct to pointer, and for any that were
     // promoted, create new promoted struct temps.

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -540,9 +540,10 @@ public:
     unsigned char lvIsTemp : 1; // Short-lifetime compiler temp
 
 #if FEATURE_IMPLICIT_BYREFS
-    unsigned char lvIsImplicitByRef : 1; // Set if the argument is an implicit byref.
-    unsigned char lvLastUseCopyOmissionCandidate : 1; // Set if the local appears as a last use that will be passed as an implicit byref.
-#endif                                   // FEATURE_IMPLICIT_BYREFS
+    unsigned char lvIsImplicitByRef : 1;              // Set if the argument is an implicit byref.
+    unsigned char lvLastUseCopyOmissionCandidate : 1; // Set if the local appears as a last use that will be passed as
+                                                      // an implicit byref.
+#endif                                                // FEATURE_IMPLICIT_BYREFS
 
 #if defined(TARGET_LOONGARCH64)
     unsigned char lvIs4Field1 : 1; // Set if the 1st field is int or float within struct for LA-ABI64.

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -540,10 +540,11 @@ public:
     unsigned char lvIsTemp : 1; // Short-lifetime compiler temp
 
 #if FEATURE_IMPLICIT_BYREFS
-    unsigned char lvIsImplicitByRef : 1;              // Set if the argument is an implicit byref.
-    unsigned char lvLastUseCopyOmissionCandidate : 1; // Set if the local appears as a last use that will be passed as
-                                                      // an implicit byref.
-#endif                                                // FEATURE_IMPLICIT_BYREFS
+    // Set if the argument is an implicit byref.
+    unsigned char lvIsImplicitByRef : 1;
+    // Set if the local appears as a last use that will be passed as an implicit byref.
+    unsigned char lvIsLastUseCopyOmissionCandidate : 1;
+#endif // FEATURE_IMPLICIT_BYREFS
 
 #if defined(TARGET_LOONGARCH64)
     unsigned char lvIs4Field1 : 1; // Set if the 1st field is int or float within struct for LA-ABI64.

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -45,6 +45,7 @@ CompPhaseNameMacro(PHASE_STR_ADRLCL,                 "Morph - Structs/AddrExp", 
 CompPhaseNameMacro(PHASE_EARLY_LIVENESS,             "Early liveness",                 false, -1, false)
 CompPhaseNameMacro(PHASE_PHYSICAL_PROMOTION,         "Physical promotion",             false, -1, false)
 CompPhaseNameMacro(PHASE_FWD_SUB,                    "Forward Substitution",           false, -1, false)
+CompPhaseNameMacro(PHASE_IMPBYREF_COPY_OMISSION,     "Identify candidates for implicit byref copy omission", false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_IMPBYREF,             "Morph - ByRefs",                 false, -1, false)
 CompPhaseNameMacro(PHASE_PROMOTE_STRUCTS,            "Morph - Promote Structs",        false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_GLOBAL,               "Morph - Global",                 false, -1, false)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3993,7 +3993,8 @@ void Compiler::fgMakeOutgoingStructArgCopy(GenTreeCall* call, CallArg* arg)
 
             if (!omitCopy && fgGlobalMorph)
             {
-                omitCopy = (varDsc->lvLastUseCopyOmissionCandidate || (implicitByRefLcl != nullptr)) && !varDsc->lvPromoted && !varDsc->lvIsStructField && ((lcl->gtFlags & GTF_VAR_DEATH) != 0);
+                omitCopy = (varDsc->lvLastUseCopyOmissionCandidate || (implicitByRefLcl != nullptr)) &&
+                           !varDsc->lvPromoted && !varDsc->lvIsStructField && ((lcl->gtFlags & GTF_VAR_DEATH) != 0);
             }
 
             if (omitCopy)
@@ -14710,12 +14711,12 @@ PhaseStatus Compiler::fgPromoteStructs()
 //   to end up with
 //
 //     [000015] --CXG+-----             ▌  CALL      void   Program:Foo(int,int)
-//     [000037] DACXG------ arg1 setup  ├──▌  STORE_LCL_VAR int    V04 tmp3         
+//     [000037] DACXG------ arg1 setup  ├──▌  STORE_LCL_VAR int    V04 tmp3
 //     [000012] --CXG+-----             │  └──▌  CALL      int    Program:Bar(S):int
 //     [000011] -----+----- arg0 in rcx │     └──▌  LCL_ADDR  long   V00 loc0         [+0]
-//     [000038] ----------- arg1 in rdx ├──▌  LCL_VAR   int    V04 tmp3         
+//     [000038] ----------- arg1 in rdx ├──▌  LCL_VAR   int    V04 tmp3
 //     [000010] -----+----- arg0 in rcx └──▌  LCL_FLD   int   (AX) V00 loc0         [+0]
-// 
+//
 //   If Bar mutates V00 then this is a problem.
 //
 // Returns:
@@ -14733,7 +14734,7 @@ PhaseStatus Compiler::fgMarkImplicitByRefCopyOmissionCandidates()
     {
         enum
         {
-            DoPreOrder = true,
+            DoPreOrder        = true,
             UseExecutionOrder = true,
         };
 
@@ -14769,7 +14770,7 @@ PhaseStatus Compiler::fgMarkImplicitByRefCopyOmissionCandidates()
                     continue;
                 }
 
-                unsigned lclNum = argNode->AsLclVarCommon()->GetLclNum();
+                unsigned   lclNum = argNode->AsLclVarCommon()->GetLclNum();
                 LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
 
                 if (varDsc->lvLastUseCopyOmissionCandidate)
@@ -14795,10 +14796,12 @@ PhaseStatus Compiler::fgMarkImplicitByRefCopyOmissionCandidates()
                     continue;
                 }
 
-                unsigned structSize = argNode->TypeIs(TYP_STRUCT) ? argNode->GetLayout(m_compiler)->GetSize() : genTypeSize(argNode);
+                unsigned structSize =
+                    argNode->TypeIs(TYP_STRUCT) ? argNode->GetLayout(m_compiler)->GetSize() : genTypeSize(argNode);
 
                 Compiler::structPassingKind passKind;
-                m_compiler->getArgTypeForStruct(arg.GetSignatureClassHandle(), &passKind, call->IsVarargs(), structSize);
+                m_compiler->getArgTypeForStruct(arg.GetSignatureClassHandle(), &passKind, call->IsVarargs(),
+                                                structSize);
 
                 if (passKind != SPK_ByReference)
                 {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85611/Runtime_85611.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85611/Runtime_85611.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_85611
+{
+    private static int s_result;
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        S s = new();
+        s.A = GetA();
+        // We need to be careful not to reorder the two accesses of 's' in the call to 'Foo.
+        // The second is marked as a last use and we make use of that to omit a copy;
+        // if we reorder them then s.A will read the mutated value inside Bar.
+        Foo(s.A, Bar(s));
+        if (s_result != 100)
+        {
+            Console.WriteLine("FAIL: Result is {0}", s_result);
+        }
+
+        return s_result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int GetA() => 100;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Foo(int field, int arg)
+    {
+        s_result = field;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Bar(S s)
+    {
+        Use(ref s);
+        s.A = 101;
+        return 42;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Use(ref S s)
+    {
+    }
+
+    private struct S
+    {
+        public int A, B, C, D, E, F, G, H;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85611/Runtime_85611.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85611/Runtime_85611.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitNoStructPromotion" Value="1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Last-use copy omission allows the JIT to avoid creating copies of struct values that are passed implicitly by-ref when the value is a last-use of a local. When we do this we effectively address expose the local for the lifetime of the call, so we mark the local as address exposed as part of doing so.

However, there is a problem where morph may reorder two uses of a such a local and break the last use information. For example, consider the following case:

```scala
[000015] --CXG------      ▌  CALL      void   Program:Foo(int,int)
[000010] ----------- arg0 ├──▌  LCL_FLD   int    V00 loc0         [+0]
[000012] --CXG------ arg1 └──▌  CALL      int    Program:Bar(S):int
[000011] ----------- arg0    └──▌  LCL_VAR   struct<S, 32> V00 loc0          (last use)
```

V00 is used both at `[000010]` and at `[000011]`, the latter as a last use. Since we only address expose V00 when we get to `[000011]` we do not mark `[000010]` with `GTF_GLOB_REF`; the net effect is the following call args morphing, where we have reordered the two occurrences illegally:

```scala
[000015] --CXG+-----             ▌  CALL      void   Program:Foo(int,int)
[000037] DACXG------ arg1 setup  ├──▌  STORE_LCL_VAR int    V04 tmp3
[000012] --CXG+-----             │  └──▌  CALL      int    Program:Bar(S):int
[000011] -----+----- arg0 in rcx │     └──▌  LCL_ADDR  long   V00 loc0         [+0]
[000038] ----------- arg1 in rdx ├──▌  LCL_VAR   int    V04 tmp3
[000010] -----+----- arg0 in rcx └──▌  LCL_FLD   int   (AX) V00 loc0         [+0]
```

This change fixes the problem by running a separate pass over the IR before morph to identify the candidates for last-use copy omission. These candidates then have `GTF_GLOB_REF` added as part of morph. The net result is then the following correct IR:

```scala
[000015] --CXG+-----             ▌  CALL      void   Runtime_85611:Foo(int,int)
[000039] DA--G------ arg0 setup  ├──▌  STORE_LCL_VAR int    V05 tmp4
[000010] ----G+-----             │  └──▌  LCL_FLD   int   (AX) V00 loc0         [+0]
[000037] DACXG------ arg1 setup  ├──▌  STORE_LCL_VAR int    V04 tmp3
[000012] --CXG+-----             │  └──▌  CALL      int    Runtime_85611:Bar(Runtime_85611+S):int
[000011] ----G+----- arg0 in rcx │     └──▌  LCL_ADDR  long   V00 loc0         [+0]
[000038] ----------- arg1 in rdx ├──▌  LCL_VAR   int    V04 tmp3
[000040] ----------- arg0 in rcx └──▌  LCL_VAR   int    V05 tmp4
```

I first started out with a fix that simply address exposed the candidates in the pass, but this has some semi-large regressions ([diffs](https://gist.github.com/jakobbotsch/b8ea7f2806f283bac75b48278a946891)) since it disables lots of optimizations that morph will do.
It's still not ideal since address exposing the local late just has the effect of making these optimizations depend on the block visit order; for .NET 9 I want to consider a fix where we instead do this optimization in the backend.

Fix #85611

Tiny number of diffs are expected with positive TP diffs in minopts due to the removal of `fgRemarkGlobalUses`. The TP impact of the pass is minor due to the use of `GTF_CALL` and the locals linked list to exit very early (about 0.03%, less than what is gained by the removal of `fgRemarkGlobalUses`).