### PR TITLE
Build less of libs for CoreCLR tools tests

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -346,7 +346,7 @@ extends:
           jobParameters:
             timeoutInMinutes: 120
             nameSuffix: CLR_Tools_Tests
-            buildArgs: -s clr.aot+clr.iltools+libs+clr.toolstests -c $(_BuildConfig) -test
+            buildArgs: -s clr.aot+clr.iltools+libs.sfx+clr.toolstests -c $(_BuildConfig) -test
             enablePublishTestResults: true
             testResultsFormat: 'xunit'
             # We want to run AOT tests when illink changes because there's share code and tests from illink which are used by AOT


### PR DESCRIPTION
Similar to #89153. I don't think we need System.Speech & co for tools tests.

Cc @dotnet/ilc-contrib @dotnet/illink-contrib @dotnet/illink @dotnet/crossgen-contrib 