### PR TITLE
Add missing translations to HashAlgorithmNames

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashAlgorithmNames.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashAlgorithmNames.cs
@@ -13,7 +13,6 @@ namespace System.Security.Cryptography
         public const string SHA256 = "SHA256";
         public const string SHA384 = "SHA384";
         public const string SHA512 = "SHA512";
-
         public const string SHA3_256 = "SHA3-256";
         public const string SHA3_384 = "SHA3-384";
         public const string SHA3_512 = "SHA3-512";
@@ -35,6 +34,12 @@ namespace System.Security.Cryptography
                 return HashAlgorithmNames.SHA384;
             if (hashAlgorithm is SHA512)
                 return HashAlgorithmNames.SHA512;
+            if (hashAlgorithm is SHA3_256)
+                return HashAlgorithmNames.SHA3_256;
+            if (hashAlgorithm is SHA3_384)
+                return HashAlgorithmNames.SHA3_384;
+            if (hashAlgorithm is SHA3_512)
+                return HashAlgorithmNames.SHA3_512;
             if (hashAlgorithm is MD5)
                 return HashAlgorithmNames.MD5;
 
@@ -65,6 +70,21 @@ namespace System.Security.Cryptography
             if (hashAlgorithmName.Equals(SHA1, StringComparison.OrdinalIgnoreCase))
             {
                 return SHA1;
+            }
+
+            if (hashAlgorithmName.Equals(SHA3_256, StringComparison.OrdinalIgnoreCase))
+            {
+                return SHA3_256;
+            }
+
+            if (hashAlgorithmName.Equals(SHA3_384, StringComparison.OrdinalIgnoreCase))
+            {
+                return SHA3_384;
+            }
+
+            if (hashAlgorithmName.Equals(SHA3_512, StringComparison.OrdinalIgnoreCase))
+            {
+                return SHA3_512;
             }
 
             if (hashAlgorithmName.Equals(MD5, StringComparison.OrdinalIgnoreCase))

--- a/src/libraries/System.Security.Cryptography/tests/HashAlgorithmNamesTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HashAlgorithmNamesTests.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+    public static class HashAlgorithmNamesTests
+    {
+        [Theory]
+        [MemberData(nameof(ValidInputs))]
+        public static void ToUpper_UnchangedValidInput(string hashAlgorithmName)
+        {
+            string actual = HashAlgorithmNames.ToUpper(hashAlgorithmName);
+            Assert.Equal(hashAlgorithmName, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidInputs))]
+        public static void ToUpper_FixesLoweredValidInput(string hashAlgorithmName)
+        {
+            string actual = HashAlgorithmNames.ToUpper(hashAlgorithmName.ToLowerInvariant());
+            Assert.Equal(hashAlgorithmName, actual);
+        }
+
+        [Fact]
+        public static void ToUpper_UnchangedFromInvalidInput()
+        {
+            string unsupported = UnsupportedHashAlgorithm.ID.ToLowerInvariant();
+            string actual = HashAlgorithmNames.ToUpper(unsupported);
+            Assert.Equal(unsupported, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidInputs))]
+        public static void ToAlgorithmName_ValidInput(string hashAlgorithmName)
+        {
+            bool hashSupported = HashProviderDispenser.HashSupported(hashAlgorithmName);
+
+            if (hashSupported)
+            {
+                using (HashAlgorithm hashAlgorithm = CreateHashAlgorithm(hashAlgorithmName));
+                string actual = HashAlgorithmNames.ToAlgorithmName(hashAlgorithm);
+                Assert.Equal(hashAlgorithmName, actual);
+            }
+        }
+
+        [Fact]
+        public static void ToAlgorithmName_ToStringUnknownInput()
+        {
+            using (HashAlgorithm hashAlgorithm = CreateHashAlgorithm(UnsupportedHashAlgorithm.ID));
+            string actual = HashAlgorithmNames.ToAlgorithmName(hashAlgorithm);
+            Assert.Equal(UnsupportedHashAlgorithm.Name, actual);
+        }
+
+        private static HashAlgorithm CreateHashAlgorithm(string hashAlgorithmName)
+        {
+            return hashAlgorithmName switch
+            {
+                HashAlgorithmNames.MD5 => MD5.Create(),
+                HashAlgorithmNames.SHA1 => SHA1.Create(),
+                HashAlgorithmNames.SHA256 => SHA256.Create(),
+                HashAlgorithmNames.SHA384 => SHA384.Create(),
+                HashAlgorithmNames.SHA512 => SHA512.Create(),
+                HashAlgorithmNames.SHA3_256 => SHA3_256.Create(),
+                HashAlgorithmNames.SHA3_384 => SHA3_384.Create(),
+                HashAlgorithmNames.SHA3_512 => SHA3_512.Create(),
+                _ => new UnsupportedHashAlgorithm()
+            };
+        }
+
+        public static IEnumerable<object[]> ValidInputs
+        {
+            get
+            {
+                yield return new object[] { HashAlgorithmNames.MD5 };
+                yield return new object[] { HashAlgorithmNames.SHA1 };
+                yield return new object[] { HashAlgorithmNames.SHA256 };
+                yield return new object[] { HashAlgorithmNames.SHA384 };
+                yield return new object[] { HashAlgorithmNames.SHA512 };
+                yield return new object[] { HashAlgorithmNames.SHA3_256 };
+                yield return new object[] { HashAlgorithmNames.SHA3_384 };
+                yield return new object[] { HashAlgorithmNames.SHA3_512 };
+            }
+        }
+
+        private class UnsupportedHashAlgorithm : HashAlgorithm
+        {
+            public static const string Name = typeof(UnsupportedHashAlgorithm).ToString();
+            public static const string ID = "UNKNOWN";
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -251,6 +251,7 @@
     <Compile Include="ECDsaTests.cs" />
     <Compile Include="ECPemExportTests.cs" />
     <Compile Include="FixedTimeEqualsTests.cs" />
+    <Compile Include="HashAlgorithmNamesTests.cs" />
     <Compile Include="HashAlgorithmNameTests.cs" />
     <Compile Include="HashAlgorithmTest.cs" />
     <Compile Include="HashAlgorithmTestDriver.cs" />


### PR DESCRIPTION
In PR #84132, the addition of SHA3 variants to the HashAlgorithmNames was incomplete, leaving out the explicit handling of the SHA3 variants from the two helper methods:
  - `ToUpper()` - Would just return the name **unchanged** (which is likely wrong as it would allow _sha3-256_ through instead of uppercasing to _SHA3-256_. That's probably wrong.
- `ToAlgorithmName()` - Would return the `ToString()` on the supplied `hashAlgorithm` instance, which would be the classname of the argument `hashAlgorithm` (e.g. `"System.Security.Cryptography.SHA3_256"`). That would not match the expectation of `"SHA3-256"` based on the other instances.
I am not sure how important these are, or if they should be wrapped in a `#if NET8_0_OR_GREATER` wrapper (only some of the new SHA3 stuff was wrapped in that PR)
