### PR TITLE
[mono] MarshalingPInvokeScanner tolerates DLLs without metadata

### DIFF
--- a/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
+++ b/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
@@ -106,7 +106,17 @@ namespace MonoTargetsTasks
         {
             using FileStream file = new FileStream(assyPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using PEReader peReader = new PEReader(file);
-            MetadataReader mdtReader = peReader.GetMetadataReader();
+            MetadataReader mdtReader;
+
+            try
+            {
+                mdtReader = peReader.GetMetadataReader();
+            }
+            catch(InvalidOperationException)
+            {
+                // If the DLL does not have metadata, the previous call will fail with InvalidOperationException.
+                return false;
+            }
 
             foreach(CustomAttributeHandle attrHandle in mdtReader.CustomAttributes)
             {

--- a/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
+++ b/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
@@ -106,18 +106,11 @@ namespace MonoTargetsTasks
         {
             using FileStream file = new FileStream(assyPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using PEReader peReader = new PEReader(file);
-            MetadataReader mdtReader;
-
-            try
+            if (!peReader.HasMetadata)
             {
-                mdtReader = peReader.GetMetadataReader();
-            }
-            catch(InvalidOperationException ex)
-            {
-                // If the DLL does not have metadata, the previous call will fail with InvalidOperationException.
-                Log.LogMessage(MessageImportance.Low, string.Format("Cannot read metadata in file {0}: {1}.", assyPath, ex.Message));
                 return false;
             }
+            MetadataReader mdtReader = peReader.GetMetadataReader();
 
             foreach(CustomAttributeHandle attrHandle in mdtReader.CustomAttributes)
             {

--- a/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
+++ b/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
@@ -112,9 +112,10 @@ namespace MonoTargetsTasks
             {
                 mdtReader = peReader.GetMetadataReader();
             }
-            catch(InvalidOperationException)
+            catch(InvalidOperationException ex)
             {
                 // If the DLL does not have metadata, the previous call will fail with InvalidOperationException.
+                Log.LogMessage(MessageImportance.Low, string.Format("Cannot read metadata in file {0}: {1}.", assyPath, ex.Message));
                 return false;
             }
 


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/issues/89429 where `MarshalingPInvokeScanner` failed when trying to acquire a `MetadataReader` over a DLL that does not have metadata. The failure is shown [here](https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-89296-merge-1bbcaf3224704de6b0/tracing_eventpipe/1/console.b87213e1.log?helixlogtype=result).

cc: @kotlarmilos 