### PR TITLE
Add ownership handle to IPC Eventpipe object

### DIFF
--- a/src/native/eventpipe/ds-ipc-pal-namedpipe.h
+++ b/src/native/eventpipe/ds-ipc-pal-namedpipe.h
@@ -29,6 +29,9 @@ struct _DiagnosticsIpc_Internal {
 	ep_char8_t pipe_name [DS_IPC_WIN32_MAX_NAMED_PIPE_LEN];
 	OVERLAPPED overlap;
 	HANDLE pipe;
+    // This handle roots the ownership of the pipe from first listen until it
+    // all sessions are closed.
+	HANDLE owningPipe;
 	bool is_listening;
 	DiagnosticsIpcConnectionMode mode;
 };


### PR DESCRIPTION
This change caches a handle to the owning call of CreateNamedPipe so we can track lifetime of the pipe throughout the channel's lifetime.