### PR TITLE
[LoongArch64] fix the compiling errors by GCC.

### DIFF
--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -8502,7 +8502,7 @@ void CodeGen::genFnPrologCalleeRegArgs()
 
                 assert(tmpArg <= REG_ARG_LAST);
                 assert(nextReg < MAX_REG_ARG);
-                assert(nextReg != i);
+                assert(nextReg != (unsigned)i);
 
                 regArg[i] = 0;
                 int count = 0;
@@ -8524,7 +8524,7 @@ void CodeGen::genFnPrologCalleeRegArgs()
                     count++;
                 }
 
-                if (nextReg == i)
+                if (nextReg == (unsigned)i)
                 {
                     GetEmitter()->emitIns_R_R_I(INS_ori, EA_PTRSIZE, REG_R21, (regNumber)tmpArg, 0);
                     regArgMaskLive &= ~genRegMask((regNumber)tmpArg);
@@ -8532,7 +8532,7 @@ void CodeGen::genFnPrologCalleeRegArgs()
                 }
                 else if (count == 0)
                 {
-                    tmpRegs[0] = i;
+                    tmpRegs[0] = (unsigned)i;
                     regArg[i]  = tmpArg;
                 }
                 else
@@ -8555,14 +8555,14 @@ void CodeGen::genFnPrologCalleeRegArgs()
                     assert(regArgNum >= 0);
                 } while (count >= 0);
 
-                if (nextReg == i)
+                if (nextReg == (unsigned)i)
                 {
                     instruction ins = (regArgMaskIsInt & (1 << regArg[i])) != 0 ? INS_slli_w : INS_ori;
                     GetEmitter()->emitIns_R_R_I(ins, EA_PTRSIZE, (regNumber)regArgInit[i], REG_R21, 0);
                     regArgNum--;
                     assert(regArgNum >= 0);
                 }
-                else if (tmpRegs[0] != i)
+                else if (tmpRegs[0] != (unsigned)i)
                 {
                     instruction ins = (regArgMaskIsInt & (1 << (i + REG_ARG_FIRST))) != 0 ? INS_slli_w : INS_ori;
                     GetEmitter()->emitIns_R_R_I(ins, EA_PTRSIZE, (regNumber)regArgInit[i],

--- a/src/coreclr/vm/loongarch64/asmhelpers.S
+++ b/src/coreclr/vm/loongarch64/asmhelpers.S
@@ -159,7 +159,7 @@ WRITE_BARRIER_END JIT_ByRefWriteBarrier
 //   $t0  : trashed
 //   $t3  : trashed
 //   $t4  : trashed
-//   t6  : trashed (incremented by 8 to implement JIT_ByRefWriteBarrier contract)
+//   $t6  : trashed (incremented by 8 to implement JIT_ByRefWriteBarrier contract)
 //
 WRITE_BARRIER_ENTRY JIT_CheckedWriteBarrier
 
@@ -305,7 +305,6 @@ WRITE_BARRIER_END JIT_WriteBarrier
 // Begin patchable literal pool
     .balign 64  // Align to power of two at least as big as patchable literal pool so that it fits optimally in cache line
 WRITE_BARRIER_ENTRY JIT_WriteBarrier_Table
-wbs_begin:
 wbs_card_table:
     .quad 0
 wbs_card_bundle_table:
@@ -382,8 +381,7 @@ NESTED_ENTRY ThePreStub, _TEXT, NoHandler
     EPILOG_BRANCH_REG  $t4
 NESTED_END ThePreStub, _TEXT
 
-// ------------------------------------------------------------------\
-
+// ------------------------------------------------------------------
 // EXTERN_C int __fastcall HelperMethodFrameRestoreState(
 // INDEBUG_COMMA(HelperMethodFrame *pFrame)
 // MachState *pState


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

 Fix the compiling errors by GCC.