### PR TITLE
Stop using computed RID for RUNTIME_IDENTIFIER property

### DIFF
--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -486,12 +486,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         {
             var fixture = sharedTestState.HostApiInvokerAppFixture;
 
-            fixture.BuiltDotnet.Exec(fixture.TestProject.AppDll, "host_runtime_contract.get_runtime_property", "APP_CONTEXT_BASE_DIRECTORY", "DOES_NOT_EXIST", "ENTRY_ASSEMBLY_NAME")
+            fixture.BuiltDotnet.Exec(fixture.TestProject.AppDll, "host_runtime_contract.get_runtime_property", "APP_CONTEXT_BASE_DIRECTORY", "RUNTIME_IDENTIFIER", "DOES_NOT_EXIST", "ENTRY_ASSEMBLY_NAME")
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining($"APP_CONTEXT_BASE_DIRECTORY = {Path.GetDirectoryName(fixture.TestProject.AppDll)}")
+                .And.HaveStdOutContaining($"RUNTIME_IDENTIFIER = {RepoDirectoriesProvider.Default.BuildRID}")
                 .And.HaveStdOutContaining($"DOES_NOT_EXIST = <none>")
                 .And.HaveStdOutContaining($"ENTRY_ASSEMBLY_NAME = {fixture.TestProject.AssemblyName}");
         }

--- a/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -185,15 +185,6 @@ namespace System.Tests
         public void OSVersion_ValidVersion_OSX()
         {
             Version version = Environment.OSVersion.Version;
-
-            // NativeAOT hard-codes the runtime identifier at build time
-            if (!PlatformDetection.IsNativeAot)
-            {
-                // verify that the Environment.OSVersion.Version matches the current RID
-                // As of 12.0, only major version numbers are included in the RID
-                Assert.Contains(version.ToString(1), RuntimeInformation.RuntimeIdentifier);
-            }
-
             Assert.True(version.Minor >= 0, "OSVersion Minor should be non-negative");
             Assert.True(version.Build >= 0, "OSVersion Build should be non-negative");
             Assert.Equal(-1, version.Revision); // Revision is never set on OSX

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
@@ -74,11 +74,9 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                 .Substring("ID=".Length)
                 .Trim('\"', '\'');
 
-            // This gets burned in at publish time on NativeAOT
-            if (PlatformDetection.IsNativeAot)
-                expectedOSName = "linux";
-
-            Assert.StartsWith(expectedOSName, RuntimeInformation.RuntimeIdentifier, StringComparison.OrdinalIgnoreCase);
+            // Should either start with linux (portable builds or NativeAOT) or the OS name (source builds)
+            Assert.True(RuntimeInformation.RuntimeIdentifier.StartsWith("linux", StringComparison.OrdinalIgnoreCase)
+                || RuntimeInformation.RuntimeIdentifier.StartsWith(expectedOSName, StringComparison.OrdinalIgnoreCase));
         }
 
         [Fact, PlatformSpecific(TestPlatforms.FreeBSD)]

--- a/src/native/corehost/fxr/command_line.cpp
+++ b/src/native/corehost/fxr/command_line.cpp
@@ -282,17 +282,15 @@ int command_line::parse_args_for_sdk_command(
 
 void command_line::print_muxer_info(const pal::string_t &dotnet_root, const pal::string_t &global_json_path)
 {
-    const pal::char_t* arch = get_current_arch_name();
     pal::string_t commit = _STRINGIFY(REPO_COMMIT_HASH);
     trace::println(_X("\n")
         _X("Host:\n")
         _X("  Version:      ") _STRINGIFY(HOST_FXR_PKG_VER) _X("\n")
-        _X("  Architecture: %s\n")
+        _X("  Architecture: ") _STRINGIFY(CURRENT_ARCH_NAME) _X("\n")
         _X("  Commit:       %s\n")
         _X("  RID:          %s"),
-        arch,
         commit.substr(0, 10).c_str(),
-        get_host_runtime_id());
+        get_runtime_id().c_str());
 
     trace::println(_X("\n")
         _X(".NET SDKs installed:"));

--- a/src/native/corehost/fxr/command_line.cpp
+++ b/src/native/corehost/fxr/command_line.cpp
@@ -289,10 +289,10 @@ void command_line::print_muxer_info(const pal::string_t &dotnet_root, const pal:
         _X("  Version:      ") _STRINGIFY(HOST_FXR_PKG_VER) _X("\n")
         _X("  Architecture: %s\n")
         _X("  Commit:       %s\n")
-        _X("  RID:          ") _STRINGIFY(HOST_RID_PLATFORM) _X("-%s"),
+        _X("  RID:          %s"),
         arch,
         commit.substr(0, 10).c_str(),
-        arch);
+        get_host_runtime_id());
 
     trace::println(_X("\n")
         _X(".NET SDKs installed:"));

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -249,23 +249,18 @@ const pal::char_t* get_current_arch_name()
     return _STRINGIFY(CURRENT_ARCH_NAME);
 }
 
-pal::string_t get_current_runtime_id(bool use_fallback)
+pal::string_t get_current_runtime_id()
 {
     pal::string_t rid;
     if (try_get_runtime_id_from_env(rid))
         return rid;
 
-    rid = pal::get_current_os_rid_platform();
-    if (rid.empty() && use_fallback)
-        rid = pal::get_current_os_fallback_rid();
+    return get_host_runtime_id();
+}
 
-    if (!rid.empty())
-    {
-        rid.append(_X("-"));
-        rid.append(get_current_arch_name());
-    }
-
-    return rid;
+const pal::char_t* get_host_runtime_id()
+{
+    return _STRINGIFY(HOST_RID_PLATFORM) _X("-") _STRINGIFY(CURRENT_ARCH_NAME);
 }
 
 bool try_get_runtime_id_from_env(pal::string_t& out_rid)
@@ -468,8 +463,8 @@ pal::string_t get_download_url(const pal::char_t* framework_name, const pal::cha
     const pal::char_t* arch = get_current_arch_name();
     url.append(_X("&arch="));
     url.append(arch);
-    url.append(_X("&rid=") _STRINGIFY(HOST_RID_PLATFORM) _X("-"));
-    url.append(arch);
+    url.append(_X("&rid="));
+    url.append(get_host_runtime_id());
 
     pal::string_t os = pal::get_current_os_rid_platform();
     if (os.empty())

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -249,17 +249,12 @@ const pal::char_t* get_current_arch_name()
     return _STRINGIFY(CURRENT_ARCH_NAME);
 }
 
-pal::string_t get_current_runtime_id()
+pal::string_t get_runtime_id()
 {
     pal::string_t rid;
     if (try_get_runtime_id_from_env(rid))
         return rid;
 
-    return get_host_runtime_id();
-}
-
-const pal::char_t* get_host_runtime_id()
-{
     return _STRINGIFY(HOST_RID_PLATFORM) _X("-") _STRINGIFY(CURRENT_ARCH_NAME);
 }
 
@@ -464,7 +459,7 @@ pal::string_t get_download_url(const pal::char_t* framework_name, const pal::cha
     url.append(_X("&arch="));
     url.append(arch);
     url.append(_X("&rid="));
-    url.append(get_host_runtime_id());
+    url.append(get_runtime_id());
 
     pal::string_t os = pal::get_current_os_rid_platform();
     if (os.empty())

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -90,8 +90,7 @@ pal::architecture get_current_arch();
 const pal::char_t* get_arch_name(pal::architecture arch);
 const pal::char_t* get_current_arch_name();
 
-pal::string_t get_current_runtime_id();
-const pal::char_t* get_host_runtime_id();
+pal::string_t get_runtime_id();
 bool try_get_runtime_id_from_env(pal::string_t& out_rid);
 
 bool multilevel_lookup_enabled();

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -90,7 +90,8 @@ pal::architecture get_current_arch();
 const pal::char_t* get_arch_name(pal::architecture arch);
 const pal::char_t* get_current_arch_name();
 
-pal::string_t get_current_runtime_id(bool use_fallback);
+pal::string_t get_current_runtime_id();
+const pal::char_t* get_host_runtime_id();
 bool try_get_runtime_id_from_env(pal::string_t& out_rid);
 
 bool multilevel_lookup_enabled();

--- a/src/native/corehost/hostpolicy/deps_format.cpp
+++ b/src/native/corehost/hostpolicy/deps_format.cpp
@@ -214,25 +214,34 @@ namespace
     };
 
     // Returns the RID determined (computed or fallback) for the platform the host is running on.
-    pal::string_t get_current_rid(const deps_json_t::rid_fallback_graph_t* rid_fallback_graph)
+    pal::string_t get_computed_current_rid(const deps_json_t::rid_fallback_graph_t* rid_fallback_graph)
     {
-        pal::string_t currentRid = get_current_runtime_id(false /*use_fallback*/);
+        pal::string_t current_rid;
+        if (!try_get_runtime_id_from_env(current_rid))
+        {
+            current_rid = pal::get_current_os_rid_platform();
+            if (!current_rid.empty())
+            {
+                current_rid.append(_X("-"));
+                current_rid.append(get_current_arch_name());
+            }
+        }
 
-        trace::info(_X("HostRID is %s"), currentRid.empty() ? _X("not available") : currentRid.c_str());
+        trace::info(_X("HostRID is %s"), current_rid.empty() ? _X("not available") : current_rid.c_str());
 
         // If the current RID is not present in the RID fallback graph, then the platform
         // is unknown to us. At this point, we will fallback to using the base RIDs and attempt
         // asset lookup using them.
         //
         // We do the same even when the RID is empty.
-        if (currentRid.empty() || (rid_fallback_graph != nullptr && rid_fallback_graph->count(currentRid) == 0))
+        if (current_rid.empty() || (rid_fallback_graph != nullptr && rid_fallback_graph->count(current_rid) == 0))
         {
-            currentRid = pal::get_current_os_fallback_rid() + pal::string_t(_X("-")) + get_current_arch_name();
+            current_rid = pal::get_current_os_fallback_rid() + pal::string_t(_X("-")) + get_current_arch_name();
 
-            trace::info(_X("Falling back to base HostRID: %s"), currentRid.c_str());
+            trace::info(_X("Falling back to base HostRID: %s"), current_rid.c_str());
         }
 
-        return currentRid;
+        return current_rid;
     }
 
     void print_host_rid_list()
@@ -322,7 +331,7 @@ void deps_json_t::perform_rid_fallback(rid_specific_assets_t* portable_assets)
     pal::string_t host_rid;
     if (m_rid_resolution_options.use_fallback_graph)
     {
-        host_rid = get_current_rid(m_rid_resolution_options.rid_fallback_graph);
+        host_rid = get_computed_current_rid(m_rid_resolution_options.rid_fallback_graph);
     }
     else
     {

--- a/src/native/corehost/hostpolicy/deps_format.cpp
+++ b/src/native/corehost/hostpolicy/deps_format.cpp
@@ -213,8 +213,12 @@ namespace
         _X("any"),
     };
 
-    // Returns the RID determined (computed or fallback) for the platform the host is running on.
-    pal::string_t get_computed_current_rid(const deps_json_t::rid_fallback_graph_t* rid_fallback_graph)
+    // Returns the RID determined (computed or fallback) for the machine the host is running on.
+    // This RID is discoved at run-time from OS APIs and/or files. It may be distro-specific and/or
+    // version-specific. This usage of the machine RID is for a backwards-compat option that relies
+    // on the computed RID. All other parts of the host use the compile-time RID corresponding to the
+    // platform for which the runtime was built.
+    pal::string_t get_current_machine_rid(const deps_json_t::rid_fallback_graph_t* rid_fallback_graph)
     {
         pal::string_t current_rid;
         if (!try_get_runtime_id_from_env(current_rid))
@@ -331,7 +335,7 @@ void deps_json_t::perform_rid_fallback(rid_specific_assets_t* portable_assets)
     pal::string_t host_rid;
     if (m_rid_resolution_options.use_fallback_graph)
     {
-        host_rid = get_computed_current_rid(m_rid_resolution_options.rid_fallback_graph);
+        host_rid = get_current_machine_rid(m_rid_resolution_options.rid_fallback_graph);
     }
     else
     {

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -280,7 +280,7 @@ int hostpolicy_context_t::initialize(const hostpolicy_init_t &hostpolicy_init, c
     coreclr_properties.add(common_property::AppContextDepsFiles, app_context_deps_str.c_str());
     coreclr_properties.add(common_property::FxDepsFile, fx_deps_str.c_str());
     coreclr_properties.add(common_property::ProbingDirectories, resolver.get_lookup_probe_directories().c_str());
-    coreclr_properties.add(common_property::RuntimeIdentifier, get_current_runtime_id(true /*use_fallback*/).c_str());
+    coreclr_properties.add(common_property::RuntimeIdentifier, get_current_runtime_id().c_str());
 
     bool set_app_paths = false;
 

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -280,7 +280,7 @@ int hostpolicy_context_t::initialize(const hostpolicy_init_t &hostpolicy_init, c
     coreclr_properties.add(common_property::AppContextDepsFiles, app_context_deps_str.c_str());
     coreclr_properties.add(common_property::FxDepsFile, fx_deps_str.c_str());
     coreclr_properties.add(common_property::ProbingDirectories, resolver.get_lookup_probe_directories().c_str());
-    coreclr_properties.add(common_property::RuntimeIdentifier, get_current_runtime_id().c_str());
+    coreclr_properties.add(common_property::RuntimeIdentifier, get_runtime_id().c_str());
 
     bool set_app_paths = false;
 


### PR DESCRIPTION
Update the property to use the host RID instead of the computed current RID. This is in line with the [.NET 8 change for selecting RID-specific assets](https://learn.microsoft.com/dotnet/core/compatibility/deployment/8.0/rid-asset-list) using the host RID instead of a computed RID.

This also moves updates the shared helper to stop using the computed RID as the current RID - that is moved into the deps resolving, which needs it. Other places use the build-time RID.

This means that `RuntimeInformation.RuntimeIdentifier` (populated by the `RUNTIME_IDENTIFIER` property) will return the RID of platform for which the runtime is built, rather than a RID that is computed at runtime (or a fallback if it could not be computed). For example, for a portable build, on Windows 11, it will be `win-x64` instead of `win10-x64` or on Ubuntu 20.04 `linux-x64` instead of `ubuntu.20.04-x64`.

cc @dsplaisted 