### PR TITLE
Implement IKeyedServiceProvider interface on ServiceProviderEngineScope

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
@@ -325,38 +325,111 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
         }
 
         [Fact]
-        public void ResolveKeyedServiceFromInjectedServiceProvider()
+        public void ResolveKeyedSingletonFromInjectedServiceProvider()
         {
-            var service1 = new Service();
-            var service2 = new Service();
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddKeyedSingleton<IService>("service1", service1);
-            serviceCollection.AddKeyedSingleton<IService>("service2", service2);
+            serviceCollection.AddKeyedSingleton<IService, Service>("key");
             serviceCollection.AddSingleton<ServiceProviderAccessor>();
 
             var provider = CreateServiceProvider(serviceCollection);
             var accessor = provider.GetRequiredService<ServiceProviderAccessor>();
 
             Assert.Null(accessor.ServiceProvider.GetService<IService>());
-            Assert.Same(service1, accessor.ServiceProvider.GetKeyedService<IService>("service1"));
-            Assert.Same(service2, accessor.ServiceProvider.GetKeyedService<IService>("service2"));
+
+            var service1 = accessor.ServiceProvider.GetKeyedService<IService>("key");
+            var service2 = accessor.ServiceProvider.GetKeyedService<IService>("key");
+
+            Assert.Same(service1, service2);
         }
 
         [Fact]
-        public void ResolveKeyedServiceFromScopeServiceProvider()
+        public void ResolveKeyedTransientFromInjectedServiceProvider()
         {
-            var service1 = new Service();
-            var service2 = new Service();
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddKeyedSingleton<IService>("service1", service1);
-            serviceCollection.AddKeyedSingleton<IService>("service2", service2);
+            serviceCollection.AddKeyedTransient<IService, Service>("key");
+            serviceCollection.AddSingleton<ServiceProviderAccessor>();
 
             var provider = CreateServiceProvider(serviceCollection);
-            var scope = provider.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            var accessor = provider.GetRequiredService<ServiceProviderAccessor>();
 
-            Assert.Null(scope.ServiceProvider.GetService<IService>());
-            Assert.Same(service1, scope.ServiceProvider.GetKeyedService<IService>("service1"));
-            Assert.Same(service2, scope.ServiceProvider.GetKeyedService<IService>("service2"));
+            Assert.Null(accessor.ServiceProvider.GetService<IService>());
+
+            var service1 = accessor.ServiceProvider.GetKeyedService<IService>("key");
+            var service2 = accessor.ServiceProvider.GetKeyedService<IService>("key");
+
+            Assert.NotSame(service1, service2);
+        }
+
+        [Fact]
+        public void ResolveKeyedSingletonFromScopeServiceProvider()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddKeyedSingleton<IService, Service>("key");
+
+            var provider = CreateServiceProvider(serviceCollection);
+            var scopeA = provider.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            var scopeB = provider.GetRequiredService<IServiceScopeFactory>().CreateScope();
+
+            Assert.Null(scopeA.ServiceProvider.GetService<IService>());
+            Assert.Null(scopeB.ServiceProvider.GetService<IService>());
+
+            var serviceA1 = scopeA.ServiceProvider.GetKeyedService<IService>("key");
+            var serviceA2 = scopeA.ServiceProvider.GetKeyedService<IService>("key");
+
+            var serviceB1 = scopeB.ServiceProvider.GetKeyedService<IService>("key");
+            var serviceB2 = scopeB.ServiceProvider.GetKeyedService<IService>("key");
+
+            Assert.Same(serviceA1, serviceA2);
+            Assert.Same(serviceB1, serviceB2);
+            Assert.Same(serviceA1, serviceB1);
+        }
+
+        [Fact]
+        public void ResolveKeyedScopedFromScopeServiceProvider()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddKeyedScoped<IService, Service>("key");
+
+            var provider = CreateServiceProvider(serviceCollection);
+            var scopeA = provider.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            var scopeB = provider.GetRequiredService<IServiceScopeFactory>().CreateScope();
+
+            Assert.Null(scopeA.ServiceProvider.GetService<IService>());
+            Assert.Null(scopeB.ServiceProvider.GetService<IService>());
+
+            var serviceA1 = scopeA.ServiceProvider.GetKeyedService<IService>("key");
+            var serviceA2 = scopeA.ServiceProvider.GetKeyedService<IService>("key");
+
+            var serviceB1 = scopeB.ServiceProvider.GetKeyedService<IService>("key");
+            var serviceB2 = scopeB.ServiceProvider.GetKeyedService<IService>("key");
+
+            Assert.Same(serviceA1, serviceA2);
+            Assert.Same(serviceB1, serviceB2);
+            Assert.NotSame(serviceA1, serviceB1);
+        }
+
+        [Fact]
+        public void ResolveKeyedTransientFromScopeServiceProvider()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddKeyedTransient<IService, Service>("key");
+
+            var provider = CreateServiceProvider(serviceCollection);
+            var scopeA = provider.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            var scopeB = provider.GetRequiredService<IServiceScopeFactory>().CreateScope();
+
+            Assert.Null(scopeA.ServiceProvider.GetService<IService>());
+            Assert.Null(scopeB.ServiceProvider.GetService<IService>());
+
+            var serviceA1 = scopeA.ServiceProvider.GetKeyedService<IService>("key");
+            var serviceA2 = scopeA.ServiceProvider.GetKeyedService<IService>("key");
+
+            var serviceB1 = scopeB.ServiceProvider.GetKeyedService<IService>("key");
+            var serviceB2 = scopeB.ServiceProvider.GetKeyedService<IService>("key");
+
+            Assert.NotSame(serviceA1, serviceA2);
+            Assert.NotSame(serviceB1, serviceB2);
+            Assert.NotSame(serviceA1, serviceB1);
         }
 
         internal interface IService { }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     [DebuggerDisplay("{DebuggerToString(),nq}")]
     [DebuggerTypeProxy(typeof(ServiceProviderEngineScopeDebugView))]
-    internal sealed class ServiceProviderEngineScope : IServiceScope, IServiceProvider, IAsyncDisposable, IServiceScopeFactory
+    internal sealed class ServiceProviderEngineScope : IServiceScope, IServiceProvider, IKeyedServiceProvider, IAsyncDisposable, IServiceScopeFactory
     {
         // For testing and debugging only
         internal IList<object> Disposables => _disposables ?? (IList<object>)Array.Empty<object>();
@@ -48,6 +48,26 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
 
             return RootProvider.GetService(ServiceIdentifier.FromServiceType(serviceType), this);
+        }
+
+        public object? GetKeyedService(Type serviceType, object? serviceKey)
+        {
+            if (_disposed)
+            {
+                ThrowHelper.ThrowObjectDisposedException();
+            }
+
+            return RootProvider.GetKeyedService(serviceType, serviceKey, this);
+        }
+
+        public object GetRequiredKeyedService(Type serviceType, object? serviceKey)
+        {
+            if (_disposed)
+            {
+                ThrowHelper.ThrowObjectDisposedException();
+            }
+
+            return RootProvider.GetRequiredKeyedService(serviceType, serviceKey, this);
         }
 
         public IServiceProvider ServiceProvider => this;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -98,11 +98,17 @@ namespace Microsoft.Extensions.DependencyInjection
         public object? GetService(Type serviceType) => GetService(ServiceIdentifier.FromServiceType(serviceType), Root);
 
         public object? GetKeyedService(Type serviceType, object? serviceKey)
-            => GetService(new ServiceIdentifier(serviceKey, serviceType), Root);
+            => GetKeyedService(serviceType, serviceKey, Root);
+
+        internal object? GetKeyedService(Type serviceType, object? serviceKey, ServiceProviderEngineScope serviceProviderEngineScope)
+            => GetService(new ServiceIdentifier(serviceKey, serviceType), serviceProviderEngineScope);
 
         public object GetRequiredKeyedService(Type serviceType, object? serviceKey)
+            => GetRequiredKeyedService(serviceType, serviceKey, Root);
+
+        internal object GetRequiredKeyedService(Type serviceType, object? serviceKey, ServiceProviderEngineScope serviceProviderEngineScope)
         {
-            object? service = GetKeyedService(serviceType, serviceKey);
+            object? service = GetKeyedService(serviceType, serviceKey, serviceProviderEngineScope);
             if (service == null)
             {
                 throw new InvalidOperationException(SR.Format(SR.NoServiceRegistered, serviceType));

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderEngineScopeTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderEngineScopeTests.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
@@ -28,6 +30,16 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             ((IDisposable)s).Dispose();
 
             Assert.Throws<ObjectDisposedException>(() => sp.GetRequiredService<IServiceProvider>());
+        }
+
+        [Fact]
+        public void ServiceProviderEngineScope_ImplementsAllServiceProviderInterfaces()
+        {
+            var engineScopeInterfaces = typeof(ServiceProviderEngineScope).GetInterfaces();
+            foreach (var serviceProviderInterface in typeof(ServiceProvider).GetInterfaces())
+            {
+                Assert.Contains(serviceProviderInterface, engineScopeInterfaces);
+            }
         }
     }
 }


### PR DESCRIPTION
My take on https://github.com/dotnet/runtime/issues/89447

Mainly, just implemented the missing interface on ServiceProviderEngineScope.

I don't know whether I missed something obscure with regards to the keyed feature -- I'm not an expert in the area -- but both cases I mentioned in the issue seem to work fine with the fix.

Fixes #89447