### PR TITLE
[HTTP] Catch and ignore exception from an external server

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
@@ -1294,8 +1294,8 @@ namespace System.Net.Http.Functional.Tests
                 {
                     Assert.Contains(expectedContent, await client.GetStringAsync(uri));
                 }
-                catch (HttpRequestException hre) when (hre.StatusCode == HttpStatusCode.GatewayTimeout || hre.StatusCode == HttpStatusCode.BadGateway ||
-                                                      (hre.InnerException is SocketException se && (se.SocketErrorCode == SocketError.WouldBlock || se.SocketErrorCode == SocketError.TryAgain)))
+                catch (HttpRequestException hre) when (hre.StatusCode is HttpStatusCode.GatewayTimeout or HttpStatusCode.BadGateway ||
+                                                      (hre.InnerException is SocketException se && (se.SocketErrorCode is SocketError.WouldBlock or SocketError.TryAgain)))
                 {
                     // Ignore the exception, the test depends on an external server that is out of our control.
                     _output.WriteLine(hre.ToString());


### PR DESCRIPTION
Specific error codes pulled from kusto:
```kql
AzureDevOpsTests
| where TestName has "GetAsync_SetAutomaticDecompression_ContentDecompressed_Deflate"
| summarize max(RunCompleted) by Message
```
|Message|max_RunCompleted|
|-|-|
|System.Net.Http.HttpRequestException : Response status code does not indicate success: 504 (Gateway Time-out). |2023-07-25T13:06:00.503Z|
|System.Net.Http.HttpRequestException : Response status code does not indicate success: 502 (Bad Gateway).	|2023-07-25T12:09:21.28Z|
|System.Net.Http.HttpRequestException : Resource temporarily unavailable (httpbin.org:80)<br/>---- System.Net.Sockets.SocketException : Resource temporarily unavailable	|2023-07-04T12:47:25.46Z|
|System.Net.Http.HttpRequestException : Resource temporarily unavailable (httpbin.org:443)<br/>---- System.Net.Sockets.SocketException : Resource temporarily unavailable	|2023-07-01T12:42:15.28Z|

Fixes #87864