### PR TITLE
Avoid some rune iteration in GetEncodedTruncatedBytesFromString

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
@@ -211,7 +211,7 @@ namespace System.IO.Compression
             }
 
             byte[] bytes;
-            if (isUTF8)
+            if (isUTF8 && encoding.GetMaxByteCount(text.Length) > maxBytes)
             {
                 int totalCodePoints = 0;
                 foreach (Rune rune in text.EnumerateRunes())


### PR DESCRIPTION
Following up on my own comment here: https://github.com/dotnet/runtime/pull/88551/files#r1265485176

When the Zip/TarArchive is using UTF8 as an encoding, it iterates through all the runes in the input to determine how much of the encoded text it can fit in the specified limit. We don't need to do that in the common case where the input is guaranteed to fit because the maximum length of a UTF8 payload is under the specified max.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.IO;
using System.IO.Compression;
using System.Text;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[HideColumns("Error", "StdDev", "Median", "RatioSD")]
public partial class Tests
{
    private ZipArchive _archive;

    [GlobalSetup]
    public void Setup() => _archive = new ZipArchive(new MemoryStream(), ZipArchiveMode.Create, false, Encoding.UTF8);

    [GlobalCleanup]
    public void Cleanup() => _archive.Dispose();

    [Benchmark]
    public void SetComment() => _archive.Comment = "This is some comment. It's long. Super long. Oh my goodness look how long it is.";
}
```

|     Method |         Toolchain |      Mean | Ratio |
|----------- |------------------ |----------:|------:|
| SetComment | \main\corerun.exe | 266.95 ns |  1.00 |
| SetComment |   \pr\corerun.exe |  41.09 ns |  0.15 |