### PR TITLE
Add a SearchValues ProbabilisticMap implementation that uses an ASCII fast path

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -415,6 +415,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Index.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\Emit\ILGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\BitVector256.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\ProbabilisticWithAsciiCharSearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\SingleCharSearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\SingleByteSearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\Any2ByteSearchValues.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
@@ -67,8 +67,7 @@ namespace System.Buffers
 
                 if (value > 127)
                 {
-                    // The values were modified concurrent with the call to SearchValues.Create
-                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+                    continue;
                 }
 
                 lookupLocal.Set(value);

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticCharSearchValues.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
 
 namespace System.Buffers
 {
@@ -14,16 +13,6 @@ namespace System.Buffers
 
         public ProbabilisticCharSearchValues(scoped ReadOnlySpan<char> values)
         {
-            if (Vector128.IsHardwareAccelerated && values.Length < 8)
-            {
-                // ProbabilisticMap does a Span.Contains check to confirm potential matches.
-                // If we have fewer than 8 values, pad them with existing ones to make the verification faster.
-                Span<char> newValues = stackalloc char[8];
-                newValues.Fill(values[0]);
-                values.CopyTo(newValues);
-                values = newValues;
-            }
-
             _values = new string(values);
             _map = new ProbabilisticMap(_values);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
@@ -1,0 +1,193 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Wasm;
+using System.Runtime.Intrinsics.X86;
+
+namespace System.Buffers
+{
+    internal sealed class ProbabilisticWithAsciiCharSearchValues<TOptimizations> : SearchValues<char>
+        where TOptimizations : struct, IndexOfAnyAsciiSearcher.IOptimizations
+    {
+        private Vector256<byte> _asciiBitmap;
+        private Vector256<byte> _inverseAsciiBitmap;
+        private ProbabilisticMap _map;
+        private readonly string _values;
+
+        public ProbabilisticWithAsciiCharSearchValues(scoped ReadOnlySpan<char> values)
+        {
+            Debug.Assert(IndexOfAnyAsciiSearcher.IsVectorizationSupported);
+            Debug.Assert(values.ContainsAnyInRange((char)0, (char)127));
+
+            IndexOfAnyAsciiSearcher.ComputeBitmap(values, out _asciiBitmap, out _);
+            _inverseAsciiBitmap = ~_asciiBitmap;
+
+            _values = new string(values);
+            _map = new ProbabilisticMap(_values);
+        }
+
+        internal override char[] GetValues() => _values.ToCharArray();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal override bool ContainsCore(char value) =>
+            ProbabilisticMap.Contains(ref Unsafe.As<ProbabilisticMap, uint>(ref _map), _values, value);
+
+        internal override int IndexOfAny(ReadOnlySpan<char> span)
+        {
+            int offset = 0;
+
+            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count)
+            {
+                // We are using IndexOfAnyAsciiSearcher to search for the first ASCII character in the set, or any non-ASCII character.
+                // We do this by inverting the bitmap and using the opposite search function (Negate instead of DontNegate).
+
+                // As we're using the inverse bitmap, we have to make sure to use the correct IOptimizations implementation
+                if ((Ssse3.IsSupported || PackedSimd.IsSupported) && typeof(TOptimizations) == typeof(IndexOfAnyAsciiSearcher.Default))
+                {
+                    offset = IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle>(
+                        ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
+                        span.Length,
+                        ref _inverseAsciiBitmap);
+                }
+                else
+                {
+                    offset = IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Default>(
+                        ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
+                        span.Length,
+                        ref _inverseAsciiBitmap);
+                }
+
+                // If we've reached the end of the span or stopped at an ASCII character, we've found the result.
+                if ((uint)offset >= (uint)span.Length || char.IsAscii(span[offset]))
+                {
+                    return offset;
+                }
+
+                // Fall back to using the ProbabilisticMap.
+                span = span.Slice(offset);
+            }
+
+            int index = ProbabilisticMap.IndexOfAny(
+                ref Unsafe.As<ProbabilisticMap, uint>(ref _map),
+                ref MemoryMarshal.GetReference(span),
+                span.Length,
+                _values);
+
+            if (index >= 0)
+            {
+                // We found a match. Account for the number of ASCII characters we've skipped previously.
+                index += offset;
+            }
+
+            return index;
+        }
+
+        internal override int IndexOfAnyExcept(ReadOnlySpan<char> span)
+        {
+            int offset = 0;
+
+            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count)
+            {
+                // Do a regular IndexOfAnyExcept for the ASCII characters. The search will stop if we encounter a non-ASCII char.
+                offset = IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, TOptimizations>(
+                    ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
+                    span.Length,
+                    ref _asciiBitmap);
+
+                // If we've reached the end of the span or stopped at an ASCII character, we've found the result.
+                if ((uint)offset >= (uint)span.Length || char.IsAscii(span[offset]))
+                {
+                    return offset;
+                }
+
+                // Fall back to a simple char-by-char search.
+                span = span.Slice(offset);
+            }
+
+            int index = ProbabilisticMap.IndexOfAnySimpleLoop<IndexOfAnyAsciiSearcher.Negate>(
+                ref MemoryMarshal.GetReference(span),
+                span.Length,
+                _values);
+
+            if (index >= 0)
+            {
+                // We found a match. Account for the number of ASCII characters we've skipped previously.
+                index += offset;
+            }
+
+            return index;
+        }
+
+        internal override int LastIndexOfAny(ReadOnlySpan<char> span)
+        {
+            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count)
+            {
+                // We are using IndexOfAnyAsciiSearcher to search for the last ASCII character in the set, or any non-ASCII character.
+                // We do this by inverting the bitmap and using the opposite search function (Negate instead of DontNegate).
+
+                int offset;
+
+                // As we're using the inverse bitmap, we have to make sure to use the correct IOptimizations implementation
+                if ((Ssse3.IsSupported || PackedSimd.IsSupported) && typeof(TOptimizations) == typeof(IndexOfAnyAsciiSearcher.Default))
+                {
+                    offset = IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle>(
+                        ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
+                        span.Length,
+                        ref _inverseAsciiBitmap);
+                }
+                else
+                {
+                    offset = IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Default>(
+                        ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
+                        span.Length,
+                        ref _inverseAsciiBitmap);
+                }
+
+                // If we've reached the end of the span or stopped at an ASCII character, we've found the result.
+                if ((uint)offset >= (uint)span.Length || char.IsAscii(span[offset]))
+                {
+                    return offset;
+                }
+
+                // Fall back to using the ProbabilisticMap.
+                span = span.Slice(0, offset + 1);
+            }
+
+            return ProbabilisticMap.LastIndexOfAny(
+                ref Unsafe.As<ProbabilisticMap, uint>(ref _map),
+                ref MemoryMarshal.GetReference(span),
+                span.Length,
+                _values);
+        }
+
+        internal override int LastIndexOfAnyExcept(ReadOnlySpan<char> span)
+        {
+            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count)
+            {
+                // Do a regular LastIndexOfAnyExcept for the ASCII characters. The search will stop if we encounter a non-ASCII char.
+                int offset = IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, TOptimizations>(
+                    ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
+                    span.Length,
+                    ref _asciiBitmap);
+
+                // If we've reached the end of the span or stopped at an ASCII character, we've found the result.
+                if ((uint)offset >= (uint)span.Length || char.IsAscii(span[offset]))
+                {
+                    return offset;
+                }
+
+                // Fall back to a simple char-by-char search.
+                span = span.Slice(0, offset + 1);
+            }
+
+            return ProbabilisticMap.LastIndexOfAnySimpleLoop<IndexOfAnyAsciiSearcher.Negate>(
+                ref MemoryMarshal.GetReference(span),
+                span.Length,
+                _values);
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
@@ -140,7 +140,29 @@ namespace System.Buffers
                 return new Latin1CharSearchValues(values);
             }
 
-            return new ProbabilisticCharSearchValues(values);
+            scoped ReadOnlySpan<char> probabilisticValues = values;
+
+            if (Vector128.IsHardwareAccelerated && values.Length < 8)
+            {
+                // ProbabilisticMap does a Span.Contains check to confirm potential matches.
+                // If we have fewer than 8 values, pad them with existing ones to make the verification faster.
+                Span<char> newValues = stackalloc char[8];
+                newValues.Fill(values[0]);
+                values.CopyTo(newValues);
+                probabilisticValues = newValues;
+            }
+
+            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && minInclusive < 128)
+            {
+                // If we have both ASCII and non-ASCII characters, use an implementation that
+                // does an optimistic ASCII fast-path and then falls back to the ProbabilisticMap.
+
+                return (Ssse3.IsSupported || PackedSimd.IsSupported) && probabilisticValues.Contains('\0')
+                    ? new ProbabilisticWithAsciiCharSearchValues<IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle>(probabilisticValues)
+                    : new ProbabilisticWithAsciiCharSearchValues<IndexOfAnyAsciiSearcher.Default>(probabilisticValues);
+            }
+
+            return new ProbabilisticCharSearchValues(probabilisticValues);
         }
 
         private static bool TryGetSingleRange<T>(ReadOnlySpan<T> values, out T minInclusive, out T maxInclusive)


### PR DESCRIPTION
Related: #89140

This is an implementation that we would use when we have a mixed set of ASCII and non-ASCII characters.
It's similar to the existing `ProbabilisticMap` implementation, but with a fast path that only looks for the ASCII characters with a faster implementation first.

For `IndexOfAny`, the `ReplaceLineEndings` benchmark shows large improvements for ASCII inputs, and as `NewLineFrequency` increases, it highlights the worst-case per-call overhead the new fast path introduces for non-ASCII texts.

For the cases where the probabilistic map is not vectorized (`IndexOfAnyExcept`, `LastIndexOfAny`, `LastIndexOfAnyExcept`), this brings massive improvements with the worst-case of relatively minor regressions.
The `-Except` variants even more so as they otherwise fall back to `O(n * m)` implementations.

The throughput difference between the ASCII fast path and the vectorized probabilistic map is large, but it might shrink somewhat once we add AVX512 support to these types, as AVX512 can use a more efficient ProbMap approach ([similar to ARM64](https://github.com/dotnet/runtime/pull/85189)).

<details>
<summary>ReplaceLineEndings benchmarks</summary>

This was done with a CR => CR replace, such that there is no allocation overhead, to highlight the `SearchValues` part of the cost.

|             Method | Toolchain | Length | NewLineFrequency | AsciiText |        Mean |     Error | Ratio |
|------------------- |---------- |------- |----------------- |---------- |------------:|----------:|------:|
| ReplaceLineEndings |      main |  10000 |                0 |     False |  1,216.2 ns |   4.36 ns |  1.00 |
| ReplaceLineEndings |        pr |  10000 |                0 |     False |  1,205.7 ns |   3.34 ns |  0.99 |
|                    |           |        |                  |           |             |           |       |
| ReplaceLineEndings |      main |  10000 |                0 |      True |  1,995.5 ns |   7.23 ns |  1.00 |
| ReplaceLineEndings |        pr |  10000 |                0 |      True |    338.4 ns |   0.74 ns |  0.17 |
|                    |           |        |                  |           |             |           |       |
| ReplaceLineEndings |      main |  10000 |             0.02 |     False |  3,362.1 ns |  19.01 ns |  1.00 |
| ReplaceLineEndings |        pr |  10000 |             0.02 |     False |  5,148.4 ns |  27.47 ns |  1.53 |
|                    |           |        |                  |           |             |           |       |
| ReplaceLineEndings |      main |  10000 |             0.02 |      True |  4,655.6 ns |  25.22 ns |  1.00 |
| ReplaceLineEndings |        pr |  10000 |             0.02 |      True |  1,939.8 ns |  16.54 ns |  0.42 |
|                    |           |        |                  |           |             |           |       |
| ReplaceLineEndings |      main |  10000 |             0.05 |     False |  7,623.3 ns |  29.90 ns |  1.00 |
| ReplaceLineEndings |        pr |  10000 |             0.05 |     False | 11,956.5 ns |  63.51 ns |  1.57 |
|                    |           |        |                  |           |             |           |       |
| ReplaceLineEndings |      main |  10000 |             0.05 |      True |  8,863.8 ns |  81.85 ns |  1.00 |
| ReplaceLineEndings |        pr |  10000 |             0.05 |      True |  5,025.0 ns |  24.73 ns |  0.57 |
|                    |           |        |                  |           |             |           |       |
| ReplaceLineEndings |      main |  10000 |              0.1 |     False | 13,317.3 ns |  86.18 ns |  1.00 |
| ReplaceLineEndings |        pr |  10000 |              0.1 |     False | 21,882.1 ns | 288.06 ns |  1.64 |
|                    |           |        |                  |           |             |           |       |
| ReplaceLineEndings |      main |  10000 |              0.1 |      True | 16,764.9 ns | 254.59 ns |  1.00 |
| ReplaceLineEndings |        pr |  10000 |              0.1 |      True |  9,018.0 ns |  42.44 ns |  0.54 |

</details>

<details>
<summary>IndexOfAnyExcept and ASCII early-match overhead benchmarks</summary>

This is for a set of only 6 values. The more values you use, the larger the factor would be for `IndexOfAnyExcept`.
|           Method | Toolchain | Length | AsciiText |        Mean |     Error | Ratio | Code Size |
|----------------- |---------- |------- |---------- |------------:|----------:|------:|----------:|
| IndexOfAnyExcept |      main |  10000 |      True | 17,968.8 ns | 129.08 ns |  1.00 |     430 B |
| IndexOfAnyExcept |        pr |  10000 |      True |    294.5 ns |   1.88 ns |  0.02 |     659 B |

To highlight the difference when finding early matches with ASCII text:
|             Method | Toolchain | NewLineFrequency | Source | Replacement | AsciiText |      Mean | Ratio |
|------------------- |---------- |----------------- |------- |------------ |---------- |----------:|------:|
| ReplaceLineEndings |      main |                1 |     CR |          CR |      True | 126.38 us |  1.00 |
| ReplaceLineEndings |        pr |                1 |     CR |          CR |      True |  84.12 us |  0.67 |

</details>

With all that in mind, do we still want to do this?