### PR TITLE
[QUIC] Add more details in PlatformNotSupportedException

### DIFF
--- a/src/libraries/System.Net.Quic/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Quic/src/Resources/Strings.resx
@@ -136,7 +136,7 @@
     <value>Stream aborted by peer ({0}).</value>
   </data>
   <data name="SystemNetQuic_PlatformNotSupported" xml:space="preserve">
-    <value>System.Net.Quic is not supported on this platform.</value>
+    <value>System.Net.Quic is not supported on this platform: {0}</value>
   </data>
   <data name="net_quic_writing_notallowed" xml:space="preserve">
     <value>Writing is not allowed on stream.</value>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -57,6 +57,7 @@ internal sealed unsafe partial class MsQuicApi
     internal static bool IsQuicSupported { get; }
 
     internal static string MsQuicLibraryVersion { get; } = "unknown";
+    internal static string? NotSupportedReason { get; }
 
     internal static bool UsesSChannelBackend { get; }
 
@@ -69,11 +70,14 @@ internal sealed unsafe partial class MsQuicApi
         bool loaded = false;
         IntPtr msQuicHandle;
 
-
         // MsQuic is using DualMode sockets and that will fail even for IPv4 if AF_INET6 is not available.
         if (!Socket.OSSupportsIPv6)
         {
-            NetEventSource.Info(null, "OS does not support dual mode sockets");
+            NotSupportedReason = "OS does not support dual mode sockets.";
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(null, NotSupportedReason);
+            }
             return;
         }
 
@@ -92,9 +96,10 @@ internal sealed unsafe partial class MsQuicApi
         if (!loaded)
         {
             // MsQuic library not loaded
+            NotSupportedReason = $"Unable to load MsQuic library version '{s_minMsQuicVersion.Major}'.";
             if (NetEventSource.Log.IsEnabled())
             {
-                NetEventSource.Info(null, $"Unable to load MsQuic library version '{s_minMsQuicVersion.Major}'.");
+                NetEventSource.Info(null, NotSupportedReason);
             }
             return;
         }
@@ -102,9 +107,14 @@ internal sealed unsafe partial class MsQuicApi
         MsQuicOpenVersion = (delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int>)NativeLibrary.GetExport(msQuicHandle, nameof(MsQuicOpenVersion));
         MsQuicClose = (delegate* unmanaged[Cdecl]<QUIC_API_TABLE*, void>)NativeLibrary.GetExport(msQuicHandle, nameof(MsQuicClose));
 
-        if (!TryOpenMsQuic(out QUIC_API_TABLE* apiTable, out _))
+        if (!TryOpenMsQuic(out QUIC_API_TABLE* apiTable, out int openStatus))
         {
             // Too low version of the library (likely pre-2.0)
+            NotSupportedReason = $"MsQuicOpenVersion for version {s_minMsQuicVersion.Major} returned {openStatus} status code.";
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(null, NotSupportedReason);
+            }
             return;
         }
 
@@ -144,9 +154,10 @@ internal sealed unsafe partial class MsQuicApi
 
             if (version < s_minMsQuicVersion)
             {
+                NotSupportedReason =  $"Incompatible MsQuic library version '{version}', expecting higher than '{s_minMsQuicVersion}'.";
                 if (NetEventSource.Log.IsEnabled())
                 {
-                    NetEventSource.Info(null, $"Incompatible MsQuic library version '{version}', expecting higher than '{s_minMsQuicVersion}'.");
+                    NetEventSource.Info(null, NotSupportedReason);
                 }
                 return;
             }
@@ -167,9 +178,10 @@ internal sealed unsafe partial class MsQuicApi
                 // Implies windows platform, check TLS1.3 availability
                 if (!IsWindowsVersionSupported())
                 {
+                    NotSupportedReason =  $"Current Windows version ({Environment.OSVersion}) is not supported by QUIC. Minimal supported version is {s_minWindowsVersion}.";
                     if (NetEventSource.Log.IsEnabled())
                     {
-                        NetEventSource.Info(null, $"Current Windows version ({Environment.OSVersion}) is not supported by QUIC. Minimal supported version is {s_minWindowsVersion}");
+                        NetEventSource.Info(null, NotSupportedReason);
                     }
                     return;
                 }
@@ -208,11 +220,6 @@ internal sealed unsafe partial class MsQuicApi
         openStatus = MsQuicOpenVersion((uint)s_minMsQuicVersion.Major, &table);
         if (StatusFailed(openStatus))
         {
-            if (NetEventSource.Log.IsEnabled())
-            {
-                NetEventSource.Info(null, $"MsQuicOpenVersion for version {s_minMsQuicVersion.Major} returned {openStatus} status code.");
-            }
-
             apiTable = null;
             return false;
         }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -64,7 +64,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     {
         if (!IsSupported)
         {
-            throw new PlatformNotSupportedException(SR.SystemNetQuic_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.Format(SR.SystemNetQuic_PlatformNotSupported, MsQuicApi.NotSupportedReason));
         }
 
         // Validate and fill in defaults for the options.

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -48,7 +48,7 @@ public sealed partial class QuicListener : IAsyncDisposable
     {
         if (!IsSupported)
         {
-            throw new PlatformNotSupportedException(SR.SystemNetQuic_PlatformNotSupported);
+            throw new PlatformNotSupportedException(SR.Format(SR.SystemNetQuic_PlatformNotSupported, MsQuicApi.NotSupportedReason));
         }
 
         // Validate and fill in defaults for the options.

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
@@ -15,10 +15,12 @@ namespace System.Net.Quic.Tests
         public static bool IsQuicUnsupported => !IsSupported;
 
         [ConditionalFact(nameof(IsQuicUnsupported))]
-        public void UnsupportedPlatforms_ThrowsPlatformNotSupportedException()
+        public async Task UnsupportedPlatforms_ThrowsPlatformNotSupportedException()
         {
-            Assert.ThrowsAsync<PlatformNotSupportedException>(async () => await CreateQuicListener());
-            Assert.ThrowsAsync<PlatformNotSupportedException>(async () => await CreateQuicConnection(new IPEndPoint(IPAddress.Loopback, 0)));
+            PlatformNotSupportedException listenerEx = await Assert.ThrowsAsync<PlatformNotSupportedException>(async () => await CreateQuicListener());
+            PlatformNotSupportedException connectionEx = await Assert.ThrowsAsync<PlatformNotSupportedException>(async () => await CreateQuicConnection(new IPEndPoint(IPAddress.Loopback, 0)));
+            Assert.Equal(listenerEx.Message, connectionEx.Message);
+            _output.WriteLine(listenerEx.Message);
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/73290", typeof(PlatformDetection), nameof(PlatformDetection.IsSingleFile))]


### PR DESCRIPTION
Contributes to #87970

The exception will contain something like: `System.Net.Quic is not supported on this platform: Unable to load MsQuic library version '2'.`