### PR TITLE
[browser] only trace ExitStatus stack trace if `diagnosticTracing` is true

### DIFF
--- a/src/mono/wasm/runtime/loader/exit.ts
+++ b/src/mono/wasm/runtime/loader/exit.ts
@@ -49,7 +49,7 @@ export function mono_exit(exit_code: number, reason?: any): void {
                 mono_log_debug("abort_startup, reason: " + reason);
                 abort_promises(reason);
             }
-            logErrorOnExit(exit_code, reason);
+            logOnExit(exit_code, reason);
             appendElementOnExit(exit_code);
             if (runtimeHelpers.jiterpreter_dump_stats) runtimeHelpers.jiterpreter_dump_stats(false);
             if (exit_code === 0 && loaderHelpers.config?.interopCleanupOnExit) {
@@ -146,9 +146,13 @@ function appendElementOnExit(exit_code: number) {
     }
 }
 
-function logErrorOnExit(exit_code: number, reason: any) {
+function logOnExit(exit_code: number, reason: any) {
     if (exit_code !== 0 && reason) {
-        const mono_log = reason instanceof runtimeHelpers.ExitStatus ? mono_log_debug : mono_log_error;
+        // ExitStatus usually is not real JS error and so stack strace is not very useful.
+        // We will use debug level for it, which will print only when diagnosticTracing is set.
+        const mono_log = reason instanceof runtimeHelpers.ExitStatus
+            ? mono_log_debug
+            : mono_log_error;
         if (typeof reason == "string") {
             mono_log(reason);
         }

--- a/src/mono/wasm/runtime/loader/exit.ts
+++ b/src/mono/wasm/runtime/loader/exit.ts
@@ -147,18 +147,20 @@ function appendElementOnExit(exit_code: number) {
 }
 
 function logErrorOnExit(exit_code: number, reason: any) {
-    if (exit_code !== 0 && reason) {
-        if (reason instanceof Error) {
+    if (exit_code !== 0 && reason && !(reason instanceof runtimeHelpers.ExitStatus)) {
+        if (typeof reason == "string") {
+            mono_log_error(reason);
+        }
+        else if (reason.stack && reason.message) {
             if (runtimeHelpers.stringify_as_error_with_stack) {
                 mono_log_error(runtimeHelpers.stringify_as_error_with_stack(reason));
             } else {
                 mono_log_error(reason.message + "\n" + reason.stack);
             }
         }
-        else if (typeof reason == "string")
-            mono_log_error(reason);
-        else
+        else {
             mono_log_error(JSON.stringify(reason));
+        }
     }
     if (loaderHelpers.config && loaderHelpers.config.logExitCode) {
         if (consoleWebSocket) {

--- a/src/mono/wasm/runtime/loader/exit.ts
+++ b/src/mono/wasm/runtime/loader/exit.ts
@@ -147,19 +147,20 @@ function appendElementOnExit(exit_code: number) {
 }
 
 function logErrorOnExit(exit_code: number, reason: any) {
-    if (exit_code !== 0 && reason && !(reason instanceof runtimeHelpers.ExitStatus)) {
+    if (exit_code !== 0 && reason) {
+        const mono_log = reason instanceof runtimeHelpers.ExitStatus ? mono_log_debug : mono_log_error;
         if (typeof reason == "string") {
-            mono_log_error(reason);
+            mono_log(reason);
         }
         else if (reason.stack && reason.message) {
             if (runtimeHelpers.stringify_as_error_with_stack) {
-                mono_log_error(runtimeHelpers.stringify_as_error_with_stack(reason));
+                mono_log(runtimeHelpers.stringify_as_error_with_stack(reason));
             } else {
-                mono_log_error(reason.message + "\n" + reason.stack);
+                mono_log(reason.message + "\n" + reason.stack);
             }
         }
         else {
-            mono_log_error(JSON.stringify(reason));
+            mono_log(JSON.stringify(reason));
         }
     }
     if (loaderHelpers.config && loaderHelpers.config.logExitCode) {

--- a/src/mono/wasm/runtime/loader/exit.ts
+++ b/src/mono/wasm/runtime/loader/exit.ts
@@ -150,7 +150,7 @@ function logOnExit(exit_code: number, reason: any) {
     if (exit_code !== 0 && reason) {
         // ExitStatus usually is not real JS error and so stack strace is not very useful.
         // We will use debug level for it, which will print only when diagnosticTracing is set.
-        const mono_log = reason instanceof runtimeHelpers.ExitStatus
+        const mono_log = runtimeHelpers.ExitStatus && reason instanceof runtimeHelpers.ExitStatus
             ? mono_log_debug
             : mono_log_error;
         if (typeof reason == "string") {

--- a/src/mono/wasm/runtime/logging.ts
+++ b/src/mono/wasm/runtime/logging.ts
@@ -91,8 +91,8 @@ export function mono_wasm_symbolicate_string(message: string): string {
 
 export function mono_wasm_stringify_as_error_with_stack(err: Error | string): string {
     let errObj: any = err;
-    if (!errObj || !errObj.stack || !(errObj instanceof Error)) {
-        errObj = new Error(errObj || "Unknown error");
+    if (!errObj || !errObj.stack) {
+        errObj = new Error(errObj ? ("" + errObj) : "Unknown error");
     }
 
     // Error


### PR DESCRIPTION
- `logErrorOnExit` - only trace ExitStatus stack trace if `diagnosticTracing` is true
- `logErrorOnExit` - reoder conditions
- `mono_wasm_stringify_as_error_with_stack` to accept objects with stack, not just errors
