### PR TITLE
[wasm][debugger] Set VSTEST_TESTHOST_SHUTDOWN_TIMEOUT to 2s

### DIFF
--- a/src/mono/wasm/debugger/Wasm.Debugger.Tests/Wasm.Debugger.Tests.csproj
+++ b/src/mono/wasm/debugger/Wasm.Debugger.Tests/Wasm.Debugger.Tests.csproj
@@ -45,6 +45,10 @@
     <ItemGroup>
       <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export DEBUGGER_TEST_PATH=$PWD/debugger-test" />
       <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set DEBUGGER_TEST_PATH=%25cd%25/debugger-test" />
+
+      <!-- See https://github.com/dotnet/runtime/issues/89409 and https://github.com/microsoft/vstest/issues/2952 -->
+      <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export VSTEST_TESTHOST_SHUTDOWN_TIMEOUT=2000" />
+      <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set VSTEST_TESTHOST_SHUTDOWN_TIMEOUT=2000" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(DebuggerHost)' == 'chrome'">


### PR DESCRIPTION
The tests have been getting randomly aborted with:
`The active test run was aborted. Reason: Test host process crashed`

This might be due to the shutdown taking too long. The default timeout
is 100ms. Increasing that to 2000ms.

Issue: https://github.com/dotnet/runtime/issues/89409
