### PR TITLE
Fix STJ source gen support for System.BinaryData.

### DIFF
--- a/src/libraries/System.Memory.Data/ref/System.Memory.Data.cs
+++ b/src/libraries/System.Memory.Data/ref/System.Memory.Data.cs
@@ -49,7 +49,7 @@ namespace System.Text.Json.Serialization
     public sealed partial class BinaryDataJsonConverter : System.Text.Json.Serialization.JsonConverter<System.BinaryData>
     {
         public BinaryDataJsonConverter() { }
-        public sealed override System.BinaryData? Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
-        public sealed override void Write(System.Text.Json.Utf8JsonWriter writer, System.BinaryData value, System.Text.Json.JsonSerializerOptions options) { }
+        public override System.BinaryData? Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
+        public override void Write(System.Text.Json.Utf8JsonWriter writer, System.BinaryData value, System.Text.Json.JsonSerializerOptions options) { }
     }
 }

--- a/src/libraries/System.Memory.Data/ref/System.Memory.Data.cs
+++ b/src/libraries/System.Memory.Data/ref/System.Memory.Data.cs
@@ -6,7 +6,7 @@
 
 namespace System
 {
-    [System.Text.Json.Serialization.JsonConverter(typeof(BinaryDataConverter))]
+    [System.Text.Json.Serialization.JsonConverterAttribute(typeof(System.Text.Json.Serialization.BinaryDataJsonConverter))]
     public partial class BinaryData
     {
         public BinaryData(byte[] data) { }
@@ -17,6 +17,8 @@ namespace System
         public BinaryData(System.ReadOnlyMemory<byte> data) { }
         public BinaryData(string data) { }
         public static System.BinaryData Empty { get { throw null; } }
+        public bool IsEmpty { get { throw null; } }
+        public int Length { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public static System.BinaryData FromBytes(byte[] data) { throw null; }
@@ -30,8 +32,6 @@ namespace System
         public static System.BinaryData FromString(string data) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public bool IsEmpty { get { throw null; } }
-        public int Length { get { throw null; } }
         public static implicit operator System.ReadOnlyMemory<byte> (System.BinaryData? data) { throw null; }
         public static implicit operator System.ReadOnlySpan<byte> (System.BinaryData? data) { throw null; }
         public byte[] ToArray() { throw null; }
@@ -43,10 +43,13 @@ namespace System
         public System.IO.Stream ToStream() { throw null; }
         public override string ToString() { throw null; }
     }
-
-    internal sealed class BinaryDataConverter : System.Text.Json.Serialization.JsonConverter<BinaryData>
+}
+namespace System.Text.Json.Serialization
+{
+    public sealed partial class BinaryDataJsonConverter : System.Text.Json.Serialization.JsonConverter<System.BinaryData>
     {
-        public sealed override BinaryData? Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
-        public sealed override void Write(System.Text.Json.Utf8JsonWriter writer, BinaryData value, System.Text.Json.JsonSerializerOptions options) { }
+        public BinaryDataJsonConverter() { }
+        public sealed override System.BinaryData? Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
+        public sealed override void Write(System.Text.Json.Utf8JsonWriter writer, System.BinaryData value, System.Text.Json.JsonSerializerOptions options) { }
     }
 }

--- a/src/libraries/System.Memory.Data/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Memory.Data/src/CompatibilitySuppressions.xml
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>T:System.BinaryData:[T:System.Text.Json.Serialization.JsonConverterAttribute]</Target>
+    <Left>lib/net462/System.Memory.Data.dll</Left>
+    <Right>lib/net462/System.Memory.Data.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>T:System.BinaryData:[T:System.Text.Json.Serialization.JsonConverterAttribute]</Target>
+    <Left>lib/net6.0/System.Memory.Data.dll</Left>
+    <Right>lib/net6.0/System.Memory.Data.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>T:System.BinaryData:[T:System.Text.Json.Serialization.JsonConverterAttribute]</Target>
+    <Left>lib/net7.0/System.Memory.Data.dll</Left>
+    <Right>lib/net7.0/System.Memory.Data.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>T:System.BinaryData:[T:System.Text.Json.Serialization.JsonConverterAttribute]</Target>
+    <Left>lib/netstandard2.0/System.Memory.Data.dll</Left>
+    <Right>lib/netstandard2.0/System.Memory.Data.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/libraries/System.Memory.Data/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Memory.Data/src/CompatibilitySuppressions.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <!-- Move JsonConverterAttribute argument from internal to a public converter type in a new namespace -->
   <Suppression>
     <DiagnosticId>CP0015</DiagnosticId>
     <Target>T:System.BinaryData:[T:System.Text.Json.Serialization.JsonConverterAttribute]</Target>

--- a/src/libraries/System.Memory.Data/src/System/BinaryDataConverter.cs
+++ b/src/libraries/System.Memory.Data/src/System/BinaryDataConverter.cs
@@ -1,18 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
-namespace System
+namespace System.Text.Json.Serialization
 {
-    internal sealed class BinaryDataConverter : JsonConverter<BinaryData>
+    /// <summary>
+    /// Serializes <see cref="BinaryData"/> instances as Base64 JSON strings.
+    /// </summary>
+    public sealed class BinaryDataJsonConverter : JsonConverter<BinaryData>
     {
+        /// <inheritdoc/>
         public sealed override BinaryData? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return BinaryData.FromBytes(reader.GetBytesFromBase64());
         }
 
+        /// <inheritdoc/>
         public sealed override void Write(Utf8JsonWriter writer, BinaryData value, JsonSerializerOptions options)
         {
             writer.WriteBase64StringValue(value.ToMemory().Span);

--- a/src/libraries/System.Memory.Data/src/System/BinaryDataConverter.cs
+++ b/src/libraries/System.Memory.Data/src/System/BinaryDataConverter.cs
@@ -9,13 +9,13 @@ namespace System.Text.Json.Serialization
     public sealed class BinaryDataJsonConverter : JsonConverter<BinaryData>
     {
         /// <inheritdoc/>
-        public sealed override BinaryData? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override BinaryData? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return BinaryData.FromBytes(reader.GetBytesFromBase64());
         }
 
         /// <inheritdoc/>
-        public sealed override void Write(Utf8JsonWriter writer, BinaryData value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, BinaryData value, JsonSerializerOptions options)
         {
             writer.WriteBase64StringValue(value.ToMemory().Span);
         }

--- a/src/libraries/System.Memory.Data/tests/System.Memory.Data.Tests.csproj
+++ b/src/libraries/System.Memory.Data/tests/System.Memory.Data.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
-    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/81702. Also fixes an issue I discovered where BOM trimming was not being done in the `ToObjectFromJson` overload accepting `JsonTypeInfo<T>`.