### PR TITLE
[WIP] Testing Vector128 test failures with Mono on win-x64

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
@@ -11,204 +11,204 @@ jobs:
 # Build CoreCLR release
 # Always as they are needed by Installer and we always build and test the Installer.
 #
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-    buildConfig: release
-    platforms:
-    - linux_x64
-    - linux_arm
-    - linux_arm64
-    - linux_musl_x64
-    - osx_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    jobParameters:
-      testGroup: innerloop
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+#     buildConfig: release
+#     platforms:
+#     - linux_x64
+#     - linux_arm
+#     - linux_arm64
+#     - linux_musl_x64
+#     - osx_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     jobParameters:
+#       testGroup: innerloop
 
-#
-# Build libraries using live CoreLib
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: Release
-    platforms:
-    - linux_x64
-    - linux_arm
-    - linux_arm64
-    - linux_musl_x64
-    - osx_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
+# #
+# # Build libraries using live CoreLib
+# #
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/libraries/build-job.yml
+#     buildConfig: Release
+#     platforms:
+#     - linux_x64
+#     - linux_arm
+#     - linux_arm64
+#     - linux_musl_x64
+#     - osx_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
 
-#
-# Libraries Release Test Execution against a release coreclr runtime
-# Only when the PR contains a libraries change
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: Release
-    platforms:
-    - linux_x64
-    - linux_arm
-    - linux_arm64
-    - linux_musl_x64
-    - osx_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    jobParameters:
-      isOfficialBuild: false
-      isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
-      testScope: innerloop
-      liveRuntimeBuildConfig: release
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
+# #
+# # Libraries Release Test Execution against a release coreclr runtime
+# # Only when the PR contains a libraries change
+# #
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+#     buildConfig: Release
+#     platforms:
+#     - linux_x64
+#     - linux_arm
+#     - linux_arm64
+#     - linux_musl_x64
+#     - osx_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+#     jobParameters:
+#       isOfficialBuild: false
+#       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
+#       testScope: innerloop
+#       liveRuntimeBuildConfig: release
+#       condition: >-
+#         or(
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+#           eq(variables['isRollingBuild'], true))
 
-#
-# CoreCLR NativeAOT release build and libraries tests
-# Only when CoreCLR or library is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    platforms:
-    - windows_x64
-    - windows_arm64
-    - osx_x64
-    - osx_arm64
-    - linux_x64
-    - linux_arm64
-    - linux_musl_x64
-    jobParameters:
-      testGroup: innerloop
-      isSingleFile: true
-      nameSuffix: NativeAOT_Libs
-      buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) /p:TestNativeAot=true /p:ArchiveTests=true
-      timeoutInMinutes: 300 # doesn't normally take this long, but I've seen Helix queues backed up for 160 minutes
-      # extra steps, run tests
-      extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      extraStepsParameters:
-        creator: dotnet-bot
-        testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
+# #
+# # CoreCLR NativeAOT release build and libraries tests
+# # Only when CoreCLR or library is changed
+# #
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/global-build-job.yml
+#     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+#     buildConfig: Release
+#     platforms:
+#     - windows_x64
+#     - windows_arm64
+#     - osx_x64
+#     - osx_arm64
+#     - linux_x64
+#     - linux_arm64
+#     - linux_musl_x64
+#     jobParameters:
+#       testGroup: innerloop
+#       isSingleFile: true
+#       nameSuffix: NativeAOT_Libs
+#       buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) /p:TestNativeAot=true /p:ArchiveTests=true
+#       timeoutInMinutes: 300 # doesn't normally take this long, but I've seen Helix queues backed up for 160 minutes
+#       # extra steps, run tests
+#       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+#       extraStepsParameters:
+#         creator: dotnet-bot
+#         testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+#       condition: >-
+#         or(
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+#           eq(variables['isRollingBuild'], true))
 
-#
-# CoreCLR NativeAOT release build (checked runtime) and libraries tests
-# Only when CoreCLR or library is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    platforms:
-    - windows_x64
-    - linux_arm64
-    jobParameters:
-      testGroup: innerloop
-      isSingleFile: true
-      nameSuffix: NativeAOT_Checked_Libs
-      buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) -rc Checked /p:TestNativeAot=true /p:ArchiveTests=true
-      timeoutInMinutes: 360
-      # extra steps, run tests
-      extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      extraStepsParameters:
-        creator: dotnet-bot
-        testRunNamePrefixSuffix: NativeAOT_Checked_$(_BuildConfig)
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
+# #
+# # CoreCLR NativeAOT release build (checked runtime) and libraries tests
+# # Only when CoreCLR or library is changed
+# #
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/global-build-job.yml
+#     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+#     buildConfig: Release
+#     platforms:
+#     - windows_x64
+#     - linux_arm64
+#     jobParameters:
+#       testGroup: innerloop
+#       isSingleFile: true
+#       nameSuffix: NativeAOT_Checked_Libs
+#       buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) -rc Checked /p:TestNativeAot=true /p:ArchiveTests=true
+#       timeoutInMinutes: 360
+#       # extra steps, run tests
+#       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+#       extraStepsParameters:
+#         creator: dotnet-bot
+#         testRunNamePrefixSuffix: NativeAOT_Checked_$(_BuildConfig)
+#       condition: >-
+#         or(
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+#           eq(variables['isRollingBuild'], true))
 
-#
-# CoreCLR NativeAOT release build (checked runtime) - SizeOpt and libraries tests
-# Only when CoreCLR or library is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    platforms:
-    - windows_x64
-    - linux_x64
-    jobParameters:
-      testGroup: innerloop
-      isSingleFile: true
-      nameSuffix: NativeAOT_Checked_Libs_SizeOpt
-      buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) -rc Checked /p:TestNativeAot=true /p:ArchiveTests=true /p:OptimizationPreference=Size
-      timeoutInMinutes: 240
-      # extra steps, run tests
-      extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      extraStepsParameters:
-        creator: dotnet-bot
-        testRunNamePrefixSuffix: NativeAOT_Checked_SizeOpt_$(_BuildConfig)
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
+# #
+# # CoreCLR NativeAOT release build (checked runtime) - SizeOpt and libraries tests
+# # Only when CoreCLR or library is changed
+# #
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/global-build-job.yml
+#     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+#     buildConfig: Release
+#     platforms:
+#     - windows_x64
+#     - linux_x64
+#     jobParameters:
+#       testGroup: innerloop
+#       isSingleFile: true
+#       nameSuffix: NativeAOT_Checked_Libs_SizeOpt
+#       buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) -rc Checked /p:TestNativeAot=true /p:ArchiveTests=true /p:OptimizationPreference=Size
+#       timeoutInMinutes: 240
+#       # extra steps, run tests
+#       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+#       extraStepsParameters:
+#         creator: dotnet-bot
+#         testRunNamePrefixSuffix: NativeAOT_Checked_SizeOpt_$(_BuildConfig)
+#       condition: >-
+#         or(
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+#           eq(variables['isRollingBuild'], true))
 
-#
-# CoreCLR NativeAOT release build (checked runtime) - SpeedOpt and libraries tests
-# Only when CoreCLR or library is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    platforms:
-    - windows_x64
-    - linux_x64
-    jobParameters:
-      testGroup: innerloop
-      isSingleFile: true
-      nameSuffix: NativeAOT_Checked_Libs_SpeedOpt
-      buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) -rc Checked /p:TestNativeAot=true /p:ArchiveTests=true /p:OptimizationPreference=Speed
-      timeoutInMinutes: 240
-      # extra steps, run tests
-      extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      extraStepsParameters:
-        creator: dotnet-bot
-        testRunNamePrefixSuffix: NativeAOT_Checked_SpeedOpt_$(_BuildConfig)
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
+# #
+# # CoreCLR NativeAOT release build (checked runtime) - SpeedOpt and libraries tests
+# # Only when CoreCLR or library is changed
+# #
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/global-build-job.yml
+#     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+#     buildConfig: Release
+#     platforms:
+#     - windows_x64
+#     - linux_x64
+#     jobParameters:
+#       testGroup: innerloop
+#       isSingleFile: true
+#       nameSuffix: NativeAOT_Checked_Libs_SpeedOpt
+#       buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) -rc Checked /p:TestNativeAot=true /p:ArchiveTests=true /p:OptimizationPreference=Speed
+#       timeoutInMinutes: 240
+#       # extra steps, run tests
+#       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+#       extraStepsParameters:
+#         creator: dotnet-bot
+#         testRunNamePrefixSuffix: NativeAOT_Checked_SpeedOpt_$(_BuildConfig)
+#       condition: >-
+#         or(
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+#           eq(variables['isRollingBuild'], true))
 
-# Run net48 tests on win-x64
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: Release
-    platforms:
-    - windows_x64
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    jobParameters:
-      framework: net48
-      runTests: true
-      testScope: innerloop
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
+# # Run net48 tests on win-x64
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/libraries/build-job.yml
+#     buildConfig: Release
+#     platforms:
+#     - windows_x64
+#     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+#     jobParameters:
+#       framework: net48
+#       runTests: true
+#       testScope: innerloop
+#       condition: >-
+#         or(
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+#           eq(variables['isRollingBuild'], true))
 
 #### MONO LEGS
 
@@ -251,124 +251,124 @@ jobs:
           eq(variables['monoContainsChange'], true),
           eq(variables['isRollingBuild'], true))
 
-#
-# Build the whole product using Mono and run runtime tests
-# Build Mono release
-# Only when libraries, mono, or the runtime tests changed
-# Currently only these architectures are needed for the runtime tests.
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-    runtimeFlavor: mono
-    buildConfig: release
-    platforms:
-    - linux_arm64
-    jobParameters:
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
+# #
+# # Build the whole product using Mono and run runtime tests
+# # Build Mono release
+# # Only when libraries, mono, or the runtime tests changed
+# # Currently only these architectures are needed for the runtime tests.
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+#     runtimeFlavor: mono
+#     buildConfig: release
+#     platforms:
+#     - linux_arm64
+#     jobParameters:
+#       condition: >-
+#         or(
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+#           eq(variables['isRollingBuild'], true))
 
-#
-# Mono Test builds with CoreCLR runtime tests using live libraries debug build
-# Only when Mono is changed
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    buildConfig: release
-    runtimeFlavor: mono
-    platforms:
-    - CoreClrTestBuildHost # Either osx_x64 or linux_x64
-    jobParameters:
-      testGroup: innerloop
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
+# #
+# # Mono Test builds with CoreCLR runtime tests using live libraries debug build
+# # Only when Mono is changed
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+#     buildConfig: release
+#     runtimeFlavor: mono
+#     platforms:
+#     - CoreClrTestBuildHost # Either osx_x64 or linux_x64
+#     jobParameters:
+#       testGroup: innerloop
+#       condition: >-
+#         or(
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+#           eq(variables['isRollingBuild'], true))
 
-#
-# Mono CoreCLR runtime Test executions using live libraries in jit mode
-# Only when Mono is changed
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: release
-    runtimeFlavor: mono
-    platforms:
-    - linux_arm64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: Release
-      liveRuntimeBuildConfig: release
-      runtimeVariant: minijit
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
+# #
+# # Mono CoreCLR runtime Test executions using live libraries in jit mode
+# # Only when Mono is changed
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+#     buildConfig: release
+#     runtimeFlavor: mono
+#     platforms:
+#     - linux_arm64
+#     helixQueueGroup: pr
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: innerloop
+#       liveLibrariesBuildConfig: Release
+#       liveRuntimeBuildConfig: release
+#       runtimeVariant: minijit
+#       condition: >-
+#         or(
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+#           eq(variables['isRollingBuild'], true))
 
-#
-# Mono CoreCLR runtime Test executions using live libraries and LLVM Full AOT
-# Only when Mono is changed
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-      - linux_x64
-      - linux_arm64
-    variables:
-      - name: timeoutPerTestInMinutes
-        value: 60
-      - name: timeoutPerTestCollectionInMinutes
-        value: 180
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_LLVMFullAot_RuntimeTests
-      runtimeVariant: llvmfullaot
-      buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true /p:MonoLLVMUseCxx11Abi=true
-      timeoutInMinutes: 300
+# #
+# # Mono CoreCLR runtime Test executions using live libraries and LLVM Full AOT
+# # Only when Mono is changed
+# #
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/global-build-job.yml
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     buildConfig: Release
+#     runtimeFlavor: mono
+#     platforms:
+#       - linux_x64
+#       - linux_arm64
+#     variables:
+#       - name: timeoutPerTestInMinutes
+#         value: 60
+#       - name: timeoutPerTestCollectionInMinutes
+#         value: 180
+#     jobParameters:
+#       testGroup: innerloop
+#       nameSuffix: AllSubsets_Mono_LLVMFullAot_RuntimeTests
+#       runtimeVariant: llvmfullaot
+#       buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+#       timeoutInMinutes: 300
 
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
-      extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
-      extraStepsParameters:
-        creator: dotnet-bot
-        llvmAotStepContainer: linux_x64_llvmaot
-      testRunNamePrefixSuffix: Mono_Release
-      extraVariablesTemplates:
-        - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+#       condition: >-
+#         or(
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+#           eq(variables['isRollingBuild'], true))
+#       extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+#       extraStepsParameters:
+#         creator: dotnet-bot
+#         llvmAotStepContainer: linux_x64_llvmaot
+#       testRunNamePrefixSuffix: Mono_Release
+#       extraVariablesTemplates:
+#         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
-#
-# Mono CoreCLR runtime Test executions using live libraries in interpreter mode
-# Only when Mono is changed
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: release
-    runtimeFlavor: mono
-    platforms:
-    - linux_arm64
-    helixQueueGroup: pr
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: innerloop
-      liveLibrariesBuildConfig: Release
-      liveRuntimeBuildConfig: release
-      runtimeVariant: monointerpreter
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
+# #
+# # Mono CoreCLR runtime Test executions using live libraries in interpreter mode
+# # Only when Mono is changed
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+#     buildConfig: release
+#     runtimeFlavor: mono
+#     platforms:
+#     - linux_arm64
+#     helixQueueGroup: pr
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: innerloop
+#       liveLibrariesBuildConfig: Release
+#       liveRuntimeBuildConfig: release
+#       runtimeVariant: monointerpreter
+#       condition: >-
+#         or(
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+#           eq(variables['isRollingBuild'], true))

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -40,140 +40,140 @@ extends:
       - ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
         - template: /eng/pipelines/common/evaluate-default-paths.yml
 
-      #
-      # Build with Release config and Debug runtimeConfiguration
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          platforms:
-          - windows_x86
-          - osx_x64
-          - osx_arm64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: Runtime_Debug
-            buildArgs: -c release -runtimeConfiguration debug
-            timeoutInMinutes: 120
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Build with Release config and Debug runtimeConfiguration
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: release
+      #     platforms:
+      #     - windows_x86
+      #     - osx_x64
+      #     - osx_arm64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: Runtime_Debug
+      #       buildArgs: -c release -runtimeConfiguration debug
+      #       timeoutInMinutes: 120
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # Build with Release config and runtimeConfiguration with MSBuild generator
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          platforms:
-          - windows_x86
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: MSBuild_CMake
-            buildArgs: -c Release -msbuild
-            timeoutInMinutes: 120
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Build with Release config and runtimeConfiguration with MSBuild generator
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: release
+      #     platforms:
+      #     - windows_x86
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: MSBuild_CMake
+      #       buildArgs: -c Release -msbuild
+      #       timeoutInMinutes: 120
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # Build with Debug config and Release runtimeConfiguration
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: debug
-          platforms:
-          - linux_x64_dev_innerloop
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: Runtime_Release
-            buildArgs: -c debug -runtimeConfiguration release
-            timeoutInMinutes: 120
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Build with Debug config and Release runtimeConfiguration
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: debug
+      #     platforms:
+      #     - linux_x64_dev_innerloop
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: Runtime_Release
+      #       buildArgs: -c debug -runtimeConfiguration release
+      #       timeoutInMinutes: 120
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # Build with RuntimeFlavor only. This exercise code paths where only RuntimeFlavor is
-      # specified. Catches cases where we depend on Configuration also being specified
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: debug
-          platforms:
-          - linux_x64_dev_innerloop
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: RuntimeFlavor_Mono
-            buildArgs: /p:RuntimeFlavor=Mono
-            timeoutInMinutes: 120
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Build with RuntimeFlavor only. This exercise code paths where only RuntimeFlavor is
+      # # specified. Catches cases where we depend on Configuration also being specified
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: debug
+      #     platforms:
+      #     - linux_x64_dev_innerloop
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: RuntimeFlavor_Mono
+      #       buildArgs: /p:RuntimeFlavor=Mono
+      #       timeoutInMinutes: 120
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # Build Mono + Libraries. This exercises the code path where we build libraries without
-      # first building CoreCLR
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: debug
-          platforms:
-          - windows_x64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: Mono_Libraries
-            buildArgs: -subset mono+libs /p:RuntimeFlavor=Mono
-            timeoutInMinutes: 120
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Build Mono + Libraries. This exercises the code path where we build libraries without
+      # # first building CoreCLR
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: debug
+      #     platforms:
+      #     - windows_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: Mono_Libraries
+      #       buildArgs: -subset mono+libs /p:RuntimeFlavor=Mono
+      #       timeoutInMinutes: 120
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # Build Libraries AllConfigurations. This exercises the code path where we build libraries for all
-      # configurations on a non Windows operating system.
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: debug
-          platforms:
-          - linux_x64_dev_innerloop
-          jobParameters:
-            nameSuffix: Libraries_AllConfigurations
-            buildArgs: -subset libs -allconfigurations
-            timeoutInMinutes: 120
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Build Libraries AllConfigurations. This exercises the code path where we build libraries for all
+      # # configurations on a non Windows operating system.
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: debug
+      #     platforms:
+      #     - linux_x64_dev_innerloop
+      #     jobParameters:
+      #       nameSuffix: Libraries_AllConfigurations
+      #       buildArgs: -subset libs -allconfigurations
+      #       timeoutInMinutes: 120
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # SourceBuild Build
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: Release
-          platforms:
-          - SourceBuild_linux_x64
-          jobParameters:
-            nameSuffix: PortableSourceBuild
-            extraStepsParameters:
-              name: SourceBuildPackages
-            timeoutInMinutes: 95
-            condition:
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true)
+      # #
+      # # SourceBuild Build
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: Release
+      #     platforms:
+      #     - SourceBuild_linux_x64
+      #     jobParameters:
+      #       nameSuffix: PortableSourceBuild
+      #       extraStepsParameters:
+      #         name: SourceBuildPackages
+      #       timeoutInMinutes: 95
+      #       condition:
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true)

--- a/eng/pipelines/runtime-extra-platforms.yml
+++ b/eng/pipelines/runtime-extra-platforms.yml
@@ -49,61 +49,55 @@ extends:
       - ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
         - template: /eng/pipelines/common/evaluate-default-paths.yml
 
-      # Add wasm jobs only for rolling builds
-      - ${{ if eq(variables.isRollingBuild, true) }}:
-        - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
-          parameters:
-            isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-            isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
-            isRollingBuild: ${{ variables.isRollingBuild }}
+      # # Add wasm jobs only for rolling builds
+      # - ${{ if eq(variables.isRollingBuild, true) }}:
+      #   - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+      #     parameters:
+      #       isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+      #       isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
+      #       isRollingBuild: ${{ variables.isRollingBuild }}
 
-      # Add iOS/tvOS jobs
-      - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
-        parameters:
-          isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-          isiOSLikeOnlyBuild: ${{ variables.isiOSLikeOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
+      # # Add iOS/tvOS jobs
+      # - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+      #   parameters:
+      #     isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+      #     isiOSLikeOnlyBuild: ${{ variables.isiOSLikeOnlyBuild }}
+      #     isRollingBuild: ${{ variables.isRollingBuild }}
 
-      # Add iOS/tvOS simulator jobs
-      #
-      # Disabled pending queue backup investigation 
-      #
-      #- template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
-      #  parameters:
-      #    isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-      #    isiOSLikeSimulatorOnlyBuild: ${{ variables.isiOSLikeSimulatorOnlyBuild }}
-      #    isRollingBuild: ${{ variables.isRollingBuild }}
+      # # Add iOS/tvOS simulator jobs
+      # - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+      #   parameters:
+      #     isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+      #     isiOSLikeSimulatorOnlyBuild: ${{ variables.isiOSLikeSimulatorOnlyBuild }}
+      #     isRollingBuild: ${{ variables.isRollingBuild }}
 
-      # Add Android jobs
-      - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
-        parameters:
-          isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-          isAndroidOnlyBuild: ${{ variables.isAndroidOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
+      # # Add Android jobs
+      # - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
+      #   parameters:
+      #     isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+      #     isAndroidOnlyBuild: ${{ variables.isAndroidOnlyBuild }}
+      #     isRollingBuild: ${{ variables.isRollingBuild }}
 
-      # Add Android emulator jobs
-      - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
-        parameters:
-          isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-          isAndroidEmulatorOnlyBuild: ${{ variables.isAndroidEmulatorOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
+      # # Add Android emulator jobs
+      # - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+      #   parameters:
+      #     isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+      #     isAndroidEmulatorOnlyBuild: ${{ variables.isAndroidEmulatorOnlyBuild }}
+      #     isRollingBuild: ${{ variables.isRollingBuild }}
 
-      # Add Mac Catalyst jobs
-      #
-      # Disabled pending queue backup investigation 
-      #
-      #- template: /eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
-      #  parameters:
-      #    isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-      #    isMacCatalystOnlyBuild: ${{ variables.isMacCatalystOnlyBuild }}
-      #    isRollingBuild: ${{ variables.isRollingBuild }}
+      # # Add Mac Catalyst jobs
+      # - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
+      #   parameters:
+      #     isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+      #     isMacCatalystOnlyBuild: ${{ variables.isMacCatalystOnlyBuild }}
+      #     isRollingBuild: ${{ variables.isRollingBuild }}
 
-      # Add Linux Bionic jobs
-      - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-linuxbionic.yml
-        parameters:
-          isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-          isLinuxBionicOnlyBuild: ${{ variables.isLinuxBionicOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
+      # # Add Linux Bionic jobs
+      # - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-linuxbionic.yml
+      #   parameters:
+      #     isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+      #     isLinuxBionicOnlyBuild: ${{ variables.isLinuxBionicOnlyBuild }}
+      #     isRollingBuild: ${{ variables.isRollingBuild }}
 
       # Any jobs that are not specific to any platform
       - ${{ if eq(variables.isNotSpecificPlatformOnlyBuild, true) }}:

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -61,71 +61,71 @@ extends:
       - ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
         - template: /eng/pipelines/common/evaluate-default-paths.yml
 
-      #
-      # Build and Test ILLink in Release config vertical for Windows, Linux and OSX
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          platforms:
-          - windows_x64
-          - osx_x64
-          - linux_x64
-          jobParameters:
-            testGroup: innerloop
-            testResultsFormat: 'vstest'
-            timeoutInMinutes: 120
-            nameSuffix: ILLink_Runtime_Testing
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-            buildArgs: -s tools.illinktests -test -c $(_BuildConfig)
+      # #
+      # # Build and Test ILLink in Release config vertical for Windows, Linux and OSX
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: release
+      #     platforms:
+      #     - windows_x64
+      #     - osx_x64
+      #     - linux_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       enablePublishTestResults: true
+      #       timeoutInMinutes: 120
+      #       nameSuffix: ILLink_Runtime_Testing
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+      #       buildArgs: -s tools.illinktests -test -c $(_BuildConfig)
 
-      #
-      # Build Release config vertical for Windows, Linux, and OSX
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          platforms:
-          - windows_x64
-          - osx_x64
-          - linux_x64
-          jobParameters:
-            testGroup: innerloop
-            timeoutInMinutes: 120
-            nameSuffix: Runtime_Release
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-            buildArgs: -s clr+libs -c $(_BuildConfig)
-            extraStepsTemplate: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
+      # #
+      # # Build Release config vertical for Windows, Linux, and OSX
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: release
+      #     platforms:
+      #     - windows_x64
+      #     - osx_x64
+      #     - linux_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       timeoutInMinutes: 120
+      #       nameSuffix: Runtime_Release
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+      #       buildArgs: -s clr+libs -c $(_BuildConfig)
+      #       extraStepsTemplate: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
 
-      #
-      # Build Release config vertical for Browser-wasm
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          platforms:
-          - browser_wasm
-          jobParameters:
-            testGroup: innerloop
-            timeoutInMinutes: 120
-            nameSuffix: Runtime_Release
-            buildArgs: -s mono+libs -c $(_BuildConfig) -p:WasmBuildNative=false -p:AotHostArchitecture=x64 -p:AotHostOS=$(_hostedOS)
-            condition:
-              or(
-                eq(variables['isRollingBuild'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_specific_except_wbt_dbg.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_NET_ILLink_Tasks'], true))
-            extraStepsTemplate: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
-            extraStepsParameters:
-                extraTestArgs: '/p:WasmBuildNative=false'
+      # #
+      # # Build Release config vertical for Browser-wasm
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: release
+      #     platforms:
+      #     - browser_wasm
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       timeoutInMinutes: 120
+      #       nameSuffix: Runtime_Release
+      #       buildArgs: -s mono+libs -c $(_BuildConfig) -p:WasmBuildNative=false -p:AotHostArchitecture=x64 -p:AotHostOS=$(_hostedOS)
+      #       condition:
+      #         or(
+      #           eq(variables['isRollingBuild'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_specific_except_wbt_dbg.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_NET_ILLink_Tasks'], true))
+      #       extraStepsTemplate: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
+      #       extraStepsParameters:
+      #           extraTestArgs: '/p:WasmBuildNative=false'

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -61,1403 +61,1379 @@ extends:
       - ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
         - template: /eng/pipelines/common/evaluate-default-paths.yml
 
-      #
-      # Build CoreCLR checked
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-          buildConfig: checked
-          platforms:
-          - linux_x86
-          - linux_x64
-          - linux_arm
-          - linux_arm64
-          - linux_riscv64
-          - linux_musl_arm
-          - linux_musl_arm64
-          - linux_musl_x64
-          - osx_arm64
-          - tizen_armel
-          - windows_x86
-          - windows_x64
-          - windows_arm64
-          jobParameters:
-            testGroup: innerloop
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build the whole product using GNU compiler toolchain
-      # When CoreCLR, Mono, Libraries, Installer and src/tests are changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: checked
-          platforms:
-          - gcc_linux_x64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: Native_GCC
-            buildArgs: -s clr.native+libs.native+mono+host.native -c $(_BuildConfig) -gcc
-            extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests.yml
-            extraStepsParameters:
-              testBuildArgs: skipmanaged skipgeneratelayout skiprestorepackages -gcc
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build CoreCLR osx_x64 checked
-      # Only when CoreCLR or Libraries is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-          buildConfig: checked
-          platforms:
-          - osx_x64
-          jobParameters:
-            testGroup: innerloop
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build CoreCLR release
-      # Always as they are needed by Installer and we always build and test the Installer.
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-          buildConfig: release
-          platforms:
-          - osx_arm64
-          - osx_x64
-          - linux_x64
-          - linux_arm
-          - linux_arm64
-          - linux_musl_x64
-          - linux_musl_arm
-          - linux_musl_arm64
-          - windows_x64
-          - windows_x86
-          - windows_arm64
-          - freebsd_x64
-          jobParameters:
-            testGroup: innerloop
-            # Mono/runtimetests also need this, but skip for wasm
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build CoreCLR Formatting Job
-      # Only when CoreCLR is changed, and only in the 'main' branch (no release branches;
-      # both Rolling and PR builds).
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
-          platforms:
-          - linux_x64
-          - windows_x64
-          jobParameters:
-            condition: >-
-              and(
-                or(
-                  eq(variables['Build.SourceBranchName'], 'main'),
-                  eq(variables['System.PullRequest.TargetBranch'], 'main')),
-                or(
-                  eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_jit.containsChange'], true),
-                  eq(variables['isRollingBuild'], true)))
-
-      #
-      # CoreCLR NativeAOT debug build and smoke tests
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: Debug
-          platforms:
-          - linux_x64
-          - windows_x64
-          variables:
-          - name: timeoutPerTestInMinutes
-            value: 60
-          - name: timeoutPerTestCollectionInMinutes
-            value: 180
-          jobParameters:
-            timeoutInMinutes: 120
-            nameSuffix: NativeAOT
-            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
-            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testBuildArgs: nativeaot tree nativeaot
-              liveLibrariesBuildConfig: Release
-            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            extraVariablesTemplates:
-              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-                parameters:
-                  testGroup: innerloop
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
-
-      #
-      # CoreCLR NativeAOT checked build and smoke tests
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: Checked
-          platforms:
-          - windows_x64
-          variables:
-          - name: timeoutPerTestInMinutes
-            value: 60
-          - name: timeoutPerTestCollectionInMinutes
-            value: 180
-          jobParameters:
-            timeoutInMinutes: 120
-            nameSuffix: NativeAOT
-            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
-            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing/eventpipe/config;tracing/eventpipe/diagnosticport;tracing/eventpipe/reverse;" test tracing/eventcounter/runtimecounters.csproj /p:BuildNativeAotFrameworkObjects=true'
-              liveLibrariesBuildConfig: Release
-            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            extraVariablesTemplates:
-              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-                parameters:
-                  testGroup: innerloop
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
-
-      #
-      # CoreCLR NativeAOT release build and smoke tests
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: Release
-          platforms:
-          - linux_x64
-          - windows_x64
-          - osx_x64
-          - linux_arm64
-          - windows_arm64
-          - osx_arm64
-          variables:
-          - name: timeoutPerTestInMinutes
-            value: 60
-          - name: timeoutPerTestCollectionInMinutes
-            value: 180
-          jobParameters:
-            testGroup: innerloop
-            timeoutInMinutes: 120
-            nameSuffix: NativeAOT
-            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
-            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testBuildArgs: 'nativeaot tree ";nativeaot;tracing/eventpipe/simpleprovidervalidation;"'
-              liveLibrariesBuildConfig: Release
-            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            extraVariablesTemplates:
-              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-                parameters:
-                  testGroup: innerloop
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
-
-      #
-      # CoreCLR NativeAOT release build and libraries tests
-      # Only when CoreCLR or library is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          buildConfig: Release
-          platforms:
-          - windows_arm64
-          - linux_arm64
-          - osx_arm64
-          jobParameters:
-            testGroup: innerloop
-            isSingleFile: true
-            nameSuffix: NativeAOT_Libraries
-            buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true /p:ArchiveTests=true
-            timeoutInMinutes: 240 # Doesn't actually take long, but we've seen the ARM64 Helix queue often get backlogged for 2+ hours
-            # extra steps, run tests
-            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
-
-      # Build and test clr tools
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: checked
-          platforms:
-          - linux_x64
-          jobParameters:
-            timeoutInMinutes: 120
-            nameSuffix: CLR_Tools_Tests
-            buildArgs: -s clr.aot+clr.iltools+libs+clr.toolstests -c $(_BuildConfig) -test
-            enablePublishTestResults: true
-            testResultsFormat: 'xunit'
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      # Build Mono AOT offset headers once, for consumption elsewhere
-      # Only when mono changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/mono/templates/generate-offsets.yml
-          buildConfig: release
-          platforms:
-          - android_x64
-          - browser_wasm
-          - tvos_arm64
-          - ios_arm64
-          - maccatalyst_x64
-          jobParameters:
-            isOfficialBuild: ${{ variables.isOfficialBuild }}
-            # needed by crossaot
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      # Build the whole product using Mono runtime
-      # Only when libraries, mono or installer are changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          runtimeFlavor: mono
-          platforms:
-          - tvossimulator_x64
-          - linux_arm
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-          - linux_musl_x64
-          - linux_riscv64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # WebAssembly legs
-      #
-      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-          alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          scenarios:
-            - normal
-            - WasmTestOnBrowser
-
-      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm_win
-          alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          scenarios:
-            - WasmTestOnBrowser
-
-      # EAT Library tests - only run on linux
-      - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-          nameSuffix: _EAT
-          runAOT: false
-          shouldRunSmokeOnly: false
-          alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-
-      # AOT Library tests
-      - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-          nameSuffix: _AOT
-          runAOT: true
-          shouldRunSmokeOnly: true
-          alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-
-      - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm_win
-          nameSuffix: _AOT
-          runAOT: true
-          shouldRunSmokeOnly: true
-          alwaysRun: ${{ variables.isRollingBuild }}
-
-      # Wasm.Build.Tests
-      - template: /eng/pipelines/common/templates/wasm-build-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-            - browser_wasm_win
-          alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-
-      # Wasm Debugger tests
-      - template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-            - browser_wasm_win
-          alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-
-      # Wasm runtime tests
-      - template: /eng/pipelines/common/templates/wasm-runtime-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-          alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-
-      # Build and Smoke Tests only - Wasm Threading Legs
-      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-          nameSuffix: _Threading_Smoke
-          extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          shouldRunSmokeOnly: true
-          alwaysRun: ${{ variables.isRollingBuild }}
-          scenarios:
-            - WasmTestOnBrowser
-
-      - template: /eng/pipelines/common/templates/wasm-build-only.yml
-        parameters:
-          platforms:
-            - browser_wasm
-          nameSuffix: _Threading_PerfTracing
-          extraBuildArgs: /p:MonoWasmBuildVariant=perftrace /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          alwaysRun: ${{ variables.isRollingBuild }}
-
-      # WASI/WASM
-
-      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-        parameters:
-          platforms:
-            - wasi_wasm
-            - wasi_wasm_win
-          nameSuffix: '_Smoke'
-          extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          shouldContinueOnError: true
-          shouldRunSmokeOnly: true
-          alwaysRun: ${{ variables.isRollingBuild }}
-          scenarios:
-            - normal
-
-      - template: /eng/pipelines/common/templates/wasm-build-tests.yml
-        parameters:
-          platforms:
-            - wasi_wasm
-            - wasi_wasm_win
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          alwaysRun: ${{ variables.isRollingBuild }}
-
-      #
-      # iOS/tvOS devices - Full AOT + AggressiveTrimming to reduce size
-      # Build the whole product using Mono and run libraries tests
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-            - ios_arm64
-            - tvos_arm64
-          variables:
-            # map dependencies variables to local variables
-            - name: librariesContainsChange
-              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-            - name: monoContainsChange
-              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono
-            buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=true /p:BuildDarwinFrameworks=true
-            timeoutInMinutes: 180
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-            # extra steps, run tests
-            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-              extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
-              condition: >-
-                or(
-                eq(variables['librariesContainsChange'], true),
-                eq(variables['monoContainsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # MacCatalyst interp - requires AOT Compilation and Interp flags
-      # Build the whole product using Mono and run libraries tests
-      #
-      #
-      # Disabled pending queue backup investigation
-      #
-      #- template: /eng/pipelines/common/platform-matrix.yml
-      #  parameters:
-      #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-      #    buildConfig: Release
-      #    runtimeFlavor: mono
-      #    platforms:
-      #    - maccatalyst_x64
-      #    - ${{ if eq(variables['isRollingBuild'], true) }}:
-      #      - maccatalyst_arm64
-      #    variables:
-      #      # map dependencies variables to local variables
-      #      - name: librariesContainsChange
-      #        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      #      - name: monoContainsChange
-      #        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
-      #    jobParameters:
-      #      testGroup: innerloop
-      #      nameSuffix: AllSubsets_Mono
-      #      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true
-      #      timeoutInMinutes: 180
-      #      condition: >-
-      #        or(
-      #          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-      #          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-      #          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-      #          eq(variables['isRollingBuild'], true))
-      #      # extra steps, run tests
-      #      extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      #      extraStepsParameters:
-      #        creator: dotnet-bot
-      #        testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-      #        condition: >-
-      #          or(
-      #            eq(variables['librariesContainsChange'], true),
-      #            eq(variables['monoContainsChange'], true),
-      #            eq(variables['isRollingBuild'], true))
-
-      #
-      # Build Mono and Installer on LLVMJIT mode
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-          - osx_x64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_LLVMJIT
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          runtimeFlavor: mono
-          platforms:
-          - linux_x64
-          - linux_arm64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_LLVMJIT
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build Mono and Installer on LLVMAOT mode
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-          - linux_x64
-          - linux_arm64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_LLVMAOT
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          runtimeFlavor: mono
-          platforms:
-          - osx_x64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_LLVMAOT
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build Mono debug
-      # Only when mono changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-          runtimeFlavor: mono
-          buildConfig: debug
-          platforms:
-          - osx_x64
-          - osx_arm64
-          - linux_x64
-          - linux_arm64
-          # - linux_musl_arm64
-          - windows_x64
-          - windows_x86
-          # - windows_arm64
-          jobParameters:
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build Mono release AOT cross-compilers
-      # Only when mono changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-          runtimeFlavor: mono
-          buildConfig: release
-          platforms:
-          - linux_x64
-          # - linux_arm64
-          # - linux_musl_arm64
-          - windows_x64
-          # - windows_x86
-          # - windows_arm64
-          jobParameters:
-            runtimeVariant: crossaot
-            dependsOn:
-            - mono_android_offsets
-            - mono_browser_offsets
-            monoCrossAOTTargetOS:
-            - android
-            - browser
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-          runtimeFlavor: mono
-          buildConfig: release
-          platforms:
-          - osx_x64
-          jobParameters:
-            runtimeVariant: crossaot
-            dependsOn:
-            - mono_android_offsets
-            - mono_browser_offsets
-            - mono_tvos_offsets
-            - mono_ios_offsets
-            - mono_maccatalyst_offsets
-            monoCrossAOTTargetOS:
-            - android
-            - browser
-            - tvos
-            - ios
-            - maccatalyst
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-          runtimeFlavor: mono
-          buildConfig: release
-          platforms:
-          - linux_arm64
-          - osx_arm64
-          jobParameters:
-            runtimeVariant: crossaot
-            dependsOn:
-            - mono_browser_offsets
-            monoCrossAOTTargetOS:
-            - browser
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build Mono release
-      # Only when libraries or mono changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-          runtimeFlavor: mono
-          buildConfig: release
-          platforms:
-          - linux_x64
-          # - linux_musl_arm64
-          - windows_x64
-          - windows_x86
-          # - windows_arm64
-          jobParameters:
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build Mono release
-      # Only when libraries, mono, or the runtime tests changed
-      # Currently only these architectures are needed for the runtime tests.
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-          runtimeFlavor: mono
-          buildConfig: release
-          platforms:
-          - osx_x64
-          - linux_arm64
-          jobParameters:
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build Mono release with LLVM AOT
-      # Only when mono, or the runtime tests changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-          runtimeFlavor: mono
-          buildConfig: release
-          platforms:
-          - linux_x64
-          - linux_arm64
-          jobParameters:
-            runtimeVariant: llvmaot
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build libraries using live CoreLib
-      # These set of libraries are built always no matter what changed
-      # The reason for that is because Corelib and Installer needs it and
-      # These are part of the test matrix for Libraries changes.
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/build-job.yml
-          buildConfig: Release
-          platforms:
-          - linux_arm
-          - linux_musl_arm
-          - linux_musl_arm64
-          - windows_arm64
-          - windows_x86
-          jobParameters:
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/build-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-          - linux_arm64
-          - linux_musl_x64
-          - linux_x64
-          - osx_arm64
-          - osx_x64
-          - windows_x64
-          - freebsd_x64
-          jobParameters:
-            testScope: innerloop
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Libraries debug build that only runs when coreclr is changed
-      # Only do this on PR builds since we use the Release builds for these test runs in CI
-      # and those are already built above
-      #
-      - ${{ if eq(variables['isRollingBuild'], false) }}:
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/libraries/build-job.yml
-            buildConfig: Debug
-            platforms:
-            - windows_x86
-            jobParameters:
-              condition: >-
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true)
-
-      #
-      # Libraries release build that only runs when coreclr is changed in PRs
-      # We need these for checked coreclr + release libraries tests runs.
-      #
-      - ${{ if eq(variables['isRollingBuild'], false) }}:
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/libraries/build-job.yml
-            buildConfig: Release
-            platforms:
-            - linux_x64
-            - windows_x64
-            jobParameters:
-              condition: >-
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true)
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/build-job.yml
-          buildConfig: Release
-          platforms:
-          - windows_x86
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          jobParameters:
-            framework: net48
-            runTests: true
-            testScope: innerloop
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/build-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-          - windows_x64
-          jobParameters:
-            framework: allConfigurations
-            runTests: true
-            useHelix: false
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Installer Build and Test
-      # These are always built since they only take like 15 minutes
-      # we expect these to be done before we finish libraries or coreclr testing.
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-            - linux_musl_arm
-            - linux_musl_arm64
-            - windows_x86
-            - windows_arm64
-            - linux_arm
-          jobParameters:
-            liveRuntimeBuildConfig: release
-            liveLibrariesBuildConfig: Release
-            runOnlyIfDependenciesSucceeded: true
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
-          buildConfig: Release
-          platforms:
-            - osx_arm64
-            - osx_x64
-            - linux_x64
-            - linux_arm64
-            - linux_musl_x64
-            - windows_x64
-            - freebsd_x64
-          jobParameters:
-            liveRuntimeBuildConfig: release
-            liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-            runOnlyIfDependenciesSucceeded: true
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # CoreCLR Test builds using live libraries release build
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-          buildConfig: checked
-          platforms:
-          - CoreClrTestBuildHost # Either osx_x64 or linux_x64
-          jobParameters:
-            testGroup: innerloop
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # CoreCLR Test executions using live libraries
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-          buildConfig: checked
-          platforms:
-          - linux_arm
-          - windows_x86
-          - windows_arm64
-          helixQueueGroup: pr
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testGroup: innerloop
-            liveLibrariesBuildConfig: Release
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-          buildConfig: checked
-          platforms:
-          - osx_x64
-          - linux_x64
-          - linux_arm64
-          - windows_x64
-          helixQueueGroup: pr
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testGroup: innerloop
-            liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-          buildConfig: checked
-          platforms:
-          - osx_arm64
-          helixQueueGroup: pr
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testGroup: innerloop
-            liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_AppleSilicon.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Mono Test builds with CoreCLR runtime tests using live libraries debug build
-      # Only when Mono is changed
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-          buildConfig: release
-          runtimeFlavor: mono
-          platforms:
-          - CoreClrTestBuildHost # Either osx_x64 or linux_x64
-          jobParameters:
-            testGroup: innerloop
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-          buildConfig: release
-          runtimeFlavor: mono
-          platforms:
-          - windows_x64
-          helixQueueGroup: pr
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testGroup: innerloop
-            liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-            liveRuntimeBuildConfig: release
-            runtimeVariant: minijit
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build the whole product using Mono and run runtime tests
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-            - osx_x64
-            - linux_arm64
-          variables:
-            - name: timeoutPerTestInMinutes
-              value: 60
-            - name: timeoutPerTestCollectionInMinutes
-              value: 180
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_Minijit_RuntimeTests
-            runtimeVariant: minijit
-            buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release
-            timeoutInMinutes: 180
-            condition: >-
-                  or(
-                    eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                    eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                    eq(variables['isRollingBuild'], true))
-
-            extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_Release
-            extraVariablesTemplates:
-              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-
-      #
-      # Mono CoreCLR runtime Test executions using live libraries in interpreter mode
-      # Only when Mono is changed
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-            - osx_x64
-          variables:
-            - name: timeoutPerTestInMinutes
-              value: 60
-            - name: timeoutPerTestCollectionInMinutes
-              value: 180
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_Interpreter_RuntimeTests
-            runtimeVariant: monointerpreter
-            buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release
-            timeoutInMinutes: 180
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-            extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_Release
-            extraVariablesTemplates:
-              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-      #
-      # Mono CoreCLR runtime Test executions using live libraries and LLVM AOT
-      # Only when Mono is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-            - linux_x64
-            # Disabled pending outcome of https://github.com/dotnet/runtime/issues/60234 investigation
-            #- linux_arm64
-          variables:
-            - name: timeoutPerTestInMinutes
-              value: 60
-            - name: timeoutPerTestCollectionInMinutes
-              value: 180
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_LLVMAot_RuntimeTests
-            runtimeVariant: llvmaot
-            buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true /p:MonoLLVMUseCxx11Abi=true
-            timeoutInMinutes: 180
-
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-            extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              llvmAotStepContainer: linux_x64_llvmaot
-            testRunNamePrefixSuffix: Mono_Release
-            extraVariablesTemplates:
-              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-
-      #
-      # Libraries Release Test Execution against a release mono runtime.
-      # Only when libraries or mono changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          runtimeFlavor: mono
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-          # - windows_x64
-          - osx_x64
-          - linux_arm64
-          - linux_x64
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          jobParameters:
-            isOfficialBuild: false
-            runtimeDisplayName: mono
-            testScope: innerloop
-            liveRuntimeBuildConfig: release
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Libraries Release Test Execution against a release mono interpreter runtime.
-      # Only when libraries or mono changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          runtimeFlavor: mono
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-          # - windows_x64
-          #- osx_x64
-          - linux_x64
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          jobParameters:
-            isOfficialBuild: false
-            interpreter: true
-            runtimeDisplayName: mono_interpreter
-            testScope: innerloop
-            liveRuntimeBuildConfig: release
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Libraries Release Test Execution against a release coreclr runtime
-      # Only when the PR contains a libraries change
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          buildConfig: Release
-          platforms:
-          - windows_x86
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          jobParameters:
-            isOfficialBuild: false
-            testScope: innerloop
-            liveRuntimeBuildConfig: release
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Libraries Debug Test Execution against a release coreclr runtime
-      # Only when the PR contains a libraries change
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-          - windows_x64
-          - osx_x64
-          - linux_x64
-          - linux_musl_x64
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          jobParameters:
-            isOfficialBuild: false
-            testScope: innerloop
-            liveRuntimeBuildConfig: release
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      # The next three jobs run checked coreclr + <either debug or release in PR> libraries tests.
-      # The matrix looks like the following, where the right columns specify which configurations
-      # the libraries tests are built in.
-      # ________________________________________
-      # | Platform         | PR      | Rolling |
-      # | ---------------- | ------- | ------- |
-      # | linux-arm64      | Debug   | Release |
-      # | windows-x86      | Debug   | Release |
-      # | linux-musl-x64   | Debug   | Release |
-      # | OSX-x64          | Debug   | Release |
-      # | linux-musl-arm   | Release | Release |
-      # | linux-musl-arm64 | Release | Release |
-      # | linux-x64        | Release | Release |
-      # | windows-x64      | Release | Release |
-
-      #
-      # Debug (PR) / Release (rolling) Libraries Test Execution against a checked runtime
-      # Only when the PR contains a coreclr change
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-          - linux_arm64
-          - windows_x86
-          - linux_musl_x64
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          helixQueueGroup: libraries
-          jobParameters:
-            testScope: innerloop
-            liveRuntimeBuildConfig: checked
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Release Libraries Test Execution against a checked runtime
-      # Only if CoreCLR or Libraries is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          buildConfig: Release
-          platforms:
-          - linux_musl_arm
-          - linux_musl_arm64
-          - linux_x64
-          - windows_x64
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          helixQueueGroup: libraries
-          jobParameters:
-            testScope: innerloop
-            liveRuntimeBuildConfig: checked
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-          - osx_x64
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          helixQueueGroup: libraries
-          jobParameters:
-            testScope: innerloop
-            liveRuntimeBuildConfig: checked
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Sourcebuild legs
-      # We have 3 important legs for source-build:
-      # - Centos.8 (ensures that known non-portable RID is working)
-      # - Linux-x64 portable (used for dependency flow and downstream PR verification)
-      # - Banana.24 - Non-existent RID to ensure we don't break RIDs we don't know about.
-      #
-      # Running all of these everywhere is wasteful. Run Banana.24 and CentOS.8 in rolling CI,
-      # Run Linux-x64 in PR.
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: Release
-          helixQueueGroup: pr
-          platforms:
-          - SourceBuild_centos8_x64
-          jobParameters:
-            nameSuffix: centos8SourceBuild
-            extraStepsParameters:
-              name: SourceBuildPackages
-            timeoutInMinutes: 95
-            condition: eq(variables['isRollingBuild'], true)
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: Release
-          helixQueueGroup: pr
-          platforms:
-          - SourceBuild_banana24_x64
-          jobParameters:
-            nameSuffix: banana24SourceBuild
-            extraStepsParameters:
-              name: SourceBuildPackages
-            timeoutInMinutes: 95
-            condition: eq(variables['isRollingBuild'], true)
+      # #
+      # # Build CoreCLR checked
+      # # Only when CoreCLR is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - linux_x86
+      #     - linux_x64
+      #     - linux_arm
+      #     - linux_arm64
+      #     - linux_riscv64
+      #     - linux_musl_arm
+      #     - linux_musl_arm64
+      #     - linux_musl_x64
+      #     - osx_arm64
+      #     - tizen_armel
+      #     - windows_x86
+      #     - windows_x64
+      #     - windows_arm64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build the whole product using GNU compiler toolchain
+      # # When CoreCLR, Mono, Libraries, Installer and src/tests are changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - gcc_linux_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: Native_GCC
+      #       buildArgs: -s clr.native+libs.native+mono+host.native -c $(_BuildConfig) -gcc
+      #       extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests.yml
+      #       extraStepsParameters:
+      #         testBuildArgs: skipmanaged skipgeneratelayout skiprestorepackages -gcc
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build CoreCLR osx_x64 checked
+      # # Only when CoreCLR or Libraries is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - osx_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build CoreCLR release
+      # # Always as they are needed by Installer and we always build and test the Installer.
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+      #     buildConfig: release
+      #     platforms:
+      #     - osx_arm64
+      #     - osx_x64
+      #     - linux_x64
+      #     - linux_arm
+      #     - linux_arm64
+      #     - linux_musl_x64
+      #     - linux_musl_arm
+      #     - linux_musl_arm64
+      #     - windows_x64
+      #     - windows_x86
+      #     - windows_arm64
+      #     - freebsd_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       # Mono/runtimetests also need this, but skip for wasm
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build CoreCLR Formatting Job
+      # # Only when CoreCLR is changed, and only in the 'main' branch (no release branches;
+      # # both Rolling and PR builds).
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
+      #     platforms:
+      #     - linux_x64
+      #     - windows_x64
+      #     jobParameters:
+      #       condition: >-
+      #         and(
+      #           or(
+      #             eq(variables['Build.SourceBranchName'], 'main'),
+      #             eq(variables['System.PullRequest.TargetBranch'], 'main')),
+      #           or(
+      #             eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_jit.containsChange'], true),
+      #             eq(variables['isRollingBuild'], true)))
+
+      # #
+      # # CoreCLR NativeAOT debug build and smoke tests
+      # # Only when CoreCLR is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     buildConfig: Debug
+      #     platforms:
+      #     - linux_x64
+      #     - windows_x64
+      #     variables:
+      #     - name: timeoutPerTestInMinutes
+      #       value: 60
+      #     - name: timeoutPerTestCollectionInMinutes
+      #       value: 180
+      #     jobParameters:
+      #       timeoutInMinutes: 120
+      #       nameSuffix: NativeAOT
+      #       buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
+      #       extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testBuildArgs: nativeaot tree nativeaot
+      #         liveLibrariesBuildConfig: Release
+      #       testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+      #       extraVariablesTemplates:
+      #         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+      #           parameters:
+      #             testGroup: innerloop
+      #             liveLibrariesBuildConfig: Release
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isFullMatrix'], true))
+
+      # #
+      # # CoreCLR NativeAOT checked build and smoke tests
+      # # Only when CoreCLR is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     buildConfig: Checked
+      #     platforms:
+      #     - windows_x64
+      #     variables:
+      #     - name: timeoutPerTestInMinutes
+      #       value: 60
+      #     - name: timeoutPerTestCollectionInMinutes
+      #       value: 180
+      #     jobParameters:
+      #       timeoutInMinutes: 120
+      #       nameSuffix: NativeAOT
+      #       buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
+      #       extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing/eventpipe/config;tracing/eventpipe/diagnosticport;tracing/eventpipe/reverse;tracing/eventpipe/processenvironment;tracing/eventpipe/simpleruntimeeventvalidation;tracing/eventpipe/processinfo2;" test tracing/eventcounter/runtimecounters.csproj /p:BuildNativeAotFrameworkObjects=true'
+      #         liveLibrariesBuildConfig: Release
+      #       testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+      #       extraVariablesTemplates:
+      #         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+      #           parameters:
+      #             testGroup: innerloop
+      #             liveLibrariesBuildConfig: Release
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isFullMatrix'], true))
+
+      # #
+      # # CoreCLR NativeAOT release build and smoke tests
+      # # Only when CoreCLR is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     buildConfig: Release
+      #     platforms:
+      #     - linux_x64
+      #     - windows_x64
+      #     - osx_x64
+      #     - linux_arm64
+      #     - windows_arm64
+      #     - osx_arm64
+      #     variables:
+      #     - name: timeoutPerTestInMinutes
+      #       value: 60
+      #     - name: timeoutPerTestCollectionInMinutes
+      #       value: 180
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       timeoutInMinutes: 120
+      #       nameSuffix: NativeAOT
+      #       buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
+      #       extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testBuildArgs: 'nativeaot tree ";nativeaot;tracing/eventpipe/providervalidation;"'
+      #         liveLibrariesBuildConfig: Release
+      #       testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+      #       extraVariablesTemplates:
+      #         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+      #           parameters:
+      #             testGroup: innerloop
+      #             liveLibrariesBuildConfig: Release
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isFullMatrix'], true))
+
+      # #
+      # # CoreCLR NativeAOT release build and libraries tests
+      # # Only when CoreCLR or library is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #     buildConfig: Release
+      #     platforms:
+      #     - windows_arm64
+      #     - linux_arm64
+      #     - osx_arm64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       isSingleFile: true
+      #       nameSuffix: NativeAOT_Libraries
+      #       buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true /p:ArchiveTests=true
+      #       timeoutInMinutes: 240 # Doesn't actually take long, but we've seen the ARM64 Helix queue often get backlogged for 2+ hours
+      #       # extra steps, run tests
+      #       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(variables['isFullMatrix'], true))
+
+      # # Build and test clr tools
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - linux_x64
+      #     jobParameters:
+      #       timeoutInMinutes: 120
+      #       nameSuffix: CLR_Tools_Tests
+      #       buildArgs: -s clr.aot+clr.iltools+libs.sfx+clr.toolstests -c $(_BuildConfig) -test
+      #       enablePublishTestResults: true
+      #       testResultsFormat: 'xunit'
+      #       # We want to run AOT tests when illink changes because there's share code and tests from illink which are used by AOT
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # # Build Mono AOT offset headers once, for consumption elsewhere
+      # # Only when mono changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/mono/templates/generate-offsets.yml
+      #     buildConfig: release
+      #     platforms:
+      #     - android_x64
+      #     - browser_wasm
+      #     - tvos_arm64
+      #     - ios_arm64
+      #     - maccatalyst_x64
+      #     jobParameters:
+      #       isOfficialBuild: ${{ variables.isOfficialBuild }}
+      #       # needed by crossaot
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # # Build the whole product using Mono runtime
+      # # Only when libraries, mono or installer are changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - tvossimulator_x64
+      #     - linux_arm
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - linux_musl_x64
+      #     - linux_riscv64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # WebAssembly legs
+      # #
+      # - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      #     scenarios:
+      #       - normal
+      #       - WasmTestOnBrowser
+
+      # - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm_win
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      #     scenarios:
+      #       - WasmTestOnBrowser
+
+      # # EAT Library tests - only run on linux
+      # - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #     nameSuffix: _EAT
+      #     runAOT: false
+      #     shouldRunSmokeOnly: false
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+
+      # # AOT Library tests
+      # - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #     nameSuffix: _AOT
+      #     runAOT: true
+      #     shouldRunSmokeOnly: true
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+
+      # - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm_win
+      #     nameSuffix: _AOT
+      #     runAOT: true
+      #     shouldRunSmokeOnly: true
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+
+      # # Wasm.Build.Tests
+      # - template: /eng/pipelines/common/templates/wasm-build-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #       - browser_wasm_win
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+
+      # # Wasm Debugger tests
+      # - template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #       - browser_wasm_win
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+
+      # # Wasm runtime tests
+      # - template: /eng/pipelines/common/templates/wasm-runtime-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+
+      # # Build and Smoke Tests only - Wasm Threading Legs
+      # - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #     nameSuffix: _Threading_Smoke
+      #     extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      #     shouldRunSmokeOnly: true
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     scenarios:
+      #       - WasmTestOnBrowser
+
+      # # WASI/WASM
+
+      # - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - wasi_wasm
+      #       - wasi_wasm_win
+      #     nameSuffix: '_Smoke'
+      #     extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      #     shouldContinueOnError: true
+      #     shouldRunSmokeOnly: true
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     scenarios:
+      #       - normal
+
+      # - template: /eng/pipelines/common/templates/wasm-build-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - wasi_wasm
+      #       - wasi_wasm_win
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+
+      # #
+      # # iOS/tvOS devices - Full AOT + AggressiveTrimming to reduce size
+      # # Build the whole product using Mono and run libraries tests
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #       - ios_arm64
+      #       - tvos_arm64
+      #     variables:
+      #       # map dependencies variables to local variables
+      #       - name: librariesContainsChange
+      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+      #       - name: monoContainsChange
+      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono
+      #       buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=true /p:BuildDarwinFrameworks=true
+      #       timeoutInMinutes: 180
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+      #       # extra steps, run tests
+      #       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+      #         extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+      #         condition: >-
+      #           or(
+      #           eq(variables['librariesContainsChange'], true),
+      #           eq(variables['monoContainsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # MacCatalyst interp - requires AOT Compilation and Interp flags
+      # # Build the whole product using Mono and run libraries tests
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - maccatalyst_x64
+      #     - ${{ if eq(variables['isRollingBuild'], true) }}:
+      #       - maccatalyst_arm64
+      #     variables:
+      #       # map dependencies variables to local variables
+      #       - name: librariesContainsChange
+      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+      #       - name: monoContainsChange
+      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono
+      #       buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true
+      #       timeoutInMinutes: 180
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+      #       # extra steps, run tests
+      #       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+      #         condition: >-
+      #           or(
+      #             eq(variables['librariesContainsChange'], true),
+      #             eq(variables['monoContainsChange'], true),
+      #             eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build Mono and Installer on LLVMJIT mode
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - osx_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono_LLVMJIT
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - linux_x64
+      #     - linux_arm64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono_LLVMJIT
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build Mono and Installer on LLVMAOT mode
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - linux_x64
+      #     - linux_arm64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono_LLVMAOT
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - osx_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono_LLVMAOT
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build Mono debug
+      # # Only when mono changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      #     runtimeFlavor: mono
+      #     buildConfig: debug
+      #     platforms:
+      #     - osx_x64
+      #     - osx_arm64
+      #     - linux_x64
+      #     - linux_arm64
+      #     # - linux_musl_arm64
+      #     - windows_x64
+      #     - windows_x86
+      #     # - windows_arm64
+      #     jobParameters:
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build Mono release AOT cross-compilers
+      # # Only when mono changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      #     runtimeFlavor: mono
+      #     buildConfig: release
+      #     platforms:
+      #     - linux_x64
+      #     - linux_musl_x64
+      #     - linux_arm64
+      #     - linux_musl_arm64
+      #     - windows_x64
+      #     # - windows_x86
+      #     # - windows_arm64
+      #     jobParameters:
+      #       runtimeVariant: crossaot
+      #       dependsOn:
+      #       - mono_android_offsets
+      #       - mono_browser_offsets
+      #       monoCrossAOTTargetOS:
+      #       - android
+      #       - browser
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      #     runtimeFlavor: mono
+      #     buildConfig: release
+      #     platforms:
+      #     - osx_x64
+      #     - osx_arm64
+      #     jobParameters:
+      #       runtimeVariant: crossaot
+      #       dependsOn:
+      #       - mono_android_offsets
+      #       - mono_browser_offsets
+      #       - mono_tvos_offsets
+      #       - mono_ios_offsets
+      #       - mono_maccatalyst_offsets
+      #       monoCrossAOTTargetOS:
+      #       - android
+      #       - browser
+      #       - tvos
+      #       - ios
+      #       - maccatalyst
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build Mono release
+      # # Only when libraries or mono changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      #     runtimeFlavor: mono
+      #     buildConfig: release
+      #     platforms:
+      #     - linux_x64
+      #     # - linux_musl_arm64
+      #     - windows_x64
+      #     - windows_x86
+      #     # - windows_arm64
+      #     jobParameters:
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build Mono release
+      # # Only when libraries, mono, or the runtime tests changed
+      # # Currently only these architectures are needed for the runtime tests.
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      #     runtimeFlavor: mono
+      #     buildConfig: release
+      #     platforms:
+      #     - osx_x64
+      #     - linux_arm64
+      #     jobParameters:
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build Mono release with LLVM AOT
+      # # Only when mono, or the runtime tests changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      #     runtimeFlavor: mono
+      #     buildConfig: release
+      #     platforms:
+      #     - linux_x64
+      #     - linux_arm64
+      #     jobParameters:
+      #       runtimeVariant: llvmaot
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build libraries using live CoreLib
+      # # These set of libraries are built always no matter what changed
+      # # The reason for that is because Corelib and Installer needs it and
+      # # These are part of the test matrix for Libraries changes.
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/build-job.yml
+      #     buildConfig: Release
+      #     platforms:
+      #     - linux_arm
+      #     - linux_musl_arm
+      #     - linux_musl_arm64
+      #     - windows_arm64
+      #     - windows_x86
+      #     jobParameters:
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/build-job.yml
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     platforms:
+      #     - linux_arm64
+      #     - linux_musl_x64
+      #     - linux_x64
+      #     - osx_arm64
+      #     - osx_x64
+      #     - windows_x64
+      #     - freebsd_x64
+      #     jobParameters:
+      #       testScope: innerloop
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Libraries debug build that only runs when coreclr is changed
+      # # Only do this on PR builds since we use the Release builds for these test runs in CI
+      # # and those are already built above
+      # #
+      # - ${{ if eq(variables['isRollingBuild'], false) }}:
+      #   - template: /eng/pipelines/common/platform-matrix.yml
+      #     parameters:
+      #       jobTemplate: /eng/pipelines/libraries/build-job.yml
+      #       buildConfig: Debug
+      #       platforms:
+      #       - windows_x86
+      #       jobParameters:
+      #         condition: >-
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true)
+
+      # #
+      # # Libraries release build that only runs when coreclr is changed in PRs
+      # # We need these for checked coreclr + release libraries tests runs.
+      # #
+      # - ${{ if eq(variables['isRollingBuild'], false) }}:
+      #   - template: /eng/pipelines/common/platform-matrix.yml
+      #     parameters:
+      #       jobTemplate: /eng/pipelines/libraries/build-job.yml
+      #       buildConfig: Release
+      #       platforms:
+      #       - linux_x64
+      #       - windows_x64
+      #       jobParameters:
+      #         condition: >-
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true)
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/build-job.yml
+      #     buildConfig: Release
+      #     platforms:
+      #     - windows_x86
+      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #     jobParameters:
+      #       framework: net48
+      #       runTests: true
+      #       testScope: innerloop
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/build-job.yml
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     platforms:
+      #     - windows_x64
+      #     jobParameters:
+      #       framework: allConfigurations
+      #       runTests: true
+      #       useHelix: false
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Installer Build and Test
+      # # These are always built since they only take like 15 minutes
+      # # we expect these to be done before we finish libraries or coreclr testing.
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     platforms:
+      #       - linux_musl_arm
+      #       - linux_musl_arm64
+      #       - windows_x86
+      #       - windows_arm64
+      #       - linux_arm
+      #     jobParameters:
+      #       liveRuntimeBuildConfig: release
+      #       liveLibrariesBuildConfig: Release
+      #       runOnlyIfDependenciesSucceeded: true
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
+      #     buildConfig: Release
+      #     platforms:
+      #       - osx_arm64
+      #       - osx_x64
+      #       - linux_x64
+      #       - linux_arm64
+      #       - linux_musl_x64
+      #       - windows_x64
+      #       - freebsd_x64
+      #     jobParameters:
+      #       liveRuntimeBuildConfig: release
+      #       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #       runOnlyIfDependenciesSucceeded: true
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # CoreCLR Test builds using live libraries release build
+      # # Only when CoreCLR is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - CoreClrTestBuildHost # Either osx_x64 or linux_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # CoreCLR Test executions using live libraries
+      # # Only when CoreCLR is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - linux_arm
+      #     - windows_x86
+      #     - windows_arm64
+      #     helixQueueGroup: pr
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       liveLibrariesBuildConfig: Release
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - osx_x64
+      #     - linux_x64
+      #     - linux_arm64
+      #     - windows_x64
+      #     helixQueueGroup: pr
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - osx_arm64
+      #     helixQueueGroup: pr
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_AppleSilicon.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Mono Test builds with CoreCLR runtime tests using live libraries debug build
+      # # Only when Mono is changed
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+      #     buildConfig: release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - CoreClrTestBuildHost # Either osx_x64 or linux_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+      #     buildConfig: release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - windows_x64
+      #     helixQueueGroup: pr
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #       liveRuntimeBuildConfig: release
+      #       runtimeVariant: minijit
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Build the whole product using Mono and run runtime tests
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #       - osx_x64
+      #       - linux_arm64
+      #     variables:
+      #       - name: timeoutPerTestInMinutes
+      #         value: 60
+      #       - name: timeoutPerTestCollectionInMinutes
+      #         value: 180
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono_Minijit_RuntimeTests
+      #       runtimeVariant: minijit
+      #       buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release
+      #       timeoutInMinutes: 180
+      #       condition: >-
+      #             or(
+      #               eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #               eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #               eq(variables['isRollingBuild'], true))
+
+      #       extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #       testRunNamePrefixSuffix: Mono_Release
+      #       extraVariablesTemplates:
+      #         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+
+      # #
+      # # Mono CoreCLR runtime Test executions using live libraries in interpreter mode
+      # # Only when Mono is changed
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #       - osx_x64
+      #     variables:
+      #       - name: timeoutPerTestInMinutes
+      #         value: 60
+      #       - name: timeoutPerTestCollectionInMinutes
+      #         value: 180
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono_Interpreter_RuntimeTests
+      #       runtimeVariant: monointerpreter
+      #       buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release
+      #       timeoutInMinutes: 180
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+      #       extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #       testRunNamePrefixSuffix: Mono_Release
+      #       extraVariablesTemplates:
+      #         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+      # #
+      # # Mono CoreCLR runtime Test executions using live libraries and LLVM AOT
+      # # Only when Mono is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #       - linux_x64
+      #       # Disabled pending outcome of https://github.com/dotnet/runtime/issues/60234 investigation
+      #       #- linux_arm64
+      #     variables:
+      #       - name: timeoutPerTestInMinutes
+      #         value: 60
+      #       - name: timeoutPerTestCollectionInMinutes
+      #         value: 180
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono_LLVMAot_RuntimeTests
+      #       runtimeVariant: llvmaot
+      #       buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+      #       timeoutInMinutes: 180
+
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+      #       extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         llvmAotStepContainer: linux_x64_llvmaot
+      #       testRunNamePrefixSuffix: Mono_Release
+      #       extraVariablesTemplates:
+      #         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+
+      # #
+      # # Libraries Release Test Execution against a release mono runtime.
+      # # Only when libraries or mono changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+      #     runtimeFlavor: mono
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     platforms:
+      #     # - windows_x64
+      #     - osx_x64
+      #     - linux_arm64
+      #     - linux_x64
+      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #     jobParameters:
+      #       isOfficialBuild: false
+      #       runtimeDisplayName: mono
+      #       testScope: innerloop
+      #       liveRuntimeBuildConfig: release
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Libraries Release Test Execution against a release mono interpreter runtime.
+      # # Only when libraries or mono changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+      #     runtimeFlavor: mono
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     platforms:
+      #     # - windows_x64
+      #     #- osx_x64
+      #     - linux_x64
+      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #     jobParameters:
+      #       isOfficialBuild: false
+      #       interpreter: true
+      #       runtimeDisplayName: mono_interpreter
+      #       testScope: innerloop
+      #       liveRuntimeBuildConfig: release
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Libraries Release Test Execution against a release coreclr runtime
+      # # Only when the PR contains a libraries change
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+      #     buildConfig: Release
+      #     platforms:
+      #     - windows_x86
+      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #     jobParameters:
+      #       isOfficialBuild: false
+      #       testScope: innerloop
+      #       liveRuntimeBuildConfig: release
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Libraries Debug Test Execution against a release coreclr runtime
+      # # Only when the PR contains a libraries change
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     platforms:
+      #     - windows_x64
+      #     - osx_x64
+      #     - linux_x64
+      #     - linux_musl_x64
+      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #     jobParameters:
+      #       isOfficialBuild: false
+      #       testScope: innerloop
+      #       liveRuntimeBuildConfig: release
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # # The next three jobs run checked coreclr + <either debug or release in PR> libraries tests.
+      # # The matrix looks like the following, where the right columns specify which configurations
+      # # the libraries tests are built in.
+      # # ________________________________________
+      # # | Platform         | PR      | Rolling |
+      # # | ---------------- | ------- | ------- |
+      # # | linux-arm64      | Debug   | Release |
+      # # | windows-x86      | Debug   | Release |
+      # # | linux-musl-x64   | Debug   | Release |
+      # # | OSX-x64          | Debug   | Release |
+      # # | linux-musl-arm   | Release | Release |
+      # # | linux-musl-arm64 | Release | Release |
+      # # | linux-x64        | Release | Release |
+      # # | windows-x64      | Release | Release |
+
+      # #
+      # # Debug (PR) / Release (rolling) Libraries Test Execution against a checked runtime
+      # # Only when the PR contains a coreclr change
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     platforms:
+      #     - linux_arm64
+      #     - windows_x86
+      #     - linux_musl_x64
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     helixQueueGroup: libraries
+      #     jobParameters:
+      #       testScope: innerloop
+      #       liveRuntimeBuildConfig: checked
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Release Libraries Test Execution against a checked runtime
+      # # Only if CoreCLR or Libraries is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+      #     buildConfig: Release
+      #     platforms:
+      #     - linux_musl_arm
+      #     - linux_musl_arm64
+      #     - linux_x64
+      #     - windows_x64
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     helixQueueGroup: libraries
+      #     jobParameters:
+      #       testScope: innerloop
+      #       liveRuntimeBuildConfig: checked
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     platforms:
+      #     - osx_x64
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     helixQueueGroup: libraries
+      #     jobParameters:
+      #       testScope: innerloop
+      #       liveRuntimeBuildConfig: checked
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+
+      # #
+      # # Sourcebuild legs
+      # # We have 3 important legs for source-build:
+      # # - Centos.8 (ensures that known non-portable RID is working)
+      # # - Linux-x64 portable (used for dependency flow and downstream PR verification)
+      # # - Banana.24 - Non-existent RID to ensure we don't break RIDs we don't know about.
+      # #
+      # # Running all of these everywhere is wasteful. Run Banana.24 and CentOS.8 in rolling CI,
+      # # Run Linux-x64 in PR.
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: Release
+      #     helixQueueGroup: pr
+      #     platforms:
+      #     - SourceBuild_centos8_x64
+      #     jobParameters:
+      #       nameSuffix: centos8SourceBuild
+      #       extraStepsParameters:
+      #         name: SourceBuildPackages
+      #       timeoutInMinutes: 95
+      #       condition: eq(variables['isRollingBuild'], true)
+
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: Release
+      #     helixQueueGroup: pr
+      #     platforms:
+      #     - SourceBuild_banana24_x64
+      #     jobParameters:
+      #       nameSuffix: banana24SourceBuild
+      #       extraStepsParameters:
+      #         name: SourceBuildPackages
+      #       timeoutInMinutes: 95
+      #       condition: eq(variables['isRollingBuild'], true)


### PR DESCRIPTION
Using CI to try to detect where the failures started occurring for Vector128Tests on win-x64 with Mono.
All pipelines are disabled - will manually trigger builds.