### PR TITLE
Fix duplicated assets in official build

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -117,7 +117,7 @@ extends:
           - linux_bionic_arm64
           - linux_bionic_x64
           jobParameters:
-            buildArgs: -s clr.nativeaotlibs+clr.nativeaotruntime+libs+packs -c $(_BuildConfig) /p:BuildNativeAOTRuntimePack=true
+            buildArgs: -s clr.nativeaotlibs+clr.nativeaotruntime+libs+packs -c $(_BuildConfig) /p:BuildNativeAOTRuntimePack=true /p:SkipLibrariesNativeRuntimePackages=true
             nameSuffix: AllSubsets_NativeAOT
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml

--- a/src/installer/pkg/projects/nativeaot-packages.proj
+++ b/src/installer/pkg/projects/nativeaot-packages.proj
@@ -1,9 +1,9 @@
 <Project>
   <Import Sdk="Microsoft.Build.Traversal" Project="Sdk.props" />
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(BuildNativeAOTRuntimePack)' != 'true'">
     <Project Include="Microsoft.DotNet.ILCompiler\Microsoft.DotNet.ILCompiler.pkgproj" />
-    <ProjectReference Condition="'$(BuildNativeAOTRuntimePack)' != 'true'" Include="@(Project)" />
+    <ProjectReference Include="@(Project)" />
     <ProjectReference Include="@(Project)" AdditionalProperties="PackageTargetRuntime=$(OutputRID)" />
   </ItemGroup>
 


### PR DESCRIPTION
The additional osx-x64 and osx-arm64 legs added for NativeAOT in https://github.com/dotnet/runtime/pull/89018 caused the `runtime.osx-*.Microsoft.DotNet.ILCompiler` and runtime.osx-*.runtime.native.System.IO.Ports` packages to be duplicated.

This change makes sure we only publish them from one leg (the CoreCLR one).