### PR TITLE
[JIT] Do not show a pop-up dialog when an assertion occurs in SuperPMI collection

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
@@ -108,6 +108,12 @@ void InitializeShim()
     }
 #endif // HOST_UNIX
 
+#ifdef HOST_WINDOWS
+    // Assertions will be sent to stderr instead of a pop-up dialog.
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif // HOST_WINDOWS
+
     Logger::Initialize();
     SetLogFilePath();
     Logger::OpenLogFile(g_logFilePath);


### PR DESCRIPTION
This prevents a pop-up dialog from showing when running SuperPMI collections encounter an assertion failure. Instead, it will write the assertion failure to 'stderr'.

Note: This doesn't fix the assertions, only prevents the pop-up dialog from showing. More info here: https://github.com/dotnet/runtime/issues/88423