### PR TITLE
Use cgroup to calculate available memory

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1294,17 +1294,27 @@ void GCToOSInterface::GetMemoryStatus(uint64_t restricted_limit, uint32_t* memor
         }
         else
         {
-            available = GetAvailablePhysicalMemory();
-
             if (memory_load != NULL)
             {
                 bool isRestricted;
                 uint64_t total = GetPhysicalMemoryLimit(&isRestricted);
 
-                if (total > available)
+                if (GetPhysicalMemoryUsed(&used))
                 {
-                    used = total - available;
-                    load = (uint32_t)(((float)used * 100) / (float)total);
+                    if (total > used)
+                    {
+                        available = total - used;
+                        load = (uint32_t)(((float)used * 100) / (float)total);
+                    }
+                }
+                else
+                {
+                    available = GetAvailablePhysicalMemory();
+                    if (total > available)
+                    {
+                        used = total - available;
+                        load = (uint32_t)(((float)used * 100) / (float)total);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Trying to fix #49317

It seems that on `GCToOSInterface::GetMemoryStatus`  the `GetPhysicalMemoryLimit` works by checking first cgroup limits, but `GetAvailablePhysicalMemory` uses `/proc/meminfo` that in a containerized environment it will report the available memory of the worker and not of the pod.
This has as a result the check `if (total > available)` will be in a lot of cases false (when the worker available memory is more than the container's limit) and to report back to gc inconsistent data.

This is more a trigger for a discussion than a ready PR, since I have no experience in c++, neither in gc. We stumble upon this problem in the organization I am working, and this is an attempt to solve a gc related performance degradation. 