### PR TITLE
Make checks for compiler-generated types more specific

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedNames.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedNames.cs
@@ -7,7 +7,7 @@ namespace ILCompiler.Dataflow
 {
     internal sealed class CompilerGeneratedNames
     {
-        internal static bool IsGeneratedMemberName(string memberName)
+        private static bool IsGeneratedMemberName(string memberName)
         {
             return memberName.Length > 0 && memberName[0] == '<';
         }
@@ -49,7 +49,7 @@ namespace ILCompiler.Dataflow
             return fieldName.Length > i + 1 && fieldName[i + 1] == '2';
         }
 
-        internal static bool IsGeneratedType(string name) => IsStateMachineType(name) || IsLambdaDisplayClass(name);
+        internal static bool IsStateMachineOrDisplayClass(string name) => IsStateMachineType(name) || IsLambdaDisplayClass(name);
 
         internal static bool IsLambdaOrLocalFunction(string methodName) => IsLambdaMethod(methodName) || IsLocalFunction(methodName);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
@@ -73,7 +73,7 @@ namespace ILCompiler.Dataflow
             internal TypeCache(MetadataType type, Logger? logger, ILProvider ilProvider)
             {
                 Debug.Assert(type == type.GetTypeDefinition());
-                Debug.Assert(!CompilerGeneratedNames.IsGeneratedMemberName(type.Name));
+                Debug.Assert(!CompilerGeneratedNames.IsStateMachineOrDisplayClass(type.Name));
 
                 Type = type;
 
@@ -194,7 +194,7 @@ namespace ILCompiler.Dataflow
                     if (TryGetStateMachineType(method, out MetadataType? stateMachineType))
                     {
                         Debug.Assert(stateMachineType.ContainingType == type ||
-                            (CompilerGeneratedNames.IsGeneratedMemberName(stateMachineType.ContainingType.Name) &&
+                            (CompilerGeneratedNames.IsStateMachineOrDisplayClass(stateMachineType.ContainingType.Name) &&
                              stateMachineType.ContainingType.ContainingType == type));
                         Debug.Assert(stateMachineType == stateMachineType.GetTypeDefinition());
 
@@ -321,7 +321,7 @@ namespace ILCompiler.Dataflow
                     MetadataType generatedType,
                     Dictionary<MetadataType, TypeArgumentInfo> generatedTypeToTypeArgs)
                 {
-                    Debug.Assert(CompilerGeneratedNames.IsGeneratedType(generatedType.Name));
+                    Debug.Assert(CompilerGeneratedNames.IsStateMachineOrDisplayClass(generatedType.Name));
                     Debug.Assert(generatedType == generatedType.GetTypeDefinition());
 
                     var typeInfo = generatedTypeToTypeArgs[generatedType];
@@ -361,7 +361,7 @@ namespace ILCompiler.Dataflow
                             else
                             {
                                 // Must be a type ref
-                                if (method.OwningType is not MetadataType owningType || !CompilerGeneratedNames.IsGeneratedType(owningType.Name))
+                                if (method.OwningType is not MetadataType owningType || !CompilerGeneratedNames.IsStateMachineOrDisplayClass(owningType.Name))
                                 {
                                     userAttrs = param;
                                 }
@@ -501,7 +501,7 @@ namespace ILCompiler.Dataflow
         {
             foreach (var nestedType in type.GetNestedTypes())
             {
-                if (!CompilerGeneratedNames.IsGeneratedMemberName(nestedType.Name))
+                if (!CompilerGeneratedNames.IsStateMachineOrDisplayClass(nestedType.Name))
                     continue;
 
                 yield return nestedType;
@@ -565,7 +565,7 @@ namespace ILCompiler.Dataflow
             // State machines can be emitted into display classes, so we may also need to go one more level up.
             // To avoid depending on implementation details, we go up until we see a non-compiler-generated type.
             // This is the counterpart to GetCompilerGeneratedNestedTypes.
-            while (userType != null && CompilerGeneratedNames.IsGeneratedMemberName(userType.Name))
+            while (userType != null && CompilerGeneratedNames.IsStateMachineOrDisplayClass(userType.Name))
                 userType = userType.ContainingType as MetadataType;
 
             if (userType is null)
@@ -607,7 +607,7 @@ namespace ILCompiler.Dataflow
         public IReadOnlyList<GenericParameterDesc?>? GetGeneratedTypeAttributes(MetadataType type)
         {
             MetadataType generatedType = (MetadataType)type.GetTypeDefinition();
-            Debug.Assert(CompilerGeneratedNames.IsGeneratedType(generatedType.Name));
+            Debug.Assert(CompilerGeneratedNames.IsStateMachineOrDisplayClass(generatedType.Name));
 
             var typeCache = GetCompilerGeneratedStateForType(generatedType);
             if (typeCache is null)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -641,7 +641,7 @@ namespace ILLink.Shared.TrimAnalysis
 
             private IReadOnlyList<GenericParameterDesc?>? GetGeneratedTypeAttributes(EcmaType typeDef)
             {
-                if (!CompilerGeneratedNames.IsGeneratedType(typeDef.Name))
+                if (!CompilerGeneratedNames.IsStateMachineOrDisplayClass(typeDef.Name))
                 {
                     return null;
                 }

--- a/src/tools/illink/src/linker/Linker.Dataflow/CompilerGeneratedNames.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/CompilerGeneratedNames.cs
@@ -5,7 +5,7 @@ namespace Mono.Linker.Dataflow
 {
 	sealed class CompilerGeneratedNames
 	{
-		internal static bool IsGeneratedMemberName (string memberName)
+		private static bool IsGeneratedMemberName (string memberName)
 		{
 			return memberName.Length > 0 && memberName[0] == '<';
 		}
@@ -47,7 +47,7 @@ namespace Mono.Linker.Dataflow
 			return fieldName.Length > i + 1 && fieldName[i + 1] == '2';
 		}
 
-		internal static bool IsGeneratedType (string name) => IsStateMachineType (name) || IsLambdaDisplayClass (name);
+		internal static bool IsStateMachineOrDisplayClass (string name) => IsStateMachineType (name) || IsLambdaDisplayClass (name);
 
 		internal static bool IsLambdaOrLocalFunction (string methodName) => IsLambdaMethod (methodName) || IsLocalFunction (methodName);
 

--- a/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/FlowAnnotations.cs
@@ -399,7 +399,7 @@ namespace ILLink.Shared.TrimAnalysis
 
 		private IReadOnlyList<ICustomAttributeProvider>? GetGeneratedTypeAttributes (TypeDefinition typeDef)
 		{
-			if (!CompilerGeneratedNames.IsGeneratedType (typeDef.Name)) {
+			if (!CompilerGeneratedNames.IsStateMachineOrDisplayClass (typeDef.Name)) {
 				return null;
 			}
 			var attrs = _context.CompilerGeneratedState.GetGeneratedTypeAttributes (typeDef);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/89191

The only types we want to consider for the compiler-generated state handling are lambda display classes, and state machine types. We used to treat all types with compiler-generated names this way, but this was too broad of a filter because it would include file-scoped classes (which get names like `<GeneratedConfigurationBinder_g>F86B5F805A26B32373DA5BA80136649730AD5F76CC2979BFEE086BEB55048B927__CoreBindingHelper`, for the configuration binder source generator).