### PR TITLE
Flow binder gen diag locations correctly & pick up more bind input patterns

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/ConfigurationBinder.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     return;
                 }
 
-                if (GetOrCreateTypeSpec(type, invocation.Location) is TypeSpec typeSpec)
+                if (GetTargetTypeForRootInvocationCore(type, invocation.Location) is TypeSpec typeSpec)
                 {
                     Dictionary<MethodsToGen_ConfigurationBinder, HashSet<TypeSpec>> types = _sourceGenSpec.TypesForGen_ConfigurationBinder_BindMethods;
 
@@ -120,10 +120,12 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         IInstanceReferenceOperation i => i.Type,
                         ILocalReferenceOperation l => l.Local.Type,
                         IFieldReferenceOperation f => f.Field.Type,
+                        IPropertyReferenceOperation o => o.Type,
                         IMethodReferenceOperation m when m.Method.MethodKind == MethodKind.Constructor => m.Method.ContainingType,
                         IMethodReferenceOperation m => m.Method.ReturnType,
                         IAnonymousFunctionOperation f => f.Symbol.ReturnType,
                         IParameterReferenceOperation p => p.Parameter.Type,
+                        IObjectCreationOperation o => o.Type,
                         _ => null
                     };
             }
@@ -180,11 +182,12 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     }
                 }
 
-                if (GetBindingConfigType(type, invocation.Location) is TypeSpec typeSpec)
+                if (GetTargetTypeForRootInvocation(type, invocation.Location) is TypeSpec typeSpec)
                 {
                     _sourceGenSpec.MethodsToGen_ConfigurationBinder |= overload;
                     RegisterTypeForMethodGen(MethodsToGen_CoreBindingHelper.GetCore, typeSpec);
                 }
+
             }
 
             private void RegisterGetValueInvocation(BinderInvocation invocation)
@@ -248,7 +251,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 }
 
                 if (IsParsableFromString(effectiveType, out _) &&
-                    GetOrCreateTypeSpec(type, invocation.Location) is TypeSpec typeSpec)
+                    GetTargetTypeForRootInvocationCore(type, invocation.Location) is TypeSpec typeSpec)
                 {
                     _sourceGenSpec.MethodsToGen_ConfigurationBinder |= overload;
                     RegisterTypeForMethodGen(MethodsToGen_CoreBindingHelper.GetValueCore, typeSpec);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/OptionsBuilderConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/OptionsBuilderConfigurationExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     return;
                 }
 
-                TypeSpec typeSpec = GetBindingConfigType(
+                TypeSpec typeSpec = GetTargetTypeForRootInvocation(
                     type: targetMethod.TypeArguments[0].WithNullableAnnotation(NullableAnnotation.None),
                     invocation.Location);
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/OptionsConfigurationServiceCollectionExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/OptionsConfigurationServiceCollectionExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     return;
                 }
 
-                TypeSpec typeSpec = GetBindingConfigType(
+                TypeSpec typeSpec = GetTargetTypeForRootInvocation(
                     type: targetMethod.TypeArguments[0].WithNullableAnnotation(NullableAnnotation.None),
                     invocation.Location);
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
@@ -286,7 +286,9 @@ namespace Microsoft.Extensions
             var config = configurationBuilder.Build();
 
             var options = new Dictionary<T, string>();
+#pragma warning disable SYSLIB1104 
             config.GetSection("IntegerKeyDictionary").Bind(options);
+#pragma warning restore SYSLIB1104
 
             Assert.Equal(3, options.Count);
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -4,11 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text.Json;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Xunit;
+using System.Collections.Immutable;
 
 namespace Microsoft.Extensions
 #if BUILDING_SOURCE_GENERATOR_TESTS
@@ -713,6 +714,34 @@ namespace Microsoft.Extensions
         public class GeolocationWrapper
         {
             public Geolocation Location { get; set; }
+        }
+
+        public class GraphWithUnsupportedMember
+        {
+            public JsonWriterOptions WriterOptions { get; set; }
+        }
+
+        public record RemoteAuthenticationOptions<TRemoteAuthenticationProviderOptions> where TRemoteAuthenticationProviderOptions : new()
+        {
+            public TRemoteAuthenticationProviderOptions GenericProp { get; } = new();
+            public OidcProviderOptions NonGenericProp { get; } = new();
+
+            public TRemoteAuthenticationProviderOptions _genericField { get; } = new();
+            public OidcProviderOptions _nonGenericField { get; } = new();
+
+            public static TRemoteAuthenticationProviderOptions StaticGenericProp { get; } = new();
+            public static OidcProviderOptions StaticNonGenericProp { get; } = new();
+
+            public static TRemoteAuthenticationProviderOptions s_GenericField = new();
+            public static OidcProviderOptions s_NonGenericField = new();
+
+            public TRemoteAuthenticationProviderOptions? NullGenericProp { get; }
+            public static OidcProviderOptions? s_NullNonGenericField;
+        }
+
+        public record OidcProviderOptions
+        {
+            public string? Authority { get; set; }
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -9,7 +9,6 @@ using System.Text.Json;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Xunit;
-using System.Collections.Immutable;
 
 namespace Microsoft.Extensions
 #if BUILDING_SOURCE_GENERATOR_TESTS

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -2069,7 +2069,6 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             var configuration = TestHelpers.GetConfigurationFromJsonString("""{ "WriterOptions": { "Indented": "true" } }""");
             var obj = new GraphWithUnsupportedMember();
             configuration.Bind(obj);
-            Assert.True(obj.WriterOptions.Indented);
 
             // Encoder prop not supported; throw if there's config data.
             configuration = TestHelpers.GetConfigurationFromJsonString("""{ "WriterOptions": { "Indented": "true", "Encoder": { "Random": "" } } }""");

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 #if BUILDING_SOURCE_GENERATOR_TESTS
 using Microsoft.Extensions.Configuration;
 #endif
@@ -541,10 +542,12 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             var expectedValue = TypeDescriptor.GetConverter(type).ConvertFromInvariantString(value);
 
             // act
+#pragma warning disable SYSLIB1104
             config.Bind(options);
             var optionsValue = options.GetType().GetProperty("Value").GetValue(options);
             var getValueValue = config.GetValue(type, "Value");
             var getValue = config.GetSection("Value").Get(type);
+#pragma warning restore SYSLIB1104
 
             // assert
             Assert.Equal(expectedValue, optionsValue);
@@ -588,6 +591,7 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             var options = Activator.CreateInstance(optionsType);
 
             // act
+#pragma warning disable SYSLIB1104
             var exception = Assert.Throws<InvalidOperationException>(
                 () => config.Bind(options));
 
@@ -596,6 +600,7 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
 
             var getException = Assert.Throws<InvalidOperationException>(
                 () => config.GetSection("Value").Get(type));
+#pragma warning restore SYSLIB1104
 
             // assert
             Assert.NotNull(exception.InnerException);
@@ -953,8 +958,7 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             configurationBuilder.AddInMemoryCollection(input);
             var config = configurationBuilder.Build();
 
-            var exception = Assert.Throws<InvalidOperationException>(
-                () => config.Bind(new TestOptions()));
+            var exception = Assert.Throws<InvalidOperationException>(() => config.Bind(new TestOptions()));
             Assert.Equal(
                 SR.Format(SR.Error_CannotActivateAbstractOrInterface, typeof(ISomeInterface)),
                 exception.Message);
@@ -1938,7 +1942,9 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
                 """);
 
             StructWithNestedStructs.DeeplyNested obj = new();
+#pragma warning disable SYSLIB1103
             configuration.Bind(obj);
+#pragma warning restore SYSLIB1103
             Assert.Equal(0, obj.Int32);
             Assert.False(obj.Boolean);
         }
@@ -2055,6 +2061,56 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         {
             Assert.Equal(3, location.Latitude);
             Assert.Equal(4, location.Longitude);
+        }
+
+        [Fact]
+        public void TestGraphWithUnsupportedMember()
+        {
+            var configuration = TestHelpers.GetConfigurationFromJsonString("""{ "WriterOptions": { "Indented": "true" } }""");
+            var obj = new GraphWithUnsupportedMember();
+            configuration.Bind(obj);
+            Assert.True(obj.WriterOptions.Indented);
+
+            // Encoder prop not supported; throw if there's config data.
+            configuration = TestHelpers.GetConfigurationFromJsonString("""{ "WriterOptions": { "Indented": "true", "Encoder": { "Random": "" } } }""");
+            Assert.Throws<InvalidOperationException>(() => configuration.Bind(obj));
+        }
+
+        [Fact]
+        public void CanBindToObjectMembers()
+        {
+            var config = TestHelpers.GetConfigurationFromJsonString("""{ "Local": { "Authority": "Auth1" } }""");
+
+            // Regression tests for https://github.com/dotnet/runtime/issues/89273 and https://github.com/dotnet/runtime/issues/89732.
+            TestBind(options => config.Bind("Local", options.GenericProp), obj => obj.GenericProp);
+            TestBind(options => config.GetSection("Local").Bind(options.NonGenericProp), obj => obj.NonGenericProp);
+            TestBind(options => config.GetSection("Local").Bind(options._genericField, _ => { }), obj => obj._genericField);
+            TestBind(options => config.Bind("Local", options._nonGenericField), obj => obj._nonGenericField);
+
+            // Check statics.
+            TestBind(options => config.GetSection("Local").Bind(RemoteAuthenticationOptions<OidcProviderOptions>.StaticGenericProp), obj => RemoteAuthenticationOptions<OidcProviderOptions>.StaticGenericProp);
+            TestBind(options => config.GetSection("Local").Bind(RemoteAuthenticationOptions<OidcProviderOptions>.StaticNonGenericProp, _ => { }), obj => RemoteAuthenticationOptions<OidcProviderOptions>.StaticNonGenericProp);
+            TestBind(options => config.Bind("Local", RemoteAuthenticationOptions<OidcProviderOptions>.s_GenericField), obj => RemoteAuthenticationOptions<OidcProviderOptions>.s_GenericField);
+            TestBind(options => config.GetSection("Local").Bind(RemoteAuthenticationOptions<OidcProviderOptions>.s_NonGenericField), obj => RemoteAuthenticationOptions<OidcProviderOptions>.s_NonGenericField);
+
+            // No null refs.
+            Assert.Throws<ArgumentNullException>(() => config.GetSection("Local").Bind(new RemoteAuthenticationOptions<OidcProviderOptions>().NullGenericProp));
+            Assert.Throws<ArgumentNullException>(() => config.GetSection("Local").Bind(RemoteAuthenticationOptions<OidcProviderOptions>.s_NullNonGenericField));
+
+            static void TestBind(Action<RemoteAuthenticationOptions<OidcProviderOptions>> configure, Func<RemoteAuthenticationOptions<OidcProviderOptions>, OidcProviderOptions> getBindedProp)
+            {
+                var obj = new RemoteAuthenticationOptions<OidcProviderOptions>();
+                configure(obj);
+                Assert.Equal("Auth1", getBindedProp(obj).Authority);
+            }
+        }
+
+        [Fact]
+        public void BinderSupportsObjCreationInput()
+        {
+            var configuration = new ConfigurationBuilder().Build();
+            // No diagnostic warning SYSLIB1104.
+            configuration.Bind(new GraphWithUnsupportedMember());
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -2094,9 +2094,14 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             TestBind(options => config.GetSection("Local").Bind(RemoteAuthenticationOptions<OidcProviderOptions>.s_NonGenericField), obj => RemoteAuthenticationOptions<OidcProviderOptions>.s_NonGenericField);
 
             // No null refs.
+#if BUILDING_SOURCE_GENERATOR_TESTS
+
             Assert.Throws<ArgumentNullException>(() => config.GetSection("Local").Bind(new RemoteAuthenticationOptions<OidcProviderOptions>().NullGenericProp));
             Assert.Throws<ArgumentNullException>(() => config.GetSection("Local").Bind(RemoteAuthenticationOptions<OidcProviderOptions>.s_NullNonGenericField));
-
+#else
+            config.GetSection("Local").Bind(new RemoteAuthenticationOptions<OidcProviderOptions>().NullGenericProp);
+            config.GetSection("Local").Bind(RemoteAuthenticationOptions<OidcProviderOptions>.s_NullNonGenericField);
+#endif
             static void TestBind(Action<RemoteAuthenticationOptions<OidcProviderOptions>> configure, Func<RemoteAuthenticationOptions<OidcProviderOptions>, OidcProviderOptions> getBindedProp)
             {
                 var obj = new RemoteAuthenticationOptions<OidcProviderOptions>();

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -2064,11 +2064,15 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         }
 
         [Fact]
+#if !BUILDING_SOURCE_GENERATOR_TESTS
+        [ActiveIssue("Investigate Build browser-wasm linux Release LibraryTests_EAT CI failure for reflection impl", TestPlatforms.Browser)]
+#endif
         public void TestGraphWithUnsupportedMember()
         {
             var configuration = TestHelpers.GetConfigurationFromJsonString("""{ "WriterOptions": { "Indented": "true" } }""");
             var obj = new GraphWithUnsupportedMember();
             configuration.Bind(obj);
+            Assert.True(obj.WriterOptions.Indented);
 
             // Encoder prop not supported; throw if there's config data.
             configuration = TestHelpers.GetConfigurationFromJsonString("""{ "WriterOptions": { "Indented": "true", "Encoder": { "Random": "" } } }""");

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/ConfigurationBindingGeneratorTests.Baselines.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/ConfigurationBindingGeneratorTests.Baselines.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -607,64 +606,54 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests
         public async Task Collections()
         {
             string source = """
-                        using System.Collections.Generic;
-                        using Microsoft.Extensions.Configuration;
+                using System.Collections.Generic;
+                using Microsoft.Extensions.Configuration;
 
-                        public class Program
-                        {
-                            public static void Main()
-                            {
-                                ConfigurationBuilder configurationBuilder = new();
-                                IConfiguration config = configurationBuilder.Build();
-                                IConfigurationSection section = config.GetSection(""MySection"");
+                public class Program
+                {
+                    public static void Main()
+                    {
+                        ConfigurationBuilder configurationBuilder = new();
+                        IConfiguration config = configurationBuilder.Build();
+                        IConfigurationSection section = config.GetSection(""MySection"");
 
-                                section.Get<MyClassWithCustomCollections>();
-                            }
+                        section.Get<MyClassWithCustomCollections>();
+                    }
 
-                            public class MyClassWithCustomCollections
-                            {
-                                public CustomDictionary<string, int> CustomDictionary { get; set; }
-                                public CustomList CustomList { get; set; }
-                                public ICustomDictionary<string> ICustomDictionary { get; set; }
-                                public ICustomSet<MyClassWithCustomCollections> ICustomCollection { get; set; }
-                                public IReadOnlyList<int> IReadOnlyList { get; set; }
-                                public IReadOnlyDictionary<MyClassWithCustomCollections, int> UnsupportedIReadOnlyDictionaryUnsupported { get; set; }
-                                public IReadOnlyDictionary<string, int> IReadOnlyDictionary { get; set; }
-                            }
+                    public class MyClassWithCustomCollections
+                    {
+                        public CustomDictionary<string, int> CustomDictionary { get; set; }
+                        public CustomList CustomList { get; set; }
+                        public ICustomDictionary<string> ICustomDictionary { get; set; }
+                        public ICustomSet<MyClassWithCustomCollections> ICustomCollection { get; set; }
+                        public IReadOnlyList<int> IReadOnlyList { get; set; }
+                        public IReadOnlyDictionary<MyClassWithCustomCollections, int> UnsupportedIReadOnlyDictionaryUnsupported { get; set; }
+                        public IReadOnlyDictionary<string, int> IReadOnlyDictionary { get; set; }
+                    }
 
-                            public class CustomDictionary<TKey, TValue> : Dictionary<TKey, TValue>
-                            {
-                            }
+                    public class CustomDictionary<TKey, TValue> : Dictionary<TKey, TValue>
+                    {
+                    }
 
-                            public class CustomList : List<string>
-                            {
-                            }
+                    public class CustomList : List<string>
+                    {
+                    }
 
-                            public interface ICustomDictionary<T> : IDictionary<T, string>
-                            {
-                            }
+                    public interface ICustomDictionary<T> : IDictionary<T, string>
+                    {
+                    }
 
-                            public interface ICustomSet<T> : ISet<T>
-                            {
-                            }
-                        }
-                        """;
+                    public interface ICustomSet<T> : ISet<T>
+                    {
+                    }
+                }
+                """;
 
             await VerifyAgainstBaselineUsingFile("Collections.generated.txt", source, assessDiagnostics: (d) =>
             {
-                Assert.Equal(6, d.Length);
-                Test(d.Where(diagnostic => diagnostic.Id is "SYSLIB1100"), "Did not generate binding logic for a type");
-                Test(d.Where(diagnostic => diagnostic.Id is "SYSLIB1101"), "Did not generate binding logic for a property on a type");
-
-                static void Test(IEnumerable<Diagnostic> d, string expectedTitle)
-                {
-                    Assert.Equal(3, d.Count());
-                    foreach (Diagnostic diagnostic in d)
-                    {
-                        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
-                        Assert.Contains(expectedTitle, diagnostic.Descriptor.Title.ToString(CultureInfo.InvariantCulture));
-                    }
-                }
+                Console.WriteLine((d.Where(diag => diag.Id == Diagnostics.TypeNotSupported.Id).Count() , d.Where(diag => diag.Id == Diagnostics.PropertyNotSupported.Id).Count()));
+                Assert.Equal(3, d.Where(diag => diag.Id == Diagnostics.TypeNotSupported.Id).Count());
+                Assert.Equal(6, d.Where(diag => diag.Id == Diagnostics.PropertyNotSupported.Id).Count());
             });
         }
     }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <!-- Type not supported; property on type not suppported; value types invalid for bind; generator could not parse target type -->
-    <NoWarn>SYSLIB1100,SYSLIB1101,SYSLIB1103,SYSLIB1104</NoWarn>
+    <!-- Type not supported; property on type not suppported -->
+    <NoWarn>SYSLIB1100,SYSLIB1101</NoWarn>
     <!-- The SDK disables the configuration binding generator by default no matter how it was referenced, so we need to enable it here for testing. -->
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>
@@ -44,9 +44,9 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Content Include="Baselines\*.generated.txt;
-             Baselines\ConfigurationBinder\*.generated.txt;
-             Baselines\OptionsBuilder\*.generated.txt;
-             Baselines\ServiceCollection\*.generated.txt">
+                      Baselines\ConfigurationBinder\*.generated.txt;
+                      Baselines\OptionsBuilder\*.generated.txt;
+                      Baselines\ServiceCollection\*.generated.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatterOptions.cs
@@ -21,6 +21,9 @@ namespace Microsoft.Extensions.Logging.Console
         /// </summary>
         public JsonWriterOptions JsonWriterOptions { get; set; }
 
+#pragma warning disable SYSLIB1100
+#pragma warning disable SYSLIB1101
         internal override void Configure(IConfiguration configuration) => configuration.Bind(this);
+#pragma warning restore
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
@@ -8,8 +8,6 @@
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
     <IsPackable>true</IsPackable>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
-    <!-- M.E.Configuration.Binder.SourceGeneration: JavaScriptEncoder not supported; no logic generated which is okay. Remove this when https://github.com/dotnet/runtime/issues/88865 is fixed.  -->
-    <NoWarn>$(NoWarn);SYSLIB1100</NoWarn>
     <PackageDescription>Console logger provider implementation for Microsoft.Extensions.Logging.</PackageDescription>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/88865.
Fixes https://github.com/dotnet/runtime/issues/89273.
Fixes https://github.com/dotnet/runtime/issues/89732.
Closes https://github.com/dotnet/runtime/issues/86653 (adds test).