### PR TITLE
Workaround a C++/CLI bug involving DIMs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs
@@ -27,7 +27,7 @@ namespace System.Numerics
           ISubtractionOperators<TSelf, TSelf, TSelf>,
           IUnaryPlusOperators<TSelf, TSelf>,
           IUnaryNegationOperators<TSelf, TSelf>,
-          IUtf8SpanFormattable,
+          // IUtf8SpanFormattable,
           IUtf8SpanParsable<TSelf>
         where TSelf : INumberBase<TSelf>?
     {
@@ -457,7 +457,9 @@ namespace System.Numerics
             return succeeded;
         }
 
-        bool IUtf8SpanFormattable.TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+        // Workaround devdiv/#1851707: C++/CLI fails to compile when encountering a Default Interface Method implemented in a derived interface
+        // bool IUtf8SpanFormattable.TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+        bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
         {
             char[]? utf16DestinationArray;
             scoped Span<char> utf16Destination;

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10799,7 +10799,7 @@ namespace System.Numerics
         static virtual TResult operator checked *(TSelf left, TOther right) { throw null; }
         static abstract TResult operator *(TSelf left, TOther right);
     }
-    public partial interface INumberBase<TSelf> : System.IEquatable<TSelf>, System.IFormattable, System.IParsable<TSelf>, System.ISpanFormattable, System.ISpanParsable<TSelf>, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf, bool>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf>, System.IUtf8SpanFormattable, System.IUtf8SpanParsable<TSelf> where TSelf : System.Numerics.INumberBase<TSelf>?
+    public partial interface INumberBase<TSelf> : System.IEquatable<TSelf>, System.IFormattable, System.IParsable<TSelf>, System.ISpanFormattable, System.ISpanParsable<TSelf>, System.Numerics.IAdditionOperators<TSelf, TSelf, TSelf>, System.Numerics.IAdditiveIdentity<TSelf, TSelf>, System.Numerics.IDecrementOperators<TSelf>, System.Numerics.IDivisionOperators<TSelf, TSelf, TSelf>, System.Numerics.IEqualityOperators<TSelf, TSelf, bool>, System.Numerics.IIncrementOperators<TSelf>, System.Numerics.IMultiplicativeIdentity<TSelf, TSelf>, System.Numerics.IMultiplyOperators<TSelf, TSelf, TSelf>, System.Numerics.ISubtractionOperators<TSelf, TSelf, TSelf>, System.Numerics.IUnaryNegationOperators<TSelf, TSelf>, System.Numerics.IUnaryPlusOperators<TSelf, TSelf>, /* System.IUtf8SpanFormattable, */ System.IUtf8SpanParsable<TSelf> where TSelf : System.Numerics.INumberBase<TSelf>?
     {
         static abstract TSelf One { get; }
         static abstract int Radix { get; }
@@ -10841,7 +10841,9 @@ namespace System.Numerics
         static virtual TSelf Parse(System.ReadOnlySpan<byte> utf8Text, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
         static abstract TSelf Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider);
         static abstract TSelf Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider);
-        bool System.IUtf8SpanFormattable.TryFormat(System.Span<byte> utf8Destination, out int bytesWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
+        // Workaround devdiv/#1851707: C++/CLI fails to compile when encountering a Default Interface Method implemented in a derived interface
+        // bool System.IUtf8SpanFormattable.TryFormat(System.Span<byte> utf8Destination, out int bytesWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
+        bool TryFormat(System.Span<byte> utf8Destination, out int bytesWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
         static TSelf System.IUtf8SpanParsable<TSelf>.Parse(System.ReadOnlySpan<byte> utf8Text, System.IFormatProvider? provider) { throw null; }
         static bool System.IUtf8SpanParsable<TSelf>.TryParse(System.ReadOnlySpan<byte> utf8Text, System.IFormatProvider? provider, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out TSelf result) { throw null; }
         protected static abstract bool TryConvertFromChecked<TOther>(TOther value, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out TSelf result)
@@ -11320,7 +11322,7 @@ namespace System.Reflection
         public object? Invoke(object? arg1, object? arg2, object? arg3) { throw null; }
         public object? Invoke(object? arg1, object? arg2, object? arg3, object? arg4) { throw null; }
         public static System.Reflection.ConstructorInvoker Create(System.Reflection.ConstructorInfo constructor) { throw null; }
-    }    
+    }
     public partial class CustomAttributeData
     {
         protected CustomAttributeData() { }


### PR DESCRIPTION
As per the title there is currently a C++/CLI bug involving implementing an instance DIM on a derived interface. This causes C++/CLI to error when using any type that implements such an interface, which in the case of `System.Numerics.INumberBase<TSelf>` includes all the primitive types (such as `Int32` or `Single`).

There were a few possible changes that would temporarily resolve this issue...

1. This change, where we stop implementing the interface but keep exposing the general functionality on the interface until we can revert.
2. We could have updated `IUtf8SpanFormattable` to have a DIM where it always throws `PlatformNotSupportedException`, but this could lead to unexpected behavior for consumers of the API
3. We could have updated `IUtf8SpanFormattable` to have a DIM where it always returns `false`, but this risks users naively doing the wrong thing and trying to grow the buffer and call the API repeatedly as that's how the other `TryFormat` APIs work
4. We could have updated `IUtf8SpanFormattable` to inherit from `ISpanFormattable` and have a DIM where it defers to that implementation

Of these options, 1 or 4 are the least risky.

4 would end up changing the shipping API surface and would not require a reversion later. It has the downside in that it requires everyone implementing `IUtf8SpanFormattable` to also support `ISpanFormattable` (that is `UTF-16`). This puts more restriction on the API surface overall. That being said, it is the better option if we believe that the C++/CLI fix will not make the .NET 8 release as avoids us introducing a diamond problem in the future as the DIM is provided in the same release that the relevant interface and API are defined.

1 (this change) will require us to revert this PR once the C++/CLI fix goes in. Not reverting this workaround will result in `INumberBase<TSelf>` not being able to implement `IUtf8SpanFormattable` without risking the introduction of a diamond problem, since other types/interfaces could implement `IUtf8SpanFormattable` with a DIM before the .NET 9 release.