### PR TITLE
Fix `LocalBuilder.IsPinned` always returning `false` on CoreCLR runtime

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -43,7 +43,7 @@ namespace System.Reflection.Emit
             if (rtType == null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType);
 
-            localBuilder = new LocalBuilder(m_localCount, localType, m_methodBuilder);
+            localBuilder = new LocalBuilder(m_localCount, localType, m_methodBuilder, pinned);
             // add the localType to local signature
             m_localSignature.AddArgument(localType, pinned);
             m_localCount++;

--- a/src/libraries/System.Reflection.Emit.ILGeneration/tests/ILGenerator/DeclareLocalTests.cs
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/tests/ILGenerator/DeclareLocalTests.cs
@@ -119,6 +119,7 @@ namespace System.Reflection.Emit.Tests
             Assert.Throws<InvalidOperationException>(() => ilGenerator.DeclareLocal(typeof(int)));
         }
 
+        [Fact]
         public void DeclareLocal_Pinned()
         {
             TypeBuilder type = Helpers.DynamicType(TypeAttributes.NotPublic);

--- a/src/libraries/System.Reflection.Emit.ILGeneration/tests/ILGenerator/DeclareLocalTests.cs
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/tests/ILGenerator/DeclareLocalTests.cs
@@ -119,6 +119,16 @@ namespace System.Reflection.Emit.Tests
             Assert.Throws<InvalidOperationException>(() => ilGenerator.DeclareLocal(typeof(int)));
         }
 
+        public void DeclareLocal_Pinned()
+        {
+            TypeBuilder type = Helpers.DynamicType(TypeAttributes.NotPublic);
+            MethodBuilder method = type.DefineMethod("TestMethod_Pinning", MethodAttributes.Public | MethodAttributes.Static);
+            ILGenerator generator = method.GetILGenerator();
+            Assert.True(generator.DeclareLocal(typeof(int).MakeByRefType(), true).IsPinned);
+            Assert.True(generator.DeclareLocal(typeof(object), true).IsPinned);
+            Assert.True(generator.DeclareLocal(typeof(byte), true).IsPinned);
+        }
+
         private void VerifyDeclareLocal(ILGenerator generator)
         {
             for (int i = 0; i < TestData.Length; i++)


### PR DESCRIPTION
Fixes #89347

I added tests for `int&`, `object` (which seems to be legal in IL according to II.23.2.9), and `byte` (since the current logic doesn't seem to check the type, so presumably this is expected to be allowed, even if it presumably does nothing meaningful at runtime? - can remove this one if it's not desired).