### PR TITLE
Enable BinSkim scan in nightly validation

### DIFF
--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -1,4 +1,6 @@
 -SourceToolsList @("policheck","credscan")
+-ArtifactToolsList @("binskim")
+-BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True")
 -TsaInstanceURL https://devdiv.visualstudio.com/
 -TsaProjectName DEVDIV
 -TsaNotificationEmail runtimerepo-infra@microsoft.com


### PR DESCRIPTION
Enabling BinSkim scan over build artifacts in [Validate-DotNet pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=827) and the .NET staging pipeline based on company requirements.

We are required to run SDL tools on official builds and implement automated bug filling for the tools output. Currently we are running SDL checks over the source code in the nightly builds and in the .NET staging pipeline, but to be compliant we need to also run BinSkim over the produced artifacts.

This PRs is enabling BinSkim checks in the `Validate SDL` job of [Validate-DotNet pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=827).

More information is in the [Automate BinSkim runs over official builds issue](https://github.com/dotnet/arcade-services/issues/2647)  
