### PR TITLE
Dynamic events

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3295,8 +3295,7 @@ void gc_heap::fire_committed_usage_event()
     size_t total_committed_in_global_free = new_committed_by_oh[recorded_committed_free_bucket] - total_committed_in_free - total_committed_in_global_decommit;
     size_t total_bookkeeping_committed = committed_bookkeeping;
 
-    GCEventFireCommittedUsage (
-        (uint16_t)1,
+    GCEventFireCommittedUsage_V1 (
         (uint64_t)total_committed_in_use,
         (uint64_t)total_committed_in_global_decommit,
         (uint64_t)total_committed_in_free,
@@ -25065,8 +25064,7 @@ void gc_heap::check_heap_count ()
 
     dynamic_heap_count_data.sample_index = (dynamic_heap_count_data.sample_index + 1) % dynamic_heap_count_data_t::sample_size;
 
-    GCEventFireDynamicHeapCountSample(
-        (uint16_t)1,
+    GCEventFireHeapCountSample_V1(
         sample.gc_elapsed_time,
         sample.soh_msl_wait_time,
         sample.uoh_msl_wait_time,
@@ -25222,8 +25220,7 @@ void gc_heap::check_heap_count ()
         dynamic_heap_count_data.space_cost_increase_per_step_up   = space_cost_increase_per_step_up;
         dynamic_heap_count_data.space_cost_decrease_per_step_down = space_cost_decrease_per_step_down;
 
-        GCEventFireDynamicHeapCountTuning(
-            (uint16_t)1,
+        GCEventFireHeapCountTuning_V1(
             (uint16_t)dynamic_heap_count_data.new_n_heaps,
             (uint64_t)VolatileLoad(&settings.gc_index),
             dynamic_heap_count_data.median_percent_overhead,
@@ -25237,7 +25234,7 @@ void gc_heap::check_heap_count ()
         if (new_n_heaps != n_heaps)
         {
             // can't have threads allocating while we change the number of heaps
-            GCToEEInterface::SuspendEE(SUSPEND_FOR_GC);
+            GCToEEInterface::SuspendEE(SUSPEND_FOR_GC_PREP);
 
             if (gc_heap::background_running_p())
             {

--- a/src/coreclr/gc/gcevent_serializers.h
+++ b/src/coreclr/gc/gcevent_serializers.h
@@ -96,6 +96,40 @@ struct EventSerializationTraits<uint32_t>
         return sizeof(uint32_t);
     }
 };
+template<>
+struct EventSerializationTraits<uint64_t>
+{
+    static void Serialize(const uint64_t& value, uint8_t** buffer)
+    {
+#if defined(BIGENDIAN)
+        **((uint32_t**)buffer) = ByteSwap64(value);
+#else
+        **((uint64_t**)buffer) = value;
+#endif // BIGENDIAN
+        *buffer += sizeof(uint64_t);
+    }
+
+    static size_t SerializedSize(const uint64_t& value)
+    {
+        return sizeof(uint64_t);
+    }
+};
+
+template<>
+struct EventSerializationTraits<float>
+{
+    static void Serialize(const float& value, uint8_t** buffer)
+    {
+        // TODO, AndrewAu, I think we can assume IEEE754?
+        **((float**)buffer) = value;
+        *buffer += sizeof(float);
+    }
+
+    static size_t SerializedSize(const float& value)
+    {
+        return sizeof(float);
+    }
+};
 
 /*
  * Helper routines for serializing lists of arguments.

--- a/src/coreclr/gc/gcevent_serializers.h
+++ b/src/coreclr/gc/gcevent_serializers.h
@@ -39,9 +39,11 @@
  */
 
 #ifdef _MSC_VER
+#define ByteSwap16 _byteswap_ushort
 #define ByteSwap32 _byteswap_ulong
 #define ByteSwap64 _byteswap_uint64
 #else
+#define ByteSwap16 __bulitin_bswap16
 #define ByteSwap32 __bulitin_bswap32
 #define ByteSwap64 __builtin_bswap64
 #endif // MSC_VER
@@ -72,12 +74,31 @@ struct EventSerializationTraits
 };
 
 /*
- * EventSerializationTraits implementation for uint32_t. Other integral types
+ * EventSerializationTraits implementation for uint16_t. Other integral types
  * can follow this pattern.
  *
  * The convention here is that integral types are always serialized as
  * little-endian.
  */
+template<>
+struct EventSerializationTraits<uint16_t>
+{
+    static void Serialize(const uint16_t& value, uint8_t** buffer)
+    {
+#if defined(BIGENDIAN)
+        **((uint16_t**)buffer) = ByteSwap16(value);
+#else
+        **((uint16_t**)buffer) = value;
+#endif // BIGENDIAN
+        *buffer += sizeof(uint16_t);
+    }
+
+    static size_t SerializedSize(const uint16_t& value)
+    {
+        return sizeof(uint16_t);
+    }
+};
+
 template<>
 struct EventSerializationTraits<uint32_t>
 {
@@ -96,6 +117,7 @@ struct EventSerializationTraits<uint32_t>
         return sizeof(uint32_t);
     }
 };
+
 template<>
 struct EventSerializationTraits<uint64_t>
 {
@@ -120,7 +142,6 @@ struct EventSerializationTraits<float>
 {
     static void Serialize(const float& value, uint8_t** buffer)
     {
-        // TODO, AndrewAu, I think we can assume IEEE754?
         **((float**)buffer) = value;
         *buffer += sizeof(float);
     }

--- a/src/coreclr/gc/gcevents.h
+++ b/src/coreclr/gc/gcevents.h
@@ -5,7 +5,7 @@
 #endif // KNOWN_EVENT
 
 #ifndef DYNAMIC_EVENT
- #define DYNAMIC_EVENT(name, level, keyword, ...)
+ #define DYNAMIC_EVENT(name, level, keyword, version, ...)
 #endif // DYNAMIC_EVENT
 
 KNOWN_EVENT(GCStart_V2, GCEventProvider_Default, GCEventLevel_Information, GCEventKeyword_GC)
@@ -48,9 +48,9 @@ KNOWN_EVENT(PrvSetGCHandle, GCEventProvider_Private, GCEventLevel_Information, G
 KNOWN_EVENT(PrvDestroyGCHandle, GCEventProvider_Private, GCEventLevel_Information, GCEventKeyword_GCHandlePrivate)
 KNOWN_EVENT(PinPlugAtGCTime, GCEventProvider_Private, GCEventLevel_Verbose, GCEventKeyword_GCPrivate)
 
-DYNAMIC_EVENT(CommittedUsage, GCEventLevel_Information, GCEventKeyword_GC)
-DYNAMIC_EVENT(DynamicHeapCountTuning, GCEventLevel_Information, GCEventKeyword_GC)
-DYNAMIC_EVENT(DynamicHeapCountSample, GCEventLevel_Information, GCEventKeyword_GC)
+DYNAMIC_EVENT(CommittedUsage, GCEventLevel_Information, GCEventKeyword_GC, 1)
+DYNAMIC_EVENT(HeapCountTuning, GCEventLevel_Information, GCEventKeyword_GC, 1)
+DYNAMIC_EVENT(HeapCountSample, GCEventLevel_Information, GCEventKeyword_GC, 1)
 
 #undef KNOWN_EVENT
 #undef DYNAMIC_EVENT

--- a/src/coreclr/gc/gcevents.h
+++ b/src/coreclr/gc/gcevents.h
@@ -48,11 +48,9 @@ KNOWN_EVENT(PrvSetGCHandle, GCEventProvider_Private, GCEventLevel_Information, G
 KNOWN_EVENT(PrvDestroyGCHandle, GCEventProvider_Private, GCEventLevel_Information, GCEventKeyword_GCHandlePrivate)
 KNOWN_EVENT(PinPlugAtGCTime, GCEventProvider_Private, GCEventLevel_Verbose, GCEventKeyword_GCPrivate)
 
-// TODO, AndrewAu, naming
-// TODO, AndrewAu, level
 DYNAMIC_EVENT(CommittedUsage, GCEventLevel_Information, GCEventKeyword_GC)
-DYNAMIC_EVENT(DynamicHeapCountData, GCEventLevel_Verbose, GCEventKeyword_GC)
-DYNAMIC_EVENT(GlobalDynamicHeapCountData, GCEventLevel_Verbose, GCEventKeyword_GC)
+DYNAMIC_EVENT(DynamicHeapCountTuning, GCEventLevel_Information, GCEventKeyword_GC)
+DYNAMIC_EVENT(DynamicHeapCountSample, GCEventLevel_Information, GCEventKeyword_GC)
 
 #undef KNOWN_EVENT
 #undef DYNAMIC_EVENT

--- a/src/coreclr/gc/gcevents.h
+++ b/src/coreclr/gc/gcevents.h
@@ -48,5 +48,11 @@ KNOWN_EVENT(PrvSetGCHandle, GCEventProvider_Private, GCEventLevel_Information, G
 KNOWN_EVENT(PrvDestroyGCHandle, GCEventProvider_Private, GCEventLevel_Information, GCEventKeyword_GCHandlePrivate)
 KNOWN_EVENT(PinPlugAtGCTime, GCEventProvider_Private, GCEventLevel_Verbose, GCEventKeyword_GCPrivate)
 
+// TODO, AndrewAu, naming
+// TODO, AndrewAu, level
+DYNAMIC_EVENT(CommittedUsage, GCEventLevel_Information, GCEventKeyword_GC)
+DYNAMIC_EVENT(DynamicHeapCountData, GCEventLevel_Verbose, GCEventKeyword_GC)
+DYNAMIC_EVENT(GlobalDynamicHeapCountData, GCEventLevel_Verbose, GCEventKeyword_GC)
+
 #undef KNOWN_EVENT
 #undef DYNAMIC_EVENT

--- a/src/coreclr/gc/gceventstatus.h
+++ b/src/coreclr/gc/gceventstatus.h
@@ -256,15 +256,15 @@ void FireDynamicEvent(const char* name, EventArgument... arguments)
       }                                                           \
   }
 
-#define DYNAMIC_EVENT(name, level, keyword, ...)                  \
-  inline bool GCEventEnabled##name() { return GCEventStatus::IsEnabled(GCEventProvider_Default, keyword, level); } \
-  template<typename... EventActualArgument>                       \
-  inline void GCEventFire##name(EventActualArgument... arguments) \
-  {                                                               \
-      if (GCEventEnabled##name())                                 \
-      {                                                           \
-          FireDynamicEvent<__VA_ARGS__>(#name, arguments...);     \
-      }                                                           \
+#define DYNAMIC_EVENT(name, level, keyword, version, ...)                        \
+  inline bool GCEventEnabled##name##_V##version() { return GCEventStatus::IsEnabled(GCEventProvider_Default, keyword, level); } \
+  template<typename... EventActualArgument>                                      \
+  inline void GCEventFire##name##_V##version(EventActualArgument... arguments)   \
+  {                                                                              \
+      if (GCEventEnabled##name##_V##version())                                   \
+      {                                                                          \
+          FireDynamicEvent<__VA_ARGS__>(#name, (uint16_t)version, arguments...); \
+      }                                                                          \
   }
 
 #include "gcevents.h"

--- a/src/coreclr/gc/gceventstatus.h
+++ b/src/coreclr/gc/gceventstatus.h
@@ -256,10 +256,16 @@ void FireDynamicEvent(const char* name, EventArgument... arguments)
       }                                                           \
   }
 
-#define DYNAMIC_EVENT(name, level, keyword, ...)                                                                   \
+#define DYNAMIC_EVENT(name, level, keyword, ...)                  \
   inline bool GCEventEnabled##name() { return GCEventStatus::IsEnabled(GCEventProvider_Default, keyword, level); } \
-  template<typename... EventActualArgument>                                                                        \
-  inline void GCEventFire##name(EventActualArgument... arguments) { FireDynamicEvent<__VA_ARGS__>(#name, arguments...); }
+  template<typename... EventActualArgument>                       \
+  inline void GCEventFire##name(EventActualArgument... arguments) \
+  {                                                               \
+      if (GCEventEnabled##name())                                 \
+      {                                                           \
+          FireDynamicEvent<__VA_ARGS__>(#name, arguments...);     \
+      }                                                           \
+  }
 
 #include "gcevents.h"
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1615,6 +1615,8 @@ private:
 
     PER_HEAP_ISOLATED_METHOD void fire_pevents();
 
+    PER_HEAP_ISOLATED_METHOD void fire_committed_usage_events();
+
 #ifdef FEATURE_BASICFREEZE
     PER_HEAP_ISOLATED_METHOD void walk_read_only_segment(heap_segment *seg, void *pvContext, object_callback_func pfnMethodTable, object_callback_func pfnObjRef);
 #endif
@@ -3377,6 +3379,10 @@ private:
 
     PER_HEAP_ISOLATED_METHOD bool compute_memory_settings(bool is_initialization, uint32_t& nhp, uint32_t nhp_from_config, size_t& seg_size_from_config,
         size_t new_current_total_committed);
+
+#ifdef USE_REGIONS
+    PER_HEAP_ISOLATED_METHOD void compute_committed_bytes(size_t& total_committed, size_t& committed_decommit, size_t& committed_free, size_t& committed_bookkeeping, size_t& new_current_total_committed, size_t& new_current_total_committed_bookkeeping, size_t* new_committed_by_oh);
+#endif
 
     PER_HEAP_METHOD void update_collection_counts ();
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1615,7 +1615,7 @@ private:
 
     PER_HEAP_ISOLATED_METHOD void fire_pevents();
 
-    PER_HEAP_ISOLATED_METHOD void fire_committed_usage_events();
+    PER_HEAP_ISOLATED_METHOD void fire_committed_usage_event();
 
 #ifdef FEATURE_BASICFREEZE
     PER_HEAP_ISOLATED_METHOD void walk_read_only_segment(heap_segment *seg, void *pvContext, object_callback_func pfnMethodTable, object_callback_func pfnObjRef);
@@ -3381,7 +3381,9 @@ private:
         size_t new_current_total_committed);
 
 #ifdef USE_REGIONS
-    PER_HEAP_ISOLATED_METHOD void compute_committed_bytes(size_t& total_committed, size_t& committed_decommit, size_t& committed_free, size_t& committed_bookkeeping, size_t& new_current_total_committed, size_t& new_current_total_committed_bookkeeping, size_t* new_committed_by_oh);
+    PER_HEAP_ISOLATED_METHOD void compute_committed_bytes(size_t& total_committed, size_t& committed_decommit, size_t& committed_free, 
+                                  size_t& committed_bookkeeping, size_t& new_current_total_committed, size_t& new_current_total_committed_bookkeeping, 
+                                  size_t* new_committed_by_oh);
 #endif
 
     PER_HEAP_METHOD void update_collection_counts ();

--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -3414,7 +3414,7 @@
                            task="GarbageCollection"
                            symbol="GCBulkRootStaticVar" message="$(string.RuntimePublisher.GCBulkRootStaticVarEventMessage)"/>
 
-                    <event value="39" version="0" level="win:LogAlways" template="GCDynamicEvent"
+                    <event value="39" version="0" level="win:Informational" template="GCDynamicEvent"
                            keywords= "GCKeyword GCHandleKeyword GCHeapDumpKeyword GCSampledObjectAllocationHighKeyword GCHeapSurvivalAndMovementKeyword ManagedHeapCollectKeyword GCHeapAndTypeNamesKeyword GCSampledObjectAllocationLowKeyword"
                            opcode="GCDynamicEvent"
                            task="GarbageCollection"


### PR DESCRIPTION
In this PR, I introduced three new events to support diagnosing issues related to [dynamic heap count tuning](https://github.com/dotnet/runtime/pull/86245).

The committed usage event will tell us how much memory the GC has committed and what they are currently used for.

The heap count sample event will tell us the measurements the dynamic heap count tuning logic takes.

The heap count tuning event will tell us how the dynamic heap count tuning logic made use of the sample and decide what is the new number of heaps.

These new events are implemented differently than the usual ones using the `GCDynamic` event provisioned for `clrgc`. This is done to make it possible to diagnose issues when customers run the new `clrgc` on .NET 6/.NET 7 runtimes.

[Here](https://github.com/microsoft/perfview/pull/1886) is the PerfView side of the PR to validate this PR actually works. 