### PR TITLE
Update PAL and GC `BitScanReverse` to use `__builtin_clz`

### DIFF
--- a/src/coreclr/gc/env/gcenv.base.h
+++ b/src/coreclr/gc/env/gcenv.base.h
@@ -300,12 +300,12 @@ inline uint8_t BitScanReverse(uint32_t *bitIndex, uint32_t mask)
 #ifdef _MSC_VER
     return _BitScanReverse((unsigned long*)bitIndex, mask);
 #else // _MSC_VER
-    // The result of __builtin_clzl is undefined when mask is zero,
+    // The result of __builtin_clz is undefined when mask is zero,
     // but it's still OK to call the intrinsic in that case (just don't use the output).
     // Unconditionally calling the intrinsic in this way allows the compiler to
     // emit branchless code for this function when possible (depending on how the
     // intrinsic is implemented for the target platform).
-    int lzcount = __builtin_clzl(mask);
+    int lzcount = __builtin_clz(mask);
     *bitIndex = static_cast<uint32_t>(31 - lzcount);
     return mask != 0 ? TRUE : FALSE;
 #endif // _MSC_VER

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -3458,7 +3458,7 @@ BitScanForward64(
 // intrinsic, which returns the number of leading 0-bits in x starting at the most significant
 // bit position (the result is undefined when x = 0).
 //
-// The same is true for BitScanReverse, except that the GCC function is __builtin_clzl.
+// The same is true for BitScanReverse, except that the GCC function is __builtin_clz.
 
 EXTERN_C
 PALIMPORT
@@ -3469,12 +3469,12 @@ BitScanReverse(
     IN OUT PDWORD Index,
     IN UINT qwMask)
 {
-    // The result of __builtin_clzl is undefined when qwMask is zero,
+    // The result of __builtin_clz is undefined when qwMask is zero,
     // but it's still OK to call the intrinsic in that case (just don't use the output).
     // Unconditionally calling the intrinsic in this way allows the compiler to
     // emit branchless code for this function when possible (depending on how the
     // intrinsic is implemented for the target platform).
-    int lzcount = __builtin_clzl(qwMask);
+    int lzcount = __builtin_clz(qwMask);
     *Index = (DWORD)(31 - lzcount);
     return qwMask != 0;
 }


### PR DESCRIPTION
The existing PAL code was using `__builtin_clzl` which is intended for platforms where `long` is 64 bits. Instead use `__builtin_clz`.

The GC version had a similar issue so I've changed that too. The JIT version was already using `__builtin_clz`.

Fixes #89340.