### PR TITLE
Create docs transport package and turn on extensions source of truth

### DIFF
--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -1,31 +1,37 @@
-<Project InitialTargets="VerifyAssemblySupportsDocsXmlGeneration">
+<Project>
 
   <PropertyGroup>
-    <UseIntellisensePackageDocXmlFile Condition="'$(UseIntellisensePackageDocXmlFile)' == ''">true</UseIntellisensePackageDocXmlFile>
+    <UseCompilerGeneratedDocXmlFile Condition="'$(UseCompilerGeneratedDocXmlFile)' == '' and $(MSBuildProjectName.StartsWith('Microsoft.Extensions.'))">true</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
-  <Target Name="VerifyAssemblySupportsDocsXmlGeneration"
-          Condition="'$(UseIntellisensePackageDocXmlFile)' != 'true'">
-    <Error Text="The 'UseIntellisensePackageDocXmlFile' property is not supported for partial facade assemblies: $(AssemblyName)"
-           Condition="'$(IsPartialFacadeAssembly)' == 'true'" />
-    <Error Text="The 'UseIntellisensePackageDocXmlFile' property is not supported for assemblies that throw PlatformNotSupportedException: $(AssemblyName)"
-           Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''" />
-  </Target>
-
-  <PropertyGroup Condition="'$(UseIntellisensePackageDocXmlFile)' == 'true'">
+  <PropertyGroup Condition="'$(UseCompilerGeneratedDocXmlFile)' != 'true'">
     <IntellisensePackageXmlRootFolder>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'microsoft.private.intellisense', '$(MicrosoftPrivateIntellisenseVersion)', 'IntellisenseFiles'))</IntellisensePackageXmlRootFolder>
     <IntellisensePackageXmlFilePathFromNetFolder>$([MSBuild]::NormalizePath('$(IntellisensePackageXmlRootFolder)', 'net', '1033', '$(AssemblyName).xml'))</IntellisensePackageXmlFilePathFromNetFolder>
     <IntellisensePackageXmlFilePathFromDotNetPlatExtFolder>$([MSBuild]::NormalizePath('$(IntellisensePackageXmlRootFolder)', 'dotnet-plat-ext', '1033', '$(AssemblyName).xml'))</IntellisensePackageXmlFilePathFromDotNetPlatExtFolder>
     <IntellisensePackageXmlFilePath Condition="'$(IntellisensePackageXmlFilePath)' == '' and Exists($(IntellisensePackageXmlFilePathFromNetFolder))">$(IntellisensePackageXmlFilePathFromNetFolder)</IntellisensePackageXmlFilePath>
     <IntellisensePackageXmlFilePath Condition="'$(IntellisensePackageXmlFilePath)' == '' and Exists($(IntellisensePackageXmlFilePathFromDotNetPlatExtFolder))">$(IntellisensePackageXmlFilePathFromDotNetPlatExtFolder)</IntellisensePackageXmlFilePath>
+
+    <!-- If the intellisense package doesn't provide an XML, use the compiler generated one instead. -->
+    <UseCompilerGeneratedDocXmlFile Condition="'$(IntellisensePackageXmlFilePath)' == '' and '$(GenerateDocumentationFile)' == 'true'">true</UseCompilerGeneratedDocXmlFile>
+
     <!-- Suppress "CS1591 - Missing XML comment for publicly visible type or member" compiler errors if
          - the intellisense package xml file is used or
          - the assembly is private (i.e. System.Private.Uri) or
          - the assembly is a PNSE assembly. -->
-    <NoWarn Condition="'$(IntellisensePackageXmlFilePath)' != '' or
+    <NoWarn Condition="'$(UseCompilerGeneratedDocXmlFile)' != 'true' or
                        '$(IsPrivateAssembly)' == 'true' or
                        '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(NoWarn);1591</NoWarn>
   </PropertyGroup>
+
+  <!-- Flow these properties to consuming projects for Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj to only
+       include the source of truth compiler generated documentation files. -->
+  <ItemDefinitionGroup>
+    <TargetPathWithTargetPlatformMoniker>
+      <UseCompilerGeneratedDocXmlFile>$(UseCompilerGeneratedDocXmlFile)</UseCompilerGeneratedDocXmlFile>
+      <IsPartialFacadeAssembly>$(IsPartialFacadeAssembly)</IsPartialFacadeAssembly>
+      <IsPlatformNotSupportedAssembly Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">true</IsPlatformNotSupportedAssembly>
+    </TargetPathWithTargetPlatformMoniker>
+  </ItemDefinitionGroup>
 
   <ItemGroup>
     <PackageDownload Include="Microsoft.Private.Intellisense" Version="[$(MicrosoftPrivateIntellisenseVersion)]" />
@@ -34,7 +40,7 @@
   <!-- Replace the compiler generated xml file in the obj folder with the one that comes from the intellisense package. -->
   <Target Name="ChangeDocumentationFileForPackaging"
           BeforeTargets="CopyFilesToOutputDirectory;DocumentationProjectOutputGroup"
-          Condition="'$(IntellisensePackageXmlFilePath)' != ''">
+          Condition="'$(UseCompilerGeneratedDocXmlFile)' != 'true' and '$(IntellisensePackageXmlFilePath)' != ''">
     <ItemGroup>
       <DocFileItem Remove="@(DocFileItem)" />
       <DocFileItem Include="$(IntellisensePackageXmlFilePath)" />

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <DisableArcadeTestFramework>true</DisableArcadeTestFramework>
     <!-- Enabling this rule will cause build failures on undocumented public APIs.
-         We cannot add it in eng/Versions.props because src/coreclr does not have access to UseIntellisensePackageDocXmlFile, which ensures
+         We cannot add it in eng/Versions.props because src/coreclr does not have access to UseCompilerGeneratedDocXmlFile, which ensures
          we only enable it in specific projects. so to avoid duplicating this property in coreclr, we can first scope it to src/libraries.
          This property needs to be declared before the ..\..\Directory.Build.props import. -->
     <SkipArcadeNoWarnCS1591>true</SkipArcadeNoWarnCS1591>

--- a/src/libraries/Microsoft.Bcl.AsyncInterfaces/src/Microsoft.Bcl.AsyncInterfaces.csproj
+++ b/src/libraries/Microsoft.Bcl.AsyncInterfaces/src/Microsoft.Bcl.AsyncInterfaces.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;$(NetFrameworkMinimum);netstandard2.1</TargetFrameworks>
     <IsPackable>true</IsPackable>
@@ -9,10 +10,14 @@ Commonly Used Types:
 System.IAsyncDisposable
 System.Collections.Generic.IAsyncEnumerable
 System.Collections.Generic.IAsyncEnumerator</PackageDescription>
+    <!-- This library uses IsPartialFacadeAssembly for which the compiler doesn't produce any XML documentation. -->
+    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
+
   <PropertyGroup>
     <IsPartialFacadeAssembly Condition="'$(TargetFramework)' == 'netstandard2.1'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
+
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Threading\Tasks\Sources\ManualResetValueTaskSourceCore.cs" />
     <Compile Include="System\Runtime\CompilerServices\AsyncIteratorMethodBuilder.cs" />
@@ -40,8 +45,10 @@ System.Collections.Generic.IAsyncEnumerator</PackageDescription>
     <Compile Include="$(CoreLibSharedDir)\System\Runtime\CompilerServices\EnumeratorCancellationAttribute.cs">
       <Link>System.Private.CoreLib\System\Runtime\CompilerServices\EnumeratorCancellationAttribute.cs</Link>
     </Compile>
+  
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>
+
 </Project>

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.csproj
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -11,6 +12,8 @@
 
 Commonly Used Types:
 System.Security.Cryptography.SP800108HmacCounterKdf</PackageDescription>
+    <!-- This library uses IsPartialFacadeAssembly for which the compiler doesn't produce any XML documentation. -->
+    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -72,4 +75,5 @@ System.Security.Cryptography.SP800108HmacCounterKdf</PackageDescription>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
+
 </Project>

--- a/src/libraries/Microsoft.Bcl.TimeProvider/src/Microsoft.Bcl.TimeProvider.csproj
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/src/Microsoft.Bcl.TimeProvider.csproj
@@ -12,6 +12,8 @@
 Commonly Used Types:
 System.TimeProvider
 System.ITimer</PackageDescription>
+    <!-- This library uses IsPartialFacadeAssembly for which the compiler doesn't produce any XML documentation. -->
+    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/CacheEntryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/CacheEntryExtensions.cs
@@ -7,6 +7,9 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Caching.Memory
 {
+    /// <summary>
+    /// Provide extensions methods for <see cref="ICacheEntry"/> operations.
+    /// </summary>
     public static class CacheEntryExtensions
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/CacheItemPriority.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/CacheItemPriority.cs
@@ -9,9 +9,24 @@ namespace Microsoft.Extensions.Caching.Memory
     /// </summary>
     public enum CacheItemPriority
     {
+        /// <summary>
+        /// The cache entry should be removed as soon as possible during memory pressure triggered cleanup.
+        /// </summary>
         Low,
+
+        /// <summary>
+        /// The cache entry should be removed if there is no other low priority cache entries during memory pressure triggered cleanup.
+        /// </summary>
         Normal,
+
+        /// <summary>
+        /// The cache entry should be removed only when there is no other low or normal priority cache entries during memory pressure triggered cleanup.
+        /// </summary>
         High,
+
+        /// <summary>
+        /// The cache entry should never be removed during memory pressure triggered cleanup.
+        /// </summary>
         NeverRemove,
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/DistributedCacheEntryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/DistributedCacheEntryExtensions.cs
@@ -5,6 +5,9 @@ using System;
 
 namespace Microsoft.Extensions.Caching.Distributed
 {
+    /// <summary>
+    /// Extension methods for <see cref="DistributedCacheEntryOptions"/> operations.
+    /// </summary>
     public static class DistributedCacheEntryExtensions
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/EvictionReason.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/EvictionReason.cs
@@ -3,32 +3,38 @@
 
 namespace Microsoft.Extensions.Caching.Memory
 {
+    /// <summary>
+    /// Specify the reasons why an entry was evicted from the cache.
+    /// </summary>
     public enum EvictionReason
     {
+        /// <summary>
+        /// The item was not removed from the cache.
+        /// </summary>
         None,
 
         /// <summary>
-        /// Manually
+        /// The item was removed from the cache manually.
         /// </summary>
         Removed,
 
         /// <summary>
-        /// Overwritten
+        /// The item was removed from the cache because it was overwritten.
         /// </summary>
         Replaced,
 
         /// <summary>
-        /// Timed out
+        /// The item was removed from the cache because it timed out.
         /// </summary>
         Expired,
 
         /// <summary>
-        /// Event
+        /// The item was removed from the cache because its token expired.
         /// </summary>
         TokenExpired,
 
         /// <summary>
-        /// Overflow
+        /// The item was removed from the cache because it exceeded its capacity.
         /// </summary>
         Capacity,
     }

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheEntryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheEntryExtensions.cs
@@ -6,6 +6,9 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Caching.Memory
 {
+    /// <summary>
+    /// Provide extensions methods for <see cref="MemoryCacheEntryOptions"/> operations.
+    /// </summary>
     public static class MemoryCacheEntryExtensions
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheExtensions.cs
@@ -7,19 +7,43 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Caching.Memory
 {
+    /// <summary>
+    /// Provide extensions methods for <see cref="IMemoryCache"/> operations.
+    /// </summary>
     public static class CacheExtensions
     {
+        /// <summary>
+        /// Gets the value associated with this key if present.
+        /// </summary>
+        /// <param name="cache">The <see cref="IMemoryCache"/> instance this method extends.</param>
+        /// <param name="key">The key of the value to get.</param>
+        /// <returns>The value associated with this key, or <c>null</c> if the key is not present.</returns>
         public static object? Get(this IMemoryCache cache, object key)
         {
             cache.TryGetValue(key, out object? value);
             return value;
         }
 
+        /// <summary>
+        /// Gets the value associated with this key if present.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the object to get.</typeparam>
+        /// <param name="cache">The <see cref="IMemoryCache"/> instance this method extends.</param>
+        /// <param name="key">The key of the value to get.</param>
+        /// <returns>The value associated with this key, or <c>default(TItem)</c> if the key is not present.</returns>
         public static TItem? Get<TItem>(this IMemoryCache cache, object key)
         {
             return (TItem?)(cache.Get(key) ?? default(TItem));
         }
 
+        /// <summary>
+        /// Try to get the value associated with the given key.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the object to get.</typeparam>
+        /// <param name="cache">The <see cref="IMemoryCache"/> instance this method extends.</param>
+        /// <param name="key">The key of the value to get.</param>
+        /// <param name="value">The value associated with the given key.</param>
+        /// <returns><c>true</c> if the key was found. <c>false</c> otherwise.</returns>
         public static bool TryGetValue<TItem>(this IMemoryCache cache, object key, out TItem? value)
         {
             if (cache.TryGetValue(key, out object? result))
@@ -41,6 +65,14 @@ namespace Microsoft.Extensions.Caching.Memory
             return false;
         }
 
+        /// <summary>
+        /// Associate a value with a key in the <see cref="IMemoryCache"/>.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the object to set.</typeparam>
+        /// <param name="cache">The <see cref="IMemoryCache"/> instance this method extends.</param>
+        /// <param name="key">The key of the entry to add.</param>
+        /// <param name="value">The value to associate with the key.</param>
+        /// <returns>The value that was set.</returns>
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value)
         {
             using ICacheEntry entry = cache.CreateEntry(key);
@@ -49,6 +81,15 @@ namespace Microsoft.Extensions.Caching.Memory
             return value;
         }
 
+        /// <summary>
+        /// Sets a cache entry with the given key and value that will expire in the given duration.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the object to set.</typeparam>
+        /// <param name="cache">The <see cref="IMemoryCache"/> instance this method extends.</param>
+        /// <param name="key">The key of the entry to add.</param>
+        /// <param name="value">The value to associate with the key.</param>
+        /// <param name="absoluteExpiration">The point in time at which the cache entry will expire.</param>
+        /// <returns>The value that was set.</returns>
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, DateTimeOffset absoluteExpiration)
         {
             using ICacheEntry entry = cache.CreateEntry(key);
@@ -58,6 +99,15 @@ namespace Microsoft.Extensions.Caching.Memory
             return value;
         }
 
+        /// <summary>
+        /// Sets a cache entry with the given key and value that will expire in the given duration from now.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the object to set.</typeparam>
+        /// <param name="cache">The <see cref="IMemoryCache"/> instance this method extends.</param>
+        /// <param name="key">The key of the entry to add.</param>
+        /// <param name="value">The value to associate with the key.</param>
+        /// <param name="absoluteExpirationRelativeToNow">The duration from now after which the cache entry will expire.</param>
+        /// <returns>The value that was set.</returns>
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, TimeSpan absoluteExpirationRelativeToNow)
         {
             using ICacheEntry entry = cache.CreateEntry(key);
@@ -67,6 +117,15 @@ namespace Microsoft.Extensions.Caching.Memory
             return value;
         }
 
+        /// <summary>
+        /// Sets a cache entry with the given key and value that will expire when <see cref="IChangeToken"/> expires.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the object to set.</typeparam>
+        /// <param name="cache">The <see cref="IMemoryCache"/> instance this method extends.</param>
+        /// <param name="key">The key of the entry to add.</param>
+        /// <param name="value">The value to associate with the key.</param>
+        /// <param name="expirationToken">The <see cref="IChangeToken"/> that causes the cache entry to expire.</param>
+        /// <returns>The value that was set.</returns>
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, IChangeToken expirationToken)
         {
             using ICacheEntry entry = cache.CreateEntry(key);
@@ -76,6 +135,15 @@ namespace Microsoft.Extensions.Caching.Memory
             return value;
         }
 
+        /// <summary>
+        /// Sets a cache entry with the given key and value and apply the values of an existing <see cref="MemoryCacheEntryOptions"/> to the created entry.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the object to set.</typeparam>
+        /// <param name="cache">The <see cref="IMemoryCache"/> instance this method extends.</param>
+        /// <param name="key">The key of the entry to add.</param>
+        /// <param name="value">The value to associate with the key.</param>
+        /// <param name="options">The existing <see cref="MemoryCacheEntryOptions"/> instance to apply to the new entry.</param>
+        /// <returns>The value that was set.</returns>
         public static TItem Set<TItem>(this IMemoryCache cache, object key, TItem value, MemoryCacheEntryOptions? options)
         {
             using ICacheEntry entry = cache.CreateEntry(key);
@@ -89,6 +157,14 @@ namespace Microsoft.Extensions.Caching.Memory
             return value;
         }
 
+        /// <summary>
+        /// Gets the value associated with this key if it exists, or generates a new entry using the provided key and a value from the given factory if the key is not found.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the object to get.</typeparam>
+        /// <param name="cache">The <see cref="IMemoryCache"/> instance this method extends.</param>
+        /// <param name="key">The key of the entry to look for or create.</param>
+        /// <param name="factory">The factory that creates the value associated with this key if the key does not exist in the cache.</param>
+        /// <returns>The value associated with this key.</returns>
         public static TItem? GetOrCreate<TItem>(this IMemoryCache cache, object key, Func<ICacheEntry, TItem> factory)
         {
             if (!cache.TryGetValue(key, out object? result))
@@ -102,6 +178,14 @@ namespace Microsoft.Extensions.Caching.Memory
             return (TItem?)result;
         }
 
+        /// <summary>
+        /// Asynchronously gets the value associated with this key if it exists, or generates a new entry using the provided key and a value from the given factory if the key is not found.
+        /// </summary>
+        /// <typeparam name="TItem">The type of the object to get.</typeparam>
+        /// <param name="cache">The <see cref="IMemoryCache"/> instance this method extends.</param>
+        /// <param name="key">The key of the entry to look for or create.</param>
+        /// <param name="factory">The factory task that creates the value associated with this key if the key does not exist in the cache.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
         public static async Task<TItem?> GetOrCreateAsync<TItem>(this IMemoryCache cache, object key, Func<ICacheEntry, Task<TItem>> factory)
         {
             if (!cache.TryGetValue(key, out object? result))

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/PostEvictionCallbackRegistration.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/PostEvictionCallbackRegistration.cs
@@ -3,10 +3,19 @@
 
 namespace Microsoft.Extensions.Caching.Memory
 {
+    /// <summary>
+    /// Represents a callback delegate that will be fired after an entry is evicted from the cache.
+    /// </summary>
     public class PostEvictionCallbackRegistration
     {
+        /// <summary>
+        /// Gets or sets the callback delegate that will be fired after an entry is evicted from the cache.
+        /// </summary>
         public PostEvictionDelegate? EvictionCallback { get; set; }
 
+        /// <summary>
+        /// Gets or sets the state to pass to the callback delegate.
+        /// </summary>
         public object? State { get; set; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -593,7 +593,10 @@ namespace Microsoft.Extensions.Caching.Memory
             Dispose(true);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Dispose the cache and clear all entries.
+        /// </summary>
+        /// <param name="disposing">Dispose the object resources if true; otherwise, take no action.</param>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -587,11 +587,13 @@ namespace Microsoft.Extensions.Caching.Memory
             }
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             Dispose(true);
         }
 
+        /// <inheritdoc />
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCacheOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCacheOptions.cs
@@ -49,6 +49,9 @@ namespace Microsoft.Extensions.Caching.Memory
             }
         }
 
+        /// <summary>
+        /// Enables ot disables the option to compact the cache when the maximum size is exceeded.
+        /// </summary>
         [EditorBrowsableAttribute(EditorBrowsableState.Never)]
         [Obsolete("This property is retained only for compatibility.  Remove use and instead call MemoryCache.Compact as needed.", error: true)]
         public bool CompactOnMemoryPressure { get; set; }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCacheOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCacheOptions.cs
@@ -8,6 +8,9 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Caching.Memory
 {
+    /// <summary>
+    /// Options class for <see cref="MemoryCache"/>.
+    /// </summary>
     public class MemoryCacheOptions : IOptions<MemoryCacheOptions>
     {
         private long _sizeLimit = NotSet;
@@ -15,6 +18,9 @@ namespace Microsoft.Extensions.Caching.Memory
 
         private const int NotSet = -1;
 
+        /// <summary>
+        /// Gets or sets the clock used by the cache for expiration.
+        /// </summary>
         public ISystemClock? Clock { get; set; }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryDistributedCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryDistributedCache.cs
@@ -11,13 +11,25 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Caching.Distributed
 {
+    /// <summary>
+    /// An implementation of <see cref="IDistributedCache"/> using <see cref="IMemoryCache"/>.
+    /// </summary>
     public class MemoryDistributedCache : IDistributedCache
     {
         private readonly MemoryCache _memCache;
 
+        /// <summary>
+        /// Creates a new <see cref="MemoryDistributedCache"/> instance.
+        /// </summary>
+        /// <param name="optionsAccessor">The options of the cache.</param>
         public MemoryDistributedCache(IOptions<MemoryDistributedCacheOptions> optionsAccessor)
             : this(optionsAccessor, NullLoggerFactory.Instance) { }
 
+        /// <summary>
+        /// Creates a new <see cref="MemoryDistributedCache"/> instance.
+        /// </summary>
+        /// <param name="optionsAccessor">The options of the cache.</param>
+        /// <param name="loggerFactory">The logger factory to create <see cref="ILogger"/> used to log messages.</param>
         public MemoryDistributedCache(IOptions<MemoryDistributedCacheOptions> optionsAccessor, ILoggerFactory loggerFactory)
         {
             ThrowHelper.ThrowIfNull(optionsAccessor);
@@ -26,6 +38,11 @@ namespace Microsoft.Extensions.Caching.Distributed
             _memCache = new MemoryCache(optionsAccessor.Value, loggerFactory);
         }
 
+        /// <summary>
+        /// Gets the specified item associated with a key from the <see cref="IMemoryCache"/> as a byte array.
+        /// </summary>
+        /// <param name="key">The key of the item to get.</param>
+        /// <returns>The byte array value of the key.</returns>
         public byte[]? Get(string key)
         {
             ThrowHelper.ThrowIfNull(key);
@@ -33,6 +50,12 @@ namespace Microsoft.Extensions.Caching.Distributed
             return (byte[]?)_memCache.Get(key);
         }
 
+        /// <summary>
+        /// Asynchronously gets the specified item associated with a key from the <see cref="IMemoryCache"/> as a byte array.
+        /// </summary>
+        /// <param name="key">The key of the item to get.</param>
+        /// <param name="token">The <see cref="CancellationToken"/> to use to cancel operation.</param>
+        /// <returns>The task for getting the byte array value associated with the specified key from the cache.</returns>
         public Task<byte[]?> GetAsync(string key, CancellationToken token = default(CancellationToken))
         {
             ThrowHelper.ThrowIfNull(key);
@@ -40,6 +63,12 @@ namespace Microsoft.Extensions.Caching.Distributed
             return Task.FromResult(Get(key));
         }
 
+        /// <summary>
+        /// Sets the specified item associated with a key in the <see cref="IMemoryCache"/> as a byte array.
+        /// </summary>
+        /// <param name="key">The key of the item to set.</param>
+        /// <param name="value">The byte array value of the item to set.</param>
+        /// <param name="options">The cache options for the item to set.</param>
         public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
         {
             ThrowHelper.ThrowIfNull(key);
@@ -55,6 +84,14 @@ namespace Microsoft.Extensions.Caching.Distributed
             _memCache.Set(key, value, memoryCacheEntryOptions);
         }
 
+        /// <summary>
+        /// Asynchronously sets the specified item associated with a key in the <see cref="IMemoryCache"/> as a byte array.
+        /// </summary>
+        /// <param name="key">The key of the item to set.</param>
+        /// <param name="value">The byte array value of the item to set.</param>
+        /// <param name="options">The cache options for the item to set.</param>
+        /// <param name="token">The <see cref="CancellationToken"/> to use to cancel operation.</param>
+        /// <returns>The task for setting the byte array value associated with the specified key in the cache.</returns>
         public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default(CancellationToken))
         {
             ThrowHelper.ThrowIfNull(key);
@@ -65,6 +102,10 @@ namespace Microsoft.Extensions.Caching.Distributed
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// Refreshes the specified item associated with a key from the <see cref="IMemoryCache"/>.
+        /// </summary>
+        /// <param name="key">The key of the item to refresh.</param>
         public void Refresh(string key)
         {
             ThrowHelper.ThrowIfNull(key);
@@ -72,6 +113,12 @@ namespace Microsoft.Extensions.Caching.Distributed
             _memCache.TryGetValue(key, out _);
         }
 
+        /// <summary>
+        /// Asynchronously refreshes the specified item associated with a key from the <see cref="IMemoryCache"/>.
+        /// </summary>
+        /// <param name="key">The key of the item to refresh.</param>
+        /// <param name="token">The <see cref="CancellationToken"/> to use to cancel operation.</param>
+        /// <returns>The task for refreshing the specified key in the cache.</returns>
         public Task RefreshAsync(string key, CancellationToken token = default(CancellationToken))
         {
             ThrowHelper.ThrowIfNull(key);
@@ -80,6 +127,10 @@ namespace Microsoft.Extensions.Caching.Distributed
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// Removes the specified item associated with a key from the <see cref="IMemoryCache"/>.
+        /// </summary>
+        /// <param name="key">The key of the item to remove.</param>
         public void Remove(string key)
         {
             ThrowHelper.ThrowIfNull(key);
@@ -87,6 +138,12 @@ namespace Microsoft.Extensions.Caching.Distributed
             _memCache.Remove(key);
         }
 
+        /// <summary>
+        /// Asynchronously removes the specified item associated with a key from the <see cref="IMemoryCache"/>.
+        /// </summary>
+        /// <param name="key">The key of the item to remove.</param>
+        /// <param name="token">The <see cref="CancellationToken"/> to use to cancel operation.</param>
+        /// <returns>The task for removing the specified key from the cache.</returns>
         public Task RemoveAsync(string key, CancellationToken token = default(CancellationToken))
         {
             ThrowHelper.ThrowIfNull(key);

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryDistributedCacheOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryDistributedCacheOptions.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.Extensions.Caching.Memory
 {
     /// <summary>
-    /// Options class for <see cref="MemoryDistributedCache"/>.
+    /// Options class for <see cref="MemoryDistributedCacheOptions"/>.
     /// </summary>
     public class MemoryDistributedCacheOptions : MemoryCacheOptions
     {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryDistributedCacheOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryDistributedCacheOptions.cs
@@ -3,8 +3,14 @@
 
 namespace Microsoft.Extensions.Caching.Memory
 {
+    /// <summary>
+    /// Options class for <see cref="MemoryDistributedCache"/>.
+    /// </summary>
     public class MemoryDistributedCacheOptions : MemoryCacheOptions
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="MemoryDistributedCacheOptions"/>.
+        /// </summary>
         public MemoryDistributedCacheOptions()
             : base()
         {

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationDebugViewContext.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationDebugViewContext.cs
@@ -8,6 +8,13 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public readonly struct ConfigurationDebugViewContext
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="ConfigurationDebugViewContext"/>.
+        /// </summary>
+        /// <param name="path">The path of the current item of the configuration.</param>
+        /// <param name="key">The key of the current item of the configuration.</param>
+        /// <param name="value">The value of the current item of the configuration.</param>
+        /// <param name="configurationProvider">The <see cref="IConfigurationProvider" /> to use to get the value of the current item.</param>
         public ConfigurationDebugViewContext(string path, string key, string? value, IConfigurationProvider configurationProvider)
         {
             Path = path;

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationKeyNameAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationKeyNameAttribute.cs
@@ -5,11 +5,21 @@ using System;
 
 namespace Microsoft.Extensions.Configuration
 {
+    /// <summary>
+    /// Specifies the key name for a configuration property.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class ConfigurationKeyNameAttribute : Attribute
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="ConfigurationKeyNameAttribute"/>.
+        /// </summary>
+        /// <param name="name">The key name.</param>
         public ConfigurationKeyNameAttribute(string name) => Name = name;
 
+        /// <summary>
+        /// The key name for a configuration property.
+        /// </summary>
         public string Name { get; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/FromKeyedServicesAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/FromKeyedServicesAttribute.cs
@@ -5,11 +5,21 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+    /// <summary>
+    /// Indicates that the parameter should be bound using the keyed service registered with the specified key.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class FromKeyedServicesAttribute : Attribute
     {
+        /// <summary>
+        /// Creates a new <see cref="FromKeyedServicesAttribute"/> instance.
+        /// </summary>
+        /// <param name="key">The key of the keyed service to bind to.</param>
         public FromKeyedServicesAttribute(object key) => Key = key;
 
+        /// <summary>
+        /// The key of the keyed service to bind to.
+        /// </summary>
         public object Key { get; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/IKeyedServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/IKeyedServiceProvider.cs
@@ -5,6 +5,10 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+    /// <summary>
+    /// IKeyedServiceProvider is a service provider that can be used to retrieve services using a key in addition
+    /// to a type.
+    /// </summary>
     public interface IKeyedServiceProvider : IServiceProvider
     {
         /// <summary>
@@ -26,8 +30,14 @@ namespace Microsoft.Extensions.DependencyInjection
         object GetRequiredKeyedService(Type serviceType, object? serviceKey);
     }
 
+    /// <summary>
+    /// Statics for use with <see cref="IKeyedServiceProvider"/>.
+    /// </summary>
     public static class KeyedService
     {
+        /// <summary>
+        /// Represents a key that matches any key.
+        /// </summary>
         public static object AnyKey { get; } = new AnyKeyObj();
 
         private sealed class AnyKeyObj

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/IServiceProviderIsKeyedService.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/IServiceProviderIsKeyedService.cs
@@ -5,10 +5,15 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+    /// <summary>
+    /// Optional service used to determine if the specified type with the specified service key is available
+    /// from the <see cref="IServiceProvider"/>.
+    /// </summary>
     public interface IServiceProviderIsKeyedService : IServiceProviderIsService
     {
         /// <summary>
-        /// Determines if the specified service type is available from the <see cref="IServiceProvider"/>.
+        /// Determines if the specified service type with the specified service key is available from the
+        /// <see cref="IServiceProvider"/>.
         /// </summary>
         /// <param name="serviceType">An object that specifies the type of service object to test.</param>
         /// <param name="serviceKey">The <see cref="ServiceDescriptor.ServiceKey"/> of the service.</param>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
@@ -247,6 +247,9 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
+        /// <summary>
+        /// Indicates whether the service is a keyed service.
+        /// </summary>
         public bool IsKeyedService => ServiceKey != null;
 
         /// <inheritdoc />

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceKeyAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceKeyAttribute.cs
@@ -5,6 +5,10 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+    /// <summary>
+    /// ServiceKeyAttribute can be specified on a parameter to inject the key that was used for
+    /// registration/resolution.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class ServiceKeyAttribute : Attribute
     {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -97,9 +97,22 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The service that was produced.</returns>
         public object? GetService(Type serviceType) => GetService(ServiceIdentifier.FromServiceType(serviceType), Root);
 
+        /// <summary>
+        /// Gets the service object of the specified type with the specified key.
+        /// </summary>
+        /// <param name="serviceType">The type of the service to get.</param>
+        /// <param name="serviceKey">The key of the service to get.</param>
+        /// <returns>The keyed service.</returns>
         public object? GetKeyedService(Type serviceType, object? serviceKey)
             => GetService(new ServiceIdentifier(serviceKey, serviceType), Root);
 
+        /// <summary>
+        /// Gets the service object of the specified type. Will throw if the service not found.
+        /// </summary>
+        /// <param name="serviceType">The type of the service to get.</param>
+        /// <param name="serviceKey">The key of the service to get.</param>
+        /// <returns>The keyed service.</returns>
+        /// <exception cref="InvalidOperationException"></exception>
         public object GetRequiredKeyedService(Type serviceType, object? serviceKey)
         {
             object? service = GetKeyedService(serviceType, serviceKey);

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/Microsoft.Extensions.DependencyModel.csproj
@@ -6,6 +6,8 @@
     <PackageDescription>Provides abstractions for reading `.deps` files. When a .NET application is compiled, the SDK generates a JSON manifest file (`&lt;ApplicationName&gt;.deps.json`) that contains information about application dependencies. You can use `Microsoft.Extensions.DependencyModel` to read information from this manifest at run time. This is useful when you want to dynamically compile code (for example, using Roslyn Emit API) referencing the same dependencies as your main application.
 
 By default, the dependency manifest contains information about the application's target framework and runtime dependencies. Set the PreserveCompilationContext project property to `true` to additionally include information about reference assemblies used during compilation.</PackageDescription>
+    <!-- The public API in this library isn't yet documented: https://github.com/dotnet/runtime/issues/43872. -->
+    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Microsoft.Extensions.FileSystemGlobbing.csproj
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Microsoft.Extensions.FileSystemGlobbing.csproj
@@ -5,6 +5,8 @@
     <EnableDefaultItems>true</EnableDefaultItems>
     <IsPackable>true</IsPackable>
     <PackageDescription>File system globbing to find files matching a specified pattern.</PackageDescription>
+    <!-- The public API in this library isn't yet documented: https://github.com/dotnet/runtime/issues/43908. -->
+    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Extensions.Hosting
 
         }
 
+        /// <inheritdoc />
         public virtual void Dispose()
         {
             _stoppingCts?.Cancel();

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/EnvironmentName.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/EnvironmentName.cs
@@ -13,8 +13,19 @@ namespace Microsoft.Extensions.Hosting
     [System.Obsolete("EnvironmentName has been deprecated. Use Microsoft.Extensions.Hosting.Environments instead.")]
     public static class EnvironmentName
     {
+        /// <summary>
+        /// The name of the Development environment.
+        /// </summary>
         public static readonly string Development = "Development";
+
+        /// <summary>
+        /// The name of the Staging environment.
+        /// </summary>
         public static readonly string Staging = "Staging";
+
+        /// <summary>
+        /// The name of the Production environment.
+        /// </summary>
         public static readonly string Production = "Production";
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ApplicationLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ApplicationLifetime.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Extensions.Hosting.Internal
         private readonly CancellationTokenSource _stoppedSource = new CancellationTokenSource();
         private readonly ILogger<ApplicationLifetime> _logger;
 
+        /// <summary>
+        /// Initializes an <see cref="ApplicationLifetime"/> instance using the specified logger.
+        /// </summary>
+        /// <param name="logger">The logger to initialize this instance with.</param>
         public ApplicationLifetime(ILogger<ApplicationLifetime> logger)
         {
             _logger = logger;

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ConsoleLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ConsoleLifetime.cs
@@ -23,9 +23,26 @@ namespace Microsoft.Extensions.Hosting.Internal
         private CancellationTokenRegistration _applicationStartedRegistration;
         private CancellationTokenRegistration _applicationStoppingRegistration;
 
+        /// <summary>
+        /// Initializes a <see cref="ConsoleLifetime"/> instance using the specified console lifetime options, host environment, host application lifetime and host options.
+        /// </summary>
+        /// <param name="options">An object used to retrieve <see cref="ConsoleLifetimeOptions"/> instances.</param>
+        /// <param name="environment">An object that contains information about the hosting environment an application is running in.</param>
+        /// <param name="applicationLifetime">An object that allows consumers to be notified of application lifetime events.</param>
+        /// <param name="hostOptions">An object used to retrieve <see cref="HostOptions"/> instances.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> or <paramref name="environment"/> or <paramref name="applicationLifetime"/> or <paramref name="hostOptions"/> is <see langword="null"/>.</exception>
         public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, IOptions<HostOptions> hostOptions)
             : this(options, environment, applicationLifetime, hostOptions, NullLoggerFactory.Instance) { }
 
+        /// <summary>
+        /// Initializes a <see cref="ConsoleLifetime"/> instance using the specified console lifetime options, host environment, host options and logger factory.
+        /// </summary>
+        /// <param name="options">An object used to retrieve <see cref="ConsoleLifetimeOptions"/> instances</param>
+        /// <param name="environment">An object that contains information about the hosting environment an application is running in.</param>
+        /// <param name="applicationLifetime">An object that allows consumers to be notified of application lifetime events.</param>
+        /// <param name="hostOptions">An object used to retrieve <see cref="HostOptions"/> instances.</param>
+        /// <param name="loggerFactory">An object to configure the logging system and create instances of <see cref="ILogger"/> from the registered <see cref="ILoggerProvider"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> or <paramref name="environment"/> or <paramref name="applicationLifetime"/> or <paramref name="hostOptions"/> is <see langword="null"/>.</exception>
         public ConsoleLifetime(IOptions<ConsoleLifetimeOptions> options, IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, IOptions<HostOptions> hostOptions, ILoggerFactory loggerFactory)
         {
             ThrowHelper.ThrowIfNull(options?.Value, nameof(options));
@@ -50,6 +67,11 @@ namespace Microsoft.Extensions.Hosting.Internal
 
         private ILogger Logger { get; }
 
+        /// <summary>
+        /// Registers the application start, application stop and shutdown handlers for this application.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous registration operation.</returns>
         public Task WaitForStartAsync(CancellationToken cancellationToken)
         {
             if (!Options.SuppressStatusMessages)
@@ -86,12 +108,20 @@ namespace Microsoft.Extensions.Hosting.Internal
             Logger.LogInformation("Application is shutting down...");
         }
 
+        /// <summary>
+        /// This method does nothing.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token instance.</param>
+        /// <returns>A <see cref="Task"/> that represents a completed task.</returns>
         public Task StopAsync(CancellationToken cancellationToken)
         {
             // There's nothing to do here
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// Unregisters the shutdown handlers and disposes the application start and application stop registrations.
+        /// </summary>
         public void Dispose()
         {
             UnregisterShutdownHandlers();

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/HostingEnvironment.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/HostingEnvironment.cs
@@ -15,12 +15,24 @@ namespace Microsoft.Extensions.Hosting.Internal
     public class HostingEnvironment : IHostingEnvironment, IHostEnvironment
 #pragma warning restore CS0618 // Type or member is obsolete
     {
+        /// <summary>
+        /// This API supports infrastructure and is not intended to be used directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public string EnvironmentName { get; set; } = string.Empty;
 
+        /// <summary>
+        /// This API supports infrastructure and is not intended to be used directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public string ApplicationName { get; set; } = string.Empty;
 
+        /// <summary>
+        /// This API supports infrastructure and is not intended to be used directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public string ContentRootPath { get; set; } = string.Empty;
 
+        /// <summary>
+        /// This API supports infrastructure and is not intended to be used directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public IFileProvider ContentRootFileProvider { get; set; } = null!;
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConfigurationConsoleLoggerSettings.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConfigurationConsoleLoggerSettings.cs
@@ -8,20 +8,33 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+    /// <summary>
+    /// Settings for a <see cref="ConsoleLogger"/>.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This type is retained only for compatibility. The recommended alternative is ConsoleLoggerOptions.")]
     public class ConfigurationConsoleLoggerSettings : IConsoleLoggerSettings
     {
         internal readonly IConfiguration _configuration;
 
+        /// <summary>
+        /// Creates a new instance of <see cref="ConfigurationConsoleLoggerSettings"/>.
+        /// </summary>
+        /// <param name="configuration">provides access to configuration values.</param>
         public ConfigurationConsoleLoggerSettings(IConfiguration configuration)
         {
             _configuration = configuration;
             ChangeToken = configuration.GetReloadToken();
         }
 
+        /// <summary>
+        /// Gets the <see cref="IChangeToken"/> propagates notifications that a change has occurred.
+        /// </summary>
         public IChangeToken? ChangeToken { get; private set; }
 
+        /// <summary>
+        /// Gets a value indicating whether scopes should be included in the message.
+        /// </summary>
         public bool IncludeScopes
         {
             get
@@ -44,12 +57,23 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
+        /// <summary>
+        /// Reload the settings from the configuration.
+        /// </summary>
+        /// <returns>The reloaded settings.</returns>
         public IConsoleLoggerSettings Reload()
         {
             ChangeToken = null!;
             return new ConfigurationConsoleLoggerSettings(_configuration);
         }
 
+        /// <summary>
+        /// Gets the log level for the specified switch.
+        /// </summary>
+        /// <param name="name">The name of the switch to look up</param>
+        /// <param name="level">An out parameter that will be set to the value of the switch if it is found. If the switch is not found, the method returns false and sets the value of level to LogLevel.None</param>
+        /// <returns>True if the switch was found, otherwise false.</returns>
+        /// <exception cref="InvalidOperationException"></exception>
         public bool TryGetSwitch(string name, out LogLevel level)
         {
             var switches = _configuration.GetSection("LogLevel");

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleFormatter.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Extensions.Logging.Console
     /// </summary>
     public abstract class ConsoleFormatter
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="ConsoleFormatter"/>.
+        /// </summary>
+        /// <param name="name"></param>
         protected ConsoleFormatter(string name)
         {
             ThrowHelper.ThrowIfNull(name);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerExtensions.Obsolete.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerExtensions.Obsolete.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Extensions.Logging
 {
     public static partial class ConsoleLoggerExtensions
     {
+        /// <summary>
+        /// This method is retained only for compatibility.
+        /// </summary>
+        /// <param name="factory">This method is retained only for compatibility.</param>
+        /// <param name="configuration">This method is retained only for compatibility.</param>
+        /// <returns>This method is retained only for compatibility.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", error: true)]
         public static Logging.ILoggerFactory AddConsole(this Logging.ILoggerFactory factory, Extensions.Configuration.IConfiguration configuration)
@@ -21,6 +27,12 @@ namespace Microsoft.Extensions.Logging
             return factory.AddConsole(settings);
         }
 
+        /// <summary>
+        /// This method is retained only for compatibility.
+        /// </summary>
+        /// <param name="factory">This method is retained only for compatibility.</param>
+        /// <param name="settings">This method is retained only for compatibility.</param>
+        /// <returns>This method is retained only for compatibility.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", error: true)]
         public static Logging.ILoggerFactory AddConsole(this Logging.ILoggerFactory factory, Console.IConsoleLoggerSettings settings)
@@ -29,6 +41,13 @@ namespace Microsoft.Extensions.Logging
             return factory;
         }
 
+        /// <summary>
+        /// This method is retained only for compatibility.
+        /// </summary>
+        /// <param name="factory">This method is retained only for compatibility.</param>
+        /// <param name="minLevel">This method is retained only for compatibility.</param>
+        /// <param name="includeScopes">This method is retained only for compatibility.</param>
+        /// <returns>This method is retained only for compatibility.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", error: true)]
         public static Logging.ILoggerFactory AddConsole(this Logging.ILoggerFactory factory, Logging.LogLevel minLevel, bool includeScopes)
@@ -37,6 +56,12 @@ namespace Microsoft.Extensions.Logging
             return factory;
         }
 
+        /// <summary>
+        /// This method is retained only for compatibility.
+        /// </summary>
+        /// <param name="factory">This method is retained only for compatibility.</param>
+        /// <param name="minLevel">This method is retained only for compatibility.</param>
+        /// <returns>This method is retained only for compatibility.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", error: true)]
         public static Logging.ILoggerFactory AddConsole(this Logging.ILoggerFactory factory, Logging.LogLevel minLevel)
@@ -45,6 +70,12 @@ namespace Microsoft.Extensions.Logging
             return factory;
         }
 
+        /// <summary>
+        /// This method is retained only for compatibility.
+        /// </summary>
+        /// <param name="factory">This method is retained only for compatibility.</param>
+        /// <param name="includeScopes">This method is retained only for compatibility.</param>
+        /// <returns>This method is retained only for compatibility.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", error: true)]
         public static Logging.ILoggerFactory AddConsole(this Logging.ILoggerFactory factory, bool includeScopes)
@@ -53,6 +84,13 @@ namespace Microsoft.Extensions.Logging
             return factory;
         }
 
+        /// <summary>
+        /// This method is retained only for compatibility.
+        /// </summary>
+        /// <param name="factory">This method is retained only for compatibility.</param>
+        /// <param name="filter">This method is retained only for compatibility.</param>
+        /// <param name="includeScopes">This method is retained only for compatibility.</param>
+        /// <returns>This method is retained only for compatibility.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", error: true)]
         public static Logging.ILoggerFactory AddConsole(this Logging.ILoggerFactory factory, System.Func<string, Logging.LogLevel, bool> filter, bool includeScopes)
@@ -61,6 +99,12 @@ namespace Microsoft.Extensions.Logging
             return factory;
         }
 
+        /// <summary>
+        /// This method is retained only for compatibility.
+        /// </summary>
+        /// <param name="factory">This method is retained only for compatibility.</param>
+        /// <param name="filter">This method is retained only for compatibility.</param>
+        /// <returns>This method is retained only for compatibility.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", error: true)]
         public static Logging.ILoggerFactory AddConsole(this Logging.ILoggerFactory factory, System.Func<string, Logging.LogLevel, bool> filter)
@@ -69,6 +113,11 @@ namespace Microsoft.Extensions.Logging
             return factory;
         }
 
+        /// <summary>
+        /// This method is retained only for compatibility.
+        /// </summary>
+        /// <param name="factory">This method is retained only for compatibility.</param>
+        /// <returns>This method is retained only for compatibility.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This method is retained only for compatibility. The recommended alternative is AddConsole(this ILoggingBuilder builder).", error: true)]
         public static Logging.ILoggerFactory AddConsole(this Logging.ILoggerFactory factory)

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerExtensions.cs
@@ -14,6 +14,9 @@ using ThrowHelper = System.ThrowHelper;
 
 namespace Microsoft.Extensions.Logging
 {
+    /// <summary>
+    /// Provides extension methods for the <see cref="ILoggingBuilder"/> and <see cref="ILoggerProviderConfiguration{ConsoleLoggerProvider}"/> classes.
+    /// </summary>
     [UnsupportedOSPlatform("browser")]
     public static partial class ConsoleLoggerExtensions
     {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerSettings.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerSettings.cs
@@ -8,23 +8,36 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+    /// <summary>
+    /// This type is retained only for compatibility. The recommended alternative is ConsoleLoggerOptions.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This type is retained only for compatibility. The recommended alternative is ConsoleLoggerOptions.", error: true)]
     public class ConsoleLoggerSettings : IConsoleLoggerSettings
     {
+        /// <inheritdoc/>
         public IChangeToken? ChangeToken { get; set; }
 
+        /// <inheritdoc/>
         public bool IncludeScopes { get; set; }
 
+        /// <summary>
+        /// This property is retained only for compatibility.
+        /// </summary>
         public bool DisableColors { get; set; }
 
+        /// <summary>
+        /// This property is retained only for compatibility.
+        /// </summary>
         public IDictionary<string, LogLevel> Switches { get; set; } = new Dictionary<string, LogLevel>();
 
+        /// <inheritdoc/>
         public IConsoleLoggerSettings Reload()
         {
             return this;
         }
 
+        /// <inheritdoc/>
         public bool TryGetSwitch(string name, out LogLevel level)
         {
             return Switches.TryGetValue(name, out level);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/IConsoleLoggerSettings.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/IConsoleLoggerSettings.cs
@@ -7,16 +7,35 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+    /// <summary>
+    /// This type is retained only for compatibility. The recommended alternative is ConsoleLoggerOptions.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This type is retained only for compatibility. The recommended alternative is ConsoleLoggerOptions.", error: true)]
     public interface IConsoleLoggerSettings
     {
+        /// <summary>
+        /// This property is retained only for compatibility.
+        /// </summary>
         bool IncludeScopes { get; }
 
+        /// <summary>
+        /// This property is retained only for compatibility.
+        /// </summary>
         IChangeToken? ChangeToken { get; }
 
+        /// <summary>
+        /// This property is retained only for compatibility.
+        /// </summary>
+        /// <param name="name">This property is retained only for compatibility.</param>
+        /// <param name="level">This property is retained only for compatibility.</param>
+        /// <returns>This property is retained only for compatibility.</returns>
         bool TryGetSwitch(string name, out LogLevel level);
 
+        /// <summary>
+        /// This method is retained only for compatibility.
+        /// </summary>
+        /// <returns>This method is retained only for compatibility.</returns>
         IConsoleLoggerSettings Reload();
     }
 }

--- a/src/libraries/Microsoft.Extensions.Primitives/src/InplaceStringBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/InplaceStringBuilder.cs
@@ -8,6 +8,9 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.Primitives
 {
+    /// <summary>
+    /// Provides a mechanism for fast, non-allocating string concatenation.
+    /// </summary>
     [DebuggerDisplay("Value = {_value}")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This type is retained only for compatibility. The recommended alternative is string.Create<TState> (int length, TState state, System.Buffers.SpanAction<char,TState> action).", error: true)]
@@ -17,6 +20,10 @@ namespace Microsoft.Extensions.Primitives
         private int _capacity;
         private string? _value;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InplaceStringBuilder"/> class.
+        /// </summary>
+        /// <param name="capacity">The suggested starting size of the <see cref="InplaceStringBuilder"/> instance.</param>
         public InplaceStringBuilder(int capacity) : this()
         {
             if (capacity < 0)
@@ -27,6 +34,9 @@ namespace Microsoft.Extensions.Primitives
             _capacity = capacity;
         }
 
+        /// <summary>
+        /// Gets the number of characters that the current <see cref="InplaceStringBuilder"/> object can contain.
+        /// </summary>
         public int Capacity
         {
             get => _capacity;
@@ -47,6 +57,10 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
+        /// <summary>
+        /// Appends a string to the end of the current <see cref="InplaceStringBuilder"/> instance.
+        /// </summary>
+        /// <param name="value">The string to append.</param>
         public void Append(string? value)
         {
             if (value == null)
@@ -57,11 +71,21 @@ namespace Microsoft.Extensions.Primitives
             Append(value, 0, value.Length);
         }
 
+        /// <summary>
+        /// Appends a string segment to the end of the current <see cref="InplaceStringBuilder"/> instance.
+        /// </summary>
+        /// <param name="segment">The string segment to append.</param>
         public void Append(StringSegment segment)
         {
             Append(segment.Buffer, segment.Offset, segment.Length);
         }
 
+        /// <summary>
+        /// Appends a substring to the end of the current <see cref="InplaceStringBuilder"/> instance.
+        /// </summary>
+        /// <param name="value">The string that contains the substring to append.</param>
+        /// <param name="offset">The starting position of the substring within value.</param>
+        /// <param name="count">The number of characters in value to append.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void Append(string? value, int offset, int count)
         {
@@ -83,6 +107,10 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
+        /// <summary>
+        /// Appends a character to the end of the current <see cref="InplaceStringBuilder"/> instance.
+        /// </summary>
+        /// <param name="c">The character to append.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe void Append(char c)
         {
@@ -99,6 +127,10 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
+        /// <summary>
+        /// Converts the value of this instance to a String.
+        /// </summary>
+        /// <returns>A string whose value is the same as this instance.</returns>
         public override string? ToString()
         {
             if (Capacity != _offset)

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegmentComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegmentComparer.cs
@@ -32,11 +32,23 @@ namespace Microsoft.Extensions.Primitives
         private StringComparison Comparison { get; }
         private StringComparer Comparer { get; }
 
+        /// <summary>
+        /// Compares two <see cref="StringSegment"/> objects and returns an indication of their relative sort order.
+        /// </summary>
+        /// <param name="x">The first <see cref="StringSegment"/> to compare.</param>
+        /// <param name="y">The second <see cref="StringSegment"/> to compare.</param>
+        /// <returns>A 32-bit signed integer that indicates the lexical relationship between the two comparands.</returns>
         public int Compare(StringSegment x, StringSegment y)
         {
             return StringSegment.Compare(x, y, Comparison);
         }
 
+        /// <summary>
+        /// Determines whether two <see cref="StringSegment"/> objects are equal.
+        /// </summary>
+        /// <param name="x">The first <see cref="StringSegment"/> to compare.</param>
+        /// <param name="y">The second <see cref="StringSegment"/> to compare.</param>
+        /// <returns><see langword="true"/> if the two <see cref="StringSegment"/> objects are equal; otherwise, <see langword="false"/>.</returns>
         public bool Equals(StringSegment x, StringSegment y)
         {
             return StringSegment.Equals(x, y, Comparison);

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringTokenizer.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringTokenizer.cs
@@ -96,14 +96,24 @@ namespace Microsoft.Extensions.Primitives
                 _index = 0;
             }
 
+            /// <summary>
+            /// Gets the current <see cref="StringSegment"/> from the <see cref="StringTokenizer"/>.
+            /// </summary>
             public StringSegment Current { get; private set; }
 
             object IEnumerator.Current => Current;
 
+            /// <summary>
+            /// Releases all resources used by the <see cref="Enumerator"/>.
+            /// </summary>
             public void Dispose()
             {
             }
 
+            /// <summary>
+            /// Advances the enumerator to the next token in the <see cref="StringTokenizer"/>.
+            /// </summary>
+            /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next token; <see langword="false"/> if the enumerator has passed the end of the <see cref="StringTokenizer"/>.</returns>
             public bool MoveNext()
             {
                 if (!_value.HasValue || _index > _value.Length)
@@ -125,6 +135,9 @@ namespace Microsoft.Extensions.Primitives
                 return true;
             }
 
+            /// <summary>
+            /// Resets the <see cref="Enumerator"/> to its initial state.
+            /// </summary>
             public void Reset()
             {
                 Current = default(StringSegment);

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
@@ -788,6 +788,10 @@ namespace Microsoft.Extensions.Primitives
             public Enumerator(ref StringValues values) : this(values._values)
             { }
 
+            /// <summary>
+            /// Advances the enumerator to the next element of the <see cref="StringValues"/>.
+            /// </summary>
+            /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the <see cref="StringValues"/>.</returns>
             public bool MoveNext()
             {
                 int index = _index;
@@ -814,6 +818,9 @@ namespace Microsoft.Extensions.Primitives
                 return _current != null;
             }
 
+            /// <summary>
+            /// Gets the element at the current position of the enumerator.
+            /// </summary>
             public string? Current => _current;
 
             object? IEnumerator.Current => _current;
@@ -823,6 +830,9 @@ namespace Microsoft.Extensions.Primitives
                 throw new NotSupportedException();
             }
 
+            /// <summary>
+            /// Releases all resources used by the <see cref="Enumerator" />.
+            /// </summary>
             public void Dispose()
             {
             }

--- a/src/libraries/Microsoft.Internal.Runtime.DotNetApiDocs.Transport/src/Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.DotNetApiDocs.Transport/src/Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj
@@ -1,0 +1,52 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)-$(TargetOS)</TargetFramework>
+    <IsShipping>false</IsShipping>
+    <!-- Reference the outputs to have them available as build outputsd. -->
+    <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>true</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
+    <EnablePackageValidation>false</EnablePackageValidation>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <PackageDescription>Internal transport package to provide dotnet-api-docs with the reference assemblies and compiler generated documentation files from dotnet/runtime.</PackageDescription>
+    <NoWarn>$(NoWarn);NU5128;NU5131</NoWarn>
+    <BuildProjectReferences Condition="'$(NoBuild)' == 'true'">false</BuildProjectReferences>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeProjectReferenceCompilerGeneratedSecondaryOutputInPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Requires Private=true to calculate ReferenceCopyLocalPaths items. -->
+    <ProjectReference Include="$(LibrariesProjectRoot)sfx-src.proj;
+                               $(LibrariesProjectRoot)oob-src.proj"
+                      PrivateAssets="all"
+                      Private="true" />
+  </ItemGroup>
+
+  <!-- Include the reference assembly and put the documentation file next to it. -->
+  <Target Name="IncludeProjectReferenceCompilerGeneratedSecondaryOutputInPackage"
+          DependsOnTargets="BuildOnlySettings;ResolveReferences">
+    <ItemGroup>
+      <ProjectReferenceCopyLocalPathNonPrivate Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('IsPrivateAssembly', 'false'))" />
+
+      <ReferenceAssemblyFile Include="@(ProjectReferenceCopyLocalPathNonPrivate->WithMetadataValue('Extension', '.dll')->Metadata('ReferenceAssembly'))" />
+      <CompilerGeneratedXmlDocFile Include="@(ProjectReferenceCopyLocalPathNonPrivate->WithMetadataValue('UseCompilerGeneratedDocXmlFile', 'true')->WithMetadataValue('Extension', '.xml'))" />
+      <TfmSpecificPackageFile Include="@(ReferenceAssemblyFile);
+                                       @(CompilerGeneratedXmlDocFile)"
+                              PackagePath="ref\$(NetCoreAppCurrent)\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PartialFacadeCompilerGeneratedXmlDocFile Include="@(CompilerGeneratedXmlDocFile->WithMetadataValue('IsPartialFacadeAssembly', 'true'))" />
+      <PlatformNotSupportedCompilerGeneratedXmlDocFile Include="@(CompilerGeneratedXmlDocFile->WithMetadataValue('IsPlatformNotSupportedAssembly', 'true'))" />
+    </ItemGroup>
+
+    <Error Text="Compiler generated XML documentation files are missing data because partial facade assemblies aren't yet supported by the repo infrastructure. Consider removing the partial facade feature or setting the 'GenerateDocumentationFile' property to false in the project file. Assemblies: @(PartialFacadeCompilerGeneratedXmlDocFile->Metadata('Filename'), ', ')."
+           Condition="'@(PartialFacadeCompilerGeneratedXmlDocFile)' != ''" />
+
+    <Error Text="Compiler generated XML documentation files are missing data because PNSE (platform not supported exception) assemblies aren't yet supported by the repo infrastructure. Consider removing the PNSE feature or setting the 'GenerateDocumentationFile' property to false in the project file. Assemblies: @(PlatformNotSupportedCompilerGeneratedXmlDocFile->Metadata('Filename'), ', ')."
+           Condition="'@(PlatformNotSupportedCompilerGeneratedXmlDocFile)' != ''" />
+  </Target>
+
+</Project>

--- a/src/libraries/Microsoft.Internal.Runtime.DotNetApiDocs.Transport/src/Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.DotNetApiDocs.Transport/src/Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)-$(TargetOS)</TargetFramework>
     <IsShipping>false</IsShipping>
-    <!-- Reference the outputs to have them available as build outputsd. -->
+    <!-- Reference the outputs to have them available as build outputs. -->
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>true</IncludeBuildOutput>

--- a/src/libraries/Microsoft.Internal.Runtime.DotNetApiDocs.Transport/src/Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.DotNetApiDocs.Transport/src/Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj
@@ -28,7 +28,10 @@
   <Target Name="IncludeProjectReferenceCompilerGeneratedSecondaryOutputInPackage"
           DependsOnTargets="BuildOnlySettings;ResolveReferences">
     <ItemGroup>
-      <ProjectReferenceCopyLocalPathNonPrivate Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('IsPrivateAssembly', 'false'))" />
+
+      <!-- Exclude private assemblies and Microsoft.Bcl.* which are pure type forwards on .NETCoreApp. -->
+      <ProjectReferenceCopyLocalPathNonPrivate Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('IsPrivateAssembly', 'false'))"
+                                               Condition="!$([System.String]::new('%(Filename)').StartsWith('Microsoft.Bcl.'))" />
 
       <ReferenceAssemblyFile Include="@(ProjectReferenceCopyLocalPathNonPrivate->WithMetadataValue('Extension', '.dll')->Metadata('ReferenceAssembly'))" />
       <CompilerGeneratedXmlDocFile Include="@(ProjectReferenceCopyLocalPathNonPrivate->WithMetadataValue('UseCompilerGeneratedDocXmlFile', 'true')->WithMetadataValue('Extension', '.xml'))" />

--- a/src/libraries/System.Formats.Cbor/src/System.Formats.Cbor.csproj
+++ b/src/libraries/System.Formats.Cbor/src/System.Formats.Cbor.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
-    <UseIntellisensePackageDocXmlFile>false</UseIntellisensePackageDocXmlFile>
+    <UseCompilerGeneratedDocXmlFile>true</UseCompilerGeneratedDocXmlFile>
     <PackageDescription>Provides classes that can read and write the CBOR data format.
 
 Commonly Used Types:
@@ -60,4 +61,5 @@ System.Formats.Cbor.CborWriter</PackageDescription>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
   </ItemGroup>
+
 </Project>

--- a/src/libraries/System.Speech/src/System.Speech.csproj
+++ b/src/libraries/System.Speech/src/System.Speech.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppPrevious)-windows;$(NetCoreAppPrevious);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -7,8 +8,8 @@
     <NoWarn>$(NoWarn);CS0649;SA1129;IDE0059;IDE0060;CA1822;CA1852</NoWarn>
     <Nullable>annotations</Nullable>
     <IsTrimmable>false</IsTrimmable>
-    <!-- Public API not fully documented. -->
-    <NoWarn>$(NoWarn);1591</NoWarn>
+    <!-- Public API not fully documented and System.Speech has a PNSE assembly which isn't yet supported by the repo infrastructure. -->
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>
     <AddNETFrameworkAssemblyReferenceToPackage>true</AddNETFrameworkAssemblyReferenceToPackage>
@@ -256,4 +257,5 @@ System.Speech.Recognition.SpeechRecognizer</PackageDescription>
     <EmbeddedResource Include="upstable_jpn.upsmap"
                       LogicalName="upstable_jpn.upsmap" />
   </ItemGroup>
+
 </Project>

--- a/src/libraries/oob-all.proj
+++ b/src/libraries/oob-all.proj
@@ -23,7 +23,8 @@
 
     <!-- Build these packages in the allconfigurations leg only. -->
     <ProjectReference Remove="Microsoft.Internal.Runtime.AspNetCore.Transport\src\Microsoft.Internal.Runtime.AspNetCore.Transport.proj;
-                              Microsoft.Internal.Runtime.WindowsDesktop.Transport\src\Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj"
+                              Microsoft.Internal.Runtime.WindowsDesktop.Transport\src\Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj;
+                              Microsoft.Internal.Runtime.DotNetApiDocs.Transport\src\Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj"
                       Condition="'$(BuildAllConfigurations)' != 'true'" />
 
     <!-- Skip these projects during source-build as they rely on external prebuilts. -->

--- a/src/libraries/oob-src.proj
+++ b/src/libraries/oob-src.proj
@@ -32,7 +32,8 @@
 
     <!-- Don't build meta-projects in the NetCoreAppCurrent vertical. -->
     <ProjectReference Remove="Microsoft.Internal.Runtime.AspNetCore.Transport\src\Microsoft.Internal.Runtime.AspNetCore.Transport.proj;
-                              Microsoft.Internal.Runtime.WindowsDesktop.Transport\src\Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj" />
+                              Microsoft.Internal.Runtime.WindowsDesktop.Transport\src\Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj;
+                              Microsoft.Internal.Runtime.DotNetApiDocs.Transport\src\Microsoft.Internal.Runtime.DotNetApiDocs.Transport.proj" />
 
     <!-- Skip these projects during source-build as they rely on external prebuilts. -->
     <ProjectReference Remove="Microsoft.Extensions.DependencyInjection.Specification.Tests\src\Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj"


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/996

- Create docs ref+xml transport package
Add a nuget package that contains all the reference assemblies and
source-of-truth API docs XML files for the current release.

- Turn on source of truth for Microsoft.Extensions.*
Make the source of truth for API docs for the Microsoft.Extensions.*
libraries dotnet/runtime instead of the intellisense package.
Disable the few projects that aren't yet documented. Same for libraries
that are already effectively source-of-truth in runtime but which aren't
documented.

@carlossanlop there are ~20 remaining undocumented APIs in all Microsoft.Extensions.*. Can you please help resolve them as part of this PR?

```
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\InplaceStringBuilder.cs(14,19): error CS1591: Missing XML comment for publicly visible type or member 'InplaceStringBuilder' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\InplaceStringBuilder.cs(20,16): error CS1591: Missing XML comment for publicly visible type or member 'InplaceStringBuilder.InplaceStringBuilder(int)' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\InplaceStringBuilder.cs(30,20): error CS1591: Missing XML comment for publicly visible type or member 'InplaceStringBuilder.Capacity' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\InplaceStringBuilder.cs(50,21): error CS1591: Missing XML comment for publicly visible type or member 'InplaceStringBuilder.Append(string?)' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\InplaceStringBuilder.cs(60,21): error CS1591: Missing XML comment for publicly visible type or member 'InplaceStringBuilder.Append(StringSegment)' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\InplaceStringBuilder.cs(66,28): error CS1591: Missing XML comment for publicly visible type or member 'InplaceStringBuilder.Append(string?, int, int)' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\InplaceStringBuilder.cs(87,28): error CS1591: Missing XML comment for publicly visible type or member 'InplaceStringBuilder.Append(char)' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\InplaceStringBuilder.cs(102,33): error CS1591: Missing XML comment for publicly visible type or member 'InplaceStringBuilder.ToString()' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\StringSegmentComparer.cs(35,20): error CS1591: Missing XML comment for publicly visible type or member 'StringSegmentComparer.Compare(StringSegment, StringSegment)' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\StringSegmentComparer.cs(40,21): error CS1591: Missing XML comment for publicly visible type or member 'StringSegmentComparer.Equals(StringSegment, StringSegment)' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\StringTokenizer.cs(99,34): error CS1591: Missing XML comment for publicly visible type or member 'StringTokenizer.Enumerator.Current' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\StringTokenizer.cs(103,25): error CS1591: Missing XML comment for publicly visible type or member 'StringTokenizer.Enumerator.Dispose()' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\StringTokenizer.cs(107,25): error CS1591: Missing XML comment for publicly visible type or member 'StringTokenizer.Enumerator.MoveNext()' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\StringTokenizer.cs(128,25): error CS1591: Missing XML comment for publicly visible type or member 'StringTokenizer.Enumerator.Reset()' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\StringValues.cs(791,25): error CS1591: Missing XML comment for publicly visible type or member 'StringValues.Enumerator.MoveNext()' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\StringValues.cs(817,28): error CS1591: Missing XML comment for publicly visible type or member 'StringValues.Enumerator.Current' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\StringValues.cs(826,25): error CS1591: Missing XML comment for publicly visible type or member 'StringValues.Enumerator.Dispose()' [C:\git\runtime2\src\libraries\Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj::TargetFramework=net8.0]

C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\FromKeyedServicesAttribute.cs(9,18): error CS1591: Missing XML comment for publicly visible type or member 'FromKeyedServicesAttribute' [C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\FromKeyedServicesAttribute.cs(11,16): error CS1591: Missing XML comment for publicly visible type or member 'FromKeyedServicesAttribute.FromKeyedServicesAttribute(object)' [C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\FromKeyedServicesAttribute.cs(13,23): error CS1591: Missing XML comment for publicly visible type or member 'FromKeyedServicesAttribute.Key' [C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\IKeyedServiceProvider.cs(8,22): error CS1591: Missing XML comment for publicly visible type or member 'IKeyedServiceProvider' [C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\IKeyedServiceProvider.cs(29,25): error CS1591: Missing XML comment for publicly visible type or member 'KeyedService' [C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\IKeyedServiceProvider.cs(31,30): error CS1591: Missing XML comment for publicly visible type or member 'KeyedService.AnyKey' [C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\IServiceProviderIsKeyedService.cs(8,22): error CS1591: Missing XML comment for publicly visible type or member 'IServiceProviderIsKeyedService' [C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\ServiceDescriptor.cs(250,21): error CS1591: Missing XML comment for publicly visible type or member 'ServiceDescriptor.IsKeyedService' [C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj::TargetFramework=net8.0]
C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\ServiceKeyAttribute.cs(9,18): error CS1591: Missing XML comment for publicly visible type or member 'ServiceKeyAttribute' [C:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj::TargetFramework=net8.0]
```