### PR TITLE
Enable Mono for using faster invoke stubs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
@@ -111,15 +111,9 @@ namespace System.Reflection
 
         private static bool TryConvertPointer(object srcObject, [NotNullWhen(true)] out object? dstPtr)
         {
-            if (srcObject is IntPtr)
+            if (srcObject is IntPtr or UIntPtr)
             {
                 dstPtr = srcObject;
-                return true;
-            }
-
-            if (srcObject is UIntPtr)
-            {
-                dstPtr = (IntPtr)(UIntPtr)srcObject;
                 return true;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokerEmitUtil.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokerEmitUtil.cs
@@ -69,18 +69,11 @@ namespace System.Reflection
 
                 if (parameterType.IsPointer)
                 {
-                    il.Emit(OpCodes.Unbox_Any, typeof(IntPtr));
+                    Unbox(il, typeof(IntPtr));
                 }
                 else if (parameterType.IsValueType)
                 {
-                    if (parameterType.IsNullableOfT)
-                    {
-                        EmitTrueNullableUnbox(il, parameterType);
-                    }
-                    else
-                    {
-                        il.Emit(OpCodes.Unbox_Any, parameterType);
-                    }
+                    Unbox(il, parameterType);
                 }
             }
 
@@ -133,18 +126,11 @@ namespace System.Reflection
 
                 if (parameterType.IsPointer)
                 {
-                    il.Emit(OpCodes.Unbox_Any, typeof(IntPtr));
+                    Unbox(il, typeof(IntPtr));
                 }
                 else if (parameterType.IsValueType)
                 {
-                    if (parameterType.IsNullableOfT)
-                    {
-                        EmitTrueNullableUnbox(il, parameterType);
-                    }
-                    else
-                    {
-                        il.Emit(OpCodes.Unbox_Any, parameterType);
-                    }
+                    Unbox(il, parameterType);
                 }
             }
 
@@ -210,10 +196,11 @@ namespace System.Reflection
             return (InvokeFunc_RefArgs)dm.CreateDelegate(typeof(InvokeFunc_RefArgs), target: null);
         }
 
-        private static void EmitTrueNullableUnbox(ILGenerator il, Type parameterType)
+        private static void Unbox(ILGenerator il, Type parameterType)
         {
-            // Unbox the true Nullable<T> created by reflection to a Nullable<T> without using
-            // OpCodes.Unbox since unboxing that is not necessarily a valid CLI operation.
+            // Unbox without using OpCodes.Unbox\UnboxAny to avoid a type check since that was already done by reflection.
+            // Also required for unboxing true nullables created by reflection since that is not necessarily a valid CLI operation.
+            Debug.Assert(parameterType.IsValueType);
             il.Emit(OpCodes.Call, Methods.Object_GetRawData());
             il.Emit(OpCodes.Ldobj, parameterType);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.cs
@@ -80,13 +80,13 @@ namespace System.Reflection
             bool copyBack = false;
             Span<bool> shouldCopyBack = new(ref copyBack);
 
-            CheckArguments(parametersSpan, copyOfArgs, shouldCopyBack, binder, culture, invokeAttr);
-
             object? ret;
             if ((_strategy & InvokerStrategy.StrategyDetermined_ObjSpanArgs) == 0)
             {
                 DetermineStrategy_ObjSpanArgs(ref _strategy, ref _invokeFunc_ObjSpanArgs, _method, _needsByRefStrategy, backwardsCompat: true);
             }
+
+            CheckArguments(parametersSpan, copyOfArgs, shouldCopyBack, binder, culture, invokeAttr);
 
             if (_invokeFunc_ObjSpanArgs is not null)
             {
@@ -98,12 +98,12 @@ namespace System.Reflection
                 {
                     throw new TargetInvocationException(e);
                 }
-
-                CopyBack(parameters, copyOfArgs, shouldCopyBack);
-                return ret;
+            }
+            else
+            {
+                ret = InvokeDirectByRefWithFewArgs(obj, copyOfArgs, invokeAttr);
             }
 
-            ret = InvokeDirectByRefWithFewArgs(obj, copyOfArgs, invokeAttr);
             CopyBack(parameters, copyOfArgs, shouldCopyBack);
             return ret;
         }
@@ -121,13 +121,13 @@ namespace System.Reflection
             Span<object?> copyOfArgs = stackArgStorage._args.AsSpan(_argCount);
             Span<bool> shouldCopyBack = stackArgStorage._shouldCopyBack.AsSpan(_argCount);
 
-            CheckArguments(parameters, copyOfArgs, shouldCopyBack, binder, culture, invokeAttr);
-
             object? ret;
             if ((_strategy & InvokerStrategy.StrategyDetermined_ObjSpanArgs) == 0)
             {
                 DetermineStrategy_ObjSpanArgs(ref _strategy, ref _invokeFunc_ObjSpanArgs, _method, _needsByRefStrategy, backwardsCompat: true);
             }
+
+            CheckArguments(parameters, copyOfArgs, shouldCopyBack, binder, culture, invokeAttr);
 
             if (_invokeFunc_ObjSpanArgs is not null)
             {
@@ -139,12 +139,13 @@ namespace System.Reflection
                 {
                     throw new TargetInvocationException(e);
                 }
-
-                CopyBack(parameters, copyOfArgs, shouldCopyBack);
-                return ret;
             }
+            else
+            {
+                ret = InvokeDirectByRefWithFewArgs(obj, copyOfArgs, invokeAttr);
 
-            ret = InvokeDirectByRefWithFewArgs(obj, copyOfArgs, invokeAttr);
+           }
+
             CopyBack(parameters, copyOfArgs, shouldCopyBack);
             return ret;
         }
@@ -378,7 +379,7 @@ namespace System.Reflection
                 }
                 else if (!ReferenceEquals(arg.GetType(), sigType))
                 {
-                    // Determine if we can use the fast path for byref types
+                    // Determine if we can use the fast path for byref types.
                     if (TryByRefFastPath(sigType, ref arg))
                     {
                         // Fast path when the value's type matches the signature type of a byref parameter.

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvokerCommon.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvokerCommon.cs
@@ -107,12 +107,11 @@ namespace System.Reflection
             }
             else
             {
-#if !MONO // Temporary until Mono can unbox a true Nullable<T>
                 if (RuntimeFeature.IsDynamicCodeSupported)
                 {
                     invokeFunc_ObjSpanArgs = CreateInvokeDelegate_ObjSpanArgs(method, backwardsCompat);
                 }
-#endif
+
                 strategy |= InvokerStrategy.StrategyDetermined_ObjSpanArgs;
             }
         }
@@ -136,12 +135,11 @@ namespace System.Reflection
             }
             else
             {
-#if !MONO // Temporary until Mono can unbox a true Nullable<T>
                 if (RuntimeFeature.IsDynamicCodeSupported)
                 {
                     invokeFunc_Obj4Args = CreateInvokeDelegate_Obj4Args(method, backwardsCompat);
                 }
-#endif
+
                 strategy |= InvokerStrategy.StrategyDetermined_Obj4Args;
             }
         }

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1792,15 +1792,8 @@ namespace System
             }
             else if (IsPointer)
             {
-                Type? vtype = value.GetType();
-                if (vtype == typeof(IntPtr))
+                if (value is IntPtr or UIntPtr)
                     return CheckValueStatus.Success;
-
-                if (vtype == typeof(UIntPtr))
-                {
-                    value = (IntPtr)(UIntPtr)value;
-                    return CheckValueStatus.Success;
-                }
 
                 if (value is Pointer pointer)
                 {

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1793,8 +1793,15 @@ namespace System
             else if (IsPointer)
             {
                 Type? vtype = value.GetType();
-                if (vtype == typeof(IntPtr) || vtype == typeof(UIntPtr))
+                if (vtype == typeof(IntPtr))
                     return CheckValueStatus.Success;
+
+                if (vtype == typeof(UIntPtr))
+                {
+                    value = (IntPtr)(UIntPtr)value;
+                    return CheckValueStatus.Success;
+                }
+
                 if (value is Pointer pointer)
                 {
                     Type pointerType = pointer.GetPointerType();


### PR DESCRIPTION
Add support for Mono to emit faster invoke stubs for both the new invoke APIs added in https://github.com/dotnet/runtime/pull/88415 as well as standard invoke.

Replacement for closed issue https://github.com/dotnet/runtime/issues/88952