### PR TITLE
NativeAOT createdump fork/exec for crash dump generation

### DIFF
--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -12,6 +12,7 @@ include(../../eng/native/configurepaths.cmake)
 include(${CLR_ENG_NATIVE_DIR}/configurecompiler.cmake)
 
 include_directories("${CLR_SRC_NATIVE_DIR}")
+include_directories("${CLR_SRC_NATIVE_DIR}/inc")
 
 if(MSVC)
   set(CMAKE_CXX_STANDARD_LIBRARIES "") # do not link against standard win32 libs i.e. kernel32, uuid, user32, etc.

--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -194,6 +194,9 @@ CrashInfo::GatherCrashInfo(DumpType dumpType)
     {
         return false;
     }
+    // Add the special (fake) memory region for the special diagnostics info
+    MemoryRegion special(PF_R, SpecialDiagInfoAddress, SpecialDiagInfoAddress + PAGE_SIZE);
+    m_memoryRegions.insert(special);
 #ifdef __APPLE__
     InitializeOtherMappings();
 #endif

--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -22,6 +22,7 @@ CrashInfo::CrashInfo(const CreateDumpOptions& options) :
     m_gatherFrames(options.CrashReport),
     m_crashThread(options.CrashThread),
     m_signal(options.Signal),
+    m_exceptionRecord(options.ExceptionRecord),
     m_moduleInfos(&ModuleInfoCompare),
     m_mainModule(nullptr),
     m_cbModuleMappings(0),
@@ -39,7 +40,7 @@ CrashInfo::CrashInfo(const CreateDumpOptions& options) :
     m_siginfo.si_signo = options.Signal;
     m_siginfo.si_code = options.SignalCode;
     m_siginfo.si_errno = options.SignalErrno;
-    m_siginfo.si_addr = options.SignalAddress;
+    m_siginfo.si_addr = (void*)options.SignalAddress;
 }
 
 CrashInfo::~CrashInfo()

--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -55,6 +55,7 @@ private:
     bool m_gatherFrames;                            // if true, add the native and managed stack frames to the thread info
     pid_t m_crashThread;                            // crashing thread id or 0 if none
     uint32_t m_signal;                              // crash signal code or 0 if none
+    uint64_t m_exceptionRecord;                     // exception record address or 0 if none
     std::string m_name;                             // exe name
     siginfo_t m_siginfo;                            // signal info (if any)
     std::string m_coreclrPath;                      // the path of the coreclr module or empty if none
@@ -115,6 +116,7 @@ public:
     inline const bool GatherFrames() const { return m_gatherFrames; }
     inline const pid_t CrashThread() const { return m_crashThread; }
     inline const uint32_t Signal() const { return m_signal; }
+    inline const uint64_t ExceptionRecord () const { return m_exceptionRecord; }
     inline const std::string& Name() const { return m_name; }
     inline const ModuleInfo* MainModule() const { return m_mainModule; }
     inline const uint64_t RuntimeBaseAddress() const { return m_runtimeBaseAddress; }

--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -137,6 +137,7 @@ typedef struct
 #include "crashreportwriter.h"
 #include "dumpwriter.h"
 #include "runtimeinfo.h"
+#include "specialdiaginfo.h"
 #endif
 
 #ifndef MAX_LONGPATH

--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -119,7 +119,8 @@ typedef struct
     int Signal;
     int SignalCode;
     int SignalErrno;
-    void* SignalAddress;
+    uint64_t SignalAddress;
+    uint64_t ExceptionRecord;
 } CreateDumpOptions;
 
 #ifdef HOST_UNIX

--- a/src/coreclr/debug/createdump/createdumpmain.cpp
+++ b/src/coreclr/debug/createdump/createdumpmain.cpp
@@ -71,11 +71,10 @@ int createdump_main(const int argc, const char* argv[])
     options.Signal = 0;
     options.CrashThread = 0;
     options.Pid = 0;
-#if defined(HOST_UNIX) && !defined(HOST_OSX)
     options.SignalCode = 0;
     options.SignalErrno = 0;
-    options.SignalAddress = nullptr;
-#endif
+    options.SignalAddress = 0;
+    options.ExceptionRecord = 0;
     bool help = false;
     int exitCode = 0;
 
@@ -141,7 +140,11 @@ int createdump_main(const int argc, const char* argv[])
             }
             else if (strcmp(*argv, "--address") == 0)
             {
-                options.SignalAddress = (void*)atoll(*++argv);
+                options.SignalAddress = atoll(*++argv);
+            }
+            else if (strcmp(*argv, "--exception-record") == 0)
+            {
+                options.ExceptionRecord = atoll(*++argv);
             }
 #endif
             else if ((strcmp(*argv, "-d") == 0) || (strcmp(*argv, "--diag") == 0))

--- a/src/coreclr/debug/createdump/dumpwriter.cpp
+++ b/src/coreclr/debug/createdump/dumpwriter.cpp
@@ -32,6 +32,27 @@ DumpWriter::OpenDump(const char* dumpFileName)
     return true;
 }
 
+bool
+DumpWriter::WriteDiagInfo(int size)
+{
+    // Write the diagnostics info header
+    SpecialDiagInfoHeader header = {
+        {SPECIAL_DIAGINFO_SIGNATURE},
+        SPECIAL_DIAGINFO_VERSION,
+        m_crashInfo.ExceptionRecord()
+    };
+    if (!WriteData(&header, sizeof(header))) {
+        return false;
+    }
+    int alignment = size - sizeof(header);
+    assert(alignment < sizeof(m_tempBuffer));
+    memset(m_tempBuffer, 0, alignment);
+    if (!WriteData(m_tempBuffer, alignment)) {
+        return false;
+    }
+    return true;
+}
+
 // Write all of the given buffer, handling short writes and EINTR. Return true iff successful.
 bool
 DumpWriter::WriteData(int fd, const void* buffer, size_t length)

--- a/src/coreclr/debug/createdump/dumpwriter.cpp
+++ b/src/coreclr/debug/createdump/dumpwriter.cpp
@@ -33,7 +33,7 @@ DumpWriter::OpenDump(const char* dumpFileName)
 }
 
 bool
-DumpWriter::WriteDiagInfo(int size)
+DumpWriter::WriteDiagInfo(size_t size)
 {
     // Write the diagnostics info header
     SpecialDiagInfoHeader header = {
@@ -44,7 +44,7 @@ DumpWriter::WriteDiagInfo(int size)
     if (!WriteData(&header, sizeof(header))) {
         return false;
     }
-    int alignment = size - sizeof(header);
+    size_t alignment = size - sizeof(header);
     assert(alignment < sizeof(m_tempBuffer));
     memset(m_tempBuffer, 0, alignment);
     if (!WriteData(m_tempBuffer, alignment)) {

--- a/src/coreclr/debug/createdump/dumpwriterelf.cpp
+++ b/src/coreclr/debug/createdump/dumpwriterelf.cpp
@@ -176,28 +176,37 @@ DumpWriter::WriteDump()
         size_t size = memoryRegion.Size();
         total += size;
 
-        while (size > 0)
+        if (address == SpecialDiagInfoAddress)
         {
-            size_t bytesToRead = std::min(size, sizeof(m_tempBuffer));
-            size_t read = 0;
-
-            if (!m_crashInfo.ReadProcessMemory((void*)address, m_tempBuffer, bytesToRead, &read)) {
-                printf_error("Error reading memory at %" PRIA PRIx64 " size %08zx FAILED %s (%d)\n", address, bytesToRead, strerror(g_readProcessMemoryErrno), g_readProcessMemoryErrno);
+            if (!WriteDiagInfo(size)) {
                 return false;
             }
+        }
+        else
+        {
+            while (size > 0)
+            {
+                size_t bytesToRead = std::min(size, sizeof(m_tempBuffer));
+                size_t read = 0;
 
-            // This can happen if the target process dies before createdump is finished
-            if (read == 0) {
-                printf_error("Error reading memory at %" PRIA PRIx64 " size %08zx returned 0 bytes read: %s (%d)\n", address, bytesToRead, strerror(g_readProcessMemoryErrno), g_readProcessMemoryErrno);
-                return false;
+                if (!m_crashInfo.ReadProcessMemory((void*)address, m_tempBuffer, bytesToRead, &read)) {
+                    printf_error("Error reading memory at %" PRIA PRIx64 " size %08zx FAILED %s (%d)\n", address, bytesToRead, strerror(g_readProcessMemoryErrno), g_readProcessMemoryErrno);
+                    return false;
+                }
+
+                // This can happen if the target process dies before createdump is finished
+                if (read == 0) {
+                    printf_error("Error reading memory at %" PRIA PRIx64 " size %08zx returned 0 bytes read: %s (%d)\n", address, bytesToRead, strerror(g_readProcessMemoryErrno), g_readProcessMemoryErrno);
+                    return false;
+                }
+
+                if (!WriteData(m_tempBuffer, read)) {
+                    return false;
+                }
+
+                address += read;
+                size -= read;
             }
-
-            if (!WriteData(m_tempBuffer, read)) {
-                return false;
-            }
-
-            address += read;
-            size -= read;
         }
     }
 

--- a/src/coreclr/debug/createdump/dumpwriterelf.h
+++ b/src/coreclr/debug/createdump/dumpwriterelf.h
@@ -56,7 +56,7 @@ public:
     static bool WriteData(int fd, const void* buffer, size_t length);
 
 private:
-    bool WriteDiagInfo(int size);
+    bool WriteDiagInfo(size_t size);
     bool WriteProcessInfo();
     bool WriteAuxv();
     size_t GetNTFileInfoSize(size_t* alignmentBytes = nullptr);

--- a/src/coreclr/debug/createdump/dumpwriterelf.h
+++ b/src/coreclr/debug/createdump/dumpwriterelf.h
@@ -56,6 +56,7 @@ public:
     static bool WriteData(int fd, const void* buffer, size_t length);
 
 private:
+    bool WriteDiagInfo(int size);
     bool WriteProcessInfo();
     bool WriteAuxv();
     size_t GetNTFileInfoSize(size_t* alignmentBytes = nullptr);

--- a/src/coreclr/debug/createdump/dumpwritermacho.cpp
+++ b/src/coreclr/debug/createdump/dumpwritermacho.cpp
@@ -229,7 +229,13 @@ DumpWriter::WriteSegments()
             (segment.initprot & VM_PROT_EXECUTE) ? 'x' : '-',
             segment.initprot);
 
-        if (address == SpecialThreadInfoAddress)
+        if (address == SpecialDiagInfoAddress)
+        {
+            if (!WriteDiagInfo(size)) {
+                return false;
+            }
+        }
+        else if (address == SpecialThreadInfoAddress)
         {
             // Write the header
             SpecialThreadInfoHeader header = {

--- a/src/coreclr/debug/createdump/dumpwritermacho.h
+++ b/src/coreclr/debug/createdump/dumpwritermacho.h
@@ -42,6 +42,7 @@ public:
     static bool WriteData(int fd, const void* buffer, size_t length);
 
 private:
+    bool WriteDiagInfo(int size);
     void BuildSegmentLoadCommands();
     void BuildThreadLoadCommands();
     bool WriteHeader(uint64_t* pFileOffset);

--- a/src/coreclr/debug/createdump/dumpwritermacho.h
+++ b/src/coreclr/debug/createdump/dumpwritermacho.h
@@ -42,7 +42,7 @@ public:
     static bool WriteData(int fd, const void* buffer, size_t length);
 
 private:
-    bool WriteDiagInfo(int size);
+    bool WriteDiagInfo(size_t size);
     void BuildSegmentLoadCommands();
     void BuildThreadLoadCommands();
     bool WriteHeader(uint64_t* pFileOffset);

--- a/src/coreclr/debug/createdump/specialdiaginfo.h
+++ b/src/coreclr/debug/createdump/specialdiaginfo.h
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ******************************************************************************
+// WARNING!!!: This code is also used by SOS in the diagnostics repo. Should be
+// updated in a backwards and forwards compatible way.
+// See: https://github.com/dotnet/diagnostics/blob/main/src/SOS/inc/specialdiaginfo.h
+// ******************************************************************************
+
+// This is a special memory region added to ELF and MachO dumps that contains extra diagnostics
+// information like the exception record for a crash for a NativeAOT app. The exception record
+// contains the pointer to the JSON formatted crash info.
+
+#define SPECIAL_DIAGINFO_SIGNATURE "DIAGINFOHEADER"
+#define SPECIAL_DIAGINFO_VERSION 1
+
+#ifdef __APPLE__
+const uint64_t SpecialDiagInfoAddress = 0x7fffffff10000000;
+#else
+#if TARGET_64BIT
+const uint64_t SpecialDiagInfoAddress = 0x00007ffffff10000;
+#else
+const uint64_t SpecialDiagInfoAddress = 0x7fff1000;
+#endif
+#endif
+
+struct SpecialDiagInfoHeader
+{
+    char Signature[16];
+    int Version;
+    uint64_t ExceptionRecordAddress;
+};

--- a/src/coreclr/debug/createdump/specialdiaginfo.h
+++ b/src/coreclr/debug/createdump/specialdiaginfo.h
@@ -27,6 +27,6 @@ const uint64_t SpecialDiagInfoAddress = 0x7fff1000;
 struct SpecialDiagInfoHeader
 {
     char Signature[16];
-    int Version;
+    int32_t Version;
     uint64_t ExceptionRecordAddress;
 };

--- a/src/coreclr/inc/clrconfignocache.h
+++ b/src/coreclr/inc/clrconfignocache.h
@@ -7,7 +7,7 @@
 // Logic for resolving configuration names.
 //
 
-#include <minipal/utils.h>
+#include<minipal/utils.h>
 
 // Config prefixes
 #define COMPLUS_PREFIX_A "COMPlus_"
@@ -23,30 +23,30 @@ class CLRConfigNoCache
     const char* _value;
 
     CLRConfigNoCache() = default;
-    CLRConfigNoCache(const char* cfg) : _value { cfg }
+    CLRConfigNoCache(LPCSTR cfg) : _value { cfg }
     { }
 
 public:
     bool IsSet() const { return _value != NULL; }
 
-    const char* AsString() const
+    LPCSTR AsString() const
     {
         _ASSERTE(IsSet());
         return _value;
     }
 
-    bool TryAsInteger(int radix, uint32_t& result) const
+    bool TryAsInteger(int radix, DWORD& result) const
     {
         _ASSERTE(IsSet());
 
         errno = 0;
-        char* endPtr;
+        LPSTR endPtr;
         result = strtoul(_value, &endPtr, radix);
         bool fSuccess = (errno != ERANGE) && (endPtr != _value);
         return fSuccess;
     }
 
-    static CLRConfigNoCache Get(const char* cfg, bool noPrefix = false, char*(*getEnvFptr)(const char*) = nullptr)
+    static CLRConfigNoCache Get(LPCSTR cfg, bool noPrefix = false, char*(*getEnvFptr)(const char*) = nullptr)
     {
         char nameBuffer[64];
         const char* fallbackPrefix = NULL;
@@ -73,17 +73,17 @@ public:
             }
 
             // Priority order is DOTNET_ and then COMPlus_.
-            strcpy(nameBuffer, DOTNET_PREFIX_A);
+            strcpy_s(nameBuffer, ARRAY_SIZE(nameBuffer), DOTNET_PREFIX_A);
             fallbackPrefix = COMPLUS_PREFIX_A;
         }
 
-        strcat(nameBuffer, cfg);
+        strcat_s(nameBuffer, ARRAY_SIZE(nameBuffer), cfg);
 
-        const char* val = getEnvFptr != NULL ? getEnvFptr(nameBuffer) : getenv(nameBuffer);
+        LPCSTR val = getEnvFptr != NULL ? getEnvFptr(nameBuffer) : getenv(nameBuffer);
         if (val == NULL && fallbackPrefix != NULL)
         {
-            strcpy(nameBuffer, fallbackPrefix);
-            strcat(nameBuffer, cfg);
+            strcpy_s(nameBuffer, ARRAY_SIZE(nameBuffer), fallbackPrefix);
+            strcat_s(nameBuffer, ARRAY_SIZE(nameBuffer), cfg);
             val = getEnvFptr != NULL ? getEnvFptr(nameBuffer) : getenv(nameBuffer);
         }
 

--- a/src/coreclr/nativeaot/Runtime/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/CMakeLists.txt
@@ -142,6 +142,7 @@ else()
 
   list(APPEND COMMON_RUNTIME_SOURCES
     unix/PalRedhawkUnix.cpp
+    unix/PalCreateDump.cpp
     ${GC_DIR}/unix/gcenv.unix.cpp
     ${GC_DIR}/unix/numasupport.cpp
     ${GC_DIR}/unix/events.cpp

--- a/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+++ b/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
@@ -17,7 +17,7 @@
 #include "thread.h"
 #include "threadstore.h"
 
-extern uint8_t* g_CrashInfoBuffer;
+extern uint8_t g_CrashInfoBuffer[];
 GPTR_DECL(MethodTable, g_pFreeObjectEEType);
 
 struct DebugTypeEntry

--- a/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+++ b/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
@@ -17,6 +17,7 @@
 #include "thread.h"
 #include "threadstore.h"
 
+extern uint8_t* g_CrashInfoBuffer;
 GPTR_DECL(MethodTable, g_pFreeObjectEEType);
 
 struct DebugTypeEntry
@@ -195,6 +196,11 @@ extern "C" void PopulateDebugHeaders()
     MAKE_DEBUG_FIELD_ENTRY(ThreadBuffer, m_rgbAllocContextBuffer);
     MAKE_DEBUG_FIELD_ENTRY(ThreadBuffer, m_threadId);
     MAKE_DEBUG_FIELD_ENTRY(ThreadBuffer, m_pThreadStressLog);
+    MAKE_DEBUG_FIELD_ENTRY(ThreadBuffer, m_pExInfoStackHead);
+
+    MAKE_SIZE_ENTRY(ExInfo);
+    MAKE_DEBUG_FIELD_ENTRY(ExInfo, m_pPrevExInfo);
+    MAKE_DEBUG_FIELD_ENTRY(ExInfo, m_exception);
 
     MAKE_SIZE_ENTRY(MethodTable);
     MAKE_DEBUG_FIELD_ENTRY(MethodTable, m_uBaseSize);
@@ -244,6 +250,8 @@ extern "C" void PopulateDebugHeaders()
     MAKE_SIZE_ENTRY(RuntimeInstance);
     MAKE_DEBUG_FIELD_ENTRY(RuntimeInstance, m_pThreadStore);
 
+    MAKE_GLOBAL_ENTRY(g_CrashInfoBuffer);
+
     RuntimeInstance *g_pTheRuntimeInstance = GetRuntimeInstance();
     MAKE_GLOBAL_ENTRY(g_pTheRuntimeInstance);
 
@@ -269,4 +277,9 @@ extern "C" void PopulateDebugHeaders()
     static_assert(MethodTable::Flags::IsGenericFlag          == 0x02000000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
     static_assert(MethodTable::Flags::ElementTypeMask        == 0x7C000000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
     static_assert(MethodTable::Flags::ElementTypeShift       == 26,         "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
+    static_assert(MethodTable::Flags::HasComponentSizeFlag   == 0x80000000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
+
+    static_assert(MethodTable::Kinds::CanonicalEEType        == 0x00000000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Kinds. If you change this value you must bump major_version_number.");
+    static_assert(MethodTable::Kinds::ParameterizedEEType    == 0x00020000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Kinds. If you change this value you must bump major_version_number.");
+    static_assert(MethodTable::Kinds::GenericTypeDefEEType   == 0x00030000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Kinds. If you change this value you must bump major_version_number.");
 }

--- a/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
+++ b/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
@@ -52,9 +52,9 @@ COOP_PINVOKE_HELPER(uint8_t *, RhGetCrashInfoBuffer, (int32_t* pcbMaxSize))
 
 #if TARGET_UNIX
 #include "PalCreateDump.h"
-COOP_PINVOKE_HELPER(void, RhCreateCrashDumpIfEnabled, (void* pExAddress, void* pExContext, void* triageBuffer, int triageBufferSize))
+COOP_PINVOKE_HELPER(void, RhCreateCrashDumpIfEnabled, (PEXCEPTION_RECORD pExceptionRecord, PCONTEXT pExContext))
 {
-    PalCreateCrashDumpIfEnabled(pExAddress, pExContext, triageBuffer, triageBufferSize);
+    PalCreateCrashDumpIfEnabled(pExceptionRecord, pExContext);
 }
 #endif
 

--- a/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
+++ b/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
@@ -51,10 +51,10 @@ COOP_PINVOKE_HELPER(uint8_t *, RhGetCrashInfoBuffer, (int32_t* pcbMaxSize))
 }
 
 #if TARGET_UNIX
-extern void PalCreateCrashDumpIfEnabled();
-COOP_PINVOKE_HELPER(void, RhCreateCrashDumpIfEnabled, ())
+#include "PalCreateDump.h"
+COOP_PINVOKE_HELPER(void, RhCreateCrashDumpIfEnabled, (void* pExAddress, void* pExContext, void* triageBuffer, int triageBufferSize))
 {
-    PalCreateCrashDumpIfEnabled();
+    PalCreateCrashDumpIfEnabled(pExAddress, pExContext, triageBuffer, triageBufferSize);
 }
 #endif
 

--- a/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
+++ b/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
@@ -37,7 +37,7 @@ bool ShouldHijackForGcStress(uintptr_t CallsiteIP, HijackType ht);
 #include "shash.inl"
 
 #define MAX_CRASHINFOBUFFER_SIZE 8192
-uint8_t g_CrashInfoBuffer[MAX_CRASHINFOBUFFER_SIZE];
+uint8_t g_CrashInfoBuffer[MAX_CRASHINFOBUFFER_SIZE] = { 0 };
 
 ThreadStore *   RuntimeInstance::GetThreadStore()
 {

--- a/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
+++ b/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
@@ -50,6 +50,14 @@ COOP_PINVOKE_HELPER(uint8_t *, RhGetCrashInfoBuffer, (int32_t* pcbMaxSize))
     return g_CrashInfoBuffer;
 }
 
+#if TARGET_UNIX
+extern void PalCreateCrashDumpIfEnabled();
+COOP_PINVOKE_HELPER(void, RhCreateCrashDumpIfEnabled, ())
+{
+    PalCreateCrashDumpIfEnabled();
+}
+#endif
+
 COOP_PINVOKE_HELPER(uint8_t *, RhGetRuntimeVersion, (int32_t* pcbLength))
 {
     *pcbLength = sizeof(CLR_PRODUCT_VERSION) - 1;           // don't include the terminating null

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.cpp
@@ -249,22 +249,4 @@ ds_rt_aot_set_environment_variable (const ep_char16_t *name, const ep_char16_t *
 #endif
 }
 
-bool
-ds_rt_aot_generate_core_dump (
-    const ep_char16_t* dumpName,
-    int32_t dumpType,
-    uint32_t flags,
-    ep_char8_t *errorMessageBuffer,
-    int32_t cbErrorMessageBuffer)
-{
-#ifdef TARGET_UNIX
-    ep_char8_t *dumpNameUtf8 = ep_rt_utf16le_to_utf8_string (dumpName, ep_rt_utf16_string_len (dumpName));
-    extern bool PalGenerateCoreDump(const char* dumpName, int dumpType, uint32_t flags, char* errorMessageBuffer, int cbErrorMessageBuffer);
-    return PalGenerateCoreDump(dumpNameUtf8, dumpType, flags, errorMessageBuffer, cbErrorMessageBuffer);
-#else
-    return false;
-#endif
-}
-
-
 #endif /* ENABLE_PERFTRACING */

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.cpp
@@ -248,4 +248,23 @@ ds_rt_aot_set_environment_variable (const ep_char16_t *name, const ep_char16_t *
     return SetEnvironmentVariableW(reinterpret_cast<LPCWSTR>(name), reinterpret_cast<LPCWSTR>(value)) ? S_OK : HRESULT_FROM_WIN32(GetLastError());
 #endif
 }
+
+bool
+ds_rt_aot_generate_core_dump (
+    const ep_char16_t* dumpName,
+    int32_t dumpType,
+    uint32_t flags,
+    ep_char8_t *errorMessageBuffer,
+    int32_t cbErrorMessageBuffer)
+{
+#ifdef TARGET_UNIX
+    ep_char8_t *dumpNameUtf8 = ep_rt_utf16le_to_utf8_string (dumpName, ep_rt_utf16_string_len (dumpName));
+    extern bool PalGenerateCoreDump(const char* dumpName, int dumpType, uint32_t flags, char* errorMessageBuffer, int cbErrorMessageBuffer);
+    return PalGenerateCoreDump(dumpNameUtf8, dumpType, flags, errorMessageBuffer, cbErrorMessageBuffer);
+#else
+    return false;
+#endif
+}
+
+
 #endif /* ENABLE_PERFTRACING */

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
@@ -183,6 +183,7 @@ ds_rt_generate_core_dump (
     STATIC_CONTRACT_NOTHROW;
 
     ds_ipc_result_t result = DS_IPC_E_FAIL;
+#ifdef TARGET_UNIX
     uint32_t flags = ds_generate_core_dump_command_payload_get_flags(payload);
     if (commandId == DS_DUMP_COMMANDID_GENERATE_CORE_DUMP)
     {
@@ -191,7 +192,6 @@ ds_rt_generate_core_dump (
     }
     const ep_char16_t *dumpName = ds_generate_core_dump_command_payload_get_dump_name (payload);
     int32_t dumpType = static_cast<int32_t>(ds_generate_core_dump_command_payload_get_dump_type (payload));
-#ifdef TARGET_UNIX
     ep_char8_t *dumpNameUtf8 = ep_rt_utf16le_to_utf8_string (dumpName, ep_rt_utf16_string_len (dumpName));
     extern bool PalGenerateCoreDump(const char* dumpName, int dumpType, uint32_t flags, char* errorMessageBuffer, int cbErrorMessageBuffer);
     if (PalGenerateCoreDump(dumpNameUtf8, dumpType, flags, errorMessageBuffer, cbErrorMessageBuffer))

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
@@ -191,14 +191,15 @@ ds_rt_generate_core_dump (
     }
     const ep_char16_t *dumpName = ds_generate_core_dump_command_payload_get_dump_name (payload);
     int32_t dumpType = static_cast<int32_t>(ds_generate_core_dump_command_payload_get_dump_type (payload));
-
-    extern bool ds_rt_aot_generate_core_dump (const ep_char16_t* dumpName, int32_t dumpType, uint32_t flags, ep_char8_t *errorMessageBuffer, int32_t cbErrorMessageBuffer);
-    if (ds_rt_aot_generate_core_dump(dumpName, dumpType, flags, errorMessageBuffer, cbErrorMessageBuffer))
+#ifdef TARGET_UNIX
+    ep_char8_t *dumpNameUtf8 = ep_rt_utf16le_to_utf8_string (dumpName, ep_rt_utf16_string_len (dumpName));
+    extern bool PalGenerateCoreDump(const char* dumpName, int dumpType, uint32_t flags, char* errorMessageBuffer, int cbErrorMessageBuffer);
+    if (PalGenerateCoreDump(dumpNameUtf8, dumpType, flags, errorMessageBuffer, cbErrorMessageBuffer))
     {
         result = DS_IPC_S_OK;
     }
-
-    return 0;
+#endif
+    return result;
 }
 
 /*

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
@@ -6,6 +6,7 @@
 #define DIAGNOSTICS_RT_AOT_H
 
 #include <eventpipe/ds-rt-config.h>
+#include <generatedumpflags.h>
 
 #ifdef ENABLE_PERFTRACING
 #include "ep-rt-aot.h"
@@ -181,8 +182,23 @@ ds_rt_generate_core_dump (
 {
     STATIC_CONTRACT_NOTHROW;
 
-    // Eventpipe driven core_dump is not currently supported in NativeAOT
-    return DS_IPC_E_NOTSUPPORTED;
+    ds_ipc_result_t result = DS_IPC_E_FAIL;
+    uint32_t flags = ds_generate_core_dump_command_payload_get_flags(payload);
+    if (commandId == DS_DUMP_COMMANDID_GENERATE_CORE_DUMP)
+    {
+        // For the old commmand, this payload field is a bool of whether to enable logging
+        flags = flags != 0 ? GenerateDumpFlagsLoggingEnabled : 0;
+    }
+    const ep_char16_t *dumpName = ds_generate_core_dump_command_payload_get_dump_name (payload);
+    int32_t dumpType = static_cast<int32_t>(ds_generate_core_dump_command_payload_get_dump_type (payload));
+
+    extern bool ds_rt_aot_generate_core_dump (const ep_char16_t* dumpName, int32_t dumpType, uint32_t flags, ep_char8_t *errorMessageBuffer, int32_t cbErrorMessageBuffer);
+    if (ds_rt_aot_generate_core_dump(dumpName, dumpType, flags, errorMessageBuffer, cbErrorMessageBuffer))
+    {
+        result = DS_IPC_S_OK;
+    }
+
+    return 0;
 }
 
 /*

--- a/src/coreclr/nativeaot/Runtime/unix/HardwareExceptions.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/HardwareExceptions.cpp
@@ -10,6 +10,7 @@
 #include "UnixContext.h"
 #include "HardwareExceptions.h"
 #include "UnixSignals.h"
+#include "PalCreateDump.h"
 
 #if defined(HOST_APPLE)
 #include <mach/mach.h>
@@ -559,6 +560,8 @@ void SIGSEGVHandler(int code, siginfo_t *siginfo, void *context)
         // Restore the original or default handler and restart h/w exception
         RestoreSignalHandler(code, &g_previousSIGSEGV);
     }
+
+    PalCreateCrashDumpIfEnabled(code, siginfo);
 }
 
 // Handler for the SIGFPE signal
@@ -579,6 +582,8 @@ void SIGFPEHandler(int code, siginfo_t *siginfo, void *context)
         // Restore the original or default handler and restart h/w exception
         RestoreSignalHandler(code, &g_previousSIGFPE);
     }
+
+    PalCreateCrashDumpIfEnabled(code, siginfo);
 }
 
 // Initialize hardware exception handling

--- a/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <sal.h>
 #include "config.h"
+#include <pthread.h>
 #include <string.h>
 #include <assert.h>
 #include <unistd.h>

--- a/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
@@ -84,8 +84,8 @@ inline uint32_t PlatformGetCurrentThreadId() {
 #define PlatformGetCurrentThreadId() (uint32_t)pthread_self()
 #endif
 
-const size_t MaxUnsigned32BitDecString = ARRAY_SIZE("4294967295") - 1;
-const size_t MaxUnsigned64BitDecString = ARRAY_SIZE("18446744073709551615") - 1;
+const size_t MaxUnsigned32BitDecString = STRING_LENGTH("4294967295");
+const size_t MaxUnsigned64BitDecString = STRING_LENGTH("18446744073709551615");
 
 /*++
 Function:
@@ -98,7 +98,7 @@ static
 char*
 FormatInt(uint32_t value)
 {
-    char* buffer = (char*)malloc(MaxUnsigned32BitDecString);
+    char* buffer = (char*)malloc(MaxUnsigned32BitDecString + 1);
     if (buffer != nullptr)
     {
         if (snprintf(buffer, MaxUnsigned32BitDecString, "%" PRIu32, value) < 0)
@@ -121,7 +121,7 @@ static
 char*
 FormatInt64(uint64_t value)
 {
-    char* buffer = (char*)malloc(MaxUnsigned64BitDecString);
+    char* buffer = (char*)malloc(MaxUnsigned64BitDecString + 1);
     if (buffer != nullptr)
     {
         if (snprintf(buffer, MaxUnsigned64BitDecString, "%" PRIu64, value) < 0)

--- a/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
@@ -431,7 +431,7 @@ PalCreateCrashDumpIfEnabled()
 }
 
 void
-PalCreateCrashDumpIfEnabled(void* pExAddress, void* pExContext, void* triageBuffer, int triageBufferSize)
+PalCreateCrashDumpIfEnabled(void* pExceptionRecord, void* pExContext)
 {
     PalCreateCrashDumpIfEnabled(SIGABRT, nullptr);
 }

--- a/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
@@ -430,6 +430,12 @@ PalCreateCrashDumpIfEnabled()
     PalCreateCrashDumpIfEnabled(SIGABRT, nullptr);
 }
 
+void
+PalCreateCrashDumpIfEnabled(void* pExAddress, void* pExContext, void* triageBuffer, int triageBufferSize)
+{
+    PalCreateCrashDumpIfEnabled(SIGABRT, nullptr);
+}
+
 /*++
 Function:
   PalGenerateCoreDump

--- a/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
@@ -289,7 +289,9 @@ CreateCrashDump(
         {
             // Ignore any error because on some CentOS and OpenSUSE distros, it isn't
             // supported but createdump works just fine.
+#ifdef _DEBUG
             fprintf(stderr, "CreateCrashDump: prctl() FAILED %s (%d)\n", strerror(errno), errno);
+#endif
         }
 #endif // HAVE_PRCTL_H && HAVE_PR_SET_PTRACER
         close(child_pipe);
@@ -568,7 +570,7 @@ PalCreateDumpInitialize()
         if (stat(program, &fileData) == -1 || !S_ISREG(fileData.st_mode))
         {
             fprintf(stderr, "DOTNET_DbgEnableMiniDump is set and the createdump binary does not exist: %s\n", program);
-            return false;
+            return true;
         }
         g_szCreateDumpPath = program;
 

--- a/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.h
+++ b/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.h
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include <signal.h>
+
+extern bool PalCreateDumpInitialize();
+extern void PalCreateCrashDumpIfEnabled();
+extern void PalCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo);
+extern void PalCreateCrashDumpIfEnabled(void* pExAddress, void* pExContext, void* triageBuffer, int triageBufferSize);

--- a/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.h
+++ b/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.h
@@ -8,4 +8,4 @@
 extern bool PalCreateDumpInitialize();
 extern void PalCreateCrashDumpIfEnabled();
 extern void PalCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo);
-extern void PalCreateCrashDumpIfEnabled(void* pExAddress, void* pExContext, void* triageBuffer, int triageBufferSize);
+extern void PalCreateCrashDumpIfEnabled(void* pExceptionRecord, void* pExContext);

--- a/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.h
+++ b/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.h
@@ -7,5 +7,5 @@
 
 extern bool PalCreateDumpInitialize();
 extern void PalCreateCrashDumpIfEnabled();
-extern void PalCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo);
+extern void PalCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo = nullptr, void* exceptionRecord = nullptr);
 extern void PalCreateCrashDumpIfEnabled(void* pExceptionRecord, void* pExContext);

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -19,6 +19,7 @@
 #include "UnixSignals.h"
 #include "UnixContext.h"
 #include "HardwareExceptions.h"
+#include "PalCreateDump.h"
 #include "cgroupcpu.h"
 #include "threadstore.h"
 #include "thread.h"
@@ -84,9 +85,6 @@ static const int tccSecondsToNanoSeconds = 1000000000;
 static const int tccMilliSecondsToMicroSeconds = 1000;
 static const int tccMilliSecondsToNanoSeconds = 1000000;
 static const int tccMicroSecondsToNanoSeconds = 1000;
-
-extern bool PalCreateDumpInitialize();
-extern void PalCreateCrashDumpIfEnabled();
 
 extern "C" void RaiseFailFastException(PEXCEPTION_RECORD arg1, PCONTEXT arg2, uint32_t arg3)
 {

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -85,9 +85,15 @@ static const int tccMilliSecondsToMicroSeconds = 1000;
 static const int tccMilliSecondsToNanoSeconds = 1000000;
 static const int tccMicroSecondsToNanoSeconds = 1000;
 
+extern bool PalCreateDumpInitialize();
+extern void PalCreateCrashDumpIfEnabled();
+
 extern "C" void RaiseFailFastException(PEXCEPTION_RECORD arg1, PCONTEXT arg2, uint32_t arg3)
 {
-    // Abort aborts the process and causes creation of a crash dump
+    // Causes creation of a crash dump if enabled
+    PalCreateCrashDumpIfEnabled();
+
+    // Aborts the process
     abort();
 }
 
@@ -418,6 +424,11 @@ REDHAWK_PALEXPORT bool REDHAWK_PALAPI PalInit()
 #endif // !USE_PORTABLE_HELPERS
 
     ConfigureSignals();
+
+    if (!PalCreateDumpInitialize())
+    {
+        return false;
+    }
 
     GCConfig::Initialize();
 

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -1114,6 +1114,9 @@ REDHAWK_PALEXPORT void REDHAWK_PALAPI PalHijack(HANDLE hThread, _In_opt_ void* p
 
     if (status != 0)
     {
+        // Causes creation of a crash dump if enabled
+        PalCreateCrashDumpIfEnabled();
+
         // Failure to send the signal is fatal. There are only two cases when sending
         // the signal can fail. First, if the signal ID is invalid and second,
         // if the thread doesn't exist anymore.

--- a/src/coreclr/nativeaot/Runtime/unix/config.h.in
+++ b/src/coreclr/nativeaot/Runtime/unix/config.h.in
@@ -3,6 +3,8 @@
 
 #cmakedefine01 HAVE_AUXV_HWCAP_H
 
+#cmakedefine01 HAVE_PRCTL_H
+#cmakedefine01 HAVE_PR_SET_PTRACER
 #cmakedefine01 HAVE_PTHREAD_ATTR_GET_NP
 #cmakedefine01 HAVE_PTHREAD_GETATTR_NP
 #cmakedefine01 HAVE_PTHREAD_CONDATTR_SETCLOCK

--- a/src/coreclr/nativeaot/Runtime/unix/configure.cmake
+++ b/src/coreclr/nativeaot/Runtime/unix/configure.cmake
@@ -15,6 +15,10 @@ endif()
 
 list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_FILE_OFFSET_BITS=64)
 
+check_include_files("sys/prctl.h" HAVE_PRCTL_H)
+check_include_files("sys/ptrace.h" HAVE_SYS_PTRACE_H)
+check_include_files("sys/auxv.h;asm/hwcap.h" HAVE_AUXV_HWCAP_H)
+
 check_library_exists(pthread pthread_create "" HAVE_LIBPTHREAD)
 check_library_exists(c pthread_create "" HAVE_PTHREAD_IN_LIBC)
 
@@ -74,6 +78,15 @@ int main()
 
   exit(ret);
 }" HAVE_CLOCK_MONOTONIC_COARSE)
+
+check_cxx_source_compiles("
+#include <sys/prctl.h>
+
+int main(int argc, char **argv)
+{
+    int flag = (int)PR_SET_PTRACER;
+    return 0;
+}" HAVE_PR_SET_PTRACER)
 
 check_symbol_exists(
     clock_gettime_nsec_np

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -30,6 +30,12 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhGetCrashInfoBuffer")]
         internal static extern unsafe byte* RhGetCrashInfoBuffer(out int cbMaxSize);
 
+#if TARGET_UNIX
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhCreateCrashDumpIfEnabled")]
+        internal static extern void RhCreateCrashDumpIfEnabled();
+#endif
+
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetRuntimeVersion")]
         internal static extern unsafe byte* RhGetRuntimeVersion(out int cbLength);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -33,7 +33,7 @@ namespace System.Runtime
 #if TARGET_UNIX
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhCreateCrashDumpIfEnabled")]
-        internal static extern void RhCreateCrashDumpIfEnabled(IntPtr pExAddress, IntPtr pExContext, IntPtr triageBufferAddress, int triageBufferSize);
+        internal static extern void RhCreateCrashDumpIfEnabled(IntPtr pExceptionRecord, IntPtr pContextRecord);
 #endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -33,7 +33,7 @@ namespace System.Runtime
 #if TARGET_UNIX
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhCreateCrashDumpIfEnabled")]
-        internal static extern void RhCreateCrashDumpIfEnabled();
+        internal static extern void RhCreateCrashDumpIfEnabled(IntPtr pExAddress, IntPtr pExContext, IntPtr triageBufferAddress, int triageBufferSize);
 #endif
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -255,7 +255,7 @@ namespace System
 #if TARGET_WINDOWS
             Interop.Kernel32.RaiseFailFastException(errorCode, pExAddress, pExContext, triageBufferAddress, triageBufferSize);
 #else
-            RuntimeImports.RhCreateCrashDumpIfEnabled();
+            RuntimeImports.RhCreateCrashDumpIfEnabled(pExAddress, pExContext, triageBufferAddress, triageBufferSize);
             Interop.Sys.Abort();
 #endif
         }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -175,6 +175,27 @@ namespace System
             }
         }
 
+        internal const uint EXCEPTION_NONCONTINUABLE = 0x1;
+        internal const uint FAIL_FAST_GENERATE_EXCEPTION_ADDRESS = 0x1;
+        internal const uint STATUS_STACK_BUFFER_OVERRUN = 0xC0000409;
+        internal const uint FAST_FAIL_EXCEPTION_DOTNET_AOT = 0x48;
+
+#pragma warning disable 649
+        internal unsafe struct EXCEPTION_RECORD
+        {
+            internal uint ExceptionCode;
+            internal uint ExceptionFlags;
+            internal IntPtr ExceptionRecord;
+            internal IntPtr ExceptionAddress;
+            internal uint NumberParameters;
+#if TARGET_64BIT
+            internal fixed ulong ExceptionInformation[15];
+#else
+            internal fixed uint ExceptionInformation[15];
+#endif
+        }
+#pragma warning restore 649
+
         private static ulong s_crashingThreadId;
 
         [DoesNotReturn]
@@ -252,10 +273,26 @@ namespace System
                 }
             }
 
-#if TARGET_WINDOWS
-            Interop.Kernel32.RaiseFailFastException(errorCode, pExAddress, pExContext, triageBufferAddress, triageBufferSize);
+            EXCEPTION_RECORD exceptionRecord;
+            // STATUS_STACK_BUFFER_OVERRUN is a "transport" exception code required by Watson to trigger the proper analyzer/provider for bucketing
+            exceptionRecord.ExceptionCode = STATUS_STACK_BUFFER_OVERRUN;
+            exceptionRecord.ExceptionFlags = EXCEPTION_NONCONTINUABLE;
+            exceptionRecord.ExceptionRecord = IntPtr.Zero;
+            exceptionRecord.ExceptionAddress = pExAddress;
+            exceptionRecord.NumberParameters = 4;
+            exceptionRecord.ExceptionInformation[0] = FAST_FAIL_EXCEPTION_DOTNET_AOT;
+            exceptionRecord.ExceptionInformation[1] = (uint)errorCode;
+#if TARGET_64BIT
+            exceptionRecord.ExceptionInformation[2] = (ulong)triageBufferAddress;
 #else
-            RuntimeImports.RhCreateCrashDumpIfEnabled(pExAddress, pExContext, triageBufferAddress, triageBufferSize);
+            exceptionRecord.ExceptionInformation[2] = (uint)triageBufferAddress;
+#endif
+            exceptionRecord.ExceptionInformation[3] = (uint)triageBufferSize;
+
+#if TARGET_WINDOWS
+            Interop.Kernel32.RaiseFailFastException(new IntPtr(&exceptionRecord), pExContext, pExAddress == IntPtr.Zero ? FAIL_FAST_GENERATE_EXCEPTION_ADDRESS : 0);
+#else
+            RuntimeImports.RhCreateCrashDumpIfEnabled(new IntPtr(&exceptionRecord), pExContext);
             Interop.Sys.Abort();
 #endif
         }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -255,6 +255,7 @@ namespace System
 #if TARGET_WINDOWS
             Interop.Kernel32.RaiseFailFastException(errorCode, pExAddress, pExContext, triageBufferAddress, triageBufferSize);
 #else
+            RuntimeImports.RhCreateCrashDumpIfEnabled();
             Interop.Sys.Abort();
 #endif
         }

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -407,8 +407,6 @@ PALAPI
 PAL_SetCreateDumpCallback(
     IN PCREATEDUMP_CALLBACK callback); 
 
-#include <generatedumpflags.h>
-
 PALIMPORT
 BOOL
 PALAPI

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -407,15 +407,7 @@ PALAPI
 PAL_SetCreateDumpCallback(
     IN PCREATEDUMP_CALLBACK callback); 
 
-// Must be the same as the copy in excep.h and the WriteDumpFlags enum in the diagnostics repo
-enum
-{
-    GenerateDumpFlagsNone = 0x00,
-    GenerateDumpFlagsLoggingEnabled = 0x01,
-    GenerateDumpFlagsVerboseLoggingEnabled = 0x02,
-    GenerateDumpFlagsCrashReportEnabled = 0x04,
-    GenerateDumpFlagsCrashReportOnlyEnabled = 0x08
-};
+#include <generatedumpflags.h>
 
 PALIMPORT
 BOOL

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -33,6 +33,7 @@ SET_DEFAULT_DEBUG_CHANNEL(PROCESS); // some headers have code with asserts, so d
 #include "pal/stackstring.hpp"
 #include "pal/signal.hpp"
 
+#include <generatedumpflags.h>
 #include <clrconfignocache.h>
 
 #include <errno.h>

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2054,8 +2054,6 @@ PROCFormatInt64(ULONG64 value)
     return buffer;
 }
 
-static const INT UndefinedDumpType = 0;
-
 /*++
 Function
   PROCBuildCreateDumpCommandLine
@@ -2120,15 +2118,18 @@ PROCBuildCreateDumpCommandLine(
 
     switch (dumpType)
     {
-        case 1: argv.push_back("--normal");
+        case DumpTypeNormal:
+            argv.push_back("--normal");
             break;
-        case 2: argv.push_back("--withheap");
+        case DumpTypeWithHeap:
+            argv.push_back("--withheap");
             break;
-        case 3: argv.push_back("--triage");
+        case DumpTypeTriage:
+            argv.push_back("--triage");
             break;
-        case 4: argv.push_back("--full");
+        case DumpTypeFull:
+            argv.push_back("--full");
             break;
-        case UndefinedDumpType:
         default:
             break;
     }
@@ -2322,13 +2323,13 @@ PROCAbortInitialize()
         const char* logFilePath = dmpLogToFileCfg.IsSet() ? dmpLogToFileCfg.AsString() : nullptr;
 
         CLRConfigNoCache dmpTypeCfg = CLRConfigNoCache::Get("DbgMiniDumpType", /*noprefix*/ false, &getenv);
-        DWORD dumpType = UndefinedDumpType;
+        DWORD dumpType = DumpTypeUnknown;
         if (dmpTypeCfg.IsSet())
         {
             (void)dmpTypeCfg.TryAsInteger(10, dumpType);
-            if (dumpType < 1 || dumpType > 4)
+            if (dumpType <= DumpTypeUnknown || dumpType > DumpTypeMax)
             {
-                dumpType = UndefinedDumpType;
+                dumpType = DumpTypeUnknown;
             }
         }
 
@@ -2399,7 +2400,7 @@ PAL_GenerateCoreDump(
 {
     std::vector<const char*> argvCreateDump;
 
-    if (dumpType < 1 || dumpType > 4)
+    if (dumpType <= DumpTypeUnknown || dumpType > DumpTypeMax)
     {
         return FALSE;
     }

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -10,6 +10,7 @@
 #ifdef ENABLE_PERFTRACING
 #include "ep-rt-coreclr.h"
 #include <clrconfignocache.h>
+#include <generatedumpflags.h>
 #include <eventpipe/ds-process-protocol.h>
 #include <eventpipe/ds-profiler-protocol.h>
 #include <eventpipe/ds-dump-protocol.h>

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -194,17 +194,7 @@ enum UnhandledExceptionLocation
 };
 
 #ifdef HOST_WINDOWS
-
-// Must be the same as the copy in pal.h and the WriteDumpFlags enum in the diagnostics repo
-enum
-{
-    GenerateDumpFlagsNone = 0x00,
-    GenerateDumpFlagsLoggingEnabled = 0x01,
-    GenerateDumpFlagsVerboseLoggingEnabled = 0x02,
-    GenerateDumpFlagsCrashReportEnabled = 0x04,
-    GenerateDumpFlagsCrashReportOnlyEnabled = 0x08
-};
-
+#include <generatedumpflags.h>
 void InitializeCrashDump();
 void CreateCrashDumpIfEnabled(bool stackoverflow = false);
 #endif

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -10,6 +10,7 @@
  *
  */
 
+#include <generatedumpflags.h>
 #include "gcrefmap.h"
 
 void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.RaiseFailFastException.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.RaiseFailFastException.cs
@@ -3,68 +3,14 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
-#pragma warning disable 649
-    internal unsafe struct EXCEPTION_RECORD
-    {
-        internal uint ExceptionCode;
-        internal uint ExceptionFlags;
-        internal IntPtr ExceptionRecord;
-        internal IntPtr ExceptionAddress;
-        internal uint NumberParameters;
-#if TARGET_64BIT
-        internal fixed ulong ExceptionInformation[15];
-#else
-        internal fixed uint ExceptionInformation[15];
-#endif
-    }
-#pragma warning restore 649
-
     internal partial class Kernel32
     {
-        private const uint EXCEPTION_NONCONTINUABLE = 0x1;
-        private const uint FAIL_FAST_GENERATE_EXCEPTION_ADDRESS = 0x1;
-        private const uint STATUS_STACK_BUFFER_OVERRUN = 0xC0000409;
-        private const uint FAST_FAIL_EXCEPTION_DOTNET_AOT = 0x48;
-
-        //
-        // NativeAOT wrapper for calling RaiseFailFastException
-        //
-
-        [DoesNotReturn]
-        internal static unsafe void RaiseFailFastException(int errorCode, IntPtr pExAddress, IntPtr pExContext, IntPtr pTriageBuffer, int cbTriageBuffer)
-        {
-            EXCEPTION_RECORD exceptionRecord;
-            // STATUS_STACK_BUFFER_OVERRUN is a "transport" exception code required by Watson to trigger the proper analyzer/provider for bucketing
-            exceptionRecord.ExceptionCode = STATUS_STACK_BUFFER_OVERRUN;
-            exceptionRecord.ExceptionFlags = EXCEPTION_NONCONTINUABLE;
-            exceptionRecord.ExceptionRecord = IntPtr.Zero;
-            exceptionRecord.ExceptionAddress = pExAddress;
-            exceptionRecord.NumberParameters = 4;
-            exceptionRecord.ExceptionInformation[0] = FAST_FAIL_EXCEPTION_DOTNET_AOT;
-            exceptionRecord.ExceptionInformation[1] = (uint)errorCode;
-#if TARGET_64BIT
-            exceptionRecord.ExceptionInformation[2] = (ulong)pTriageBuffer;
-#else
-            exceptionRecord.ExceptionInformation[2] = (uint)pTriageBuffer;
-#endif
-            exceptionRecord.ExceptionInformation[3] = (uint)cbTriageBuffer;
-
-            RaiseFailFastException(
-                &exceptionRecord,
-                pExContext,
-                pExAddress == IntPtr.Zero ? FAIL_FAST_GENERATE_EXCEPTION_ADDRESS : 0);
-        }
-
         [LibraryImport(Libraries.Kernel32, EntryPoint = "RaiseFailFastException")]
         [DoesNotReturn]
-        private static unsafe partial void RaiseFailFastException(
-            EXCEPTION_RECORD* pExceptionRecord,
-            IntPtr pContextRecord,
-            uint dwFlags);
+        public static unsafe partial void RaiseFailFastException(IntPtr pExceptionRecord, IntPtr pContextRecord, uint dwFlags);
     }
 }

--- a/src/native/inc/clrconfignocache.h
+++ b/src/native/inc/clrconfignocache.h
@@ -7,7 +7,7 @@
 // Logic for resolving configuration names.
 //
 
-#include<minipal/utils.h>
+#include <minipal/utils.h>
 
 // Config prefixes
 #define COMPLUS_PREFIX_A "COMPlus_"
@@ -23,30 +23,30 @@ class CLRConfigNoCache
     const char* _value;
 
     CLRConfigNoCache() = default;
-    CLRConfigNoCache(LPCSTR cfg) : _value { cfg }
+    CLRConfigNoCache(const char* cfg) : _value { cfg }
     { }
 
 public:
     bool IsSet() const { return _value != NULL; }
 
-    LPCSTR AsString() const
+    const char* AsString() const
     {
         _ASSERTE(IsSet());
         return _value;
     }
 
-    bool TryAsInteger(int radix, DWORD& result) const
+    bool TryAsInteger(int radix, uint32_t& result) const
     {
         _ASSERTE(IsSet());
 
         errno = 0;
-        LPSTR endPtr;
+        char* endPtr;
         result = strtoul(_value, &endPtr, radix);
         bool fSuccess = (errno != ERANGE) && (endPtr != _value);
         return fSuccess;
     }
 
-    static CLRConfigNoCache Get(LPCSTR cfg, bool noPrefix = false, char*(*getEnvFptr)(const char*) = nullptr)
+    static CLRConfigNoCache Get(const char* cfg, bool noPrefix = false, char*(*getEnvFptr)(const char*) = nullptr)
     {
         char nameBuffer[64];
         const char* fallbackPrefix = NULL;
@@ -73,17 +73,17 @@ public:
             }
 
             // Priority order is DOTNET_ and then COMPlus_.
-            strcpy_s(nameBuffer, ARRAY_SIZE(nameBuffer), DOTNET_PREFIX_A);
+            strcpy(nameBuffer, DOTNET_PREFIX_A);
             fallbackPrefix = COMPLUS_PREFIX_A;
         }
 
-        strcat_s(nameBuffer, ARRAY_SIZE(nameBuffer), cfg);
+        strcat(nameBuffer, cfg);
 
-        LPCSTR val = getEnvFptr != NULL ? getEnvFptr(nameBuffer) : getenv(nameBuffer);
+        const char* val = getEnvFptr != NULL ? getEnvFptr(nameBuffer) : getenv(nameBuffer);
         if (val == NULL && fallbackPrefix != NULL)
         {
-            strcpy_s(nameBuffer, ARRAY_SIZE(nameBuffer), fallbackPrefix);
-            strcat_s(nameBuffer, ARRAY_SIZE(nameBuffer), cfg);
+            strcpy(nameBuffer, fallbackPrefix);
+            strcat(nameBuffer, cfg);
             val = getEnvFptr != NULL ? getEnvFptr(nameBuffer) : getenv(nameBuffer);
         }
 

--- a/src/native/inc/generatedumpflags.h
+++ b/src/native/inc/generatedumpflags.h
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+// --------------------------------------------------------------------------------------------------
+// generatedumpflags.h
+//
+// Dump generation flags
+//
+// Must be the same as the WriteDumpFlags enum in the diagnostics repo
+
+#pragma once
+
+enum GenerateDumpFlags
+{
+    GenerateDumpFlagsNone = 0x00,
+    GenerateDumpFlagsLoggingEnabled = 0x01,
+    GenerateDumpFlagsVerboseLoggingEnabled = 0x02,
+    GenerateDumpFlagsCrashReportEnabled = 0x04,
+    GenerateDumpFlagsCrashReportOnlyEnabled = 0x08
+};

--- a/src/native/inc/generatedumpflags.h
+++ b/src/native/inc/generatedumpflags.h
@@ -6,10 +6,10 @@
 //
 // Dump generation flags
 //
-// Must be the same as the WriteDumpFlags enum in the diagnostics repo
 
 #pragma once
 
+// Must be the same as the WriteDumpFlags enum in the diagnostics repo
 enum GenerateDumpFlags
 {
     GenerateDumpFlagsNone = 0x00,
@@ -17,4 +17,15 @@ enum GenerateDumpFlags
     GenerateDumpFlagsVerboseLoggingEnabled = 0x02,
     GenerateDumpFlagsCrashReportEnabled = 0x04,
     GenerateDumpFlagsCrashReportOnlyEnabled = 0x08
+};
+
+// Must be the same as the DumpType enum in the diagnostics repo
+enum DumpType
+{
+    DumpTypeUnknown = 0,
+    DumpTypeNormal = 1,
+    DumpTypeWithHeap = 2,
+    DumpTypeTriage = 3,
+    DumpTypeFull = 4,
+    DumpTypeMax = 4
 };


### PR DESCRIPTION
Port the .NET Core createdump fork/exec code to NativeAOT.

Add src/native/inc/generatedumpflags.h. Remove dup definitions of this enum.

Move and port clrconfignocache.h from src/coreclr/inc to src/native/inc (added the "inc" directory to native).

Is the clrconfignocache.h ok in src/native/inc? It being C++ code.  

Should I move PalCreateDump.cpp from the src/coreclr/native/Runtime dir to src/native and do the work now in the .NET Core PAL to use this (mostly) common code?