### PR TITLE
Update `RuntimeEnvironment.GetSystemVersion()`

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
@@ -34,6 +34,6 @@ namespace System.Runtime.InteropServices
         [Obsolete(Obsoletions.RuntimeEnvironmentMessage, DiagnosticId = Obsoletions.RuntimeEnvironmentDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static object GetRuntimeInterfaceAsObject(Guid clsid, Guid riid) => throw new PlatformNotSupportedException();
 
-        public static string GetSystemVersion() => typeof(object).Assembly.ImageRuntimeVersion;
+        public static string GetSystemVersion() => "v" + Environment.Version;
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
@@ -34,6 +34,6 @@ namespace System.Runtime.InteropServices
         [Obsolete(Obsoletions.RuntimeEnvironmentMessage, DiagnosticId = Obsoletions.RuntimeEnvironmentDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static object GetRuntimeInterfaceAsObject(Guid clsid, Guid riid) => throw new PlatformNotSupportedException();
 
-        public static string GetSystemVersion() => $"v{Environment.Version};
+        public static string GetSystemVersion() => $"v{Environment.Version}";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
@@ -34,6 +34,6 @@ namespace System.Runtime.InteropServices
         [Obsolete(Obsoletions.RuntimeEnvironmentMessage, DiagnosticId = Obsoletions.RuntimeEnvironmentDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static object GetRuntimeInterfaceAsObject(Guid clsid, Guid riid) => throw new PlatformNotSupportedException();
 
-        public static string GetSystemVersion() => "v" + Environment.Version;
+        public static string GetSystemVersion() => $"v{Environment.Version};
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/RuntimeEnvironmentTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/RuntimeEnvironmentTests.cs
@@ -17,7 +17,8 @@ namespace System.Runtime.InteropServices
         [Fact]
         public void RuntimeEnvironmentSysVersion()
         {
-            Assert.NotEmpty(RuntimeEnvironment.GetSystemVersion());
+            // The historical format of this API is "vX.Y.Z", so we validate and retain that.
+            Assert.Equal($"v{Environment.Version}", RuntimeEnvironment.GetSystemVersion());
         }
 
 #pragma warning disable SYSLIB0019 // RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException.


### PR DESCRIPTION
This API is now emitting a valid version in alignment with https://github.com/dotnet/runtime/issues/28788.

Fixes #87908 