### PR TITLE
[mono] Fix second pass of MarshallingPInvokeScanner with metadata-free DLLs

### DIFF
--- a/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
+++ b/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
@@ -81,6 +81,9 @@ namespace MonoTargetsTasks
 
             using FileStream file = new FileStream(assyPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using PEReader peReader = new PEReader(file);
+            if (!peReader.HasMetadata)
+                return; // Just return. There are no metadata in the DLL to help us with remaining types.
+
             MetadataReader mdtReader = peReader.GetMetadataReader();
 
             SignatureDecoder<Compatibility, object> decoder = new(mmtcp, mdtReader, null!);
@@ -107,9 +110,8 @@ namespace MonoTargetsTasks
             using FileStream file = new FileStream(assyPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using PEReader peReader = new PEReader(file);
             if (!peReader.HasMetadata)
-            {
-                return false;
-            }
+                return false; // No types in this DLL means no incompatible marshaling constructs.
+
             MetadataReader mdtReader = peReader.GetMetadataReader();
 
             foreach(CustomAttributeHandle attrHandle in mdtReader.CustomAttributes)

--- a/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
+++ b/src/tasks/MonoTargetsTasks/MarshalingPInvokeScanner/MarshalingPInvokeScanner.cs
@@ -74,17 +74,16 @@ namespace MonoTargetsTasks
 
         private void ResolveInconclusiveTypes(HashSet<string> incompatible, string assyPath, MinimalMarshalingTypeCompatibilityProvider mmtcp)
         {
-            string assyName = MetadataReader.GetAssemblyName(assyPath).Name!;
-            HashSet<string> inconclusiveTypes = mmtcp.GetInconclusiveTypesForAssembly(assyName);
-            if(inconclusiveTypes.Count == 0)
-                return;
-
             using FileStream file = new FileStream(assyPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using PEReader peReader = new PEReader(file);
             if (!peReader.HasMetadata)
                 return; // Just return. There are no metadata in the DLL to help us with remaining types.
 
             MetadataReader mdtReader = peReader.GetMetadataReader();
+            string assyName = mdtReader.GetString(mdtReader.GetAssemblyDefinition().Name);
+            HashSet<string> inconclusiveTypes = mmtcp.GetInconclusiveTypesForAssembly(assyName);
+            if(inconclusiveTypes.Count == 0)
+                return;
 
             SignatureDecoder<Compatibility, object> decoder = new(mmtcp, mdtReader, null!);
 


### PR DESCRIPTION
This fixes the second pass of https://github.com/dotnet/runtime/issues/89429 when trying to read DLLs that have no metadata. The first pass was addressed in https://github.com/dotnet/runtime/pull/89430. 