### PR TITLE
Use AVX512 intrinsics for number conversion when possible

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -393,7 +393,11 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector128<double> ConvertToDouble(Vector128<long> vector)
         {
-            if (Sse2.IsSupported)
+            if (Avx512DQ.VL.IsSupported)
+            {
+                return Avx512DQ.VL.ConvertToVector128Double(vector);
+            }
+            else if (Sse2.IsSupported)
             {
                 // Based on __m256d int64_to_double_fast_precise(const __m256i v)
                 // from https://stackoverflow.com/a/41223013/12860347. CC BY-SA 4.0
@@ -434,7 +438,11 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector128<double> ConvertToDouble(Vector128<ulong> vector)
         {
-            if (Sse2.IsSupported)
+            if (Avx512DQ.VL.IsSupported)
+            {
+                return Avx512DQ.VL.ConvertToVector128Double(vector);
+            }
+            else if (Sse2.IsSupported)
             {
                 // Based on __m256d uint64_to_double_fast_precise(const __m256i v)
                 // from https://stackoverflow.com/a/41223013/12860347. CC BY-SA 4.0
@@ -487,10 +495,17 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector128<long> ConvertToInt64(Vector128<double> vector)
         {
-            return Create(
-                Vector64.ConvertToInt64(vector._lower),
-                Vector64.ConvertToInt64(vector._upper)
-            );
+            if (Avx512DQ.VL.IsSupported)
+            {
+                return Avx512DQ.VL.ConvertToVector128Int64(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector64.ConvertToInt64(vector._lower),
+                    Vector64.ConvertToInt64(vector._upper)
+                );
+            }
         }
 
         /// <summary>Converts a <see cref="Vector128{Int32}" /> to a <see cref="Vector128{Single}" />.</summary>
@@ -571,10 +586,17 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector128<uint> ConvertToUInt32(Vector128<float> vector)
         {
-            return Create(
-                Vector64.ConvertToUInt32(vector._lower),
-                Vector64.ConvertToUInt32(vector._upper)
-            );
+            if (Avx512DQ.VL.IsSupported)
+            {
+                return Avx512DQ.VL.ConvertToVector128UInt32(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector64.ConvertToUInt32(vector._lower),
+                    Vector64.ConvertToUInt32(vector._upper)
+                );
+            }
         }
 
         /// <summary>Converts a <see cref="Vector128{Double}" /> to a <see cref="Vector128{UInt64}" />.</summary>
@@ -585,10 +607,17 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector128<ulong> ConvertToUInt64(Vector128<double> vector)
         {
-            return Create(
-                Vector64.ConvertToUInt64(vector._lower),
-                Vector64.ConvertToUInt64(vector._upper)
-            );
+            if (Avx512DQ.VL.IsSupported)
+            {
+                return Avx512DQ.VL.ConvertToVector128UInt64(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector64.ConvertToUInt64(vector._lower),
+                    Vector64.ConvertToUInt64(vector._upper)
+                );
+            }
         }
 
         /// <summary>Copies a <see cref="Vector128{T}" /> to a given array.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -497,7 +497,7 @@ namespace System.Runtime.Intrinsics
         {
             if (Avx512DQ.VL.IsSupported)
             {
-                return Avx512DQ.VL.ConvertToVector128Int64(vector);
+                return Avx512DQ.VL.ConvertToVector128Int64WithTruncation(vector);
             }
             else
             {
@@ -588,7 +588,7 @@ namespace System.Runtime.Intrinsics
         {
             if (Avx512DQ.VL.IsSupported)
             {
-                return Avx512DQ.VL.ConvertToVector128UInt32(vector);
+                return Avx512DQ.VL.ConvertToVector128UInt32WithTruncation(vector);
             }
             else
             {
@@ -609,7 +609,7 @@ namespace System.Runtime.Intrinsics
         {
             if (Avx512DQ.VL.IsSupported)
             {
-                return Avx512DQ.VL.ConvertToVector128UInt64(vector);
+                return Avx512DQ.VL.ConvertToVector128UInt64WithTruncation(vector);
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -324,7 +324,11 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector256<double> ConvertToDouble(Vector256<long> vector)
         {
-            if (Avx2.IsSupported)
+            if (Avx512DQ.VL.IsSupported)
+            {
+                return Avx512DQ.VL.ConvertToVector256Double(vector);
+            }
+            else if (Avx2.IsSupported)
             {
                 // Based on __m256d int64_to_double_fast_precise(const __m256i v)
                 // from https://stackoverflow.com/a/41223013/12860347. CC BY-SA 4.0
@@ -357,7 +361,11 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector256<double> ConvertToDouble(Vector256<ulong> vector)
         {
-            if (Avx2.IsSupported)
+            if (Avx512DQ.VL.IsSupported)
+            {
+                return Avx512DQ.VL.ConvertToVector256Double(vector);
+            }
+            else if (Avx2.IsSupported)
             {
                 // Based on __m256d uint64_to_double_fast_precise(const __m256i v)
                 // from https://stackoverflow.com/a/41223013/12860347. CC BY-SA 4.0
@@ -402,10 +410,17 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector256<long> ConvertToInt64(Vector256<double> vector)
         {
-            return Create(
-                Vector128.ConvertToInt64(vector._lower),
-                Vector128.ConvertToInt64(vector._upper)
-            );
+            if (Avx512DQ.VL.IsSupported)
+            {
+                return Avx512DQ.VL.ConvertToVector256Int64(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector128.ConvertToInt64(vector._lower),
+                    Vector128.ConvertToInt64(vector._upper)
+                );
+            }
         }
 
         /// <summary>Converts a <see cref="Vector256{Int32}" /> to a <see cref="Vector256{Single}" />.</summary>
@@ -476,10 +491,17 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector256<uint> ConvertToUInt32(Vector256<float> vector)
         {
-            return Create(
-                Vector128.ConvertToUInt32(vector._lower),
-                Vector128.ConvertToUInt32(vector._upper)
-            );
+            if (Avx512DQ.VL.IsSupported)
+            {
+                return Avx512DQ.VL.ConvertToVector256UInt32(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector128.ConvertToUInt32(vector._lower),
+                    Vector128.ConvertToUInt32(vector._upper)
+                );
+            }
         }
 
         /// <summary>Converts a <see cref="Vector256{Double}" /> to a <see cref="Vector256{UInt64}" />.</summary>
@@ -490,10 +512,17 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector256<ulong> ConvertToUInt64(Vector256<double> vector)
         {
-            return Create(
-                Vector128.ConvertToUInt64(vector._lower),
-                Vector128.ConvertToUInt64(vector._upper)
-            );
+            if (Avx512DQ.VL.IsSupported)
+            {
+                return Avx512DQ.VL.ConvertToVector256UInt64(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector128.ConvertToUInt64(vector._lower),
+                    Vector128.ConvertToUInt64(vector._upper)
+                );
+            }
         }
 
         /// <summary>Copies a <see cref="Vector256{T}" /> to a given array.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -412,7 +412,7 @@ namespace System.Runtime.Intrinsics
         {
             if (Avx512DQ.VL.IsSupported)
             {
-                return Avx512DQ.VL.ConvertToVector256Int64(vector);
+                return Avx512DQ.VL.ConvertToVector256Int64WithTruncation(vector);
             }
             else
             {
@@ -493,7 +493,7 @@ namespace System.Runtime.Intrinsics
         {
             if (Avx512DQ.VL.IsSupported)
             {
-                return Avx512DQ.VL.ConvertToVector256UInt32(vector);
+                return Avx512DQ.VL.ConvertToVector256UInt32WithTruncation(vector);
             }
             else
             {
@@ -514,7 +514,7 @@ namespace System.Runtime.Intrinsics
         {
             if (Avx512DQ.VL.IsSupported)
             {
-                return Avx512DQ.VL.ConvertToVector256UInt64(vector);
+                return Avx512DQ.VL.ConvertToVector256UInt64WithTruncation(vector);
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
@@ -324,10 +324,17 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector512<double> ConvertToDouble(Vector512<long> vector)
         {
-            return Create(
-                Vector256.ConvertToDouble(vector._lower),
-                Vector256.ConvertToDouble(vector._upper)
-            );
+            if (Avx512DQ.IsSupported)
+            {
+                return Avx512DQ.ConvertToVector512Double(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector256.ConvertToDouble(vector._lower),
+                    Vector256.ConvertToDouble(vector._upper)
+                );
+            }
         }
 
         /// <summary>Converts a <see cref="Vector512{UInt64}" /> to a <see cref="Vector512{Double}" />.</summary>
@@ -338,10 +345,17 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector512<double> ConvertToDouble(Vector512<ulong> vector)
         {
-            return Create(
-                Vector256.ConvertToDouble(vector._lower),
-                Vector256.ConvertToDouble(vector._upper)
-            );
+            if (Avx512DQ.IsSupported)
+            {
+                return Avx512DQ.ConvertToVector512Double(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector256.ConvertToDouble(vector._lower),
+                    Vector256.ConvertToDouble(vector._upper)
+                );
+            }
         }
 
         /// <summary>Converts a <see cref="Vector512{Single}" /> to a <see cref="Vector512{Int32}" />.</summary>
@@ -364,10 +378,17 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector512<long> ConvertToInt64(Vector512<double> vector)
         {
-            return Create(
-                Vector256.ConvertToInt64(vector._lower),
-                Vector256.ConvertToInt64(vector._upper)
-            );
+            if (Avx512DQ.IsSupported)
+            {
+                return Avx512DQ.ConvertToVector512Int64(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector256.ConvertToInt64(vector._lower),
+                    Vector256.ConvertToInt64(vector._upper)
+                );
+            }
         }
 
         /// <summary>Converts a <see cref="Vector512{Int32}" /> to a <see cref="Vector512{Single}" />.</summary>
@@ -405,10 +426,17 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector512<uint> ConvertToUInt32(Vector512<float> vector)
         {
-            return Create(
-                Vector256.ConvertToUInt32(vector._lower),
-                Vector256.ConvertToUInt32(vector._upper)
-            );
+            if (Avx512DQ.IsSupported)
+            {
+                return Avx512DQ.ConvertToVector512UInt32(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector256.ConvertToUInt32(vector._lower),
+                    Vector256.ConvertToUInt32(vector._upper)
+                );
+            }
         }
 
         /// <summary>Converts a <see cref="Vector512{Double}" /> to a <see cref="Vector512{UInt64}" />.</summary>
@@ -419,10 +447,17 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector512<ulong> ConvertToUInt64(Vector512<double> vector)
         {
-            return Create(
-                Vector256.ConvertToUInt64(vector._lower),
-                Vector256.ConvertToUInt64(vector._upper)
-            );
+            if (Avx512DQ.IsSupported)
+            {
+                return Avx512DQ.ConvertToVector512UInt64(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector256.ConvertToUInt64(vector._lower),
+                    Vector256.ConvertToUInt64(vector._upper)
+                );
+            }
         }
 
         /// <summary>Copies a <see cref="Vector512{T}" /> to a given array.</summary>


### PR DESCRIPTION
This PR implements AVX512DQ intrinsics where possible for converting integers to floating points and vice versa.

Usecase: I had been working on vectorized PRNGs [in my Fast.PRNGs .NET library](https://github.com/martinothamar/Fast.PRNGs.NET) and [in my simd-rand Rust library](https://github.com/martinothamar/simd-rand). I was unable to match the performance in the Rust implementation partially due to uint64 -> double conversion being slower (when running on hardware with AVX512).

I did also search for related issues, where I found this: #85207. I think this fixes the first few bullet points there.

I benchmarked with disasm for a ulong -> double Vector256 conversion which seems to look good. I used a modified Vector256 version of this benchmark: https://github.com/dotnet/performance/blob/981a1a6730a5c54b3292428690ac9948e68c4823/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128.cs#L36
My only modification was not using a `static readonly` field to convert in the benchmark method, rather initializing a member field in a `GlobalSetup` method using random values (it had some small effect on the generated code). I noticed an open issue relating to the benchmarking setup: https://github.com/dotnet/performance/issues/2555. I could contribute benchmarks for wider vectors, but when doing conversion in a loop I struggled and didn't manage to avoid some dead code elimination to mess up the generated code, so the benchmarks would look pretty similar to the current 128bit ones, aside from the static data. Is there a good way to try to prevent these types of compiler optimizations from benchmark code? Something like the [black_box](https://doc.rust-lang.org/stable/std/hint/fn.black_box.html) intrinsic in Rust, or inline asm tricks commonly used in C/C++

# Benchmarks

## Before

## .NET 8.0.0 (8.0.23.32907), X64 RyuJIT AVX2
```assembly
; System.Runtime.Intrinsics.Tests.Perf_Vector256.ConvertULongToDoubleBenchmark()
       vzeroupper
       vmovups   ymm0,[rdi+8]
       vpblendd  ymm1,ymm0,[7F9E757F1580],0AA
       vpsrlq    ymm0,ymm0,20
       vpxor     ymm0,ymm0,[7F9E757F15A0]
       vsubpd    ymm0,ymm0,[7F9E757F15C0]
       vaddpd    ymm0,ymm0,ymm1
       vmovups   [rsi],ymm0
       mov       rax,rsi
       vzeroupper
       ret
; Total bytes of code 54
```

```

BenchmarkDotNet v0.13.7-nightly.20230717.35, Ubuntu 22.04.2 LTS (Jammy Jellyfish)
11th Gen Intel Core i7-11800H 2.30GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.100-preview.6.23330.14
  [Host]     : .NET 8.0.0 (8.0.23.32907), X64 RyuJIT AVX2
  Job-JPWDTA : .NET 8.0.0 (8.0.23.32907), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:EnableUnsafeBinaryFormatterSerialization=true  IterationTime=250.0000 ms  
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1  

```
|                        Method |      Mean |     Error |    StdDev |    Median |       Min |       Max | Code Size | Allocated |
|------------------------------ |----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
| ConvertULongToDoubleBenchmark | 0.2772 ns | 0.0546 ns | 0.0628 ns | 0.2719 ns | 0.1851 ns | 0.4117 ns |      54 B |         - |




## After

## .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2
```assembly
; System.Runtime.Intrinsics.Tests.Perf_Vector256.ConvertULongToDoubleBenchmark()
       vzeroupper
       vcvtuqq2pd ymm0,[rdi+8]
       vmovups   [rsi],ymm0
       mov       rax,rsi
       vzeroupper
       ret
; Total bytes of code 24
```


```

BenchmarkDotNet v0.13.7-nightly.20230717.35, Ubuntu 22.04.2 LTS (Jammy Jellyfish)
11th Gen Intel Core i7-11800H 2.30GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.100-preview.6.23330.14
  [Host]     : .NET 8.0.0 (8.0.23.32907), X64 RyuJIT AVX2
  Job-ASZUPG : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:EnableUnsafeBinaryFormatterSerialization=true  Toolchain=CoreRun  
IterationTime=250.0000 ms  MaxIterationCount=20  MinIterationCount=15  
WarmupCount=1  

```
|                        Method |      Mean |     Error |    StdDev |    Median |    Min |       Max | Code Size | Allocated |
|------------------------------ |----------:|----------:|----------:|----------:|-------:|----------:|----------:|----------:|
| ConvertULongToDoubleBenchmark | 0.0277 ns | 0.0251 ns | 0.0289 ns | 0.0218 ns | 0.0 ns | 0.0868 ns |      24 B |         - |
