### PR TITLE
Added IAsyncDisposable to TextReader

### DIFF
--- a/src/libraries/System.IO/tests/StreamReader/StreamReader.DisposeAsync.cs
+++ b/src/libraries/System.IO/tests/StreamReader/StreamReader.DisposeAsync.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class StreamReader_disposeAsyncTest
+    {
+
+        [Fact]
+        public void DisposeAsync_CanInvokeMultipleTimes()
+        {
+            var ms = new MemoryStream();
+            var sr = new StreamReader(ms);
+            Assert.True(sr.DisposeAsync().IsCompletedSuccessfully);
+            Assert.True(sr.DisposeAsync().IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public void DisposeAsync_CanDisposeAsyncAfterDispose()
+        {
+            var ms = new MemoryStream();
+            var sr = new StreamReader(ms);
+            sr.Dispose();
+            Assert.True(sr.DisposeAsync().IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_LeaveOpenTrue_LeftOpen()
+        {
+            var ms = new MemoryStream();
+            var sr = new StreamReader(ms, Encoding.ASCII, false, 0x1000, leaveOpen: true);
+            await sr.DisposeAsync();
+            Assert.Equal(0, ms.Position); // doesn't throw
+        }
+
+        [Fact]
+        public async Task DisposeAsync_DerivedTypeForcesDisposeToBeUsedUnlessOverridden()
+        {
+            var ms = new MemoryStream();
+            var sr = new OverrideDisposeStreamReader(ms);
+            Assert.False(sr.DisposeInvoked);
+            await sr.DisposeAsync();
+            Assert.True(sr.DisposeInvoked);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_DerivedTypeDisposeAsyncInvoked()
+        {
+            var ms = new MemoryStream();
+            var sr = new OverrideDisposeAndDisposeAsyncStreamReader(ms);
+            Assert.False(sr.DisposeInvoked);
+            Assert.False(sr.DisposeAsyncInvoked);
+            await sr.DisposeAsync();
+            Assert.False(sr.DisposeInvoked);
+            Assert.True(sr.DisposeAsyncInvoked);
+        }
+
+        private sealed class OverrideDisposeStreamReader : StreamReader
+        {
+            public bool DisposeInvoked;
+            public OverrideDisposeStreamReader(Stream output) : base(output) { }
+            protected override void Dispose(bool disposing) => DisposeInvoked = true;
+        }
+
+        private sealed class OverrideDisposeAndDisposeAsyncStreamReader : StreamReader
+        {
+            public bool DisposeInvoked, DisposeAsyncInvoked;
+            public OverrideDisposeAndDisposeAsyncStreamReader(Stream output) : base(output) { }
+            protected override void Dispose(bool disposing) => DisposeInvoked = true;
+            public override ValueTask DisposeAsync() { DisposeAsyncInvoked = true; return default; }
+        }
+    }
+}

--- a/src/libraries/System.IO/tests/System.IO.Tests.csproj
+++ b/src/libraries/System.IO/tests/System.IO.Tests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="MemoryStream\MemoryStreamTests.cs" />
     <Compile Include="StreamReader\StreamReader.CtorTests.cs" />
     <Compile Include="StreamReader\StreamReaderTests.cs" />
+    <Compile Include="StreamReader\StreamReader.DisposeAsync.cs" />
     <Compile Include="StreamReader\StreamReaderTests_Serial.cs" />
     <Compile Include="StreamWriter\StreamWriter.BaseStream.cs" />
     <Compile Include="StreamWriter\StreamWriter.CloseTests.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -297,17 +297,16 @@ namespace System.IO
             {
                 if (!_disposed)
                 {
-                    ThrowIfDisposed();
                     CheckAsyncTaskInProgress();
                 }
             }
             finally
             {
-                await CloseStreamFromDisposeAsync(disposing: true).ConfigureAwait(false);
+                await CloseStreamFromDisposeAsync().ConfigureAwait(false);
             }
             GC.SuppressFinalize(this);
         }
-        private async ValueTask CloseStreamFromDisposeAsync(bool disposing)
+        private async ValueTask CloseStreamFromDisposeAsync()
         {
             // Dispose of our resources if this StreamWriter is closable.
             if (_closable && !_disposed)
@@ -315,17 +314,15 @@ namespace System.IO
                 try
                 {
                     // Attempt to close the stream even if there was an IO error from Flushing.
-                    // Note that Stream.Close() can potentially throw here (may or may not be
+                    // Note that Stream.DisposeAsync() can potentially throw here (may or may not be
                     // due to the same Flush error). In this case, we still need to ensure
                     // cleaning up internal resources, hence the finally block.
-                    if (disposing)
-                    {
-                        await _stream.DisposeAsync().ConfigureAwait(false);
-                    }
+                    await _stream.DisposeAsync().ConfigureAwait(false);
                 }
                 finally
                 {
                     _disposed = true;
+                    _charPos = 0;
                     _charLen = 0;
                     await base.DisposeAsync().ConfigureAwait(false);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -265,7 +265,7 @@ namespace System.IO
                 // Dispose of our resources if this StreamReader is closable.
                 if (_closable && !_disposed)
                 {
-                    // Attempt to close the stream even
+                    // Attempt to close the stream
                     // Note that Stream.Close() can potentially throw here.
                     // In this case, we still need to ensure
                     // cleaning up internal resources, hence the finally block.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamWriter.cs
@@ -255,12 +255,12 @@ namespace System.IO
             }
             finally
             {
-                await CloseStreamFromDisposeAsync(disposing: true).ConfigureAwait(false);
+                await CloseStreamFromDisposeAsync().ConfigureAwait(false);
             }
             GC.SuppressFinalize(this);
         }
 
-        private async ValueTask CloseStreamFromDisposeAsync(bool disposing)
+        private async ValueTask CloseStreamFromDisposeAsync()
         {
             // Dispose of our resources if this StreamWriter is closable.
             if (_closable && !_disposed)
@@ -268,13 +268,10 @@ namespace System.IO
                 try
                 {
                     // Attempt to close the stream even if there was an IO error from Flushing.
-                    // Note that Stream.Close() can potentially throw here (may or may not be
+                    // Note that Stream.DisposeAsync() can potentially throw here (may or may not be
                     // due to the same Flush error). In this case, we still need to ensure
                     // cleaning up internal resources, hence the finally block.
-                    if (disposing)
-                    {
-                        await _stream.DisposeAsync().ConfigureAwait(false);
-                    }
+                    await _stream.DisposeAsync().ConfigureAwait(false);
                 }
                 finally
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamWriter.cs
@@ -189,13 +189,17 @@ namespace System.IO
 
         protected override void Dispose(bool disposing)
         {
+            if (_disposed)
+            {
+                return;
+            }
             try
             {
                 // We need to flush any buffered data if we are being closed/disposed.
                 // Also, we never close the handles for stdout & friends.  So we can safely
                 // write any buffered data to those streams even during finalization, which
                 // is generally the right thing to do.
-                if (!_disposed && disposing)
+                if (disposing)
                 {
                     // Note: flush on the underlying stream can throw (ex., low disk space)
                     CheckAsyncTaskInProgress();
@@ -210,10 +214,10 @@ namespace System.IO
 
         private void CloseStreamFromDispose(bool disposing)
         {
-            // Dispose of our resources if this StreamWriter is closable.
-            if (_closable && !_disposed)
+            try
             {
-                try
+                // Dispose of our resources if this StreamWriter is closable.
+                if (_closable && !_disposed)
                 {
                     // Attempt to close the stream even if there was an IO error from Flushing.
                     // Note that Stream.Close() can potentially throw here (may or may not be
@@ -224,12 +228,12 @@ namespace System.IO
                         _stream.Close();
                     }
                 }
-                finally
-                {
-                    _disposed = true;
-                    _charLen = 0;
-                    base.Dispose(disposing);
-                }
+            }
+            finally
+            {
+                _disposed = true;
+                _charLen = 0;
+                base.Dispose(disposing);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -17,7 +17,7 @@ namespace System.IO
     //
     // This class is intended for character input, not bytes.
     // There are methods on the Stream class for reading bytes.
-    public abstract partial class TextReader : MarshalByRefObject, IDisposable
+    public abstract partial class TextReader : MarshalByRefObject, IDisposable, IAsyncDisposable
     {
         // Create our own instance to avoid static field initialization order problems on Mono.
         public static readonly TextReader Null = new StreamReader.NullStreamReader();
@@ -38,6 +38,19 @@ namespace System.IO
 
         protected virtual void Dispose(bool disposing)
         {
+        }
+
+        public virtual ValueTask DisposeAsync()
+        {
+            try
+            {
+                Dispose();
+                return default;
+            }
+            catch (Exception exc)
+            {
+                return ValueTask.FromException(exc);
+            }
         }
 
         // Returns the next available character without actually reading it from

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10210,6 +10210,7 @@ namespace System.IO
         public override void Close() { }
         public void DiscardBufferedData() { }
         protected override void Dispose(bool disposing) { }
+        public override System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         public override int Peek() { throw null; }
         public override int Read() { throw null; }
         public override int Read(char[] buffer, int index, int count) { throw null; }
@@ -10325,13 +10326,14 @@ namespace System.IO
         public override System.Threading.Tasks.Task WriteLineAsync(string? value) { throw null; }
         public override System.Threading.Tasks.Task WriteLineAsync(System.Text.StringBuilder? value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
-    public abstract partial class TextReader : System.MarshalByRefObject, System.IDisposable
+    public abstract partial class TextReader : System.MarshalByRefObject, System.IAsyncDisposable, System.IDisposable
     {
         public static readonly System.IO.TextReader Null;
         protected TextReader() { }
         public virtual void Close() { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+        public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         public virtual int Peek() { throw null; }
         public virtual int Read() { throw null; }
         public virtual int Read(char[] buffer, int index, int count) { throw null; }


### PR DESCRIPTION
* added IAsyncDisposable to TextReader. 
* Implemnted IAsyncDisposable for StreamReader as it is implemented for StreamWriter. 
* Changed StreamWriter to call base.Dispose(disposing) and set _disposed to true, even if stream is not closable

fixes #88244 #88246

I still think there are some bugs in StreamWriter and I think it makes sense to add `CloseAsync()` to Stream, since as of now, it is still always calling `Dispose(true)` which is sync, but I will open another issue for that.