### PR TITLE
Specify callback calling convention for callbacks on Windows x86 causes crashes on Mono.

### DIFF
--- a/eng/pipelines/libraries/outerloop-mono.yml
+++ b/eng/pipelines/libraries/outerloop-mono.yml
@@ -25,7 +25,13 @@ extends:
             runtimeFlavor: mono
             platforms:
               - windows_x64
-              - windows_x86
+              - linux_x64
+              - osx_x64
+              - ${{ if eq(variables['isRollingBuild'], true) }}:
+                - android_x64
+                - linux_arm
+                - linux_musl_x64
+                - windows_x86
             jobParameters:
               testScope: outerloop
               nameSuffix: AllSubsets_Mono
@@ -35,6 +41,29 @@ extends:
               # extra steps, run tests
               extraStepsTemplate: /eng/pipelines/libraries/helix.yml
               extraStepsParameters:
+                testScope: outerloop
+                creator: dotnet-bot
+                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/common/global-build-job.yml
+            helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+            buildConfig: Release
+            runtimeFlavor: mono
+            platforms:
+            - browser_wasm
+            jobParameters:
+              testScope: outerloop
+              nameSuffix: AllSubsets_Mono
+              buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) -testscope outerloop /p:ArchiveTests=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+              timeoutInMinutes: 180
+              includeAllPlatforms: ${{ variables['isRollingBuild'] }}
+              # extra steps, run tests
+              extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+              extraStepsParameters:
+                scenarios:
+                - normal
                 testScope: outerloop
                 creator: dotnet-bot
                 testRunNamePrefixSuffix: Mono_$(_BuildConfig)

--- a/eng/pipelines/libraries/outerloop-mono.yml
+++ b/eng/pipelines/libraries/outerloop-mono.yml
@@ -25,13 +25,7 @@ extends:
             runtimeFlavor: mono
             platforms:
               - windows_x64
-              - linux_x64
-              - osx_x64
-              - ${{ if eq(variables['isRollingBuild'], true) }}:
-                - android_x64
-                - linux_arm
-                - linux_musl_x64
-                - windows_x86
+              - windows_x86
             jobParameters:
               testScope: outerloop
               nameSuffix: AllSubsets_Mono
@@ -41,29 +35,6 @@ extends:
               # extra steps, run tests
               extraStepsTemplate: /eng/pipelines/libraries/helix.yml
               extraStepsParameters:
-                testScope: outerloop
-                creator: dotnet-bot
-                testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/common/global-build-job.yml
-            helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-            buildConfig: Release
-            runtimeFlavor: mono
-            platforms:
-            - browser_wasm
-            jobParameters:
-              testScope: outerloop
-              nameSuffix: AllSubsets_Mono
-              buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) -testscope outerloop /p:ArchiveTests=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-              timeoutInMinutes: 180
-              includeAllPlatforms: ${{ variables['isRollingBuild'] }}
-              # extra steps, run tests
-              extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-              extraStepsParameters:
-                scenarios:
-                - normal
                 testScope: outerloop
                 creator: dotnet-bot
                 testRunNamePrefixSuffix: Mono_$(_BuildConfig)

--- a/src/coreclr/scripts/genEventPipe.py
+++ b/src/coreclr/scripts/genEventPipe.py
@@ -181,11 +181,9 @@ def generateClrEventPipeWriteEventsImpl(
     eventPipeCallbackCastExpr = ""
     if target_cpp:
         eventPipeCallbackCastExpr = "reinterpret_cast<EventPipeCallback>"
-    else:
-        eventPipeCallbackCastExpr = "(EventPipeCallback)"
 
     if runtimeFlavor.mono:
-        WriteEventImpl.append("void " + callbackName + "(const uint8_t *, unsigned long, uint8_t, uint64_t,	uint64_t, EventFilterDescriptor *, void *);\n\n")
+        WriteEventImpl.append("void EP_CALLBACK_CALLTYPE " + callbackName + "(const uint8_t *, unsigned long, uint8_t, uint64_t, uint64_t, EventFilterDescriptor *, void *);\n\n")
 
     if extern: WriteEventImpl.append('extern "C" ')
     WriteEventImpl.append(

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/AssemblyInfo.cs
@@ -3,5 +3,3 @@
 
 using System;
 using Xunit;
-
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/88992", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsX86Process))]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/AssemblyInfo.cs
@@ -6,4 +6,3 @@ using Xunit;
 
 [assembly: SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131", ~RuntimeConfiguration.Release)]
 [assembly: SkipOnPlatform(TestPlatforms.Browser, "System.Net.Sockets is not supported on Browser")]
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/88992", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsX86Process))]

--- a/src/libraries/System.Runtime.Caching/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Runtime.Caching/tests/AssemblyInfo.cs
@@ -3,5 +3,3 @@
 
 using System;
 using Xunit;
-
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/88992", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsX86Process))]

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/AssemblyInfo.cs
@@ -3,5 +3,3 @@
 
 using System;
 using Xunit;
-
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/88992", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsX86Process))]

--- a/src/libraries/System.Transactions.Local/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Transactions.Local/tests/AssemblyInfo.cs
@@ -3,5 +3,3 @@
 
 using System;
 using Xunit;
-
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/88992", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsX86Process))]

--- a/src/mono/mono/eventpipe/ep-rt-mono-profiler-provider.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono-profiler-provider.c
@@ -2965,6 +2965,7 @@ ep_on_error:
 }
 
 void
+EP_CALLBACK_CALLTYPE
 EventPipeEtwCallbackDotNETRuntimeMonoProfiler (
 	const uint8_t *source_id,
 	unsigned long is_enabled,

--- a/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
@@ -4336,6 +4336,7 @@ ep_on_error:
 }
 
 void
+EP_CALLBACK_CALLTYPE
 EventPipeEtwCallbackDotNETRuntime (
 	const uint8_t *source_id,
 	unsigned long is_enabled,

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -889,6 +889,7 @@ ep_rt_mono_fini (void)
 }
 
 void
+EP_CALLBACK_CALLTYPE
 EventPipeEtwCallbackDotNETRuntimeRundown (
 	const uint8_t *source_id,
 	unsigned long is_enabled,
@@ -904,6 +905,7 @@ EventPipeEtwCallbackDotNETRuntimeRundown (
 }
 
 void
+EP_CALLBACK_CALLTYPE
 EventPipeEtwCallbackDotNETRuntimePrivate (
 	const uint8_t *source_id,
 	unsigned long is_enabled,
@@ -919,6 +921,7 @@ EventPipeEtwCallbackDotNETRuntimePrivate (
 }
 
 void
+EP_CALLBACK_CALLTYPE
 EventPipeEtwCallbackDotNETRuntimeStress (
 	const uint8_t *source_id,
 	unsigned long is_enabled,

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1920,6 +1920,7 @@ ep_rt_write_event_contention_stop (
 */
 
 void
+EP_CALLBACK_CALLTYPE
 EventPipeEtwCallbackDotNETRuntime (
 	const uint8_t *source_id,
 	unsigned long is_enabled,
@@ -1930,6 +1931,7 @@ EventPipeEtwCallbackDotNETRuntime (
 	void *callback_data);
 
 void
+EP_CALLBACK_CALLTYPE
 EventPipeEtwCallbackDotNETRuntimeRundown (
 	const uint8_t *source_id,
 	unsigned long is_enabled,
@@ -1940,6 +1942,7 @@ EventPipeEtwCallbackDotNETRuntimeRundown (
 	void *callback_data);
 
 void
+EP_CALLBACK_CALLTYPE
 EventPipeEtwCallbackDotNETRuntimePrivate (
 	const uint8_t *source_id,
 	unsigned long is_enabled,
@@ -1950,6 +1953,7 @@ EventPipeEtwCallbackDotNETRuntimePrivate (
 	void *callback_data);
 
 void
+EP_CALLBACK_CALLTYPE
 EventPipeEtwCallbackDotNETRuntimeStress (
 	const uint8_t *source_id,
 	unsigned long is_enabled,
@@ -1960,6 +1964,7 @@ EventPipeEtwCallbackDotNETRuntimeStress (
 	void *callback_data);
 
 void
+EP_CALLBACK_CALLTYPE
 EventPipeEtwCallbackDotNETRuntimeMonoProfiler (
 	const uint8_t *source_id,
 	unsigned long is_enabled,

--- a/src/mono/mono/eventpipe/test/ep-provider-callback-dataqueue-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-provider-callback-dataqueue-tests.c
@@ -25,6 +25,7 @@ test_provider_callback_data_queue_setup (void)
 
 static
 void
+EP_CALLBACK_CALLTYPE
 provider_callback (
 	const uint8_t *source_id,
 	unsigned long is_enabled,

--- a/src/mono/mono/eventpipe/test/ep-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-tests.c
@@ -598,6 +598,7 @@ static bool provider_callback_data;
 
 static
 void
+EP_CALLBACK_CALLTYPE
 provider_callback (
 	const uint8_t *source_id,
 	unsigned long is_enabled,

--- a/src/mono/mono/eventpipe/test/ep-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-tests.c
@@ -360,7 +360,7 @@ test_enable_disable_default_provider_config (void)
 
 	test_location = 2;
 
-	result = validate_default_provider_config ((EventPipeSession *)session_id);
+	result = validate_default_provider_config ((EventPipeSession *)(uintptr_t)session_id);
 	ep_raise_error_if_nok (result == NULL);
 
 	test_location = 3;
@@ -409,7 +409,7 @@ test_enable_disable_multiple_default_provider_config (void)
 
 	test_location = 2;
 
-	result = validate_default_provider_config ((EventPipeSession *)session_id_1);
+	result = validate_default_provider_config ((EventPipeSession *)(uintptr_t)session_id_1);
 	ep_raise_error_if_nok (result == NULL);
 
 	test_location = 3;
@@ -441,7 +441,7 @@ test_enable_disable_multiple_default_provider_config (void)
 
 	test_location = 5;
 
-	result = validate_default_provider_config ((EventPipeSession *)session_id_2);
+	result = validate_default_provider_config ((EventPipeSession *)(uintptr_t)session_id_2);
 	ep_raise_error_if_nok (result == NULL);
 
 	test_location = 6;
@@ -491,7 +491,7 @@ test_enable_disable_provider_config (void)
 
 	test_location = 2;
 
-	EventPipeSessionProviderList *provider_list = ep_session_get_providers ((EventPipeSession *)session_id);
+	EventPipeSessionProviderList *provider_list = ep_session_get_providers ((EventPipeSession *)(uintptr_t)session_id);
 	EventPipeSessionProvider *session_provider = ep_session_provider_list_find_by_name (ep_session_provider_list_get_providers (provider_list), TEST_PROVIDER_NAME);
 	ep_raise_error_if_nok (session_provider != NULL);
 
@@ -572,7 +572,7 @@ test_enable_disable_provider_parse_default_config (void)
 
 	test_location = 2;
 
-	result = validate_default_provider_config ((EventPipeSession *)session_id);
+	result = validate_default_provider_config ((EventPipeSession *)(uintptr_t)session_id);
 	ep_raise_error_if_nok (result == NULL);
 
 	test_location = 3;
@@ -796,7 +796,7 @@ test_session_write_event (void)
 
 	EventPipeEventPayload payload;;
 	ep_event_payload_init (&payload, NULL, 0);
-	write_result = ep_session_write_event ((EventPipeSession *)session_id, ep_rt_thread_get_handle (), ep_event, &payload, NULL, NULL, NULL, NULL);
+	write_result = ep_session_write_event ((EventPipeSession *)(uintptr_t)session_id, ep_rt_thread_get_handle (), ep_event, &payload, NULL, NULL, NULL, NULL);
 	ep_event_payload_fini (&payload);
 
 	ep_raise_error_if_nok (write_result == true);
@@ -849,14 +849,14 @@ test_session_write_event_seq_point (void)
 
 	EventPipeEventPayload payload;;
 	ep_event_payload_init (&payload, NULL, 0);
-	write_result = ep_session_write_event ((EventPipeSession *)session_id, ep_rt_thread_get_handle (), ep_event, &payload, NULL, NULL, NULL, NULL);
+	write_result = ep_session_write_event ((EventPipeSession *)(uintptr_t)session_id, ep_rt_thread_get_handle (), ep_event, &payload, NULL, NULL, NULL, NULL);
 	ep_event_payload_fini (&payload);
 
 	ep_raise_error_if_nok (write_result == true);
 
 	test_location = 5;
 
-	ep_session_write_sequence_point_unbuffered ((EventPipeSession *)session_id);
+	ep_session_write_sequence_point_unbuffered ((EventPipeSession *)(uintptr_t)session_id);
 
 ep_on_exit:
 	ep_disable (session_id);
@@ -906,20 +906,20 @@ test_session_write_wait_get_next_event (void)
 
 	EventPipeEventPayload payload;;
 	ep_event_payload_init (&payload, NULL, 0);
-	write_result = ep_session_write_event ((EventPipeSession *)session_id, ep_rt_thread_get_handle (), ep_event, &payload, NULL, NULL, NULL, NULL);
+	write_result = ep_session_write_event ((EventPipeSession *)(uintptr_t)session_id, ep_rt_thread_get_handle (), ep_event, &payload, NULL, NULL, NULL, NULL);
 	ep_event_payload_fini (&payload);
 
 	ep_raise_error_if_nok (write_result == true);
 
 	test_location = 5;
 
-	EventPipeEventInstance *event_instance = ep_session_get_next_event ((EventPipeSession *)session_id);
+	EventPipeEventInstance *event_instance = ep_session_get_next_event ((EventPipeSession *)(uintptr_t)session_id);
 
 	ep_raise_error_if_nok (event_instance != NULL);
 
 	test_location = 6;
 
-	event_instance = ep_session_get_next_event ((EventPipeSession *)session_id);
+	event_instance = ep_session_get_next_event ((EventPipeSession *)(uintptr_t)session_id);
 
 	ep_raise_error_if_nok (event_instance == NULL);
 
@@ -971,14 +971,14 @@ test_session_write_get_next_event (void)
 
 	// Starts as signaled.
 	// TODO: Is this expected behavior, just a way to notify observer that we are up and running?
-	uint32_t test = ep_rt_wait_event_wait ((ep_rt_wait_event_handle_t *)ep_session_get_wait_event ((EventPipeSession *)session_id), 0, false);
+	uint32_t test = ep_rt_wait_event_wait ((ep_rt_wait_event_handle_t *)ep_session_get_wait_event ((EventPipeSession *)(uintptr_t)session_id), 0, false);
 	ep_raise_error_if_nok (test == 0);
 
 	test_location = 5;
 
 	EventPipeEventPayload payload;;
 	ep_event_payload_init (&payload, NULL, 0);
-	write_result = ep_session_write_event ((EventPipeSession *)session_id, ep_rt_thread_get_handle (), ep_event, &payload, NULL, NULL, NULL, NULL);
+	write_result = ep_session_write_event ((EventPipeSession *)(uintptr_t)session_id, ep_rt_thread_get_handle (), ep_event, &payload, NULL, NULL, NULL, NULL);
 	ep_event_payload_fini (&payload);
 
 	ep_raise_error_if_nok (write_result == true);
@@ -987,17 +987,17 @@ test_session_write_get_next_event (void)
 
 	// TODO: Is this really the correct behavior, first write signals event, meaning that buffer will converted to read only
 	// with just one event in it.
-	test = ep_rt_wait_event_wait ((ep_rt_wait_event_handle_t *)ep_session_get_wait_event ((EventPipeSession *)session_id), 0, false);
+	test = ep_rt_wait_event_wait ((ep_rt_wait_event_handle_t *)ep_session_get_wait_event ((EventPipeSession *)(uintptr_t)session_id), 0, false);
 	ep_raise_error_if_nok (test == 0);
 
 	test_location = 7;
 
-	EventPipeEventInstance *event_instance = ep_session_get_next_event ((EventPipeSession *)session_id);
+	EventPipeEventInstance *event_instance = ep_session_get_next_event ((EventPipeSession *)(uintptr_t)session_id);
 	ep_raise_error_if_nok (event_instance != NULL);
 
 	test_location = 8;
 
-	event_instance = ep_session_get_next_event ((EventPipeSession *)session_id);
+	event_instance = ep_session_get_next_event ((EventPipeSession *)(uintptr_t)session_id);
 	ep_raise_error_if_nok (event_instance == NULL);
 
 ep_on_exit:
@@ -1048,7 +1048,7 @@ test_session_write_suspend_event (void)
 
 	EventPipeEventPayload payload;;
 	ep_event_payload_init (&payload, NULL, 0);
-	write_result = ep_session_write_event ((EventPipeSession *)session_id, ep_rt_thread_get_handle (), ep_event, &payload, NULL, NULL, NULL, NULL);
+	write_result = ep_session_write_event ((EventPipeSession *)(uintptr_t)session_id, ep_rt_thread_get_handle (), ep_event, &payload, NULL, NULL, NULL, NULL);
 	ep_event_payload_fini (&payload);
 
 	ep_raise_error_if_nok (write_result == true);

--- a/src/native/eventpipe/ds-ipc.c
+++ b/src/native/eventpipe/ds-ipc.c
@@ -229,10 +229,18 @@ ipc_log_poll_handles (dn_vector_t *ipc_poll_handles)
 	} DN_VECTOR_FOREACH_END;
 }
 
+static
+bool
+EP_CALLBACK_CALLTYPE
+ipc_stream_factory_callback (void)
+{
+	return ds_ipc_stream_factory_any_suspended_ports ();
+}
+
 bool
 ds_ipc_stream_factory_init (void)
 {
-	ep_ipc_stream_factory_callback_set (ds_ipc_stream_factory_any_suspended_ports);
+	ep_ipc_stream_factory_callback_set (ipc_stream_factory_callback);
 	_ds_port_array = dn_vector_ptr_alloc ();
 	return _ds_port_array != NULL;
 }

--- a/src/native/eventpipe/ep-types-forward.h
+++ b/src/native/eventpipe/ep-types-forward.h
@@ -175,9 +175,14 @@ typedef int64_t ep_system_timestamp_t;
 /*
  * EventPipe Callbacks.
  */
+#if defined(_WIN32) && defined(_M_IX86)
+#define EP_CALLBACK_CALLTYPE __stdcall
+#else
+#define EP_CALLBACK_CALLTYPE
+#endif
 
 // Define the event pipe callback to match the ETW callback signature.
-typedef void (*EventPipeCallback)(
+typedef void (EP_CALLBACK_CALLTYPE *EventPipeCallback)(
 	const uint8_t *source_id,
 	unsigned long is_enabled,
 	uint8_t level,
@@ -186,7 +191,7 @@ typedef void (*EventPipeCallback)(
 	EventFilterDescriptor *filter_data,
 	void *callback_data);
 
-typedef void (*EventPipeSessionSynchronousCallback)(
+typedef void (EP_CALLBACK_CALLTYPE *EventPipeSessionSynchronousCallback)(
 	EventPipeProvider *provider,
 	uint32_t event_id,
 	uint32_t event_version,
@@ -201,7 +206,7 @@ typedef void (*EventPipeSessionSynchronousCallback)(
 	uintptr_t *stack_frames,
 	void *additional_data);
 
-typedef bool (*EventPipeIpcStreamFactorySuspendedPortsCallback)(void);
+typedef bool (EP_CALLBACK_CALLTYPE *EventPipeIpcStreamFactorySuspendedPortsCallback)(void);
 
 #endif /* ENABLE_PERFTRACING */
 #endif /* __EVENTPIPE_TYPES_FORWARD_H__ */

--- a/src/native/libs/Common/pal_compiler.h
+++ b/src/native/libs/Common/pal_compiler.h
@@ -57,6 +57,14 @@ do_abort_unless (bool condition, const char* fmt, ...)
 #endif
 #endif // PALEXPORT
 
+#ifndef PAL_CALLBACK_CALLTYPE
+#if defined(_WIN32) && defined(_M_IX86)
+#define PAL_CALLBACK_CALLTYPE __stdcall
+#else
+#define PAL_CALLBACK_CALLTYPE
+#endif
+#endif // PAL_CALLBACK_CALLTYPE
+
 #ifndef EXTERN_C
 #ifdef __cplusplus
 #define EXTERN_C extern "C"

--- a/src/native/libs/System.Globalization.Native/pal_calendarData.h
+++ b/src/native/libs/System.Globalization.Native/pal_calendarData.h
@@ -67,7 +67,7 @@ typedef enum
 } CalendarDataType;
 
 // the function pointer definition for the callback used in EnumCalendarInfo
-typedef void (*EnumCalendarInfoCallback)(const UChar*, const void*);
+typedef void (PAL_CALLBACK_CALLTYPE *EnumCalendarInfoCallback)(const UChar*, const void*);
 
 PALEXPORT int32_t GlobalizationNative_GetCalendars(const UChar* localeName,
                                                    CalendarId* calendars,


### PR DESCRIPTION
Fixes #88992.

CoreCLR runtime build using stdcall while Mono uses cdecl (default for c/c++ source files) as default calling convention. If a native runtime function takes a reverse pinvoke managed callback, this difference will cause issues on Mono Windows x86 since reverse pinvoke callbacks uses stdcall on Windows x86, but native functions calling callbacks have been prototyped to use the "default" calling convention used by native runtime build.

* Since CoreCLR already uses stdcall on Windows x86 this change won't change anything on CoreCLR.
* On Windows x64 stdcall == cdecl so this change won't change anything on CoreCLR, Mono or NativeAOT.

PR also re-enable test suites previously disabled due to this issue as well as making sure native EventPipe tests suites build/run/ pass using Mono Windows x86.