### PR TITLE
Improve choice of IndexOfXx routine for some TryFindNextStartingPosition implementations

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -901,8 +901,6 @@ namespace System.Text.RegularExpressions
                         Ldloc(textSpanLocal);
                     }
 
-                    Debug.Assert(!primarySet.Negated || (primarySet.Chars is null && primarySet.AsciiSet is null));
-
                     if (primarySet.Chars is not null)
                     {
                         switch (primarySet.Chars.Length)
@@ -910,14 +908,14 @@ namespace System.Text.RegularExpressions
                             case 1:
                                 // tmp = ...IndexOf(setChars[0]);
                                 Ldc(primarySet.Chars[0]);
-                                Call(s_spanIndexOfChar);
+                                Call(primarySet.Negated ? s_spanIndexOfAnyExceptChar : s_spanIndexOfChar);
                                 break;
 
                             case 2:
                                 // tmp = ...IndexOfAny(setChars[0], setChars[1]);
                                 Ldc(primarySet.Chars[0]);
                                 Ldc(primarySet.Chars[1]);
-                                Call(s_spanIndexOfAnyCharChar);
+                                Call(primarySet.Negated ? s_spanIndexOfAnyExceptCharChar : s_spanIndexOfAnyCharChar);
                                 break;
 
                             case 3:
@@ -925,13 +923,13 @@ namespace System.Text.RegularExpressions
                                 Ldc(primarySet.Chars[0]);
                                 Ldc(primarySet.Chars[1]);
                                 Ldc(primarySet.Chars[2]);
-                                Call(s_spanIndexOfAnyCharCharChar);
+                                Call(primarySet.Negated ? s_spanIndexOfAnyExceptCharCharChar : s_spanIndexOfAnyCharCharChar);
                                 break;
 
                             default:
                                 Ldstr(new string(primarySet.Chars));
                                 Call(s_stringAsSpanMethod);
-                                Call(s_spanIndexOfAnySpan);
+                                Call(primarySet.Negated ? s_spanIndexOfAnyExceptSpan : s_spanIndexOfAnySpan);
                                 break;
                         }
                     }
@@ -1166,6 +1164,8 @@ namespace System.Text.RegularExpressions
 
                 if (set.Chars is { Length: 1 })
                 {
+                    Debug.Assert(!set.Negated);
+
                     // pos = inputSpan.Slice(0, pos).LastIndexOf(set.Chars[0]);
                     Ldloca(inputSpan);
                     Ldc(0);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 
 namespace System.Text.RegularExpressions
 {
@@ -95,7 +94,7 @@ namespace System.Text.RegularExpressions
                 if (RegexPrefixAnalyzer.FindFirstCharClass(root) is string charClass)
                 {
                     // See if the set is limited to holding only a few characters.
-                    Span<char> scratch = stackalloc char[5]; // max optimized by IndexOfAny today
+                    Span<char> scratch = stackalloc char[5]; // max efficiently optimized by IndexOfAny today
                     int scratchCount;
                     char[]? chars = null;
                     if (!RegexCharClass.IsNegated(charClass) &&
@@ -109,12 +108,14 @@ namespace System.Text.RegularExpressions
                     {
                         // The set contains one and only one character, meaning every match starts
                         // with the same literal value (potentially case-insensitive). Search for that.
+                        Debug.Assert(!RegexCharClass.IsNegated(charClass));
                         FixedDistanceLiteral = (chars[0], null, 0);
                         FindMode = FindNextStartingPositionMode.LeadingChar_RightToLeft;
                     }
                     else
                     {
                         // The set may match multiple characters.  Search for that.
+                        Debug.Assert(!RegexCharClass.IsNegated(charClass) || chars is null);
                         FixedDistanceSets = new List<FixedDistanceSet>()
                         {
                             new FixedDistanceSet(chars, charClass, 0)
@@ -154,22 +155,32 @@ namespace System.Text.RegularExpressions
 
             // As a backup, see if we can find a literal after a leading atomic loop.  That might be better than whatever sets we find, so
             // we want to know whether we have one in our pocket before deciding whether to use a leading set (we'll prefer a leading
-            // set if it's something for which we can vectorize a search).
+            // set if it's something for which we can search efficiently).
             (RegexNode LoopNode, (char Char, string? String, char[]? Chars) Literal)? literalAfterLoop = RegexPrefixAnalyzer.FindLiteralFollowingLeadingLoop(root);
 
-            // If we got such sets, we'll likely use them.  However, if the best of them is something that doesn't support a vectorized
-            // search and we did successfully find a literal after an atomic loop we could search instead, we prefer the vectorizable search.
+            // If we got such sets, we'll likely use them.  However, if the best of them is something that doesn't support an efficient
+            // search and we did successfully find a literal after an atomic loop we could search instead, we prefer the efficient search.
+            // For example, if we have a negated set, we will still prefer the literal-after-an-atomic-loop because negated sets typically
+            // contain _many_ characters (e.g. [^a] is everything but 'a') and are thus more likely to very quickly match, which means any
+            // vectorization employed is less likely to kick in and be worth the startup overhead.
             if (fixedDistanceSets is not null)
             {
+                // Sort the sets by "quality", such that whatever set is first is the one deemed most efficient to use.
+                // In some searches, we may use multiple sets, so we want the subsequent ones to also be the efficiency runners-up.
                 RegexPrefixAnalyzer.SortFixedDistanceSetsByQuality(fixedDistanceSets);
-                if (fixedDistanceSets[0].Chars is not null || literalAfterLoop is null)
+
+                // If there is no literal after the loop, use whatever set we got.
+                // If there is a literal after the loop, consider it to be better than a negated set and better than a set with many characters.
+                if (literalAfterLoop is null ||
+                    (fixedDistanceSets[0].Chars is not null && !fixedDistanceSets[0].Negated))
                 {
                     // Determine whether to do searching based on one or more sets or on a single literal. Compiled engines
                     // don't need to special-case literals as they already do codegen to create the optimal lookup based on
                     // the set's characteristics.
                     if (!compiled &&
                         fixedDistanceSets.Count == 1 &&
-                        fixedDistanceSets[0].Chars is { Length: 1 })
+                        fixedDistanceSets[0].Chars is { Length: 1 } &&
+                        !fixedDistanceSets[0].Negated)
                     {
                         FixedDistanceLiteral = (fixedDistanceSets[0].Chars![0], null, fixedDistanceSets[0].Distance);
                         FindMode = FindNextStartingPositionMode.FixedDistanceChar_LeftToRight;
@@ -186,8 +197,9 @@ namespace System.Text.RegularExpressions
 
                         // Store the sets, and compute which mode to use.
                         FixedDistanceSets = fixedDistanceSets;
-                        FindMode = (fixedDistanceSets.Count == 1 && fixedDistanceSets[0].Distance == 0) ? FindNextStartingPositionMode.LeadingSet_LeftToRight
-                            : FindNextStartingPositionMode.FixedDistanceSets_LeftToRight;
+                        FindMode = (fixedDistanceSets.Count == 1 && fixedDistanceSets[0].Distance == 0) ?
+                            FindNextStartingPositionMode.LeadingSet_LeftToRight :
+                            FindNextStartingPositionMode.FixedDistanceSets_LeftToRight;
                         _asciiLookups = new uint[fixedDistanceSets.Count][];
                     }
                     return;
@@ -322,6 +334,7 @@ namespace System.Text.RegularExpressions
             return best;
         }
 
+#if SYSTEM_TEXT_REGULAREXPRESSIONS
         /// <summary>Try to advance to the next starting position that might be a location for a match.</summary>
         /// <param name="textSpan">The text to search.</param>
         /// <param name="pos">The position in <paramref name="textSpan"/>.  This is updated with the found position.</param>
@@ -578,12 +591,11 @@ namespace System.Text.RegularExpressions
                     {
                         FixedDistanceSet primarySet = FixedDistanceSets![0];
                         char[]? chars = primarySet.Chars;
-                        string set = primarySet.Set;
 
                         ReadOnlySpan<char> span = textSpan.Slice(pos);
                         if (chars is not null)
                         {
-                            int i = span.IndexOfAny(chars);
+                            int i = primarySet.Negated ? span.IndexOfAnyExcept(chars) : span.IndexOfAny(chars);
                             if (i >= 0)
                             {
                                 pos += i;
@@ -595,7 +607,7 @@ namespace System.Text.RegularExpressions
                             ref uint[]? startingAsciiLookup = ref _asciiLookups![0];
                             for (int i = 0; i < span.Length; i++)
                             {
-                                if (RegexCharClass.CharInClass(span[i], set, ref startingAsciiLookup))
+                                if (RegexCharClass.CharInClass(span[i], primarySet.Set, ref startingAsciiLookup))
                                 {
                                     pos += i;
                                     return true;
@@ -653,7 +665,8 @@ namespace System.Text.RegularExpressions
                             for (int inputPosition = pos; inputPosition <= endMinusRequiredLength; inputPosition++)
                             {
                                 int offset = inputPosition + primarySet.Distance;
-                                int index = textSpan.Slice(offset).IndexOfAny(primarySet.Chars);
+                                ReadOnlySpan<char> textSpanAtOffset = textSpan.Slice(offset);
+                                int index = primarySet.Negated ? textSpanAtOffset.IndexOfAnyExcept(primarySet.Chars) : textSpanAtOffset.IndexOfAny(primarySet.Chars);
                                 if (index < 0)
                                 {
                                     break;
@@ -769,6 +782,7 @@ namespace System.Text.RegularExpressions
                     return true;
             }
         }
+#endif
     }
 
     /// <summary>Mode to use for searching for the next location of a possible match.</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -1419,7 +1419,7 @@ namespace System.Text.RegularExpressions
         /// A tuple of data about the literal: only one of the Char/String/SetChars fields is relevant.
         /// The Negated value indicates whether the Char/SetChars should be considered exclusionary.
         /// </returns>
-        public StartingLiteralData? FindStartingLiteral(int maxSetCharacters = 5) // 5 is max optimized by IndexOfAny today
+        public StartingLiteralData? FindStartingLiteral(int maxSetCharacters = 5) // 5 is max efficiently optimized by IndexOfAny today
         {
             Debug.Assert(maxSetCharacters >= 0 && maxSetCharacters <= 128, $"{nameof(maxSetCharacters)} == {maxSetCharacters} should be small enough to be stack allocated.");
 


### PR DESCRIPTION
Earlier in .NET 8, we updated the Regex compiler and source generator to be able to vectorize a search for any set, not just simple ones.  When one of the main routines couldn't be used, we emit a specialized IndexOfAny helper that uses SearchValues to search for any matching ASCII character or a Unicode character, and if it encounters a Unicode character, it falls back to a linear scan.  This meant that a bunch of sets that wouldn't previously have taken these paths now do, but some of those sets have more efficient means of searching; for example, for the set `[^aA]` that searches case-insensitive for anything other than an 'A', with these scheme we'll emit a whole routine that uses SearchValues with a fallback, but we could just use IndexOfAnyExcept('A', 'a').  This fixes the compiler / source generator to prefer such helpers instead when available.

For example, previously `[GeneratedRegex(@"[^Aa]")]` would result in this being emitted:
```C#
        /// <summary>Finds the next index of any character that matches a character in the set [^Aa].</summary>
        [MethodImpl(MethodImplOptions.AggressiveInlining)]
        internal static int IndexOfNonAsciiOrAny_43339B0AA38B69F44701E535D8179738784663016A5CB17A6B1AEB2FB5F9D08F(this ReadOnlySpan<char> span)
        {
            int i = span.IndexOfAnyExcept(Utilities.s_ascii_200000002000000);
            if ((uint)i < (uint)span.Length)
            {
                if (char.IsAscii(span[i]))
                {
                    return i;
                }
        
                do
                {
                    if (((span[i] | 0x20) != 'a'))
                    {
                        return i;
                    }
                    i++;
                }
                while ((uint)i < (uint)span.Length);
            }
        
            return -1;
        }
        
        /// <summary>Supports searching for characters in or not in "Aa".</summary>
        internal static readonly SearchValues<char> s_ascii_200000002000000 = SearchValues.Create("Aa");
```
which is then used like:
```C#
int i = inputSpan.Slice(pos).IndexOfNonAsciiOrAny_43339B0AA38B69F44701E535D8179738784663016A5CB17A6B1AEB2FB5F9D08F();
```

Now, that method isn't emitted, and the usage ends up just being:
```C#
int i = inputSpan.Slice(pos).IndexOfAnyExcept('A', 'a');
```

Fixes https://github.com/dotnet/runtime/issues/84150