### PR TITLE
[Mono]: Align GetProcessinfo3 diagnostics command for MacCatalyst.

### DIFF
--- a/src/native/eventpipe/ds-sources.c
+++ b/src/native/eventpipe/ds-sources.c
@@ -28,7 +28,7 @@
 #define PORTABLE_RID_OS "linux-musl"
 #elif defined(TARGET_LINUX)
 #define PORTABLE_RID_OS "linux"
-#elif defined(TARGET_OSX)
+#elif defined(TARGET_OSX) && !defined(TARGET_MACCAT)
 #define PORTABLE_RID_OS "osx"
 #else
 #define PORTABLE_RID_OS "unix"

--- a/src/native/eventpipe/ep-event-source.c
+++ b/src/native/eventpipe/ep-event-source.c
@@ -19,7 +19,9 @@ const ep_char8_t* _ep_os_info = "tvOS";
 #elif defined(HOST_IOS)
 const ep_char8_t* _ep_os_info = "iOS";
 #elif defined(HOST_WATCHOS)
-const ep_char8_t* _ep_os_info = "WatchOS";
+const ep_char8_t* _ep_os_info = "watchOS";
+#elif defined(HOST_MACCAT)
+const ep_char8_t* _ep_os_info = "MacCatalyst";
 #elif defined(__APPLE__)
 const ep_char8_t* _ep_os_info = "macOS";
 #elif defined(HOST_ANDROID)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/88325.