### PR TITLE
Use JIT intrinsic for UTF8 encoding in Utf8.TryWrite's AppendLiteral

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.Sealed.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.Sealed.cs
@@ -155,6 +155,7 @@ namespace System.Text
                 return base.TryGetBytes(chars, bytes, out bytesWritten);
             }
 
+            /// <summary>Same as Encoding.UTF8.TryGetBytes, except with refs, returning the number of bytes written (or -1 if the operation fails), and optimized for a constant input.</summary>
             [MethodImpl(MethodImplOptions.NoInlining)]
             [Intrinsic] // Can be unrolled by JIT
             internal static unsafe int ReadUtf8(ref char input, int inputLength, ref byte output, int outputLength)


### PR DESCRIPTION
@EgorBo, the right things don't seem to be happening here, or else I'm misunderstanding how it's supposed to work.  I still see a call to ReadUtf8 in the asm.