### PR TITLE
Disable networking in XML resolver in AOT compilers

### DIFF
--- a/src/coreclr/tools/aot/AotCompilerCommon.props
+++ b/src/coreclr/tools/aot/AotCompilerCommon.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <TieredCompilation>false</TieredCompilation>
+    <EventSourceSupport>true</EventSourceSupport>
+    <OptimizationPreference>Speed</OptimizationPreference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Replace this line with the documented property once https://github.com/dotnet/runtime/issues/83495 is fixed -->
+    <RuntimeHostConfigurationOption Include="System.Xml.XmlResolver.IsNetworkingEnabledByDefault"
+                                    Value="false"
+                                    Trim="true" />
+  </ItemGroup>
+</Project>

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.props
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.props
@@ -12,11 +12,9 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <Configurations>Debug;Release;Checked</Configurations>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
-    <TieredCompilation>false</TieredCompilation>
-    <EventSourceSupport>true</EventSourceSupport>
-    <OptimizationPreference>Speed</OptimizationPreference>
   </PropertyGroup>
+
+  <Import Project="../AotCompilerCommon.props" />
 
   <PropertyGroup>
     <SelfContained>true</SelfContained>

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.props
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.props
@@ -13,11 +13,10 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <Configurations>Debug;Release;Checked</Configurations>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
-    <EventSourceSupport>true</EventSourceSupport>
-    <OptimizationPreference>Speed</OptimizationPreference>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
+
+  <Import Project="../AotCompilerCommon.props" />
 
   <ItemGroup Label="Embedded Resources">
     <EmbeddedResource Include="Properties\Resources.resx">


### PR DESCRIPTION
Use the switch introduced in #84169. The AOT compilers don't need this. Speeds up the build by a couple seconds because we no longer compile garbage. Shrinks size of ilc.exe from 15.2 MB to 11.1 MB.

One the Native AOT side, this will only kick in once we update the SDK used to build the repo to something that has this (RC1?). On the crossgen2 side this takes effect immediately.

Cc @dotnet/ilc-contrib 