### PR TITLE
[wasm][debugger] Do not pause on exceptions from our framework js files if JMC is enabled

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -406,6 +406,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             SdbAgent = sdbAgent;
             PauseOnExceptions = pauseOnExceptions;
             Destroyed = false;
+            FrameworkScriptList = new();
         }
         public ExecutionContext CreateChildAsyncExecutionContext(SessionId sessionId)
             => new ExecutionContext(null, Id, AuxData, PauseOnExceptions)
@@ -434,6 +435,8 @@ namespace Microsoft.WebAssembly.Diagnostics
         public int ThreadId { get; set; }
         public int Id { get; set; }
         public ExecutionContext ParentContext { get; private set; }
+
+        public List<int> FrameworkScriptList { get; init; }
         public SessionId SessionId { get; private set; }
 
         public bool PausedOnWasm { get; set; }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -245,23 +245,23 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
                 default:
                     {
-                        //avoid pausing when justMyCode is enabled and it's a framework function
                         if (JustMyCode)
                         {
                             if (!Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
                                 return false;
+                            //avoid pausing when justMyCode is enabled and it's a framework function
                             var scriptId = args?["callFrames"]?[0]?["location"]?["scriptId"]?.Value<int>();
                             if (scriptId is not null && context.FrameworkScriptList.Contains(scriptId.Value))
                             {
                                 await SendCommand(sessionId, "Debugger.stepOut", new JObject(), token);
                                 return true;
                             }
-                        }
-                        //avoid pausing when justMyCode is enabled and it's a wasm function
-                        if (JustMyCode && args?["callFrames"]?[0]?["scopeChain"]?[0]?["type"]?.Value<string>()?.Equals("wasm-expression-stack") == true)
-                        {
-                            await SendCommand(sessionId, "Debugger.stepOut", new JObject(), token);
-                            return true;
+                            //avoid pausing when justMyCode is enabled and it's a wasm function
+                            if (args?["callFrames"]?[0]?["scopeChain"]?[0]?["type"]?.Value<string>()?.Equals("wasm-expression-stack") == true)
+                            {
+                                await SendCommand(sessionId, "Debugger.stepOut", new JObject(), token);
+                                return true;
+                            }
                         }
                         break;
                     }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -249,15 +249,15 @@ namespace Microsoft.WebAssembly.Diagnostics
                         {
                             if (!Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
                                 return false;
-                            //avoid pausing when justMyCode is enabled and it's a framework function
-                            var scriptId = args?["callFrames"]?[0]?["location"]?["scriptId"]?.Value<int>();
-                            if (scriptId is not null && context.FrameworkScriptList.Contains(scriptId.Value))
+                            //avoid pausing when justMyCode is enabled and it's a wasm function
+                            if (args?["callFrames"]?[0]?["scopeChain"]?[0]?["type"]?.Value<string>()?.Equals("wasm-expression-stack") == true)
                             {
                                 await SendCommand(sessionId, "Debugger.stepOut", new JObject(), token);
                                 return true;
                             }
-                            //avoid pausing when justMyCode is enabled and it's a wasm function
-                            if (args?["callFrames"]?[0]?["scopeChain"]?[0]?["type"]?.Value<string>()?.Equals("wasm-expression-stack") == true)
+                            //avoid pausing when justMyCode is enabled and it's a framework function
+                            var scriptId = args?["callFrames"]?[0]?["location"]?["scriptId"]?.Value<int>();
+                            if (!context.IsSkippingHiddenMethod && !context.IsSteppingThroughMethod && scriptId is not null && context.FrameworkScriptList.Contains(scriptId.Value))
                             {
                                 await SendCommand(sessionId, "Debugger.stepOut", new JObject(), token);
                                 return true;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -148,7 +148,15 @@ namespace Microsoft.WebAssembly.Diagnostics
                         Contexts.ClearContexts(sessionId);
                         return false;
                     }
-
+                case "Debugger.scriptParsed":
+                    {
+                        if (args["url"]?.ToString()?.Contains("/_framework/") == true) //is from dotnet runtime framework
+                        {
+                            if (Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
+                                context.FrameworkScriptList.Add(args["scriptId"].Value<int>());
+                        }
+                        return false;
+                    }
                 case "Debugger.paused":
                     {
                         return await OnDebuggerPaused(sessionId, args, token);
@@ -237,6 +245,18 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
                 default:
                     {
+                        //avoid pausing when justMyCode is enabled and it's a framework function
+                        if (JustMyCode)
+                        {
+                            if (!Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
+                                return false;
+                            var scriptId = args?["callFrames"]?[0]?["location"]?["scriptId"]?.Value<int>();
+                            if (scriptId is not null && context.FrameworkScriptList.Contains(scriptId.Value))
+                            {
+                                await SendCommand(sessionId, "Debugger.stepOut", new JObject(), token);
+                                return true;
+                            }
+                        }
                         //avoid pausing when justMyCode is enabled and it's a wasm function
                         if (JustMyCode && args?["callFrames"]?[0]?["scopeChain"]?[0]?["type"]?.Value<string>()?.Equals("wasm-expression-stack") == true)
                         {


### PR DESCRIPTION
Skip any pause in our framework code if JMC is enabled.

I don't know how we can create a test case for it. 
This exception is only reproducible in a NON English OS.

https://github.com/dotnet/runtime/issues/76101