### PR TITLE
Ensure that `EqualsAny(x & y, Zero)` uses the right `GenCondition`

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -2119,6 +2119,7 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
                         if (cmpOp == GT_EQ)
                         {
                             testIntrinsicId = NI_AVX512F_PTESTNM;
+                            cmpCnd          = GenCondition::NE;
                         }
 
                         node->Op(1) = op1Intrinsic->Op(1);

--- a/src/tests/JIT/HardwareIntrinsics/General/HwiOp/CompareVectorWithZero.cs
+++ b/src/tests/JIT/HardwareIntrinsics/General/HwiOp/CompareVectorWithZero.cs
@@ -10,52 +10,326 @@ public class CompareVectorWithZero
 {
     [ActiveIssue("https://github.com/dotnet/runtime/pull/65632#issuecomment-1046294324", TestRuntimes.Mono)]
     [Fact]
-    public static void AllTests()
+    public static void TestVector64Equality()
     {
-        Test(Vector128.Create(0));
-        Test(Vector128.Create(0.0f));
-        Test(Vector128.Create(-0.0f));
-        Test(Vector128.Create(0.0));
-        Test(Vector128.Create(-0.0));
-        
-        TestReversed(Vector128.Create(0));
-        TestReversed(Vector128.Create(0.0f));
-        TestReversed(Vector128.Create(-0.0f));
-        TestReversed(Vector128.Create(0.0));
-        TestReversed(Vector128.Create(-0.0));
+        TestEquality(Vector64.Create(0));
+        TestEquality(Vector64.Create(0.0f));
+        TestEquality(Vector64.Create(-0.0f));
+        TestEquality(Vector64.Create(0.0));
+        TestEquality(Vector64.Create(-0.0));
 
-        Test(Vector128.Create(-10));
-        Test(Vector128.Create(10));
-        Test(Vector128.Create((sbyte)-10));
-        Test(Vector128.Create((ushort)10));
-        Test(Vector64.Create(0));
-        Test(Vector64.Create(0.0f));
-        Test(Vector64.Create(-0.0f));
-        Test(Vector64.Create(0.0));
-        Test(Vector64.Create(-0.0));
-        Test(Vector64.Create(-10));
-        Test(Vector64.Create(10));
-        Test(Vector64.Create((sbyte)-10));
-        Test(Vector64.Create((ushort)10));
-        Test(Vector128.Create(0, 0, 0, 0, 0, 0, 0, 1));
-        Test(Vector128.Create(0, 0, 0, 0, 0, 0, 0, -1));
-        Test(Vector64.Create(0, 0, 0, 0, 0, 0, 0, 1));
-        Test(Vector64.Create(0, 0, 0, 0, 0, 0, 0, -1));
+        TestEqualityUsingReversedInputs(Vector64.Create(0));
+        TestEqualityUsingReversedInputs(Vector64.Create(0.0f));
+        TestEqualityUsingReversedInputs(Vector64.Create(-0.0f));
+        TestEqualityUsingReversedInputs(Vector64.Create(0.0));
+        TestEqualityUsingReversedInputs(Vector64.Create(-0.0));
 
-        Test(Vector128.Create(0, 0, 0, 0, 0, 0, 1, 0));
-        Test(Vector128.Create(0, 0, 0, 0, 0, 0, 1, 0));
-        Test(Vector64.Create(0, 0, 0, 0, 0, 0, -1, 0));
-        Test(Vector64.Create(0, 0, 0, 0, 0, 0, -1, 0));
+        TestEquality(Vector64.Create(-10));
+        TestEquality(Vector64.Create(10));
+        TestEquality(Vector64.Create((sbyte)-10));
+        TestEquality(Vector64.Create((ushort)10));
+        TestEquality(Vector64.Create(0, 0, 0, 0, 0, 0, 0, 1));
+        TestEquality(Vector64.Create(0, 0, 0, 0, 0, 0, 0, -1));
 
-        Test(Vector128.Create(0, 0, 0, 1, 0, 0, 0, 1));
-        Test(Vector128.Create(0, 0, 0, -1, 0, 0, 0, -1));
-        Test(Vector64.Create(0, 0, 0, 1, 0, 0, 0, 1));
-        Test(Vector64.Create(0, 0, 0, -1, 0, 0, 0, -1));
+        TestEqualityUsingAnd(Vector64.Create(0), Vector64.Create(0));
+        TestEqualityUsingAnd(Vector64.Create(0.0f), Vector64.Create(0.0f));
+        TestEqualityUsingAnd(Vector64.Create(-0.0f), Vector64.Create(-0.0f));
+        TestEqualityUsingAnd(Vector64.Create(0.0), Vector64.Create(0.0));
+        TestEqualityUsingAnd(Vector64.Create(-0.0), Vector64.Create(-0.0));
 
-        TestReversed(Vector128.Create(0, 0, 0, 1, 0, 0, 0, 1));
-        TestReversed(Vector128.Create(0, 0, 0, -1, 0, 0, 0, -1));
-        TestReversed(Vector64.Create(0, 0, 0, 1, 0, 0, 0, 1));
-        TestReversed(Vector64.Create(0, 0, 0, -1, 0, 0, 0, -1));
+        TestEqualityUsingAndNot(Vector64.Create(0), Vector64.Create(0));
+        TestEqualityUsingAndNot(Vector64.Create(0.0f), Vector64.Create(0.0f));
+        TestEqualityUsingAndNot(Vector64.Create(-0.0f), Vector64.Create(-0.0f));
+        TestEqualityUsingAndNot(Vector64.Create(0.0), Vector64.Create(0.0));
+        TestEqualityUsingAndNot(Vector64.Create(-0.0), Vector64.Create(-0.0));
+
+        TestEquality(Vector64.Create(0, 0, 0, 0, 0, 0, -1, 0));
+        TestEquality(Vector64.Create(0, 0, 0, 0, 0, 0, -1, 0));
+
+        TestEquality(Vector64.Create(0, 0, 0, 1, 0, 0, 0, 1));
+        TestEquality(Vector64.Create(0, 0, 0, -1, 0, 0, 0, -1));
+
+        TestEqualityUsingReversedInputs(Vector64.Create(0, 0, 0, 1, 0, 0, 0, 1));
+        TestEqualityUsingReversedInputs(Vector64.Create(0, 0, 0, -1, 0, 0, 0, -1));
+    }
+
+    [ActiveIssue("https://github.com/dotnet/runtime/pull/65632#issuecomment-1046294324", TestRuntimes.Mono)]
+    [Fact]
+    public static void TestVector128Equality()
+    {
+        TestEquality(Vector128.Create(0));
+        TestEquality(Vector128.Create(0.0f));
+        TestEquality(Vector128.Create(-0.0f));
+        TestEquality(Vector128.Create(0.0));
+        TestEquality(Vector128.Create(-0.0));
+
+        TestEqualityUsingReversedInputs(Vector128.Create(0));
+        TestEqualityUsingReversedInputs(Vector128.Create(0.0f));
+        TestEqualityUsingReversedInputs(Vector128.Create(-0.0f));
+        TestEqualityUsingReversedInputs(Vector128.Create(0.0));
+        TestEqualityUsingReversedInputs(Vector128.Create(-0.0));
+
+        TestEquality(Vector128.Create(-10));
+        TestEquality(Vector128.Create(10));
+        TestEquality(Vector128.Create((sbyte)-10));
+        TestEquality(Vector128.Create((ushort)10));
+        TestEquality(Vector128.Create(0, 0, 0, 0, 0, 0, 0, 1));
+        TestEquality(Vector128.Create(0, 0, 0, 0, 0, 0, 0, -1));
+
+        TestEqualityUsingAnd(Vector128.Create(0), Vector128.Create(0));
+        TestEqualityUsingAnd(Vector128.Create(0.0f), Vector128.Create(0.0f));
+        TestEqualityUsingAnd(Vector128.Create(-0.0f), Vector128.Create(-0.0f));
+        TestEqualityUsingAnd(Vector128.Create(0.0), Vector128.Create(0.0));
+        TestEqualityUsingAnd(Vector128.Create(-0.0), Vector128.Create(-0.0));
+
+        TestEqualityUsingAndNot(Vector128.Create(0), Vector128.Create(0));
+        TestEqualityUsingAndNot(Vector128.Create(0.0f), Vector128.Create(0.0f));
+        TestEqualityUsingAndNot(Vector128.Create(-0.0f), Vector128.Create(-0.0f));
+        TestEqualityUsingAndNot(Vector128.Create(0.0), Vector128.Create(0.0));
+        TestEqualityUsingAndNot(Vector128.Create(-0.0), Vector128.Create(-0.0));
+
+        TestEquality(Vector128.Create(0, 0, 0, 0, 0, 0, 1, 0));
+        TestEquality(Vector128.Create(0, 0, 0, 0, 0, 0, 1, 0));
+
+        TestEquality(Vector128.Create(0, 0, 0, 1, 0, 0, 0, 1));
+        TestEquality(Vector128.Create(0, 0, 0, -1, 0, 0, 0, -1));
+
+        TestEqualityUsingReversedInputs(Vector128.Create(0, 0, 0, 1, 0, 0, 0, 1));
+        TestEqualityUsingReversedInputs(Vector128.Create(0, 0, 0, -1, 0, 0, 0, -1));
+    }
+
+    [ActiveIssue("https://github.com/dotnet/runtime/pull/65632#issuecomment-1046294324", TestRuntimes.Mono)]
+    [Fact]
+    public static void TestVector256Equality()
+    {
+        TestEquality(Vector256.Create(0));
+        TestEquality(Vector256.Create(0.0f));
+        TestEquality(Vector256.Create(-0.0f));
+        TestEquality(Vector256.Create(0.0));
+        TestEquality(Vector256.Create(-0.0));
+
+        TestEqualityUsingReversedInputs(Vector256.Create(0));
+        TestEqualityUsingReversedInputs(Vector256.Create(0.0f));
+        TestEqualityUsingReversedInputs(Vector256.Create(-0.0f));
+        TestEqualityUsingReversedInputs(Vector256.Create(0.0));
+        TestEqualityUsingReversedInputs(Vector256.Create(-0.0));
+
+        TestEquality(Vector256.Create(-10));
+        TestEquality(Vector256.Create(10));
+        TestEquality(Vector256.Create((sbyte)-10));
+        TestEquality(Vector256.Create((ushort)10));
+        TestEquality(Vector256.Create(0, 0, 0, 0, 0, 0, 0, 1));
+        TestEquality(Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1));
+
+        TestEqualityUsingAnd(Vector256.Create(0), Vector256.Create(0));
+        TestEqualityUsingAnd(Vector256.Create(0.0f), Vector256.Create(0.0f));
+        TestEqualityUsingAnd(Vector256.Create(-0.0f), Vector256.Create(-0.0f));
+        TestEqualityUsingAnd(Vector256.Create(0.0), Vector256.Create(0.0));
+        TestEqualityUsingAnd(Vector256.Create(-0.0), Vector256.Create(-0.0));
+
+        TestEqualityUsingAndNot(Vector256.Create(0), Vector256.Create(0));
+        TestEqualityUsingAndNot(Vector256.Create(0.0f), Vector256.Create(0.0f));
+        TestEqualityUsingAndNot(Vector256.Create(-0.0f), Vector256.Create(-0.0f));
+        TestEqualityUsingAndNot(Vector256.Create(0.0), Vector256.Create(0.0));
+        TestEqualityUsingAndNot(Vector256.Create(-0.0), Vector256.Create(-0.0));
+    }
+
+    [ActiveIssue("https://github.com/dotnet/runtime/pull/65632#issuecomment-1046294324", TestRuntimes.Mono)]
+    [Fact]
+    public static void TestVector512Equality()
+    {
+        TestEquality(Vector512.Create(0));
+        TestEquality(Vector512.Create(0.0f));
+        TestEquality(Vector512.Create(-0.0f));
+        TestEquality(Vector512.Create(0.0));
+        TestEquality(Vector512.Create(-0.0));
+
+        TestEqualityUsingReversedInputs(Vector512.Create(0));
+        TestEqualityUsingReversedInputs(Vector512.Create(0.0f));
+        TestEqualityUsingReversedInputs(Vector512.Create(-0.0f));
+        TestEqualityUsingReversedInputs(Vector512.Create(0.0));
+        TestEqualityUsingReversedInputs(Vector512.Create(-0.0));
+
+        TestEquality(Vector512.Create(-10));
+        TestEquality(Vector512.Create(10));
+        TestEquality(Vector512.Create((sbyte)-10));
+        TestEquality(Vector512.Create((ushort)10));
+        TestEquality(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 1));
+        TestEquality(Vector512.Create(0, 0, 0, 0, 0, 0, 0, -1));
+
+        TestEqualityUsingAnd(Vector512.Create(0), Vector512.Create(0));
+        TestEqualityUsingAnd(Vector512.Create(0.0f), Vector512.Create(0.0f));
+        TestEqualityUsingAnd(Vector512.Create(-0.0f), Vector512.Create(-0.0f));
+        TestEqualityUsingAnd(Vector512.Create(0.0), Vector512.Create(0.0));
+        TestEqualityUsingAnd(Vector512.Create(-0.0), Vector512.Create(-0.0));
+
+        TestEqualityUsingAndNot(Vector512.Create(0), Vector512.Create(0));
+        TestEqualityUsingAndNot(Vector512.Create(0.0f), Vector512.Create(0.0f));
+        TestEqualityUsingAndNot(Vector512.Create(-0.0f), Vector512.Create(-0.0f));
+        TestEqualityUsingAndNot(Vector512.Create(0.0), Vector512.Create(0.0));
+        TestEqualityUsingAndNot(Vector512.Create(-0.0), Vector512.Create(-0.0));
+    }
+
+    [ActiveIssue("https://github.com/dotnet/runtime/pull/65632#issuecomment-1046294324", TestRuntimes.Mono)]
+    [Fact]
+    public static void TestVector64Inequality()
+    {
+        TestInequality(Vector64.Create(0));
+        TestInequality(Vector64.Create(0.0f));
+        TestInequality(Vector64.Create(-0.0f));
+        TestInequality(Vector64.Create(0.0));
+        TestInequality(Vector64.Create(-0.0));
+
+        TestInequalityUsingReversedInputs(Vector64.Create(0));
+        TestInequalityUsingReversedInputs(Vector64.Create(0.0f));
+        TestInequalityUsingReversedInputs(Vector64.Create(-0.0f));
+        TestInequalityUsingReversedInputs(Vector64.Create(0.0));
+        TestInequalityUsingReversedInputs(Vector64.Create(-0.0));
+
+        TestInequality(Vector64.Create(-10));
+        TestInequality(Vector64.Create(10));
+        TestInequality(Vector64.Create((sbyte)-10));
+        TestInequality(Vector64.Create((ushort)10));
+        TestInequality(Vector64.Create(0, 0, 0, 0, 0, 0, 0, 1));
+        TestInequality(Vector64.Create(0, 0, 0, 0, 0, 0, 0, -1));
+
+        TestInequalityUsingAnd(Vector64.Create(0), Vector64.Create(0));
+        TestInequalityUsingAnd(Vector64.Create(0.0f), Vector64.Create(0.0f));
+        TestInequalityUsingAnd(Vector64.Create(-0.0f), Vector64.Create(-0.0f));
+        TestInequalityUsingAnd(Vector64.Create(0.0), Vector64.Create(0.0));
+        TestInequalityUsingAnd(Vector64.Create(-0.0), Vector64.Create(-0.0));
+
+        TestInequalityUsingAndNot(Vector64.Create(0), Vector64.Create(0));
+        TestInequalityUsingAndNot(Vector64.Create(0.0f), Vector64.Create(0.0f));
+        TestInequalityUsingAndNot(Vector64.Create(-0.0f), Vector64.Create(-0.0f));
+        TestInequalityUsingAndNot(Vector64.Create(0.0), Vector64.Create(0.0));
+        TestInequalityUsingAndNot(Vector64.Create(-0.0), Vector64.Create(-0.0));
+
+        TestInequality(Vector64.Create(0, 0, 0, 0, 0, 0, -1, 0));
+        TestInequality(Vector64.Create(0, 0, 0, 0, 0, 0, -1, 0));
+
+        TestInequality(Vector64.Create(0, 0, 0, 1, 0, 0, 0, 1));
+        TestInequality(Vector64.Create(0, 0, 0, -1, 0, 0, 0, -1));
+
+        TestInequalityUsingReversedInputs(Vector64.Create(0, 0, 0, 1, 0, 0, 0, 1));
+        TestInequalityUsingReversedInputs(Vector64.Create(0, 0, 0, -1, 0, 0, 0, -1));
+    }
+
+    [ActiveIssue("https://github.com/dotnet/runtime/pull/65632#issuecomment-1046294324", TestRuntimes.Mono)]
+    [Fact]
+    public static void TestVector128Inequality()
+    {
+        TestInequality(Vector128.Create(0));
+        TestInequality(Vector128.Create(0.0f));
+        TestInequality(Vector128.Create(-0.0f));
+        TestInequality(Vector128.Create(0.0));
+        TestInequality(Vector128.Create(-0.0));
+
+        TestInequalityUsingReversedInputs(Vector128.Create(0));
+        TestInequalityUsingReversedInputs(Vector128.Create(0.0f));
+        TestInequalityUsingReversedInputs(Vector128.Create(-0.0f));
+        TestInequalityUsingReversedInputs(Vector128.Create(0.0));
+        TestInequalityUsingReversedInputs(Vector128.Create(-0.0));
+
+        TestInequality(Vector128.Create(-10));
+        TestInequality(Vector128.Create(10));
+        TestInequality(Vector128.Create((sbyte)-10));
+        TestInequality(Vector128.Create((ushort)10));
+        TestInequality(Vector128.Create(0, 0, 0, 0, 0, 0, 0, 1));
+        TestInequality(Vector128.Create(0, 0, 0, 0, 0, 0, 0, -1));
+
+        TestInequalityUsingAnd(Vector128.Create(0), Vector128.Create(0));
+        TestInequalityUsingAnd(Vector128.Create(0.0f), Vector128.Create(0.0f));
+        TestInequalityUsingAnd(Vector128.Create(-0.0f), Vector128.Create(-0.0f));
+        TestInequalityUsingAnd(Vector128.Create(0.0), Vector128.Create(0.0));
+        TestInequalityUsingAnd(Vector128.Create(-0.0), Vector128.Create(-0.0));
+
+        TestInequalityUsingAndNot(Vector128.Create(0), Vector128.Create(0));
+        TestInequalityUsingAndNot(Vector128.Create(0.0f), Vector128.Create(0.0f));
+        TestInequalityUsingAndNot(Vector128.Create(-0.0f), Vector128.Create(-0.0f));
+        TestInequalityUsingAndNot(Vector128.Create(0.0), Vector128.Create(0.0));
+        TestInequalityUsingAndNot(Vector128.Create(-0.0), Vector128.Create(-0.0));
+
+        TestInequality(Vector128.Create(0, 0, 0, 0, 0, 0, 1, 0));
+        TestInequality(Vector128.Create(0, 0, 0, 0, 0, 0, 1, 0));
+
+        TestInequality(Vector128.Create(0, 0, 0, 1, 0, 0, 0, 1));
+        TestInequality(Vector128.Create(0, 0, 0, -1, 0, 0, 0, -1));
+
+        TestInequalityUsingReversedInputs(Vector128.Create(0, 0, 0, 1, 0, 0, 0, 1));
+        TestInequalityUsingReversedInputs(Vector128.Create(0, 0, 0, -1, 0, 0, 0, -1));
+    }
+
+    [ActiveIssue("https://github.com/dotnet/runtime/pull/65632#issuecomment-1046294324", TestRuntimes.Mono)]
+    [Fact]
+    public static void TestVector256Inequality()
+    {
+        TestInequality(Vector256.Create(0));
+        TestInequality(Vector256.Create(0.0f));
+        TestInequality(Vector256.Create(-0.0f));
+        TestInequality(Vector256.Create(0.0));
+        TestInequality(Vector256.Create(-0.0));
+
+        TestInequalityUsingReversedInputs(Vector256.Create(0));
+        TestInequalityUsingReversedInputs(Vector256.Create(0.0f));
+        TestInequalityUsingReversedInputs(Vector256.Create(-0.0f));
+        TestInequalityUsingReversedInputs(Vector256.Create(0.0));
+        TestInequalityUsingReversedInputs(Vector256.Create(-0.0));
+
+        TestInequality(Vector256.Create(-10));
+        TestInequality(Vector256.Create(10));
+        TestInequality(Vector256.Create((sbyte)-10));
+        TestInequality(Vector256.Create((ushort)10));
+        TestInequality(Vector256.Create(0, 0, 0, 0, 0, 0, 0, 1));
+        TestInequality(Vector256.Create(0, 0, 0, 0, 0, 0, 0, -1));
+
+        TestInequalityUsingAnd(Vector256.Create(0), Vector256.Create(0));
+        TestInequalityUsingAnd(Vector256.Create(0.0f), Vector256.Create(0.0f));
+        TestInequalityUsingAnd(Vector256.Create(-0.0f), Vector256.Create(-0.0f));
+        TestInequalityUsingAnd(Vector256.Create(0.0), Vector256.Create(0.0));
+        TestInequalityUsingAnd(Vector256.Create(-0.0), Vector256.Create(-0.0));
+
+        TestInequalityUsingAndNot(Vector256.Create(0), Vector256.Create(0));
+        TestInequalityUsingAndNot(Vector256.Create(0.0f), Vector256.Create(0.0f));
+        TestInequalityUsingAndNot(Vector256.Create(-0.0f), Vector256.Create(-0.0f));
+        TestInequalityUsingAndNot(Vector256.Create(0.0), Vector256.Create(0.0));
+        TestInequalityUsingAndNot(Vector256.Create(-0.0), Vector256.Create(-0.0));
+    }
+
+    [ActiveIssue("https://github.com/dotnet/runtime/pull/65632#issuecomment-1046294324", TestRuntimes.Mono)]
+    [Fact]
+    public static void TestVector512Inequality()
+    {
+        TestInequality(Vector512.Create(0));
+        TestInequality(Vector512.Create(0.0f));
+        TestInequality(Vector512.Create(-0.0f));
+        TestInequality(Vector512.Create(0.0));
+        TestInequality(Vector512.Create(-0.0));
+
+        TestInequalityUsingReversedInputs(Vector512.Create(0));
+        TestInequalityUsingReversedInputs(Vector512.Create(0.0f));
+        TestInequalityUsingReversedInputs(Vector512.Create(-0.0f));
+        TestInequalityUsingReversedInputs(Vector512.Create(0.0));
+        TestInequalityUsingReversedInputs(Vector512.Create(-0.0));
+
+        TestInequality(Vector512.Create(-10));
+        TestInequality(Vector512.Create(10));
+        TestInequality(Vector512.Create((sbyte)-10));
+        TestInequality(Vector512.Create((ushort)10));
+        TestInequality(Vector512.Create(0, 0, 0, 0, 0, 0, 0, 1));
+        TestInequality(Vector512.Create(0, 0, 0, 0, 0, 0, 0, -1));
+
+        TestInequalityUsingAnd(Vector512.Create(0), Vector512.Create(0));
+        TestInequalityUsingAnd(Vector512.Create(0.0f), Vector512.Create(0.0f));
+        TestInequalityUsingAnd(Vector512.Create(-0.0f), Vector512.Create(-0.0f));
+        TestInequalityUsingAnd(Vector512.Create(0.0), Vector512.Create(0.0));
+        TestInequalityUsingAnd(Vector512.Create(-0.0), Vector512.Create(-0.0));
+
+        TestInequalityUsingAndNot(Vector512.Create(0), Vector512.Create(0));
+        TestInequalityUsingAndNot(Vector512.Create(0.0f), Vector512.Create(0.0f));
+        TestInequalityUsingAndNot(Vector512.Create(-0.0f), Vector512.Create(-0.0f));
+        TestInequalityUsingAndNot(Vector512.Create(0.0), Vector512.Create(0.0));
+        TestInequalityUsingAndNot(Vector512.Create(-0.0), Vector512.Create(-0.0));
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -69,22 +343,162 @@ public class CompareVectorWithZero
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static void Test<T>(Vector128<T> v) where T : unmanaged =>
-        AssertTrue((v == Vector128<T>.Zero) == 
-                   (v == Vector128.Create(ToVar(default(T)))));
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    static void Test<T>(Vector64<T> v) where T : unmanaged =>
-        AssertTrue((v == Vector64<T>.Zero) == 
+    static void TestEquality<T>(Vector64<T> v) where T : unmanaged =>
+        AssertTrue((v == Vector64<T>.Zero) ==
                    (v == Vector64.Create(ToVar(default(T)))));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static void TestReversed<T>(Vector128<T> v) where T : unmanaged =>
-        AssertTrue((Vector128<T>.Zero == v) == 
+    static void TestEquality<T>(Vector128<T> v) where T : unmanaged =>
+        AssertTrue((v == Vector128<T>.Zero) ==
                    (v == Vector128.Create(ToVar(default(T)))));
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static void TestReversed<T>(Vector64<T> v) where T : unmanaged =>
-        AssertTrue((Vector64<T>.Zero == v) == 
+    static void TestEquality<T>(Vector256<T> v) where T : unmanaged =>
+        AssertTrue((v == Vector256<T>.Zero) ==
+                   (v == Vector256.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEquality<T>(Vector512<T> v) where T : unmanaged =>
+        AssertTrue((v == Vector512<T>.Zero) ==
+                   (v == Vector512.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEqualityUsingAnd<T>(Vector64<T> v1, Vector64<T> v2) where T : unmanaged =>
+        AssertTrue(((v1 & v2) == Vector64<T>.Zero) ==
+                   ((v1 & v2) == Vector64.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEqualityUsingAnd<T>(Vector128<T> v1,Vector128<T> v2) where T : unmanaged =>
+        AssertTrue(((v1 & v2) == Vector128<T>.Zero) ==
+                   ((v1 & v2) == Vector128.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEqualityUsingAnd<T>(Vector256<T> v1, Vector256<T> v2) where T : unmanaged =>
+        AssertTrue(((v1 & v2) == Vector256<T>.Zero) ==
+                   ((v1 & v2) == Vector256.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEqualityUsingAnd<T>(Vector512<T> v1, Vector512<T> v2) where T : unmanaged =>
+        AssertTrue(((v1 & v2) == Vector512<T>.Zero) ==
+                   ((v1 & v2) == Vector512.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEqualityUsingAndNot<T>(Vector64<T> v1, Vector64<T> v2) where T : unmanaged =>
+        AssertTrue((Vector64.AndNot(v1, v2) == Vector64<T>.Zero) ==
+                   (Vector64.AndNot(v1, v2) == Vector64.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEqualityUsingAndNot<T>(Vector128<T> v1,Vector128<T> v2) where T : unmanaged =>
+        AssertTrue((Vector128.AndNot(v1, v2) == Vector128<T>.Zero) ==
+                   (Vector128.AndNot(v1, v2) == Vector128.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEqualityUsingAndNot<T>(Vector256<T> v1, Vector256<T> v2) where T : unmanaged =>
+        AssertTrue((Vector256.AndNot(v1, v2) == Vector256<T>.Zero) ==
+                   (Vector256.AndNot(v1, v2) == Vector256.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEqualityUsingAndNot<T>(Vector512<T> v1, Vector512<T> v2) where T : unmanaged =>
+        AssertTrue((Vector512.AndNot(v1, v2) == Vector512<T>.Zero) ==
+                   (Vector512.AndNot(v1, v2) == Vector512.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEqualityUsingReversedInputs<T>(Vector64<T> v) where T : unmanaged =>
+        AssertTrue((Vector64<T>.Zero == v) ==
                    (v == Vector64.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEqualityUsingReversedInputs<T>(Vector128<T> v) where T : unmanaged =>
+        AssertTrue((Vector128<T>.Zero == v) ==
+                   (v == Vector128.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEqualityUsingReversedInputs<T>(Vector256<T> v) where T : unmanaged =>
+        AssertTrue((Vector256<T>.Zero == v) ==
+                   (v == Vector256.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestEqualityUsingReversedInputs<T>(Vector512<T> v) where T : unmanaged =>
+        AssertTrue((Vector512<T>.Zero == v) ==
+                   (v == Vector512.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequality<T>(Vector64<T> v) where T : unmanaged =>
+        AssertTrue((v != Vector64<T>.Zero) ==
+                   (v != Vector64.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequality<T>(Vector128<T> v) where T : unmanaged =>
+        AssertTrue((v != Vector128<T>.Zero) ==
+                   (v != Vector128.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequality<T>(Vector256<T> v) where T : unmanaged =>
+        AssertTrue((v != Vector256<T>.Zero) ==
+                   (v != Vector256.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequality<T>(Vector512<T> v) where T : unmanaged =>
+        AssertTrue((v != Vector512<T>.Zero) ==
+                   (v != Vector512.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequalityUsingAnd<T>(Vector64<T> v1, Vector64<T> v2) where T : unmanaged =>
+        AssertTrue(((v1 & v2) != Vector64<T>.Zero) ==
+                   ((v1 & v2) != Vector64.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequalityUsingAnd<T>(Vector128<T> v1,Vector128<T> v2) where T : unmanaged =>
+        AssertTrue(((v1 & v2) != Vector128<T>.Zero) ==
+                   ((v1 & v2) != Vector128.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequalityUsingAnd<T>(Vector256<T> v1, Vector256<T> v2) where T : unmanaged =>
+        AssertTrue(((v1 & v2) != Vector256<T>.Zero) ==
+                   ((v1 & v2) != Vector256.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequalityUsingAnd<T>(Vector512<T> v1, Vector512<T> v2) where T : unmanaged =>
+        AssertTrue(((v1 & v2) != Vector512<T>.Zero) ==
+                   ((v1 & v2) != Vector512.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequalityUsingAndNot<T>(Vector64<T> v1, Vector64<T> v2) where T : unmanaged =>
+        AssertTrue((Vector64.AndNot(v1, v2) != Vector64<T>.Zero) ==
+                   (Vector64.AndNot(v1, v2) != Vector64.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequalityUsingAndNot<T>(Vector128<T> v1,Vector128<T> v2) where T : unmanaged =>
+        AssertTrue((Vector128.AndNot(v1, v2) != Vector128<T>.Zero) ==
+                   (Vector128.AndNot(v1, v2) != Vector128.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequalityUsingAndNot<T>(Vector256<T> v1, Vector256<T> v2) where T : unmanaged =>
+        AssertTrue((Vector256.AndNot(v1, v2) != Vector256<T>.Zero) ==
+                   (Vector256.AndNot(v1, v2) != Vector256.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequalityUsingAndNot<T>(Vector512<T> v1, Vector512<T> v2) where T : unmanaged =>
+        AssertTrue((Vector512.AndNot(v1, v2) != Vector512<T>.Zero) ==
+                   (Vector512.AndNot(v1, v2) != Vector512.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequalityUsingReversedInputs<T>(Vector64<T> v) where T : unmanaged =>
+        AssertTrue((Vector64<T>.Zero != v) ==
+                   (v != Vector64.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequalityUsingReversedInputs<T>(Vector128<T> v) where T : unmanaged =>
+        AssertTrue((Vector128<T>.Zero != v) ==
+                   (v != Vector128.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequalityUsingReversedInputs<T>(Vector256<T> v) where T : unmanaged =>
+        AssertTrue((Vector256<T>.Zero != v) ==
+                   (v != Vector256.Create(ToVar(default(T)))));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestInequalityUsingReversedInputs<T>(Vector512<T> v) where T : unmanaged =>
+        AssertTrue((Vector512<T>.Zero != v) ==
+                   (v != Vector512.Create(ToVar(default(T)))));
 }

--- a/src/tests/JIT/HardwareIntrinsics/General/HwiOp/CompareVectorWithZero_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/HwiOp/CompareVectorWithZero_r.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>Embedded</DebugType>
+    <Optimize />
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="CompareVectorWithZero.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/HardwareIntrinsics/General/HwiOp/CompareVectorWithZero_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/General/HwiOp/CompareVectorWithZero_ro.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <DebugType>Embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildProjectName).cs" />
+    <Compile Include="CompareVectorWithZero.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We were missing test coverage for Vector256/Vector512 from the tests meant to cover this. 1 line JIT change with many lines of tests