### PR TITLE
Fix arm64 line numbers in stacktraces

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -3363,7 +3363,11 @@ BOOL StackTraceInfo::AppendElement(BOOL bAllowAllocMem, UINT_PTR currentIP, UINT
         // This is a workaround to fix the generation of stack traces from exception objects so that
         // they point to the line that actually generated the exception instead of the line
         // following.
-        if (!(pCf->HasFaulted() || pCf->IsIPadjusted()) && pStackTraceElem->ip != 0)
+        if (pCf->IsIPadjusted())
+        {
+            pStackTraceElem->flags |= STEF_IP_ADJUSTED;
+        }
+        else if (!pCf->HasFaulted() && pStackTraceElem->ip != 0)
         {
             pStackTraceElem->ip -= 1;
             pStackTraceElem->flags |= STEF_IP_ADJUSTED;


### PR DESCRIPTION
In some cases, the line numbers in stack traces on arm64 and possibly other architectures can be wrong. This is due to the previous adjustment of the code address for the frame not being recognized by the IL offset extraction code, which adjusts it again unnecessarily.

Close #81526