### PR TITLE
Fix opt-cross-module using non version safe tokens

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -11,6 +11,7 @@ using Internal.JitInterface;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 using Internal.CorConstants;
+using System.Diagnostics;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
@@ -246,6 +247,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         // be consistent in all runs of the compiler
         void SetModuleTokenForTypeSystemEntity<T>(ConcurrentDictionary<T, ModuleToken> dictionary, T tse, ModuleToken token)
         {
+            // We can only use tokens from the manifest mutable module or from one of the modules that versions
+            // with the current compilation. Any other module tokens may change while the code executes
+            if (token.Module != _manifestMutableModule && _compilationModuleGroup.VersionsWithModule((ModuleDesc)token.Module));
+            {
+                throw new InternalCompilerErrorException("Invalid usage of a token from a module not within the version bubble");
+            }
+
             if (!dictionary.TryAdd(tse, token))
             {
                 ModuleToken oldToken;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -249,7 +249,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             // We can only use tokens from the manifest mutable module or from one of the modules that versions
             // with the current compilation. Any other module tokens may change while the code executes
-            if (token.Module != _manifestMutableModule && _compilationModuleGroup.VersionsWithModule((ModuleDesc)token.Module));
+            if (token.Module != _manifestMutableModule && _compilationModuleGroup.VersionsWithModule((ModuleDesc)token.Module))
             {
                 throw new InternalCompilerErrorException("Invalid usage of a token from a module not within the version bubble");
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -249,7 +249,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             // We can only use tokens from the manifest mutable module or from one of the modules that versions
             // with the current compilation. Any other module tokens may change while the code executes
-            if (token.Module != _manifestMutableModule && _compilationModuleGroup.VersionsWithModule((ModuleDesc)token.Module));
+            if (token.Module != _manifestMutableModule && !_compilationModuleGroup.VersionsWithModule((ModuleDesc)token.Module))
             {
                 throw new InternalCompilerErrorException("Invalid usage of a token from a module not within the version bubble");
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -766,9 +766,7 @@ namespace Internal.JitInterface
 
                 if (MethodBeingCompiled.GetTypicalMethodDefinition() is EcmaMethod ecmaMethod)
                 {
-                    // At the moment the ILBody fixup generation is only safe for the System module, as further typerefs may not be safe to encode at this time. When we expand
-                    // cross module inlining to support other modules, this will need to be fixed.
-                    if (methodIL.GetMethodILScopeDefinition() is IEcmaMethodIL && _compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout && ecmaMethod.Module == ecmaMethod.Context.SystemModule ||
+                    if ((methodIL.GetMethodILScopeDefinition() is IEcmaMethodIL && _compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout && ecmaMethod.Module == ecmaMethod.Context.SystemModule) ||
                         (!_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(MethodBeingCompiled) &&
                             _compilation.NodeFactory.CompilationModuleGroup.CrossModuleInlineable(MethodBeingCompiled)))
                     {
@@ -778,7 +776,27 @@ namespace Internal.JitInterface
 
                     // Harvest the method being compiled for the purpose of populating the type resolver
                     var resolver = _compilation.NodeFactory.Resolver;
-                    resolver.AddModuleTokenForMethod(MethodBeingCompiled, new ModuleToken(ecmaMethod.Module, ecmaMethod.Handle));
+                    if (_compilation.CompilationModuleGroup.VersionsWithModule(ecmaMethod.Module))
+                    {
+                        resolver.AddModuleTokenForMethod(MethodBeingCompiled, new ModuleToken(ecmaMethod.Module, ecmaMethod.Handle));
+                    }
+                    else
+                    {
+                        // Cross module optimization scenario. If we aren't able to come up with a token for the method being compiled, then force it to be
+                        // computed.
+                        // NOTE: Technically, we could arrange to require only the set of tokens necessary to describe the type that owns this method
+                        // as well as the parameters and return value to the method. The token for the actual method is not required.
+                        EntityHandle? handle = _compilation.NodeFactory.ManifestMetadataTable._mutableModule.TryGetExistingEntityHandle(ecmaMethod);
+                        if (handle.HasValue)
+                        {
+                            resolver.AddModuleTokenForMethod(MethodBeingCompiled, new ModuleToken(_compilation.NodeFactory.ManifestMetadataTable._mutableModule, handle.Value));
+                        }
+                        else
+                        {
+                            _ilBodiesNeeded = _ilBodiesNeeded ?? new List<EcmaMethod>();
+                            _ilBodiesNeeded.Add(ecmaMethod);
+                        }
+                    }
                 }
                 var compilationResult = CompileMethodInternal(methodCodeNodeNeedingCode, methodIL);
                 codeGotPublished = true;


### PR DESCRIPTION
Fix issue where in some cases the compiler would generate references using tokens from modules not in the current module set.

Also add an assert to detect cases where this might happen