### PR TITLE
Fix potential BitCast bug for platforms without unaligned reads

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -253,7 +253,7 @@ namespace System.Runtime.CompilerServices
             {
                 ThrowHelper.ThrowNotSupportedException();
             }
-            return As<TFrom, TTo>(ref source);
+            return ReadUnaligned<TTo>(ref As<TFrom, byte>(ref source));
         }
 
         /// <summary>


### PR DESCRIPTION
BitCast could potentially make an invalid read when reinterpreting a type to another that requires higher alignment, which could possibly cause a fault on Mono ARMv6.