### PR TITLE
Update description of DOTNET_JitStressProcedureSplitting

### DIFF
--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -167,8 +167,7 @@ CONFIG_INTEGER(JitStressBiasedCSE, W("JitStressBiasedCSE"), 0x101)     // Intern
 CONFIG_INTEGER(JitStressModeNamesOnly, W("JitStressModeNamesOnly"), 0) // Internal Jit stress: if nonzero, only enable
                                                                        // stress modes listed in JitStressModeNames
 CONFIG_INTEGER(JitStressProcedureSplitting, W("JitStressProcedureSplitting"), 0) // Always split after the first basic
-                                                                                 // block. Skips functions with EH
-                                                                                 // for simplicity.
+                                                                                 // block.
 CONFIG_INTEGER(JitStressRegs, W("JitStressRegs"), 0)
 CONFIG_STRING(JitStressRegsRange, W("JitStressRegsRange")) // Only apply JitStressRegs to methods in this hash range
 


### PR DESCRIPTION
When the JitStressProcedureSplitting mode was first implemented, we decided to skip functions with exception handling, since we hadn't decided how to handle cold EH funclets just yet. But for about a year now, JitStressProcedureSplitting has worked with functions with EH (see [Compiler::fgDetermineFirstColdBlock](https://github.com/dotnet/runtime/blob/1138b247eca270835a53ff14fbcc04b4e9b263fd/src/coreclr/jit/flowgraph.cpp#L3331)), so its description in jitconfigvalues.h should reflect this.