### PR TITLE
Add [DebuggerGuidedStepThrough] to new invoker methods

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
@@ -28,16 +28,19 @@ namespace System.Reflection
             return new ConstructorInvoker(runtimeConstructor);
         }
 
+        [DebuggerGuidedStepThrough]
         public object Invoke()
         {
             return _methodBaseInvoker.CreateInstanceWithFewArgs(new Span<object?>());
         }
 
+        [DebuggerGuidedStepThrough]
         public object Invoke(object? arg1)
         {
             return _methodBaseInvoker.CreateInstanceWithFewArgs(new Span<object?>(ref arg1));
         }
 
+        [DebuggerGuidedStepThrough]
         public object Invoke(object? arg1, object? arg2)
         {
             StackAllocatedArguments argStorage = default;
@@ -46,6 +49,7 @@ namespace System.Reflection
             return _methodBaseInvoker.CreateInstanceWithFewArgs(argStorage._args.AsSpan(2));
         }
 
+        [DebuggerGuidedStepThrough]
         public object Invoke(object? arg1, object? arg2, object? arg3)
         {
             StackAllocatedArguments argStorage = default;
@@ -55,6 +59,7 @@ namespace System.Reflection
             return _methodBaseInvoker.CreateInstanceWithFewArgs(argStorage._args.AsSpan(3));
         }
 
+        [DebuggerGuidedStepThrough]
         public object Invoke(object? arg1, object? arg2, object? arg3, object? arg4)
         {
             StackAllocatedArguments argStorage = default;
@@ -65,6 +70,7 @@ namespace System.Reflection
             return _methodBaseInvoker.CreateInstanceWithFewArgs(argStorage._args.AsSpan(4));
         }
 
+        [DebuggerGuidedStepThrough]
         public object Invoke(Span<object?> arguments)
         {
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Internal.Reflection.Core.Execution;
+using System.Diagnostics;
 using System.Reflection.Runtime.MethodInfos;
 using static System.Reflection.DynamicInvokeInfo;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
@@ -32,13 +32,17 @@ namespace System.Reflection
         [DebuggerGuidedStepThrough]
         public object Invoke()
         {
-            return _methodBaseInvoker.CreateInstanceWithFewArgs(new Span<object?>());
+            object result = _methodBaseInvoker.CreateInstanceWithFewArgs(new Span<object?>());
+            DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
+            return result;
         }
 
         [DebuggerGuidedStepThrough]
         public object Invoke(object? arg1)
         {
-            return _methodBaseInvoker.CreateInstanceWithFewArgs(new Span<object?>(ref arg1));
+            object result = _methodBaseInvoker.CreateInstanceWithFewArgs(new Span<object?>(ref arg1));
+            DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
+            return result;
         }
 
         [DebuggerGuidedStepThrough]
@@ -47,7 +51,9 @@ namespace System.Reflection
             StackAllocatedArguments argStorage = default;
             argStorage._args.Set(0, arg1);
             argStorage._args.Set(1, arg2);
-            return _methodBaseInvoker.CreateInstanceWithFewArgs(argStorage._args.AsSpan(2));
+            object result = _methodBaseInvoker.CreateInstanceWithFewArgs(argStorage._args.AsSpan(2));
+            DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
+            return result;
         }
 
         [DebuggerGuidedStepThrough]
@@ -57,7 +63,9 @@ namespace System.Reflection
             argStorage._args.Set(0, arg1);
             argStorage._args.Set(1, arg2);
             argStorage._args.Set(2, arg3);
-            return _methodBaseInvoker.CreateInstanceWithFewArgs(argStorage._args.AsSpan(3));
+            object result = _methodBaseInvoker.CreateInstanceWithFewArgs(argStorage._args.AsSpan(3));
+            DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
+            return result;
         }
 
         [DebuggerGuidedStepThrough]
@@ -68,14 +76,17 @@ namespace System.Reflection
             argStorage._args.Set(1, arg2);
             argStorage._args.Set(2, arg3);
             argStorage._args.Set(3, arg4);
-            return _methodBaseInvoker.CreateInstanceWithFewArgs(argStorage._args.AsSpan(4));
+            object result = _methodBaseInvoker.CreateInstanceWithFewArgs(argStorage._args.AsSpan(4));
+            DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
+            return result;
         }
 
         [DebuggerGuidedStepThrough]
         public object Invoke(Span<object?> arguments)
         {
-
-            return _methodBaseInvoker.CreateInstance(arguments);
+            object result = _methodBaseInvoker.CreateInstance(arguments);
+            DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
+            return result;
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/MethodInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/MethodInvoker.cs
@@ -41,6 +41,7 @@ namespace System.Reflection
             throw new ArgumentException(SR.Argument_MustBeRuntimeMethod, nameof(method));
         }
 
+        [DebuggerGuidedStepThrough]
         public object? Invoke(object? obj)
         {
             object? result = _methodBaseInvoker.InvokeDirectWithFewArgs(obj, new Span<object?>());
@@ -48,6 +49,7 @@ namespace System.Reflection
             return result;
         }
 
+        [DebuggerGuidedStepThrough]
         public object? Invoke(object? obj, object? arg1)
         {
             object? result = _methodBaseInvoker.InvokeDirectWithFewArgs(obj, new Span<object?>(ref arg1));
@@ -55,6 +57,7 @@ namespace System.Reflection
             return result;
         }
 
+        [DebuggerGuidedStepThrough]
         public object? Invoke(object? obj, object? arg1, object? arg2)
         {
             StackAllocatedArguments argStorage = default;
@@ -66,6 +69,7 @@ namespace System.Reflection
             return result;
         }
 
+        [DebuggerGuidedStepThrough]
         public object? Invoke(object? obj, object? arg1, object? arg2, object? arg3)
         {
             StackAllocatedArguments argStorage = default;
@@ -78,6 +82,7 @@ namespace System.Reflection
             return result;
         }
 
+        [DebuggerGuidedStepThrough]
         public object? Invoke(object? obj, object? arg1, object? arg2, object? arg3, object? arg4)
         {
             StackAllocatedArguments argStorage = default;


### PR DESCRIPTION
Add these missing attributes to make the [newly added invoker APIs](https://github.com/dotnet/runtime/pull/88415) consistent with the standard invoke APIs in NativeAOT.

CoreClr info: using "Just My Code" does work with the newly added invoker APIs for CoreClr; that is, you can step into the invoked method. With "Just My Code" off, however, the stepped-into method is hit-or-miss for both the new invoker APIs as well as the existing ones (one of the internal framework methods will be stepped into). We could add `[DebuggerHidden]` and `[DebuggerStepThrough]` to more methods to make step-in work when "Just My Code" is off, like we already have in the standard invoke code, although in general that doesn't work either and\or is fragile due to reflection calling non-reflection code such as in Span, Signature, etc. which would also need these attributes.