### PR TITLE
Block inlining of IntroSort

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -2207,6 +2207,8 @@ namespace System
                 }
             }
 
+            // IntroSort is recursive; block it from being inlined into itself as
+            // this is currenly not profitable.
             [MethodImpl(MethodImplOptions.NoInlining)]
             private void IntroSort(int lo, int hi, int depthLimit)
             {
@@ -2422,6 +2424,8 @@ namespace System
                 }
             }
 
+            // IntroSort is recursive; block it from being inlined into itself as
+            // this is currenly not profitable.
             [MethodImpl(MethodImplOptions.NoInlining)]
             private void IntroSort(int lo, int hi, int depthLimit)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -2207,6 +2207,7 @@ namespace System
                 }
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             private void IntroSort(int lo, int hi, int depthLimit)
             {
                 Debug.Assert(hi >= lo);
@@ -2421,6 +2422,7 @@ namespace System
                 }
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             private void IntroSort(int lo, int hi, int depthLimit)
             {
                 Debug.Assert(hi >= lo);

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
@@ -128,6 +128,7 @@ namespace System.Collections.Generic
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void IntroSort(Span<T> keys, int depthLimit, Comparison<T> comparer)
         {
             Debug.Assert(!keys.IsEmpty);
@@ -402,6 +403,7 @@ namespace System.Collections.Generic
             j = t;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void IntroSort(Span<T> keys, int depthLimit)
         {
             Debug.Assert(!keys.IsEmpty);

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
@@ -128,6 +128,8 @@ namespace System.Collections.Generic
             }
         }
 
+        // IntroSort is recursive; block it from being inlined into itself as
+        // this is currenly not profitable.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void IntroSort(Span<T> keys, int depthLimit, Comparison<T> comparer)
         {
@@ -403,6 +405,8 @@ namespace System.Collections.Generic
             j = t;
         }
 
+        // IntroSort is recursive; block it from being inlined into itself as
+        // this is currenly not profitable.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void IntroSort(Span<T> keys, int depthLimit)
         {


### PR DESCRIPTION
With PGO and (via #88749) one level of recursive inlining enabled, the jit sees the recursive call made by `IntroSort` as an attractive inline candidate, but it isn't.

Fixes #89106.