### PR TITLE
[wasm] Fix perf pipeline

### DIFF
--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -410,7 +410,7 @@ if [[ -n "$wasm_bundle_directory" ]]; then
     fi
 
     # Workaround: escaping the quotes around `--wasmArgs=..` so they get retained for the actual command line
-    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --wasmEngine /home/helixbot/.jsvu/$javascript_engine \\\"--wasmArgs=$wasm_args \\\" --cli \$HELIX_CORRELATION_PAYLOAD/dotnet/dotnet --wasmDataDir \$HELIX_CORRELATION_PAYLOAD/wasm-data"
+    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --wasmEngine /home/helixbot/.jsvu/$javascript_engine --wasmArgs \\\"$wasm_args\\\" --cli \$HELIX_CORRELATION_PAYLOAD/dotnet/dotnet --wasmDataDir \$HELIX_CORRELATION_PAYLOAD/wasm-data"
     if [[ "$wasmaot" == "true" ]]; then
         extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --aotcompilermode wasm --buildTimeout 3600"
     fi


### PR DESCRIPTION
[wasm] Perf - update to track a regression in bdn argument parsing

Passing arguments to bdn as `"--wasmArgs=--expose_wasm --module"` broke
with the latest update. Now this gets incorrectly parsed. Instead, what
works is: `--wasmArgs "--expose_wasm --module"`.

This resulted in, `v8` being passed only the *default* value of `--expose_wasm`, and thus perf runs failing with:
```
[2023/07/18 04:48:37][INFO] test-main.js:7: SyntaxError: Cannot use import statement outside a module
[2023/07/18 04:48:37][INFO] import { dotnet, exit } from './_framework/dotnet.js';
[2023/07/18 04:48:37][INFO] ^^^^^^
[2023/07/18 04:48:37][INFO] SyntaxError: Cannot use import statement outside a module
```