### PR TITLE
Fixed python warning: DeprecationWarning: There is no current event loop

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -606,7 +606,8 @@ class AsyncSubprocessHelper:
             else:
                 loop = asyncio.new_event_loop()
 
-        asyncio.set_event_loop(loop)
+            asyncio.set_event_loop(loop)
+            
         loop.run_until_complete(self.__run_to_completion__(async_callback, *extra_args))
         os.environ.clear()
         os.environ.update(reset_env)

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -539,10 +539,6 @@ class AsyncSubprocessHelper:
         self.verbose = verbose
         self.subproc_count_queue = None
 
-        if 'win32' in sys.platform:
-            # Windows specific event-loop policy & cmd
-            asyncio.set_event_loop(asyncio.ProactorEventLoop())
-
     async def __get_item__(self, item, index, size, async_callback, *extra_args):
         """ Wrapper to the async callback which will schedule based on the queue
         """
@@ -600,7 +596,17 @@ class AsyncSubprocessHelper:
         """
 
         reset_env = os.environ.copy()
-        loop = asyncio.get_event_loop()
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            if 'win32' in sys.platform:
+                # Windows specific event-loop policy & cmd
+                loop = asyncio.ProactorEventLoop()
+            else:
+                loop = asyncio.new_event_loop()
+
+        asyncio.set_event_loop(loop)
         loop.run_until_complete(self.__run_to_completion__(async_callback, *extra_args))
         os.environ.clear()
         os.environ.update(reset_env)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/84710

`get_event_loop` raises a deprecation warning if cannot find the current running event loop - this will eventually turn into a RuntimeError in the future.

There is also behavior where even calling `get_event_loop` right after `set_event_loop` will still produce a deprecation warning, example:
```python
loop = asyncio.ProactorEventLoop()
asyncio.set_event_loop(loop)
loop = asyncio.get_event_loop() # still produces a deprecation warning
```

Therefore, we will not use `get_event_loop` at all, and instead try to use `get_running_loop` - and if that raises a RuntimeError, then we create an event loop.