### PR TITLE
JIT: Clamp basic block IL ranges when splitting blocks

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -4664,8 +4664,8 @@ BasicBlock* Compiler::fgSplitBlockAfterStatement(BasicBlock* curr, Statement* st
 
         IL_OFFSET splitPointILOffset = fgFindBlockILOffset(newBlock);
 
-        curr->bbCodeOffsEnd  = splitPointILOffset;
-        newBlock->bbCodeOffs = splitPointILOffset;
+        curr->bbCodeOffsEnd  = max(curr->bbCodeOffs, splitPointILOffset);
+        newBlock->bbCodeOffs = min(splitPointILOffset, newBlock->bbCodeOffsEnd);
     }
     else
     {
@@ -4781,11 +4781,11 @@ BasicBlock* Compiler::fgSplitBlockAfterNode(BasicBlock* curr, GenTree* node)
             }
         }
 
-        curr->bbCodeOffsEnd = splitPointILOffset;
+        curr->bbCodeOffsEnd = max(curr->bbCodeOffs, splitPointILOffset);
 
         // Also use this as the beginning offset of the next block. Presumably we could/should
         // look to see if the first node is a GT_IL_OFFSET node, and use that instead.
-        newBlock->bbCodeOffs = splitPointILOffset;
+        newBlock->bbCodeOffs = min(splitPointILOffset, newBlock->bbCodeOffsEnd);
     }
     else
     {


### PR DESCRIPTION
In release, code motion/compaction may lead to statements ending up in blocks that don't contain their IL offset. This can cause splitting of blocks to create meaningless IL ranges such as [057..020). Since we maintain these IL ranges on a best-effort basis, just clamp them when we do the splitting.

Fix #88348