### PR TITLE
[wasm] CI: Don't run chrome debugger tests on runtime-wasm if they

### DIFF
--- a/eng/pipelines/common/templates/wasm-debugger-tests.yml
+++ b/eng/pipelines/common/templates/wasm-debugger-tests.yml
@@ -24,8 +24,6 @@ jobs:
       # map dependencies variables to local variables
       - name: alwaysRunVar
         value: ${{ parameters.alwaysRun }}
-      - name: runOnlyOnWasmPipelinesVar
-        value: ${{ parameters.runOnlyOnWasmOnlyPipelines }}
       - name: shouldRunOnDefaultPipelines
         value: $[
           or(
@@ -53,7 +51,7 @@ jobs:
           eq(variables['alwaysRunVar'], true),
           and(
             eq(variables['isDefaultPipeline'], variables['shouldRunOnDefaultPipelines']),
-            ne(variables['runOnlyOnWasmPipelinesVar'], 'true')))
+            eq(${{ parameters.isWasmOnlyBuild }}, ${{ parameters.runOnlyOnWasmOnlyPipelines }})))
       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
       extraStepsParameters:
         creator: dotnet-bot

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DelegateTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DelegateTests.cs
@@ -11,7 +11,6 @@ using Xunit.Abstractions;
 
 namespace DebuggerTests
 {
-
     public class DelegateTests : DebuggerTests
     {
         public DelegateTests(ITestOutputHelper testOutput) : base(testOutput)


### PR DESCRIPTION
.. already run on `runtime`. This is already enforced for other wasm
jobs.
