### PR TITLE
Remove --flat from default dsymutil options

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -101,12 +101,26 @@
     <PropertyGroup>
       <_symbolExt Condition="'$(OS)' == 'Windows_NT'">$(NativeSymbolExt)</_symbolExt>
       <_symbolExt Condition="'$(OS)' != 'Windows_NT'">$(NativeBinaryExt)$(NativeSymbolExt)</_symbolExt>
-    </PropertyGroup>    
+      <_symbolSourcePath>$(NativeOutputPath)$(TargetName)$(_symbolExt)</_symbolSourcePath>
+      <_symbolTargetPath>$(PublishDir)\$(TargetName)$(_symbolExt)</_symbolTargetPath>
+      <!-- If the symbol is a dsym bundle, it's a folder not a file. -->
+      <_symbolIsFile Condition="'$(_symbolExt)' == '.dsym'">false</_symbolIsFile>
+      <_symbolIsFile Condition="'$(_symbolIsFile)' == ''">true</_symbolIsFile>
+    </PropertyGroup>
 
-    <!-- replace native symbol file if it exists -->
-    <Delete Files="$(PublishDir)\$(TargetName)$(_symbolExt)" />
-    <Copy SourceFiles="$(NativeOutputPath)$(TargetName)$(_symbolExt)" DestinationFolder="$(PublishDir)"
-      Condition="Exists('$(NativeOutputPath)$(TargetName)$(_symbolExt)') and '$(CopyOutputSymbolsToPublishDirectory)' == 'true'" />
+    <ItemGroup>
+      <_symbolRecursivePath Include="$(NativeOutputPath)$(TargetName)$(_symbolExt)/**/*" />
+    </ItemGroup>
+
+    <!-- replace native symbol file if it exists. On Mac, the symbol path may be a folder-->
+    <Delete Files="$(_symbolTargetPath)" Condition="'$(_symbolIsFile)' == 'true' and Exists('$(_symbolTargetPath)')" />
+    <Copy SourceFiles="$(_symbolSourcePath)" DestinationFolder="$(PublishDir)"
+      Condition="'$(_symbolIsFile)' == 'true' and Exists('$(_symbolSourcePath)')" />
+
+    <!-- Copy folder otherwise -->
+    <RemoveDir Directories="$(_symbolTargetPath)" Condition="'$(_symbolIsFile)' == 'false' and Exists('$(_symbolTargetPath)')" />
+    <Copy SourceFiles="@(_symbolRecursivePath)" DestinationFolder="$(_symbolTargetPath)/%(RecursiveDir)"
+      Condition="'$(_symbolIsFile)' == 'false' and Exists('$(_symbolSourcePath)')" />
   </Target>
 
 </Project>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -19,7 +19,6 @@ The .NET Foundation licenses this file to you under the MIT license.
     <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang</CppCompilerAndLinker>
     <CppLinker>$(CppCompilerAndLinker)</CppLinker>
     <CppLibCreator>ar</CppLibCreator>
-    <DsymUtilOptions Condition="'$(_IsApplePlatform)' == 'true'">--flat</DsymUtilOptions>
     <_SymbolPrefix Condition="'$(_IsApplePlatform)' == 'true'">_</_SymbolPrefix>
     <LinkerFlavor Condition="'$(LinkerFlavor)' == '' and '$(_targetOS)' == 'freebsd'">lld</LinkerFlavor>
     <LinkerFlavor Condition="'$(LinkerFlavor)' == '' and '$(_linuxLibcFlavor)' == 'bionic'">lld</LinkerFlavor>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -64,9 +64,9 @@ The .NET Foundation licenses this file to you under the MIT license.
     <NativeBinaryExt Condition="'$(IsNativeExecutable)' != 'true' and '$(_targetOS)' == 'win' and '$(NativeLib)' == 'Static'">.lib</NativeBinaryExt>
     <NativeBinaryExt Condition="'$(IsNativeExecutable)' != 'true' and '$(_targetOS)' != 'win' and '$(NativeLib)' == 'Static'">.a</NativeBinaryExt>
 
-    <NativeSymbolExt Condition="'$(_IsApplePlatform)' == 'true'">.dwarf</NativeSymbolExt>
-    <NativeSymbolExt Condition="'$(_targetOS)' == 'win'">.pdb</NativeSymbolExt>
-    <NativeSymbolExt Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true'">.dbg</NativeSymbolExt>
+    <NativeSymbolExt Condition="'$(NativeSymbolExt)' == '' and '$(_IsApplePlatform)' == 'true'">.dsym</NativeSymbolExt>
+    <NativeSymbolExt Condition="'$(NativeSymbolExt)' == '' and '$(_targetOS)' == 'win'">.pdb</NativeSymbolExt>
+    <NativeSymbolExt Condition="'$(NativeSymbolExt)' == ''">.dbg</NativeSymbolExt>
 
     <ExportsFileExt Condition="'$(_targetOS)' == 'win'">.def</ExportsFileExt>
     <ExportsFileExt Condition="'$(_targetOS)' != 'win'">.exports</ExportsFileExt>

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
@@ -37,6 +37,9 @@
     <IlcFrameworkPath>$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)</IlcFrameworkPath>
     <IlcFrameworkNativePath>$(MicrosoftNetCoreAppRuntimePackNativeDir)</IlcFrameworkNativePath>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <!-- Use .dwarf files instead of .dsym files since our symbol exporting may not safely handle folders. -->
+    <NativeSymbolExt>.dwarf</NativeSymbolExt>
+    <DsymUtilOptions>--flat</DsymUtilOptions>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -216,7 +216,6 @@
     <CustomNativeMain>true</CustomNativeMain>
     <_IsApplePlatform Condition="'$(TargetsAppleMobile)' == 'true'">true</_IsApplePlatform>
     <_IsiOSLikePlatform Condition="'$(TargetsAppleMobile)' == 'true'">true</_IsiOSLikePlatform>
-    <DsymUtilOptions Condition="'$(_IsApplePlatform)' == 'true'">--flat</DsymUtilOptions>
     <_SymbolPrefix Condition="'$(_IsApplePlatform)' == 'true'">_</_SymbolPrefix>
   </PropertyGroup>
 


### PR DESCRIPTION
--flat is a diagnostic-only option and not fully supported. It can still be specified if necessary through the DsymUtilOptions property and NativeSymbolExt property, but it will no longer be the default.