### PR TITLE
Avoid boxing in Enum.HasFlag in Tier0

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3146,12 +3146,12 @@ void Compiler::impImportAndPushBox(CORINFO_RESOLVED_TOKEN* pResolvedToken)
         //    *(temp+4) = expr
 
         // NOTE: Don't re-use temps for boxed Enum values to, potentially, avoid boxing in Enum.HasFlag
-        const bool dontShareBoxedTemps =
-            opts.OptimizationDisabled() && varTypeIsIntegral(exprToBox) &&
+        const bool shareBoxedTemps =
+            opts.OptimizationDisabled() && !(varTypeIsIntegral(exprToBox) &&
             info.compCompHnd->isEnum(pResolvedToken->hClass, nullptr) == TypeCompareState::Must &&
-            !lvaHaveManyLocals() && !opts.compDbgCode && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT);
+            !lvaHaveManyLocals() && !opts.compDbgCode && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT));
 
-        if (!dontShareBoxedTemps && opts.OptimizationDisabled())
+        if (shareBoxedTemps)
         {
             // For minopts/debug code, try and minimize the total number
             // of box temps by reusing an existing temp when possible.

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3151,13 +3151,15 @@ void Compiler::impImportAndPushBox(CORINFO_RESOLVED_TOKEN* pResolvedToken)
 
         // Avoid sharing in some tier 0 cases to, potentially, avoid boxing in Enum.HasFlag.
         if (shareBoxedTemps && varTypeIsIntegral(exprToBox) && !lvaHaveManyLocals() &&
-            (info.compCompHnd->isEnum(pResolvedToken->hClass, nullptr) != TypeCompareState::Must)
+            (info.compCompHnd->isEnum(pResolvedToken->hClass, nullptr) != TypeCompareState::Must))
         {
             shareBoxedTemps = false;
         }
 
         if (shareBoxedTemps)
         {
+            // For minopts/debug code, try and minimize the total number
+            // of box temps by reusing an existing temp when possible.
             if (impBoxTempInUse || impBoxTemp == BAD_VAR_NUM)
             {
                 impBoxTemp = lvaGrabTemp(true DEBUGARG("Reusable Box Helper"));

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3145,7 +3145,13 @@ void Compiler::impImportAndPushBox(CORINFO_RESOLVED_TOKEN* pResolvedToken)
         // and the other you get
         //    *(temp+4) = expr
 
-        if (opts.OptimizationDisabled())
+        // NOTE: Don't re-use temps for boxed Enum values to, potentially, avoid boxing in Enum.HasFlag
+        const bool dontShareBoxed =
+            opts.OptimizationDisabled() && varTypeIsIntegral(exprToBox) &&
+            info.compCompHnd->isEnum(pResolvedToken->hClass, nullptr) == TypeCompareState::Must &&
+            !lvaHaveManyLocals() && !opts.compDbgCode && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT);
+
+        if (!dontShareBoxed && opts.OptimizationDisabled())
         {
             // For minopts/debug code, try and minimize the total number
             // of box temps by reusing an existing temp when possible.

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3146,12 +3146,12 @@ void Compiler::impImportAndPushBox(CORINFO_RESOLVED_TOKEN* pResolvedToken)
         //    *(temp+4) = expr
 
         // NOTE: Don't re-use temps for boxed Enum values to, potentially, avoid boxing in Enum.HasFlag
-        const bool dontShareBoxed =
+        const bool dontShareBoxedTemps =
             opts.OptimizationDisabled() && varTypeIsIntegral(exprToBox) &&
             info.compCompHnd->isEnum(pResolvedToken->hClass, nullptr) == TypeCompareState::Must &&
             !lvaHaveManyLocals() && !opts.compDbgCode && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT);
 
-        if (!dontShareBoxed && opts.OptimizationDisabled())
+        if (opts.OptimizationDisabled())
         {
             // For minopts/debug code, try and minimize the total number
             // of box temps by reusing an existing temp when possible.

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3151,7 +3151,7 @@ void Compiler::impImportAndPushBox(CORINFO_RESOLVED_TOKEN* pResolvedToken)
             info.compCompHnd->isEnum(pResolvedToken->hClass, nullptr) == TypeCompareState::Must &&
             !lvaHaveManyLocals() && !opts.compDbgCode && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT);
 
-        if (opts.OptimizationDisabled())
+        if (!dontShareBoxedTemps && opts.OptimizationDisabled())
         {
             // For minopts/debug code, try and minimize the total number
             // of box temps by reusing an existing temp when possible.

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2580,6 +2580,10 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
             case NI_System_RuntimeType_get_TypeHandle:
             case NI_System_RuntimeTypeHandle_ToIntPtr:
 
+            // This one is not simple, but it will help us
+            // to avoid some unnecessary boxing
+            case NI_System_Enum_HasFlag:
+
             // Most atomics are compiled to single instructions
             case NI_System_Threading_Interlocked_And:
             case NI_System_Threading_Interlocked_Or:


### PR DESCRIPTION
We see a lot of cases when methods stay in Tier0 despite being called a lot in large apps (the "tier1 promotion queue" problem) so we'd better remove allocations in Tier0 too where possible, I gave up on this opt in https://github.com/dotnet/runtime/pull/77357 but I still think it's useful:

```cs
bool Test(MyEnum e) => e.HasFlag(MyEnum.B);
```
Main (Tier0):
```asm
; Assembly listing for method Program:Test(int):bool (Tier0)	
       push     rbp	
       sub      rsp, 48	
       lea      rbp, [rsp+30H]	
       xor      eax, eax	
       mov      qword ptr [rbp-08H], rax	
       mov      qword ptr [rbp-10H], rax	
       mov      dword ptr [rbp+10H], ecx	
       mov      rcx, 0x7FFAE2C3B208	
       call     CORINFO_HELP_NEWSFAST  ;; <--- Allocation
       mov      gword ptr [rbp-08H], rax	
       mov      rcx, gword ptr [rbp-08H]	
       mov      eax, dword ptr [rbp+10H]	
       mov      dword ptr [rcx+08H], eax	
       mov      rcx, 0x7FFAE2C3B208
       call     CORINFO_HELP_NEWSFAST  ;; <--- Allocation
       mov      gword ptr [rbp-10H], rax	
       mov      rcx, gword ptr [rbp-10H]	
       mov      dword ptr [rcx+08H], 1	
       mov      rcx, gword ptr [rbp-08H]	
       mov      rdx, gword ptr [rbp-10H]	
       call     [System.Enum:HasFlag(System.Enum):bool:this]	
       nop	
       add      rsp, 48	
       pop      rbp	
       ret	
; Total bytes of code 103
```
PR (Tier0):
```asm
; Assembly listing for method Program:Test(int):bool (Tier0)
       push     rbp
       sub      rsp, 32
       lea      rbp, [rsp+20H]
       xor      eax, eax
       mov      qword ptr [rbp-08H], rax
       mov      qword ptr [rbp-10H], rax
       mov      dword ptr [rbp+10H], ecx
       mov      eax, dword ptr [rbp+10H]
       mov      dword ptr [rbp-14H], eax
       mov      eax, dword ptr [rbp-14H]
       and      eax, 1
       cmp      eax, 1
       sete     al
       movzx    rax, al
       add      rsp, 32
       pop      rbp
       ret
; Total bytes of code 50
```