### PR TITLE
[AndroidAppBuilder] add missing includes to template

### DIFF
--- a/src/tasks/AndroidAppBuilder/Templates/CMakeLists-android.txt
+++ b/src/tasks/AndroidAppBuilder/Templates/CMakeLists-android.txt
@@ -8,6 +8,8 @@ if(ANDROID_NDK_MAJOR VERSION_LESS "23")
     message(FATAL_ERROR "Error: need at least Android NDK 23, got ${ANDROID_NDK_REVISION}!")
 endif()
 
+add_compile_options(-Werror=missing-prototypes -Werror=missing-declarations -Wall -std=c99)
+
 add_library(
     monodroid
     SHARED

--- a/src/tasks/AndroidAppBuilder/Templates/monodroid-librarymode.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid-librarymode.c
@@ -9,6 +9,19 @@
 #include <assert.h>
 #include <unistd.h>
 
+/********* exported symbols *********/
+
+void
+Java_net_dot_MonoRunner_setEnv (JNIEnv* env, jobject thiz, jstring j_key, jstring j_value);
+
+int
+Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_testresults_dir, jstring j_entryPointLibName, jobjectArray j_args, long current_local_time);
+
+/********* imported symbols *********/
+void SayHello ();
+
+/********* implementation *********/
+
 static void
 strncpy_str (JNIEnv *env, char *buff, jstring str, int nbuff)
 {
@@ -19,9 +32,8 @@ strncpy_str (JNIEnv *env, char *buff, jstring str, int nbuff)
         (*env)->ReleaseStringUTFChars (env, str, copy_buff);
 }
 
-void SayHello ();
-
-int invoke_netlibrary_entrypoints (void)
+static int
+invoke_netlibrary_entrypoints (void)
 {
     SayHello ();
 

--- a/src/tasks/AndroidAppBuilder/Templates/monodroid.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid.c
@@ -3,10 +3,13 @@
 
 #include <mono/utils/mono-publib.h>
 #include <mono/utils/mono-logger.h>
+#include <mono/metadata/appdomain.h>
 #include <mono/metadata/assembly.h>
+#include <mono/metadata/class.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/mono-gc.h>
 #include <mono/metadata/exception.h>
+#include <mono/metadata/object.h>
 #include <mono/jit/jit.h>
 #include <mono/jit/mono-private-unstable.h>
 
@@ -22,6 +25,22 @@
 #include <sys/mman.h>
 #include <assert.h>
 #include <unistd.h>
+
+/********* exported symbols *********/
+
+/* JNI exports */
+
+void
+Java_net_dot_MonoRunner_setEnv (JNIEnv* env, jobject thiz, jstring j_key, jstring j_value);
+
+int
+Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_testresults_dir, jstring j_entryPointLibName, jobjectArray j_args, long current_local_time);
+
+// called from C#
+void
+invoke_external_native_api (void (*callback)(void));
+
+/********* implementation *********/
 
 static char *bundle_path;
 static char *executable;
@@ -124,7 +143,7 @@ free_aot_data (MonoAssembly *assembly, int size, void *user_data, void *handle)
     munmap (handle, size);
 }
 
-char *
+static char *
 strdup_printf (const char *msg, ...)
 {
     va_list args;
@@ -165,7 +184,7 @@ mono_droid_fetch_exception_property_string (MonoObject *obj, const char *name, b
     return str ? mono_string_to_utf8 (str) : NULL;
 }
 
-void
+static void
 unhandled_exception_handler (MonoObject *exc, void *user_data)
 {
     MonoClass *type = mono_object_get_class (exc);
@@ -181,7 +200,7 @@ unhandled_exception_handler (MonoObject *exc, void *user_data)
     exit (1);
 }
 
-void
+static void
 log_callback (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data)
 {
     LOG_INFO ("(%s %s) %s", log_domain, log_level, message);
@@ -195,14 +214,14 @@ log_callback (const char *log_domain, const char *log_level, const char *message
 void register_aot_modules (void);
 #endif
 
-void
+static void
 cleanup_runtime_config (MonovmRuntimeConfigArguments *args, void *user_data)
 {
     free (args);
     free (user_data);
 }
 
-int
+static int
 mono_droid_runtime_init (const char* executable, int managed_argc, char* managed_argv[], int local_date_time_offset)
 {
     // NOTE: these options can be set via command line args for adb or xharness, see AndroidSampleApp.csproj


### PR DESCRIPTION
Treat missing protoype warnings as errors so this doesn't happen again.

Fixes https://github.com/dotnet/runtime/issues/69601