### PR TITLE
[mono] Register static rgctx trampolines in the JIT info tables.

### DIFF
--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -65,7 +65,7 @@ mono_ldftn (MonoMethod *method)
 	} else {
 		addr = mono_create_jump_trampoline (method, FALSE, error);
 		if (mono_method_needs_static_rgctx_invoke (method, FALSE))
-                        addr = mono_create_static_rgctx_trampoline (method, addr);
+			addr = mono_create_static_rgctx_trampoline (method, addr);
 	}
 	if (!is_ok (error)) {
 		mono_error_set_pending_exception (error);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4029,6 +4029,7 @@ mini_init_delegate (MonoDelegateHandle delegate, MonoObjectHandle target, gpoint
 	MonoDelegateTrampInfo *info = NULL;
 
 	if (mono_use_interpreter) {
+		g_assert (method || del->interp_method);
 		mini_get_interp_callbacks ()->init_delegate (del, &info, error);
 		return_if_nok (error);
 	}

--- a/src/mono/mono/mini/mini-trampolines.c
+++ b/src/mono/mono/mini/mini-trampolines.c
@@ -129,6 +129,16 @@ mono_create_static_rgctx_trampoline (MonoMethod *m, gpointer addr)
 	else
 		res = mono_arch_get_static_rgctx_trampoline (jit_mm->mem_manager, ctx, addr);
 
+	/* This address might be passed to mini_init_delegate () which needs to look up the method */
+	MonoJitInfo *ji;
+
+	ji = mini_alloc_jinfo (jit_mm, MONO_SIZEOF_JIT_INFO);
+	ji->code_start = MINI_FTNPTR_TO_ADDR (res);
+	/* Doesn't matter, just need to be able to look up the exact address */
+	ji->code_size = 4;
+	ji->d.method = m;
+	mono_jit_info_table_add (ji);
+
 	jit_mm_lock (jit_mm);
 	/* Duplicates inserted while we didn't hold the lock are OK */
 	info = (RgctxTrampInfo *)m_method_alloc (m, sizeof (RgctxTrampInfo));


### PR DESCRIPTION
mini_init_delegate () needs to do a reverse lookup from address to method, and its possible for the address to be a static rgctx trampoline if the address is the result of mono_ldftn ().

Fixes https://github.com/dotnet/runtime/issues/89076.