### PR TITLE
Reduce ProbabilisticWithAsciiCharSearchValues overhead on non-ASCII texts

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
@@ -40,7 +40,9 @@ namespace System.Buffers
         {
             int offset = 0;
 
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count)
+            // We check whether the first character is ASCII before calling into IndexOfAnyAsciiSearcher
+            // in order to minimize the overhead this fast-path has on non-ASCII texts.
+            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count && char.IsAscii(span[0]))
             {
                 // We are using IndexOfAnyAsciiSearcher to search for the first ASCII character in the set, or any non-ASCII character.
                 // We do this by inverting the bitmap and using the opposite search function (Negate instead of DontNegate).
@@ -100,7 +102,9 @@ namespace System.Buffers
         {
             int offset = 0;
 
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count)
+            // We check whether the first character is ASCII before calling into IndexOfAnyAsciiSearcher
+            // in order to minimize the overhead this fast-path has on non-ASCII texts.
+            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count && char.IsAscii(span[0]))
             {
                 // Do a regular IndexOfAnyExcept for the ASCII characters. The search will stop if we encounter a non-ASCII char.
                 offset = IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, TOptimizations>(
@@ -134,7 +138,9 @@ namespace System.Buffers
 
         internal override int LastIndexOfAny(ReadOnlySpan<char> span)
         {
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count)
+            // We check whether the last character is ASCII before calling into IndexOfAnyAsciiSearcher
+            // in order to minimize the overhead this fast-path has on non-ASCII texts.
+            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count && char.IsAscii(span[^1]))
             {
                 // We are using IndexOfAnyAsciiSearcher to search for the last ASCII character in the set, or any non-ASCII character.
                 // We do this by inverting the bitmap and using the opposite search function (Negate instead of DontNegate).
@@ -186,7 +192,9 @@ namespace System.Buffers
 
         internal override int LastIndexOfAnyExcept(ReadOnlySpan<char> span)
         {
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count)
+            // We check whether the last character is ASCII before calling into IndexOfAnyAsciiSearcher
+            // in order to minimize the overhead this fast-path has on non-ASCII texts.
+            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count && char.IsAscii(span[^1]))
             {
                 // Do a regular LastIndexOfAnyExcept for the ASCII characters. The search will stop if we encounter a non-ASCII char.
                 int offset = IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, TOptimizations>(


### PR DESCRIPTION
Small followup after #89155, it looks like checking one character first is a good tradeoff here.

|             Method | Toolchain | NewLineFrequency | Length | AsciiText |      Mean |     Error | Ratio |
|------------------- |---------- |----------------- |------- |---------- |----------:|----------:|------:|
| ReplaceLineEndings |      main |              0.1 |  10000 |     False | 14.030 us | 0.2180 us |  1.00 |
| ReplaceLineEndings |        pr |              0.1 |  10000 |     False | 21.557 us | 0.0933 us |  1.54 |
| ReplaceLineEndings |       pr2 |              0.1 |  10000 |     False | 15.030 us | 0.0738 us |  1.07 |
|                    |           |                  |        |           |           |           |       |
| ReplaceLineEndings |      main |              0.1 |  10000 |      True | 16.548 us | 0.0696 us |  1.00 |
| ReplaceLineEndings |        pr |              0.1 |  10000 |      True |  8.871 us | 0.0254 us |  0.54 |
| ReplaceLineEndings |       pr2 |              0.1 |  10000 |      True |  9.019 us | 0.0361 us |  0.55 |
