### PR TITLE
[PERF] Cleanup tool build changes

### DIFF
--- a/eng/pipelines/coreclr/templates/run-scenarios-job.yml
+++ b/eng/pipelines/coreclr/templates/run-scenarios-job.yml
@@ -153,28 +153,6 @@ jobs:
     - script: cp -r $(PerformanceDirectory)/scripts $(WorkItemDirectory)/scripts/ && cp -r $(PerformanceDirectory)/src/scenarios/shared $(WorkItemDirectory)/shared/ && cp -r $(PerformanceDirectory)/src/scenarios/staticdeps/ $(WorkItemDirectory)/staticdeps/
       displayName: Copy scenario support files (Linux/MAC)
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
-    # Set DOTNET_ROOT
-    - script: |
-        echo "##vso[task.setvariable variable=DOTNET_ROOT;]$(PayloadDirectory)/dotnet"
-        echo "Set DOTNET_ROOT to $(PayloadDirectory)/dotnet"
-      displayName: Explicitly set DOTNET_ROOT (Non-Windows)
-      condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
-    - powershell: |
-        Write-Host "##vso[task.setvariable variable=DOTNET_ROOT;]$(PayloadDirectory)\dotnet"
-        Write-Host "Set DOTNET_ROOT to $(PayloadDirectory)\dotnet"
-      displayName: Explicitly set DOTNET_ROOT (Windows)
-      condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
-    # Set PATH
-    - script: |
-        echo "##vso[task.setvariable variable=PATH;]$(DOTNET_ROOT):$(PATH)"
-        echo "Set PATH to $(DOTNET_ROOT):$(PATH)"
-      displayName: Explicitly set PATH (Non-Windows)
-      condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
-    - powershell: |
-        Write-Host "##vso[task.setvariable variable=PATH;]$(DOTNET_ROOT);$(PATH)"
-        Write-Host "Set PATH to $(DOTNET_ROOT);$(PATH)"
-      displayName: Explicitly set PATH (Windows)
-      condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
     # build Startup
     - script: $(PayloadDirectory)\dotnet\dotnet.exe publish -c Release -o $(WorkItemDirectory)\Startup -f net7.0 -r win-$(Architecture) $(PerformanceDirectory)\src\tools\ScenarioMeasurement\Startup\Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
       displayName: Build Startup tool (Windows)


### PR DESCRIPTION
Remove now unnecessary fix for building perf tools. Cleaning up per: https://github.com/dotnet/performance/issues/3153. Runtime version of https://github.com/dotnet/performance/pull/3179.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2232928&view=results