### PR TITLE
Simplify test DLL lookup logic

### DIFF
--- a/src/tests/baseservices/callconvs/TestCallingConventions.cs
+++ b/src/tests/baseservices/callconvs/TestCallingConventions.cs
@@ -10,36 +10,11 @@ using Xunit;
 
 unsafe class Program
 {
-    class NativeFunctions
-    {
-        public const string Name = nameof(NativeFunctions);
-
-        public static string GetFileName()
-        {
-            if (OperatingSystem.IsWindows())
-                return $"{Name}.dll";
-
-            if (OperatingSystem.IsLinux())
-                return $"lib{Name}.so";
-
-            if (OperatingSystem.IsMacOS())
-                return $"lib{Name}.dylib";
-
-            throw new PlatformNotSupportedException();
-        }
-
-        public static string GetFullPath()
-        {
-            string currentAssemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            return Path.Combine(currentAssemblyPath, GetFileName());
-        }
-    }
-
     static void BlittableFunctionPointers()
     {
         Console.WriteLine($"Running {nameof(BlittableFunctionPointers)}...");
 
-        IntPtr mod = NativeLibrary.Load(NativeFunctions.GetFullPath());
+        IntPtr mod = NativeLibrary.Load("NativeFunctions", Assembly.GetExecutingAssembly(), null);
         var cbDefault = NativeLibrary.GetExport(mod, "DoubleInt").ToPointer();
         var cbCdecl = NativeLibrary.GetExport(mod, "DoubleIntCdecl").ToPointer();
         var cbStdcall = NativeLibrary.GetExport(mod, "DoubleIntStdcall").ToPointer();
@@ -116,7 +91,7 @@ unsafe class Program
     {
         Console.WriteLine($"Running {nameof(NonblittableFunctionPointers)}...");
 
-        IntPtr mod = NativeLibrary.Load(NativeFunctions.GetFullPath());
+        IntPtr mod = NativeLibrary.Load("NativeFunctions", Assembly.GetExecutingAssembly(), null);
         var cbDefault = NativeLibrary.GetExport(mod, "ToUpper").ToPointer();
         var cbCdecl = NativeLibrary.GetExport(mod, "ToUpperCdecl").ToPointer();
         var cbStdcall = NativeLibrary.GetExport(mod, "ToUpperStdcall").ToPointer();

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -721,9 +721,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/RuntimeConfiguration/TestConfig/*">
             <Issue>Test expects being run with corerun</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/callconvs/TestCallingConventions/**">
-            <Issue>https://github.com/dotnet/runtime/issues/81677</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/debugging/debuginfo/tester/*">
             <Issue>Just-in-time compilation test</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes #81677 by making the test single file friendly.

Cc @dotnet/interop-contrib 