### PR TITLE
Longer timeouts for perf slow jobs

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -238,7 +238,7 @@ extends:
               runKind: micro
               runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
               logicalmachine: 'perfampere'
-              timeoutInMinutes: 500
+              timeoutInMinutes: 780
 
       # run coreclr Windows arm64 ampere no dynamic pgo microbenchmarks perf job
         - template: /eng/pipelines/common/platform-matrix.yml
@@ -256,7 +256,7 @@ extends:
               runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
               logicalmachine: 'perfampere'
               pgoRunType: -NoDynamicPGO
-              timeoutInMinutes: 500
+              timeoutInMinutes: 780
 
         # run coreclr cloudvm microbenchmarks perf job
         # this run is added temporarily for measuring AVX-512 performance


### PR DESCRIPTION
At the moment the "Windows arm64 ampere" jobs are timing out, i.e. [this](https://dev.azure.com/dnceng/internal/_build/results?buildId=2232732&view=logs&j=00e7343a-b829-5180-f419-06cd08cd1ad7).