### PR TITLE
[Android] Enable skipped networking tests

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -203,11 +203,6 @@ namespace System.Net.Http.Functional.Tests
 
             var options = new GenericLoopbackOptions { Address = address };
 
-            if (PlatformDetection.IsAndroid && options.UseSsl && address == IPAddress.IPv6Loopback)
-            {
-                throw new SkipTestException("TargetHost cannot be set to an IPv6 address on Android because the string doesn't conform to the STD 3 ASCII rules");
-            }
-
             await LoopbackServerFactory.CreateServerAsync(async (server, url) =>
             {
                 _output.WriteLine(url.ToString());
@@ -284,11 +279,6 @@ namespace System.Net.Http.Functional.Tests
             {
                 // Host header is not supported on HTTP/2 and later.
                 return;
-            }
-
-            if (PlatformDetection.IsAndroid && useSsl && address == IPAddress.IPv6Loopback)
-            {
-                throw new SkipTestException("TargetHost cannot be set to an IPv6 address on Android because the string doesn't conform to the STD 3 ASCII rules");
             }
 
             var options = new LoopbackServer.Options { Address = address, UseSsl = useSsl };

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocksProxyTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocksProxyTest.cs
@@ -35,11 +35,6 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            if (PlatformDetection.IsAndroid && useSsl && host == "::1")
-            {
-                throw new SkipTestException("TargetHost cannot be set to an IPv6 address on Android because the string doesn't conform to the STD 3 ASCII rules");
-            }
-
             await LoopbackServerFactory.CreateClientAndServerAsync(
                 async uri =>
                 {


### PR DESCRIPTION
Closes #79143

There is no need to skip these tests on Android anymore.