### PR TITLE
[hot_reload] Check for added fields earlier in compute_class_bitmap

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddStaticField/AddStaticField.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddStaticField/AddStaticField.cs
@@ -19,4 +19,11 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
         }
 
     }
+    public class AddStaticField2
+    {
+        public static int Test()
+        {
+            return -1;
+        }
+    }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddStaticField/AddStaticField_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddStaticField/AddStaticField_v1.cs
@@ -22,4 +22,13 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
         }
 
     }
+    public class AddStaticField2
+    {
+        private static int A {get; set;}
+        public static int Test()
+        {
+            A = 11;
+            return A + A;
+        }
+    }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -302,6 +302,9 @@ namespace System.Reflection.Metadata
 
                 string result = x.GetField;
                 Assert.Equal("4567", result);
+
+                int aa = System.Reflection.Metadata.ApplyUpdate.Test.AddStaticField2.Test();
+                Assert.Equal(22, aa);
             });
         }
 

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -834,6 +834,11 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 		while ((field = mono_class_get_fields_internal (p, &iter))) {
 			MonoType *type;
 
+			/* metadadta-update: added fields aren't stored in the object, don't
+			 * contribute to the GC descriptor. */
+			if (m_field_is_from_update (field))
+				continue;
+
 			if (static_fields) {
 				if (!(field->type->attrs & (FIELD_ATTRIBUTE_STATIC | FIELD_ATTRIBUTE_HAS_FIELD_RVA)))
 					continue;
@@ -846,11 +851,6 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 			/* FIXME: should not happen, flag as type load error */
 			if (m_type_is_byref (field->type))
 				break;
-
-			/* metadadta-update: added fields aren't stored in the object, don't
-			 * contribute to the GC descriptor. */
-			if (m_field_is_from_update (field))
-				continue;
 
 			int field_offset = m_field_get_offset (field);
 
@@ -2211,13 +2211,13 @@ mono_class_create_runtime_vtable (MonoClass *klass, MonoError *error)
 
 	iter = NULL;
 	while ((field = mono_class_get_fields_internal (klass, &iter))) {
+		if (m_field_is_from_update (field))
+			continue;
 		if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 			continue;
 		if (mono_field_is_deleted (field))
 			continue;
 		/* metadata-update: added fields are stored external to the object, and don't contribute to the bitmap */
-		if (m_field_is_from_update (field))
-			continue;
 		if (!(field->type->attrs & FIELD_ATTRIBUTE_LITERAL)) {
 			gint32 special_static = m_class_has_no_special_static_fields (klass) ? SPECIAL_STATIC_NONE : field_is_special_static (klass, field);
 			if (special_static != SPECIAL_STATIC_NONE) {

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -834,7 +834,7 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 		while ((field = mono_class_get_fields_internal (p, &iter))) {
 			MonoType *type;
 
-			/* metadadta-update: added fields aren't stored in the object, don't
+			/* metadata-update: added fields aren't stored in the object, don't
 			 * contribute to the GC descriptor. */
 			if (m_field_is_from_update (field))
 				continue;

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -2211,13 +2211,13 @@ mono_class_create_runtime_vtable (MonoClass *klass, MonoError *error)
 
 	iter = NULL;
 	while ((field = mono_class_get_fields_internal (klass, &iter))) {
+		/* metadata-update: added fields are stored external to the object, and don't contribute to the bitmap */
 		if (m_field_is_from_update (field))
 			continue;
 		if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 			continue;
 		if (mono_field_is_deleted (field))
 			continue;
-		/* metadata-update: added fields are stored external to the object, and don't contribute to the bitmap */
 		if (!(field->type->attrs & FIELD_ATTRIBUTE_LITERAL)) {
 			gint32 special_static = m_class_has_no_special_static_fields (klass) ? SPECIAL_STATIC_NONE : field_is_special_static (klass, field);
 			if (special_static != SPECIAL_STATIC_NONE) {


### PR DESCRIPTION
Added fields don't contribute to the class bitmap, and they also might not have their type resolved yet - move the "is from update" check before we need to access the field's type

Fixes https://github.com/dotnet/runtime/issues/86172
