### PR TITLE
Have callee/callerSaveRegs() use an array based lookup

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -106,25 +106,25 @@ inline bool _our_GetThreadCycles(unsigned __int64* cycleOut)
 #endif // which host OS
 
 const BYTE genTypeSizes[] = {
-#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, tf) sz,
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) sz,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const BYTE genTypeAlignments[] = {
-#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, tf) al,
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) al,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const BYTE genTypeStSzs[] = {
-#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, tf) st,
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) st,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const BYTE genActualTypes[] = {
-#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, tf) jitType,
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) jitType,
 #include "typelist.h"
 #undef DEF_TP
 };

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3369,6 +3369,13 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     rbmFltCalleeTrash   = RBM_FLT_CALLEE_TRASH_INIT;
     cntCalleeTrashFloat = CNT_CALLEE_TRASH_FLOAT_INIT;
 
+    const regMaskTP varTypeCalleeTrashRegs[TYP_COUNT] = {
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) ctr,
+#include "typelist.h"
+#undef DEF_TP
+    };
+    memcpy(this->varTypeCalleeTrashRegs, varTypeCalleeTrashRegs, sizeof(regMaskTP) * TYP_COUNT);
+
     if (canUseEvexEncoding())
     {
         rbmAllFloat |= RBM_HIGHFLOAT;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10897,21 +10897,21 @@ private:
     regMaskTP rbmAllFloat;
     regMaskTP rbmFltCalleeTrash;
     unsigned  cntCalleeTrashFloat;
+    regMaskTP varTypeCalleeTrashRegs[TYP_COUNT];
 
 public:
-    regMaskTP get_RBM_ALLFLOAT() const
+    FORCEINLINE regMaskTP get_RBM_ALLFLOAT() const
     {
         return this->rbmAllFloat;
     }
-    regMaskTP get_RBM_FLT_CALLEE_TRASH() const
+    FORCEINLINE regMaskTP get_RBM_FLT_CALLEE_TRASH() const
     {
         return this->rbmFltCalleeTrash;
     }
-    unsigned get_CNT_CALLEE_TRASH_FLOAT() const
+    FORCEINLINE unsigned get_CNT_CALLEE_TRASH_FLOAT() const
     {
         return this->cntCalleeTrashFloat;
     }
-
 #endif // TARGET_AMD64
 
 }; // end of class Compiler

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -590,13 +590,13 @@ void emitterStats(FILE* fout)
 /*****************************************************************************/
 
 const unsigned short emitTypeSizes[] = {
-#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, tf) sze,
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) sze,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const unsigned short emitTypeActSz[] = {
-#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, tf) asze,
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) asze,
 #include "typelist.h"
 #undef DEF_TP
 };

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -713,12 +713,12 @@ LinearScan::LinearScan(Compiler* theCompiler)
 #if defined(TARGET_AMD64)
     rbmAllFloat       = compiler->rbmAllFloat;
     rbmFltCalleeTrash = compiler->rbmFltCalleeTrash;
+    memcpy(varTypeCalleeTrashRegs, compiler->varTypeCalleeTrashRegs, sizeof(regMaskTP) * TYP_COUNT);
 #endif // TARGET_AMD64
 
     if (!compiler->canUseEvexEncoding())
     {
-        availableRegCount -= CNT_HIGHFLOAT;
-        availableRegCount -= CNT_MASK_REGS;
+        availableRegCount -= (CNT_HIGHFLOAT + CNT_MASK_REGS);
     }
 #endif // TARGET_XARCH
 

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -804,7 +804,7 @@ LinearScan::LinearScan(Compiler* theCompiler)
     // Initialize the availableRegs to use for each TYP_*
     CLANG_FORMAT_COMMENT_ANCHOR;
 
-#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, tf)                                             \
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf)                                   \
     availableRegs[static_cast<int>(TYP_##tn)] = &regFld;
 #include "typelist.h"
 #undef DEF_TP

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -2043,7 +2043,7 @@ private:
 
     unsigned availableRegCount;
 
-    unsigned get_AVAILABLE_REG_COUNT() const
+    FORCEINLINE unsigned get_AVAILABLE_REG_COUNT() const
     {
         return this->availableRegCount;
     }
@@ -2066,20 +2066,30 @@ private:
         return varTypeCalleeSaveRegs[rt];
     }
 
+#if defined(TARGET_AMD64)
+    // Not all of the callee trash values are constant, so don't declare this as a method local static
+    // doing so results in significantly more complex codegen and we'd rather just initialize this once
+    // as part of initializing LSRA instead
+    regMaskTP varTypeCalleeTrashRegs[TYP_COUNT];
+#endif // TARGET_AMD64
+
     //------------------------------------------------------------------------
     // callerSaveRegs: Get the set of caller-save registers of the given RegisterType
     //
     FORCEINLINE regMaskTP callerSaveRegs(RegisterType rt) const
     {
+#if !defined(TARGET_AMD64)
         static const regMaskTP varTypeCalleeTrashRegs[] = {
 #define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) ctr,
 #include "typelist.h"
 #undef DEF_TP
         };
+#endif // !TARGET_AMD64
 
         assert((unsigned)rt < ArrLen(varTypeCalleeTrashRegs));
         return varTypeCalleeTrashRegs[rt];
     }
+
 };
 
 /*XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -2029,11 +2029,11 @@ private:
     regMaskTP rbmAllFloat;
     regMaskTP rbmFltCalleeTrash;
 
-    regMaskTP get_RBM_ALLFLOAT() const
+    FORCEINLINE regMaskTP get_RBM_ALLFLOAT() const
     {
         return this->rbmAllFloat;
     }
-    regMaskTP get_RBM_FLT_CALLEE_TRASH() const
+    FORCEINLINE regMaskTP get_RBM_FLT_CALLEE_TRASH() const
     {
         return this->rbmFltCalleeTrash;
     }
@@ -2054,7 +2054,7 @@ private:
     // NOTE: we currently don't need a LinearScan `this` pointer for this definition, and some callers
     // don't have one available, so make is static.
     //
-    static regMaskTP calleeSaveRegs(RegisterType rt)
+    static FORCEINLINE regMaskTP calleeSaveRegs(RegisterType rt)
     {
         static const regMaskTP varTypeCalleeSaveRegs[] = {
 #define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) csr,
@@ -2069,7 +2069,7 @@ private:
     //------------------------------------------------------------------------
     // callerSaveRegs: Get the set of caller-save registers of the given RegisterType
     //
-    regMaskTP callerSaveRegs(RegisterType rt) const
+    FORCEINLINE regMaskTP callerSaveRegs(RegisterType rt) const
     {
         static const regMaskTP varTypeCalleeTrashRegs[] = {
 #define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) ctr,

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -73,14 +73,6 @@ inline bool useFloatReg(var_types type)
 }
 
 //------------------------------------------------------------------------
-// registerTypesEquivalent: Check to see if two RegisterTypes are equivalent
-//
-inline bool registerTypesEquivalent(RegisterType a, RegisterType b)
-{
-    return varTypeIsIntegralOrI(a) == varTypeIsIntegralOrI(b);
-}
-
-//------------------------------------------------------------------------
 // RefInfo: Captures the necessary information for a definition that is "in-flight"
 //          during `buildIntervals` (i.e. a tree-node definition has been encountered,
 //          but not its use). This includes the RefPosition and its associated
@@ -2064,7 +2056,14 @@ private:
     //
     static regMaskTP calleeSaveRegs(RegisterType rt)
     {
-        return varTypeIsIntegralOrI(rt) ? RBM_INT_CALLEE_SAVED : RBM_FLT_CALLEE_SAVED;
+        static const regMaskTP varTypeCalleeSaveRegs[] = {
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) csr,
+#include "typelist.h"
+#undef DEF_TP
+        };
+
+        assert((unsigned)rt < ArrLen(varTypeCalleeSaveRegs));
+        return varTypeCalleeSaveRegs[rt];
     }
 
     //------------------------------------------------------------------------
@@ -2072,7 +2071,14 @@ private:
     //
     regMaskTP callerSaveRegs(RegisterType rt) const
     {
-        return varTypeIsIntegralOrI(rt) ? RBM_INT_CALLEE_TRASH : RBM_FLT_CALLEE_TRASH;
+        static const regMaskTP varTypeCalleeTrashRegs[] = {
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) ctr,
+#include "typelist.h"
+#undef DEF_TP
+        };
+
+        assert((unsigned)rt < ArrLen(varTypeCalleeTrashRegs));
+        return varTypeCalleeTrashRegs[rt];
     }
 };
 

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -1210,7 +1210,8 @@ bool LinearScan::buildKillPositionsForNode(GenTree* tree, LsraLocation currentLo
                         // If there are no callee-saved registers, the call could kill all the registers.
                         // This is a valid state, so in that case assert should not trigger. The RA will spill in order
                         // to free a register later.
-                        assert(compiler->opts.compDbgEnC || (calleeSaveRegs(varDsc->lvType) == RBM_NONE));
+                        assert(compiler->opts.compDbgEnC || (calleeSaveRegs(varDsc->lvType) == RBM_NONE) ||
+                               varTypeIsStruct(varDsc->lvType));
                     }
                 }
             }

--- a/src/coreclr/jit/typelist.h
+++ b/src/coreclr/jit/typelist.h
@@ -25,47 +25,50 @@
     al      - alignment
     regTyp  - LSRA: type of register to use
     regFld  - LSRA: field to use to track available registers
+    csr     - LSRA: registers to use for callee save  (caller trash)
+    ctr     - LSRA: registers to use for callee trash (caller save)
     tf      - flags
 
-DEF_TP(tn      ,nm        , jitType,     sz,sze,asze, st,al, regTyp,    regFld,              tf     )
+DEF_TP(tn      ,nm        , jitType,     sz,sze,asze, st,al,regTyp,    regFld,              csr                      ctr
+tf     )
 */
 
 // clang-format off
-DEF_TP(UNDEF   ,"<UNDEF>" , TYP_UNDEF,   0,  0,  0,   0, 0, VTR_INT,   availableIntRegs,    VTF_ANY)
-DEF_TP(VOID    ,"void"    , TYP_VOID,    0,  0,  0,   0, 0, VTR_INT,   availableIntRegs,    VTF_ANY)
+DEF_TP(UNDEF   ,"<UNDEF>" , TYP_UNDEF,   0,  0,  0,   0, 0, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_ANY)
+DEF_TP(VOID    ,"void"    , TYP_VOID,    0,  0,  0,   0, 0, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_ANY)
 
-DEF_TP(BOOL    ,"bool"    , TYP_INT,     1,  1,  4,   1, 1, VTR_INT,   availableIntRegs,    VTF_INT|VTF_UNS)
-DEF_TP(BYTE    ,"byte"    , TYP_INT,     1,  1,  4,   1, 1, VTR_INT,   availableIntRegs,    VTF_INT)
-DEF_TP(UBYTE   ,"ubyte"   , TYP_INT,     1,  1,  4,   1, 1, VTR_INT,   availableIntRegs,    VTF_INT|VTF_UNS)
+DEF_TP(BOOL    ,"bool"    , TYP_INT,     1,  1,  4,   1, 1, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_INT|VTF_UNS)
+DEF_TP(BYTE    ,"byte"    , TYP_INT,     1,  1,  4,   1, 1, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_INT)
+DEF_TP(UBYTE   ,"ubyte"   , TYP_INT,     1,  1,  4,   1, 1, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_INT|VTF_UNS)
 
-DEF_TP(SHORT   ,"short"   , TYP_INT,     2,  2,  4,   1, 2, VTR_INT,   availableIntRegs,    VTF_INT)
-DEF_TP(USHORT  ,"ushort"  , TYP_INT,     2,  2,  4,   1, 2, VTR_INT,   availableIntRegs,    VTF_INT|VTF_UNS)
+DEF_TP(SHORT   ,"short"   , TYP_INT,     2,  2,  4,   1, 2, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_INT)
+DEF_TP(USHORT  ,"ushort"  , TYP_INT,     2,  2,  4,   1, 2, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_INT|VTF_UNS)
 
-DEF_TP(INT     ,"int"     , TYP_INT,     4,  4,  4,   1, 4, VTR_INT,   availableIntRegs,    VTF_INT|VTF_I32)
-DEF_TP(UINT    ,"uint"    , TYP_INT,     4,  4,  4,   1, 4, VTR_INT,   availableIntRegs,    VTF_INT|VTF_UNS|VTF_I32) // Only used in GT_CAST nodes
+DEF_TP(INT     ,"int"     , TYP_INT,     4,  4,  4,   1, 4, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_INT|VTF_I32)
+DEF_TP(UINT    ,"uint"    , TYP_INT,     4,  4,  4,   1, 4, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_INT|VTF_UNS|VTF_I32) // Only used in GT_CAST nodes
 
-DEF_TP(LONG    ,"long"    , TYP_LONG,    8,EPS,EPS,   2, 8, VTR_INT,   availableIntRegs,    VTF_INT|VTF_I64)
-DEF_TP(ULONG   ,"ulong"   , TYP_LONG,    8,EPS,EPS,   2, 8, VTR_INT,   availableIntRegs,    VTF_INT|VTF_UNS|VTF_I64) // Only used in GT_CAST nodes
+DEF_TP(LONG    ,"long"    , TYP_LONG,    8,EPS,EPS,   2, 8, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_INT|VTF_I64)
+DEF_TP(ULONG   ,"ulong"   , TYP_LONG,    8,EPS,EPS,   2, 8, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_INT|VTF_UNS|VTF_I64) // Only used in GT_CAST nodes
 
-DEF_TP(FLOAT   ,"float"   , TYP_FLOAT,   4,  4,  4,   1, 4, VTR_FLOAT, availableFloatRegs,  VTF_FLT)
-DEF_TP(DOUBLE  ,"double"  , TYP_DOUBLE,  8,  8,  8,   2, 8, VTR_FLOAT, availableDoubleRegs, VTF_FLT)
+DEF_TP(FLOAT   ,"float"   , TYP_FLOAT,   4,  4,  4,   1, 4, VTR_FLOAT, availableFloatRegs,  RBM_FLT_CALLEE_SAVED,    RBM_FLT_CALLEE_TRASH,    VTF_FLT)
+DEF_TP(DOUBLE  ,"double"  , TYP_DOUBLE,  8,  8,  8,   2, 8, VTR_FLOAT, availableDoubleRegs, RBM_FLT_CALLEE_SAVED,    RBM_FLT_CALLEE_TRASH,    VTF_FLT)
 
-DEF_TP(REF     ,"ref"     , TYP_REF,     PS,GCS,GCS, PST,PS, VTR_INT,   availableIntRegs,    VTF_ANY|VTF_GCR|VTF_I)
-DEF_TP(BYREF   ,"byref"   , TYP_BYREF,   PS,BRS,BRS, PST,PS, VTR_INT,   availableIntRegs,    VTF_ANY|VTF_BYR|VTF_I)
-DEF_TP(STRUCT  ,"struct"  , TYP_STRUCT,  0,  0,  0,   1, 4, VTR_INT,   availableIntRegs,    VTF_S)
+DEF_TP(REF     ,"ref"     , TYP_REF,     PS,GCS,GCS, PST,PS,VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_ANY|VTF_GCR|VTF_I)
+DEF_TP(BYREF   ,"byref"   , TYP_BYREF,   PS,BRS,BRS, PST,PS,VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_ANY|VTF_BYR|VTF_I)
+DEF_TP(STRUCT  ,"struct"  , TYP_STRUCT,  0,  0,  0,   1, 4, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_S)
 
 #ifdef FEATURE_SIMD
-DEF_TP(SIMD8    ,"simd8"  , TYP_SIMD8,    8, 8,  8,   2, 8, VTR_FLOAT, availableDoubleRegs, VTF_S|VTF_VEC)
-DEF_TP(SIMD12   ,"simd12" , TYP_SIMD12,  12,16, 16,   4,16, VTR_FLOAT, availableDoubleRegs, VTF_S|VTF_VEC)
-DEF_TP(SIMD16   ,"simd16" , TYP_SIMD16,  16,16, 16,   4,16, VTR_FLOAT, availableDoubleRegs, VTF_S|VTF_VEC)
+DEF_TP(SIMD8    ,"simd8"  , TYP_SIMD8,    8, 8,  8,   2, 8, VTR_FLOAT, availableDoubleRegs, RBM_FLT_CALLEE_SAVED,    RBM_FLT_CALLEE_TRASH,    VTF_S|VTF_VEC)
+DEF_TP(SIMD12   ,"simd12" , TYP_SIMD12,  12,16, 16,   4,16, VTR_FLOAT, availableDoubleRegs, RBM_FLT_CALLEE_SAVED,    RBM_FLT_CALLEE_TRASH,    VTF_S|VTF_VEC)
+DEF_TP(SIMD16   ,"simd16" , TYP_SIMD16,  16,16, 16,   4,16, VTR_FLOAT, availableDoubleRegs, RBM_FLT_CALLEE_SAVED,    RBM_FLT_CALLEE_TRASH,    VTF_S|VTF_VEC)
 #if defined(TARGET_XARCH)
-DEF_TP(SIMD32   ,"simd32" , TYP_SIMD32,  32,32, 32,   8,16, VTR_FLOAT, availableDoubleRegs, VTF_S|VTF_VEC)
-DEF_TP(SIMD64   ,"simd64" , TYP_SIMD64,  64,64, 64,  16,16, VTR_FLOAT, availableDoubleRegs, VTF_S|VTF_VEC)
-DEF_TP(MASK     ,"mask"   , TYP_MASK,     8, 8,  8,   2, 8, VTR_MASK,  availableMaskRegs,   VTF_ANY)
+DEF_TP(SIMD32   ,"simd32" , TYP_SIMD32,  32,32, 32,   8,16, VTR_FLOAT, availableDoubleRegs, RBM_FLT_CALLEE_SAVED,    RBM_FLT_CALLEE_TRASH,    VTF_S|VTF_VEC)
+DEF_TP(SIMD64   ,"simd64" , TYP_SIMD64,  64,64, 64,  16,16, VTR_FLOAT, availableDoubleRegs, RBM_FLT_CALLEE_SAVED,    RBM_FLT_CALLEE_TRASH,    VTF_S|VTF_VEC)
+DEF_TP(MASK     ,"mask"   , TYP_MASK,     8, 8,  8,   2, 8, VTR_MASK,  availableMaskRegs,   (0),                     (0),                     VTF_ANY)
 #endif // TARGET_XARCH
 #endif // FEATURE_SIMD
 
-DEF_TP(UNKNOWN ,"unknown" ,TYP_UNKNOWN,  0,  0,  0,   0, 0, VTR_INT,   availableIntRegs,    VTF_ANY)
+DEF_TP(UNKNOWN ,"unknown" ,TYP_UNKNOWN,  0,  0,  0,   0, 0, VTR_INT,   availableIntRegs,    RBM_INT_CALLEE_SAVED,    RBM_INT_CALLEE_TRASH,    VTF_ANY)
 // clang-format on
 
 #undef GCS

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -79,13 +79,13 @@ const signed char       opcodeSizes[] =
 // clang-format on
 
 const BYTE varTypeClassification[] = {
-#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, tf) tf,
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) tf,
 #include "typelist.h"
 #undef DEF_TP
 };
 
 const BYTE varTypeRegister[] = {
-#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, tf) regTyp,
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) regTyp,
 #include "typelist.h"
 #undef DEF_TP
 };
@@ -111,7 +111,7 @@ extern const BYTE opcodeArgKinds[] = {
 const char* varTypeName(var_types vt)
 {
     static const char* const varTypeNames[] = {
-#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, tf) nm,
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) nm,
 #include "typelist.h"
 #undef DEF_TP
     };

--- a/src/coreclr/jit/vartypesdef.h
+++ b/src/coreclr/jit/vartypesdef.h
@@ -8,7 +8,7 @@
 
 enum var_types : BYTE
 {
-#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, tf) TYP_##tn,
+#define DEF_TP(tn, nm, jitType, sz, sze, asze, st, al, regTyp, regFld, csr, ctr, tf) TYP_##tn,
 #include "typelist.h"
 #undef DEF_TP
     TYP_COUNT


### PR DESCRIPTION
Extracted from https://github.com/dotnet/runtime/pull/89059, alternative to https://github.com/dotnet/runtime/pull/89349