### PR TITLE
Make a copy of 'clrjit' binary for use in SuperPMI collect to avoid heap errors when the same 'clrjit' binary is used

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -650,11 +650,13 @@ class SuperPMICollect:
         self.collection_shim_path = os.path.join(self.core_root, self.collection_shim_name)
 
         jit_name = get_jit_name(coreclr_args)
-        jit_name_ext = os.path.splitext(jit_name)[1]
-        jit_name_without_ext = os.path.splitext(jit_name)[0]
-        self.jit_path = os.path.join(coreclr_args.core_root, jit_name)
-        self.superpmi_jit_path = os.path.join(coreclr_args.core_root, jit_name_without_ext + "_superpmi." + jit_name_ext)
-        shutil.copyfile(self.jit_path, self.superpmi_jit_path)
+        if coreclr_args.crossgen2:
+            jit_name_ext = os.path.splitext(jit_name)[1]
+            jit_name_without_ext = os.path.splitext(jit_name)[0]
+            self.superpmi_jit_path = os.path.join(coreclr_args.core_root, jit_name_without_ext + "_superpmi." + jit_name_ext)
+            shutil.copyfile(self.jit_path, self.superpmi_jit_path)
+        else:
+            self.superpmi_jit_path = self.jit_path
 
         self.superpmi_path = determine_superpmi_tool_path(coreclr_args)
         self.mcs_path = determine_mcs_tool_path(coreclr_args)
@@ -779,6 +781,10 @@ class SuperPMICollect:
 
         if passed:
             logging.info("Generated MCH file: %s", self.final_mch_file)
+
+        # Cleanup the copy of the JIT binary.
+        if self.coreclr_args.crossgen2 and not self.coreclr_args.skip_cleanup:
+            os.remove(self.superpmi_jit_path)
 
         return passed
 

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -649,7 +649,13 @@ class SuperPMICollect:
 
         self.collection_shim_path = os.path.join(self.core_root, self.collection_shim_name)
 
-        self.jit_path = os.path.join(coreclr_args.core_root, get_jit_name(coreclr_args))
+        jit_name = get_jit_name(coreclr_args)
+        jit_name_ext = os.path.splitext(jit_name)[1]
+        jit_name_without_ext = os.path.splitext(jit_name)[0]
+        self.jit_path = os.path.join(coreclr_args.core_root, jit_name)
+        self.superpmi_jit_path = os.path.join(coreclr_args.core_root, jit_name_without_ext + "_superpmi." + jit_name_ext)
+        shutil.copyfile(self.jit_path, self.superpmi_jit_path)
+
         self.superpmi_path = determine_superpmi_tool_path(coreclr_args)
         self.mcs_path = determine_mcs_tool_path(coreclr_args)
 
@@ -797,7 +803,7 @@ class SuperPMICollect:
 
             root_env = {}
             root_env["SuperPMIShimLogPath"] = self.temp_location
-            root_env["SuperPMIShimPath"] = self.jit_path
+            root_env["SuperPMIShimPath"] = self.superpmi_jit_path
 
             dotnet_env = {}
             dotnet_env["EnableExtraSuperPmiQueries"] = "1"

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -650,7 +650,10 @@ class SuperPMICollect:
         self.collection_shim_path = os.path.join(self.core_root, self.collection_shim_name)
 
         jit_name = get_jit_name(coreclr_args)
+        self.jit_path = os.path.join(coreclr_args.core_root, jit_name)
         if coreclr_args.crossgen2:
+            # There are issues when running SuperPMI and crossgen2 when using the same JIT binary. 
+            # Therefore, we produce a copy of the JIT binary for SuperPMI to use. 
             jit_name_ext = os.path.splitext(jit_name)[1]
             jit_name_without_ext = os.path.splitext(jit_name)[0]
             self.superpmi_jit_path = os.path.join(coreclr_args.core_root, jit_name_without_ext + "_superpmi." + jit_name_ext)


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/88423

When performing a SuperPMI collection using `superpmi.py`, it will make a local copy of 'clrjit.dll' and name it 'clrjit_superpmi.dll'. This avoids heap errors when crossgen2 and superpmi are running together on the same 'clrjit.dll'.