### PR TITLE
[Perf] Cache key size in CngKey

### DIFF
--- a/src/libraries/System.Security.Cryptography.Cng/tests/CngKeyTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/CngKeyTests.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+using Xunit.Sdk;
+
+namespace System.Security.Cryptography.Tests
+{
+    public static class CngTests
+    {
+        [Theory]
+        [MemberData(nameof(AllPublicProperties))]
+        public static void AllProperties_ThrowOnDisposal(string propertyName)
+        {
+            // Create a dummy key. Use a fast-ish algorithm.
+            // If we can't query the property even on a fresh key, exclude it from the tests.
+
+            PropertyInfo propInfo = typeof(CngKey).GetProperty(propertyName);
+            CngKey theKey = CngKey.Create(CngAlgorithm.ECDsaP256);
+
+            try
+            {
+                propInfo.GetValue(theKey);
+            }
+            catch
+            {
+                throw new SkipException($"Property getter CngKey.{propertyName} threw an exception; skipping test.");
+            }
+
+            // We've queried the property. Now dispose the object and query the property again.
+            // We should see an ObjectDisposedException.
+
+            theKey.Dispose();
+            Assert.ThrowsAny<ObjectDisposedException>(() =>
+                propInfo.GetValue(theKey, BindingFlags.DoNotWrapExceptions, null, null, null));
+        }
+
+        public static IEnumerable<object[]> AllPublicProperties()
+        {
+            foreach (PropertyInfo pi in typeof(CngKey).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            {
+                if (pi.GetMethod is not null && !typeof(SafeHandle).IsAssignableFrom(pi.PropertyType))
+                {
+                    yield return new[] { pi.Name };
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Cng/tests/CngKeyTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/CngKeyTests.cs
@@ -5,11 +5,10 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Xunit;
-using Xunit.Sdk;
 
 namespace System.Security.Cryptography.Tests
 {
-    public static class CngTests
+    public static class CngKeyTests
     {
         [Theory]
         [MemberData(nameof(AllPublicProperties))]
@@ -27,7 +26,11 @@ namespace System.Security.Cryptography.Tests
             }
             catch
             {
-                throw new SkipException($"Property getter CngKey.{propertyName} threw an exception; skipping test.");
+                // Property getter threw an exception. It's nonsensical for us to query
+                // whether this same getter throws ObjectDisposedException once the object
+                // is disposed. So we'll just mark this test as success.
+
+                return;
             }
 
             // We've queried the property. Now dispose the object and query the property again.

--- a/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -82,6 +82,7 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\TestData.cs" />
     <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs"
              Link="CommonTest\System\IO\PositionValueStream.cs" />
+    <Compile Include="CngKeyTests.cs" />
     <Compile Include="CngPkcs8Tests.cs" />
     <Compile Include="DSACngPkcs8Tests.cs" />
     <Compile Include="DSACngProvider.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngKey.StandardProperties.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngKey.StandardProperties.cs
@@ -20,6 +20,7 @@ namespace System.Security.Cryptography
         // Key properties
         //
 
+        private int _cachedKeySize;
 
         /// <summary>
         ///     Algorithm group this key can be used with
@@ -170,6 +171,14 @@ namespace System.Security.Cryptography
         {
             get
             {
+                // Key size lookup is a common operation, and we don't want to incur the
+                // LRPC overhead to query lsass for the information. Since the key size
+                // cannot be changed on an existing key, we'll cache it.
+                if (_cachedKeySize != 0)
+                {
+                    return _cachedKeySize;
+                }
+
                 int keySize = 0;
 
                 // Attempt to use PublicKeyLength first as it returns the correct value for ECC keys
@@ -215,6 +224,7 @@ namespace System.Security.Cryptography
                     }
                 }
 
+                _cachedKeySize = keySize;
                 return keySize;
             }
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngKey.StandardProperties.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngKey.StandardProperties.cs
@@ -20,7 +20,8 @@ namespace System.Security.Cryptography
         // Key properties
         //
 
-        private int _cachedKeySize;
+        private const int CachedKeySizeUninitializedSentinel = -1;
+        private int _cachedKeySize = CachedKeySizeUninitializedSentinel;
 
         /// <summary>
         ///     Algorithm group this key can be used with
@@ -173,59 +174,64 @@ namespace System.Security.Cryptography
             {
                 // Key size lookup is a common operation, and we don't want to incur the
                 // LRPC overhead to query lsass for the information. Since the key size
-                // cannot be changed on an existing key, we'll cache it.
-                if (_cachedKeySize != 0)
+                // cannot be changed on an existing key, we'll cache it. For consistency
+                // with other properties, we'll still throw if the underlying handle has
+                // been closed.
+                if (_cachedKeySize == CachedKeySizeUninitializedSentinel || _keyHandle.IsClosed)
                 {
-                    return _cachedKeySize;
+                    _cachedKeySize = ComputeKeySize();
                 }
+                return _cachedKeySize;
 
-                int keySize = 0;
-
-                // Attempt to use PublicKeyLength first as it returns the correct value for ECC keys
-                ErrorCode errorCode = Interop.NCrypt.NCryptGetIntProperty(
-                    _keyHandle,
-                    KeyPropertyName.PublicKeyLength,
-                    ref keySize);
-
-                if (errorCode != ErrorCode.ERROR_SUCCESS)
+                int ComputeKeySize()
                 {
-                    // Fall back to Length (< Windows 10)
-                    errorCode = Interop.NCrypt.NCryptGetIntProperty(
+                    int keySize = 0;
+
+                    // Attempt to use PublicKeyLength first as it returns the correct value for ECC keys
+                    ErrorCode errorCode = Interop.NCrypt.NCryptGetIntProperty(
                         _keyHandle,
-                        KeyPropertyName.Length,
+                        KeyPropertyName.PublicKeyLength,
                         ref keySize);
-                }
 
-                if (errorCode != ErrorCode.ERROR_SUCCESS)
-                {
-                    throw errorCode.ToCryptographicException();
-                }
-
-                // The platform crypto provider always returns "0" for EC keys when asked for a key size. This
-                // has been observed in Windows 10 and most recently observed in Windows 11 22H2.
-                // The Algorithm NCrypt Property only returns the Algorithm Group, so that doesn't work either.
-                // What does work is the ECCCurveName.
-                CngAlgorithmGroup? algorithmGroup = AlgorithmGroup;
-
-                if (keySize == 0 && Provider == CngProvider.MicrosoftPlatformCryptoProvider &&
-                    (algorithmGroup == CngAlgorithmGroup.ECDiffieHellman || algorithmGroup == CngAlgorithmGroup.ECDsa))
-                {
-                    string? curve = _keyHandle.GetPropertyAsString(KeyPropertyName.ECCCurveName, CngPropertyOptions.None);
-
-                    switch (curve)
+                    if (errorCode != ErrorCode.ERROR_SUCCESS)
                     {
-                        // nistP192 and nistP224 don't have named curve accelerators but we can handle them.
-                        // These string values match the names in https://learn.microsoft.com/en-us/windows/win32/seccng/cng-named-elliptic-curves
-                        case "nistP192": return 192;
-                        case "nistP224": return 224;
-                        case nameof(ECCurve.NamedCurves.nistP256): return 256;
-                        case nameof(ECCurve.NamedCurves.nistP384): return 384;
-                        case nameof(ECCurve.NamedCurves.nistP521): return 521;
+                        // Fall back to Length (< Windows 10)
+                        errorCode = Interop.NCrypt.NCryptGetIntProperty(
+                            _keyHandle,
+                            KeyPropertyName.Length,
+                            ref keySize);
                     }
-                }
 
-                _cachedKeySize = keySize;
-                return keySize;
+                    if (errorCode != ErrorCode.ERROR_SUCCESS)
+                    {
+                        throw errorCode.ToCryptographicException();
+                    }
+
+                    // The platform crypto provider always returns "0" for EC keys when asked for a key size. This
+                    // has been observed in Windows 10 and most recently observed in Windows 11 22H2.
+                    // The Algorithm NCrypt Property only returns the Algorithm Group, so that doesn't work either.
+                    // What does work is the ECCCurveName.
+                    CngAlgorithmGroup? algorithmGroup = AlgorithmGroup;
+
+                    if (keySize == 0 && Provider == CngProvider.MicrosoftPlatformCryptoProvider &&
+                        (algorithmGroup == CngAlgorithmGroup.ECDiffieHellman || algorithmGroup == CngAlgorithmGroup.ECDsa))
+                    {
+                        string? curve = _keyHandle.GetPropertyAsString(KeyPropertyName.ECCCurveName, CngPropertyOptions.None);
+
+                        switch (curve)
+                        {
+                            // nistP192 and nistP224 don't have named curve accelerators but we can handle them.
+                            // These string values match the names in https://learn.microsoft.com/en-us/windows/win32/seccng/cng-named-elliptic-curves
+                            case "nistP192": return 192;
+                            case "nistP224": return 224;
+                            case nameof(ECCurve.NamedCurves.nistP256): return 256;
+                            case nameof(ECCurve.NamedCurves.nistP384): return 384;
+                            case nameof(ECCurve.NamedCurves.nistP521): return 521;
+                        }
+                    }
+
+                    return keySize;
+                }
             }
         }
 


### PR DESCRIPTION
An internal partner is reporting that they're seeing CNG signature validation latency show up as a bottleneck. The culprit seems to be that each signing \& validation operation queries the `CngKey.KeySize` property.

https://github.com/dotnet/runtime/blob/5d7b16f3ccc2680dde0270b2190ab4adb0f813b7/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSACng.Key.cs#L20-L26

https://github.com/dotnet/runtime/blob/5d7b16f3ccc2680dde0270b2190ab4adb0f813b7/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngAlgorithmCore.cs#L47-L56

The `CngKey.KeySize` property is not cached anywhere in the system, which means that each query to this property results in an LRPC call back into lsass or lsaiso. This context switch is what appears to be introducing the latency.

Since `CngKey` instances can't change their key size once created, we can cache the key size on our end without requiring calls back through the `NCrypt*` (lsass) layer. That significantly reduces the latency.

```cs
public class CngRunner
{
    private RSACng _rsa;
    private ECDsaCng _ecdsa;

    private static byte[] _emptyDigest = new byte[256 / 8];
    private byte[] _rsaSignedHash;
    private byte[] _ecdsaSignedHash;

    [GlobalSetup]
    public void Setup()
    {
        _rsa = new RSACng(2048);
        _ecdsa = new ECDsaCng(256);

        _rsaSignedHash = _rsa.SignHash(_emptyDigest, HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
        if (!Rsa_VerifyHash()) { throw new CryptographicException("Self-test failed."); }

        _ecdsaSignedHash = _ecdsa.SignHash(_emptyDigest);
        if (!Ecdsa_VerifyHash()) { throw new CryptographicException("Self-test failed."); }
    }

    [Benchmark]
    public bool Rsa_VerifyHash() => _rsa.VerifyHash(_emptyDigest, _rsaSignedHash, HashAlgorithmName.SHA256, RSASignaturePadding.Pss);

    [Benchmark]
    public bool Ecdsa_VerifyHash() => _ecdsa.VerifyHash(_emptyDigest, _ecdsaSignedHash);
}
```

|           Method |        Job |    Toolchain |      Mean |    Error |   StdDev | Ratio |
|----------------- |----------- |------------- |----------:|---------:|---------:|------:|
|   Rsa_VerifyHash | Job-EBVYOU | cngkey_cache |  48.03 μs | 0.140 μs | 0.131 μs |  0.38 |
|   Rsa_VerifyHash | Job-QBWHWJ |         main | 125.42 μs | 0.505 μs | 0.394 μs |  1.00 |
|                  |            |              |           |          |          |       |
| Ecdsa_VerifyHash | Job-EBVYOU | cngkey_cache | 220.13 μs | 2.552 μs | 2.731 μs |  0.75 |
| Ecdsa_VerifyHash | Job-QBWHWJ |         main | 295.14 μs | 0.885 μs | 0.739 μs |  1.00 |

### Open discussion

Technically this is a behavioral change, since it means that the `CngKey.KeySize` property will remain accessible on an otherwise disposed instance, just as long as it has already been fetched at least once prior to disposal. I could easily add a disposed check (and unit test to validate this behavior) if we think preserving the earlier behavior is worthwhile.