### PR TITLE
SBLK_MASK_LOCK_THREADID allow tid up to 65535 (#88772)

### DIFF
--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -103,14 +103,14 @@ typedef DPTR(EnCSyncBlockInfo) PTR_EnCSyncBlockInfo;
 #define BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX    0x08000000
 
 // if BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX is clear, the rest of the header dword is laid out as follows:
-// - lower ten bits (bits 0 thru 9) is thread id used for the thin locks
+// - lower sixteen bits (bits 0 thru 15) is thread id used for the thin locks
 //   value is zero if no thread is holding the lock
-// - following six bits (bits 10 thru 15) is recursion level used for the thin locks
+// - following six bits (bits 16 thru 21) is recursion level used for the thin locks
 //   value is zero if lock is not taken or only taken once by the same thread
-#define SBLK_MASK_LOCK_THREADID             0x000003FF   // special value of 0 + 1023 thread ids
-#define SBLK_MASK_LOCK_RECLEVEL             0x0000FC00   // 64 recursion levels
-#define SBLK_LOCK_RECLEVEL_INC              0x00000400   // each level is this much higher than the previous one
-#define SBLK_RECLEVEL_SHIFT                 10           // shift right this much to get recursion level
+#define SBLK_MASK_LOCK_THREADID             0x0000FFFF   // special value of 0 + 65535 thread ids
+#define SBLK_MASK_LOCK_RECLEVEL             0x003F0000   // 64 recursion levels
+#define SBLK_LOCK_RECLEVEL_INC              0x00010000   // each level is this much higher than the previous one
+#define SBLK_RECLEVEL_SHIFT                 16           // shift right this much to get recursion level
 
 // add more bits here... (adjusting the following mask to make room)
 


### PR DESCRIPTION
## Customer Impact - from @dickens-code 

Our apps require low latency performance and we are trying hard to reduce memory allocation in order to minimise GC occurrences.

We noticed that one of our apps experiences a very long GC pause of 2 seconds, and with the help of @cshung, we discovered that our app is having very large sync block memory space (20 million sync blocks), which introduced a very long time of sync block scanning during GC events.

We found out that new sync blocks are introduced when thread ID > 1024 is taking object locks and we tried to release the limit of thread ID to 65535 and the sync block memory space size was obviously improved

With the custom-built `coreclr.dll` we observed that our app's GC pauses were brought down to around 100ms which makes more sense according to our business requirements

## Testing

- [x] GC Perf Sim 
	- [x] Normal Server 
	- [x] Normal Workstation 
	- [ ] Large Pages Server 
	- [ ] Large Pages Workstation 
	- [x] Low Memory Container 
	- [x] High Memory Load
- [x] Microbenchmarks 
	- [x] Workstation 
	- [x] Server
- [x] ASPNet Benchmarks 
	- [x] JsonMin_Windows 
	- [x]  Fortunes ETF_Windows 
	- [x] Stage1Grpc_Windows 

Test failures are known - on my machine, I don't have sufficient memory to pass the 20GB large pages test case, all other large page test cases are passing.

## Risk

Low - the bits were not used for anything before this fix, and the change is merged to main for 2 weeks with no regression found.