### PR TITLE
[NativeAOT] Properly implement `System.Linq.Expressions` substitutions according to the recent refactoring 

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
@@ -37,9 +37,8 @@
       <ReproResponseLines Include="--feature:System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=false" />
       <ReproResponseLines Include="--feature:System.Diagnostics.Tracing.EventSource.IsSupported=false" />
       <ReproResponseLines Include="--feature:System.Resources.ResourceManager.AllowCustomResourceTypes=false" />
-      <ReproResponseLines Include="--feature:System.Linq.Expressions.CanCompileToIL=false" />
       <ReproResponseLines Include="--feature:System.Linq.Expressions.CanEmitObjectArrayDelegate=false" />
-      <ReproResponseLines Include="--feature:System.Linq.Expressions.CanCreateArbitraryDelegates=false" />
+      <ReproResponseLines Include="--feature:System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported=false" />
     </ItemGroup>
 
     <WriteLinesToFile File="$(OutputPath)\compile-with-$(LibrariesConfiguration)-libs.rsp"

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerOptionsBuilder.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerOptionsBuilder.cs
@@ -41,9 +41,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 			Options.FeatureSwitches.Add ("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", false);
 			Options.FeatureSwitches.Add ("System.Resources.ResourceManager.AllowCustomResourceTypes", false);
-			Options.FeatureSwitches.Add ("System.Linq.Expressions.CanCompileToIL", false);
 			Options.FeatureSwitches.Add ("System.Linq.Expressions.CanEmitObjectArrayDelegate", false);
-			Options.FeatureSwitches.Add ("System.Linq.Expressions.CanCreateArbitraryDelegates", false);
+			Options.FeatureSwitches.Add ("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", false);
 			Options.FeatureSwitches.Add ("System.Diagnostics.Debugger.IsSupported", false);
 			Options.FeatureSwitches.Add ("System.Text.Encoding.EnableUnsafeUTF7Encoding", false);
 			Options.FeatureSwitches.Add ("System.Diagnostics.Tracing.EventSource.IsSupported", false);

--- a/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.xml
+++ b/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.xml
@@ -1,7 +1,13 @@
 <linker>
   <assembly fullname="System.Linq.Expressions">
+    <type fullname="System.Linq.Expressions.LambdaExpression">
+      <method signature="System.Boolean get_CanCompileToIL()" feature="System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported" featurevalue="false" body="stub" value="false" />
+    </type>
     <type fullname="System.Dynamic.Utils.DelegateHelpers">
       <method signature="System.Boolean get_CanEmitObjectArrayDelegate()" feature="System.Linq.Expressions.CanEmitObjectArrayDelegate" featurevalue="false" body="stub" value="false" />
+    </type>
+    <type fullname="System.Linq.Expressions.Interpreter.CallInstruction">
+      <method signature="System.Boolean get_CanCreateArbitraryDelegates()" feature="System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported" featurevalue="false" body="stub" value="false" />
     </type>
   </assembly>
 </linker>


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/89308 introduced a regression for NativeAOT because the changes assumed that ILC trimming can propagate constants over methods. As this is not true, the `Ref.Emit` backend is not trimmed away by ILC anymore increasing the app size. 

This PR fixes this regression, by adjusting the `System.Linq.Expressions` substitutions to wire `DynamicCodeSupported` feature switch value to `get_CanCompileToIL` and `get_CanCreateArbitraryDelegates` and substitute them with `false` - avoiding the constant propagation over methods limitation. 

Additionally, I cleaned up a few places that had left overs of the removed private feature switches.

Verified that the regression has been fixed by adding a reference to `System.Linq.Expressions` in the HelloiOS sample and AOTing with and without changes in the PR:

| HelloiOS sample   | main | this PR |
|-------------------|------|---------|
| Size on disk (Mb) | 53,3 | 12,14   |

Thanks @vitek-karas for figuring out the right approach.

@dotnet/ilc-contrib 

---
Fixes https://github.com/dotnet/runtime/issues/89527