### PR TITLE
[release/6.0] Update ds-ipc-pal-namedpipe to fix shutdown race

### DIFF
--- a/src/native/eventpipe/ds-ipc-pal-namedpipe.c
+++ b/src/native/eventpipe/ds-ipc-pal-namedpipe.c
@@ -635,10 +635,8 @@ ds_ipc_close (
 {
 	EP_ASSERT (ipc != NULL);
 
-	// don't attempt cleanup on shutdown and let the OS handle it
-    // except in the case of listen pipes - if they leak the process
-    // will fail to reinitialize the pipe for embedding scenarios.
-	if (is_shutdown && ipc->mode != DS_IPC_CONNECTION_MODE_LISTEN) {
+	// don't attempt cleanup on shutdown and let the OS handle it.
+	if (is_shutdown) {
 		if (callback)
 			callback ("Closing without cleaning underlying handles", 100);
 		return;


### PR DESCRIPTION
Partial fix for https://github.com/dotnet/runtime/issues/89621

# Description

Works around a regression introduced in 6.0.20 around reading/writing to the IPC while VM shutdown is happening. The diagnostic server thread might race VM shutdown, and end up using an IPC handle that has been closed as part of a GetOverlappedResult call, that in turn will end up closing the handle. 

The shutdown cleanup was added as a measure to ensure mono on Windows embedding scenarios would work after the EventPipe IPC got torn down. 

# Customer Impact

This can lead to hard to diagnose bugs on embedding scenarios where handle reuse is possible and the race will cause reused handles to be closed or odd reading behavior that's hard to diagnose. Currently EventPipe doesn't have any coordination mechanism during shutdown to make sure diagnostic server thread stops during shutdown, so it can't close any of the resources since they might still be used and their error paths lead to unexpected results. 

# Regression

Fixes regression introduced during last servicing.

# Risk

Regresses scenario of embedding mono on Windows.