### PR TITLE
[mono][ios] Enable System.Formats.Cbor test on apple mobile devices

### DIFF
--- a/src/libraries/System.Formats.Cbor/tests/PropertyTests/CborPropertyTests.cs
+++ b/src/libraries/System.Formats.Cbor/tests/PropertyTests/CborPropertyTests.cs
@@ -178,7 +178,6 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Property(Replay = ReplaySeed, MaxTest = MaxTests, Arbitrary = new[] { typeof(CborRandomGenerators) })]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73150", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CborDocument_Roundtrip(CborPropertyTestContext input)
         {
             byte[] encoding = CborDocumentSerializer.encode(input);


### PR DESCRIPTION
This PR enables the `CborDocument_Roundtrip` test which passed locally on a device.

Fixes https://github.com/dotnet/runtime/issues/73150