### PR TITLE
SPMI: Do not consider BADCODE as a replay failure

### DIFF
--- a/src/coreclr/jit/error.cpp
+++ b/src/coreclr/jit/error.cpp
@@ -251,6 +251,8 @@ void debugError(const char* msg, const char* file, unsigned line)
 
     LogEnv* env = JitTls::GetLogEnv();
 
+    JITDUMP("\nCOMPILATION FAILED: %s (%s:%d)\n", msg, tail, line);
+
     logf(LL_ERROR, "COMPILATION FAILED: file: %s:%d compiling method %s reason %s\n", tail, line,
          env->compiler->info.compFullName, msg);
 

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
@@ -395,7 +395,7 @@ JitInstance::Result JitInstance::CompileMethod(MethodContext* MethodToCompile, i
 
                 default:
                     LogError("Unknown target architecture");
-                break;
+                    break;
             }
 
             // If the target architecture doesn't match the expected target architecture
@@ -405,9 +405,9 @@ JitInstance::Result JitInstance::CompileMethod(MethodContext* MethodToCompile, i
             {
                 jitResult = CORJIT_OK;
             }
-
         }
-        if (jitResult == CORJIT_OK)
+
+        if ((jitResult == CORJIT_OK) || (jitResult == CORJIT_BADCODE))
         {
             // capture the results of compilation
             pParam->pThis->mc->cr->recCompileMethod(&NEntryBlock, &NCodeSizeBlock, jitResult);


### PR DESCRIPTION
BADCODE should not be bucketed as a replay failure since it is expected as a result of some patterns of illegal IL. Considering it a replay failure does not allow us to differentiate it from JIT bugs (such as JIT assert or JIT crash).

Contributes to #47540 and #47546.