### PR TITLE
Properly close malformed PKCS12 files when enumerating stores

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
@@ -353,7 +353,7 @@ int32_t CryptoNative_X509StoreCtxRebuildChain(X509_STORE_CTX* ctx)
 int32_t CryptoNative_X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback, void* appData)
 {
     ERR_clear_error();
-    
+
     X509_STORE_CTX_set_verify_cb(ctx, callback);
 
     return X509_STORE_CTX_set_app_data(ctx, appData);
@@ -526,6 +526,10 @@ static X509* ReadNextPublicCert(DIR* dir, X509Stack* tmpStack, char* pathTmp, si
                     {
                         return cert;
                     }
+                }
+                else
+                {
+                    fclose(fp);
                 }
             }
         }


### PR DESCRIPTION
Currently, we are calling `fopen` on files when enumerating the directory for .p12 files, then passing the FILE to `d2i_PKCS12_fp`. If `d2i_PKCS12_fp` returns NULL, then we are leaving the file open indefinitely. This can happen if `d2i_PKCS12_fp` tries to open a file that is empty. This was observed in https://github.com/dotnet/runtime/issues/89345 where there were many open handles to these empty files. 

This changes the NULL case of `d2i_PKCS12_fp` to close the file handle.

Closes #89345