### PR TITLE
Efcore issue 31178

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Extensions.DependencyInjection
             public bool IsScope => !_serviceProvider.Root.IsRootScope;
         }
 
-        private class ServiceAccessor
+        private sealed class ServiceAccessor
         {
             public ServiceCallSite? CallSite { get; set; }
             public Func<ServiceProviderEngineScope, object?>? RealizedService { get; set; }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -151,10 +151,10 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 ThrowHelper.ThrowObjectDisposedException();
             }
-            ServiceAccessor realizedService = _serviceAccessors.GetOrAdd(serviceIdentifier, _createServiceAccessor);
-            OnResolve(realizedService.CallSite, serviceProviderEngineScope);
+            ServiceAccessor serviceAccessor = _serviceAccessors.GetOrAdd(serviceIdentifier, _createServiceAccessor);
+            OnResolve(serviceAccessor.CallSite, serviceProviderEngineScope);
             DependencyInjectionEventSource.Log.ServiceResolved(this, serviceIdentifier.ServiceType);
-            object? result = realizedService.RealizedService?.Invoke(serviceProviderEngineScope);
+            object? result = serviceAccessor.RealizedService?.Invoke(serviceProviderEngineScope);
             System.Diagnostics.Debug.Assert(result is null || CallSiteFactory.IsService(serviceIdentifier));
             return result;
         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -21,14 +21,14 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         private readonly CallSiteValidator? _callSiteValidator;
 
-        private readonly Func<ServiceIdentifier, Func<ServiceProviderEngineScope, object?>> _createServiceAccessor;
+        private readonly Func<ServiceIdentifier, ServiceAccessor> _createServiceAccessor;
 
         // Internal for testing
         internal ServiceProviderEngine _engine;
 
         private bool _disposed;
 
-        private readonly ConcurrentDictionary<ServiceIdentifier, Func<ServiceProviderEngineScope, object?>> _realizedServices;
+        private readonly ConcurrentDictionary<ServiceIdentifier, ServiceAccessor> _serviceAccessors;
 
         internal CallSiteFactory CallSiteFactory { get; }
 
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Root = new ServiceProviderEngineScope(this, isRootScope: true);
             _engine = GetEngine();
             _createServiceAccessor = CreateServiceAccessor;
-            _realizedServices = new ConcurrentDictionary<ServiceIdentifier, Func<ServiceProviderEngineScope, object?>>();
+            _serviceAccessors = new ConcurrentDictionary<ServiceIdentifier, ServiceAccessor>();
 
             CallSiteFactory = new CallSiteFactory(serviceDescriptors);
             // The list of built in services that aren't part of the list of service descriptors
@@ -137,9 +137,12 @@ namespace Microsoft.Extensions.DependencyInjection
             _callSiteValidator?.ValidateCallSite(callSite);
         }
 
-        private void OnResolve(ServiceCallSite callSite, IServiceScope scope)
+        private void OnResolve(ServiceCallSite? callSite, IServiceScope scope)
         {
-            _callSiteValidator?.ValidateResolution(callSite, scope, Root);
+            if (callSite != null)
+            {
+                _callSiteValidator?.ValidateResolution(callSite, scope, Root);
+            }
         }
 
         internal object? GetService(ServiceIdentifier serviceIdentifier, ServiceProviderEngineScope serviceProviderEngineScope)
@@ -148,9 +151,10 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 ThrowHelper.ThrowObjectDisposedException();
             }
-
-            Func<ServiceProviderEngineScope, object?> realizedService = _realizedServices.GetOrAdd(serviceIdentifier, _createServiceAccessor);
-            var result = realizedService.Invoke(serviceProviderEngineScope);
+            ServiceAccessor realizedService = _serviceAccessors.GetOrAdd(serviceIdentifier, _createServiceAccessor);
+            OnResolve(realizedService.CallSite, serviceProviderEngineScope);
+            DependencyInjectionEventSource.Log.ServiceResolved(this, serviceIdentifier.ServiceType);
+            object? result = realizedService.RealizedService?.Invoke(serviceProviderEngineScope);
             System.Diagnostics.Debug.Assert(result is null || CallSiteFactory.IsService(serviceIdentifier));
             return result;
         }
@@ -176,7 +180,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-        private Func<ServiceProviderEngineScope, object?> CreateServiceAccessor(ServiceIdentifier serviceIdentifier)
+        private ServiceAccessor CreateServiceAccessor(ServiceIdentifier serviceIdentifier)
         {
             ServiceCallSite? callSite = CallSiteFactory.GetCallSite(serviceIdentifier, new CallSiteChain());
             if (callSite != null)
@@ -188,28 +192,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 if (callSite.Cache.Location == CallSiteResultCacheLocation.Root)
                 {
                     object? value = CallSiteRuntimeResolver.Instance.Resolve(callSite, Root);
-                    return scope =>
-                    {
-                        DependencyInjectionEventSource.Log.ServiceResolved(this, serviceIdentifier.ServiceType);
-                        return value;
-                    };
+                    return new ServiceAccessor { CallSite = callSite, RealizedService = scope => value };
                 }
 
                 Func<ServiceProviderEngineScope, object?> realizedService = _engine.RealizeService(callSite);
-                return scope =>
-                {
-                    OnResolve(callSite, scope);
-                    DependencyInjectionEventSource.Log.ServiceResolved(this, serviceIdentifier.ServiceType);
-                    return realizedService(scope);
-                };
+                return new ServiceAccessor { CallSite = callSite, RealizedService = realizedService };
             }
-
-            return _ => null;
+            return new ServiceAccessor { CallSite = callSite, RealizedService = _ => null };
         }
 
         internal void ReplaceServiceAccessor(ServiceCallSite callSite, Func<ServiceProviderEngineScope, object?> accessor)
         {
-            _realizedServices[new ServiceIdentifier(callSite.Key, callSite.ServiceType)] = accessor;
+            _serviceAccessors[new ServiceIdentifier(callSite.Key, callSite.ServiceType)] = new ServiceAccessor
+            {
+                CallSite = callSite,
+                RealizedService = accessor
+            };
         }
 
         internal IServiceScope CreateScope()
@@ -261,6 +259,12 @@ namespace Microsoft.Extensions.DependencyInjection
             public List<object> Disposables => new List<object>(_serviceProvider.Root.Disposables);
             public bool Disposed => _serviceProvider.Root.Disposed;
             public bool IsScope => !_serviceProvider.Root.IsRootScope;
+        }
+
+        private class ServiceAccessor
+        {
+            public ServiceCallSite? CallSite { get; set; }
+            public Func<ServiceProviderEngineScope, object?>? RealizedService { get; set; }
         }
     }
 }


### PR DESCRIPTION
@steveharter
This is related to https://github.com/dotnet/efcore/pull/31178 and https://github.com/dotnet/runtime/issues/89109
Reworked the logic a bit and made it look like what it was before [this PR](https://github.com/dotnet/runtime/pull/87354). This helps pass failed tests of efcore. Could you please check it