### PR TITLE
Add more verifications in EventPipe rundownvalidation test.

### DIFF
--- a/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.cs
+++ b/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.cs
@@ -42,12 +42,30 @@ namespace Tracing.Tests.RundownValidation
 
         private static Func<EventPipeEventSource, Func<int>> _DoesRundownContainMethodEvents = (source) =>
         {
+            bool hasRuntimeStart = false;
+            bool hasMethodDCStopInit = false;
+            bool hasMethodDCStopComplete = false;
+            bool hasLoaderModuleDCStop = false;
+            bool hasLoaderDomainModuleDCStop = false;
+            bool hasAssemblyModuleDCStop = false;
             bool hasMethodDCStopVerbose = false;
             bool hasMethodILToNativeMap = false;
+            bool hasAppDomainDCStop = false;
+
             ClrRundownTraceEventParser rundownParser = new ClrRundownTraceEventParser(source);
+            rundownParser.RuntimeStart += (eventData) => hasRuntimeStart = true;
+            rundownParser.MethodDCStopInit += (eventData) => hasMethodDCStopInit = true;
+            rundownParser.MethodDCStopComplete += (eventData) => hasMethodDCStopComplete = true;
+            rundownParser.LoaderModuleDCStop += (eventData) => hasLoaderModuleDCStop = true;
+            rundownParser.LoaderDomainModuleDCStop += (eventData) => hasLoaderDomainModuleDCStop = true;
+            rundownParser.LoaderAssemblyDCStop += (eventData) => hasAssemblyModuleDCStop = true;
             rundownParser.MethodDCStopVerbose += (eventData) => hasMethodDCStopVerbose = true;
             rundownParser.MethodILToNativeMapDCStop += (eventData) => hasMethodILToNativeMap = true;
-            return () => hasMethodDCStopVerbose && hasMethodILToNativeMap ? 100 : -1;
+            rundownParser.LoaderAppDomainDCStop += (eventData) => hasAppDomainDCStop = true;
+            return () =>
+                hasRuntimeStart && hasMethodDCStopInit && hasMethodDCStopComplete &&
+                hasLoaderModuleDCStop && hasLoaderDomainModuleDCStop && hasAssemblyModuleDCStop &&
+                hasMethodDCStopVerbose && hasMethodILToNativeMap && hasAppDomainDCStop ? 100 : -1;
         };
     }
 }


### PR DESCRIPTION
Subtle changes done in:

https://github.com/dotnet/runtime/pull/85558

like a change where one of the utf8->utf16 conversion routines changed behavior when passing in a string that is "" and len 0. In previous implementation it would return a new string "", but in new update change, it starts to return NULL. That in turn would cause some fields in some EventPipe events on Mono to fail serialize (using "" if value is not present), and that knocked out a couple of rundown events on Mono that was detected and fixed in https://github.com/dotnet/runtime/pull/88634.

It would been ideal to catch this issue as part of CI, but turns out that our existing rundownvalidation test only tests a couple of rundown events, and not any of the module/assembly events that was affected by above change.

This commit adds validation that the following additional rundown events are included in the rundown event stream:

```
RuntimeStart
MethodDCStopInit
MethodDCStopComplete
LoaderModuleDCStop
LoaderDomainModuleDCStop
LoadAssemblyDCStop
LoadAppDomainDCStop
```

This would at least make sure the majority of important rundown events are present.