### PR TITLE
Remove `AssemblyMetadata(".NETFrameworkAssembly", "")` attributes

### DIFF
--- a/docs/design/tools/illink/trimmed-assemblies.md
+++ b/docs/design/tools/illink/trimmed-assemblies.md
@@ -182,7 +182,6 @@ If there is a use case for specifying trimmable assemblies on the command-line, 
 We will use `AssemblyMetadataAttribute` to specify `IsTrimmable` on an assembly, instead of introducing a new attribute. The existing attribute seems well-suited for this use case, as it is already similarly used to control servicing for framework assemblies, for example via:
 
 ```csharp
-[assembly: AssemblyMetadata(".NETFrameworkAssembly", "")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: AssemblyMetadata("PreferInbox", "True")]
 ```

--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -8,8 +8,6 @@
     <Description Condition="'$(Description)' == ''">$(AssemblyName)</Description>
   </PropertyGroup>
 
-  <!-- Assembly metadata indicating that an assembly is a framework (as opposed to user) assembly:
-       Test projects need to not have this because of the way "IsFrameworkAssembly" APIs work to check this. -->
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(IsTestSupportProject)' != 'true'">
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
       <_Parameter1>Serviceable</_Parameter1>

--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -12,10 +12,6 @@
        Test projects need to not have this because of the way "IsFrameworkAssembly" APIs work to check this. -->
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(IsTestSupportProject)' != 'true'">
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
-      <_Parameter1>.NETFrameworkAssembly</_Parameter1>
-      <_Parameter2></_Parameter2>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
       <_Parameter1>Serviceable</_Parameter1>
       <_Parameter2>True</_Parameter2>
     </AssemblyAttribute>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml
@@ -347,13 +347,6 @@
     <type fullname="System.Reflection.AssemblyMetadataAttribute">
       <attribute internal="RemoveAttributeInstances">
         <argument type="System.Object">
-          <argument>.NETFrameworkAssembly</argument>
-        </argument>
-      </attribute>
-    </type>
-    <type fullname="System.Reflection.AssemblyMetadataAttribute">
-      <attribute internal="RemoveAttributeInstances">
-        <argument type="System.Object">
           <argument>RepositoryUrl</argument>
         </argument>
       </attribute>

--- a/src/libraries/System.Private.CoreLib/src/Internal/AssemblyAttributes.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/AssemblyAttributes.cs
@@ -12,7 +12,6 @@ using System.Resources;
 [assembly: DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32)]
 
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyMetadata(".NETFrameworkAssembly", "")]
 [assembly: AssemblyMetadata("IsTrimmable", "True")]
 
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
This is likely a .NET Native leftover that is currently breaking .NET Native. This attribute indicates to the .NET Native compiler that the assembly can be trimmed.

We're currently setting this on assemblies that no longer carry RD.XML to make this safe. Without this attribute, the .NET Native compiler will root the assembly and we should no longer see trimming issues with it.

Cc @eerhardt @tarekgh @ericstj 

Fixes #44697.