### PR TITLE
JIT: Set some limits in gtSplitTree stress testing

### DIFF
--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1438,7 +1438,7 @@ public:
 
             if (nodeInfo.IsLclVarWrite())
             {
-                // If this node is a lclVar write, it must be not alias a lclVar with an outstanding read
+                // If this node is a lclVar write, it must not alias a lclVar with an outstanding read
                 SmallHashTable<GenTree*, GenTree*>* reads;
                 if (unusedLclVarReads.TryGetValue(nodeInfo.LclNum(), &reads))
                 {


### PR DESCRIPTION
These limits are hit only by the CseTest and ManyFields tests over all our SPMI collections.

Fix #88028