### PR TITLE
Move JsonSerializerOptions initialization logic to a shared helper.

### DIFF
--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.AsyncEnumerable.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.AsyncEnumerable.cs
@@ -67,11 +67,7 @@ namespace System.Net.Http.Json
             JsonSerializerOptions? options,
             CancellationToken cancellationToken)
         {
-            options ??= JsonSerializerOptions.Default;
-            options.MakeReadOnly();
-
-            var jsonTypeInfo = (JsonTypeInfo<TValue>)options.GetTypeInfo(typeof(TValue));
-
+            var jsonTypeInfo = (JsonTypeInfo<TValue>)JsonHelpers.GetJsonTypeInfo(typeof(TValue), options);
             return ReadFromJsonAsAsyncEnumerableCore(content, jsonTypeInfo, cancellationToken);
         }
 

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
@@ -35,7 +35,7 @@ namespace System.Net.Http.Json
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
         public static JsonContent Create<T>(T inputValue, MediaTypeHeaderValue? mediaType = null, JsonSerializerOptions? options = null)
-            => Create(inputValue, GetJsonTypeInfo(typeof(T), options), mediaType);
+            => Create(inputValue, JsonHelpers.GetJsonTypeInfo(typeof(T), options), mediaType);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
@@ -44,7 +44,7 @@ namespace System.Net.Http.Json
             ThrowHelper.ThrowIfNull(inputType);
             EnsureTypeCompatibility(inputValue, inputType);
 
-            return new JsonContent(inputValue, GetJsonTypeInfo(inputType, options), mediaType);
+            return new JsonContent(inputValue, JsonHelpers.GetJsonTypeInfo(inputType, options), mediaType);
         }
 
         public static JsonContent Create<T>(T? inputValue, JsonTypeInfo<T> jsonTypeInfo,
@@ -134,20 +134,6 @@ namespace System.Net.Http.Json
 #endif
                 }
             }
-        }
-
-        [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        private static JsonTypeInfo GetJsonTypeInfo(Type inputType, JsonSerializerOptions? options)
-        {
-            Debug.Assert(inputType is not null);
-
-            // Ensure the options supports the call to GetTypeInfo
-            options ??= JsonHelpers.s_defaultSerializerOptions;
-            options.TypeInfoResolver ??= JsonSerializerOptions.Default.TypeInfoResolver;
-            options.MakeReadOnly();
-
-            return options.GetTypeInfo(inputType);
         }
 
         private static void EnsureTypeCompatibility(object? inputValue, Type inputType)

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonHelpers.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonHelpers.cs
@@ -2,15 +2,32 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 namespace System.Net.Http.Json
 {
     internal static class JsonHelpers
     {
         internal static readonly JsonSerializerOptions s_defaultSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+        [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
+        internal static JsonTypeInfo GetJsonTypeInfo(Type type, JsonSerializerOptions? options)
+        {
+            Debug.Assert(type is not null);
+
+            // Resolves JsonTypeInfo metadata using the appropriate JsonSerializerOptions configuration,
+            // following the semantics of the JsonSerializer reflection methods.
+            options ??= s_defaultSerializerOptions;
+            options.TypeInfoResolver ??= JsonSerializerOptions.Default.TypeInfoResolver;
+            options.MakeReadOnly();
+
+            return options.GetTypeInfo(type);
+        }
 
         internal static MediaTypeHeaderValue GetDefaultMediaType() => new("application/json") { CharSet = "utf-8" };
 


### PR DESCRIPTION
Following up on a couple of community PRs made in #89614 and #89258 this PR consolidates the `JsonSerializerOptions` initialization logic behind a shared helper method, fixing a minor inconsistency in the process.