### PR TITLE
[mono][android] Always include marshal-ilgen

### DIFF
--- a/src/mono/msbuild/android/build/AndroidBuild.targets
+++ b/src/mono/msbuild/android/build/AndroidBuild.targets
@@ -41,8 +41,14 @@
       <_MonoHeaderPath>$([MSBuild]::NormalizeDirectory($(MicrosoftNetCoreAppRuntimePackRidNativeDir), 'include', 'mono-2.0'))</_MonoHeaderPath>
     </PropertyGroup>
 
-    <PropertyGroup>
-      <RuntimeComponents Condition="'$(RuntimeComponents)' == ''" >marshal-ilgen</RuntimeComponents>
+    <!-- Make sure marshal-ilgen is included in the components list. -->
+    <ItemGroup Condition="'$(RuntimeComponents)' != '*'">
+      <_RuntimeComponentList Include="$(RuntimeComponents)" />
+      <_RuntimeComponentList Include="marshal-ilgen" KeepDuplicates="false"/>
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(RuntimeComponents)' != '*'">
+      <RuntimeComponents>@(_RuntimeComponentList)</RuntimeComponents>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(_IsLibraryMode)' == 'true'">

--- a/src/mono/sample/Android/AndroidSampleApp.csproj
+++ b/src/mono/sample/Android/AndroidSampleApp.csproj
@@ -44,6 +44,16 @@
     <Message Importance="High" Text="Path: $(PublishDir)" />
     <Message Importance="High" Text="SourceDir: $(OutputPath)" />
 
+    <!-- Make sure marshal-ilgen is included in the components list. -->
+    <ItemGroup>
+      <_RuntimeComponentList Include="$(RuntimeComponents)" />
+      <_RuntimeComponentList Include="marshal-ilgen" KeepDuplicates="false"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <RuntimeComponents>@(_RuntimeComponentList)</RuntimeComponents>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(ForceAOT)' == 'true' and '$(AOTWithLibraryFiles)' == 'true'">
       <_AotOutputType>Library</_AotOutputType>
       <_AotLibraryFormat>So</_AotLibraryFormat>


### PR DESCRIPTION
`marshal-ilgen` is now included in the runtime component list in Android builds and AndroidSampleApp. Addresses https://github.com/dotnet/runtime/issues/78833.