### PR TITLE
Only register System.Diagnostics section on net7 and later

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ImplicitMachineConfigHost.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ImplicitMachineConfigHost.cs
@@ -80,9 +80,11 @@ namespace System.Configuration
         <section name='runtime' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
         <section name='assemblyBinding' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
         <section name='satelliteassemblies' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
-        <section name='startup' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
-        <section name='system.diagnostics' type='System.Diagnostics.SystemDiagnosticsSection, System.Configuration.ConfigurationManager' allowLocation='false' />
-        <section name='system.runtime.remoting' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
+        <section name='startup' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />" +
+#if NET7_0_OR_GREATER
+@"        <section name='system.diagnostics' type='System.Diagnostics.SystemDiagnosticsSection, System.Configuration.ConfigurationManager' allowLocation='false' />" +
+#endif
+@"        <section name='system.runtime.remoting' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
         <section name='windows' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
     </configSections>
     <configProtectedData defaultProvider='RsaProtectedConfigurationProvider'>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/88456

This is the smallest fix that addresses the problem.  We cannot bring back the section and it's types to older frameworks because those depend on API that was added.