### PR TITLE
[wasm][debugger] Adding test for #42421

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/AsyncTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/AsyncTests.cs
@@ -154,5 +154,20 @@ namespace DebuggerTests
                 }
             );
         }
+
+        [ConditionalFact(nameof(WasmSingleThreaded), nameof(RunningOnChrome))]
+        public async Task StepOutOfAsyncMethod()
+        {
+            await SetJustMyCode(true);
+            string source_file = "dotnet://debugger-test.dll/debugger-async-step.cs";
+
+            await SetBreakpointInMethod("debugger-test.dll", "DebuggerTests.AsyncStepClass", "TestAsyncStepOut2", 2);
+            await EvaluateAndCheck(
+                "window.setTimeout(function() { invoke_static_method_async('[debugger-test] DebuggerTests.AsyncStepClass:TestAsyncStepOut'); }, 1);",
+                "dotnet://debugger-test.dll/debugger-async-step.cs", 21, 12,
+                "DebuggerTests.AsyncStepClass.TestAsyncStepOut2");
+
+            await StepAndCheck(StepKind.Out, source_file, 16, 8, "DebuggerTests.AsyncStepClass.TestAsyncStepOut");
+        }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -839,9 +839,9 @@ namespace DebuggerTests
         [Theory]
         [InlineData("IDefaultInterface", "DefaultMethod", "Evaluate", "DefaultInterfaceMethod.Evaluate", 1089, 1005, 1003, 1007)]
         [InlineData("IExtendIDefaultInterface", "IDefaultInterface.DefaultMethodToOverride", "Evaluate", "DefaultInterfaceMethod.Evaluate", 1090, 1049, 1047, 1051)]
-        [InlineData("IDefaultInterface", "DefaultMethodAsync", "EvaluateAsync", "System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start<IDefaultInterface.<DefaultMethodAsync>d__3>", 37, 1018, 1016, 1020)]
+        [InlineData("IDefaultInterface", "DefaultMethodAsync", "EvaluateAsync", "DefaultInterfaceMethod.EvaluateAsync", 1097, 1018, 1016, 1020)]
         [InlineData("IDefaultInterface", "DefaultMethodStatic", "EvaluateStatic", "DefaultInterfaceMethod.EvaluateStatic", 1126, 1024, 1022, 1026)]
-        [InlineData("IDefaultInterface", "DefaultMethodAsyncStatic", "EvaluateAsyncStatic", "System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start<IDefaultInterface.<DefaultMethodAsyncStatic>d__5>", 37, 1033, 1031, 1035)]
+        [InlineData("IDefaultInterface", "DefaultMethodAsyncStatic", "EvaluateAsyncStatic", "DefaultInterfaceMethod.EvaluateAsyncStatic", 1131, 1033, 1031, 1035)]
         public async Task BreakInDefaultInterfaceMethod(
             string dimClassName, string dimName, string entryMethod,  string prevFrameInDim, int evaluateAsPrevFrameLine, int dimAsPrevFrameLine, int functionLocationLine, int functionEndLine)
         {

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -52,7 +52,8 @@
   <Target Name="PrepareForWasmBuildApp" DependsOnTargets="Build">
     <Error Condition="!Exists('$(MicrosoftNetCoreAppRuntimePackRidDir)native')"
            Text="Cannot find %24(MicrosoftNetCoreAppRuntimePackRidDir)=$(MicrosoftNetCoreAppRuntimePackRidDir)native. Make sure to set the runtime configuration with %24(RuntimeConfiguration). Current value: $(RuntimeConfiguration)" />
-
+    <!-- Remove pdb from System.Private.CoreLib to have the same scenario that we have in a Blazor/Wasm user app -->
+    <Delete Files="$(MicrosoftNetCoreAppRuntimePackRidDir)native/System.Private.CoreLib.pdb" />   
     <PropertyGroup>
       <EnableDefaultWasmAssembliesToBundle>false</EnableDefaultWasmAssembliesToBundle>
       <WasmAppDir>$(AppDir)</WasmAppDir>


### PR DESCRIPTION
The test pauses on `System.Threading.Tasks.Task.NotifyDebuggerOfWaitCompletionIfNecessary` (part of the async machinery) when it tries to `StepOut`, but it shouldn't because it's  non-user code, but in our debugger-tests we have the PDB of `System.Private.CoreLib`, because of which we don't know that this is not a user code.

In this PR I removed the pdb of SPC then it will work as expected in a real user app.

Fixes #42421