### PR TITLE
[release/8.0-preview7] Fix bug in EqualsIgnoreCaseUtf8_Scalar

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.Utf8.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.Utf8.cs
@@ -296,13 +296,7 @@ namespace System.Globalization
                     return true;
                 }
 
-                if (!Utf8Utility.UInt32OrdinalIgnoreCaseAscii(valueAu32, valueBu32))
-                {
-                    return false;
-                }
-
-                byteOffset += 4;
-                length -= 4;
+                return Utf8Utility.UInt32OrdinalIgnoreCaseAscii(valueAu32, valueBu32);
             }
 
             Debug.Assert(length == 0);

--- a/src/libraries/System.Text.Json/tests/Common/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/NumberHandlingTests.cs
@@ -873,7 +873,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("\u0020Inf\u0069ni\u0074y")] // " Infinity"
         [InlineData("\u002BInf\u0069nity")] // "+Infinity"
 #pragma warning restore xUnit1025
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/89094", TestPlatforms.OSX)]
         public async Task FloatingPointConstants_Fail(string testString)
         {
             string testStringAsJson = $@"""{testString}""";


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/runtime/pull/89152 since bot didn't react to `/backport` command

Fixes https://github.com/dotnet/runtime/issues/89200