### PR TITLE
Tar: Only treat reparse points marked as junctions or symlinks as actual tar symlinks

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FindFirstFileEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FindFirstFileEx.cs
@@ -24,6 +24,21 @@ internal static partial class Interop
             return FindFirstFileExPrivate(fileName, FINDEX_INFO_LEVELS.FindExInfoBasic, ref data, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, 0);
         }
 
+        internal static void GetFindData(string fullPath, bool isDirectory, bool ignoreAccessDenied, ref WIN32_FIND_DATA findData)
+        {
+            using SafeFindHandle handle = FindFirstFile(Path.TrimEndingDirectorySeparator(fullPath), ref findData);
+            if (handle.IsInvalid)
+            {
+                int errorCode = Marshal.GetLastPInvokeError();
+                // File not found doesn't make much sense coming from a directory.
+                if (isDirectory && errorCode == Errors.ERROR_FILE_NOT_FOUND)
+                    errorCode = Errors.ERROR_PATH_NOT_FOUND;
+                if (ignoreAccessDenied && errorCode == Errors.ERROR_ACCESS_DENIED)
+                    return;
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+            }
+        }
+
         internal enum FINDEX_INFO_LEVELS : uint
         {
             FindExInfoStandard = 0x0u,

--- a/src/libraries/System.Formats.Tar/src/System.Formats.Tar.csproj
+++ b/src/libraries/System.Formats.Tar/src/System.Formats.Tar.csproj
@@ -45,7 +45,14 @@
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs" Link="Common\Interop\Windows\Interop.Errors.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs" Link="Common\Interop\Windows\Interop.Libraries.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.CreateHardLink.cs" Link="Common\Interop\Windows\Kernel32\Interop.CreateHardLink.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FILE_TIME.cs" Link="Common\Interop\Windows\Kernel32\Interop.FILE_TIME.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FindFirstFileEx.cs" Link="Common\Interop\Windows\Kernel32\Interop.FindFirstFileEx.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FileOperations.cs" Link="Common\Interop\Windows\Kernel32\Interop.FileOperations.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FindClose.cs" Link="Common\Interop\Windows\Kernel32\Interop.FindClose.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FormatMessage.cs" Link="Common\Interop\Windows\Kernel32\Interop.FormatMessage.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.MAX_PATH.cs" Link="Common\Interop\Windows\Kernel32\Interop.MAX_PATH.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WIN32_FIND_DATA.cs" Link="Common\Interop\Windows\Kernel32\Interop.WIN32_FIND_DATA.cs" />
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" Link="Common\Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" />
     <Compile Include="$(CommonPath)System\IO\Archiving.Utils.Windows.cs" Link="Common\System\IO\Archiving.Utils.Windows.cs" />
     <Compile Include="$(CommonPath)System\IO\PathInternal.Windows.cs" Link="Common\System\IO\PathInternal.Windows.cs" />
     <Compile Include="$(CommonPath)System\IO\Win32Marshal.cs" Link="Common\System\IO\Win32Marshal.cs" />

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -215,6 +215,9 @@ namespace System.Formats.Tar
             return entryType;
         }
 
+        // Chooses the compatible regular file entry type for the specified format.
+        internal static TarEntryType GetRegularFileEntryTypeForFormat(TarEntryFormat format) => format is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+
         /// <summary>Parses a byte span that represents an ASCII string containing a number in octal base.</summary>
         internal static T ParseOctal<T>(ReadOnlySpan<byte> buffer) where T : struct, INumber<T>
         {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Unix.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Unix.cs
@@ -31,7 +31,7 @@ namespace System.Formats.Tar
                 Interop.Sys.FileTypes.S_IFCHR => TarEntryType.CharacterDevice,
                 Interop.Sys.FileTypes.S_IFIFO => TarEntryType.Fifo,
                 Interop.Sys.FileTypes.S_IFLNK => TarEntryType.SymbolicLink,
-                Interop.Sys.FileTypes.S_IFREG => Format is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile,
+                Interop.Sys.FileTypes.S_IFREG => TarHelpers.GetRegularFileEntryTypeForFormat(Format),
                 Interop.Sys.FileTypes.S_IFDIR => TarEntryType.Directory,
                 _ => throw new IOException(SR.Format(SR.TarUnsupportedFile, fullPath)),
             };

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Unix.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Unix.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.Formats.Tar
 {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Windows.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Windows.cs
@@ -34,8 +34,9 @@ namespace System.Formats.Tar
                 }
                 else
                 {
-                    // Treat any other reparse point as regular file
-                    entryType = TarHelpers.GetRegularFileEntryTypeForFormat(Format);
+                    // All other reparse points are not supported since they cannot be
+                    // represented in a tar file using the existing entry types.
+                    throw new IOException(SR.Format(SR.TarUnsupportedFile, fullPath));
                 }
             }
             else if (isDirectory)

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Windows.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Windows.cs
@@ -44,7 +44,7 @@ namespace System.Formats.Tar
             }
             else if ((attributes & (FileAttributes.Normal | FileAttributes.Archive)) != 0)
             {
-                entryType = Format is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+                entryType = TarHelpers.GetRegularFileEntryTypeForFormat(Format);
             }
             else
             {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Windows.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Windows.cs
@@ -3,8 +3,6 @@
 
 using System.Diagnostics;
 using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.Formats.Tar
 {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Windows.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Windows.cs
@@ -21,12 +21,12 @@ namespace System.Formats.Tar
 
             bool isDirectory = (attributes & FileAttributes.Directory) != 0;
 
-            Interop.Kernel32.WIN32_FIND_DATA data = default;
-            Interop.Kernel32.GetFindData(fullPath, isDirectory, ignoreAccessDenied: false, ref data);
-
             TarEntryType entryType;
             if ((attributes & FileAttributes.ReparsePoint) != 0)
             {
+                Interop.Kernel32.WIN32_FIND_DATA data = default;
+                Interop.Kernel32.GetFindData(fullPath, isDirectory, ignoreAccessDenied: false, ref data);
+
                 if (data.dwReserved0 is Interop.Kernel32.IOReparseOptions.IO_REPARSE_TAG_SYMLINK or
                                         Interop.Kernel32.IOReparseOptions.IO_REPARSE_TAG_MOUNT_POINT)
                 {

--- a/src/libraries/System.Formats.Tar/tests/Manual/ManualTests.cs
+++ b/src/libraries/System.Formats.Tar/tests/Manual/ManualTests.cs
@@ -38,7 +38,7 @@ public class ManualTests : TarTestsBase
 
         using (TarWriter writer = new(s, leaveOpen: true))
         {
-            TarEntry writeEntry = InvokeTarEntryCreationConstructor(entryFormat, entryFormat is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile, "foo");
+            TarEntry writeEntry = InvokeTarEntryCreationConstructor(entryFormat, GetRegularFileEntryTypeForFormat(entryFormat), "foo");
             writeEntry.DataStream = new SimulatedDataStream(size);
             writer.WriteEntry(writeEntry);
         }

--- a/src/libraries/System.Formats.Tar/tests/Manual/ManualTestsAsync.cs
+++ b/src/libraries/System.Formats.Tar/tests/Manual/ManualTestsAsync.cs
@@ -27,7 +27,7 @@ public class ManualTestsAsync : TarTestsBase
 
         await using (TarWriter writer = new(s, leaveOpen: true))
         {
-            TarEntry writeEntry = InvokeTarEntryCreationConstructor(entryFormat, entryFormat is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile, "foo");
+            TarEntry writeEntry = InvokeTarEntryCreationConstructor(entryFormat, GetRegularFileEntryTypeForFormat(entryFormat), "foo");
             writeEntry.DataStream = new SimulatedDataStream(size);
             await writer.WriteEntryAsync(writeEntry);
         }

--- a/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
+++ b/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
@@ -78,6 +78,8 @@
     <Compile Include="TarFile\TarFile.ExtractToDirectory.File.Tests.Windows.cs" />
     <Compile Include="TarFile\TarFile.ExtractToDirectoryAsync.File.Tests.Windows.cs" />
     <Compile Include="TarWriter\TarWriter.File.Base.Windows.cs" />
+    <Compile Include="TarWriter\TarWriter.WriteEntry.File.Tests.Windows.cs" />
+    <Compile Include="TarWriter\TarWriter.WriteEntryAsync.File.Tests.Windows.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Interop.BOOL.cs" Link="Common\Interop\Windows\Interop.BOOL.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Errors.cs" Link="Common\Interop\Windows\Interop.Errors.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs" Link="Common\Interop\Windows\Interop.Libraries.cs" />

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.Base.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.Base.cs
@@ -224,7 +224,7 @@ namespace System.Formats.Tar.Tests
                     int directoriesCount = entries.Count(e => e.EntryType == TarEntryType.Directory);
                     Assert.Equal(10, directoriesCount);
 
-                    TarEntryType actualEntryType = format is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+                    TarEntryType actualEntryType = GetRegularFileEntryTypeForFormat(format);
 
                     for (int i = 0; i < 10; i++)
                     {
@@ -423,7 +423,7 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(expectedContents, contents);
             }
 
-            TarEntryType expectedEntryType = format == TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+            TarEntryType expectedEntryType = GetRegularFileEntryTypeForFormat(format);
             Assert.Equal(expectedEntryType, file.EntryType);
 
             Assert.Equal(AssetGid, file.Gid);

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.Base.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.Base.cs
@@ -201,7 +201,7 @@ namespace System.Formats.Tar.Tests
             int directoriesCount = entries.Count(e => e.EntryType == TarEntryType.Directory);
             Assert.Equal(10, directoriesCount);
 
-            TarEntryType actualEntryType = format is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+            TarEntryType actualEntryType = GetRegularFileEntryTypeForFormat(format);
 
             for (int i = 0; i < 10; i++)
             {
@@ -382,7 +382,7 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(expectedContents, contents);
             }
 
-            TarEntryType expectedEntryType = format == TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+            TarEntryType expectedEntryType = GetRegularFileEntryTypeForFormat(format);
             Assert.Equal(expectedEntryType, file.EntryType);
 
             Assert.Equal(AssetGid, file.Gid);

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -479,6 +479,8 @@ namespace System.Formats.Tar.Tests
             return entryType;
         }
 
+        protected static TarEntryType GetRegularFileEntryTypeForFormat(TarEntryFormat format) => format is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+
         protected static TarEntry InvokeTarEntryCreationConstructor(TarEntryFormat targetFormat, TarEntryType entryType, string entryName)
             => targetFormat switch
             {

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Windows.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Windows.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Xunit;
+
+namespace System.Formats.Tar.Tests;
+
+public partial class TarWriter_WriteEntry_File_Tests : TarWriter_File_Base
+{
+    [Theory]
+    [InlineData(TarEntryFormat.V7)]
+    [InlineData(TarEntryFormat.Ustar)]
+    [InlineData(TarEntryFormat.Pax)]
+    [InlineData(TarEntryFormat.Gnu)]
+    public void Add_Junction_As_SymbolicLink(TarEntryFormat format)
+    {
+        using TempDirectory root = new TempDirectory();
+        string targetName = "TargetDirectory";
+        string junctionName = "JunctionDirectory";
+        string targetPath = Path.Join(root.Path, targetName);
+        string junctionPath = Path.Join(root.Path, junctionName);
+
+        Directory.CreateDirectory(targetPath);
+
+        Assert.True(MountHelper.CreateJunction(junctionPath, targetPath));
+        DirectoryInfo junctionInfo = new(junctionPath);
+
+        using MemoryStream archive = new MemoryStream();
+        using (TarWriter writer = new TarWriter(archive, format, leaveOpen: true))
+        {
+            writer.WriteEntry(fileName: junctionPath, entryName: junctionPath);
+        }
+
+        archive.Position = 0;
+        using (TarReader reader = new TarReader(archive))
+        {
+            TarEntry entry = reader.GetNextEntry();
+            Assert.Equal(format, entry.Format);
+
+            Assert.NotNull(entry);
+            Assert.Equal(junctionPath, entry.Name);
+            Assert.Equal(targetPath, entry.LinkName);
+            Assert.Equal(TarEntryType.SymbolicLink, entry.EntryType);
+            Assert.Null(entry.DataStream);
+
+            VerifyPlatformSpecificMetadata(junctionPath, entry);
+
+            Assert.Null(reader.GetNextEntry());
+        }
+    }
+}

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Windows.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Windows.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.Formats.Tar.Tests;
 
@@ -48,5 +50,23 @@ public partial class TarWriter_WriteEntry_File_Tests : TarWriter_File_Base
 
             Assert.Null(reader.GetNextEntry());
         }
+    }
+
+    [Theory]
+    [InlineData(TarEntryFormat.V7)]
+    [InlineData(TarEntryFormat.Ustar)]
+    [InlineData(TarEntryFormat.Pax)]
+    [InlineData(TarEntryFormat.Gnu)]
+    public void Add_Unsupported_ReparsePoints_Throws(TarEntryFormat format)
+    {
+        string? appExecLinkPath = MountHelper.GetAppExecLinkPath();
+        if (appExecLinkPath == null)
+        {
+            throw new SkipTestException("Could not find an appexeclink in this machine.");
+        }
+
+        using MemoryStream archive = new MemoryStream();
+        using TarWriter writer = new TarWriter(archive, format, leaveOpen: true);
+        Assert.Throws<IOException>(() => writer.WriteEntry(fileName: appExecLinkPath, "UnsupportedAppExecLink"));
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Windows.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Windows.cs
@@ -52,7 +52,7 @@ public partial class TarWriter_WriteEntry_File_Tests : TarWriter_File_Base
         }
     }
 
-    [Theory]
+    [ConditionalTheory]
     [InlineData(TarEntryFormat.V7)]
     [InlineData(TarEntryFormat.Ustar)]
     [InlineData(TarEntryFormat.Pax)]
@@ -66,7 +66,7 @@ public partial class TarWriter_WriteEntry_File_Tests : TarWriter_File_Base
         }
 
         using MemoryStream archive = new MemoryStream();
-        using TarWriter writer = new TarWriter(archive, format, leaveOpen: true);
+        using TarWriter writer = new TarWriter(archive, format);
         Assert.Throws<IOException>(() => writer.WriteEntry(fileName: appExecLinkPath, "UnsupportedAppExecLink"));
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.cs
@@ -95,7 +95,7 @@ namespace System.Formats.Tar.Tests
                 Assert.NotNull(entry);
                 Assert.Equal(format, entry.Format);
                 Assert.Equal(fileName, entry.Name);
-                TarEntryType expectedEntryType = format is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+                TarEntryType expectedEntryType = GetRegularFileEntryTypeForFormat(format);
                 Assert.Equal(expectedEntryType, entry.EntryType);
                 Assert.True(entry.Length > 0);
                 Assert.NotNull(entry.DataStream);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Tests.cs
@@ -337,7 +337,7 @@ namespace System.Formats.Tar.Tests
             MemoryStream ms = new();
             using (TarWriter writer = new(ms, true))
             {
-                TarEntryType entryType = format == TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+                TarEntryType entryType = GetRegularFileEntryTypeForFormat(format);
                 entry = InvokeTarEntryCreationConstructor(format, entryType, maxPathComponent);
                 writer.WriteEntry(entry);
 
@@ -469,7 +469,7 @@ namespace System.Formats.Tar.Tests
         {
             foreach (var entryFormat in new[] { TarEntryFormat.V7, TarEntryFormat.Ustar, TarEntryFormat.Pax, TarEntryFormat.Gnu })
             {
-                foreach (var entryType in new[] { entryFormat == TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile, TarEntryType.Directory, TarEntryType.SymbolicLink })
+                foreach (var entryType in new[] { GetRegularFileEntryTypeForFormat(entryFormat), TarEntryType.Directory, TarEntryType.SymbolicLink })
                 {
                     foreach (bool unseekableStream in new[] { false, true })
                     {
@@ -520,7 +520,7 @@ namespace System.Formats.Tar.Tests
             using Stream s = unseekableStream ? new WrappedStream(ms, ms.CanRead, ms.CanWrite, canSeek: false) : ms;
 
             using TarWriter writer = new(s);
-            TarEntry writeEntry = InvokeTarEntryCreationConstructor(entryFormat, entryFormat is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile, "foo");
+            TarEntry writeEntry = InvokeTarEntryCreationConstructor(entryFormat, GetRegularFileEntryTypeForFormat(entryFormat), "foo");
             writeEntry.DataStream = new SimulatedDataStream(FileSizeOverLimit);
 
             Assert.Equal(FileSizeOverLimit, writeEntry.Length);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.Windows.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.Windows.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Formats.Tar.Tests;
+
+public partial class TarWriter_WriteEntryAsync_File_Tests : TarWriter_File_Base
+{
+    [Theory]
+    [InlineData(TarEntryFormat.V7)]
+    [InlineData(TarEntryFormat.Ustar)]
+    [InlineData(TarEntryFormat.Pax)]
+    [InlineData(TarEntryFormat.Gnu)]
+    public async Task Add_Junction_As_SymbolicLink_Async(TarEntryFormat format)
+    {
+        using TempDirectory root = new TempDirectory();
+        string targetName = "TargetDirectory";
+        string junctionName = "JunctionDirectory";
+        string targetPath = Path.Join(root.Path, targetName);
+        string junctionPath = Path.Join(root.Path, junctionName);
+
+        Directory.CreateDirectory(targetPath);
+
+        Assert.True(MountHelper.CreateJunction(junctionPath, targetPath));
+        DirectoryInfo junctionInfo = new(junctionPath);
+
+        await using MemoryStream archive = new MemoryStream();
+        await using (TarWriter writer = new TarWriter(archive, format, leaveOpen: true))
+        {
+            await writer.WriteEntryAsync(fileName: junctionPath, entryName: junctionPath);
+        }
+
+        archive.Position = 0;
+        await using (TarReader reader = new TarReader(archive))
+        {
+            TarEntry entry = await reader.GetNextEntryAsync();
+            Assert.Equal(format, entry.Format);
+
+            Assert.NotNull(entry);
+            Assert.Equal(junctionPath, entry.Name);
+            Assert.Equal(targetPath, entry.LinkName);
+            Assert.Equal(TarEntryType.SymbolicLink, entry.EntryType);
+            Assert.Null(entry.DataStream);
+
+            VerifyPlatformSpecificMetadata(junctionPath, entry);
+
+            Assert.Null(await reader.GetNextEntryAsync());
+        }
+    }
+}

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.Windows.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.Windows.cs
@@ -52,7 +52,7 @@ public partial class TarWriter_WriteEntryAsync_File_Tests : TarWriter_File_Base
         }
     }
 
-    [Theory]
+    [ConditionalTheory]
     [InlineData(TarEntryFormat.V7)]
     [InlineData(TarEntryFormat.Ustar)]
     [InlineData(TarEntryFormat.Pax)]
@@ -66,7 +66,7 @@ public partial class TarWriter_WriteEntryAsync_File_Tests : TarWriter_File_Base
         }
 
         await using MemoryStream archive = new MemoryStream();
-        await using TarWriter writer = new TarWriter(archive, format, leaveOpen: true);
+        await using TarWriter writer = new TarWriter(archive, format);
         await Assert.ThrowsAsync<IOException>(() => writer.WriteEntryAsync(fileName: appExecLinkPath, "UnsupportedAppExecLink"));
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.cs
@@ -102,7 +102,7 @@ namespace System.Formats.Tar.Tests
                         Assert.NotNull(entry);
                         Assert.Equal(format, entry.Format);
                         Assert.Equal(fileName, entry.Name);
-                        TarEntryType expectedEntryType = format is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
+                        TarEntryType expectedEntryType = GetRegularFileEntryTypeForFormat(format);
                         Assert.Equal(expectedEntryType, entry.EntryType);
                         Assert.True(entry.Length > 0);
                         Assert.NotNull(entry.DataStream);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Tests.cs
@@ -439,7 +439,7 @@ namespace System.Formats.Tar.Tests
 
             string tarFilePath = GetTestFilePath();
             await using TarWriter writer = new(File.Create(tarFilePath));
-            TarEntry writeEntry = InvokeTarEntryCreationConstructor(entryFormat, entryFormat is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile, "foo");
+            TarEntry writeEntry = InvokeTarEntryCreationConstructor(entryFormat, GetRegularFileEntryTypeForFormat(entryFormat), "foo");
             writeEntry.DataStream = new SimulatedDataStream(FileSizeOverLimit);
 
             Assert.Equal(FileSizeOverLimit, writeEntry.Length);

--- a/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystem.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystem.cs
@@ -471,33 +471,5 @@ namespace System.IO.Tests
 
             Directory.SetCurrentDirectory(Path.GetTempPath());
         }
-
-        protected static string? GetAppExecLinkPath()
-        {
-            string localAppDataPath = Environment.GetEnvironmentVariable("LOCALAPPDATA");
-            if (localAppDataPath is null)
-            {
-                return null;
-            }
-
-            string windowsAppsDir = Path.Join(localAppDataPath, "Microsoft", "WindowsApps");
-
-            if (!Directory.Exists(windowsAppsDir))
-            {
-                return null;
-            }
-
-            var opts = new EnumerationOptions { RecurseSubdirectories = true };
-
-            return new FileSystemEnumerable<string?>(
-                windowsAppsDir,
-                (ref FileSystemEntry entry) => entry.ToFullPath(),
-                opts)
-            {
-                ShouldIncludePredicate = (ref FileSystemEntry entry) =>
-                    FileSystemName.MatchesWin32Expression("*.exe", entry.FileName) &&
-                    (entry.Attributes & FileAttributes.ReparsePoint) != 0
-            }.FirstOrDefault();
-        }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/File/SymbolicLinks.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/SymbolicLinks.cs
@@ -50,7 +50,7 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public void UnsupportedLink_ReturnsNull()
         {
-            string unsupportedLinkPath = GetAppExecLinkPath();
+            string unsupportedLinkPath = MountHelper.GetAppExecLinkPath();
             if (unsupportedLinkPath is null)
             {
                 return;

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/SymbolicLinks.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/SymbolicLinks.cs
@@ -47,7 +47,7 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public void UnsupportedLink_ReturnsNull()
         {
-            string unsupportedLinkPath = GetAppExecLinkPath();
+            string unsupportedLinkPath = MountHelper.GetAppExecLinkPath();
             if (unsupportedLinkPath is null)
             {
                 return;


### PR DESCRIPTION
The current code only checks if it's a reparse point and adds the filesystem object as a symlink, which is wrong for many types of reparse points. Only those marked as junctions or symlinks should be treated as tar symlinks.

I added a test to confirm that a junction is stored as symlink. I am unsure how to create other types of reparse points so I didn't add tests for that, but since those are rarer cases, I would prefer to tackle them separately if requested.

cc @billfreist, thanks for reporting this.

Fixes https://github.com/dotnet/runtime/issues/82949