### PR TITLE
Fix OSX like Test Failure on Socket.Connect

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -229,7 +229,7 @@ namespace System.Net.Sockets.Tests
             await ConnectAsync(s, new IPEndPoint(listenAt, ((IPEndPoint)listener.LocalEndPoint).Port));
             Assert.True(s.Connected);
             // According to the OSX man page, it's enough connecting to an invalid address to dissolve the connection. (0 port connection returns error on OSX)
-            await ConnectAsync(s, new IPEndPoint(secondConnection, PlatformDetection.IsOSX ? 1 : 0));
+            await ConnectAsync(s, new IPEndPoint(secondConnection, PlatformDetection.IsOSXLike ? 1 : 0));
             Assert.True(s.Connected);
         }
     }


### PR DESCRIPTION
Fixes #89166
