### PR TITLE
Remove unnecessary assignments of `MSBuildAllProjects`.

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1Reader/System.Security.Cryptography.Asn1Reader.Shared.projitems
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1Reader/System.Security.Cryptography.Asn1Reader.Shared.projitems
@@ -1,6 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <HasSharedItems>true</HasSharedItems>
     <SharedGUID>4aaf81e6-6cdc-44fa-adfd-d7b47b9c998f</SharedGUID>
   </PropertyGroup>

--- a/src/libraries/Common/tests/System/Net/Security/Kerberos/System.Net.Security.Kerberos.Shared.projitems
+++ b/src/libraries/Common/tests/System/Net/Security/Kerberos/System.Net.Security.Kerberos.Shared.projitems
@@ -1,6 +1,5 @@
 ﻿<Project>
   <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <HasSharedItems>true</HasSharedItems>
     <SharedGUID>4aaf81e6-6cdc-44fa-adfd-d7b47b9c998f</SharedGUID>
   </PropertyGroup>

--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/buildTransitive/Microsoft.Extensions.Configuration.UserSecrets.targets
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/buildTransitive/Microsoft.Extensions.Configuration.UserSecrets.targets
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <GenerateUserSecretsAttribute Condition="'$(GenerateUserSecretsAttribute)'==''">true</GenerateUserSecretsAttribute>
   </PropertyGroup>
 

--- a/src/tools/illink/src/ILLink.Shared/ILLink.Shared.projitems
+++ b/src/tools/illink/src/ILLink.Shared/ILLink.Shared.projitems
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <HasSharedItems>true</HasSharedItems>
     <SharedGUID>92f5e753-2179-46dc-bdce-736858c18dc7</SharedGUID>
   </PropertyGroup>


### PR DESCRIPTION
The `MSBuildAllProjects` proprerty [does not need to be manually assigned since MSBuild 16.0](https://www.panopticoncentral.net/2019/07/12/msbuildallprojects-considered-harmful/). This PR removes all assignments to it.

One use in `Microsoft.Extensions.Configuration.UserSecrets.targets` was conditioned on earlier versions of MSBuild since the file is user-facing. The others were on internal files.