### PR TITLE
Use managed NTLM/SPNEGO on Apple platforms by default

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
@@ -19,7 +19,10 @@ namespace System.Net
 {
     internal partial class NegotiateAuthenticationPal
     {
-        private static bool UseManagedNtlm { get; } = AppContext.TryGetSwitch("System.Net.Security.UseManagedNtlm", out bool useManagedNtlm) && useManagedNtlm;
+        private static bool UseManagedNtlm { get; } =
+            AppContext.TryGetSwitch("System.Net.Security.UseManagedNtlm", out bool useManagedNtlm) ?
+            useManagedNtlm :
+            OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsMacCatalyst();
 
         public static NegotiateAuthenticationPal Create(NegotiateAuthenticationClientOptions clientOptions)
         {

--- a/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Security;
 using System.Net.Test.Common;
@@ -148,15 +149,23 @@ namespace System.Net.Security.Tests
             Assert.False(fakeNtlmServer.IsMICPresent);
         }
 
-        [ConditionalFact(nameof(IsNtlmAvailable))]
-        public void NtlmCorrectExchangeTest()
+        public static IEnumerable<object[]> TestCredentials()
         {
-            using FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(s_testCredentialRight);
+            yield return new object[] { new NetworkCredential("rightusername", "rightpassword") };
+            yield return new object[] { new NetworkCredential("rightusername", "rightpassword", "rightdomain") };
+            yield return new object[] { new NetworkCredential("rightusername@rightdomain.com", "rightpassword") };
+        } 
+
+        [ConditionalTheory(nameof(IsNtlmAvailable))]
+        [MemberData(nameof(TestCredentials))]
+        public void NtlmCorrectExchangeTest(NetworkCredential credential)
+        {
+            using FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(credential);
             NegotiateAuthentication ntAuth = new NegotiateAuthentication(
                 new NegotiateAuthenticationClientOptions
                 {
                     Package = "NTLM",
-                    Credential = s_testCredentialRight,
+                    Credential = credential,
                     TargetName = "HTTP/foo",
                     RequiredProtectionLevel = ProtectionLevel.Sign
                 });
@@ -191,7 +200,6 @@ namespace System.Net.Security.Tests
         }
 
         [ConditionalFact(nameof(IsNtlmAvailable))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/65678", TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst)]
         public void NtlmSignatureTest()
         {
             using FakeNtlmServer fakeNtlmServer = new FakeNtlmServer(s_testCredentialRight);


### PR DESCRIPTION
Apple implementation of NTLM has two major compatibility issues:
- It always splits user name by `@` into name and domain. Unfortunately this has different semantics on the wire. It may work in some cases, but it fails when the NTLM is relayed to directory controller with different name, and for long user names. Issue #82547.
- NTLM signatures are generated incorrectly and can cause buffer overflows. Issue #65678.

Let's try to use the managed NTLM implementation on Apple platforms now that we can support it with Kerberos at the same time. There's still an opt-out through setting `UseManagedNtlm` app context switch to `false`.

Fixes #65678
Fixes #82547