### PR TITLE
Delete NativeAOT_StaticInitialization

### DIFF
--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -236,11 +236,4 @@ static struct InitializeRuntimePointerHelper
         RhSetRuntimeInitializationCallback(&InitializeRuntime);
     }
 } initializeRuntimePointerHelper;
-
-extern "C" void* NativeAOT_StaticInitialization();
-
-void* NativeAOT_StaticInitialization()
-{
-    return &initializeRuntimePointerHelper;
-}
 #endif // NATIVEAOT_DLL

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -143,7 +143,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-Wl,-z,relro" Condition="'$(_IsApplePlatform)' != 'true'" />
       <!-- binskim warning BA3011 The BIND_NOW flag is missing -->
       <LinkerArg Include="-Wl,-z,now" Condition="'$(_IsApplePlatform)' != 'true'" />
-      <LinkerArg Include="-Wl,-u,$(_SymbolPrefix)NativeAOT_StaticInitialization" Condition="'$(NativeLib)' == 'Shared' or '$(CustomNativeMain)' == 'true'" />
       <!-- this workaround can be deleted once the minimum supported glibc version
            (runtime's official build machine's glibc version) is at least 2.33
            see https://github.com/bminor/glibc/commit/99468ed45f5a58f584bab60364af937eb6f8afda -->

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -89,7 +89,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="/INCREMENTAL:NO" />
       <LinkerArg Condition="'$(LinkerSubsystem)' != ''" Include="/SUBSYSTEM:$(LinkerSubsystem)" />
       <LinkerArg Condition="'$(OutputType)' == 'WinExe' or '$(OutputType)' == 'Exe'" Include="/ENTRY:$(EntryPointSymbol) /NOEXP /NOIMPLIB" />
-      <LinkerArg Condition="'$(NativeLib)' == 'Shared' or '$(CustomNativeMain)' == 'true'" Include="/INCLUDE:NativeAOT_StaticInitialization" />
       <LinkerArg Include="/NATVIS:&quot;$(MSBuildThisFileDirectory)NativeAOT.natvis&quot;" />
       <LinkerArg Condition="'$(ControlFlowGuard)' == 'Guard'" Include="/guard:cf" />
     </ItemGroup>


### PR DESCRIPTION
Undoes workaround from dotnet/runtimelab#270. Since bootstrapper no longer ships as a static library (as of #74623 it's an object file instead), we should no longer need this hack to force linker into looking at the archive.

Cc @dotnet/ilc-contrib 