### PR TITLE
`IUnknown` is also valid for call to `DllGetClassObject`

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
@@ -123,7 +123,8 @@ namespace Internal.Runtime.InteropServices
                 throw new NotSupportedException(SR.NotSupported_COM);
             }
 
-            if (cxt.InterfaceId != typeof(IClassFactory).GUID
+            if (cxt.InterfaceId != Marshal.IID_IUnknown
+                && cxt.InterfaceId != typeof(IClassFactory).GUID
                 && cxt.InterfaceId != typeof(IClassFactory2).GUID)
             {
                 throw new NotSupportedException();


### PR DESCRIPTION
Fixes #85715