### PR TITLE
Fix EventLog test CanReadAndWriteMessages

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/NativeWrapper.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/NativeWrapper.cs
@@ -967,7 +967,13 @@ namespace System.Diagnostics.Eventing.Reader
                 EventLogException.Throw(error);
             }
 
-            int len = bufferNeeded - 1; // buffer includes null terminator
+
+            // buffer may include null terminators
+            int len = bufferNeeded;
+            while (len > 0 && buffer[len - 1] == '\0')
+            {
+                len--;
+            }
             if (len <= 0)
                 return string.Empty;
 

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogMessagesTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogMessagesTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.Eventing.Reader;
 using System.IO;
 using System.Reflection;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Win32.SafeHandles;
 using Xunit;
 
@@ -53,38 +52,35 @@ namespace System.Diagnostics.Tests
         [ConditionalFact(typeof(Helpers), nameof(Helpers.HasAssemblyFilesIsElevatedAndSupportsEventLogs))]
         public void CanReadAndWriteMessages()
         {
-            RemoteExecutor.Invoke(() =>
+            string messageDllPath = Path.Combine(Path.GetDirectoryName(typeof(EventLog).Assembly.Location), "System.Diagnostics.EventLog.Messages.dll");
+            EventSourceCreationData log = new EventSourceCreationData($"TestEventMessageSource {Guid.NewGuid()}", "Application")
             {
-                string messageDllPath = Path.Combine(Path.GetDirectoryName(typeof(EventLog).Assembly.Location), "System.Diagnostics.EventLog.Messages.dll");
-                EventSourceCreationData log = new EventSourceCreationData($"TestEventMessageSource {Guid.NewGuid()}", "Application")
-                {
-                    MessageResourceFile = messageDllPath
-                };
-                try
-                {
-                    if (EventLog.SourceExists(log.Source))
-                    {
-                        EventLog.DeleteEventSource(log.Source);
-                    }
-
-                    EventLog.CreateEventSource(log);
-                    string message = $"Hello {Guid.NewGuid()}";
-                    Helpers.Retry(() => EventLog.WriteEntry(log.Source, message));
-
-                    using (EventLogReader reader = new EventLogReader(new EventLogQuery("Application", PathType.LogName, $"*[System/Provider/@Name=\"{log.Source}\"]")))
-                    {
-                        EventRecord evt = reader.ReadEvent();
-
-                        string logMessage = evt.FormatDescription();
-
-                        Assert.Equal(message, logMessage);
-                    }
-                }
-                finally
+                MessageResourceFile = messageDllPath
+            };
+            try
+            {
+                if (EventLog.SourceExists(log.Source))
                 {
                     EventLog.DeleteEventSource(log.Source);
                 }
-            }).Dispose();
+
+                EventLog.CreateEventSource(log);
+                string message = $"Hello {Guid.NewGuid()}";
+                Helpers.Retry(() => EventLog.WriteEntry(log.Source, message));
+
+                using (EventLogReader reader = new EventLogReader(new EventLogQuery("Application", PathType.LogName, $"*[System/Provider/@Name=\"{log.Source}\"]")))
+                {
+                    EventRecord evt = reader.ReadEvent();
+
+                    string logMessage = evt.FormatDescription();
+
+                    Assert.Equal(message, logMessage);
+                }
+            }
+            finally
+            {
+                EventLog.DeleteEventSource(log.Source);
+            }
         }
     }
 }

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogMessagesTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogMessagesTests.cs
@@ -53,7 +53,6 @@ namespace System.Diagnostics.Tests
         public static bool HasAssemblyFilesIsElevatedAndSupportsEventLogs => PlatformDetection.HasAssemblyFiles && Helpers.IsElevatedAndSupportsEventLogs;
 
         [ConditionalFact(nameof(HasAssemblyFilesIsElevatedAndSupportsEventLogs))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88224", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version22000OrGreater))]
         public void CanReadAndWriteMessages()
         {
             string messageDllPath = Path.Combine(Path.GetDirectoryName(typeof(EventLog).Assembly.Location), "System.Diagnostics.EventLog.Messages.dll");

--- a/src/libraries/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -1,10 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.Diagnostics.Eventing.Reader;
 using System.Threading;
-using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 // Implementation is not robust with respect to concurrently writing and reading log
@@ -14,7 +12,7 @@ namespace System.Diagnostics.Tests
 {
     internal class Helpers
     {
-        public static bool HasAssemblyFilesIsElevatedAndSupportsEventLogs => PlatformDetection.HasAssemblyFiles && RemoteExecutor.IsSupported && SupportsEventLogs;
+        public static bool HasAssemblyFilesIsElevatedAndSupportsEventLogs => PlatformDetection.HasAssemblyFiles && IsElevatedAndSupportsEventLogs;
         public static bool NotElevatedAndSupportsEventLogs { get => !AdminHelpers.IsProcessElevated() && SupportsEventLogs; }
         public static bool IsElevatedAndSupportsEventLogs { get => AdminHelpers.IsProcessElevated() && SupportsEventLogs; }
         public static bool SupportsEventLogs { get => PlatformDetection.IsNotWindowsNanoNorServerCore && PlatformDetection.IsNotWindowsIoTCore; }

--- a/src/libraries/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel;
 using System.Diagnostics.Eventing.Reader;
 using System.Threading;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 // Implementation is not robust with respect to concurrently writing and reading log
@@ -13,8 +14,9 @@ namespace System.Diagnostics.Tests
 {
     internal class Helpers
     {
-        public static bool NotElevatedAndSupportsEventLogs { get => !AdminHelpers.IsProcessElevated() && SupportsEventLogs; }
-        public static bool IsElevatedAndSupportsEventLogs { get => AdminHelpers.IsProcessElevated() && SupportsEventLogs; }
+        public static bool HasAssemblyFilesIsElevatedAndSupportsEventLogs => PlatformDetection.HasAssemblyFiles && IsElevatedAndSupportsEventLogs;
+        public static bool NotElevatedAndSupportsEventLogs { get => !RemoteExecutor.IsSupported && SupportsEventLogs; }
+        public static bool IsElevatedAndSupportsEventLogs { get => RemoteExecutor.IsSupported && SupportsEventLogs; }
         public static bool SupportsEventLogs { get => PlatformDetection.IsNotWindowsNanoNorServerCore && PlatformDetection.IsNotWindowsIoTCore; }
 
         // Retry that eats exceptions: for "best effort cleanup"

--- a/src/libraries/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -14,9 +14,9 @@ namespace System.Diagnostics.Tests
 {
     internal class Helpers
     {
-        public static bool HasAssemblyFilesIsElevatedAndSupportsEventLogs => PlatformDetection.HasAssemblyFiles && IsElevatedAndSupportsEventLogs;
-        public static bool NotElevatedAndSupportsEventLogs { get => !RemoteExecutor.IsSupported && SupportsEventLogs; }
-        public static bool IsElevatedAndSupportsEventLogs { get => RemoteExecutor.IsSupported && SupportsEventLogs; }
+        public static bool HasAssemblyFilesIsElevatedAndSupportsEventLogs => PlatformDetection.HasAssemblyFiles && RemoteExecutor.IsSupported && SupportsEventLogs;
+        public static bool NotElevatedAndSupportsEventLogs { get => !AdminHelpers.IsProcessElevated() && SupportsEventLogs; }
+        public static bool IsElevatedAndSupportsEventLogs { get => AdminHelpers.IsProcessElevated() && SupportsEventLogs; }
         public static bool SupportsEventLogs { get => PlatformDetection.IsNotWindowsNanoNorServerCore && PlatformDetection.IsNotWindowsIoTCore; }
 
         // Retry that eats exceptions: for "best effort cleanup"

--- a/src/libraries/System.Diagnostics.EventLog/tests/System.Diagnostics.EventLog.Tests.csproj
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System.Diagnostics.EventLog.Tests.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
-    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EventInstanceTests.cs" />

--- a/src/libraries/System.Diagnostics.EventLog/tests/System.Diagnostics.EventLog.Tests.csproj
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System.Diagnostics.EventLog.Tests.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EventInstanceTests.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/88224

I ran this in an elevated console and it failed with the reported error:
```
===========================================================================================================
    Discovering: System.Diagnostics.EventLog.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Diagnostics.EventLog.Tests (found 123 of 125 test cases)
    Starting:    System.Diagnostics.EventLog.Tests (parallel test collections = on, max threads = 16)
      System.Diagnostics.Tests.EventLogMessagesTests.CanReadAndWriteMessages [FAIL]
        Assert.Equal() Failure
                                          (pos 42)
        Expected: ···1b-86c3-93c25c528d55
        Actual:   ···1b-86c3-93c25c528d55\0
                                          (pos 42)
        Stack Trace:
          C:\Users\calope\source\repos\runtime\src\libraries\System.Diagnostics.EventLog\tests\EventLogMessagesTests.cs(80,0): at System.Diagnostics.
  Tests.EventLogMessagesTests.CanReadAndWriteMessages()
             at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
          C:\Users\calope\source\repos\runtime\src\coreclr\System.Private.CoreLib\src\System\Reflection\MethodBaseInvoker.CoreCLR.cs(36,0): at System
  .Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
          C:\Users\calope\source\repos\runtime\src\libraries\System.Private.CoreLib\src\System\Reflection\MethodBaseInvoker.cs(57,0): at System.Refle
  ction.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

It seems the problem is that the buffer may end up with multiple null terminators, so I adjusted the code to make sure we remove them all.