### PR TITLE
Enable new analyzer CA1868: 'Unnecessary call to 'Contains' for sets' and fix findings

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -483,6 +483,9 @@ dotnet_diagnostic.CA1863.severity = suggestion
 # CA1864: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
 dotnet_diagnostic.CA1864.severity = warning
 
+# CA1868: Unnecessary call to 'Contains' for sets
+dotnet_diagnostic.CA1868.severity = warning
+
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none
 

--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -480,6 +480,9 @@ dotnet_diagnostic.CA1863.severity = none
 # CA1864: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
 dotnet_diagnostic.CA1864.severity = none
 
+# CA1868: Unnecessary call to 'Contains' for sets
+dotnet_diagnostic.CA1868.severity = none
+
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ModuleInitializerListNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ModuleInitializerListNode.cs
@@ -113,9 +113,8 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     foreach (var module in allModules)
                     {
-                        if (!markedModules.Contains(module))
+                        if (markedModules.Add(module))
                         {
-                            markedModules.Add(module);
                             if (modulesWithCctor.Contains(module.Module))
                                 sortedModules.Add(module.Module);
                             break;

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DgmlWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DgmlWriter.cs
@@ -158,10 +158,8 @@ namespace ILCompiler.DependencyAnalysisFramework
         void IDependencyAnalyzerLogEdgeVisitor<DependencyContextType>.VisitEdge(DependencyNodeCore<DependencyContextType> nodeDepender, DependencyNodeCore<DependencyContextType> nodeDependerOther, DependencyNodeCore<DependencyContextType> nodeDependedOn, string reason)
         {
             var combinedNode = new Tuple<DependencyNodeCore<DependencyContextType>, DependencyNodeCore<DependencyContextType>>(nodeDepender, nodeDependerOther);
-            if (!_combinedNodesEdgeVisited.Contains(combinedNode))
+            if (_combinedNodesEdgeVisited.Add(combinedNode))
             {
-                _combinedNodesEdgeVisited.Add(combinedNode);
-
                 _xmlWrite.WriteStartElement("Link");
                 _xmlWrite.WriteAttributeString("Source", _nodeMappings[nodeDepender].ToString());
                 _xmlWrite.WriteAttributeString("Target", _nodeMappings[combinedNode].ToString());

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePartDefinition.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePartDefinition.cs
@@ -185,10 +185,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
                                 }
                                 else
                                 {
-                                    if (!candidates.Add(candidatePart))
-                                    {
-                                        alreadyProcessed = true;
-                                    }
+                                    alreadyProcessed |= !candidates.Add(candidatePart);
                                 }
                                 if (!alreadyProcessed)
                                 {

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePartDefinition.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePartDefinition.cs
@@ -185,13 +185,9 @@ namespace System.ComponentModel.Composition.ReflectionModel
                                 }
                                 else
                                 {
-                                    if (candidates.Contains(candidatePart))
+                                    if (!candidates.Add(candidatePart))
                                     {
                                         alreadyProcessed = true;
-                                    }
-                                    else
-                                    {
-                                        candidates.Add(candidatePart);
                                     }
                                 }
                                 if (!alreadyProcessed)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -472,9 +472,8 @@ namespace System.Diagnostics.Metrics
                     }
                 }
 
-                if (!_sharedSessionClientIds.Contains(clientId))
+                if (_sharedSessionClientIds.Add(clientId))
                 {
-                    _sharedSessionClientIds.Add(clientId);
                     Interlocked.Increment(ref _sharedSessionRefCount);
                 }
             }

--- a/src/tasks/MobileBuildTasks/Android/AndroidProject.cs
+++ b/src/tasks/MobileBuildTasks/Android/AndroidProject.cs
@@ -122,9 +122,8 @@ namespace Microsoft.Android.Build
                 string rootPath = Path.GetDirectoryName(lib)!;
                 string libName = Path.GetFileName(lib);
 
-                if (!libDirs.Contains(rootPath))
+                if (libDirs.Add(rootPath))
                 {
-                    libDirs.Add(rootPath);
                     ret.Append($"-L {rootPath} ");
                 }
                 ret.Append($"-l:{libName} ");

--- a/src/tools/illink/src/ILLink.Shared/Annotations.cs
+++ b/src/tools/illink/src/ILLink.Shared/Annotations.cs
@@ -79,8 +79,7 @@ namespace ILLink.Shared
 			var values = new HashSet<DynamicallyAccessedMemberTypes> (
 								Enum.GetValues (typeof (DynamicallyAccessedMemberTypes))
 								.Cast<DynamicallyAccessedMemberTypes> ());
-			if (!values.Contains (DynamicallyAccessedMemberTypes.Interfaces))
-				values.Add (DynamicallyAccessedMemberTypes.Interfaces);
+			values.Add (DynamicallyAccessedMemberTypes.Interfaces);
 			return values.ToArray ();
 		}
 


### PR DESCRIPTION
See https://github.com/dotnet/roslyn-analyzers/pull/6767 and https://github.com/dotnet/runtime/issues/85490.