### PR TITLE
[Mono] Look for Native Signal SIMD Context

### DIFF
--- a/src/mono/mono/utils/mono-context.c
+++ b/src/mono/mono/utils/mono-context.c
@@ -554,8 +554,12 @@ mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 		size += fpctx_temp->head.size;
 	} while (size + sizeof (struct fpsimd_context) <= sizeof (((ucontext_t*)sigctx)->uc_mcontext.__reserved));
 
-	for (int i = 0; i < 32; ++i)
-		mctx->fregs [i] = fpctx->vregs [i];
+	if (fpctx->head.magic == FPSIMD_MAGIC)
+		for (int i = 0; i < 32; ++i)
+			mctx->fregs [i] = fpctx->vregs [i];
+	else
+		for (int i = 0; i < 32; ++i)
+			mctx->fregs [i] = 0;
 #endif
 	/* FIXME: apple */
 #endif

--- a/src/mono/mono/utils/mono-context.c
+++ b/src/mono/mono/utils/mono-context.c
@@ -534,10 +534,28 @@ mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 #endif
 #ifdef __linux__
 	struct fpsimd_context *fpctx = (struct fpsimd_context*)&((ucontext_t*)sigctx)->uc_mcontext.__reserved;
-	int i;
 
-	g_assert (fpctx->head.magic == FPSIMD_MAGIC);
-	for (i = 0; i < 32; ++i)
+	size_t size = 0;
+    do
+    {
+        struct fpsimd_context *fpctx_temp = (struct fpsimd_context *)&(((ucontext_t*)sigctx)->uc_mcontext.__reserved[size]);
+
+        if(fpctx_temp->head.magic == FPSIMD_MAGIC)
+        {
+            g_assert (fpctx_temp->head.size >= sizeof(struct fpsimd_context));
+            g_assert (size + fpctx_temp->head.size <= sizeof(((ucontext_t*)sigctx)->uc_mcontext.__reserved));
+
+			fpctx = fpctx_temp;
+			break;
+        }
+
+        if (fpctx_temp->head.size == 0)
+			break;
+
+        size += fpctx_temp->head.size;
+    } while (size + sizeof(struct fpsimd_context) <= sizeof(((ucontext_t*)sigctx)->uc_mcontext.__reserved));
+
+	for (int i = 0; i < 32; ++i)
 		mctx->fregs [i] = fpctx->vregs [i];
 #endif
 	/* FIXME: apple */

--- a/src/mono/mono/utils/mono-context.c
+++ b/src/mono/mono/utils/mono-context.c
@@ -536,24 +536,23 @@ mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 	struct fpsimd_context *fpctx = (struct fpsimd_context*)&((ucontext_t*)sigctx)->uc_mcontext.__reserved;
 
 	size_t size = 0;
-    do
-    {
-        struct fpsimd_context *fpctx_temp = (struct fpsimd_context *)&(((ucontext_t*)sigctx)->uc_mcontext.__reserved[size]);
+	do {
+		struct fpsimd_context *fpctx_temp = (struct fpsimd_context*)&(((ucontext_t*)sigctx)->uc_mcontext.__reserved[size]);
 
-        if(fpctx_temp->head.magic == FPSIMD_MAGIC)
-        {
-            g_assert (fpctx_temp->head.size >= sizeof(struct fpsimd_context));
-            g_assert (size + fpctx_temp->head.size <= sizeof(((ucontext_t*)sigctx)->uc_mcontext.__reserved));
+		if (fpctx_temp->head.magic == FPSIMD_MAGIC)
+		{
+			g_assert (fpctx_temp->head.size >= sizeof (struct fpsimd_context));
+			g_assert (size + fpctx_temp->head.size <= sizeof (((ucontext_t*)sigctx)->uc_mcontext.__reserved));
 
 			fpctx = fpctx_temp;
 			break;
-        }
+		}
 
-        if (fpctx_temp->head.size == 0)
+		if (fpctx_temp->head.size == 0)
 			break;
 
-        size += fpctx_temp->head.size;
-    } while (size + sizeof(struct fpsimd_context) <= sizeof(((ucontext_t*)sigctx)->uc_mcontext.__reserved));
+		size += fpctx_temp->head.size;
+	} while (size + sizeof (struct fpsimd_context) <= sizeof (((ucontext_t*)sigctx)->uc_mcontext.__reserved));
 
 	for (int i = 0; i < 32; ++i)
 		mctx->fregs [i] = fpctx->vregs [i];


### PR DESCRIPTION
This PR add the logic to find the native signal SIMD context, instead of assuming the first one in the array is the one. If not found, it is okay to proceed from the first context as well.

Somehow, when running android arm64 apps on x64 emulators, the SIMD context doesn't exist.

Testing: Followed the reproduction steps provided by the customer using VS 2022 (https://github.com/dotnet/runtime/issues/62201#issuecomment-1645169782)

Fixes #62201