### PR TITLE
Don't include empty prefix with EnvironmentVariablesConfigurationProvider

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
     /// <summary>
     /// An environment variable based <see cref="ConfigurationProvider"/>.
     /// </summary>
-    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public class EnvironmentVariablesConfigurationProvider : ConfigurationProvider
     {
         private const string MySqlServerPrefix = "MYSQLCONNSTR_";
@@ -52,7 +51,14 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
         /// </summary>
         /// <returns> The configuration name. </returns>
         public override string ToString()
-            => $"{GetType().Name} Prefix: '{_prefix}'";
+        {
+            string s = GetType().Name;
+            if (!string.IsNullOrEmpty(_prefix))
+            {
+                s += $" Prefix: '{_prefix}'";
+            }
+            return s;
+        }
 
         internal void Load(IDictionary envVariables)
         {
@@ -117,16 +123,5 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
         }
 
         private static string Normalize(string key) => key.Replace("__", ConfigurationPath.KeyDelimiter);
-
-        private string DebuggerToString()
-        {
-            var debugText = GetType().Name;
-
-            if (!string.IsNullOrEmpty(_prefix))
-            {
-                debugText += $" Prefix: '{_prefix}'";
-            }
-            return debugText;
-        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.Extensions.Configuration.EnvironmentVariables
 {
     /// <summary>
     /// An environment variable based <see cref="ConfigurationProvider"/>.
     /// </summary>
+    [DebuggerDisplay("{DebuggerToString(),nq}")]
     public class EnvironmentVariablesConfigurationProvider : ConfigurationProvider
     {
         private const string MySqlServerPrefix = "MYSQLCONNSTR_";
@@ -115,5 +117,16 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
         }
 
         private static string Normalize(string key) => key.Replace("__", ConfigurationPath.KeyDelimiter);
+
+        private string DebuggerToString()
+        {
+            var debugText = GetType().Name;
+
+            if (!string.IsNullOrEmpty(_prefix))
+            {
+                debugText += $" Prefix: '{_prefix}'";
+            }
+            return debugText;
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace Microsoft.Extensions.Configuration.EnvironmentVariables
 {

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             Assert.Equal("SqlClient", envConfigSrc.Get("DEFAULTCONNECTION:PROVIDER"));
             Assert.Equal("AnotherTestConnectionString", envConfigSrc.Get("Inventory:CONNECTIONSTRING"));
             Assert.Equal("MySql", envConfigSrc.Get("Inventory:Provider"));
-            Assert.Equal("EnvironmentVariablesConfigurationProvider Prefix: ''", envConfigSrc.ToString());
+            Assert.Equal("EnvironmentVariablesConfigurationProvider", envConfigSrc.ToString());
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationSectionDebugView.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationSectionDebugView.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Extensions.Configuration
 
         public override string ToString()
         {
-            var s = $"Path = {Path}";
+            var s = $@"Path = {Path}";
             if (Value is not null)
             {
-                s += $", Value = {Value}";
+                s += $@", Value = ""{Value}""";
             }
             if (Provider is not null)
             {

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationSectionDebugView.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationSectionDebugView.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Extensions.Configuration
 
         public override string ToString()
         {
-            var s = $@"Path = {Path}";
+            var s = $"Path = {Path}";
             if (Value is not null)
             {
-                s += $@", Value = ""{Value}""";
+                s += $", Value = {Value}";
             }
             if (Provider is not null)
             {


### PR DESCRIPTION
Don't include an empty prefix for `EnvironmentVariablesConfigurationProvider`. Makes config debug view cleaner to view:

![image](https://github.com/dotnet/runtime/assets/303201/cf90e379-031e-4efd-a853-a81c59342c0a)

Note that this is a runtime change to `ToString`. It needs to be modified in `ToString` because it's used to build up the debug view string.