### PR TITLE
Fix new hits for analyzer CA2249

### DIFF
--- a/src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs
@@ -279,7 +279,7 @@ namespace System.Net
             // If we are already logged in and the server returns 530 then
             // the server does not support re-issuing a USER command,
             // tear down the connection and start all over again
-            if (entry.Command.IndexOf("USER", StringComparison.Ordinal) != -1)
+            if (entry.Command.Contains("USER"))
             {
                 // The server may not require a password for this user, so bypass the password command
                 if (status == FtpStatusCode.LoggedInProceed)
@@ -302,7 +302,7 @@ namespace System.Net
             }
 
             if (_loginState != FtpLoginState.LoggedIn
-                && entry.Command.IndexOf("PASS", StringComparison.Ordinal) != -1)
+                && entry.Command.Contains("PASS"))
             {
                 // Note the fact that we logged in
                 if (status == FtpStatusCode.NeedLoginAccount || status == FtpStatusCode.LoggedInProceed)
@@ -428,7 +428,7 @@ namespace System.Net
             else
             {
                 // We only use CWD to reset ourselves back to the login directory.
-                if (entry.Command.IndexOf("CWD", StringComparison.Ordinal) != -1)
+                if (entry.Command.Contains("CWD"))
                 {
                     _establishedServerDirectory = _requestedServerDirectory;
                 }

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -450,7 +450,7 @@ namespace System.Net
                 //
                 // if not check if the user is trying to set chunked:
                 //
-                fChunked = (value.IndexOf(ChunkedHeader, StringComparison.OrdinalIgnoreCase) != -1);
+                fChunked = (value.Contains(ChunkedHeader, StringComparison.OrdinalIgnoreCase));
 
                 //
                 // prevent them from adding chunked, or from adding an Encoding without
@@ -587,8 +587,8 @@ namespace System.Net
                     return;
                 }
 
-                fKeepAlive = (value.IndexOf("keep-alive", StringComparison.OrdinalIgnoreCase) != -1);
-                fClose = (value.IndexOf("close", StringComparison.OrdinalIgnoreCase) != -1);
+                fKeepAlive = (value.Contains("keep-alive", StringComparison.OrdinalIgnoreCase));
+                fClose = (value.Contains("close", StringComparison.OrdinalIgnoreCase));
 
                 //
                 // Prevent keep-alive and close from being added
@@ -642,7 +642,7 @@ namespace System.Net
                 // Prevent 100-continues from being added
                 //
 
-                fContinue100 = (value.IndexOf(ContinueHeader, StringComparison.OrdinalIgnoreCase) != -1);
+                fContinue100 = (value.Contains(ContinueHeader, StringComparison.OrdinalIgnoreCase));
 
                 if (fContinue100)
                 {

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
@@ -1309,7 +1309,7 @@ namespace System.Xml
             {
                 // string.Empty is a valid uri but not "   "
                 s = TrimString(s);
-                if (s.Length == 0 || s.IndexOf("##", StringComparison.Ordinal) != -1)
+                if (s.Length == 0 || s.Contains("##"))
                 {
                     throw new FormatException(SR.Format(SR.XmlConvert_BadFormat, s, "Uri"));
                 }
@@ -1331,7 +1331,7 @@ namespace System.Xml
             if (s != null && s.Length > 0)
             { //string.Empty is a valid uri but not "   "
                 s = TrimString(s);
-                if (s.Length == 0 || s.IndexOf("##", StringComparison.Ordinal) != -1)
+                if (s.Length == 0 || s.Contains("##"))
                 {
                     return new FormatException(SR.Format(SR.XmlConvert_BadFormat, s, "Uri"));
                 }


### PR DESCRIPTION
Already enabled in dotnet/runtime: https://github.com/dotnet/runtime/blob/08acbb7ad7154e9d18227e4b00e4c9f41af1fffa/eng/CodeAnalysis.src.globalconfig#L635

A new case was added here: https://github.com/dotnet/roslyn-analyzers/pull/6774

cc @dotnet/ncl and @dotnet/area-system-xml , this PR touches code in both your areas.