### PR TITLE
Enable configuration FunctionalTests.ArrayTests.DifferentConfigSources_Merged_* tests on ios/tvos

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ArrayTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ArrayTests.cs
@@ -47,7 +47,6 @@ i=ini_i.i.i.i
 ";
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60583", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void DifferentConfigSources_Merged_KeysAreSorted()
         {
             var config = BuildConfig();
@@ -76,7 +75,6 @@ i=ini_i.i.i.i
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60583", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void DifferentConfigSources_Merged_WithOverwrites()
         {
             var config = BuildConfig();


### PR DESCRIPTION
8.0 triage: checking if https://github.com/dotnet/runtime/issues/60583 can be closed.