### PR TITLE
Add CollectionBuilder attribute to some immutable collection interfaces

### DIFF
--- a/src/libraries/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/libraries/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -131,6 +131,7 @@ namespace System.Collections.Immutable
         System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items);
         bool TryGetKey(TKey equalKey, out TKey actualKey);
     }
+    [System.Runtime.CompilerServices.CollectionBuilderAttribute(typeof(System.Collections.Immutable.ImmutableList), "Create")]
     public partial interface IImmutableList<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
     {
         System.Collections.Immutable.IImmutableList<T> Add(T value);
@@ -148,6 +149,7 @@ namespace System.Collections.Immutable
         System.Collections.Immutable.IImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T>? equalityComparer);
         System.Collections.Immutable.IImmutableList<T> SetItem(int index, T value);
     }
+    [System.Runtime.CompilerServices.CollectionBuilderAttribute(typeof(System.Collections.Immutable.ImmutableQueue), "Create")]
     public partial interface IImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
     {
         bool IsEmpty { get; }
@@ -156,6 +158,7 @@ namespace System.Collections.Immutable
         System.Collections.Immutable.IImmutableQueue<T> Enqueue(T value);
         T Peek();
     }
+    [System.Runtime.CompilerServices.CollectionBuilderAttribute(typeof(System.Collections.Immutable.ImmutableHashSet), "Create")]
     public partial interface IImmutableSet<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.IEnumerable
     {
         System.Collections.Immutable.IImmutableSet<T> Add(T value);
@@ -174,6 +177,7 @@ namespace System.Collections.Immutable
         bool TryGetValue(T equalValue, out T actualValue);
         System.Collections.Immutable.IImmutableSet<T> Union(System.Collections.Generic.IEnumerable<T> other);
     }
+    [System.Runtime.CompilerServices.CollectionBuilderAttribute(typeof(System.Collections.Immutable.ImmutableStack), "Create")]
     public partial interface IImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
     {
         bool IsEmpty { get; }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableList.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Immutable
 {
@@ -14,6 +14,7 @@ namespace System.Collections.Immutable
     /// Mutations on this list generate new lists.  Incremental changes to a list share as much memory as possible with the prior versions of a list,
     /// while allowing garbage collection to clean up any unique list data that is no longer being referenced.
     /// </remarks>
+    [CollectionBuilder(typeof(ImmutableList), nameof(ImmutableList.Create))]
     public interface IImmutableList<T> : IReadOnlyList<T>
     {
         /// <summary>

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableQueue.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableQueue.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Immutable
 {
@@ -10,6 +10,7 @@ namespace System.Collections.Immutable
     /// An immutable queue.
     /// </summary>
     /// <typeparam name="T">The type of elements in the queue.</typeparam>
+    [CollectionBuilder(typeof(ImmutableQueue), nameof(ImmutableQueue.Create))]
     public interface IImmutableQueue<T> : IEnumerable<T>
     {
         /// <summary>

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableSet.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Immutable
 {
@@ -14,6 +14,7 @@ namespace System.Collections.Immutable
     /// Mutations on this set generate new sets.  Incremental changes to a set share as much memory as possible with the prior versions of a set,
     /// while allowing garbage collection to clean up any unique set data that is no longer being referenced.
     /// </remarks>
+    [CollectionBuilder(typeof(ImmutableHashSet), nameof(ImmutableHashSet.Create))]
     public interface IImmutableSet<T> : IReadOnlyCollection<T>
     {
         /// <summary>

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableStack.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/IImmutableStack.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Immutable
 {
@@ -10,6 +10,7 @@ namespace System.Collections.Immutable
     /// An immutable stack.
     /// </summary>
     /// <typeparam name="T">The type of elements stored in the stack.</typeparam>
+    [CollectionBuilder(typeof(ImmutableStack), nameof(ImmutableStack.Create))]
     public interface IImmutableStack<T> : IEnumerable<T>
     {
         /// <summary>


### PR DESCRIPTION
Roslyn asked that these be added. Adding these attributes to the immutable interfaces was discussed as part of https://github.com/dotnet/runtime/issues/87569#issuecomment-1634635140 and left up to the working group to decide what to do with it, which is this PR.