### PR TITLE
[Mono]: Fix iOS/Android sample diagnostics config.

### DIFF
--- a/src/mono/sample/Android/Makefile
+++ b/src/mono/sample/Android/Makefile
@@ -10,7 +10,7 @@ DEPLOY_AND_RUN?=true
 #If DIAGNOSTIC_PORTS is enabled, RUNTIME_COMPONENTS must also be enabled.
 #If RUNTIME_COMPONENTS is enabled, DIAGNOSTIC_PORTS is optional.
 #If RUNTIME_COMPONENTS is enabled, DIAGNOSTIC_PORTS is disabled, use DOTNET_DiagnosticPorts when launching application to enable diagnostics.
-#RUNTIME_COMPONENTS=diagnostics_tracing
+#RUNTIME_COMPONENTS=marshal-ilgen;diagnostics_tracing
 #DIAGNOSTIC_PORTS=10.0.2.2:9000,nosuspend
 #DIAGNOSTIC_PORTS=10.0.2.2:9000,suspend
 #DIAGNOSTIC_PORTS=$(DOTNET_DiagnosticPorts)

--- a/src/mono/sample/iOS/Makefile
+++ b/src/mono/sample/iOS/Makefile
@@ -10,7 +10,7 @@ STRIP_DEBUG_SYMBOLS?=false # only used when measuring SOD via build-appbundle ma
 #If DIAGNOSTIC_PORTS is enabled, RUNTIME_COMPONENTS must also be enabled.
 #If RUNTIME_COMPONENTS is enabled, DIAGNOSTIC_PORTS is optional.
 #If RUNTIME_COMPONENTS is enabled, DIAGNOSTIC_PORTS is disabled, use DOTNET_DiagnosticPorts when launching application to enable diagnostics.
-#RUNTIME_COMPONENTS=diagnostics_tracing
+#RUNTIME_COMPONENTS=marshal-ilgen;diagnostics_tracing
 #DIAGNOSTIC_PORTS=127.0.0.1:9000,nosuspend
 #DIAGNOSTIC_PORTS=127.0.0.1:9000,suspend
 #DIAGNOSTIC_PORTS=$(DOTNET_DiagnosticPorts)
@@ -43,8 +43,8 @@ run: clean appbuilder
 	/p:TargetArchitecture=$(MONO_ARCH) \
 	/p:MonoEnableLLVM=$(USE_LLVM) \
 	/p:DeployAndRun=$(DEPLOY_AND_RUN) \
-	/p:RuntimeComponents="$(RUNTIME_COMPONENTS)" \
-	/p:DiagnosticPorts="$(DIAGNOSTIC_PORTS)" \
+	'/p:RuntimeComponents="$(RUNTIME_COMPONENTS)"' \
+	'/p:DiagnosticPorts="$(DIAGNOSTIC_PORTS)"' \
 	/bl
 
 run-sim: clean appbuilder
@@ -55,8 +55,8 @@ run-sim: clean appbuilder
 	/p:MonoEnableLLVM=$(USE_LLVM) \
 	/p:MonoForceInterpreter=false \
 	/p:DeployAndRun=$(DEPLOY_AND_RUN) \
-	/p:RuntimeComponents="$(RUNTIME_COMPONENTS)" \
-	/p:DiagnosticPorts="$(DIAGNOSTIC_PORTS)" \
+	'/p:RuntimeComponents="$(RUNTIME_COMPONENTS)"' \
+	'/p:DiagnosticPorts="$(DIAGNOSTIC_PORTS)"' \
 	/bl
 
 run-sim-interp: clean appbuilder
@@ -67,8 +67,8 @@ run-sim-interp: clean appbuilder
 	/p:MonoEnableLLVM=$(USE_LLVM) \
 	/p:MonoForceInterpreter=true \
 	/p:DeployAndRun=$(DEPLOY_AND_RUN) \
-	/p:RuntimeComponents="$(RUNTIME_COMPONENTS)" \
-	/p:DiagnosticPorts="$(DIAGNOSTIC_PORTS)" \
+	'/p:RuntimeComponents="$(RUNTIME_COMPONENTS)"' \
+	'/p:DiagnosticPorts="$(DIAGNOSTIC_PORTS)"' \
 	/bl
 
 run-catalyst: clean appbuilder
@@ -80,6 +80,7 @@ run-catalyst: clean appbuilder
 	/p:MonoForceInterpreter=false \
 	/p:DeployAndRun=$(DEPLOY_AND_RUN) \
 	/p:EnableAppSandbox=$(APP_SANDBOX) \
+	'/p:RuntimeComponents="$(RUNTIME_COMPONENTS)"' \
 	/bl
 
 run-catalyst-interp: clean appbuilder
@@ -91,6 +92,7 @@ run-catalyst-interp: clean appbuilder
 	/p:MonoForceInterpreter=true \
 	/p:DeployAndRun=$(DEPLOY_AND_RUN) \
 	/p:EnableAppSandbox=$(APP_SANDBOX) \
+	'/p:RuntimeComponents="$(RUNTIME_COMPONENTS)"' \
 	/bl
 
 clean:


### PR DESCRIPTION
Update iOS/Android sample diagnostics config to align with .net8 changes.

* marshal-ilgen is a default component that needs to be included in component specifications.
* Make sure properties including "," don't get truncated when passed to msbuild for iOS samples.
* Apply diagnostics defaults to maccatalyst sample build (when enabled).