### PR TITLE
Update (remove most) most of CLRTestKind, GenerateRunScript, RestorePackages

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
+++ b/src/tests/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
@@ -2,9 +2,7 @@
   <PropertyGroup>
     <AssemblyName>TestLibrary</AssemblyName>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <GenerateRunScript>false</GenerateRunScript>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Common/XHarnessRunnerLibrary/XHarnessRunnerLibrary.csproj
+++ b/src/tests/Common/XHarnessRunnerLibrary/XHarnessRunnerLibrary.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <CLRTestKind>BuildOnly</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <GenerateRunScript>false</GenerateRunScript>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <EnableDefaultItems>true</EnableDefaultItems>
     <Nullable>enable</Nullable>

--- a/src/tests/Common/XUnitWrapperLibrary/XUnitWrapperLibrary.csproj
+++ b/src/tests/Common/XUnitWrapperLibrary/XUnitWrapperLibrary.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <CLRTestKind>BuildOnly</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <GenerateRunScript>false</GenerateRunScript>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <EnableDefaultItems>true</EnableDefaultItems>
     <Nullable>enable</Nullable>

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -38,7 +38,7 @@
     <OutputType Condition="('$(IsMergedTestRunnerAssembly)' == 'true' and !$(BuildAsStandalone)) or '$(RequiresProcessIsolation)' == 'true'">Exe</OutputType>
 
     <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Exe'">BuildAndRun</CLRTestKind>
-    <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildOnly</CLRTestKind>
+    <CLRTestKind Condition="'$(CLRTestKind)' == ''">SharedLibrary</CLRTestKind>
     <CLRTestPriority Condition="'$(CLRTestPriority)' == ''">0</CLRTestPriority>
 
     <!-- Merged test runner assemblies might not have any non-generated sources, and that's okay -->

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/ApplyUpdateReferencedAssembly/ApplyUpdateReferencedAssembly.csproj
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/ApplyUpdateReferencedAssembly/ApplyUpdateReferencedAssembly.csproj
@@ -3,7 +3,6 @@
     <TestRuntime>true</TestRuntime>
     <DeltaScript>deltascript.json</DeltaScript>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <!-- to call AsssemblyExtensions.ApplyUpdate we need Optimize=false, EmitDebugInformation=true in all configurations -->
     <Optimize>false</Optimize>
     <EmitDebugInformation>true</EmitDebugInformation>

--- a/src/tests/GC/API/GCSettings/ILatencyTest.csproj
+++ b/src/tests/GC/API/GCSettings/ILatencyTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ILatencyTest.cs" />

--- a/src/tests/GC/API/GCSettings/InducedGen0GC.csproj
+++ b/src/tests/GC/API/GCSettings/InducedGen0GC.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InducedGen0GC.cs" />

--- a/src/tests/GC/API/GCSettings/InducedGen1GC.csproj
+++ b/src/tests/GC/API/GCSettings/InducedGen1GC.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InducedGen1GC.cs" />

--- a/src/tests/GC/API/GCSettings/InducedGen2GC.csproj
+++ b/src/tests/GC/API/GCSettings/InducedGen2GC.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InducedGen2GC.cs" />

--- a/src/tests/GC/Features/HeapExpansion/GCUtil_HeapExpansion.csproj
+++ b/src/tests/GC/Features/HeapExpansion/GCUtil_HeapExpansion.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GCUtil.cs" />

--- a/src/tests/GC/Features/Pinning/PinningOther/GCUtil_Pinning.csproj
+++ b/src/tests/GC/Features/Pinning/PinningOther/GCUtil_Pinning.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GCUtil.cs" />

--- a/src/tests/GC/LargeMemory/largeobject.csproj
+++ b/src/tests/GC/LargeMemory/largeobject.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="largeobject.cs" />

--- a/src/tests/GC/LargeMemory/memcheck.csproj
+++ b/src/tests/GC/LargeMemory/memcheck.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="memcheck.cs" />

--- a/src/tests/GC/Regressions/v2.0-beta2/476725/ManagedTest.csproj
+++ b/src/tests/GC/Regressions/v2.0-beta2/476725/ManagedTest.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ManagedTest.cs" />

--- a/src/tests/GC/Regressions/v2.0-beta2/485617/Managed.csproj
+++ b/src/tests/GC/Regressions/v2.0-beta2/485617/Managed.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Managed.cs" />

--- a/src/tests/GC/Scenarios/BinTree/bintree.csproj
+++ b/src/tests/GC/Scenarios/BinTree/bintree.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="bintree.cs" />

--- a/src/tests/GC/Scenarios/Boxing/doubLink.csproj
+++ b/src/tests/GC/Scenarios/Boxing/doubLink.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="doubLink.cs" />

--- a/src/tests/GC/Scenarios/DoublinkList/DoubLink.csproj
+++ b/src/tests/GC/Scenarios/DoublinkList/DoubLink.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DoubLink.cs" />

--- a/src/tests/GC/Scenarios/DoublinkList/DoubLink_V2.csproj
+++ b/src/tests/GC/Scenarios/DoublinkList/DoubLink_V2.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DoubLink.cs" />

--- a/src/tests/GC/Scenarios/FinalNStruct/strmap.csproj
+++ b/src/tests/GC/Scenarios/FinalNStruct/strmap.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="strmap.cs" />

--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.csproj
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestExecutionArguments>-unittest</CLRTestExecutionArguments>
-    <GenerateRunScript>false</GenerateRunScript>
     <IsLongRunningGCTest>true</IsLongRunningGCTest>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/Activator/Servers/AssemblyA.csproj
+++ b/src/tests/Interop/COM/Activator/Servers/AssemblyA.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyA.cs" />

--- a/src/tests/Interop/COM/Activator/Servers/AssemblyB.csproj
+++ b/src/tests/Interop/COM/Activator/Servers/AssemblyB.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyB.cs" />

--- a/src/tests/Interop/COM/Activator/Servers/AssemblyC.csproj
+++ b/src/tests/Interop/COM/Activator/Servers/AssemblyC.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyC.cs" />

--- a/src/tests/Interop/COM/Activator/Servers/AssemblyContracts.csproj
+++ b/src/tests/Interop/COM/Activator/Servers/AssemblyContracts.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyContracts.cs" />

--- a/src/tests/Interop/COM/NETServer/NETServer.DefaultInterfaces.ilproj
+++ b/src/tests/Interop/COM/NETServer/NETServer.DefaultInterfaces.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NETServer.DefaultInterfaces.il" />

--- a/src/tests/Interop/COM/NETServer/NETServer.csproj
+++ b/src/tests/Interop/COM/NETServer/NETServer.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/Interop/DisabledRuntimeMarshalling/Native_Default/DisabledRuntimeMarshallingNative_Default.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/Native_Default/DisabledRuntimeMarshallingNative_Default.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/DisabledRuntimeMarshalling/Native_DisabledMarshalling/DisabledRuntimeMarshallingNative_DisabledMarshalling.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/Native_DisabledMarshalling/DisabledRuntimeMarshallingNative_DisabledMarshalling.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/ExecInDefAppDom/InjectedCode/InjectedCode.csproj
+++ b/src/tests/Interop/ExecInDefAppDom/InjectedCode/InjectedCode.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Interop/ICastable/ICastable.CoreLib.csproj
+++ b/src/tests/Interop/ICastable/ICastable.CoreLib.csproj
@@ -7,7 +7,6 @@
   -->
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <AssemblyName>System.Private.CoreLib</AssemblyName>
     <Nullable>disable</Nullable>
     <NoWarn>$(NoWarn);nullable</NoWarn>

--- a/src/tests/Interop/ICustomMarshaler/ConflictingNames/CustomMarshaler.csproj
+++ b/src/tests/Interop/ICustomMarshaler/ConflictingNames/CustomMarshaler.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CustomMarshaler.cs" />

--- a/src/tests/Interop/ICustomMarshaler/ConflictingNames/CustomMarshaler2.csproj
+++ b/src/tests/Interop/ICustomMarshaler/ConflictingNames/CustomMarshaler2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <DefineConstants>$(DefineConstants);CUSTOMMARSHALERS2</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/NativeLibrary/AssemblyLoadContext/TestAsm/TestAsm.csproj
+++ b/src/tests/Interop/NativeLibrary/AssemblyLoadContext/TestAsm/TestAsm.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/PInvoke/Miscellaneous/CopyCtor/CopyCtorUtil.ilproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/CopyCtor/CopyCtorUtil.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CopyCtorUtil.il" />

--- a/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/ManagedDll1/ManagedDll1.csproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/ManagedDll1/ManagedDll1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/ManagedDll2/ManagedDll2.csproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/ManagedDll2/ManagedDll2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionUtil.ilproj
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionUtil.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SuppressGCTransitionUtil.il" />

--- a/src/tests/Interop/UnmanagedCallConv/PInvokesIL.ilproj
+++ b/src/tests/Interop/UnmanagedCallConv/PInvokesIL.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PInvokesIL.il" />

--- a/src/tests/Interop/UnmanagedCallersOnly/InvalidCSharp.ilproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/InvalidCSharp.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InvalidCallbacks.il" />

--- a/src/tests/JIT/Directed/ExcepFilters/mixed3/mixed3.ilproj
+++ b/src/tests/JIT/Directed/ExcepFilters/mixed3/mixed3.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/IL/PInvokeTail/PInvokeTail.ilproj
+++ b/src/tests/JIT/Directed/IL/PInvokeTail/PInvokeTail.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Directed/PREFIX/PrimitiveVT/helper.csproj
+++ b/src/tests/JIT/Directed/PREFIX/PrimitiveVT/helper.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/Directed/PREFIX/unaligned/1/cpobj_unaligned_1.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/1/cpobj_unaligned_1.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/PREFIX/unaligned/1/ldobj_unaligned_1.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/1/ldobj_unaligned_1.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/PREFIX/unaligned/1/localloc_unaligned_1.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/1/localloc_unaligned_1.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/PREFIX/unaligned/4/cpobj_unaligned_4.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/4/cpobj_unaligned_4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/PREFIX/unaligned/4/ldobj_unaligned_4.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/4/ldobj_unaligned_4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/PREFIX/unaligned/4/localloc_unaligned_4.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/4/localloc_unaligned_4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/PREFIX/volatile/1/cpobj_volatile.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/volatile/1/cpobj_volatile.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/PREFIX/volatile/1/ldobj_volatile.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/volatile/1/ldobj_volatile.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/PREFIX/volatile/1/localloc_volatile.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/volatile/1/localloc_volatile.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/RVAInit/gcref1.ilproj
+++ b/src/tests/JIT/Directed/RVAInit/gcref1.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/RVAInit/gcref2.ilproj
+++ b/src/tests/JIT/Directed/RVAInit/gcref2.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/RVAInit/nested.ilproj
+++ b/src/tests/JIT/Directed/RVAInit/nested.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for IlasmRoundTripIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- ildasm cannot support field RVAs precisely -->
     <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>

--- a/src/tests/JIT/Directed/RVAInit/simple.ilproj
+++ b/src/tests/JIT/Directed/RVAInit/simple.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for IlasmRoundTripIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- ildasm cannot support field RVAs precisely -->
     <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>

--- a/src/tests/JIT/Directed/RVAInit/simplearg.ilproj
+++ b/src/tests/JIT/Directed/RVAInit/simplearg.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/UnrollLoop/loop2_cs_d.csproj
+++ b/src/tests/JIT/Directed/UnrollLoop/loop2_cs_d.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Directed/UnrollLoop/loop2_cs_do.csproj
+++ b/src/tests/JIT/Directed/UnrollLoop/loop2_cs_do.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Directed/UnrollLoop/loop2_cs_r.csproj
+++ b/src/tests/JIT/Directed/UnrollLoop/loop2_cs_r.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Directed/UnrollLoop/loop2_cs_ro.csproj
+++ b/src/tests/JIT/Directed/UnrollLoop/loop2_cs_ro.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Directed/array-il/_Arrayscomplex3.ilproj
+++ b/src/tests/JIT/Directed/array-il/_Arrayscomplex3.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/coverage/importer/Desktop/ldfldstatic1_d.ilproj
+++ b/src/tests/JIT/Directed/coverage/importer/Desktop/ldfldstatic1_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/coverage/importer/Desktop/ldfldstatic1_r.ilproj
+++ b/src/tests/JIT/Directed/coverage/importer/Desktop/ldfldstatic1_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/coverage/importer/Desktop/stfldstatic1_Desktop_d.ilproj
+++ b/src/tests/JIT/Directed/coverage/importer/Desktop/stfldstatic1_Desktop_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/coverage/importer/Desktop/stfldstatic1_Desktop_r.ilproj
+++ b/src/tests/JIT/Directed/coverage/importer/Desktop/stfldstatic1_Desktop_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/coverage/importer/Desktop/subovfun1_Desktop_d.ilproj
+++ b/src/tests/JIT/Directed/coverage/importer/Desktop/subovfun1_Desktop_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/coverage/importer/Desktop/subovfun1_Desktop_r.ilproj
+++ b/src/tests/JIT/Directed/coverage/importer/Desktop/subovfun1_Desktop_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/coverage/oldtests/tls1.ilproj
+++ b/src/tests/JIT/Directed/coverage/oldtests/tls1.ilproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <RestorePackages>true</RestorePackages>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/Directed/coverage/oldtests/tls2.ilproj
+++ b/src/tests/JIT/Directed/coverage/oldtests/tls2.ilproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <RestorePackages>true</RestorePackages>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/Directed/coverage/oldtests/tlstest_d.ilproj
+++ b/src/tests/JIT/Directed/coverage/oldtests/tlstest_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/coverage/oldtests/tlstest_r.ilproj
+++ b/src/tests/JIT/Directed/coverage/oldtests/tlstest_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/debugging/debuginfo/attribute.csproj
+++ b/src/tests/JIT/Directed/debugging/debuginfo/attribute.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Optimize>false</Optimize>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Directed/debugging/debuginfo/tests_d.ilproj
+++ b/src/tests/JIT/Directed/debugging/debuginfo/tests_d.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>library</OutputType>
     <IlasmFlags>$(IlasmFlags) -DEBUG=IMPL</IlasmFlags>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="attribute.csproj" />

--- a/src/tests/JIT/Directed/debugging/debuginfo/tests_r.ilproj
+++ b/src/tests/JIT/Directed/debugging/debuginfo/tests_r.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>library</OutputType>
     <IlasmFlags>$(IlasmFlags) -DEBUG=OPT</IlasmFlags>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="attribute.csproj" />

--- a/src/tests/JIT/Directed/perffix/primitivevt/nativeinthelper.ilproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/nativeinthelper.ilproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Directed/pinvoke/calli_excep.ilproj
+++ b/src/tests/JIT/Directed/pinvoke/calli_excep.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <RestorePackages>true</RestorePackages>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/pinvoke/tail_pinvoke.ilproj
+++ b/src/tests/JIT/Directed/pinvoke/tail_pinvoke.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/IL_Conformance/Old/Base/add_ovf.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/add_ovf.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/and.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/and.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/beq.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/beq.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/beq_s.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/beq_s.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/bge.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/bge.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/bge_s.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/bge_s.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/bgt.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/bgt.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/bgt_s.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/bgt_s.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ble.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ble.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ble_s.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ble_s.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/blt.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/blt.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/blt_s.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/blt_s.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/bne.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/bne.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/bne_s.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/bne_s.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/br.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/br.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/br_s.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/br_s.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/brfalse.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/brfalse.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/brfalse_s.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/brfalse_s.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/brtrue.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/brtrue.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/brtrue_s.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/brtrue_s.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/call.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/call.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ceq.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ceq.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/cgt.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/cgt.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ckfinite.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ckfinite.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/clt.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/clt.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/conv.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/conv.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/conv_ovf.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/conv_ovf.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/cpblk.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/cpblk.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/div.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/div.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/dup.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/dup.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/initblk.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/initblk.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/jmp.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/jmp.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ldarg_n.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ldarg_n.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ldarg_starg.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ldarg_starg.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ldargs_stargs.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ldargs_stargs.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ldc.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ldc.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ldc_i4_n.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ldc_i4_n.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ldftn_calli.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ldftn_calli.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ldind_stind.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ldind_stind.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ldloc_stloc.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ldloc_stloc.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ldloca.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ldloca.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ldnull.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ldnull.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/mul.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/mul.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/mul_ovf.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/mul_ovf.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/neg.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/neg.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/nop.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/nop.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/not.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/not.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/or.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/or.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/pop.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/pop.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/rem.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/rem.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/ret.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/ret.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/shl.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/shl.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/shr.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/shr.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/sub.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/sub.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/sub_ovf.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/sub_ovf.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/switch.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/switch.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/tailcall.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/tailcall.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/unaligned.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/unaligned.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/volatile.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/volatile.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Base/xor.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Base/xor.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ConvDLL.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ConvDLL.ilproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <RestorePackages>true</RestorePackages>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/Conv_I4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/Conv_I4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/Conv_I8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/Conv_I8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/Conv_R4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/Conv_R4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_I4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_I4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_i.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_i1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_i1.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_i2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_i2.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_i4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_i8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_u1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_u1.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_u2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_u2.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_u4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_ovf_u8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_r4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/add_r8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/and_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/and_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/and_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/and_u8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_i.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_r4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_r8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_r4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_r8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_u.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_u.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_r4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_r8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_u.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_u.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_u8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_un_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_un_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_un_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bgt_un_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_u.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_u.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_u8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_un_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_un_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_un_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ble_un_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_u.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_u.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_u8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_un_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_un_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_un_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/blt_un_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_u.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_u.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_u8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_un_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_un_r4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_un_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_un_r8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/br_Conformance.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/br_Conformance.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/brfalse_Conformance.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/brfalse_Conformance.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/brtrue_Conformance.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/brtrue_Conformance.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_br.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_br.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_brfalse.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_brfalse.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_brtrue.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_brtrue.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_call.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_call.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_cpblk.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_cpblk.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_initblk.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_initblk.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_ldvirtftn.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_ldvirtftn.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_localloc.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_localloc.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_nop.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_nop.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_ret.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_ret.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_switch.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/c_switch.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/call_Conformance.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/call_Conformance.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ceq_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ceq_i.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ceq_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ceq_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ceq_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ceq_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ceq_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ceq_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ceq_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ceq_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_u.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_u.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_u8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_un_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_un_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_un_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cgt_un_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ckfinite_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ckfinite_r4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ckfinite_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ckfinite_r8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_u.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_u.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_u8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_un_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_un_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_un_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/clt_un_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i4_i1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i4_i1.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i4_i2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i4_i2.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i4_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i4_u4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_i4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_u8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_r8_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_r8_i.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_r8_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_r8_i4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_r8_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_r8_i8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_u4_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_u4_i.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_u4_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_u4_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_u4_u1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_u4_u1.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_u4_u2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_u4_u2.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_u8_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_u8_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_u8_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_u8_u4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cpblk_Conformance.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/cpblk_Conformance.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/div_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/div_i4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/div_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/div_i8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/div_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/div_r4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/div_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/div_r8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/div_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/div_u4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/div_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/div_u8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/dup4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/dup4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/dup8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/dup8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/dupi.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/dupi.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/initblk_Conformance.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/initblk_Conformance.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_i.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_ref.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_ref.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarga_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarga_i.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarga_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarga_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarga_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarga_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarga_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarga_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarga_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarga_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarga_ref.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarga_ref.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldc_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldc_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldc_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldc_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldc_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldc_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldc_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldc_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldftn.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldftn.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_i.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_i1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_i1.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_i2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_i2.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_ref.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_ref.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_u1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_u1.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_u2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_u2.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldind_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldloc_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldloc_i.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldloc_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldloc_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldloc_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldloc_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldloc_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldloc_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldloc_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldloc_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldloc_ref.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldloc_ref.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldnull_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldnull_i.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldnull_ref.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldnull_ref.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldvirtftn_Conformance_Base.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldvirtftn_Conformance_Base.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/localloc_Conformance_Base.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/localloc_Conformance_Base.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_i1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_i1.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_i2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_i2.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_i4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_i8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_u1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_u1.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_u2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_u2.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_u4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_ovf_u8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_r4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/mul_r8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/neg_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/neg_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/neg_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/neg_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/neg_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/neg_r4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/neg_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/neg_r8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/nop_Conformance.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/nop_Conformance.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/not_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/not_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/not_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/not_u8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/or_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/or_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/or_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/or_u8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/pop4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/pop4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/pop8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/pop8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/popi.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/popi.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/refs.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/refs.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/rem_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/rem_i4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/rem_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/rem_i8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/rem_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/rem_r8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/rem_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/rem_u4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/rem_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/rem_u8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_Conformance.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_Conformance.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_i.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_ref.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ret_ref.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/shl_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/shl_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/shl_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/shl_u8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/shr_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/shr_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/shr_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/shr_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/shr_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/shr_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/shr_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/shr_u8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sizeof.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sizeof.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/starg_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/starg_i.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/starg_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/starg_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/starg_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/starg_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/starg_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/starg_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/starg_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/starg_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/starg_ref.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/starg_ref.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_i1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_i1.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_i2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_i2.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_ref.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_ref.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stloc_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stloc_i.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stloc_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stloc_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stloc_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stloc_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stloc_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stloc_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stloc_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stloc_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stloc_ref.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stloc_ref.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_i.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_i1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_i1.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_i2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_i2.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_i4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_i8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_u1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_u1.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_u2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_u2.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_u4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_ovf_u8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_r4.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/sub_r8.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/switch_Conformance.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/switch_Conformance.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/xor_u4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/xor_u4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/xor_u8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/xor_u8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/AutoInit.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/AutoInit.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/heap_ovf.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/heap_ovf.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldarg_s_i1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldarg_s_i1.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldarg_s_i2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldarg_s_i2.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldarg_s_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldarg_s_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldarg_s_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldarg_s_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldarg_s_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldarg_s_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldarg_s_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldarg_s_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldloc_s_i1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldloc_s_i1.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldloc_s_i2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldloc_s_i2.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldloc_s_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldloc_s_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldloc_s_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldloc_s_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldloc_s_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldloc_s_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldloc_s_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldloc_s_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldloca_s_i1.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldloca_s_i1.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldloca_s_i2.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldloca_s_i2.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldloca_s_i4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldloca_s_i4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldloca_s_i8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldloca_s_i8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldloca_s_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldloca_s_r4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/directed/ldloca_s_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/ldloca_s_r8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/Box_Unbox.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/Box_Unbox.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/array_tests.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/array_tests.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/callintf.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/callintf.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/callnonvirt.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/callnonvirt.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/callstatic.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/callstatic.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/callsuper.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/callsuper.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/callvirt.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/callvirt.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/castclass.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/castclass.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/cpobj.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/cpobj.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/field_tests.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/field_tests.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/fielda_tests.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/fielda_tests.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/initobj.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/initobj.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/isinst.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/isinst.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/ldlen.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/ldlen.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/ldobj.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/ldobj.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/ldstr.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/ldstr.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/ldtoken.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/ldtoken.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/ldvirtftn_objectmodel.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/ldvirtftn_objectmodel.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/localloc_objectmodel.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/localloc_objectmodel.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/newobj.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/newobj.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/seh_tests.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/seh_tests.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/IL_Conformance/Old/objectmodel/throw.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/objectmodel/throw.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Intrinsics/TypeIntrinsicsEnums.ilproj
+++ b/src/tests/JIT/Intrinsics/TypeIntrinsicsEnums.ilproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <RestorePackages>true</RestorePackages>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_b_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_b_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_b_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_b_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_i4_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_i4_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_i4_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_i4_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_objref_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_objref_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-    <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_objref_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_objref_d.ilproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_objref_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_objref_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_objref_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_objref_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_r4_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_r4_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_r4_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_r4_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_r8_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_r8_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_r8_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_r8_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_struct_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_struct_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_struct_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_struct_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_u8_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_u8_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Arrays/huge/huge_u8_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/huge/huge_u8_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/misc/address_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/address_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/misc/address_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/address_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/misc/arrres_il_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/arrres_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- https://github.com/dotnet/runtime/issues/68060 -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>

--- a/src/tests/JIT/Methodical/Arrays/misc/ldelem_get_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/ldelem_get_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/misc/ldelem_get_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/ldelem_get_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/misc/length0_d.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/length0_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/misc/length0_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/length0_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/finally_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/finally_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/finally_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/finally_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/huge_filter_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/huge_filter_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/huge_filter_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/huge_filter_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/jump_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/jump_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/jump_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/jump_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/localloc_boxunbox_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/localloc_boxunbox_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/localloc_boxunbox_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/localloc_boxunbox_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/simple_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/simple_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/simple_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/simple_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/tailcall_boxunbox_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/tailcall_boxunbox_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/tailcall_boxunbox_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/tailcall_boxunbox_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/try_boxunbox_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/try_boxunbox_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/boxunbox/try_boxunbox_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/boxunbox/try_boxunbox_r.ilproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/callconv/instance_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/callconv/instance_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/callconv/instance_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/callconv/instance_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/functional/fibo_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/functional/fibo_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/functional/fibo_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/functional/fibo_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/misc/concurgc_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/misc/concurgc_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <!-- The test leaves a secondary thread running -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>

--- a/src/tests/JIT/Methodical/Boxing/misc/concurgc_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/misc/concurgc_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <!-- The test leaves a secondary thread running -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>

--- a/src/tests/JIT/Methodical/Boxing/misc/nestval_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/misc/nestval_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/misc/nestval_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/misc/nestval_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/misc/typedref_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/misc/typedref_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/misc/typedref_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/misc/typedref_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/seh/fault_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/seh/fault_d.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-    <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/seh/fault_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/seh/fault_d.ilproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/seh/fault_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/seh/fault_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/seh/filter_seh_Boxing_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/seh/filter_seh_Boxing_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/seh/filter_seh_Boxing_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/seh/filter_seh_Boxing_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/seh/try_seh_d.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/seh/try_seh_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/seh/try_seh_r.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/seh/try_seh_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Boxing/xlang/sinlib_cs.csproj
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sinlib_cs.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/Methodical/Boxing/xlang/sinlib_il.ilproj
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sinlib_il.ilproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '32'">true</CLRTestTargetUnsupported>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '32'">true</CLRTestTargetUnsupported>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_box_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_box_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_box_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_box_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '32'">true</CLRTestTargetUnsupported>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '32'">true</CLRTestTargetUnsupported>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_box_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_box_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_box_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_box_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Invoke/implicit/i4i1_d.ilproj
+++ b/src/tests/JIT/Methodical/Invoke/implicit/i4i1_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Invoke/implicit/i4i1_r.ilproj
+++ b/src/tests/JIT/Methodical/Invoke/implicit/i4i1_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Invoke/implicit/i4i2_d.ilproj
+++ b/src/tests/JIT/Methodical/Invoke/implicit/i4i2_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Invoke/implicit/i4i2_r.ilproj
+++ b/src/tests/JIT/Methodical/Invoke/implicit/i4i2_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Invoke/implicit/i4u1_d.ilproj
+++ b/src/tests/JIT/Methodical/Invoke/implicit/i4u1_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Invoke/implicit/i4u1_r.ilproj
+++ b/src/tests/JIT/Methodical/Invoke/implicit/i4u1_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Invoke/implicit/iu1_d.ilproj
+++ b/src/tests/JIT/Methodical/Invoke/implicit/iu1_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/Invoke/implicit/iu1_r.ilproj
+++ b/src/tests/JIT/Methodical/Invoke/implicit/iu1_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/NaN/intrinsic_nonf_d.ilproj
+++ b/src/tests/JIT/Methodical/NaN/intrinsic_nonf_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/NaN/intrinsic_nonf_r.ilproj
+++ b/src/tests/JIT/Methodical/NaN/intrinsic_nonf_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/callconv/jumps1_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/callconv/jumps1_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/callconv/jumps1_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/callconv/jumps1_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/callconv/jumps2_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/callconv/jumps2_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/VT/callconv/jumps2_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/callconv/jumps2_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/VT/callconv/jumps3_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/callconv/jumps3_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/VT/callconv/jumps3_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/callconv/jumps3_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/VT/callconv/jumps4_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/callconv/jumps4_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/VT/callconv/jumps4_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/callconv/jumps4_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/VT/callconv/jumps5_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/callconv/jumps5_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/callconv/jumps5_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/callconv/jumps5_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/han3_ctor_il_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/han3_ctor_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/han3_ctor_il_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/han3_ctor_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/han3_il_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/han3_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/han3_il_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/han3_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/han3_ref_il_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/han3_ref_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/han3_ref_il_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/han3_ref_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/hanoi2_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/hanoi2_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/hanoi2_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/hanoi2_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/hanoi_il_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/hanoi_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/hanoi_il_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/hanoi_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/knight_il_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/knight_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/knight_il_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/knight_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/nested_il_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/nested_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/etc/nested_il_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/etc/nested_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/VT/port/huge_gcref_d.ilproj
+++ b/src/tests/JIT/Methodical/VT/port/huge_gcref_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/VT/port/huge_gcref_r.ilproj
+++ b/src/tests/JIT/Methodical/VT/port/huge_gcref_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/cctor/misc/testlib_misc.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/testlib_misc.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/Methodical/cctor/xassem/testlib_xassem.csproj
+++ b/src/tests/JIT/Methodical/cctor/xassem/testlib_xassem.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/eh/deadcode/deadEHregionacrossBB_d.ilproj
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadEHregionacrossBB_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/eh/deadcode/deadEHregionacrossBB_r.ilproj
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadEHregionacrossBB_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/eh/deadcode/deadcodeincatch_d.ilproj
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadcodeincatch_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/eh/deadcode/deadcodeincatch_r.ilproj
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadcodeincatch_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/eh/deadcode/deadoponerror_d.ilproj
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadoponerror_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/eh/deadcode/deadoponerror_r.ilproj
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadoponerror_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/flowgraph/bug619534/moduleLibrary.csproj
+++ b/src/tests/JIT/Methodical/flowgraph/bug619534/moduleLibrary.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/Methodical/flowgraph/dev10_bug675304/loopIV_init.ilproj
+++ b/src/tests/JIT/Methodical/flowgraph/dev10_bug675304/loopIV_init.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/flowgraph/dev10_bug679008/helper.ilproj
+++ b/src/tests/JIT/Methodical/flowgraph/dev10_bug679008/helper.ilproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
     <MonoAotIncompatible>true</MonoAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/nonvirtualcall/classic_d.ilproj
+++ b/src/tests/JIT/Methodical/nonvirtualcall/classic_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/nonvirtualcall/classic_r.ilproj
+++ b/src/tests/JIT/Methodical/nonvirtualcall/classic_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/nonvirtualcall/delegate_d.ilproj
+++ b/src/tests/JIT/Methodical/nonvirtualcall/delegate_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/nonvirtualcall/delegate_r.ilproj
+++ b/src/tests/JIT/Methodical/nonvirtualcall/delegate_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/nonvirtualcall/generics_d.ilproj
+++ b/src/tests/JIT/Methodical/nonvirtualcall/generics_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/nonvirtualcall/generics_r.ilproj
+++ b/src/tests/JIT/Methodical/nonvirtualcall/generics_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/refany/format_d.ilproj
+++ b/src/tests/JIT/Methodical/refany/format_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/refany/format_r.ilproj
+++ b/src/tests/JIT/Methodical/refany/format_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/refany/indcall_d.ilproj
+++ b/src/tests/JIT/Methodical/refany/indcall_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/refany/indcall_r.ilproj
+++ b/src/tests/JIT/Methodical/refany/indcall_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/refany/lcs_d.ilproj
+++ b/src/tests/JIT/Methodical/refany/lcs_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/refany/lcs_r.ilproj
+++ b/src/tests/JIT/Methodical/refany/lcs_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/refany/longsig_d.ilproj
+++ b/src/tests/JIT/Methodical/refany/longsig_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/refany/longsig_r.ilproj
+++ b/src/tests/JIT/Methodical/refany/longsig_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/refany/shortsig_d.ilproj
+++ b/src/tests/JIT/Methodical/refany/shortsig_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/refany/shortsig_r.ilproj
+++ b/src/tests/JIT/Methodical/refany/shortsig_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/stringintern/testgenstr.csproj
+++ b/src/tests/JIT/Methodical/stringintern/testgenstr.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/Methodical/stringintern/teststr.csproj
+++ b/src/tests/JIT/Methodical/stringintern/teststr.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'x86'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'x86'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <DebugType>Full</DebugType>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <DebugType>Full</DebugType>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'x86'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_32Bit_x86_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There are arch-specific versions of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm_d.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm_r.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof_Target_64Bit_and_arm_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- There is a 32 and 64 version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/Regression/CLR-x86-EJIT/V1-M12-Beta2/b47392/b47392.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-EJIT/V1-M12-Beta2/b47392/b47392.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/csharpgenerictypes.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/csharpgenerictypes.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b213516/lib-219037.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b213516/lib-219037.ilproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b423721/c1.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b423721/c1.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/Desktop/b609988_Desktop.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/Desktop/b609988_Desktop.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Regression/Dev11/External/Dev11_243742/dll.csproj
+++ b/src/tests/JIT/Regression/Dev11/External/Dev11_243742/dll.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/Regression/Dev11/External/dev11_132534/jmpwrappers.ilproj
+++ b/src/tests/JIT/Regression/Dev11/External/dev11_132534/jmpwrappers.ilproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Regression/Dev11/External/dev11_13748/ReflectOnField.ilproj
+++ b/src/tests/JIT/Regression/Dev11/External/dev11_13748/ReflectOnField.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Regression/Dev11/External/dev11_145295/ilpart.ilproj
+++ b/src/tests/JIT/Regression/Dev11/External/dev11_145295/ilpart.ilproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_205323/starg0.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_205323/starg0.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_206786/handleMath.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_206786/handleMath.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_279829/DevDiv_279829.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_279829/DevDiv_279829.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <Optimize>true</Optimize>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_22583/base.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_22583/base.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/Regression/JitBlue/GitHub_22583/lib.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_22583/lib.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/Regression/JitBlue/devdiv_902271/DevDiv_902271.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/devdiv_902271/DevDiv_902271.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for JitOptimizationSensitive -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/VS-ia64-JIT/M00/b112348/b112348.ilproj
+++ b/src/tests/JIT/Regression/VS-ia64-JIT/M00/b112348/b112348.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b301479/b301479.csproj
+++ b/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b301479/b301479.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b91944/b91944.csproj
+++ b/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b91944/b91944.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RestorePackages>false</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-M02/b12011/b12011.ilproj
+++ b/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-M02/b12011/b12011.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <!-- Test relies on rva_statics support see #2451 -->
     <DisableProjectBuild>true</DisableProjectBuild>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/VS-ia64-JIT/V2.0-RTM/b286991/b286991.ilproj
+++ b/src/tests/JIT/Regression/VS-ia64-JIT/V2.0-RTM/b286991/b286991.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/common/localloc_common.ilproj
+++ b/src/tests/JIT/common/localloc_common.ilproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <RestorePackages>true</RestorePackages>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/common.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/common.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f32_common.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f32_common.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f32_interop_cpp.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f32_interop_cpp.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f32_managed.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f32_managed.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_common.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_common.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_interop_cpp.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_interop_cpp.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_managed.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_managed.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f32_common.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f32_common.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f32_interop_cpp.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f32_interop_cpp.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f32_managed.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f32_managed.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f64_common.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f64_common.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f64_interop_cpp.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f64_interop_cpp.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f64_managed.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f64_managed.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/jit64/localloc/ehverify/eh05_dynamic_il.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh05_dynamic_il.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh06_dynamic.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh06_dynamic.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh07_dynamic.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh07_dynamic.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh07_large.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh07_large.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <MonoAotIncompatible>true</MonoAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh07_small.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh07_small.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh08_dynamic.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh08_dynamic.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh11_dynamic.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh11_dynamic.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh11_large.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh11_large.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh11_small.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh11_small.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh12_dynamic.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh12_dynamic.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh12_large.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh12_large.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh12_small.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh12_small.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh13_dynamic.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh13_dynamic.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh13_large.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh13_large.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh13_small.ilproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh13_small.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/jit64/regress/vsw/286991/test_286991.ilproj
+++ b/src/tests/JIT/jit64/regress/vsw/286991/test_286991.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/JIT/jit64/regress/vsw/568666/library1.csproj
+++ b/src/tests/JIT/jit64/regress/vsw/568666/library1.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/jit64/regress/vsw/568666/library2.csproj
+++ b/src/tests/JIT/jit64/regress/vsw/568666/library2.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/Devirtualization/UncommonEnums.ilproj
+++ b/src/tests/JIT/opt/Devirtualization/UncommonEnums.ilproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <RestorePackages>true</RestorePackages>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />

--- a/src/tests/JIT/opt/Inline/regression/mismatch32/mismatch32.ilproj
+++ b/src/tests/JIT/opt/Inline/regression/mismatch32/mismatch32.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/opt/Inline/regression/mismatch64/mismatch64.ilproj
+++ b/src/tests/JIT/opt/Inline/regression/mismatch64/mismatch64.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/opt/Inline/tests/calli.ilproj
+++ b/src/tests/JIT/opt/Inline/tests/calli.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/IsKnownConstant/TypeGetTypeCodeEnums.ilproj
+++ b/src/tests/JIT/opt/IsKnownConstant/TypeGetTypeCodeEnums.ilproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <RestorePackages>true</RestorePackages>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived1.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived1.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived10.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived10.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived11.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived11.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived12.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived12.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived13.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived13.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived14.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived14.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived15.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived15.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived16.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived16.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived17.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived17.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived18.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived18.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived19.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived19.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived2.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived2.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived20.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived20.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived3.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived3.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived4.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived4.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived5.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived5.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived6.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived6.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived7.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived7.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived8.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived8.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived9.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived9.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest1.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest1.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest10.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest10.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest2.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest2.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest3.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest3.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest4.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest4.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest5.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest5.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest6.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest6.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest7.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest7.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest8.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest8.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest9.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest9.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/Loader/CollectibleAssemblies/ByRefLocals/SpanAccessor.csproj
+++ b/src/tests/Loader/CollectibleAssemblies/ByRefLocals/SpanAccessor.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SpanAccessor.cs" />

--- a/src/tests/Loader/CollectibleAssemblies/ByRefLocals/Unloaded.csproj
+++ b/src/tests/Loader/CollectibleAssemblies/ByRefLocals/Unloaded.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="SpanAccessor.csproj" />

--- a/src/tests/Loader/CollectibleAssemblies/ResolvedFromDifferentContext/TestClass.csproj
+++ b/src/tests/Loader/CollectibleAssemblies/ResolvedFromDifferentContext/TestClass.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/Loader/CollectibleAssemblies/ResolvedFromDifferentContext/TestInterface.csproj
+++ b/src/tests/Loader/CollectibleAssemblies/ResolvedFromDifferentContext/TestInterface.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/Loader/CollectibleAssemblies/Statics/Accessor.csproj
+++ b/src/tests/Loader/CollectibleAssemblies/Statics/Accessor.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Accessor.cs" />

--- a/src/tests/Loader/CollectibleAssemblies/Statics/Unloaded.csproj
+++ b/src/tests/Loader/CollectibleAssemblies/Statics/Unloaded.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="Accessor.csproj" />

--- a/src/tests/Loader/ContextualReflection/ContextualReflectionDependency.csproj
+++ b/src/tests/Loader/ContextualReflection/ContextualReflectionDependency.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ContextualReflectionDependency.cs" />

--- a/src/tests/Loader/StartupHooks/Hooks/Basic.csproj
+++ b/src/tests/Loader/StartupHooks/Hooks/Basic.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Basic.cs" />

--- a/src/tests/Loader/StartupHooks/Hooks/Invalid/InstanceMethod.csproj
+++ b/src/tests/Loader/StartupHooks/Hooks/Invalid/InstanceMethod.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
     <DefineConstants>$(DefineConstants);INSTANCE_METHOD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/StartupHooks/Hooks/Invalid/MultipleIncorrectSignatures.csproj
+++ b/src/tests/Loader/StartupHooks/Hooks/Invalid/MultipleIncorrectSignatures.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
     <DefineConstants>$(DefineConstants);INSTANCE_METHOD;NOT_PARAMETERLESS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/StartupHooks/Hooks/Invalid/NoInitializeMethod.csproj
+++ b/src/tests/Loader/StartupHooks/Hooks/Invalid/NoInitializeMethod.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InvalidHook.cs" />

--- a/src/tests/Loader/StartupHooks/Hooks/Invalid/NonVoidReturn.csproj
+++ b/src/tests/Loader/StartupHooks/Hooks/Invalid/NonVoidReturn.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
     <DefineConstants>$(DefineConstants);NONVOID_RETURN</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/StartupHooks/Hooks/Invalid/NotParameterless.csproj
+++ b/src/tests/Loader/StartupHooks/Hooks/Invalid/NotParameterless.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
     <DefineConstants>$(DefineConstants);NOT_PARAMETERLESS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/StartupHooks/Hooks/PrivateInitialize.csproj
+++ b/src/tests/Loader/StartupHooks/Hooks/PrivateInitialize.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PrivateInitialize.cs" />

--- a/src/tests/Loader/binding/tracing/AssemblyToLoad.csproj
+++ b/src/tests/Loader/binding/tracing/AssemblyToLoad.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
     <AssemblyName Condition="'$(AssemblyNameSuffix)'!=''">$(AssemblyName)_$(AssemblyNameSuffix)</AssemblyName>
     <CleanFile>$(AssemblyName).FileListAbsolute.txt</CleanFile>
   </PropertyGroup>

--- a/src/tests/Loader/binding/tracing/AssemblyToLoadDependency.csproj
+++ b/src/tests/Loader/binding/tracing/AssemblyToLoadDependency.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyToLoadDependency.cs" />

--- a/src/tests/Loader/classloader/Casting/punninglib.ilproj
+++ b/src/tests/Loader/classloader/Casting/punninglib.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="punninglib.il" />

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github60486.csproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github60486.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/A.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/A.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="A.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/B.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/B.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="B.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/C.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/C.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="C.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/Dictionary.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/Dictionary.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Dictionary.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenBaseType.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenBaseType.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenBaseType.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenDerive1.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenDerive1.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenDerive1.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenDerive2.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenDerive2.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenDerive2.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenDerive3.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenDerive3.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenDerive3.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenRetType.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenRetType.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenRetType.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenTestType.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenTestType.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenTestType.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenToNonGen1.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenToNonGen1.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenToNonGen1.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenToNonGen2.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenToNonGen2.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenToNonGen2.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenToNonGen3.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/GenToNonGen3.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenToNonGen3.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenThroughGen1.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenThroughGen1.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NonGenThroughGen1.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenThroughGen2.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenThroughGen2.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NonGenThroughGen2.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenThroughGen3.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenThroughGen3.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NonGenThroughGen3.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenThroughGen4.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenThroughGen4.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NonGenThroughGen4.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenericDerived1.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenericDerived1.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NonGenericDerived1.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenericDerived2.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenericDerived2.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NonGenericDerived2.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenericDerived3.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenericDerived3.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NonGenericDerived3.il" />

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenericDerived4.ilproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/Modules/NonGenericDerived4.ilproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NonGenericDerived4.il" />

--- a/src/tests/Loader/classloader/PrivateInterfaceImpl/Test6_FriendPriInterface.ilproj
+++ b/src/tests/Loader/classloader/PrivateInterfaceImpl/Test6_FriendPriInterface.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Test6_FriendPriInterface.il" />

--- a/src/tests/Loader/classloader/PrivateInterfaceImpl/Test6_forwarder.ilproj
+++ b/src/tests/Loader/classloader/PrivateInterfaceImpl/Test6_forwarder.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Test6_forwarder.il" />

--- a/src/tests/Loader/classloader/PrivateInterfaceImpl/Test6_supplier.ilproj
+++ b/src/tests/Loader/classloader/PrivateInterfaceImpl/Test6_supplier.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Test6_supplier.il" />

--- a/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextCommonCs.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextCommonCs.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTest/GenericContextCommonAndImplementation.ilproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTest/GenericContextCommonAndImplementation.ilproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTestDefaultImp/GenericContextCommonAndImplementation.ilproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTestDefaultImp/GenericContextCommonAndImplementation.ilproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTestDefaultImpCallDefaultImp/GenericContextCommonAndImplementation.ilproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTestDefaultImpCallDefaultImp/GenericContextCommonAndImplementation.ilproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/TypeHierarchy/TypeHierarchyCommonCs.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/TypeHierarchy/TypeHierarchyCommonCs.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/Loader/classloader/TypeForwarding/UnitTest/MyDep.ilproj
+++ b/src/tests/Loader/classloader/TypeForwarding/UnitTest/MyDep.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MyDep.il" />

--- a/src/tests/Loader/classloader/TypeForwarding/UnitTest/MyDep2.csproj
+++ b/src/tests/Loader/classloader/TypeForwarding/UnitTest/MyDep2.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MyDep2.cs" />

--- a/src/tests/Loader/classloader/TypeForwarding/UnitTest/MyDep3.csproj
+++ b/src/tests/Loader/classloader/TypeForwarding/UnitTest/MyDep3.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MyDep3.cs" />

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TestFramework/TestFramework.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TestFramework/TestFramework.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/generics/ByRefLike/InvalidCSharp.ilproj
+++ b/src/tests/Loader/classloader/generics/ByRefLike/InvalidCSharp.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'Mono'">true</DisableProjectBuild>
   </PropertyGroup>

--- a/src/tests/Loader/classloader/generics/Instantiation/Regressions/607/check2.ilproj
+++ b/src/tests/Loader/classloader/generics/Instantiation/Regressions/607/check2.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="check2.il" />

--- a/src/tests/Loader/classloader/generics/Variance/Delegates/Lib.ilproj
+++ b/src/tests/Loader/classloader/generics/Variance/Delegates/Lib.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Lib.il" />

--- a/src/tests/Loader/classloader/generics/Variance/IL/Lib.ilproj
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Lib.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Lib.il" />

--- a/src/tests/Loader/classloader/generics/Variance/IL/VarInterfaceLib2.ilproj
+++ b/src/tests/Loader/classloader/generics/Variance/IL/VarInterfaceLib2.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="VarInterfaceLib2.il" />

--- a/src/tests/Loader/classloader/generics/Variance/IL/varlib.ilproj
+++ b/src/tests/Loader/classloader/generics/Variance/IL/varlib.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="varlib.il" />

--- a/src/tests/Loader/classloader/generics/Variance/Interfaces/Lib.ilproj
+++ b/src/tests/Loader/classloader/generics/Variance/Interfaces/Lib.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Lib.il" />

--- a/src/tests/Loader/classloader/generics/Variance/Methods/Lib.ilproj
+++ b/src/tests/Loader/classloader/generics/Variance/Methods/Lib.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Lib.il" />

--- a/src/tests/Loader/classloader/generics/Variance/Methods/Lib2.ilproj
+++ b/src/tests/Loader/classloader/generics/Variance/Methods/Lib2.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Lib2.il" />

--- a/src/tests/Loader/classloader/methodoverriding/regressions/576621/test.ilproj
+++ b/src/tests/Loader/classloader/methodoverriding/regressions/576621/test.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test.il" />

--- a/src/tests/Loader/classloader/methodoverriding/regressions/592026/test.ilproj
+++ b/src/tests/Loader/classloader/methodoverriding/regressions/592026/test.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test.il" />

--- a/src/tests/Loader/classloader/methodoverriding/regressions/dev10_432038/foo1.csproj
+++ b/src/tests/Loader/classloader/methodoverriding/regressions/dev10_432038/foo1.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="foo1.cs" />

--- a/src/tests/Loader/classloader/methodoverriding/regressions/dev10_432038/foo2.csproj
+++ b/src/tests/Loader/classloader/methodoverriding/regressions/dev10_432038/foo2.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="foo2.cs" />

--- a/src/tests/Loader/classloader/methodoverriding/regressions/dev10_432038/interface.csproj
+++ b/src/tests/Loader/classloader/methodoverriding/regressions/dev10_432038/interface.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="interface.cs" />

--- a/src/tests/Loader/classloader/nesting/Regressions/dev10_602978/Library.csproj
+++ b/src/tests/Loader/classloader/nesting/Regressions/dev10_602978/Library.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Library.cs" />

--- a/src/tests/Loader/classloader/nesting/coreclr/nesting16.ilproj
+++ b/src/tests/Loader/classloader/nesting/coreclr/nesting16.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="nesting16.il" />

--- a/src/tests/Loader/classloader/nesting/coreclr/nesting3.ilproj
+++ b/src/tests/Loader/classloader/nesting/coreclr/nesting3.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="nesting3.il" />

--- a/src/tests/Loader/classloader/regressions/421439/RefX1.ilproj
+++ b/src/tests/Loader/classloader/regressions/421439/RefX1.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="RefX1.il" />

--- a/src/tests/Loader/classloader/regressions/421439/ValX1.ilproj
+++ b/src/tests/Loader/classloader/regressions/421439/ValX1.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ValX1.il" />

--- a/src/tests/Loader/classloader/regressions/429802/BarImpl.ilproj
+++ b/src/tests/Loader/classloader/regressions/429802/BarImpl.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BarImpl.il" />

--- a/src/tests/Loader/classloader/regressions/429802/MyBar.ilproj
+++ b/src/tests/Loader/classloader/regressions/429802/MyBar.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MyBar.il" />

--- a/src/tests/Loader/classloader/regressions/440935/Bar.ilproj
+++ b/src/tests/Loader/classloader/regressions/440935/Bar.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Bar.il" />

--- a/src/tests/Loader/classloader/regressions/440935/Foo.ilproj
+++ b/src/tests/Loader/classloader/regressions/440935/Foo.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Foo.il" />

--- a/src/tests/Loader/classloader/regressions/451034/Type.ilproj
+++ b/src/tests/Loader/classloader/regressions/451034/Type.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Type.il" />

--- a/src/tests/Loader/classloader/regressions/583649/Type_Class42.ilproj
+++ b/src/tests/Loader/classloader/regressions/583649/Type_Class42.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Type_Class42.il" />

--- a/src/tests/Loader/classloader/regressions/dd52/test.ilproj
+++ b/src/tests/Loader/classloader/regressions/dd52/test.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test.il" />

--- a/src/tests/Loader/classloader/regressions/dev10_398410/utility.csproj
+++ b/src/tests/Loader/classloader/regressions/dev10_398410/utility.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="utility.cs" />

--- a/src/tests/Loader/classloader/regressions/dev10_403582/genmeth.ilproj
+++ b/src/tests/Loader/classloader/regressions/dev10_403582/genmeth.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="genmeth.il" />

--- a/src/tests/Loader/classloader/regressions/dev10_403582/gentype.ilproj
+++ b/src/tests/Loader/classloader/regressions/dev10_403582/gentype.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="gentype.il" />

--- a/src/tests/Loader/classloader/regressions/dev10_813331/Library1.csproj
+++ b/src/tests/Loader/classloader/regressions/dev10_813331/Library1.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Library1.cs" />

--- a/src/tests/Loader/classloader/regressions/dev10_813331/Library2.csproj
+++ b/src/tests/Loader/classloader/regressions/dev10_813331/Library2.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Library2.cs" />

--- a/src/tests/Loader/classloader/regressions/dev10_897464/Test.ilproj
+++ b/src/tests/Loader/classloader/regressions/dev10_897464/Test.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Test.il" />

--- a/src/tests/Loader/classloader/regressions/vsw529206/moduleCctorThrow.ilproj
+++ b/src/tests/Loader/classloader/regressions/vsw529206/moduleCctorThrow.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="moduleCctorThrow.il" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-1-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-1-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-1-1-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-10-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-10-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-1-10-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-11-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-11-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-1-11-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-12-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-12-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-1-12-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-2-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-2-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-1-2-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-5-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-5-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-1-5-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-6-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-6-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-1-6-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-7-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-7-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-1-7-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-8-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-8-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-1-8-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-9-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-1-9-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-1-9-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-2-10-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-2-10-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-2-10-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-2-11-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-2-11-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-2-11-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-2-12-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-2-12-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-2-12-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-2-5-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-2-5-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-2-5-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-2-6-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-2-6-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-2-6-3D.cs" />

--- a/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-2-9-3D.csproj
+++ b/src/tests/Loader/classloader/v1/Beta1/Layout/Matrix/cs/L-2-9-3D.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="L-2-9-3D.cs" />

--- a/src/tests/Regressions/coreclr/22021/provider.ilproj
+++ b/src/tests/Regressions/coreclr/22021/provider.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="provider.il" />

--- a/src/tests/baseservices/callconvs/CallFunctionPointers.ilproj
+++ b/src/tests/baseservices/callconvs/CallFunctionPointers.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CallFunctionPointers.il" />

--- a/src/tests/baseservices/compilerservices/RuntimeWrappedException/StringThrower.ilproj
+++ b/src/tests/baseservices/compilerservices/RuntimeWrappedException/StringThrower.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="StringThrower.il" />

--- a/src/tests/baseservices/compilerservices/modulector/moduleCctor.ilproj
+++ b/src/tests/baseservices/compilerservices/modulector/moduleCctor.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="moduleCctor.il" />

--- a/src/tests/baseservices/exceptions/regressions/v4.0/640474/other.csproj
+++ b/src/tests/baseservices/exceptions/regressions/v4.0/640474/other.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/baseservices/exceptions/regressions/whidbeym3.3/302680/data.csproj
+++ b/src/tests/baseservices/exceptions/regressions/whidbeym3.3/302680/data.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/baseservices/exceptions/simple/ILHelper.ilproj
+++ b/src/tests/baseservices/exceptions/simple/ILHelper.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/baseservices/exceptions/simple/VT.ilproj
+++ b/src/tests/baseservices/exceptions/simple/VT.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/baseservices/ilasm_ildasm/regression/dd130885/xlib.csproj
+++ b/src/tests/baseservices/ilasm_ildasm/regression/dd130885/xlib.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/baseservices/ilasm_ildasm/regression/vswhidbey267905/267905.csproj
+++ b/src/tests/baseservices/ilasm_ildasm/regression/vswhidbey267905/267905.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/baseservices/ilasm_ildasm/regression/vswhidbey305155/305155.csproj
+++ b/src/tests/baseservices/ilasm_ildasm/regression/vswhidbey305155/305155.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/baseservices/ilasm_ildasm/regression/vswhidbey395914/395914.csproj
+++ b/src/tests/baseservices/ilasm_ildasm/regression/vswhidbey395914/395914.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/baseservices/multidimmarray/enum.csproj
+++ b/src/tests/baseservices/multidimmarray/enum.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/baseservices/typeequivalence/contracts/TypeContracts.csproj
+++ b/src/tests/baseservices/typeequivalence/contracts/TypeContracts.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Types.cs" />

--- a/src/tests/baseservices/typeequivalence/impl/PunningLib.ilproj
+++ b/src/tests/baseservices/typeequivalence/impl/PunningLib.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PunningLib.il" />

--- a/src/tests/baseservices/typeequivalence/impl/TypeImpl.csproj
+++ b/src/tests/baseservices/typeequivalence/impl/TypeImpl.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Impls.cs" />

--- a/src/tests/baseservices/typeequivalence/istypeequivalent/typeequivalenttypes_1.csproj
+++ b/src/tests/baseservices/typeequivalence/istypeequivalent/typeequivalenttypes_1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <DefineConstants>$(DefineConstants);TYPEEQUIVALENCEASSEMBLY_1</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/baseservices/typeequivalence/istypeequivalent/typeequivalenttypes_2.csproj
+++ b/src/tests/baseservices/typeequivalence/istypeequivalent/typeequivalenttypes_2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <DefineConstants>$(DefineConstants);TYPEEQUIVALENCEASSEMBLY_2</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/baseservices/typeequivalence/pia/PIAContract.csproj
+++ b/src/tests/baseservices/typeequivalence/pia/PIAContract.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Types.cs" />

--- a/src/tests/baseservices/typeequivalence/signatures/basetestclassesil.ilproj
+++ b/src/tests/baseservices/typeequivalence/signatures/basetestclassesil.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="basetestclassesil.il" />

--- a/src/tests/baseservices/typeequivalence/signatures/testclassesil.ilproj
+++ b/src/tests/baseservices/typeequivalence/signatures/testclassesil.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="testclassesil.il" />

--- a/src/tests/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints.csproj
+++ b/src/tests/nativeaot/GenerateUnmanagedEntryPoints/GenerateUnmanagedEntryPoints.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints>
     <!--

--- a/src/tests/nativeaot/SmokeTests/ControlFlowGuard/ControlFlowGuard.csproj
+++ b/src/tests/nativeaot/SmokeTests/ControlFlowGuard/ControlFlowGuard.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ControlFlowGuard>Guard</ControlFlowGuard>

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
@@ -1,8 +1,6 @@
-
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Currently only tracking DWARF info on Linux -->
     <CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'linux'">true</CLRTestTargetUnsupported>

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.csproj
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/tests/nativeaot/SmokeTests/Exceptions/Exceptions.csproj
+++ b/src/tests/nativeaot/SmokeTests/Exceptions/Exceptions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ServerGarbageCollection>true</ServerGarbageCollection>

--- a/src/tests/nativeaot/SmokeTests/FrameworkStrings/Baseline.csproj
+++ b/src/tests/nativeaot/SmokeTests/FrameworkStrings/Baseline.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Test infra issue on apple devices: https://github.com/dotnet/runtime/issues/89917 -->
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/nativeaot/SmokeTests/FrameworkStrings/UseSystemResourceKeys.csproj
+++ b/src/tests/nativeaot/SmokeTests/FrameworkStrings/UseSystemResourceKeys.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <DefineConstants>$(DefineConstants);RESOURCE_KEYS</DefineConstants>
     

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <!-- Sanitizers increase the binary size, so it ends up outside of our expected range. -->

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx2.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <!-- Sanitizers increase the binary size, so it ends up outside of our expected range. -->

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx512.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx512.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64' or '$(TargetsOSX)' == 'true'">true</CLRTestTargetUnsupported>
     <!-- Sanitizers increase the binary size, so it ends up outside of our expected range. -->

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx_NoAvx2.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Avx_NoAvx2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <!-- Sanitizers increase the binary size, so it ends up outside of our expected range. -->

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Baseline.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Baseline.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <!-- Sanitizers increase the binary size, so it ends up outside of our expected range. -->

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Sse42.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Sse42.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <!-- Sanitizers increase the binary size, so it ends up outside of our expected range. -->

--- a/src/tests/nativeaot/SmokeTests/MultiModule/Library.csproj
+++ b/src/tests/nativeaot/SmokeTests/MultiModule/Library.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build;IlcCompile">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <IlcMultiModule>true</IlcMultiModule>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/MultiModule/MultiModule.csproj
+++ b/src/tests/nativeaot/SmokeTests/MultiModule/MultiModule.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.csproj
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.csproj
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection_FromUsage.csproj
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection_FromUsage.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);REFLECTION_FROM_USAGE</DefineConstants>

--- a/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.csproj
+++ b/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NativeLib>Shared</NativeLib>

--- a/src/tests/nativeaot/SmokeTests/StackTraceMetadata/StackTraceMetadata.csproj
+++ b/src/tests/nativeaot/SmokeTests/StackTraceMetadata/StackTraceMetadata.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/src/tests/nativeaot/SmokeTests/StackTraceMetadata/StackTraceMetadata_Stripped.csproj
+++ b/src/tests/nativeaot/SmokeTests/StackTraceMetadata/StackTraceMetadata_Stripped.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/TrimmingBehaviors.csproj
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/TrimmingBehaviors.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NullabilityInfoContextSupport>false</NullabilityInfoContextSupport>

--- a/src/tests/nativeaot/SmokeTests/UnitTests/UnitTests.csproj
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/UnitTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/tests/nativeaot/SmokeTests/Win32Resources/Win32Resources.csproj
+++ b/src/tests/nativeaot/SmokeTests/Win32Resources/Win32Resources.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/profiler/common/profiler_common.csproj
+++ b/src/tests/profiler/common/profiler_common.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/profiler/elt/slowpathcommon.csproj
+++ b/src/tests/profiler/elt/slowpathcommon.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/profiler/unittest/unloadlibrary.csproj
+++ b/src/tests/profiler/unittest/unloadlibrary.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <Optimize>true</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/readytorun/HardwareIntrinsics/X86/CpuId_R2R_Avx.csproj
+++ b/src/tests/readytorun/HardwareIntrinsics/X86/CpuId_R2R_Avx.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="('$(TargetArchitecture)' != 'x64' AND '$(TargetArchitecture)' != 'x86') OR ('$(RuntimeFlavor)' != 'coreclr')">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/readytorun/HardwareIntrinsics/X86/CpuId_R2R_Avx2.csproj
+++ b/src/tests/readytorun/HardwareIntrinsics/X86/CpuId_R2R_Avx2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="('$(TargetArchitecture)' != 'x64' AND '$(TargetArchitecture)' != 'x86') OR ('$(RuntimeFlavor)' != 'coreclr')">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/readytorun/HardwareIntrinsics/X86/CpuId_R2R_Avx512.csproj
+++ b/src/tests/readytorun/HardwareIntrinsics/X86/CpuId_R2R_Avx512.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="('$(TargetArchitecture)' != 'x64' AND '$(TargetArchitecture)' != 'x86') OR ('$(RuntimeFlavor)' != 'coreclr')">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/readytorun/HardwareIntrinsics/X86/CpuId_R2R_Avx_NoAvx2.csproj
+++ b/src/tests/readytorun/HardwareIntrinsics/X86/CpuId_R2R_Avx_NoAvx2.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="('$(TargetArchitecture)' != 'x64' AND '$(TargetArchitecture)' != 'x86') OR ('$(RuntimeFlavor)' != 'coreclr')">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/readytorun/HardwareIntrinsics/X86/CpuId_R2R_Baseline.csproj
+++ b/src/tests/readytorun/HardwareIntrinsics/X86/CpuId_R2R_Baseline.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="('$(TargetArchitecture)' != 'x64' AND '$(TargetArchitecture)' != 'x86') OR ('$(RuntimeFlavor)' != 'coreclr')">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/readytorun/HardwareIntrinsics/X86/CpuId_R2R_Sse42.csproj
+++ b/src/tests/readytorun/HardwareIntrinsics/X86/CpuId_R2R_Sse42.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="('$(TargetArchitecture)' != 'x64' AND '$(TargetArchitecture)' != 'x86') OR ('$(RuntimeFlavor)' != 'coreclr')">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/readytorun/crossboundarylayout/a/a.csproj
+++ b/src/tests/readytorun/crossboundarylayout/a/a.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/readytorun/crossboundarylayout/b/b.csproj
+++ b/src/tests/readytorun/crossboundarylayout/b/b.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/readytorun/crossboundarylayout/d/d.csproj
+++ b/src/tests/readytorun/crossboundarylayout/d/d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/readytorun/crossboundarylayout/e/e.csproj
+++ b/src/tests/readytorun/crossboundarylayout/e/e.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/readytorun/crossgen2/helperdll.csproj
+++ b/src/tests/readytorun/crossgen2/helperdll.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/readytorun/crossgen2/helperildll.ilproj
+++ b/src/tests/readytorun/crossgen2/helperildll.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="helperildll.il" />

--- a/src/tests/readytorun/fieldlayout/fieldlayout.csproj
+++ b/src/tests/readytorun/fieldlayout/fieldlayout.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>exe</OutputType>
-    <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>

--- a/src/tests/readytorun/multifolder/FolderA/FolderA.csproj
+++ b/src/tests/readytorun/multifolder/FolderA/FolderA.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/readytorun/multifolder/FolderB/FolderB.csproj
+++ b/src/tests/readytorun/multifolder/FolderB/FolderB.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
-    <GenerateRunScript>false</GenerateRunScript>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/readytorun/tests/fieldgetter.ilproj
+++ b/src/tests/readytorun/tests/fieldgetter.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="fieldgetter.il" />

--- a/src/tests/readytorun/tests/genericsload/genericslib.ilproj
+++ b/src/tests/readytorun/tests/genericsload/genericslib.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="genericslib.il" />

--- a/src/tests/readytorun/tests/testv1/test.csproj
+++ b/src/tests/readytorun/tests/testv1/test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\fieldgetter.ilproj" />

--- a/src/tests/readytorun/tests/testv2/test.csproj
+++ b/src/tests/readytorun/tests/testv2/test.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>library</OutputType>
     <DefineConstants>$(DefineConstants);V2</DefineConstants>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\fieldgetter.ilproj" />

--- a/src/tests/reflection/DefaultInterfaceMethods/GetInterfaceMapProvider.ilproj
+++ b/src/tests/reflection/DefaultInterfaceMethods/GetInterfaceMapProvider.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GetInterfaceMapProvider.il" />

--- a/src/tests/reflection/DefaultInterfaceMethods/InvokeProvider.ilproj
+++ b/src/tests/reflection/DefaultInterfaceMethods/InvokeProvider.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InvokeProvider.il" />

--- a/src/tests/reflection/GenericAttribute/GenericAttributeMetadata.ilproj
+++ b/src/tests/reflection/GenericAttribute/GenericAttributeMetadata.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenericAttributeMetadata.il" />

--- a/src/tests/reflection/Modifiers/modifiersdata.ilproj
+++ b/src/tests/reflection/Modifiers/modifiersdata.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="modifiersdata.il" />

--- a/src/tests/reflection/RefEmit/Dependency.csproj
+++ b/src/tests/reflection/RefEmit/Dependency.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Dependency.cs" />

--- a/src/tests/reflection/StaticInterfaceMembers/provider.ilproj
+++ b/src/tests/reflection/StaticInterfaceMembers/provider.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="provider.il" />

--- a/src/tests/tracing/common/common.csproj
+++ b/src/tests/tracing/common/common.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/tracing/eventpipe/applystartuphook/hooks/Basic.csproj
+++ b/src/tests/tracing/eventpipe/applystartuphook/hooks/Basic.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Basic.cs" />

--- a/src/tests/tracing/eventpipe/common/common.csproj
+++ b/src/tests/tracing/eventpipe/common/common.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <OutputType>Library</OutputType>
-    <CLRTestKind>SharedLibrary</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
I came across these while looking at the set of properties in order to generate some error checking for merged groups. As best as I can tell, most of these are very old uses that likely have had the test system changed from under them. They cause confusion when encountered.

- RestorePackages - I think has been replaced by the logic that bulk restores.
- CLRTestKind - A (somewhat) more recent change was #61942, which changed the default for CLRTestKind from "BuildAndRun" to "BuildAndRun if exe, else BuildOnly". However, BuildOnly appears to be intended for exes - build the exe but not test infrastructure to execute it as another project will handle that. I think SharedLibrary is what was intended here. Many OutputType=library tests specify BuildOnly or SharedLibrary, which seem incorrect and (now) unnecessary.
- GenerateRunScript - This is unconditionally set (overriding individual project files) in src/tests/Directory.Build.targets.