### PR TITLE
Fix ABI and Interop issues with InlineArray types

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ImpliedRepeatedFieldDesc.cs
+++ b/src/coreclr/tools/Common/Compiler/ImpliedRepeatedFieldDesc.cs
@@ -9,13 +9,14 @@ namespace ILCompiler
     {
         private readonly FieldDesc _underlyingFieldDesc;
 
-        public ImpliedRepeatedFieldDesc(FieldDesc underlyingFieldDesc, int fieldIndex)
+        public ImpliedRepeatedFieldDesc(DefType owningType, FieldDesc underlyingFieldDesc, int fieldIndex)
         {
+            OwningType = owningType;
             _underlyingFieldDesc = underlyingFieldDesc;
             FieldIndex = fieldIndex;
         }
 
-        public override DefType OwningType => _underlyingFieldDesc.OwningType;
+        public override DefType OwningType { get; }
 
         public override TypeDesc FieldType => _underlyingFieldDesc.FieldType;
 
@@ -38,13 +39,12 @@ namespace ILCompiler
         protected override int ClassCode => 31666958;
 
         public override EmbeddedSignatureData[] GetEmbeddedSignatureData() => _underlyingFieldDesc.GetEmbeddedSignatureData();
+
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => _underlyingFieldDesc.HasCustomAttribute(attributeNamespace, attributeName);
+
         protected override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
         {
-            if (other is not ImpliedRepeatedFieldDesc impliedRepeatedFieldDesc)
-            {
-                return -1;
-            }
+            var impliedRepeatedFieldDesc = (ImpliedRepeatedFieldDesc)other;
 
             int result = comparer.Compare(_underlyingFieldDesc, impliedRepeatedFieldDesc._underlyingFieldDesc);
 
@@ -56,15 +56,8 @@ namespace ILCompiler
             return FieldIndex.CompareTo(impliedRepeatedFieldDesc.FieldIndex);
         }
 
-        public override LayoutInt Offset
-        {
-            get
-            {
-                LayoutInt elementSize = FieldType.GetElementSize();
-                return elementSize.IsIndeterminate ? LayoutInt.Indeterminate : new LayoutInt(elementSize.AsInt * FieldIndex);
-            }
-        }
-
         public override MarshalAsDescriptor GetMarshalAsDescriptor() => _underlyingFieldDesc.GetMarshalAsDescriptor();
+
+        public override string Name => $"{_underlyingFieldDesc.Name}[{FieldIndex}]";
     }
 }

--- a/src/coreclr/tools/Common/Compiler/ImpliedRepeatedFieldDesc.cs
+++ b/src/coreclr/tools/Common/Compiler/ImpliedRepeatedFieldDesc.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.TypeSystem;
+
+namespace ILCompiler
+{
+    public sealed class ImpliedRepeatedFieldDesc : FieldDesc
+    {
+        private readonly FieldDesc _underlyingFieldDesc;
+
+        public ImpliedRepeatedFieldDesc(FieldDesc underlyingFieldDesc, int fieldIndex)
+        {
+            _underlyingFieldDesc = underlyingFieldDesc;
+            FieldIndex = fieldIndex;
+        }
+
+        public override DefType OwningType => _underlyingFieldDesc.OwningType;
+
+        public override TypeDesc FieldType => _underlyingFieldDesc.FieldType;
+
+        public override bool HasEmbeddedSignatureData => _underlyingFieldDesc.HasEmbeddedSignatureData;
+
+        public override bool IsStatic => _underlyingFieldDesc.IsStatic;
+
+        public override bool IsInitOnly => _underlyingFieldDesc.IsInitOnly;
+
+        public override bool IsThreadStatic => _underlyingFieldDesc.IsThreadStatic;
+
+        public override bool HasRva => _underlyingFieldDesc.HasRva;
+
+        public override bool IsLiteral => _underlyingFieldDesc.IsLiteral;
+
+        public override TypeSystemContext Context => _underlyingFieldDesc.Context;
+
+        public int FieldIndex { get; }
+
+        protected override int ClassCode => 31666958;
+
+        public override EmbeddedSignatureData[] GetEmbeddedSignatureData() => _underlyingFieldDesc.GetEmbeddedSignatureData();
+        public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => _underlyingFieldDesc.HasCustomAttribute(attributeNamespace, attributeName);
+        protected override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
+        {
+            if (other is not ImpliedRepeatedFieldDesc impliedRepeatedFieldDesc)
+            {
+                return -1;
+            }
+
+            int result = comparer.Compare(_underlyingFieldDesc, impliedRepeatedFieldDesc._underlyingFieldDesc);
+
+            if (result != 0)
+            {
+                return result;
+            }
+
+            return FieldIndex.CompareTo(impliedRepeatedFieldDesc.FieldIndex);
+        }
+
+        public override LayoutInt Offset
+        {
+            get
+            {
+                LayoutInt elementSize = FieldType.GetElementSize();
+                return elementSize.IsIndeterminate ? LayoutInt.Indeterminate : new LayoutInt(elementSize.AsInt * FieldIndex);
+            }
+        }
+
+        public override MarshalAsDescriptor GetMarshalAsDescriptor() => _underlyingFieldDesc.GetMarshalAsDescriptor();
+    }
+}

--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -776,6 +776,10 @@ namespace ILCompiler
                 }
             }
 
+            if (firstField is null)
+            {
+                return false;
+            }
             TypeDesc firstFieldElementType = firstField.FieldType;
 
             // A fixed buffer type is always a value type that has exactly one value type field at offset 0

--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -771,7 +771,7 @@ namespace ILCompiler
             {
                 if (!field.IsStatic)
                 {
-                    firstField ??= field;
+                    firstField = field;
                     break;
                 }
             }

--- a/src/coreclr/tools/Common/Compiler/TypeWithRepeatedFields.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeWithRepeatedFields.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using Internal.TypeSystem;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// This type represents a type that has one field in metadata,
+    /// but has that field repeated at runtime to represent an array of elements inline.
+    /// </summary>
+    public sealed partial class TypeWithRepeatedFields : MetadataType
+    {
+        private int? _numFields;
+        private FieldDesc[] _fields;
+
+        public TypeWithRepeatedFields(MetadataType underlyingType)
+        {
+            MetadataType = underlyingType;
+        }
+
+        internal MetadataType MetadataType { get; }
+
+        internal int NumFields
+        {
+            get
+            {
+                if (_numFields.HasValue)
+                {
+                    return _numFields.Value;
+                }
+                int size = MetadataType.InstanceFieldSize.AsInt;
+                FieldDesc firstField = GetFirstInstanceField();
+
+                _numFields = size / firstField.FieldType.GetElementSize().AsInt;
+                return _numFields.Value;
+            }
+        }
+
+        private FieldDesc GetFirstInstanceField()
+        {
+            FieldDesc firstField = null;
+            foreach (var field in MetadataType.GetFields())
+            {
+                if (field.IsStatic)
+                {
+                    continue;
+                }
+
+                firstField = field;
+                break;
+            }
+
+            Debug.Assert(firstField is not null);
+            return firstField;
+        }
+
+        private FieldDesc[] ComputeFields()
+        {
+            var fields = new FieldDesc[NumFields];
+
+            FieldDesc firstField = GetFirstInstanceField();
+
+            for (int i = 0; i < NumFields; i++)
+            {
+                fields[i] = new ImpliedRepeatedFieldDesc(this, firstField, i);
+            }
+
+            return fields;
+        }
+
+        public override IEnumerable<FieldDesc> GetFields()
+        {
+            if (_fields is null)
+            {
+                Interlocked.CompareExchange(ref _fields, ComputeFields(), null);
+            }
+            return _fields;
+        }
+
+        public override ClassLayoutMetadata GetClassLayout() => MetadataType.GetClassLayout();
+        public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => MetadataType.HasCustomAttribute(attributeNamespace, attributeName);
+        public override IEnumerable<MetadataType> GetNestedTypes() => MetadataType.GetNestedTypes();
+        public override MetadataType GetNestedType(string name) => MetadataType.GetNestedType(name);
+        public override int GetInlineArrayLength() => MetadataType.GetInlineArrayLength();
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(string name) => MetadataType.FindMethodsImplWithMatchingDeclName(name);
+        public override int GetHashCode() => MetadataType.GetHashCode();
+        protected override MethodImplRecord[] ComputeVirtualMethodImplsForType() => MetadataType.VirtualMethodImplsForType;
+        protected override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer) => comparer.Compare(MetadataType, ((TypeWithRepeatedFields)other).MetadataType);
+
+        protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
+        {
+            TypeFlags flags = 0;
+
+            if ((mask & TypeFlags.CategoryMask) != 0)
+            {
+                flags |= MetadataType.Category;
+            }
+
+            if ((mask & TypeFlags.HasGenericVarianceComputed) != 0)
+            {
+                flags |= TypeFlags.HasGenericVarianceComputed;
+
+                if (MetadataType.HasVariance)
+                    flags |= TypeFlags.HasGenericVariance;
+            }
+
+            if ((mask & TypeFlags.HasFinalizerComputed) != 0)
+            {
+                flags |= TypeFlags.HasFinalizerComputed;
+
+                if (MetadataType.HasFinalizer)
+                    flags |= TypeFlags.HasFinalizer;
+            }
+
+            if ((mask & TypeFlags.AttributeCacheComputed) != 0)
+            {
+                flags |= TypeFlags.AttributeCacheComputed;
+
+                if (MetadataType.IsByRefLike)
+                    flags |= TypeFlags.IsByRefLike;
+
+                if (MetadataType.IsInlineArray)
+                    flags |= TypeFlags.IsInlineArray;
+
+                if (MetadataType.IsIntrinsic)
+                    flags |= TypeFlags.IsIntrinsic;
+            }
+
+            return flags;
+        }
+
+        public override string Namespace => MetadataType.Namespace;
+
+        public override string Name => MetadataType.Name;
+
+        public override DefType[] ExplicitlyImplementedInterfaces => MetadataType.ExplicitlyImplementedInterfaces;
+
+        public override bool IsExplicitLayout => MetadataType.IsExplicitLayout;
+
+        public override bool IsSequentialLayout => MetadataType.IsSequentialLayout;
+
+        public override bool IsBeforeFieldInit => MetadataType.IsBeforeFieldInit;
+
+        public override ModuleDesc Module => MetadataType.Module;
+
+        public override MetadataType MetadataBaseType => MetadataType.MetadataBaseType;
+
+        public override DefType BaseType => MetadataType.BaseType;
+
+        public override bool IsSealed => MetadataType.IsSealed;
+
+        public override bool IsAbstract => MetadataType.IsAbstract;
+
+        public override DefType ContainingType => MetadataType.ContainingType;
+
+        public override PInvokeStringFormat PInvokeStringFormat => MetadataType.PInvokeStringFormat;
+
+        public override string DiagnosticName => MetadataType.DiagnosticName;
+
+        public override string DiagnosticNamespace => MetadataType.DiagnosticNamespace;
+
+        public override TypeSystemContext Context => MetadataType.Context;
+
+        protected override int ClassCode => 779393465;
+    }
+}

--- a/src/coreclr/tools/Common/Compiler/TypeWithRepeatedFields.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeWithRepeatedFields.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -83,12 +84,12 @@ namespace ILCompiler
 
         public override ClassLayoutMetadata GetClassLayout() => MetadataType.GetClassLayout();
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => MetadataType.HasCustomAttribute(attributeNamespace, attributeName);
-        public override IEnumerable<MetadataType> GetNestedTypes() => MetadataType.GetNestedTypes();
-        public override MetadataType GetNestedType(string name) => MetadataType.GetNestedType(name);
+        public override IEnumerable<MetadataType> GetNestedTypes() => (IEnumerable<MetadataType>)EmptyTypes;
+        public override MetadataType GetNestedType(string name) => null;
         public override int GetInlineArrayLength() => MetadataType.GetInlineArrayLength();
         public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(string name) => MetadataType.FindMethodsImplWithMatchingDeclName(name);
         public override int GetHashCode() => MetadataType.GetHashCode();
-        protected override MethodImplRecord[] ComputeVirtualMethodImplsForType() => MetadataType.VirtualMethodImplsForType;
+        protected override MethodImplRecord[] ComputeVirtualMethodImplsForType() => Array.Empty<MethodImplRecord>();
         protected override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer) => comparer.Compare(MetadataType, ((TypeWithRepeatedFields)other).MetadataType);
 
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask)
@@ -137,7 +138,7 @@ namespace ILCompiler
 
         public override string Name => MetadataType.Name;
 
-        public override DefType[] ExplicitlyImplementedInterfaces => MetadataType.ExplicitlyImplementedInterfaces;
+        public override DefType[] ExplicitlyImplementedInterfaces => (DefType[])EmptyTypes;
 
         public override bool IsExplicitLayout => MetadataType.IsExplicitLayout;
 
@@ -151,9 +152,9 @@ namespace ILCompiler
 
         public override DefType BaseType => MetadataType.BaseType;
 
-        public override bool IsSealed => MetadataType.IsSealed;
+        public override bool IsSealed => true;
 
-        public override bool IsAbstract => MetadataType.IsAbstract;
+        public override bool IsAbstract => false;
 
         public override DefType ContainingType => MetadataType.ContainingType;
 
@@ -166,5 +167,7 @@ namespace ILCompiler
         public override TypeSystemContext Context => MetadataType.Context;
 
         protected override int ClassCode => 779393465;
+
+        public override IEnumerable<MethodDesc> GetMethods() => MethodDesc.EmptyMethods;
     }
 }

--- a/src/coreclr/tools/Common/Compiler/TypeWithRepeatedFields.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeWithRepeatedFields.cs
@@ -138,7 +138,7 @@ namespace ILCompiler
 
         public override string Name => MetadataType.Name;
 
-        public override DefType[] ExplicitlyImplementedInterfaces => (DefType[])EmptyTypes;
+        public override DefType[] ExplicitlyImplementedInterfaces => Array.Empty<DefType>();
 
         public override bool IsExplicitLayout => MetadataType.IsExplicitLayout;
 

--- a/src/coreclr/tools/Common/Compiler/TypeWithRepeatedFieldsFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeWithRepeatedFieldsFieldLayoutAlgorithm.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.TypeSystem;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Represents an algorithm that computes field layout for intrinsic vector types (Vector64/Vector128/Vector256).
+    /// </summary>
+    public class TypeWithRepeatedFieldsFieldLayoutAlgorithm : FieldLayoutAlgorithm
+    {
+        private readonly FieldLayoutAlgorithm _fallbackAlgorithm;
+
+        public TypeWithRepeatedFieldsFieldLayoutAlgorithm(FieldLayoutAlgorithm fallbackAlgorithm)
+        {
+            _fallbackAlgorithm = fallbackAlgorithm;
+        }
+
+        public override ComputedInstanceFieldLayout ComputeInstanceLayout(DefType defType, InstanceLayoutKind layoutKind)
+        {
+            var type = (TypeWithRepeatedFields)defType;
+
+            ComputedInstanceFieldLayout layoutFromMetadata = _fallbackAlgorithm.ComputeInstanceLayout(type.MetadataType, layoutKind);
+
+            FieldAndOffset[] offsets = layoutFromMetadata.Offsets;
+
+            if (offsets is not null)
+            {
+                var fieldOffsets = new FieldAndOffset[type.NumFields];
+
+                LayoutInt cumulativeOffset = new LayoutInt(0);
+                int fieldIndex = 0;
+                foreach (FieldDesc field in type.GetFields())
+                {
+                    if (field.IsStatic)
+                    {
+                        continue;
+                    }
+                    fieldOffsets[fieldIndex++] = new FieldAndOffset(field, cumulativeOffset);
+                    cumulativeOffset += field.FieldType.GetElementSize();
+                }
+
+                offsets = fieldOffsets;
+            }
+
+            return new ComputedInstanceFieldLayout
+            {
+                ByteCountUnaligned = layoutFromMetadata.ByteCountUnaligned,
+                ByteCountAlignment = layoutFromMetadata.ByteCountAlignment,
+                FieldAlignment = layoutFromMetadata.FieldAlignment,
+                FieldSize = layoutFromMetadata.FieldSize,
+                Offsets = offsets,
+                LayoutAbiStable = layoutFromMetadata.LayoutAbiStable
+            };
+        }
+
+        public override ComputedStaticFieldLayout ComputeStaticFieldLayout(DefType defType, StaticLayoutKind layoutKind)
+        {
+            return _fallbackAlgorithm.ComputeStaticFieldLayout(((TypeWithRepeatedFields)defType).MetadataType, layoutKind);
+        }
+
+        public override bool ComputeContainsGCPointers(DefType type)
+        {
+            return _fallbackAlgorithm.ComputeContainsGCPointers(((TypeWithRepeatedFields)type).MetadataType);
+        }
+
+        public override bool ComputeIsUnsafeValueType(DefType type)
+        {
+            return _fallbackAlgorithm.ComputeIsUnsafeValueType(((TypeWithRepeatedFields)type).MetadataType);
+        }
+
+        public override ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type)
+        {
+            return _fallbackAlgorithm.ComputeValueTypeShapeCharacteristics(((TypeWithRepeatedFields)type).MetadataType);
+        }
+    }
+}

--- a/src/coreclr/tools/Common/JitInterface/LoongArch64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/LoongArch64PassStructInRegister.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Diagnostics;
+using ILCompiler;
 using Internal.TypeSystem;
 
 namespace Internal.JitInterface
@@ -40,23 +41,7 @@ namespace Internal.JitInterface
             TypeDesc firstFieldElementType = firstField.FieldType;
             int firstFieldSize = firstFieldElementType.GetElementSize().AsInt;
 
-            // InlineArray types and fixed buffer types have implied repeated fields.
-            bool hasImpliedRepeatedFields = mdType.IsInlineArray;
-            if (!hasImpliedRepeatedFields)
-            {
-                // A fixed buffer type is always a value type that has exactly one value type field at offset 0
-                // and who's size is an exact multiple of the size of the field.
-                // It is possible that we catch a false positive with this check, but that chance is extremely slim
-                // and the user can always change their structure to something more descriptive of what they want
-                // instead of adding additional padding at the end of a one-field structure.
-                // We do this check here to save looking up the FixedBufferAttribute when loading the field
-                // from metadata.
-                hasImpliedRepeatedFields = numIntroducedFields == 1
-                                && firstFieldElementType.IsValueType
-                                && firstField.Offset.AsInt == 0
-                                && mdType.HasLayout()
-                                && ((typeDesc.GetElementSize().AsInt % firstFieldSize) == 0);
-            }
+            bool hasImpliedRepeatedFields = mdType.HasImpliedRepeatedFields();
 
             if (hasImpliedRepeatedFields)
             {

--- a/src/coreclr/tools/Common/JitInterface/LoongArch64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/LoongArch64PassStructInRegister.cs
@@ -40,9 +40,9 @@ namespace Internal.JitInterface
             TypeDesc firstFieldElementType = firstField.FieldType;
             int firstFieldSize = firstFieldElementType.GetElementSize().AsInt;
 
-            
-            bool isFixedBuffer = mdType.IsInlineArray;
-            if (!isFixedBuffer)
+            // InlineArray types and fixed buffer types have implied repeated fields.
+            bool hasImpliedRepeatedFields = mdType.IsInlineArray;
+            if (!hasImpliedRepeatedFields)
             {
                 // A fixed buffer type is always a value type that has exactly one value type field at offset 0
                 // and who's size is an exact multiple of the size of the field.
@@ -51,14 +51,14 @@ namespace Internal.JitInterface
                 // instead of adding additional padding at the end of a one-field structure.
                 // We do this check here to save looking up the FixedBufferAttribute when loading the field
                 // from metadata.
-                isFixedBuffer = numIntroducedFields == 1
+                hasImpliedRepeatedFields = numIntroducedFields == 1
                                 && firstFieldElementType.IsValueType
                                 && firstField.Offset.AsInt == 0
                                 && mdType.HasLayout()
                                 && ((typeDesc.GetElementSize().AsInt % firstFieldSize) == 0);
             }
 
-            if (isFixedBuffer)
+            if (hasImpliedRepeatedFields)
             {
                 numIntroducedFields = typeDesc.GetElementSize().AsInt / firstFieldSize;
                 if (numIntroducedFields > 2)

--- a/src/coreclr/tools/Common/JitInterface/LoongArch64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/LoongArch64PassStructInRegister.cs
@@ -40,18 +40,23 @@ namespace Internal.JitInterface
             TypeDesc firstFieldElementType = firstField.FieldType;
             int firstFieldSize = firstFieldElementType.GetElementSize().AsInt;
 
-            // A fixed buffer type is always a value type that has exactly one value type field at offset 0
-            // and who's size is an exact multiple of the size of the field.
-            // It is possible that we catch a false positive with this check, but that chance is extremely slim
-            // and the user can always change their structure to something more descriptive of what they want
-            // instead of adding additional padding at the end of a one-field structure.
-            // We do this check here to save looking up the FixedBufferAttribute when loading the field
-            // from metadata.
-            bool isFixedBuffer = numIntroducedFields == 1
-                                    && firstFieldElementType.IsValueType
-                                    && firstField.Offset.AsInt == 0
-                                    && mdType.HasLayout()
-                                    && ((typeDesc.GetElementSize().AsInt % firstFieldSize) == 0);
+            
+            bool isFixedBuffer = mdType.IsInlineArray;
+            if (!isFixedBuffer)
+            {
+                // A fixed buffer type is always a value type that has exactly one value type field at offset 0
+                // and who's size is an exact multiple of the size of the field.
+                // It is possible that we catch a false positive with this check, but that chance is extremely slim
+                // and the user can always change their structure to something more descriptive of what they want
+                // instead of adding additional padding at the end of a one-field structure.
+                // We do this check here to save looking up the FixedBufferAttribute when loading the field
+                // from metadata.
+                isFixedBuffer = numIntroducedFields == 1
+                                && firstFieldElementType.IsValueType
+                                && firstField.Offset.AsInt == 0
+                                && mdType.HasLayout()
+                                && ((typeDesc.GetElementSize().AsInt % firstFieldSize) == 0);
+            }
 
             if (isFixedBuffer)
             {

--- a/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
@@ -40,9 +40,10 @@ namespace Internal.JitInterface
             TypeDesc firstFieldElementType = firstField.FieldType;
             int firstFieldSize = firstFieldElementType.GetElementSize().AsInt;
 
-            bool isFixedBuffer = mdType.IsInlineArray;
+            // InlineArray types and fixed buffer types have implied repeated fields.
+            bool hasImpliedRepeatedFields = mdType.IsInlineArray;
 
-            if (!isFixedBuffer)
+            if (!hasImpliedRepeatedFields)
             {
                 // A fixed buffer type is always a value type that has exactly one value type field at offset 0
                 // and who's size is an exact multiple of the size of the field.
@@ -51,7 +52,7 @@ namespace Internal.JitInterface
                 // instead of adding additional padding at the end of a one-field structure.
                 // We do this check here to save looking up the FixedBufferAttribute when loading the field
                 // from metadata.
-                isFixedBuffer = numIntroducedFields == 1
+                hasImpliedRepeatedFields = numIntroducedFields == 1
                                 && firstFieldElementType.IsValueType
                                 && firstField.Offset.AsInt == 0
                                 && mdType.HasLayout()
@@ -59,7 +60,7 @@ namespace Internal.JitInterface
 
             }
 
-            if (isFixedBuffer)
+            if (hasImpliedRepeatedFields)
             {
                 numIntroducedFields = typeDesc.GetElementSize().AsInt / firstFieldSize;
                 if (numIntroducedFields > 2)

--- a/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
@@ -40,18 +40,24 @@ namespace Internal.JitInterface
             TypeDesc firstFieldElementType = firstField.FieldType;
             int firstFieldSize = firstFieldElementType.GetElementSize().AsInt;
 
-            // A fixed buffer type is always a value type that has exactly one value type field at offset 0
-            // and who's size is an exact multiple of the size of the field.
-            // It is possible that we catch a false positive with this check, but that chance is extremely slim
-            // and the user can always change their structure to something more descriptive of what they want
-            // instead of adding additional padding at the end of a one-field structure.
-            // We do this check here to save looking up the FixedBufferAttribute when loading the field
-            // from metadata.
-            bool isFixedBuffer = numIntroducedFields == 1
-                                    && firstFieldElementType.IsValueType
-                                    && firstField.Offset.AsInt == 0
-                                    && mdType.HasLayout()
-                                    && ((typeDesc.GetElementSize().AsInt % firstFieldSize) == 0);
+            bool isFixedBuffer = mdType.IsInlineArray;
+
+            if (!isFixedBuffer)
+            {
+                // A fixed buffer type is always a value type that has exactly one value type field at offset 0
+                // and who's size is an exact multiple of the size of the field.
+                // It is possible that we catch a false positive with this check, but that chance is extremely slim
+                // and the user can always change their structure to something more descriptive of what they want
+                // instead of adding additional padding at the end of a one-field structure.
+                // We do this check here to save looking up the FixedBufferAttribute when loading the field
+                // from metadata.
+                isFixedBuffer = numIntroducedFields == 1
+                                && firstFieldElementType.IsValueType
+                                && firstField.Offset.AsInt == 0
+                                && mdType.HasLayout()
+                                && ((typeDesc.GetElementSize().AsInt % firstFieldSize) == 0);
+
+            }
 
             if (isFixedBuffer)
             {

--- a/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Diagnostics;
+using ILCompiler;
 using Internal.TypeSystem;
 
 namespace Internal.JitInterface
@@ -39,26 +40,7 @@ namespace Internal.JitInterface
 
             TypeDesc firstFieldElementType = firstField.FieldType;
             int firstFieldSize = firstFieldElementType.GetElementSize().AsInt;
-
-            // InlineArray types and fixed buffer types have implied repeated fields.
-            bool hasImpliedRepeatedFields = mdType.IsInlineArray;
-
-            if (!hasImpliedRepeatedFields)
-            {
-                // A fixed buffer type is always a value type that has exactly one value type field at offset 0
-                // and who's size is an exact multiple of the size of the field.
-                // It is possible that we catch a false positive with this check, but that chance is extremely slim
-                // and the user can always change their structure to something more descriptive of what they want
-                // instead of adding additional padding at the end of a one-field structure.
-                // We do this check here to save looking up the FixedBufferAttribute when loading the field
-                // from metadata.
-                hasImpliedRepeatedFields = numIntroducedFields == 1
-                                && firstFieldElementType.IsValueType
-                                && firstField.Offset.AsInt == 0
-                                && mdType.HasLayout()
-                                && ((typeDesc.GetElementSize().AsInt % firstFieldSize) == 0);
-
-            }
+            bool hasImpliedRepeatedFields = mdType.HasImpliedRepeatedFields();
 
             if (hasImpliedRepeatedFields)
             {

--- a/src/coreclr/tools/Common/JitInterface/SystemVStructClassificator.cs
+++ b/src/coreclr/tools/Common/JitInterface/SystemVStructClassificator.cs
@@ -255,25 +255,7 @@ namespace Internal.JitInterface
 
             TypeDesc firstFieldElementType = firstField.FieldType;
             int firstFieldSize = firstFieldElementType.GetElementSize().AsInt;
-
-            // InlineArray types and fixed buffer types have implied repeated fields.
-            bool hasImpliedRepeatedFields = mdType.IsInlineArray;
-
-            if (!hasImpliedRepeatedFields)
-            {
-                // A fixed buffer type is always a value type that has exactly one value type field at offset 0
-                // and who's size is an exact multiple of the size of the field.
-                // It is possible that we catch a false positive with this check, but that chance is extremely slim
-                // and the user can always change their structure to something more descriptive of what they want
-                // instead of adding additional padding at the end of a one-field structure.
-                // We do this check here to save looking up the FixedBufferAttribute when loading the field
-                // from metadata.
-                hasImpliedRepeatedFields = numIntroducedFields == 1
-                                && firstFieldElementType.IsValueType
-                                && firstField.Offset.AsInt == 0
-                                && mdType.HasLayout()
-                                && ((typeDesc.GetElementSize().AsInt % firstFieldSize) == 0);
-            }
+            bool hasImpliedRepeatedFields = mdType.HasImpliedRepeatedFields();
 
             if (hasImpliedRepeatedFields)
             {

--- a/src/coreclr/tools/Common/JitInterface/SystemVStructClassificator.cs
+++ b/src/coreclr/tools/Common/JitInterface/SystemVStructClassificator.cs
@@ -256,18 +256,23 @@ namespace Internal.JitInterface
             TypeDesc firstFieldElementType = firstField.FieldType;
             int firstFieldSize = firstFieldElementType.GetElementSize().AsInt;
 
-            // A fixed buffer type is always a value type that has exactly one value type field at offset 0
-            // and who's size is an exact multiple of the size of the field.
-            // It is possible that we catch a false positive with this check, but that chance is extremely slim
-            // and the user can always change their structure to something more descriptive of what they want
-            // instead of adding additional padding at the end of a one-field structure.
-            // We do this check here to save looking up the FixedBufferAttribute when loading the field
-            // from metadata.
-            bool isFixedBuffer = numIntroducedFields == 1
-                                    && firstFieldElementType.IsValueType
-                                    && firstField.Offset.AsInt == 0
-                                    && mdType.HasLayout()
-                                    && ((typeDesc.GetElementSize().AsInt % firstFieldSize) == 0);
+            bool isFixedBuffer = mdType.IsInlineArray;
+
+            if (!isFixedBuffer)
+            {
+                // A fixed buffer type is always a value type that has exactly one value type field at offset 0
+                // and who's size is an exact multiple of the size of the field.
+                // It is possible that we catch a false positive with this check, but that chance is extremely slim
+                // and the user can always change their structure to something more descriptive of what they want
+                // instead of adding additional padding at the end of a one-field structure.
+                // We do this check here to save looking up the FixedBufferAttribute when loading the field
+                // from metadata.
+                isFixedBuffer = numIntroducedFields == 1
+                                && firstFieldElementType.IsValueType
+                                && firstField.Offset.AsInt == 0
+                                && mdType.HasLayout()
+                                && ((typeDesc.GetElementSize().AsInt % firstFieldSize) == 0);
+            }
 
             if (isFixedBuffer)
             {

--- a/src/coreclr/tools/Common/JitInterface/SystemVStructClassificator.cs
+++ b/src/coreclr/tools/Common/JitInterface/SystemVStructClassificator.cs
@@ -231,6 +231,7 @@ namespace Internal.JitInterface
             TypeDesc firstFieldElementType = firstField.FieldType;
             int firstFieldSize = firstFieldElementType.GetElementSize().AsInt;
             bool hasImpliedRepeatedFields = mdType.HasImpliedRepeatedFields();
+            TypeDesc typeDescForFieldSearch = hasImpliedRepeatedFields ? new TypeWithRepeatedFields(mdType) : typeDesc;
 
             if (hasImpliedRepeatedFields)
             {
@@ -238,8 +239,13 @@ namespace Internal.JitInterface
             }
 
             int fieldIndex = 0;
-            foreach (FieldDesc field in typeDesc.GetInstanceFieldsWithImpliedRepeatedFields())
+            foreach (FieldDesc field in typeDescForFieldSearch.GetFields())
             {
+                if (field.IsStatic)
+                {
+                    continue;
+                }
+
                 Debug.Assert(fieldIndex < numIntroducedFields);
 
                 int fieldOffset = field.Offset.AsInt;

--- a/src/coreclr/tools/Common/JitInterface/SystemVStructClassificator.cs
+++ b/src/coreclr/tools/Common/JitInterface/SystemVStructClassificator.cs
@@ -64,31 +64,6 @@ namespace Internal.JitInterface
             public int[]                       FieldOffsets;
         };
 
-        private static class FieldEnumerator
-        {
-            internal static IEnumerable<FieldDesc> GetInstanceFields(TypeDesc typeDesc, bool hasImpliedRepeatedFields, int numIntroducedFields)
-            {
-                foreach (FieldDesc field in typeDesc.GetFields())
-                {
-                    if (field.IsStatic)
-                        continue;
-
-                    if (hasImpliedRepeatedFields)
-                    {
-                        for (int i = 0; i < numIntroducedFields; i++)
-                        {
-                            yield return field;
-                        }
-                        break;
-                    }
-                    else
-                    {
-                        yield return field;
-                    }
-                }
-            }
-        }
-
         public static void GetSystemVAmd64PassStructInRegisterDescriptor(TypeDesc typeDesc, out SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR structPassInRegDescPtr)
         {
             structPassInRegDescPtr = default;
@@ -263,11 +238,11 @@ namespace Internal.JitInterface
             }
 
             int fieldIndex = 0;
-            foreach (FieldDesc field in FieldEnumerator.GetInstanceFields(typeDesc, hasImpliedRepeatedFields, numIntroducedFields))
+            foreach (FieldDesc field in typeDesc.GetInstanceFieldsWithImpliedRepeatedFields())
             {
                 Debug.Assert(fieldIndex < numIntroducedFields);
 
-                int fieldOffset = hasImpliedRepeatedFields ? fieldIndex * firstFieldSize : field.Offset.AsInt;
+                int fieldOffset = field.Offset.AsInt;
                 int normalizedFieldOffset = fieldOffset + startOffsetOfStruct;
 
                 int fieldSize = field.FieldType.GetElementSize().AsInt;

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.FieldLayout.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.FieldLayout.cs
@@ -11,7 +11,7 @@ namespace Internal.TypeSystem
     {
         private LayoutInt _offset = FieldAndOffset.InvalidOffset;
 
-        public LayoutInt Offset
+        public virtual LayoutInt Offset
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.FieldLayout.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.FieldLayout.cs
@@ -11,7 +11,7 @@ namespace Internal.TypeSystem
     {
         private LayoutInt _offset = FieldAndOffset.InvalidOffset;
 
-        public virtual LayoutInt Offset
+        public LayoutInt Offset
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StructMarshallingThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StructMarshallingThunk.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using ILCompiler;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Interop;
 using Debug = System.Diagnostics.Debug;
@@ -139,7 +140,7 @@ namespace Internal.IL.Stubs
             Debug.Assert(_interopStateManager != null);
 
             int numInstanceFields = 0;
-            foreach (var field in ManagedType.GetFields())
+            foreach (var field in ManagedType.GetInstanceFieldsWithImpliedRepeatedFields())
             {
                 if (field.IsStatic)
                     continue;
@@ -160,13 +161,8 @@ namespace Internal.IL.Stubs
 
             int index = 0;
 
-            foreach (FieldDesc field in ManagedType.GetFields())
+            foreach (FieldDesc field in ManagedType.GetInstanceFieldsWithImpliedRepeatedFields())
             {
-                if (field.IsStatic)
-                {
-                    continue;
-                }
-
                 marshallers[index] = Marshaller.CreateMarshaller(field.FieldType,
                                                                     null,   /* parameterIndex */
                                                                     null,   /* customModifierData */
@@ -195,13 +191,8 @@ namespace Internal.IL.Stubs
             IEnumerator<FieldDesc> nativeEnumerator = NativeType.GetFields().GetEnumerator();
 
             int index = 0;
-            foreach (var managedField in ManagedType.GetFields())
+            foreach (var managedField in ManagedType.GetInstanceFieldsWithInlineArrayRepeatedFields())
             {
-                if (managedField.IsStatic)
-                {
-                    continue;
-                }
-
                 bool notEmpty = nativeEnumerator.MoveNext();
                 Debug.Assert(notEmpty);
 
@@ -262,13 +253,8 @@ namespace Internal.IL.Stubs
             ILCodeStream codeStream = pInvokeILCodeStreams.MarshallingCodeStream;
             IEnumerator<FieldDesc> nativeEnumerator = NativeType.GetFields().GetEnumerator();
             int index = 0;
-            foreach (var managedField in ManagedType.GetFields())
+            foreach (var managedField in ManagedType.GetInstanceFieldsWithImpliedRepeatedFields())
             {
-                if (managedField.IsStatic)
-                {
-                    continue;
-                }
-
                 bool notEmpty = nativeEnumerator.MoveNext();
                 Debug.Assert(notEmpty);
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using ILCompiler;
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem.Interop
@@ -199,25 +200,16 @@ namespace Internal.TypeSystem.Interop
             bool isAnsi = ManagedStructType.PInvokeStringFormat == PInvokeStringFormat.AnsiClass;
 
             int numFields = 0;
-            foreach (FieldDesc field in ManagedStructType.GetFields())
+            foreach (FieldDesc field in ManagedStructType.GetInstanceFieldsWithInlineArrayRepeatedFields())
             {
-                if (field.IsStatic)
-                {
-                    continue;
-                }
                 numFields++;
             }
 
             _fields = new NativeStructField[numFields];
 
             int index = 0;
-            foreach (FieldDesc field in ManagedStructType.GetFields())
+            foreach (FieldDesc field in ManagedStructType.GetInstanceFieldsWithInlineArrayRepeatedFields())
             {
-                if (field.IsStatic)
-                {
-                    continue;
-                }
-
                 var managedType = field.FieldType;
 
                 TypeDesc nativeType;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
@@ -36,6 +36,7 @@ namespace ILCompiler
         private readonly VectorOfTFieldLayoutAlgorithm _vectorOfTFieldLayoutAlgorithm;
         private readonly VectorFieldLayoutAlgorithm _vectorFieldLayoutAlgorithm;
         private readonly Int128FieldLayoutAlgorithm _int128FieldLayoutAlgorithm;
+        private readonly TypeWithRepeatedFieldsFieldLayoutAlgorithm _typeWithRepeatedFieldsFieldLayoutAlgorithm;
 
         private TypeDesc[] _arrayOfTInterfaces;
         private ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
@@ -52,6 +53,7 @@ namespace ILCompiler
             _vectorOfTFieldLayoutAlgorithm = new VectorOfTFieldLayoutAlgorithm(_metadataFieldLayoutAlgorithm);
             _vectorFieldLayoutAlgorithm = new VectorFieldLayoutAlgorithm(_metadataFieldLayoutAlgorithm);
             _int128FieldLayoutAlgorithm = new Int128FieldLayoutAlgorithm(_metadataFieldLayoutAlgorithm);
+            _typeWithRepeatedFieldsFieldLayoutAlgorithm = new TypeWithRepeatedFieldsFieldLayoutAlgorithm(_metadataFieldLayoutAlgorithm);
 
             _delegateInfoHashtable = new DelegateInfoHashtable(delegateFeatures);
 
@@ -78,6 +80,8 @@ namespace ILCompiler
                 return _vectorFieldLayoutAlgorithm;
             else if (Int128FieldLayoutAlgorithm.IsIntegerType(type))
                 return _int128FieldLayoutAlgorithm;
+            else if (type is TypeWithRepeatedFields)
+                return _typeWithRepeatedFieldsFieldLayoutAlgorithm;
             else
                 return _metadataFieldLayoutAlgorithm;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -31,6 +31,8 @@
 
   <ItemGroup>
     <Compile Include="..\..\Common\Compiler\ImpliedRepeatedFieldDesc.cs" Link="Compiler\ImpliedRepeatedFieldDesc.cs" />
+    <Compile Include="..\..\Common\Compiler\TypeWithRepeatedFields.cs" Link="Compiler\TypeWithRepeatedFields.cs" />
+    <Compile Include="..\..\Common\Compiler\TypeWithRepeatedFieldsFieldLayoutAlgorithm.cs" Link="Compiler\TypeWithRepeatedFieldsFieldLayoutAlgorithm.cs" />
     <Compile Include="..\..\Common\Compiler\Win32Resources\ResourceData.cs" Link="Compiler\Win32Resources\ResourceData.cs" />
     <Compile Include="..\..\Common\Compiler\Win32Resources\ResourceData.Reader.cs" Link="Compiler\Win32Resources\ResourceData.Reader.cs" />
     <Compile Include="..\..\Common\Compiler\Win32Resources\ResourceData.ResourcesDataModel.cs" Link="Compiler\Win32Resources\ResourceData.ResourcesDataModel.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Common\Compiler\ImpliedRepeatedFieldDesc.cs" Link="Compiler\ImpliedRepeatedFieldDesc.cs" />
     <Compile Include="..\..\Common\Compiler\Win32Resources\ResourceData.cs" Link="Compiler\Win32Resources\ResourceData.cs" />
     <Compile Include="..\..\Common\Compiler\Win32Resources\ResourceData.Reader.cs" Link="Compiler\Win32Resources\ResourceData.Reader.cs" />
     <Compile Include="..\..\Common\Compiler\Win32Resources\ResourceData.ResourcesDataModel.cs" Link="Compiler\Win32Resources\ResourceData.ResourcesDataModel.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -49,6 +49,7 @@ namespace ILCompiler
         private VectorOfTFieldLayoutAlgorithm _vectorOfTFieldLayoutAlgorithm;
         private VectorFieldLayoutAlgorithm _vectorFieldLayoutAlgorithm;
         private Int128FieldLayoutAlgorithm _int128FieldLayoutAlgorithm;
+        private TypeWithRepeatedFieldsFieldLayoutAlgorithm _typeWithRepeatedFieldsFieldLayoutAlgorithm;
         private RuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
 
         public ReadyToRunCompilerContext(
@@ -80,6 +81,8 @@ namespace ILCompiler
             // Int128 and UInt128 should be ABI stable on all currently supported platforms
             _int128FieldLayoutAlgorithm = new Int128FieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);
 
+            _typeWithRepeatedFieldsFieldLayoutAlgorithm = new TypeWithRepeatedFieldsFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);
+
             if (oldTypeSystemContext != null)
             {
                 InheritOpenModules(oldTypeSystemContext);
@@ -107,6 +110,10 @@ namespace ILCompiler
             else if (Int128FieldLayoutAlgorithm.IsIntegerType(type))
             {
                 return _int128FieldLayoutAlgorithm;
+            }
+            else if (type is TypeWithRepeatedFields)
+            {
+                return _typeWithRepeatedFieldsFieldLayoutAlgorithm;
             }
             else
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -33,6 +33,7 @@
   <Import Project="..\..\Common\Compiler\GenericCycleDetection\GenericCycleDetection.projitems" />
 
   <ItemGroup>
+    <Compile Include="..\..\Common\Compiler\ImpliedRepeatedFieldDesc.cs" Link="Compiler\ImpliedRepeatedFieldDesc.cs" />
     <Compile Include="..\..\Common\Internal\Runtime\CorConstants.cs" Link="Common\CorConstants.cs" />
     <Compile Include="..\..\Common\Internal\Runtime\ReadyToRunConstants.cs" Link="Common\ReadyToRunConstants.cs" />
     <Compile Include="..\..\Common\Internal\Runtime\ReadyToRunInstructionSet.cs" Link="Common\ReadyToRunInstructionSet.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -34,6 +34,8 @@
 
   <ItemGroup>
     <Compile Include="..\..\Common\Compiler\ImpliedRepeatedFieldDesc.cs" Link="Compiler\ImpliedRepeatedFieldDesc.cs" />
+    <Compile Include="..\..\Common\Compiler\TypeWithRepeatedFields.cs" Link="Compiler\TypeWithRepeatedFields.cs" />
+    <Compile Include="..\..\Common\Compiler\TypeWithRepeatedFieldsFieldLayoutAlgorithm.cs" Link="Compiler\TypeWithRepeatedFieldsFieldLayoutAlgorithm.cs" />
     <Compile Include="..\..\Common\Internal\Runtime\CorConstants.cs" Link="Common\CorConstants.cs" />
     <Compile Include="..\..\Common\Internal\Runtime\ReadyToRunConstants.cs" Link="Common\ReadyToRunConstants.cs" />
     <Compile Include="..\..\Common\Internal\Runtime\ReadyToRunInstructionSet.cs" Link="Common\ReadyToRunInstructionSet.cs" />

--- a/src/coreclr/vm/classlayoutinfo.cpp
+++ b/src/coreclr/vm/classlayoutinfo.cpp
@@ -978,6 +978,10 @@ EEClassNativeLayoutInfo* EEClassNativeLayoutInfo::CollectNativeLayoutFieldMetada
 
         if (hr != S_FALSE)
         {
+            // Validity of the InlineArray attribute is checked at type-load time,
+            // so we only assert here as we should have already checked this and failed
+            // type load if this condition is false.
+            _ASSERTE(cbVal >= (sizeof(INT32) + 2));
             if (cbVal >= (sizeof(INT32) + 2))
             {
                 INT32 repeat = GET_UNALIGNED_VAL32((byte*)pVal + 2);

--- a/src/coreclr/vm/classlayoutinfo.cpp
+++ b/src/coreclr/vm/classlayoutinfo.cpp
@@ -967,6 +967,27 @@ EEClassNativeLayoutInfo* EEClassNativeLayoutInfo::CollectNativeLayoutFieldMetada
 
         CONSISTENCY_CHECK(hr == S_OK);
     }
+    else if (pMT->GetClass()->IsInlineArray())
+    {
+        // If the type is an inline array, we need to calculate the size based on the number of elements.
+        const void* pVal;                  // The custom value.
+        ULONG       cbVal;                 // Size of the custom value.
+        HRESULT hr = pMT->GetCustomAttribute(
+            WellKnownAttribute::InlineArrayAttribute,
+            &pVal, &cbVal);
+
+        if (hr != S_FALSE)
+        {
+            if (cbVal >= (sizeof(INT32) + 2))
+            {
+                INT32 repeat = GET_UNALIGNED_VAL32((byte*)pVal + 2);
+                if (repeat > 0)
+                {
+                    classSizeInMetadata = repeat * pInfoArray[0].m_nfd.NativeSize();
+                }
+            }
+        }
+    }
 
     BYTE parentAlignmentRequirement = 0;
     if (fParentHasLayout)

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -3881,20 +3881,22 @@ static void CreateStructStub(ILStubState* pss,
     EEClassNativeLayoutInfo const* pNativeLayoutInfo = pMT->GetNativeLayoutInfo();
 
     int numFields = pNativeLayoutInfo->GetNumFields();
-    // Build up marshaling information for each of the method's parameters
-    SIZE_T cbFieldMarshalInfo;
-    if (!ClrSafeInt<SIZE_T>::multiply(sizeof(MarshalInfo), numFields, cbFieldMarshalInfo))
-    {
-        COMPlusThrowHR(COR_E_OVERFLOW);
-    }
 
     CorNativeLinkType nlType = pMT->GetCharSet();
 
     NativeFieldDescriptor const* pFieldDescriptors = pNativeLayoutInfo->GetNativeFieldDescriptors();
 
+    const bool isInlineArray = pMT->GetClass()->IsInlineArray();
+    if (isInlineArray)
+    {
+        _ASSERTE(pNativeLayoutInfo->GetSize() % pFieldDescriptors[0].NativeSize() == 0);
+        numFields = pNativeLayoutInfo->GetSize() / pFieldDescriptors[0].NativeSize();
+    }
+
     for (int i = 0; i < numFields; ++i)
     {
-        NativeFieldDescriptor const& nativeFieldDescriptor = pFieldDescriptors[i];
+        // For inline arrays, we only have one field descriptor that we need to reuse for each field.
+        NativeFieldDescriptor const& nativeFieldDescriptor = isInlineArray ? pFieldDescriptors[0] : pFieldDescriptors[i];
         PTR_FieldDesc pFD = nativeFieldDescriptor.GetFieldDesc();
         SigPointer fieldSig = pFD->GetSigPointer();
         // The first byte in a field signature is always 0x6 per ECMA 335. Skip over this byte to get to the rest of the signature for the MarshalInfo constructor.
@@ -3920,7 +3922,12 @@ static void CreateStructStub(ILStubState* pss,
             DEBUG_ARG(pSigDesc->m_pDebugClassName)
             DEBUG_ARG(-1 /* field */));
 
-        pss->MarshalField(&mlInfo, pFD->GetOffset(), nativeFieldDescriptor.GetExternalOffset(), pFD);
+        // When we have an inline array, we need to calculate the offset based on how many elements we've already seen.
+        // Otherwise, we have a specific field descriptor for the given field that contains the correct offset info.
+        UINT32 managedOffset = isInlineArray ? (i * pFD->GetSize()) : pFD->GetOffset();
+        UINT32 externalOffset = isInlineArray ? (i * nativeFieldDescriptor.NativeSize()) : nativeFieldDescriptor.GetExternalOffset();
+
+        pss->MarshalField(&mlInfo, managedOffset, externalOffset, pFD);
     }
 
     if (pMD->IsDynamicMethod())

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3001,7 +3001,7 @@ bool MethodTable::IsLoongArch64OnlyOneField(MethodTable * pMT)
 
                 // InlineArray types and fixed buffer types have implied repeated fields.
                 // Checking if a type is an InlineArray type is cheap, so we'll do that first.
-                bool hasImpliedRepeatedFields = HasImpliedRepeatedFields(this);
+                bool hasImpliedRepeatedFields = HasImpliedRepeatedFields(pMT);
 
                 if (hasImpliedRepeatedFields)
                 {
@@ -3617,7 +3617,7 @@ bool MethodTable::IsRiscv64OnlyOneField(MethodTable * pMT)
 
                 // InlineArray types and fixed buffer types have implied repeated fields.
                 // Checking if a type is an InlineArray type is cheap, so we'll do that first.
-                bool hasImpliedRepeatedFields = HasImpliedRepeatedFields(this);
+                bool hasImpliedRepeatedFields = HasImpliedRepeatedFields(pMT);
 
                 if (hasImpliedRepeatedFields)
                 {

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -2195,6 +2195,15 @@ namespace
     // Does this type have fields that are implicitly defined through repetition and not explicitly defined in metadata?
     bool HasImpliedRepeatedFields(MethodTable* pMT, MethodTable* pFirstFieldValueType = nullptr)
     {
+        CONTRACTL
+        {
+            THROWS;
+            GC_TRIGGERS;
+            MODE_ANY;
+            PRECONDITION(CheckPointer(pMT));
+        }
+        CONTRACTL_END;
+
         // InlineArray types and fixed buffer types have implied repeated fields.
         // Checking if a type is an InlineArray type is cheap, so we'll do that first.
         if (pMT->GetClass()->IsInlineArray())

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3001,7 +3001,7 @@ bool MethodTable::IsLoongArch64OnlyOneField(MethodTable * pMT)
 
                 // InlineArray types and fixed buffer types have implied repeated fields.
                 // Checking if a type is an InlineArray type is cheap, so we'll do that first.
-                bool hasImpliedRepeatedFields = HasImpliedRepeatedFields(pMT);
+                bool hasImpliedRepeatedFields = HasImpliedRepeatedFields(pMethodTable);
 
                 if (hasImpliedRepeatedFields)
                 {
@@ -3249,7 +3249,7 @@ int MethodTable::GetLoongArch64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cl
 
                 // InlineArray types and fixed buffer types have implied repeated fields.
                 // Checking if a type is an InlineArray type is cheap, so we'll do that first.
-                bool hasImpliedRepeatedFields = HasImpliedRepeatedFields(this);
+                bool hasImpliedRepeatedFields = HasImpliedRepeatedFields(pMethodTable);
 
                 if (hasImpliedRepeatedFields)
                 {
@@ -3617,7 +3617,7 @@ bool MethodTable::IsRiscv64OnlyOneField(MethodTable * pMT)
 
                 // InlineArray types and fixed buffer types have implied repeated fields.
                 // Checking if a type is an InlineArray type is cheap, so we'll do that first.
-                bool hasImpliedRepeatedFields = HasImpliedRepeatedFields(pMT);
+                bool hasImpliedRepeatedFields = HasImpliedRepeatedFields(pMethodTable);
 
                 if (hasImpliedRepeatedFields)
                 {
@@ -3865,7 +3865,7 @@ int MethodTable::GetRiscv64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
 
                 // InlineArray types and fixed buffer types have implied repeated fields.
                 // Checking if a type is an InlineArray type is cheap, so we'll do that first.
-                bool hasImpliedRepeatedFields = HasImpliedRepeatedFields(this);
+                bool hasImpliedRepeatedFields = HasImpliedRepeatedFields(pMethodTable);
 
                 if (hasImpliedRepeatedFields)
                 {

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -2197,9 +2197,7 @@ namespace
     {
         CONTRACTL
         {
-            THROWS;
-            GC_TRIGGERS;
-            MODE_ANY;
+            STANDARD_VM_CHECK;
             PRECONDITION(CheckPointer(pMT));
         }
         CONTRACTL_END;
@@ -2331,13 +2329,7 @@ bool MethodTable::ClassifyEightBytesWithManagedLayout(SystemVStructRegisterPassi
                                                      bool useNativeLayout,
                                                      MethodTable** pByValueClassCache)
 {
-    CONTRACTL
-    {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
+    STANDARD_VM_CONTRACT;
 
     DWORD numIntroducedFields = GetNumIntroducedInstanceFields();
 
@@ -2542,13 +2534,7 @@ bool MethodTable::ClassifyEightBytesWithNativeLayout(SystemVStructRegisterPassin
                                                     unsigned int startOffsetOfStruct,
                                                     EEClassNativeLayoutInfo const* pNativeLayoutInfo)
 {
-    CONTRACTL
-    {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
+    STANDARD_VM_CONTRACT;
 
 #ifdef DACCESS_COMPILE
     // No register classification for this case.

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.cs
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.cs
@@ -330,6 +330,10 @@ public class Managed
     [DllImport("MarshalStructAsParam")]
     static extern bool MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest(FixedArrayClassificationTest str, float f);
     [DllImport("MarshalStructAsParam")]
+    static extern bool MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest(InlineArrayClassificationTest str, float f);
+    [DllImport("MarshalStructAsParam")]
+    static extern bool MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest(InlineArrayWithWrappedIntClassificationTest str, float f);
+    [DllImport("MarshalStructAsParam")]
     static extern bool MarshalStructAsParam_AsSeqByValUnicodeCharArrayClassification(UnicodeCharArrayClassification str, float f);
     [DllImport("MarshalStructAsParam")]
     static extern int GetStringLength(AutoString str);
@@ -688,10 +692,45 @@ public class Managed
                         },
                         f = 56.789f
                     };
+
                     if (!MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest(fixedArrayTest, fixedArrayTest.f))
                     {
                         Console.WriteLine("\tFAILED! Managed to Native failed in MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest. Expected:True;Actual:False");
                         failures++;
+                    }
+
+                    Console.WriteLine("\tCalling MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest with inline array...");
+                    {
+                        InlineArrayClassificationTest inlineArrayTest = new()
+                        {
+                            f = 56.789f
+                        };
+                        inlineArrayTest.arr[0] = 123456;
+                        inlineArrayTest.arr[1] = 78910;
+                        inlineArrayTest.arr[2] = 1234;
+
+                        if (!MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest(inlineArrayTest, inlineArrayTest.f))
+                        {
+                            Console.WriteLine("\tFAILED! Managed to Native failed in MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest. Expected:True;Actual:False");
+                            failures++;
+                        }
+                    }
+
+                    Console.WriteLine("\tCalling MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest with inline array...");
+                    {
+                        InlineArrayWithWrappedIntClassificationTest inlineArrayTest = new()
+                        {
+                            f = 56.789f
+                        };
+                        inlineArrayTest.arr[0] = new(123456);
+                        inlineArrayTest.arr[1] = new(78910);
+                        inlineArrayTest.arr[2] = new(1234);
+
+                        if (!MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest(inlineArrayTest, inlineArrayTest.f))
+                        {
+                            Console.WriteLine("\tFAILED! Managed to Native failed in MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest. Expected:True;Actual:False");
+                            failures++;
+                        }
                     }
                     break;
                 case StructID.UnicodeCharArrayClassificationId:

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.cs
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.cs
@@ -2613,6 +2613,7 @@ public class Managed
         HFA hfa = GetHFA(12.34f, 52.12f, 64.124f, 675.452351322f);
         if (hfa.f1 != 12.34f || hfa.f2 != 52.12f || hfa.f3 != 64.124f || hfa.f4 != 675.452351322f)
         {
+            failures++;
             Console.WriteLine("4-float structure returned from native to managed failed.");
         }
 
@@ -2624,14 +2625,23 @@ public class Managed
             if (multiple != 2 * i)
             {
                 Console.WriteLine("Structure of 20 ints returned from native to managed failed.");
+                failures++;
             }
             i++;
         }
 
         MultipleBool bools = GetBools(true, true);
-        if (!bools.b1 || !bools.b2)
+        if (!bools[0] || !bools[1])
         {
             Console.WriteLine("Structure of two bools marshalled to BOOLs returned from native to managed failed");
+            failures++;
+        }
+
+        bools = GetBools(true, false);
+        if (!bools[0] || bools[1])
+        {
+            Console.WriteLine("Structure of two bools marshalled to BOOLs returned from native to managed failed");
+            failures++;
         }
     }
 

--- a/src/tests/Interop/StructMarshalling/PInvoke/Struct.cs
+++ b/src/tests/Interop/StructMarshalling/PInvoke/Struct.cs
@@ -411,10 +411,10 @@ public struct ManyInts
 
 
 [StructLayout(LayoutKind.Sequential)]
+[InlineArray(2)]
 public struct MultipleBool
 {
-    public bool b1;
-    public bool b2;
+    public bool b;
 }
 
 [StructLayout(LayoutKind.Explicit)]

--- a/src/tests/Interop/StructMarshalling/PInvoke/Struct.cs
+++ b/src/tests/Interop/StructMarshalling/PInvoke/Struct.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 public class Common
@@ -458,6 +459,32 @@ public unsafe struct FixedBufferClassificationTest
     public NonBlittableFloat f;
 }
 
+[StructLayout(LayoutKind.Sequential)]
+public struct InlineArrayClassificationTest
+{
+    [InlineArray(3)]
+    public struct IntArray3
+    {
+        public int i;
+    }
+
+    public IntArray3 arr;
+    public float f;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct InlineArrayWithWrappedIntClassificationTest
+{
+    [InlineArray(3)]
+    public struct IntWrapperArray3
+    {
+        public Int32Wrapper i;
+    }
+
+    public IntWrapperArray3 arr;
+    public float f;
+}
+
 // A non-blittable wrapper for a float value.
 // Used to force a type with a float field to be non-blittable
 // and take a different code path.
@@ -475,9 +502,9 @@ public struct NonBlittableFloat
     public float F => arr[0];
 }
 
-public struct Int32Wrapper
+public struct Int32Wrapper(int i)
 {
-    public int i;
+    public int i = i;
 }
 
 [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
Detect inline arrays and treat them similarly to fixed buffers in ABI register classification.

This fixes a crash where the following type would segfault in CoreCLR on Linux x64 during type load:

```csharp

[StructLayout(LayoutKind.Sequential)]
public struct InlineArrayWithWrappedIntClassificationTest
{
    [InlineArray(3)]
    public struct IntWrapperArray3
    {
        public Int32Wrapper i;
    }

    public IntWrapperArray3 arr;
    public float f;
}

public struct Int32Wrapper(int i)
{
    public int i = i;
}
```

Additionally, this PR also fixes marshalling and native ABI classification of `InlineArray` types with non-blittable fields. Previously, we were not calculating the correct size, ABI classification, or marshalling logic for non-blittable `InlineArray` types.