### PR TITLE
Get the normal event accessors generated

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MemberTypes.cs
@@ -305,6 +305,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
@@ -312,6 +313,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -372,6 +374,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			private event EventHandler<EventArgs> PrivateEvent;
@@ -379,6 +382,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -440,6 +444,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			public event EventHandler<EventArgs> HideEvent;
@@ -496,11 +501,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			public event EventHandler<EventArgs> HideEvent;
 
@@ -568,17 +575,20 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -651,21 +661,25 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1377,6 +1391,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
@@ -1384,6 +1399,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1408,6 +1424,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			private event EventHandler<EventArgs> PrivateEvent;
@@ -1415,6 +1432,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1448,6 +1466,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			public event EventHandler<EventArgs> HideEvent;
@@ -1471,11 +1490,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			public event EventHandler<EventArgs> HideEvent;
 
@@ -1508,17 +1529,20 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			protected event EventHandler<EventArgs> ProtectedEventOnBase;
 			private event EventHandler<EventArgs> PrivateEventOnBase;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]
@@ -1547,21 +1571,25 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
+			[method: ExpectLocalsModified]
 			[method: ExpectBodyModified]
 			protected event EventHandler<EventArgs> ProtectedEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> HideEvent;
 
 			[Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMemberTypes.cs
@@ -211,6 +211,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler PublicEvent;
 
 			event EventHandler NonPublicEvent;
@@ -224,6 +225,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			event EventHandler NonPublicEvent;
 
 			public event EventHandler PublicEven;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/EventUsedViaReflection.cs
@@ -201,6 +201,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			public event EventHandler<EventArgs> PublicEvent;
 		}
@@ -211,6 +212,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			internal event EventHandler<EventArgs> InternalEvent;
 			[Kept]
 			[KeptBackingField]
@@ -221,11 +223,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 		}
 
@@ -235,6 +239,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			internal event EventHandler<EventArgs> InternalEvent;
 			[Kept]
 			[KeptBackingField]
@@ -245,11 +250,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			private event EventHandler<EventArgs> PrivateEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 		}
 
@@ -259,11 +266,13 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> IfEvent;
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> ElseEvent;
 		}
 
@@ -278,6 +287,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> IfEvent;
 		}
 
@@ -289,6 +299,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEventOnBase;
 		}
 		[KeptBaseType (typeof (BaseClass))]
@@ -302,12 +313,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			private event EventHandler<EventArgs> MarkedDueToIgnoreCaseEvent;
 		}
 
@@ -324,12 +337,14 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 
 			[Kept]
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			private event EventHandler<EventArgs> MarkedDueToPutRefDispPropertyEvent;
 		}
 	}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/RuntimeReflectionExtensionsCalls.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/RuntimeReflectionExtensionsCalls.cs
@@ -120,6 +120,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> PublicEvent;
 
 			[Kept]
@@ -195,6 +196,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			[KeptEventAddMethod]
 			[KeptEventRemoveMethod]
 			[method: ExpectBodyModified]
+			[method: ExpectLocalsModified]
 			public event EventHandler<EventArgs> Event;
 
 			[Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompilationMetadataProvider.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompilationMetadataProvider.cs
@@ -155,6 +155,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				yield return Path.Combine (referenceDir, "System.Runtime.dll");
 				yield return Path.Combine (referenceDir, "System.Runtime.Extensions.dll");
 				yield return Path.Combine (referenceDir, "System.Runtime.InteropServices.dll");
+				yield return Path.Combine (referenceDir, "System.Threading.dll");
 			} else {
 				yield return "mscorlib.dll";
 			}


### PR DESCRIPTION
Because System.Threading.dll was not referenced, this led to Roslyn generating the Delegate.Combine based accessor which does not have any locals.  https://github.com/dotnet/roslyn/blob/520e2f10078ab0e5f85c78fdd95d786d78b9676a/src/Compilers/CSharp/Portable/Compiler/MethodBodySynthesizer.cs#L323-L520

In our UnityLinker test framework we have 2 cases currently.  Mono, which will reference mscorlib.dll, and Roslyn will find `System.Threading.Interlocked.CompareExchange` and use the normal approach.

And currently I have our coreclr tests referencing System.Threading.dll for no great reason.  This is how I stumbled on this.

While this change isn't strictly necessary, I think it's better to have coverage on the `System.Threading.Interlocked.CompareExchange` approach because that's what would normally be generated.  It's also the more complex case for the linker to handle since it has to clear the locals.