### PR TITLE
[NativeAOT] Replace GVMLookupForSlot internal cache with generic cache similar to CastCache

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -9,7 +9,7 @@ using System.Threading;
 
 namespace System.Runtime.CompilerServices
 {
-    internal static class CastCache
+    internal static class CastCacheContainer
     {
         // In coreclr the table is allocated and written to on the native side.
         internal static int[]? s_table;
@@ -17,7 +17,7 @@ namespace System.Runtime.CompilerServices
 
     internal static unsafe class CastHelpers
     {
-        private static CastCacheImpl CastCacheInstance => new CastCacheImpl(CastCache.s_table!);
+        private static CastCache CastCacheInstance => new CastCache(CastCacheContainer.s_table!);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern object IsInstanceOfAny_NoCacheLookup(void* toTypeHnd, object obj);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -14,12 +14,6 @@ namespace System.Runtime.CompilerServices
         // In coreclr the table is allocated and written to on the native side.
         internal static int[]? s_table;
 
-        private static CastCache CastCacheInstance
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => new CastCache(s_table!);
-        }
-
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern object IsInstanceOfAny_NoCacheLookup(void* toTypeHnd, object obj);
 
@@ -45,7 +39,7 @@ namespace System.Runtime.CompilerServices
                 void* mt = RuntimeHelpers.GetMethodTable(obj);
                 if (mt != toTypeHnd)
                 {
-                    CastResult result = CastCacheInstance.TryGet((nuint)mt, (nuint)toTypeHnd);
+                    CastResult result = CastCache.TryGet(s_table!, (nuint)mt, (nuint)toTypeHnd);
                     if (result == CastResult.CanCast)
                     {
                         // do nothing
@@ -195,7 +189,7 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static object? IsInstance_Helper(void* toTypeHnd, object obj)
         {
-            CastResult result = CastCacheInstance.TryGet((nuint)RuntimeHelpers.GetMethodTable(obj), (nuint)toTypeHnd);
+            CastResult result = CastCache.TryGet(s_table!, (nuint)RuntimeHelpers.GetMethodTable(obj), (nuint)toTypeHnd);
             if (result == CastResult.CanCast)
             {
                 return obj;
@@ -224,7 +218,7 @@ namespace System.Runtime.CompilerServices
                 void* mt = RuntimeHelpers.GetMethodTable(obj);
                 if (mt != toTypeHnd)
                 {
-                    result = CastCacheInstance.TryGet((nuint)mt, (nuint)toTypeHnd);
+                    result = CastCache.TryGet(s_table!, (nuint)mt, (nuint)toTypeHnd);
                     if (result != CastResult.CanCast)
                     {
                         goto slowPath;
@@ -248,7 +242,7 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static object? ChkCast_Helper(void* toTypeHnd, object obj)
         {
-            CastResult result = CastCacheInstance.TryGet((nuint)RuntimeHelpers.GetMethodTable(obj), (nuint)toTypeHnd);
+            CastResult result = CastCache.TryGet(s_table!, (nuint)RuntimeHelpers.GetMethodTable(obj), (nuint)toTypeHnd);
             if (result == CastResult.CanCast)
             {
                 return obj;
@@ -465,7 +459,7 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void StelemRef_Helper(ref object? element, void* elementType, object obj)
         {
-            CastResult result = CastCacheInstance.TryGet((nuint)RuntimeHelpers.GetMethodTable(obj), (nuint)elementType);
+            CastResult result = CastCache.TryGet(s_table!, (nuint)RuntimeHelpers.GetMethodTable(obj), (nuint)elementType);
             if (result == CastResult.CanCast)
             {
                 WriteBarrier(ref element, obj);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -9,15 +9,16 @@ using System.Threading;
 
 namespace System.Runtime.CompilerServices
 {
-    internal static class CastCacheContainer
+    internal static unsafe class CastHelpers
     {
         // In coreclr the table is allocated and written to on the native side.
         internal static int[]? s_table;
-    }
 
-    internal static unsafe class CastHelpers
-    {
-        private static CastCache CastCacheInstance => new CastCache(CastCacheContainer.s_table!);
+        private static CastCache CastCacheInstance
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => new CastCache(s_table!);
+        }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern object IsInstanceOfAny_NoCacheLookup(void* toTypeHnd, object obj);

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -24,7 +24,7 @@ namespace System.Runtime
     [EagerStaticClassConstruction]
     internal static class TypeCast
     {
-        private static CastCacheImpl s_castCache = new CastCacheImpl();
+        private static CastCache s_castCache = new CastCache();
 
         [Flags]
         internal enum AssignmentVariation

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -21,8 +21,11 @@ namespace System.Runtime
     //
     /////////////////////////////////////////////////////////////////////////////////////////////////////
 
+    [EagerStaticClassConstruction]
     internal static class TypeCast
     {
+        private static CastCacheImpl s_castCache = new CastCacheImpl();
+
         [Flags]
         internal enum AssignmentVariation
         {
@@ -1159,7 +1162,7 @@ namespace System.Runtime
                 return true;
 
             nuint sourceAndVariation = (nuint)pSourceType + (uint)variation;
-            CastResult result = CastCache.TryGet(sourceAndVariation, (nuint)(pTargetType));
+            CastResult result = s_castCache.TryGet(sourceAndVariation, (nuint)(pTargetType));
             if (result != CastResult.MaybeCast)
             {
                 return result == CastResult.CanCast;
@@ -1187,7 +1190,7 @@ namespace System.Runtime
             // Update the cache
             //
             nuint sourceAndVariation = (nuint)pSourceType + (uint)variation;
-            CastCache.TrySet(sourceAndVariation, (nuint)pTargetType, result);
+            s_castCache.TrySet(sourceAndVariation, (nuint)pTargetType, result);
 
             return result;
         }

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -24,7 +24,15 @@ namespace System.Runtime
     [EagerStaticClassConstruction]
     internal static class TypeCast
     {
-        private static CastCache s_castCache = new CastCache();
+#if DEBUG
+        private const int InitialCacheSize = 8;    // MUST BE A POWER OF TWO
+        private const int MaximumCacheSize = 512;  // make this lower than release to make it easier to reach this in tests.
+#else
+        private const int InitialCacheSize = 128;  // MUST BE A POWER OF TWO
+        private const int MaximumCacheSize = 4096; // 4096 * sizeof(CastCacheEntry) is 98304 bytes on 64bit. We will rarely need this much though.
+#endif // DEBUG
+
+        private static CastCache s_castCache = new CastCache(InitialCacheSize, MaximumCacheSize);
 
         [Flags]
         internal enum AssignmentVariation

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/LibraryInitializer.cs
@@ -19,7 +19,6 @@ namespace Internal.Runtime.CompilerHelpers
         {
             PreallocatedOutOfMemoryException.Initialize();
             ClassConstructorRunner.Initialize();
-            TypeLoaderExports.Initialize();
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
@@ -105,10 +105,10 @@ namespace System.Runtime
 
 
         // Initialize the cache eagerly to avoid null checks.
-        private static Cache<Key, Value> s_cache;
+        private static GenericCache<Key, Value> s_cache;
         internal static void Initialize()
         {
-            s_cache = new Cache<Key, Value>(InitialCacheSize, MaximumCacheSize);
+            s_cache = new GenericCache<Key, Value>(InitialCacheSize, MaximumCacheSize);
         }
 
         private static Value LookupOrAdd(IntPtr context, IntPtr signature)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
@@ -103,7 +103,6 @@ namespace System.Runtime
         private const int MaximumCacheSize = 128 * 1024;
 #endif // DEBUG
 
-
         // Initialize the cache eagerly to avoid null checks.
         private static GenericCache<Key, Value> s_cache;
         internal static void Initialize()

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
@@ -8,7 +8,7 @@ namespace System.Runtime.CompilerServices
     }
 
     // trivial implementation of the cast cache
-    internal unsafe struct CastCacheImpl
+    internal unsafe struct CastCache
     {
         internal CastResult TryGet(nuint source, nuint target)
         {

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
@@ -8,14 +8,14 @@ namespace System.Runtime.CompilerServices
     }
 
     // trivial implementation of the cast cache
-    internal static unsafe class CastCache
+    internal unsafe struct CastCacheImpl
     {
-        internal static CastResult TryGet(nuint source, nuint target)
+        internal CastResult TryGet(nuint source, nuint target)
         {
             return CastResult.MaybeCast;
         }
 
-        internal static void TrySet(nuint source, nuint target, bool result)
+        internal void TrySet(nuint source, nuint target, bool result)
         {
         }
     }

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
@@ -10,6 +10,10 @@ namespace System.Runtime.CompilerServices
     // trivial implementation of the cast cache
     internal unsafe struct CastCache
     {
+        public CastCache(int initialCacheSize, int maxCacheSize)
+        {
+        }
+
         internal CastResult TryGet(nuint source, nuint target)
         {
             return CastResult.MaybeCast;

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -1168,7 +1168,7 @@ DEFINE_CLASS(NULLABLE_COMPARER, CollectionsGeneric, NullableComparer`1)
 
 DEFINE_CLASS(INATTRIBUTE, Interop, InAttribute)
 
-DEFINE_CLASS(CASTCACHE, CompilerServices, CastCache)
+DEFINE_CLASS(CASTCACHE, CompilerServices, CastHelpers)
 DEFINE_FIELD(CASTCACHE, TABLE, s_table)
 
 DEFINE_CLASS(CASTHELPERS, CompilerServices, CastHelpers)

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -774,8 +774,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncValueTaskMethodBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncValueTaskMethodBuilderT.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncVoidMethodBuilder.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CastCache.cs" Condition="'$(FeatureCoreCLR)' == 'true' or '$(FeatureNativeAot)' == 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\GenericCache.cs" Condition="'$(FeatureCoreCLR)' == 'true' or '$(FeatureNativeAot)' == 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CastCache.cs" Condition="'$(FeatureMono)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\GenericCache.cs" Condition="'$(FeatureMono)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CallerArgumentExpressionAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CallerFilePathAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CallerLineNumberAttribute.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -775,6 +775,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncValueTaskMethodBuilderT.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncVoidMethodBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CastCache.cs" Condition="'$(FeatureCoreCLR)' == 'true' or '$(FeatureNativeAot)' == 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\GenericCache.cs" Condition="'$(FeatureCoreCLR)' == 'true' or '$(FeatureNativeAot)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CallerArgumentExpressionAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CallerFilePathAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CallerLineNumberAttribute.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
@@ -150,7 +150,14 @@ namespace System.Runtime.CompilerServices
         internal CastResult TryGet(nuint source, nuint target)
         {
             // table is always initialized and is not null.
-            ref int tableData = ref TableData(_table!);
+            return TryGet(_table!, source, target);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static CastResult TryGet(int[] table, nuint source, nuint target)
+        {
+            // table is always initialized and is not null.
+            ref int tableData = ref TableData(table);
 
             int index = KeyToBucket(ref tableData, source, target);
             for (int i = 0; i < BUCKET_SIZE;)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
@@ -36,13 +36,6 @@ namespace System.Runtime.CompilerServices
         private int _initialCacheSize;
         private int _maxCacheSize;
 
-        // wraps existing table
-        public CastCache(int[] table)
-        {
-            _table = table;
-        }
-
-        // creates a new cache instance
         public CastCache(int initialCacheSize, int maxCacheSize)
         {
             Debug.Assert(BitOperations.PopCount((uint)initialCacheSize) == 1 && initialCacheSize > 1);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
@@ -15,19 +15,9 @@ namespace System.Runtime.CompilerServices
         MaybeCast = 2
     }
 
-#if NATIVEAOT
-    [EagerStaticClassConstruction]
-#endif
-    internal static unsafe class CastCache
+    internal unsafe struct CastCacheImpl
     {
-
-#if CORECLR
-        // In coreclr the table is written to only on the native side. T
-        // This is all we need to implement TryGet.
-        private static int[]? s_table;
-#else
-
-  #if DEBUG
+#if DEBUG
         private const int INITIAL_CACHE_SIZE = 8;    // MUST BE A POWER OF TWO
         private const int MAXIMUM_CACHE_SIZE = 512;  // make this lower than release to make it easier to reach this in tests.
   #else
@@ -37,25 +27,39 @@ namespace System.Runtime.CompilerServices
 
         private const int VERSION_NUM_SIZE = 29;
         private const uint VERSION_NUM_MASK = (1 << VERSION_NUM_SIZE) - 1;
+        private const int BUCKET_SIZE = 8;
 
-        // A trivial 2-elements table used for "flushing" the cache. Nothing is ever stored in this table.
-        // It is required that we are able to allocate this.
-        private static int[] s_sentinelTable = CreateCastCache(2, throwOnFail: true)!;
-
-        // when flushing, remember the last size.
-        private static int s_lastFlushSize = INITIAL_CACHE_SIZE;
+        // nothing is ever stored into this, so we can use a static instance.
+        private static int[]? s_sentinelTable;
 
         // The actual storage.
-        // Initialize to the sentinel in DEBUG as if just flushed, to ensure the sentinel can be handled in Set.
-        private static int[] s_table =
-  #if !DEBUG
+        private int[] _table;
+
+        // when flushing, remember the last size.
+        private int _lastFlushSize;
+
+        // wraps existing table
+        public CastCacheImpl(int[] table)
+        {
+            _table = table;
+        }
+
+        // creates a new cache instance
+        public CastCacheImpl()
+        {
+            // A trivial 2-elements table used for "flushing" the cache.
+            // Nothing is ever stored in such a small table and identity of the sentinel is not important.
+            // It is required that we are able to allocate this, we may need this in OOM cases.
+            s_sentinelTable ??= CreateCastCache(2, throwOnFail: true);
+
+            _table =
+#if !DEBUG
+            // Initialize to the sentinel in DEBUG as if just flushed, to ensure the sentinel can be handled in Set.
             CreateCastCache(INITIAL_CACHE_SIZE) ??
-  #endif
-            s_sentinelTable;
-
-#endif // CORECLR
-
-        private const int BUCKET_SIZE = 8;
+#endif
+            s_sentinelTable!;
+            _lastFlushSize = INITIAL_CACHE_SIZE;
+        }
 
         [StructLayout(LayoutKind.Sequential)]
         private struct CastCacheEntry
@@ -139,10 +143,10 @@ namespace System.Runtime.CompilerServices
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static CastResult TryGet(nuint source, nuint target)
+        internal CastResult TryGet(nuint source, nuint target)
         {
             // table is always initialized and is not null.
-            ref int tableData = ref TableData(s_table!);
+            ref int tableData = ref TableData(_table!);
 
             int index = KeyToBucket(ref tableData, source, target);
             for (int i = 0; i < BUCKET_SIZE;)
@@ -159,7 +163,7 @@ namespace System.Runtime.CompilerServices
 
                 if (entrySource == source)
                 {
-                    // in CoreCLR we do ordinary reads of the entry parts and
+                    // we do ordinary reads of the entry parts and
                     // Interlocked.ReadMemoryBarrier() before reading the version
                     nuint entryTargetAndResult = pEntry._targetAndResult;
                     // target never has its lower bit set.
@@ -204,7 +208,6 @@ namespace System.Runtime.CompilerServices
         // in CoreClr the cache is only updated in the native code
         //
         // The following helpers must match native implementations in castcache.h and castcache.cpp
-#if !CORECLR
 
         // we generally do not OOM in casts, just return null unless throwOnFail is specified.
         private static int[]? CreateCastCache(int size, bool throwOnFail = false)
@@ -252,20 +255,20 @@ namespace System.Runtime.CompilerServices
             return table;
         }
 
-        internal static void TrySet(nuint source, nuint target, bool result)
+        internal void TrySet(nuint source, nuint target, bool result)
         {
             int bucket;
             ref int tableData = ref *(int*)0;
 
             do
             {
-                tableData = ref TableData(s_table);
+                tableData = ref TableData(_table);
                 if (TableMask(ref tableData) == 1)
                 {
                     // 2-element table is used as a sentinel.
                     // we did not allocate a real table yet or have flushed it.
                     // try replacing the table, but do not insert anything.
-                    MaybeReplaceCacheWithLarger(s_lastFlushSize);
+                    MaybeReplaceCacheWithLarger(_lastFlushSize);
                     return;
                 }
 
@@ -333,7 +336,7 @@ namespace System.Runtime.CompilerServices
             } while (TryGrow(ref tableData));
 
             // reread tableData after TryGrow.
-            tableData = ref TableData(s_table);
+            tableData = ref TableData(_table);
 
             if (TableMask(ref tableData) == 1)
             {
@@ -381,19 +384,22 @@ namespace System.Runtime.CompilerServices
             return TableMask(ref tableData) + 1;
         }
 
-        private static void FlushCurrentCache()
+        private void FlushCurrentCache()
         {
-            ref int tableData = ref TableData(s_table);
+            ref int tableData = ref TableData(_table);
             int lastSize = CacheElementCount(ref tableData);
             if (lastSize < INITIAL_CACHE_SIZE)
                 lastSize = INITIAL_CACHE_SIZE;
 
-            s_lastFlushSize = lastSize;
+            // store the last size to use when creating a new table
+            // it is just a hint, not needed for correctness, so no synchronization
+            // with the writing of the table
+            _lastFlushSize = lastSize;
             // flushing is just replacing the table with a sentinel.
-            s_table = s_sentinelTable;
+            _table = s_sentinelTable!;
         }
 
-        private static bool MaybeReplaceCacheWithLarger(int size)
+        private bool MaybeReplaceCacheWithLarger(int size)
         {
             int[]? newTable = CreateCastCache(size);
             if (newTable == null)
@@ -401,11 +407,11 @@ namespace System.Runtime.CompilerServices
                 return false;
             }
 
-            s_table = newTable;
+            _table = newTable;
             return true;
         }
 
-        private static bool TryGrow(ref int tableData)
+        private bool TryGrow(ref int tableData)
         {
             int newSize = CacheElementCount(ref tableData) * 2;
             if (newSize <= MAXIMUM_CACHE_SIZE)
@@ -415,6 +421,5 @@ namespace System.Runtime.CompilerServices
 
             return false;
         }
-#endif   // !CORECLR
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -412,6 +415,420 @@ namespace System.Runtime.CompilerServices
         }
 
         private bool TryGrow(ref int tableData)
+        {
+            int newSize = CacheElementCount(ref tableData) * 2;
+            if (newSize <= MAXIMUM_CACHE_SIZE)
+            {
+                return MaybeReplaceCacheWithLarger(newSize);
+            }
+
+            return false;
+        }
+    }
+
+    internal unsafe struct Cache<TKey, TValue>
+    {
+#if DEBUG
+        private const int INITIAL_CACHE_SIZE = 8;    // MUST BE A POWER OF TWO
+        private const int MAXIMUM_CACHE_SIZE = 512;  // make this lower than release to make it easier to reach this in tests.
+#else
+        private const int INITIAL_CACHE_SIZE = 128;  // MUST BE A POWER OF TWO
+        private const int MAXIMUM_CACHE_SIZE = 4096; // Same as in CastCache. We will rarely need this much though.
+#endif // DEBUG
+
+        private const int VERSION_NUM_SIZE = 29;
+        private const uint VERSION_NUM_MASK = (1 << VERSION_NUM_SIZE) - 1;
+        private const int BUCKET_SIZE = 8;
+
+        // nothing is ever stored into this, so we can use a static instance.
+        private static Entry[]? s_sentinelTable;
+
+        // The actual storage.
+        private Entry[] _table;
+
+        // when flushing, remember the last size.
+        private int _lastFlushSize;
+
+        // creates a new cache instance
+        public Cache()
+        {
+            // A trivial 2-elements table used for "flushing" the cache.
+            // Nothing is ever stored in such a small table and identity of the sentinel is not important.
+            // It is required that we are able to allocate this, we may need this in OOM cases.
+            s_sentinelTable ??= CreateCastCache(2, throwOnFail: true);
+
+            _table =
+#if !DEBUG
+            // Initialize to the sentinel in DEBUG as if just flushed, to ensure the sentinel can be handled in Set.
+            CreateCastCache(INITIAL_CACHE_SIZE) ??
+#endif
+            s_sentinelTable!;
+            _lastFlushSize = INITIAL_CACHE_SIZE;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct UnmanagedPart
+        {
+            // version has the following structure:
+            // [ distance:3bit |  versionNum:29bit ]
+            //
+            // distance is how many iterations the entry is from it ideal position.
+            // we use that for preemption.
+            //
+            // versionNum is a monotonically increasing numerical tag.
+            // Writer "claims" entry by atomically incrementing the tag. Thus odd number indicates an entry in progress.
+            // Upon completion of adding an entry the tag is incremented again making it even. Even number indicates a complete entry.
+            //
+            // Readers will read the version twice before and after retrieving the entry.
+            // To have a usable entry both reads must yield the same even version.
+            //
+            [FieldOffset(0)]
+            internal uint _version;
+            [FieldOffset(sizeof(int))]
+            internal int _hash;
+
+            // AuxData
+            [FieldOffset(0)]
+            internal int tableMask;
+            [FieldOffset(sizeof(int))]
+            internal byte hashShift;
+            [FieldOffset(sizeof(int) + 1)]
+            internal byte victimCounter;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct Entry
+        {
+            internal UnmanagedPart _unmanagedPart;
+            internal TKey _key;
+            internal TValue _value;
+
+            [UnscopedRef]
+            public ref uint Version => ref _unmanagedPart._version;
+            [UnscopedRef]
+            public ref int Hash => ref _unmanagedPart._hash;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int KeyToBucket(ref Entry tableData, TKey key)
+        {
+            int hashShift = HashShift(ref tableData);
+            int hash = key!.GetHashCode();
+#if TARGET_64BIT
+            return (int)(((ulong)hash * 11400714819323198485ul) >> hashShift);
+#else
+            return (int)(((uint)hash * 2654435769u) >> hashShift);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ref Entry TableData(Entry[] table)
+        {
+            // element 0 is used for embedded aux data
+            return ref table[0];
+            // return ref Unsafe.As<byte, UnmanagedPart>(ref Unsafe.AddByteOffset(ref table.GetRawData(), (nint)sizeof(nint)));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ref byte HashShift(ref Entry tableData)
+        {
+            return ref tableData._unmanagedPart.hashShift;
+        }
+
+        // TableMask is "size - 1"
+        // we need that more often that we need size
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ref int TableMask(ref Entry tableData)
+        {
+            return ref tableData._unmanagedPart.tableMask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ref byte VictimCounter(ref Entry tableData)
+        {
+            return ref tableData._unmanagedPart.victimCounter;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ref Entry Element(ref Entry tableData, int index)
+        {
+            // element 0 is used for embedded aux data, skip it
+            return ref Unsafe.Add(ref tableData, index + 1);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool TryGet(TKey key, out TValue? value)
+        {
+            // table is always initialized and is not null.
+            ref Entry tableData = ref TableData(_table!);
+            int hash = key!.GetHashCode();
+
+            int index = KeyToBucket(ref tableData, key);
+            for (int i = 0; i < BUCKET_SIZE;)
+            {
+                ref Entry pEntry = ref Element(ref tableData, index);
+
+                // we must read in this order: version -> [entry parts] -> version
+                // if version is odd or changes, the entry is inconsistent and thus ignored
+                uint version = Volatile.Read(ref pEntry.Version);
+
+                // mask the lower version bit to make it even.
+                // This way we can check if version is odd or changing in just one compare.
+                version &= unchecked((uint)~1);
+
+                if (hash == pEntry.Hash && EqualityComparer<TKey>.Default.Equals(key, pEntry._key))
+                {
+                    // we do ordinary reads of the value and
+                    // Interlocked.ReadMemoryBarrier() before reading the version
+                    value = pEntry._value;
+
+                    // make sure the second read of 'version' happens after reading 'source' and 'targetAndResults'
+                    //
+                    // We can either:
+                    // - use acquires for both _source and _targetAndResults or
+                    // - issue a load barrier before reading _version
+                    // benchmarks on available hardware (Jan 2020) show that use of a read barrier is cheaper.
+                    Interlocked.ReadMemoryBarrier();
+
+                    if (version != pEntry.Version)
+                    {
+                        // oh, so close, the entry is in inconsistent state.
+                        // it is either changing or has changed while we were reading.
+                        // treat it as a miss.
+                        break;
+                    }
+
+                    return true;
+                }
+
+                if (version == 0)
+                {
+                    // the rest of the bucket is unclaimed, no point to search further
+                    break;
+                }
+
+                // quadratic reprobe
+                i++;
+                index = (index + i) & TableMask(ref tableData);
+            }
+
+            value = default;
+            return false;
+        }
+
+        // the rest is the support for updating the cache.
+        // in CoreClr the cache is only updated in the native code
+        //
+        // The following helpers must match native implementations in castcache.h and castcache.cpp
+
+        // we generally do not OOM in casts, just return null unless throwOnFail is specified.
+        private static Entry[]? CreateCastCache(int size, bool throwOnFail = false)
+        {
+            // size must be positive
+            Debug.Assert(size > 1);
+            // size must be a power of two
+            Debug.Assert((size & (size - 1)) == 0);
+
+            Entry[]? table = null;
+            try
+            {
+                table = new Entry[size + 1];
+            }
+            catch (OutOfMemoryException) when (!throwOnFail)
+            {
+            }
+
+            if (table == null)
+            {
+                size = INITIAL_CACHE_SIZE;
+                try
+                {
+                    table = new Entry[size + 1];
+                }
+                catch (OutOfMemoryException)
+                {
+                }
+            }
+
+            if (table == null)
+            {
+                return table;
+            }
+
+            ref Entry tableData = ref TableData(table);
+
+            // set the table mask. we need it often, do not want to compute each time.
+            TableMask(ref tableData) = size - 1;
+
+            // Fibonacci hash reduces the value into desired range by shifting right by the number of leading zeroes in 'size-1'
+            byte shift = (byte)BitOperations.LeadingZeroCount(size - 1);
+            HashShift(ref tableData) = shift;
+
+            return table;
+        }
+
+        internal void TrySet(TKey key, TValue value)
+        {
+            int bucket;
+            int hash = key!.GetHashCode();
+            ref Entry tableData = ref Unsafe.NullRef<Entry>();
+
+            do
+            {
+                tableData = ref TableData(_table);
+                if (TableMask(ref tableData) == 1)
+                {
+                    // 2-element table is used as a sentinel.
+                    // we did not allocate a real table yet or have flushed it.
+                    // try replacing the table, but do not insert anything.
+                    MaybeReplaceCacheWithLarger(_lastFlushSize);
+                    return;
+                }
+
+                bucket = KeyToBucket(ref tableData, key);
+                int index = bucket;
+                ref Entry pEntry = ref Element(ref tableData, index);
+
+                for (int i = 0; i < BUCKET_SIZE;)
+                {
+                    // claim the entry if unused or is more distant than us from its origin.
+                    // Note - someone familiar with Robin Hood hashing will notice that
+                    //        we do the opposite - we are "robbing the poor".
+                    //        Robin Hood strategy improves average lookup in a lossles dictionary by reducing
+                    //        outliers via giving preference to more distant entries.
+                    //        What we have here is a lossy cache with outliers bounded by the bucket size.
+                    //        We improve average lookup by giving preference to the "richer" entries.
+                    //        If we used Robin Hood strategy we could eventually end up with all
+                    //        entries in the table being maximally "poor".
+
+                    uint version = pEntry.Version;
+
+                    // mask the lower version bit to make it even.
+                    // This way we will detect both if version is changing (odd) or has changed (even, but different).
+                    version &= unchecked((uint)~1);
+
+                    if ((version & VERSION_NUM_MASK) >= (VERSION_NUM_MASK - 2))
+                    {
+                        // If exactly VERSION_NUM_MASK updates happens between here and publishing, we may not recognize a race.
+                        // It is extremely unlikely, but to not worry about the possibility, lets not allow version to go this high and just get a new cache.
+                        // This will not happen often.
+                        FlushCurrentCache();
+                        return;
+                    }
+
+                    if (version == 0 || (version >> VERSION_NUM_SIZE) > i)
+                    {
+                        uint newVersion = ((uint)i << VERSION_NUM_SIZE) + (version & VERSION_NUM_MASK) + 1;
+                        uint versionOrig = Interlocked.CompareExchange(ref pEntry.Version, newVersion, version);
+                        if (versionOrig == version)
+                        {
+                            pEntry.Hash = hash;
+                            pEntry._key = key;
+                            pEntry._value = value;
+
+                            // entry is in inconsistent state and cannot be read or written to until we
+                            // update the version, which is the last thing we do here
+                            Volatile.Write(ref pEntry.Version, newVersion + 1);
+                            return;
+                        }
+                        // someone snatched the entry. try the next one in the bucket.
+                    }
+
+                    if (hash == pEntry.Hash && EqualityComparer<TKey>.Default.Equals(key, pEntry._key))
+                    {
+                        // looks like we already have an entry for this.
+                        // duplicate entries are harmless, but a bit of a waste.
+                        return;
+                    }
+
+                    // quadratic reprobe
+                    i++;
+                    index += i;
+                    pEntry = ref Element(ref tableData, index & TableMask(ref tableData));
+                }
+
+                // bucket is full.
+            } while (TryGrow(ref tableData));
+
+            // reread tableData after TryGrow.
+            tableData = ref TableData(_table);
+
+            if (TableMask(ref tableData) == 1)
+            {
+                // do not insert into a sentinel.
+                return;
+            }
+
+            // pick a victim somewhat randomly within a bucket
+            // NB: ++ is not interlocked. We are ok if we lose counts here. It is just a number that changes.
+            byte victimDistance = (byte)(VictimCounter(ref tableData)++ & (BUCKET_SIZE - 1));
+            // position the victim in a quadratic reprobe bucket
+            int victim = (victimDistance * victimDistance + victimDistance) / 2;
+
+            {
+                ref Entry pEntry = ref Element(ref tableData, (bucket + victim) & TableMask(ref tableData));
+
+                uint version = pEntry.Version;
+
+                // mask the lower version bit to make it even.
+                // This way we will detect both if version is changing (odd) or has changed (even, but different).
+                version &= unchecked((uint)~1);
+
+                if ((version & VERSION_NUM_MASK) >= (VERSION_NUM_MASK - 2))
+                {
+                    // If exactly VERSION_NUM_MASK updates happens between here and publishing, we may not recognize a race.
+                    // It is extremely unlikely, but to not worry about the possibility, lets not allow version to go this high and just get a new cache.
+                    // This will not happen often.
+                    FlushCurrentCache();
+                    return;
+                }
+
+                uint newVersion = (uint)((victimDistance << VERSION_NUM_SIZE) + (version & VERSION_NUM_MASK) + 1);
+                uint versionOrig = Interlocked.CompareExchange(ref pEntry.Version, newVersion, version);
+
+                if (versionOrig == version)
+                {
+                    pEntry.Hash = hash;
+                    pEntry._key = key;
+                    pEntry._value = value;
+                    Volatile.Write(ref pEntry.Version, newVersion + 1);
+                }
+            }
+        }
+
+        private static int CacheElementCount(ref Entry tableData)
+        {
+            return TableMask(ref tableData) + 1;
+        }
+
+        private void FlushCurrentCache()
+        {
+            ref Entry tableData = ref TableData(_table);
+            int lastSize = CacheElementCount(ref tableData);
+            if (lastSize < INITIAL_CACHE_SIZE)
+                lastSize = INITIAL_CACHE_SIZE;
+
+            // store the last size to use when creating a new table
+            // it is just a hint, not needed for correctness, so no synchronization
+            // with the writing of the table
+            _lastFlushSize = lastSize;
+            // flushing is just replacing the table with a sentinel.
+            _table = s_sentinelTable!;
+        }
+
+        private bool MaybeReplaceCacheWithLarger(int size)
+        {
+            Entry[]? newTable = CreateCastCache(size);
+            if (newTable == null)
+            {
+                return false;
+            }
+
+            _table = newTable;
+            return true;
+        }
+
+        private bool TryGrow(ref Entry tableData)
         {
             int newSize = CacheElementCount(ref tableData) * 2;
             if (newSize <= MAXIMUM_CACHE_SIZE)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericCache.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
@@ -40,8 +38,8 @@ namespace System.Runtime.CompilerServices
         internal byte victimCounter;
     }
 
-    // TKey may contain references, but we want it to be a struct,
-    // so that equality is devirtualized.
+    // NOTE: It is ok if TKey contains references, but we want it to be a struct,
+    //       so that equality is devirtualized.
     internal unsafe struct GenericCache<TKey, TValue>
         where TKey: struct, IEquatable<TKey>
     {
@@ -74,6 +72,9 @@ namespace System.Runtime.CompilerServices
         // creates a new cache instance
         public GenericCache(int initialCacheSize, int maxCacheSize)
         {
+            Debug.Assert(BitOperations.PopCount((uint)initialCacheSize) == 1 && initialCacheSize > 1);
+            Debug.Assert(BitOperations.PopCount((uint)maxCacheSize) == 1 && maxCacheSize >= initialCacheSize);
+
             _initialCacheSize = initialCacheSize;
             _maxCacheSize = maxCacheSize;
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/85927

- the new cache is basically a generic form of `CastCache`. It is completely lock-free and slightly faster than the currently used caching scheme.
- unlike the ad-hoc caching scheme used in GVM, the new cache is a standalone implementation and may be used in other similar scenarios.
- refactored `CastCache` can now also be used for other purposes (no longer assumes a single static instance)