### PR TITLE
Fix ConnectCallback_UseNamedPipe_Success test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -305,4 +305,7 @@
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)StreamConformanceTests\StreamConformanceTests.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.IO.Pipelines" Version="7.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #73772
This test was only disabled for `IsNativeAot`, but I can repro the failure locally.

The main issue seems to be that the `loopbackConnection.DisposeAsync` is waiting for the client to disconnect, but the client will only disconnect once the loopback stream is disposed.

A minimal change here could be to just add a `client.Dispose` at the end of the inner block, but while I was looking into this I just rewrote it into our more common shape of separating out the client and server.