### PR TITLE
Fix COM object leak

### DIFF
--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/interopt.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/interopt.cs
@@ -19,15 +19,23 @@ namespace System.DirectoryServices.AccountManagement
     {
         public static int ADsOpenObject(string path, string userName, string password, int flags, [In, Out] ref Guid iid, [Out, MarshalAs(UnmanagedType.Interface)] out object ppObject)
         {
+            IntPtr ppObjPtr = IntPtr.Zero;
             try
             {
-                int hr = Interop.Activeds.ADsOpenObject(path, userName, password, flags, ref iid, out IntPtr ppObjPtr);
+                int hr = Interop.Activeds.ADsOpenObject(path, userName, password, flags, ref iid, out ppObjPtr);
                 ppObject = Marshal.GetObjectForIUnknown(ppObjPtr);
                 return hr;
             }
             catch (EntryPointNotFoundException)
             {
                 throw new InvalidOperationException(SR.AdsiNotInstalled);
+            }
+            finally
+            {
+                if (ppObjPtr != IntPtr.Zero)
+                {
+                    Marshal.Release(ppObjPtr);
+                }
             }
         }
 


### PR DESCRIPTION
Fix a case where we accidentally leaked a COM object reference in System.DirectoryServices.AccountManagement.

I validated that there's no other cases where we missed a leak in the rest of the codebase. The rest of the cases where we use COM interop either didn't have this issue or get their COM object references through COM Activation, so they don't go through LibraryImport at all.

Fixes #83269
