### PR TITLE
[wasm][debugger] Fix test failing on firefox

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -1581,14 +1581,13 @@ namespace DebuggerTests
             }
         }
 
-        internal async Task SetJustMyCode(bool enabled)
+        internal virtual async Task SetJustMyCode(bool enabled)
         {
             var req = JObject.FromObject(new { JustMyCodeStepping = enabled });
             var res = await cli.SendCommand("DotnetDebugger.setDebuggerProperty", req, token);
             Assert.True(res.IsOk);
             Assert.Equal(res.Value["justMyCodeEnabled"], enabled);
         }
-
 
         internal async Task SetSymbolOptions(JObject param)
         {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestFirefox.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestFirefox.cs
@@ -182,6 +182,8 @@ public class DebuggerTestFirefox : DebuggerTestBase
                 });
     }
 
+    internal override Task SetJustMyCode(bool enabled) => Task.CompletedTask;
+
     internal override async Task<JObject> SendCommandAndCheck(JObject args, string method, string script_loc, int line, int column, string function_name,
             Func<JObject, Task> wait_for_event_fn = null, Func<JToken, Task> locals_fn = null, string waitForEvent = Inspector.PAUSE)
     {


### PR DESCRIPTION
Do not send `SetJustMyCode` on firefox, as it does not support this
setting.

On-behalf-of: @thaystg

Fixes: https://github.com/dotnet/runtime/issues/89602