### PR TITLE
Disable MacCatalyst too in PalCreateDump.cpp

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
@@ -50,7 +50,7 @@
 #include <minipal/utils.h>
 #include <generatedumpflags.h>
 
-#if !defined(HOST_IOS) && !defined(HOST_TVOS)
+#if !defined(HOST_MACCATALYST) && !defined(HOST_IOS) && !defined(HOST_TVOS)
 
 // Crash dump generating program arguments. MAX_ARGV_ENTRIES is the max number
 // of entries if every createdump option/argument is passed.
@@ -334,7 +334,7 @@ CreateCrashDump(
     return true;
 }
 
-#endif // !defined(HOST_IOS) && !defined(HOST_TVOS)
+#endif // !defined(HOST_MACCATALYST) && !defined(HOST_IOS) && !defined(HOST_TVOS)
 
 /*++
 Function:
@@ -352,7 +352,7 @@ Parameters:
 void
 PalCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo, void* exceptionRecord)
 {
-#if !defined(HOST_IOS) && !defined(HOST_TVOS)
+#if !defined(HOST_MACCATALYST) && !defined(HOST_IOS) && !defined(HOST_TVOS)
     // If enabled, launch the create minidump utility and wait until it completes
     if (g_argvCreateDump[0] != nullptr)
     {
@@ -438,7 +438,7 @@ PalCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo, void* exceptionRecor
         free(signalAddressArg);
         free(exceptionRecordArg);
     }
-#endif // !defined(HOST_IOS) && !defined(HOST_TVOS)
+#endif // !defined(HOST_MACCATALYST) && !defined(HOST_IOS) && !defined(HOST_TVOS)
 }
 
 void
@@ -482,7 +482,7 @@ PalGenerateCoreDump(
     char* errorMessageBuffer,
     int cbErrorMessageBuffer)
 {
-#if !defined(HOST_IOS) && !defined(HOST_TVOS)
+#if !defined(HOST_MACCATALYST) && !defined(HOST_IOS) && !defined(HOST_TVOS)
     const char* argvCreateDump[MAX_ARGV_ENTRIES];
     if (dumpType <= DumpTypeUnknown || dumpType > DumpTypeMax)
     {
@@ -500,7 +500,7 @@ PalGenerateCoreDump(
     return result;
 #else
     return false;
-#endif // !defined(HOST_IOS) && !defined(HOST_TVOS)
+#endif // !defined(HOST_MACCATALYST) && !defined(HOST_IOS) && !defined(HOST_TVOS)
 }
 
 /*++
@@ -519,7 +519,7 @@ Return
 bool
 PalCreateDumpInitialize()
 {
-#if !defined(HOST_IOS) && !defined(HOST_TVOS)
+#if !defined(HOST_MACCATALYST) && !defined(HOST_IOS) && !defined(HOST_TVOS)
     bool enabled = false;
     RhConfig::Environment::TryGetBooleanValue("DbgEnableMiniDump", &enabled);
     if (enabled)
@@ -614,7 +614,7 @@ PalCreateDumpInitialize()
             return false;
         }
     }
-#endif // !defined(HOST_IOS) && !defined(HOST_TVOS)
+#endif // !defined(HOST_MACCATALYST) && !defined(HOST_IOS) && !defined(HOST_TVOS)
 
     return true;
 }


### PR DESCRIPTION
While you can fork/exec on MacCatalyst if the App Sandbox is enabled (required for AppStore) you can't write to arbitrary paths except those requested by the user through e.g. an Open File dialog which isn't possible here.