### PR TITLE
[mono][tests] Use RecursiveDir property to create app bundle for Helix

### DIFF
--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -62,21 +62,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <!-- 
-        Checks if the directory name "AppleAssembliesToBundle" is equal to the "AssemblyName",
-        if they match, consider it as the root directory and copy the files there,
-        otherwise, copy the files to a subdirectory.
-      -->
-      <BundleFiles Condition="'%(AppleAssembliesToBundle._IsNative)' != 'true' and ($([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('%(AppleAssembliesToBundle.Identity)')))) == '$(AssemblyName)' or '$(IsRuntimeTests)' != 'true')"
-              Include="@(AppleAssembliesToBundle)"                    TargetDir="publish" />
-      <BundleFiles Condition="'%(AppleAssembliesToBundle._IsNative)' != 'true' and $([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('%(AppleAssembliesToBundle.Identity)')))) != '$(AssemblyName)' and  '$(IsRuntimeTests)' == 'true'"
-                   Include="@(AppleAssembliesToBundle)"               TargetDir="publish\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('%(AppleAssembliesToBundle.Identity)'))))" />
-
-      <BundleFiles Include="@(AppleNativeFilesToBundle)"              TargetDir="publish" />
-
-      <BundleFiles Include="$(MonoProjectRoot)\msbuild\apple\data\*"  TargetDir="publish" />
+      <BundleFiles Condition="'%(AppleAssembliesToBundle._IsNative)' != 'true'"
+                   Include="@(AppleAssembliesToBundle)"         TargetDir="publish\%(AppleAssembliesToBundle.RecursiveDir)" />
+      <BundleFiles Include="@(AppleNativeFilesToBundle)"        TargetDir="publish\%(AppleNativeFilesToBundle.RecursiveDir)" />
+      <BundleFiles Include="$(RuntimeConfigFilePath)"           TargetDir="publish" />
+      <BundleFiles Include="$(MonoProjectRoot)\msbuild\apple\data\*" TargetDir="publish" />
       <ExtraFiles Condition="'%(AppleAssembliesToBundle._IsNative)' == 'true'"
-                  Include="@(AppleAssembliesToBundle)"                TargetDir="extraFiles" />
+                   Include="@(AppleAssembliesToBundle)"          TargetDir="extraFiles\%(AppleAssembliesToBundle.RecursiveDir)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(DebuggerSupport)' == 'true'">

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -274,6 +274,7 @@
 
   <Target Name="BuildMonoiOSApp">
     <PropertyGroup>
+      <IntermediateOutputPath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)'))</IntermediateOutputPath>
       <CMDDIR_Grandparent>$([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetDirectoryName($(_CMDDIR)))))</CMDDIR_Grandparent>
       <CategoryWithSlash>$([System.String]::Copy('$(_CMDDIR)').Replace("$(CMDDIR_Grandparent)/",""))</CategoryWithSlash>
       <Category>$([System.String]::Copy('$(CategoryWithSlash)').Replace('/','_'))</Category>


### PR DESCRIPTION
This PR reverts creating app bundle for Helix using RecursiveDir property.

Fixes https://github.com/dotnet/runtime/issues/89491