### PR TITLE
[browser] dispose more JS proxies

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -233,7 +233,7 @@ namespace System.Net.Http
 
                 cancellationToken.ThrowIfCancellationRequested();
                 JSObject fetchResponse = await BrowserHttpInterop.CancelationHelper(promise, cancellationToken, abortController, null).ConfigureAwait(true);
-                return new WasmFetchResponse(fetchResponse, abortRegistration.Value);
+                return new WasmFetchResponse(fetchResponse, abortController, abortRegistration.Value);
             }
             catch (Exception)
             {
@@ -314,15 +314,17 @@ namespace System.Net.Http
         public readonly object ThisLock = new object();
 #endif
         public JSObject? FetchResponse;
+        private readonly JSObject _abortController;
         private readonly CancellationTokenRegistration _abortRegistration;
         private bool _isDisposed;
 
-        public WasmFetchResponse(JSObject fetchResponse, CancellationTokenRegistration abortRegistration)
+        public WasmFetchResponse(JSObject fetchResponse, JSObject abortController, CancellationTokenRegistration abortRegistration)
         {
             ArgumentNullException.ThrowIfNull(fetchResponse);
 
             FetchResponse = fetchResponse;
             _abortRegistration = abortRegistration;
+            _abortController = abortController;
         }
 
         public void ThrowIfDisposed()
@@ -351,6 +353,7 @@ namespace System.Net.Http
                         return;
                     self._isDisposed = true;
                     self._abortRegistration.Dispose();
+                    self._abortController.Dispose();
                     if (!self.FetchResponse!.IsDisposed)
                     {
                         BrowserHttpInterop.AbortResponse(self.FetchResponse);
@@ -363,6 +366,7 @@ namespace System.Net.Http
 #else
             _isDisposed = true;
             _abortRegistration.Dispose();
+            _abortController.Dispose();
             if (FetchResponse != null)
             {
                 if (!FetchResponse.IsDisposed)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -321,6 +321,7 @@ namespace System.Net.Http
         public WasmFetchResponse(JSObject fetchResponse, JSObject abortController, CancellationTokenRegistration abortRegistration)
         {
             ArgumentNullException.ThrowIfNull(fetchResponse);
+            ArgumentNullException.ThrowIfNull(abortController);
 
             FetchResponse = fetchResponse;
             _abortRegistration = abortRegistration;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -239,6 +239,7 @@ namespace System.Net.Http
             {
                 // this would also trigger abort
                 abortRegistration?.Dispose();
+                abortController?.Dispose();
                 throw;
             }
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -615,6 +615,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser is relaxed about validating HTTP headers")]
         public async Task FailedRequests_ConnectionClosedWhileReceivingHeaders_Recorded()
         {
             using CancellationTokenSource cancelServerCts = new CancellationTokenSource();

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSException.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSException.cs
@@ -13,6 +13,7 @@ namespace System.Runtime.InteropServices.JavaScript
     public sealed class JSException : Exception
     {
         internal JSObject? jsException;
+        internal string? combinedStackTrace;
 
         /// <summary>
         /// Initializes a new instance of the JSException class with a specified error message.
@@ -21,11 +22,13 @@ namespace System.Runtime.InteropServices.JavaScript
         public JSException(string msg) : base(msg)
         {
             jsException = null;
+            combinedStackTrace = null;
         }
 
         internal JSException(string msg, JSObject? jsException) : base(msg)
         {
             this.jsException = jsException;
+            this.combinedStackTrace = null;
         }
 
         /// <inheritdoc />
@@ -33,6 +36,10 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             get
             {
+                if (combinedStackTrace != null)
+                {
+                    return combinedStackTrace;
+                }
                 var bs = base.StackTrace;
                 if (jsException == null)
                 {
@@ -42,16 +49,19 @@ namespace System.Runtime.InteropServices.JavaScript
 #if FEATURE_WASM_THREADS
                 if (jsException.OwnerThreadId != Thread.CurrentThread.ManagedThreadId)
                 {
-                    return null;
+                    return bs;
                 }
 #endif
                 string? jsStackTrace = jsException.GetPropertyAsString("stack");
+
+                // after this, we don't need jsException proxy anymore
+                jsException.Dispose();
+                jsException = null;
+
                 if (jsStackTrace == null)
                 {
-                    if (bs == null)
-                    {
-                        return null;
-                    }
+                    combinedStackTrace = bs;
+                    return combinedStackTrace;
                 }
                 else if (jsStackTrace.StartsWith(Message + "\n"))
                 {
@@ -62,11 +72,15 @@ namespace System.Runtime.InteropServices.JavaScript
 
                 if (bs == null)
                 {
-                    return jsStackTrace;
+                    combinedStackTrace = jsStackTrace;
                 }
-                return base.StackTrace + "\r\n" + jsStackTrace;
-            }
 
+                combinedStackTrace = bs != null
+                    ? bs + Environment.NewLine + jsStackTrace
+                    : jsStackTrace;
+
+                return combinedStackTrace;
+            }
         }
 
         /// <inheritdoc />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -559,9 +559,7 @@
     <SmokeTestProject Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
     -->
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\System.Net.WebSockets.Client.Tests.csproj" />
-    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/88084
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
-    -->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -559,7 +559,9 @@
     <SmokeTestProject Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
     -->
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\System.Net.WebSockets.Client.Tests.csproj" />
+    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/88084
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
+    -->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/runtime/globals.ts
+++ b/src/mono/wasm/runtime/globals.ts
@@ -5,7 +5,6 @@
 /// <reference path="./types/v8.d.ts" />
 /// <reference path="./types/node.d.ts" />
 
-import { mono_log_error } from "./logging";
 import { RuntimeAPI } from "./types/index";
 import type { GlobalObjects, EmscriptenInternals, RuntimeHelpers, LoaderHelpers, DotnetModuleInternal, PromiseAndController } from "./types/internal";
 
@@ -87,11 +86,6 @@ export function mono_assert(condition: unknown, messageFactory: string | (() => 
     const message = "Assert failed: " + (typeof messageFactory === "function"
         ? messageFactory()
         : messageFactory);
-    const abort = runtimeHelpers.mono_wasm_abort;
     const error = new Error(message);
-    if (abort) {
-        mono_log_error(message, error);
-        abort();
-    }
-    throw error;
+    runtimeHelpers.abort(error);
 }

--- a/src/mono/wasm/runtime/globals.ts
+++ b/src/mono/wasm/runtime/globals.ts
@@ -88,9 +88,10 @@ export function mono_assert(condition: unknown, messageFactory: string | (() => 
         ? messageFactory()
         : messageFactory);
     const abort = runtimeHelpers.mono_wasm_abort;
+    const error = new Error(message);
     if (abort) {
-        mono_log_error(message);
+        mono_log_error(message, error);
         abort();
     }
-    throw new Error(message);
+    throw error;
 }

--- a/src/mono/wasm/runtime/loader/globals.ts
+++ b/src/mono/wasm/runtime/loader/globals.ts
@@ -8,7 +8,7 @@ import type { MonoConfig, RuntimeAPI } from "../types";
 import { assert_runtime_running, is_exited, is_runtime_running, mono_exit } from "./exit";
 import { assertIsControllablePromise, createPromiseController, getPromiseController } from "./promise-controller";
 import { mono_download_assets, resolve_asset_path } from "./assets";
-import { mono_log_error, setup_proxy_console } from "./logging";
+import { setup_proxy_console } from "./logging";
 import { hasDebuggingEnabled } from "./blazor/_Polyfill";
 import { invokeLibraryInitializers } from "./libraryInitializers";
 
@@ -17,20 +17,20 @@ export const ENVIRONMENT_IS_WEB = typeof window == "object";
 export const ENVIRONMENT_IS_WORKER = typeof importScripts == "function";
 export const ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
 
-export let runtimeHelpers: RuntimeHelpers = null as any;
-export let loaderHelpers: LoaderHelpers = null as any;
-export let exportedRuntimeAPI: RuntimeAPI = null as any;
-export let INTERNAL: any;
+export let runtimeHelpers: RuntimeHelpers = {} as any;
+export let loaderHelpers: LoaderHelpers = {} as any;
+export let exportedRuntimeAPI: RuntimeAPI = {} as any;
+export let INTERNAL: any = {};
 export let _loaderModuleLoaded = false; // please keep it in place also as rollup guard
 
 export const globalObjectsRoot: GlobalObjects = {
     mono: {},
     binding: {},
-    internal: {},
+    internal: INTERNAL,
     module: {},
-    loaderHelpers: {},
-    runtimeHelpers: {},
-    api: {}
+    loaderHelpers,
+    runtimeHelpers,
+    api: exportedRuntimeAPI,
 } as any;
 
 setLoaderGlobals(globalObjectsRoot);
@@ -59,7 +59,8 @@ export function setLoaderGlobals(
         mono_wasm_bindings_is_ready: false,
         javaScriptExports: {} as any,
         config: globalObjects.module.config,
-        diagnosticTracing: false
+        diagnosticTracing: false,
+        abort: (reason: any) => { throw reason; },
     });
     Object.assign(loaderHelpers, {
         config: globalObjects.module.config,
@@ -111,10 +112,6 @@ export function mono_assert(condition: unknown, messageFactory: string | (() => 
     const message = "Assert failed: " + (typeof messageFactory === "function"
         ? messageFactory()
         : messageFactory);
-    const abort = globalObjectsRoot.runtimeHelpers.mono_wasm_abort;
-    if (abort) {
-        mono_log_error(message);
-        abort();
-    }
-    throw new Error(message);
+    const error = new Error(message);
+    runtimeHelpers.abort(error);
 }

--- a/src/mono/wasm/runtime/marshal-to-js.ts
+++ b/src/mono/wasm/runtime/marshal-to-js.ts
@@ -197,8 +197,10 @@ function _marshal_delegate_to_js(arg: JSMarshalerArgument, _?: MarshalerType, re
             return runtimeHelpers.javaScriptExports.call_delegate(gc_handle, arg1_js, arg2_js, arg3_js, res_converter, arg1_converter, arg2_converter, arg3_converter);
         };
         result.dispose = () => {
-            teardown_managed_proxy(result, gc_handle);
-            result.isDisposed = true;
+            if (!result.isDisposed) {
+                teardown_managed_proxy(result, gc_handle);
+                result.isDisposed = true;
+            }
         };
         result.isDisposed = false;
         if (BuildConfiguration === "Debug") {

--- a/src/mono/wasm/runtime/marshal-to-js.ts
+++ b/src/mono/wasm/runtime/marshal-to-js.ts
@@ -5,7 +5,7 @@ import MonoWasmThreads from "consts:monoWasmThreads";
 import BuildConfiguration from "consts:configuration";
 
 import cwraps from "./cwraps";
-import { _lookup_js_owned_object, mono_wasm_get_jsobj_from_js_handle, mono_wasm_get_js_handle, setup_managed_proxy } from "./gc-handles";
+import { _lookup_js_owned_object, mono_wasm_get_jsobj_from_js_handle, mono_wasm_get_js_handle, setup_managed_proxy, teardown_managed_proxy } from "./gc-handles";
 import { Module, createPromiseController, loaderHelpers, mono_assert, runtimeHelpers } from "./globals";
 import {
     ManagedObject, ManagedError,
@@ -197,6 +197,7 @@ function _marshal_delegate_to_js(arg: JSMarshalerArgument, _?: MarshalerType, re
             return runtimeHelpers.javaScriptExports.call_delegate(gc_handle, arg1_js, arg2_js, arg3_js, res_converter, arg1_converter, arg2_converter, arg3_converter);
         };
         result.dispose = () => {
+            teardown_managed_proxy(result, gc_handle);
             result.isDisposed = true;
         };
         result.isDisposed = false;

--- a/src/mono/wasm/runtime/marshal-to-js.ts
+++ b/src/mono/wasm/runtime/marshal-to-js.ts
@@ -198,8 +198,8 @@ function _marshal_delegate_to_js(arg: JSMarshalerArgument, _?: MarshalerType, re
         };
         result.dispose = () => {
             if (!result.isDisposed) {
-                teardown_managed_proxy(result, gc_handle);
                 result.isDisposed = true;
+                teardown_managed_proxy(result, gc_handle);
             }
         };
         result.isDisposed = false;

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -344,7 +344,12 @@ function mono_wasm_pre_init_essential(isWorker: boolean): void {
 
     init_c_exports();
     runtimeHelpers.mono_wasm_exit = cwraps.mono_wasm_exit;
-    runtimeHelpers.mono_wasm_abort = cwraps.mono_wasm_abort;
+    runtimeHelpers.abort = (reason: any) => {
+        if (!loaderHelpers.is_exited()) {
+            cwraps.mono_wasm_abort();
+        }
+        throw reason;
+    };
     cwraps_internal(INTERNAL);
     if (WasmEnableLegacyJsInterop && !linkerDisableLegacyJsInterop) {
         cwraps_mono_api(MONO);

--- a/src/mono/wasm/runtime/types/internal.ts
+++ b/src/mono/wasm/runtime/types/internal.ts
@@ -174,7 +174,7 @@ export type RuntimeHelpers = {
     ExitStatus: ExitStatusError;
     quit: Function,
     mono_wasm_exit?: (code: number) => void,
-    mono_wasm_abort?: () => void,
+    abort: (reason: any) => void,
     javaScriptExports: JavaScriptExports,
     storeMemorySnapshotPending: boolean,
     memorySnapshotCacheKey: string,

--- a/src/mono/wasm/runtime/web-socket.ts
+++ b/src/mono/wasm/runtime/web-socket.ts
@@ -94,8 +94,9 @@ export function ws_wasm_create(uri: string, sub_protocols: string[] | null, rece
     const local_on_error = (ev: any) => {
         if (ws[wasm_ws_is_aborted]) return;
         ws.removeEventListener("message", local_on_message);
-
-        reject_promises(ws, new Error(ev.message || "WebSocket error"));
+        const error = new Error(ev.message || "WebSocket error");
+        mono_log_warn("WebSocket error", error);
+        reject_promises(ws, error);
     };
     ws.addEventListener("message", local_on_message);
     ws.addEventListener("open", local_on_open, { once: true });


### PR DESCRIPTION
- explicitly dispose HTTP `AbortController`
- dispose `JSException` proxy as soon as it was evaluated
- fix `dispose()` for JS proxy of a delegate
- dispose `onClose` delegate in WS
- disable `FailedRequests_ConnectionClosedWhileReceivingHeaders_Recorded` test because of timeouts
- make `mono_assert` to print stack trace
- reorder `UninstallWebWorkerInterop` so that JS could still call the proxies disposal.
