### PR TITLE
Lsra JitStressRegs mode SpillAlways fixes

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -4869,6 +4869,7 @@ void LinearScan::allocateRegisters()
 
         if (spillAlways() && lastAllocatedRefPosition != nullptr && !lastAllocatedRefPosition->IsPhysRegRef() &&
             !lastAllocatedRefPosition->getInterval()->isInternal &&
+            (!lastAllocatedRefPosition->RegOptional() || (lastAllocatedRefPosition->registerAssignment != RBM_NONE)) &&
             (RefTypeIsDef(lastAllocatedRefPosition->refType) || lastAllocatedRefPosition->getInterval()->isLocalVar))
         {
             assert(lastAllocatedRefPosition->registerAssignment != RBM_NONE);
@@ -5013,7 +5014,7 @@ void LinearScan::allocateRegisters()
                     {
                         // Available registers should not hold constants
                         assert(isRegAvailable(reg, physRegRecord->registerType));
-                        assert(!isRegConstant(reg, physRegRecord->registerType));
+                        assert(!isRegConstant(reg, physRegRecord->registerType) || spillAlways());
                         assert(nextIntervalRef[reg] == MaxLocation);
                         assert(spillCost[reg] == 0);
                     }

--- a/src/coreclr/scripts/superpmi_replay.py
+++ b/src/coreclr/scripts/superpmi_replay.py
@@ -35,7 +35,6 @@ jit_flags_all = [
     "JitStressRegs=8",
     "JitStressRegs=0x10",
     "JitStressRegs=0x80",
-    "JitStressRegs=0x800",
     "JitStressRegs=0x1000",
 ]
 

--- a/src/coreclr/scripts/superpmi_replay.py
+++ b/src/coreclr/scripts/superpmi_replay.py
@@ -35,6 +35,7 @@ jit_flags_all = [
     "JitStressRegs=8",
     "JitStressRegs=0x10",
     "JitStressRegs=0x80",
+    "JitStressRegs=0x800",
     "JitStressRegs=0x1000",
 ]
 


### PR DESCRIPTION
We have `spillAlways()` stress mode, but seems we never ran it. I have fixed the issues reported in https://github.com/dotnet/runtime/issues/88937 and also trying to add `JitStressRegs=0x800` in superpmi-replay run to see how it goes. If there are lot of failures, I will revert the superpmi-replay change and open a tracking issue for .NET 9.

Fixes: #88937 