### PR TITLE
Remove illink test workaround for removed declaring type

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -36,6 +36,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.ReturnWithRequirementsAlwaysThrows ();
 
 			UnsupportedReturnType ();
+			UnsupportedReturnTypeAndParameter (null);
 		}
 
 		static Type NoRequirements ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -32,6 +32,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.PropertyPublicParameterlessConstructorWithExplicitAccessors = null;
 			instance.PropertyPublicConstructorsWithExplicitAccessors = null;
 			instance.PropertyNonPublicConstructorsWithExplicitAccessors = null;
+			_ = PropertyWithUnsupportedType;
 
 			TestAutomaticPropagation ();
 

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -974,16 +974,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 				var actualMember = origin?.Provider as IMemberDefinition;
 				var expectedOriginMember = expectedOriginProvider as IMemberDefinition;
-				if (actualMember?.FullName == expectedOriginMember.FullName)
-					return true;
-
-				// Compensate for cases where for some reason the OM doesn't preserve the declaring types
-				// on certain things after trimming.
-				if (actualMember != null && actualMember?.DeclaringType == null &&
-					actualMember?.Name == expectedOriginMember.Name)
-					return true;
-
-				return false;
+				return actualMember?.FullName == expectedOriginMember.FullName;
 			}
 		}
 


### PR DESCRIPTION
The object model wouldn't preserve declaring typesin these cases because the warnings are produced for members that are removed. Fixing the testcases to preserve these members lets us remove this workaround.