### PR TITLE
[wasm-mt] Enable System.Xml.Tests.TC_SchemaSet_XmlResolver tests

### DIFF
--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
@@ -54,7 +54,6 @@ namespace System.Xml.XmlSchemaTests
 
         //[Variation(Desc = "v4 - schema(Local)->schema(Local)", Priority = 1)]
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/75183", TestPlatforms.Browser)]
         public void v4()
         {
             using (new AllowDefaultResolverContext())
@@ -70,7 +69,6 @@ namespace System.Xml.XmlSchemaTests
 
         //[Variation(Desc = "v5 - schema(Local)->schema(Local)->schema(Local)", Priority = 1)]
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/75183", TestPlatforms.Browser)]
         public void v5()
         {
             using (new AllowDefaultResolverContext())


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/75183 (enables tests).

```
[09:23:53] info: [2023-07-27T09:23:53.416Z] [PASS] System.Xml.XmlSchemaTests.TC_SchemaSet_XmlResolver.v3
[09:23:53] info: [2023-07-27T09:23:53.420Z] [PASS] System.Xml.XmlSchemaTests.TC_SchemaSet_XmlResolver.v4
[09:23:53] info: [2023-07-27T09:23:53.423Z] [PASS] System.Xml.XmlSchemaTests.TC_SchemaSet_XmlResolver.v5
[09:23:53] info: [2023-07-27T09:23:53.425Z] [PASS] System.Xml.XmlSchemaTests.TC_SchemaSet_XmlResolver.v1
[09:23:53] info: [2023-07-27T09:23:53.427Z] [PASS] System.Xml.XmlSchemaTests.TC_SchemaSet_XmlResolver.v2
[09:23:53] info: [2023-07-27T09:23:53.430Z] [PASS] System.Xml.XmlSchemaTests.TC_SchemaSet_XmlResolver.v6
```