### PR TITLE
Set BaseSize of interfaces to 0

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -790,7 +790,13 @@ namespace ILCompiler.DependencyAnalysis
                 int pointerSize = _type.Context.Target.PointerSize;
                 int objectSize;
 
-                if (_type.IsDefType)
+                if (_type.IsInterface)
+                {
+                    // Interfaces don't live on the GC heap. Don't bother computing a number.
+                    // Zero compresses better than any useless number we would come up with.
+                    return 0;
+                }
+                else if (_type.IsDefType)
                 {
                     LayoutInt instanceByteCount = ((DefType)_type).InstanceByteCount;
 


### PR DESCRIPTION
We were computing these as the minimum object size. This number is meaningless because they don't get allocated on the GC heap. A zero compresses better in the dehydrated data format. Surprisingly saves like 0.1% on Hello World despite being such an insignificant thing.

Cc @dotnet/ilc-contrib 