### PR TITLE
[mono][interp] Add lock when allocating from method mempool

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -1286,10 +1286,15 @@ compute_arg_offset (MonoMethodSignature *sig, int index)
 static gpointer
 imethod_alloc0 (InterpMethod *imethod, size_t size)
 {
-	if (imethod->method->dynamic)
-		return mono_mempool_alloc0 (((MonoDynamicMethod*)imethod->method)->mp, (guint)size);
-	else
+	if (imethod->method->dynamic) {
+		MonoJitMemoryManager *jit_mm = get_default_jit_mm ();
+		jit_mm_lock (jit_mm);
+		gpointer ret = mono_mempool_alloc0 (((MonoDynamicMethod*)imethod->method)->mp, (guint)size);
+		jit_mm_unlock (jit_mm);
+		return ret;
+	} else {
 		return m_method_alloc0 (imethod->method, (guint)size);
+	}
 }
 
 static guint32*

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -1290,10 +1290,15 @@ interp_get_icall_sig (MonoMethodSignature *sig);
 static gpointer
 imethod_alloc0 (TransformData *td, size_t size)
 {
-	if (td->rtm->method->dynamic)
-		return mono_mempool_alloc0 (((MonoDynamicMethod*)td->rtm->method)->mp, (guint)size);
-	else
+	if (td->rtm->method->dynamic) {
+		MonoJitMemoryManager *jit_mm = get_default_jit_mm ();
+		jit_mm_lock (jit_mm);
+		gpointer ret = mono_mempool_alloc0 (((MonoDynamicMethod*)td->rtm->method)->mp, (guint)size);
+		jit_mm_unlock (jit_mm);
+		return ret;
+	} else {
 		return mono_mem_manager_alloc0 (td->mem_manager, (guint)size);
+	}
 }
 
 static void


### PR DESCRIPTION
MonoMemPool does not support multithreaded allocation. We lock on default jit_mm lock for convenience, since it is widely used in interpreter. We might want to consider using a separate lock.