### PR TITLE
Run Antigen/Fuzzlyn on Saturdays too

### DIFF
--- a/eng/pipelines/coreclr/exploratory.yml
+++ b/eng/pipelines/coreclr/exploratory.yml
@@ -2,8 +2,8 @@
 trigger: none
 
 schedules:
-- cron: "0 14 * * 0"
-  displayName: Sun at 6:00 AM (UTC-8:00)
+- cron: "0 14 * * 0,6"
+  displayName: Sat and Sun at 6:00 AM (UTC-8:00)
   branches:
     include:
     - main


### PR DESCRIPTION
Up the frequency of the Antigen and Fuzzlyn runs to also run on Saturdays during these last weeks of .NET 8 development.