### PR TITLE
Remove nullable return from ConstructorInvoker.Invoke()

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
@@ -28,17 +28,17 @@ namespace System.Reflection
             return new ConstructorInvoker(runtimeConstructor);
         }
 
-        public object? Invoke()
+        public object Invoke()
         {
             return _methodBaseInvoker.CreateInstanceWithFewArgs(new Span<object?>());
         }
 
-        public object? Invoke(object? arg1)
+        public object Invoke(object? arg1)
         {
             return _methodBaseInvoker.CreateInstanceWithFewArgs(new Span<object?>(ref arg1));
         }
 
-        public object? Invoke(object? arg1, object? arg2)
+        public object Invoke(object? arg1, object? arg2)
         {
             StackAllocatedArguments argStorage = default;
             argStorage._args.Set(0, arg1);
@@ -46,7 +46,7 @@ namespace System.Reflection
             return _methodBaseInvoker.CreateInstanceWithFewArgs(argStorage._args.AsSpan(2));
         }
 
-        public object? Invoke(object? arg1, object? arg2, object? arg3)
+        public object Invoke(object? arg1, object? arg2, object? arg3)
         {
             StackAllocatedArguments argStorage = default;
             argStorage._args.Set(0, arg1);
@@ -55,7 +55,7 @@ namespace System.Reflection
             return _methodBaseInvoker.CreateInstanceWithFewArgs(argStorage._args.AsSpan(3));
         }
 
-        public object? Invoke(object? arg1, object? arg2, object? arg3, object? arg4)
+        public object Invoke(object? arg1, object? arg2, object? arg3, object? arg4)
         {
             StackAllocatedArguments argStorage = default;
             argStorage._args.Set(0, arg1);
@@ -65,7 +65,7 @@ namespace System.Reflection
             return _methodBaseInvoker.CreateInstanceWithFewArgs(argStorage._args.AsSpan(4));
         }
 
-        public object? Invoke(Span<object?> arguments)
+        public object Invoke(Span<object?> arguments)
         {
 
             return _methodBaseInvoker.CreateInstance(arguments);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
@@ -46,11 +46,11 @@ namespace System.Reflection
             Initialize(argumentTypes, out _strategy, out _invokerArgFlags, out _needsByRefStrategy);
         }
 
-        public object? Invoke() => Invoke(null, null, null, null);
-        public object? Invoke(object? arg1) => Invoke(arg1, null, null, null);
-        public object? Invoke(object? arg1, object? arg2) => Invoke(arg1, arg2, null, null);
-        public object? Invoke(object? arg1, object? arg2, object? arg3) => Invoke(arg1, arg2, arg3, null);
-        public object? Invoke(object? arg1, object? arg2, object? arg3, object? arg4)
+        public object Invoke() => Invoke(null, null, null, null);
+        public object Invoke(object? arg1) => Invoke(arg1, null, null, null);
+        public object Invoke(object? arg1, object? arg2) => Invoke(arg1, arg2, null, null);
+        public object Invoke(object? arg1, object? arg2, object? arg3) => Invoke(arg1, arg2, arg3, null);
+        public object Invoke(object? arg1, object? arg2, object? arg3, object? arg4)
         {
             if ((_invocationFlags & (InvocationFlags.NoInvoke | InvocationFlags.ContainsStackPointers)) != 0)
             {
@@ -82,7 +82,7 @@ namespace System.Reflection
             // Check fast path first.
             if (_invokeFunc_Obj4Args is not null)
             {
-                return _invokeFunc_Obj4Args(obj: null, arg1, arg2, arg3, arg4);
+                return _invokeFunc_Obj4Args(obj: null, arg1, arg2, arg3, arg4)!;
             }
 
             if ((_strategy & InvokerStrategy.StrategyDetermined_Obj4Args) == 0)
@@ -90,14 +90,14 @@ namespace System.Reflection
                 DetermineStrategy_Obj4Args(ref _strategy, ref _invokeFunc_Obj4Args, _method, _needsByRefStrategy, backwardsCompat: false);
                 if (_invokeFunc_Obj4Args is not null)
                 {
-                    return _invokeFunc_Obj4Args(obj: null, arg1, arg2, arg3, arg4);
+                    return _invokeFunc_Obj4Args(obj: null, arg1, arg2, arg3, arg4)!;
                 }
             }
 
             return InvokeDirectByRef(arg1, arg2, arg3, arg4);
         }
 
-        public object? Invoke(Span<object?> arguments)
+        public object Invoke(Span<object?> arguments)
         {
             if (!_needsByRefStrategy)
             {
@@ -137,7 +137,7 @@ namespace System.Reflection
             return InvokeWithFewArgs(arguments);
         }
 
-        internal object? InvokeWithFewArgs(Span<object?> arguments)
+        internal object InvokeWithFewArgs(Span<object?> arguments)
         {
             Debug.Assert(_argCount <= MaxStackAllocArgCount);
 
@@ -155,7 +155,7 @@ namespace System.Reflection
             // Check fast path first.
             if (_invokeFunc_ObjSpanArgs is not null)
             {
-                return _invokeFunc_ObjSpanArgs(obj : null, copyOfArgs);
+                return _invokeFunc_ObjSpanArgs(obj : null, copyOfArgs)!;
                 // No need to call CopyBack here since there are no ref values.
             }
 
@@ -164,22 +164,22 @@ namespace System.Reflection
                 DetermineStrategy_ObjSpanArgs(ref _strategy, ref _invokeFunc_ObjSpanArgs, _method, _needsByRefStrategy, backwardsCompat: false);
                 if (_invokeFunc_ObjSpanArgs is not null)
                 {
-                    return _invokeFunc_ObjSpanArgs(obj: null, copyOfArgs);
+                    return _invokeFunc_ObjSpanArgs(obj: null, copyOfArgs)!;
                 }
             }
 
-            object? ret = InvokeDirectByRefWithFewArgs(copyOfArgs);
+            object ret = InvokeDirectByRefWithFewArgs(copyOfArgs);
             CopyBack(arguments, copyOfArgs, shouldCopyBack);
             return ret;
         }
 
-        internal object? InvokeDirectByRef(object? arg1 = null, object? arg2 = null, object? arg3 = null, object? arg4 = null)
+        internal object InvokeDirectByRef(object? arg1 = null, object? arg2 = null, object? arg3 = null, object? arg4 = null)
         {
             StackAllocatedArguments stackStorage = new(arg1, arg2, arg3, arg4);
             return InvokeDirectByRefWithFewArgs(stackStorage._args.AsSpan(_argCount));
         }
 
-        internal unsafe object? InvokeDirectByRefWithFewArgs(Span<object?> copyOfArgs)
+        internal unsafe object InvokeDirectByRefWithFewArgs(Span<object?> copyOfArgs)
         {
             if ((_strategy & InvokerStrategy.StrategyDetermined_RefArgs) == 0)
             {
@@ -200,14 +200,14 @@ namespace System.Reflection
                     ByReference.Create(ref copyOfArgs[i]);
             }
 
-            return _invokeFunc_RefArgs!(obj: null, pByRefFixedStorage);
+            return _invokeFunc_RefArgs!(obj: null, pByRefFixedStorage)!;
         }
 
-        internal unsafe object? InvokeWithManyArgs(Span<object?> arguments)
+        internal unsafe object InvokeWithManyArgs(Span<object?> arguments)
         {
             Span<object?> copyOfArgs;
             GCFrameRegistration regArgStorage;
-            object? ret;
+            object ret;
 
             if ((_strategy & InvokerStrategy.StrategyDetermined_ObjSpanArgs) == 0)
             {
@@ -232,7 +232,7 @@ namespace System.Reflection
                         copyOfArgs[i] = arg;
                     }
 
-                    ret = _invokeFunc_ObjSpanArgs(obj: null, copyOfArgs);
+                    ret = _invokeFunc_ObjSpanArgs(obj: null, copyOfArgs)!;
                     // No need to call CopyBack here since there are no ref values.
                 }
                 finally
@@ -274,7 +274,7 @@ namespace System.Reflection
                             ByReference.Create(ref Unsafe.AsRef<object>(pStorage + i));
                     }
 
-                    ret = _invokeFunc_RefArgs!(obj: null, pByRefStorage);
+                    ret = _invokeFunc_RefArgs!(obj: null, pByRefStorage)!;
                     CopyBack(arguments, copyOfArgs, shouldCopyBack);
                 }
                 finally

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -11315,12 +11315,12 @@ namespace System.Reflection
     public sealed partial class ConstructorInvoker
     {
         internal ConstructorInvoker() { }
-        public object? Invoke(System.Span<object?> arguments) { throw null; }
-        public object? Invoke() { throw null; }
-        public object? Invoke(object? arg1) { throw null; }
-        public object? Invoke(object? arg1, object? arg2) { throw null; }
-        public object? Invoke(object? arg1, object? arg2, object? arg3) { throw null; }
-        public object? Invoke(object? arg1, object? arg2, object? arg3, object? arg4) { throw null; }
+        public object Invoke(System.Span<object?> arguments) { throw null; }
+        public object Invoke() { throw null; }
+        public object Invoke(object? arg1) { throw null; }
+        public object Invoke(object? arg1, object? arg2) { throw null; }
+        public object Invoke(object? arg1, object? arg2, object? arg3) { throw null; }
+        public object Invoke(object? arg1, object? arg2, object? arg3, object? arg4) { throw null; }
         public static System.Reflection.ConstructorInvoker Create(System.Reflection.ConstructorInfo constructor) { throw null; }
     }
     public partial class CustomAttributeData


### PR DESCRIPTION
The nullability for recent issue https://github.com/dotnet/runtime/pull/88415 was incorrect for `ConstructorInvoker`'s `Invoke()` return value - it shouldn't be nullable.

This is unlike `ConstructorInfo.Invoke()` which can return `null` if the incoming `obj` parameter is non-null in which case the constructor is called on `obj` without allocation. Since `ConstructorInvoker` doesn't have an `obj` parameter, it will always allocate and return an object (and call the constructor on it).

Mail sent to FXDC for approval request.