### PR TITLE
Remove unnecessary closures from Logging{Scope}HttpMessageHandler.SendCoreAsync

### DIFF
--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Extensions.Http.Logging
         private Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
         {
             ThrowHelper.ThrowIfNull(request);
-            return Core(request, cancellationToken);
+            return Core(request, useAsync, cancellationToken);
 
-            async Task<HttpResponseMessage> Core(HttpRequestMessage request, CancellationToken cancellationToken)
+            async Task<HttpResponseMessage> Core(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
             {
                 Func<string, bool> shouldRedactHeaderValue = _options?.ShouldRedactHeaderValue ?? _shouldNotRedactHeaderValue;
 

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingScopeHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingScopeHttpMessageHandler.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Extensions.Http.Logging
         private Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
         {
             ThrowHelper.ThrowIfNull(request);
-            return Core(request, cancellationToken);
+            return Core(request, useAsync, cancellationToken);
 
-            async Task<HttpResponseMessage> Core(HttpRequestMessage request, CancellationToken cancellationToken)
+            async Task<HttpResponseMessage> Core(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
             {
                 var stopwatch = ValueStopwatch.StartNew();
 


### PR DESCRIPTION
The local async function is closing over the outer `useAsync` parameter, and because it's an async method, that closure is a class.  Thus the decompiled method previously looked like:
```C#
private Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
{
    <>c__DisplayClass5_0 <>c__DisplayClass5_ = new <>c__DisplayClass5_0();
    <>c__DisplayClass5_.<>4__this = this;
    <>c__DisplayClass5_.useAsync = useAsync;
    System.ThrowHelper.ThrowIfNull(request, "request");
    return <>c__DisplayClass5_.<SendCoreAsync>g__Core|0(request, cancellationToken);
}
```
and with this change now looks like:
```C#
private Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
{
    System.ThrowHelper.ThrowIfNull(request, "request");
    return <SendCoreAsync>g__Core|5_0(request, useAsync, cancellationToken);
}
```
