### PR TITLE
Fix MSB4120 warning in Microsoft.NETCore.App.Runtime.props

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -123,9 +123,10 @@
         <IsNative>true</IsNative>
       </RuntimeFiles>
 
-      <FrameworkReleaseFiles Condition="'$(TargetsMacCatalyst)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'" Include="$(MonoArtifactsPath)\Mono.release.framework\*.*" />
-      <FrameworkDebugFiles Condition="'$(TargetsMacCatalyst)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'" Include="$(MonoArtifactsPath)\Mono.debug.framework\*.*" />
+      <MonoFrameworkReleaseFiles Condition="'$(TargetsMacCatalyst)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'" Include="$(MonoArtifactsPath)\Mono.release.framework\*.*" />
+      <MonoFrameworkDebugFiles Condition="'$(TargetsMacCatalyst)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'" Include="$(MonoArtifactsPath)\Mono.debug.framework\*.*" />
       <MonoIncludeFiles Include="$(MonoArtifactsPath)\include\**\*.*" />
+      <MonoBuildFiles Include="$(MonoArtifactsPath)\build\**\*.*" />
     </ItemGroup>
 
     <Error Condition="'@(RuntimeFiles)' == ''" Text="The '$(RuntimeFlavor)' subset must be built before building this project." />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
@@ -81,26 +81,22 @@
         <TargetPath>tools</TargetPath>
       </RuntimeFiles>
 
-      <RuntimeFiles
-        Include="@(MonoIncludeFiles)"
-        ExcludeFromDataFiles="true">
-        <TargetPath>runtimes/$(RuntimeIdentifier)/native/include/%(RecursiveDir)</TargetPath>
-      </RuntimeFiles>
-
-      <RuntimeFiles Condition="'$(TargetsMacCatalyst)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'"
-        Include="@(FrameworkReleaseFiles)"
-        ExcludeFromDataFiles="true">
+      <RuntimeFiles Include="@(MonoFrameworkReleaseFiles)"
+                    ExcludeFromDataFiles="true">
         <TargetPath>runtimes/$(RuntimeIdentifier)/native/Mono.release.framework/%(RecursiveDir)</TargetPath>
       </RuntimeFiles>
 
-      <RuntimeFiles Condition="'$(TargetsMacCatalyst)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'"
-        Include="@(FrameworkDebugFiles)"
-        ExcludeFromDataFiles="true">
+      <RuntimeFiles Include="@(MonoFrameworkDebugFiles)"
+                    ExcludeFromDataFiles="true">
         <TargetPath>runtimes/$(RuntimeIdentifier)/native/Mono.debug.framework/%(RecursiveDir)</TargetPath>
       </RuntimeFiles>
 
-      <RuntimeFiles Condition="'$(RuntimeFlavor)' == 'Mono'"
-                    Include="$(MonoArtifactsPath)\build\**\*.*"
+      <RuntimeFiles Include="@(MonoIncludeFiles)"
+                    ExcludeFromDataFiles="true">
+        <TargetPath>runtimes/$(RuntimeIdentifier)/native/include/%(RecursiveDir)</TargetPath>
+      </RuntimeFiles>
+
+      <RuntimeFiles Include="@(MonoBuildFiles)"
                     ExcludeFromDataFiles="true">
         <TargetPath>runtimes/$(RuntimeIdentifier)/build/%(RecursiveDir)</TargetPath>
       </RuntimeFiles>


### PR DESCRIPTION
> MSB4120: Item 'RuntimeFiles' definition within target references itself via (qualified or unqualified) metadatum 'RecursiveDir'. This can lead to unintended expansion and cross-applying of pre-existing items.

Fix this by introducing a new item in liveBuilds.targets and also simplify the conditions a bit.