### PR TITLE
Fix System.BinaryData tests failing in AOT.

### DIFF
--- a/src/libraries/System.Memory.Data/tests/System.Memory.Data.Tests.csproj
+++ b/src/libraries/System.Memory.Data/tests/System.Memory.Data.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes test failures reported in https://github.com/dotnet/runtime/issues/88982#issuecomment-1646754675 that have been caused by https://github.com/dotnet/runtime/pull/88480.

The failing tests could have easily been converted to source gen, however this is currently blocked by https://github.com/dotnet/runtime/issues/81702. Given that this is blocking use of `BinaryData` in source gen we should consider an RC1 fix (which requires change in public API) cc @eerhardt @ericstj