### PR TITLE
Add more meaningful assert message to PerformanceCounter test that fails intermittently in Win11 arm64

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterCategoryTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterCategoryTests.cs
@@ -271,7 +271,7 @@ namespace System.Diagnostics.Tests
             PerformanceCounterCategory pcc = new PerformanceCounterCategory("Processor");
 
             string[] instances = Helpers.RetryOnAllPlatformsWithClosingResources(() => pcc.GetInstanceNames());
-            Assert.True(instances.Length > 0);
+            AssertExtensions.GreaterThan(instances.Length, 0, "PerformanceCounterCategory.GetInstanceNames() returned 0.");
 
             foreach (string instance in instances)
             {


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/issues/83317 so that I can attach a proper unique message to KnownBuildError when it happens again.

The failure happens very rarely: 21 hits in the last 3 months (unsure if engineeringdata deleted results older than 3 months). It only happens in PRs (no rolling build results) and it happens in Win11, mostly in arm64, and a couple of hits happened in x64.
