### PR TITLE
Add CreateParameter() to DbBatchCommand

### DIFF
--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -2001,6 +2001,8 @@ namespace System.Data.Common
         public abstract int RecordsAffected { get; }
         public System.Data.Common.DbParameterCollection Parameters { get { throw null; } }
         protected abstract System.Data.Common.DbParameterCollection DbParameterCollection { get; }
+        public virtual DbParameter CreateParameter() { throw null; }
+        public virtual bool CanCreateParameter { get { throw null; } }
     }
     public abstract class DbBatchCommandCollection : System.Collections.Generic.IList<DbBatchCommand>
     {

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbBatchCommand.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbBatchCommand.cs
@@ -17,5 +17,11 @@ namespace System.Data.Common
         public DbParameterCollection Parameters => DbParameterCollection;
 
         protected abstract DbParameterCollection DbParameterCollection { get; }
+
+        public virtual DbParameter CreateParameter()
+            => throw new NotSupportedException();
+
+        public virtual bool CanCreateParameter
+            => false;
     }
 }


### PR DESCRIPTION
Please see [this note](https://github.com/dotnet/runtime/issues/82326#issuecomment-1651787313) on the usage of covariant return types (for the first time in ADO.NET AFAIK).

Closes #82326