### PR TITLE
[NativeAOT] Refactor System.Linq.Expressions feature switches

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -41,6 +41,13 @@ The .NET Foundation licenses this file to you under the MIT license.
     <DynamicCodeSupport Condition="'$(DynamicCodeSupport)' == ''">false</DynamicCodeSupport>
   </PropertyGroup>
 
+  <!-- Configure LINQ expressions -->
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Linq.Expressions.CanEmitObjectArrayDelegate"
+                                    Value="false"
+                                    Trim="true" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(SuppressAotAnalysisWarnings)' == 'true'">
     <EnableAotAnalyzer Condition="'$(EnableAotAnalyzer)' == ''">false</EnableAotAnalyzer>
   </PropertyGroup>
@@ -273,11 +280,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="@(UnmanagedEntryPointsAssembly->'--generateunmanagedentrypoints:%(Identity)')" />
 
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--feature:System.Reflection.IsReflectionExecutionAvailable=false" />
-
-      <!-- Configure LINQ expressions - disable Emit everywhere -->
-      <IlcArg Include="--feature:System.Linq.Expressions.CanCompileToIL=false" />
-      <IlcArg Include="--feature:System.Linq.Expressions.CanEmitObjectArrayDelegate=false" />
-      <IlcArg Include="--feature:System.Linq.Expressions.CanCreateArbitraryDelegates=false" />
 
       <!-- Linux Bionic doesn't ship GSSAPI, so enable managed implementation -->
       <IlcArg Condition="'$(_linuxLibcFlavor)' == 'bionic'" Include="--feature:System.Net.Security.UseManagedNtlm=true" />

--- a/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.xml
+++ b/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.xml
@@ -1,13 +1,7 @@
 <linker>
   <assembly fullname="System.Linq.Expressions">
-    <type fullname="System.Linq.Expressions.LambdaExpression">
-      <method signature="System.Boolean get_CanCompileToIL()" feature="System.Linq.Expressions.CanCompileToIL" featurevalue="false" body="stub" value="false" />
-    </type>
     <type fullname="System.Dynamic.Utils.DelegateHelpers">
       <method signature="System.Boolean get_CanEmitObjectArrayDelegate()" feature="System.Linq.Expressions.CanEmitObjectArrayDelegate" featurevalue="false" body="stub" value="false" />
-    </type>
-    <type fullname="System.Linq.Expressions.Interpreter.CallInstruction">
-      <method signature="System.Boolean get_CanCreateArbitraryDelegates()" feature="System.Linq.Expressions.CanCreateArbitraryDelegates" featurevalue="false" body="stub" value="false" />
     </type>
   </assembly>
 </linker>


### PR DESCRIPTION
This PR:
- Removes redundant private feature switches for `System.Linq.Expressions.dll`: `CanCompileToIL` and `CanCreateArbitraryDelegates` as they are now respecting `IsDynamicCodeSupported`:
https://github.com/dotnet/runtime/blob/79823768e461a865019d7bdf70cfe0fcbeb99288/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs#L29
https://github.com/dotnet/runtime/blob/79823768e461a865019d7bdf70cfe0fcbeb99288/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs#L19
- Sets the `CanEmitObjectArrayDelegate` into the `RuntimeHostConfigurationOption` item so other tools (like ILLink) can can also understand the desired trimming configuration
    - This fixes `System.Linq.Expressions` support with Xamarin+NativeAOT as `CanEmitObjectArrayDelegate` gets removed during ILLink trimming due to constant propagation, which makes the property not visible when it reaches ILCompiler during the build process
    
PS: If desired, I can pull out all the other explicit feature switches to the `RuntimeHostConfigurationOption` like: 

https://github.com/dotnet/runtime/blob/79823768e461a865019d7bdf70cfe0fcbeb99288/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets#L275

and friends

---
Fixes https://github.com/dotnet/runtime/issues/89171

/cc @dotnet/ilc-contrib 