### PR TITLE
Fix hits for new analyzer CA1862

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSASignatureDeformatter.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSASignatureDeformatter.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography
 
         public override void SetHashAlgorithm(string strName)
         {
-            if (strName.ToUpperInvariant() != HashAlgorithmNames.SHA1)
+            if (!strName.Equals(HashAlgorithmNames.SHA1, StringComparison.InvariantCultureIgnoreCase))
             {
                 // To match desktop, throw here
                 throw new CryptographicUnexpectedOperationException(SR.Cryptography_InvalidOperation);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSASignatureFormatter.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSASignatureFormatter.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography
 
         public override void SetHashAlgorithm(string strName)
         {
-            if (strName.ToUpperInvariant() != HashAlgorithmNames.SHA1)
+            if (!strName.Equals(HashAlgorithmNames.SHA1, StringComparison.InvariantCultureIgnoreCase))
             {
                 // To match desktop, throw here
                 throw new CryptographicUnexpectedOperationException(SR.Cryptography_InvalidOperation);


### PR DESCRIPTION
Added the ability to diagnose equality comparisons like `string.ToLower() == string.ToLower()`.

https://github.com/dotnet/roslyn-analyzers/pull/6720