### PR TITLE
Try to improve EventSource_ParallelRequests_LogsNewConnectionIdForEachRequest reliability

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -902,13 +902,11 @@ namespace System.Net.Http.Functional.Tests
         public TelemetryTest_Http11(ITestOutputHelper output) : base(output) { }
 
         [OuterLoop]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/89035", TestPlatforms.OSX)]
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void EventSource_ParallelRequests_LogsNewConnectionIdForEachRequest()
         {
             RemoteExecutor.Invoke(async () =>
             {
-                TimeSpan timeout = TimeSpan.FromSeconds(60);
                 const int NumParallelRequests = 4;
 
                 using var listener = new TestEventListener("System.Net.Http", EventLevel.Verbose, eventCounterInterval: 0.1d);
@@ -926,26 +924,31 @@ namespace System.Net.Http.Functional.Tests
                         Task<HttpResponseMessage>[] responseTasks = Enumerable.Repeat(uri, NumParallelRequests)
                             .Select(_ => client.GetAsync(uri))
                             .ToArray();
-                        await Task.WhenAll(responseTasks).WaitAsync(timeout);
-                    }, async server =>
+
+                        await TestHelper.WhenAllCompletedOrAnyFailed(responseTasks);
+                    },
+                    async server =>
                     {
-                        ManualResetEventSlim allConnectionsOpen = new(false);
+                        TaskCompletionSource allConnectionsOpen = new(TaskCreationOptions.RunContinuationsAsynchronously);
                         int connectionCounter = 0;
 
                         Task[] parallelConnectionTasks = Enumerable.Repeat(server, NumParallelRequests)
                             .Select(_ => server.AcceptConnectionAsync(HandleConnectionAsync))
                             .ToArray();
 
-                        await Task.WhenAll(parallelConnectionTasks);
+                        await TestHelper.WhenAllCompletedOrAnyFailed(parallelConnectionTasks);
 
                         async Task HandleConnectionAsync(GenericLoopbackConnection connection)
                         {
+                            await connection.ReadRequestDataAsync().WaitAsync(TestHelper.PassingTestTimeout);
+
                             if (Interlocked.Increment(ref connectionCounter) == NumParallelRequests)
                             {
-                                allConnectionsOpen.Set();
+                                allConnectionsOpen.SetResult();
                             }
-                            await connection.ReadRequestDataAsync().WaitAsync(timeout);
-                            allConnectionsOpen.Wait(timeout);
+
+                            await allConnectionsOpen.Task.WaitAsync(TestHelper.PassingTestTimeout);
+
                             await connection.SendResponseAsync(HttpStatusCode.OK);
                         }
                     });

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -951,7 +951,8 @@ namespace System.Net.Http.Functional.Tests
 
                             await connection.SendResponseAsync(HttpStatusCode.OK);
                         }
-                    });
+                    }, options: new GenericLoopbackOptions { ListenBacklog = NumParallelRequests });
+
                     await WaitForEventCountersAsync(events);
                 });
 


### PR DESCRIPTION
Closes #89035. We can reopen it if it continues to fail

Working on a guess here, if the server tasks are unblocked too soon, they might quickly process the request, and the client will assign another request to that connection. As a result, some server connections may never receive a request, which causes the test to time out.

The main change is unblocking the server tasks **after** we've read all client requests.
Then I also changed the `WhenAll`s to `WhenAllCompletedOrAnyFailed` to see if we can get better error information.

Edit: While that race might have happened, after switching to `WhenAllCompletedOrAnyFailed` the logs show that the server was rejecting connections. Not seeing failures anymore after raising the `ListenBacklog`.