### PR TITLE
FIX #87983 - Enable events for LogAlways

### DIFF
--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -5806,7 +5806,8 @@ bool EventPipeHelper::IsEnabled(DOTNET_TRACE_CONTEXT Context, UCHAR Level, ULONG
         return false;
     }
 
-    if (Level <= Context.EventPipeProvider.Level)
+    if ((Level <= Context.EventPipeProvider.Level) ||
+        (Context.EventPipeProvider.Level == EP_EVENT_LEVEL_LOGALWAYS))
     {
         return (Keyword == (ULONGLONG)0) || (Keyword & Context.EventPipeProvider.EnabledKeywordsBitmask) != 0;
     }

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -153,9 +153,14 @@ provider_compute_event_enable_mask (
 				// The event is enabled if:
 				//  - The provider is enabled.
 				//  - The event keywords are unspecified in the manifest (== 0) or when masked with the enabled config are != 0.
-				//  - The event level is LogAlways or the provider's verbosity level is set to greater than the event's verbosity level in the manifest.
+				//  - The event level is LogAlways
+                //    or the provider's verbosity level is LogAlways
+                //    or the provider's verbosity level is set to greater than the event's verbosity level in the manifest.
 				bool keyword_enabled = (keywords == 0) || ((session_keyword & keywords) != 0);
-				bool level_enabled = ((event_level == EP_EVENT_LEVEL_LOGALWAYS) || (session_level >= event_level));
+				bool level_enabled = (event_level == EP_EVENT_LEVEL_LOGALWAYS) ||
+                    (session_level == EP_EVENT_LEVEL_LOGALWAYS) ||
+                    (session_level >= event_level);
+
 				if (provider_enabled && keyword_enabled && level_enabled)
 					result = result | ep_session_get_mask (session);
 			}


### PR DESCRIPTION
Repro of Issue #87983 demonstrates that when an EventListener enables events for NativeRuntimeEventSource with EventLevel.LogAlways then OnEventWritten receives no events.

With a change in [src/native/eventpipe/ep-provider.c](https://github.com/dotnet/runtime/compare/main...n77y:runtime:dev/n77y/fix87983#diff-0006f3e88931b16ef51cb49926a1773353ace02067ffd98bf05bde2f7729e00a) most events should fire.
With a change in [src/coreclr/vm/eventtrace.cpp](https://github.com/dotnet/runtime/compare/main...n77y:runtime:dev/n77y/fix87983#diff-f80cf2bff10b2a70c36d809ecebf292fc861e3fa88a93c73090f5dbc0456d373) the rest should fire.
With a change in [System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventDispatcher.cs](https://github.com/dotnet/runtime/compare/main...n77y:runtime:dev/n77y/fix87983#diff-868eb0967febc075d2c0868e6700e84cb708dea56a128eca231af28a65e91d26) LogAlways will be treated as the highest level.

The issue was that the provider's level being LogAlways was not accounted for when enabling events and when firing them.

Test app that is helpful reproing the issue and providing useful information:

```c#
using System;
using System.Collections.Concurrent;
using System.Collections.Generic;
using System.Diagnostics;
using System.Diagnostics.Tracing;
using System.Linq;
using System.Threading;

Listener listener = Listener.Create(/*
    EventLevel.Informational//*/
    );
Stopwatch stopwatch = Stopwatch.StartNew();

while (stopwatch.Elapsed.TotalSeconds < 5d)
{
    Thread.Sleep(Random.Shared.Next().ToString().GetHashCode() & sbyte.MaxValue);
}
listener.DumpEvents();

internal sealed class Listener : EventListener
{
    public static EventLevel NextLevel = EventLevel.LogAlways;
    private readonly ConcurrentDictionary<string, int> Distinct = new();
    private EventLevel Level = EventLevel.LogAlways;
    private Listener? listener = null;

    public static Listener Create(params EventLevel[] levels)
    {
        NextLevel = levels.FirstOrDefault(EventLevel.LogAlways);
        return new()
        {
            listener = (levels.Length > 1) ? Create(levels[1..]) : null,
        };
    }

    public void DumpEvents()
    {
        Dispose();
        Console.WriteLine($"\n{nameof(Level)}\t\t{Level}");
        Console.WriteLine($"{nameof(Distinct)}\t{Distinct.Count}");
        Console.WriteLine($"Total\t\t{Distinct.Values.Sum()}");

        foreach (KeyValuePair<string, int> e in Distinct.OrderByDescending(e => e.Value))
        {
            Console.WriteLine($"#{e.Value}\t{e.Key}");
        }
        listener?.DumpEvents();
    }

    protected override void OnEventSourceCreated(EventSource source)
    {
        if (source.Name is "Microsoft-Windows-DotNETRuntime")
        {
            Level = NextLevel;
            EnableEvents(source, Level, EventKeywords.All);
        }
    }

    protected override void OnEventWritten(EventWrittenEventArgs e)
    {
        string str = $"{e.EventId}\t{e.EventSource.Name}\t{e.EventName}";
        Distinct[str] = Distinct.GetValueOrDefault(str, 0) + 1;
    }
}