### PR TITLE
Fix handling ThreadAbortException at the end of catch

### DIFF
--- a/src/coreclr/pal/inc/unixasmmacrosarm64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosarm64.inc
@@ -359,3 +359,20 @@ $__RedirectionStubEndFuncName
 #endif
 
 .endm
+
+//-----------------------------------------------------------------------------
+// Macro used to check (in debug builds only) whether the stack is 16-bytes aligned (a requirement before calling
+// out into C++/OS code). Invoke this directly after your prolog (if the stack frame size is fixed) or directly
+// before a call (if you have a frame pointer and a dynamic stack). A breakpoint will be invoked if the stack
+// is misaligned.
+//
+.macro  CHECK_STACK_ALIGNMENT
+
+#ifdef _DEBUG
+        add     x9, sp, xzr
+        tst     x9, #15
+        beq     0f
+        EMIT_BREAKPOINT
+0:
+#endif
+.endm

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -704,6 +704,7 @@ else(CLR_CMAKE_TARGET_WIN32)
             ${ARCH_SOURCES_DIR}/jithelpers_singleappdomain.S
             ${ARCH_SOURCES_DIR}/jithelpers_slow.S
             ${ARCH_SOURCES_DIR}/pinvokestubs.S
+            ${ARCH_SOURCES_DIR}/redirectedhandledjitcase.S
             ${ARCH_SOURCES_DIR}/theprestubamd64.S
             ${ARCH_SOURCES_DIR}/thunktemplates.S
             ${ARCH_SOURCES_DIR}/unixasmhelpers.S

--- a/src/coreclr/vm/amd64/redirectedhandledjitcase.S
+++ b/src/coreclr/vm/amd64/redirectedhandledjitcase.S
@@ -30,7 +30,7 @@
         test            rsp, 0x0f
         jnz             C_FUNC(\stub\()_FixRsp)
 
-\stub\()_RspAligned:
+LOCAL_LABEL(\stub\()_RspAligned):
 
         // Any stack operations hereafter must be recorded in the unwind info, but
         // only nonvolatile register locations are needed.  Anything else is only
@@ -62,7 +62,7 @@
 // straightforward.
 LEAF_ENTRY \stub\()_FixRsp, _TEXT
 
-        call           \stub\()_RspAligned
+        call            LOCAL_LABEL(\stub\()_RspAligned)
 
         // Target should not return.
         int             3

--- a/src/coreclr/vm/amd64/redirectedhandledjitcase.S
+++ b/src/coreclr/vm/amd64/redirectedhandledjitcase.S
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.intel_syntax noprefix
+#include "unixasmmacros.inc"
+#include "asmconstants.h"
+
+#define FaultingExceptionFrame_StackAlloc (SIZEOF__GSCookie + SIZEOF__FaultingExceptionFrame)
+#define FaultingExceptionFrame_FrameOffset SIZEOF__GSCookie
+#define OFFSET_OF_FRAME (8 + SIZEOF_GSCookie)
+
+.macro GenerateRedirectedStubWithFrame stub, target
+
+    //
+    // This is the primary function to which execution will be redirected to.
+    //
+    NESTED_ENTRY \stub, _TEXT, NoHandler
+
+        //
+        // IN: rdi: original IP before redirect
+        //     rsi: Rip from the Thread::GetAbortContext()
+        //
+
+        mov             rdx, rsp
+
+        // This push of the return address must not be recorded in the unwind
+        // info.  After this push, unwinding will work.
+        push            rdi
+
+        test            rsp, 0x0f
+        jnz             \stub\()_FixRsp
+
+\stub\()_RspAligned:
+
+        // Any stack operations hereafter must be recorded in the unwind info, but
+        // only nonvolatile register locations are needed.  Anything else is only
+        // a "sub rsp, 8" to the unwinder.
+
+        alloc_stack     OFFSET_OF_FRAME + SIZEOF__FaultingExceptionFrame
+
+        END_PROLOGUE
+
+        lea             rdi, [rsp + OFFSET_OF_FRAME]
+
+        mov             dword ptr [rdi], 0                                                          // Initialize vtbl (it is not strictly necessary)
+        mov             dword ptr [rdi + OFFSETOF__FaultingExceptionFrame__m_fFilterExecuted], 0    // Initialize BOOL for personality routine
+
+        call C_FUNC(\target)
+
+        // Target should not return.
+        int             3
+
+    NESTED_END \stub, _TEXT
+
+// This function is used by the stub above to adjust the stack alignment.  The
+// stub can't conditionally push something on the stack because the unwind
+// encodings have no way to express that.
+//
+// CONSIDER: we could move the frame pointer above the FaultingExceptionFrame,
+// and detect the misalignment adjustment in
+// GetFrameFromRedirectedStubStackFrame.  This is probably less code and more
+// straightforward.
+LEAF_ENTRY \stub\()_FixRsp, _TEXT
+
+        call            \stub\()_RspAligned
+
+        // Target should not return.
+        int             3
+
+LEAF_END \stub\()_FixRsp, _TEXT
+
+.endm
+
+REDIRECT_FOR_THROW_CONTROL_FRAME_SIZE = 8
+
+NESTED_ENTRY RedirectForThrowControl2, _TEXT, NoHandler
+
+        // On entry
+        // rdi -> FaultingExceptionFrame
+        // rsi -> Rip from the Thread::GetAbortContext()
+        // rdx -> Original RSP
+
+        push_register   rax // Align stack
+
+        END_PROLOGUE
+
+        mov             [rdx - 8], rsi // Set return address slot to the Rip from the Thread::GetAbortContext()
+
+        call            C_FUNC(ThrowControlForThread)
+
+        // ThrowControlForThread doesn't return.
+        int             3
+
+NESTED_END RedirectForThrowControl2, _TEXT
+
+GenerateRedirectedStubWithFrame RedirectForThrowControl, RedirectForThrowControl2

--- a/src/coreclr/vm/amd64/redirectedhandledjitcase.S
+++ b/src/coreclr/vm/amd64/redirectedhandledjitcase.S
@@ -28,7 +28,7 @@
         push            rdi
 
         test            rsp, 0x0f
-        jnz             \stub\()_FixRsp
+        jnz             C_FUNC(\stub\()_FixRsp)
 
 \stub\()_RspAligned:
 
@@ -62,7 +62,7 @@
 // straightforward.
 LEAF_ENTRY \stub\()_FixRsp, _TEXT
 
-        call            \stub\()_RspAligned
+        call            C_FUNC(\stub\()_RspAligned)
 
         // Target should not return.
         int             3

--- a/src/coreclr/vm/amd64/redirectedhandledjitcase.S
+++ b/src/coreclr/vm/amd64/redirectedhandledjitcase.S
@@ -62,7 +62,7 @@
 // straightforward.
 LEAF_ENTRY \stub\()_FixRsp, _TEXT
 
-        call            C_FUNC(\stub\()_RspAligned)
+        call           \stub\()_RspAligned
 
         // Target should not return.
         int             3

--- a/src/coreclr/vm/amd64/unixstubs.cpp
+++ b/src/coreclr/vm/amd64/unixstubs.cpp
@@ -5,11 +5,6 @@
 
 extern "C"
 {
-    void RedirectForThrowControl()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
     void STDMETHODCALLTYPE JIT_ProfilerEnterLeaveTailcallStub(UINT_PTR ProfilerHandle)
     {
     }

--- a/src/coreclr/vm/arm/ehhelpers.S
+++ b/src/coreclr/vm/arm/ehhelpers.S
@@ -68,6 +68,31 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
         .endm
 
 // ------------------------------------------------------------------
+//
+// Helpers for ThreadAbort exceptions
+//
+
+        NESTED_ENTRY RedirectForThreadAbort2, _TEXT, NoHandler
+        PROLOG_PUSH  "{r7, lr}"
+
+        // stack must be 8 byte aligned
+        CHECK_STACK_ALIGNMENT
+
+        // On entry:
+        //
+        // r0 = address of FaultingExceptionFrame
+        //
+        // Invoke the helper to setup the FaultingExceptionFrame and raise the exception
+        bl              C_FUNC(ThrowControlForThread)
+
+        // ThrowControlForThread doesn't return.
+        EMIT_BREAKPOINT
+
+        NESTED_END RedirectForThreadAbort2, _TEXT
+
+GenerateRedirectedStubWithFrame RedirectForThreadAbort, RedirectForThreadAbort2
+
+// ------------------------------------------------------------------
 
         // This helper enables us to call into a funclet after applying the non-volatiles
         NESTED_ENTRY CallEHFunclet, _TEXT, NoHandler

--- a/src/coreclr/vm/arm/unixstubs.cpp
+++ b/src/coreclr/vm/arm/unixstubs.cpp
@@ -2,16 +2,3 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "common.h"
-
-extern "C"
-{
-    void RedirectForThrowControl()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
-    void RedirectForThreadAbort()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-};

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -697,6 +697,30 @@ NESTED_END CallEHFilterFunclet, _TEXT
 
 .endm
 
+// ------------------------------------------------------------------
+//
+// Helpers for ThreadAbort exceptions
+//
+
+        NESTED_ENTRY RedirectForThreadAbort2, _TEXT, NoHandler
+        PROLOG_SAVE_REG_PAIR_INDEXED fp,lr, -16
+
+        // stack must be 16 byte aligned
+        CHECK_STACK_ALIGNMENT
+
+        // On entry:
+        //
+        // x0 = address of FaultingExceptionFrame
+        //
+        // Invoke the helper to setup the FaultingExceptionFrame and raise the exception
+        bl              C_FUNC(ThrowControlForThread)
+
+        // ThrowControlForThread doesn't return.
+        EMIT_BREAKPOINT
+
+        NESTED_END RedirectForThreadAbort2, _TEXT
+
+GenerateRedirectedStubWithFrame RedirectForThreadAbort, RedirectForThreadAbort2
 
 // ------------------------------------------------------------------
 // ResolveWorkerChainLookupAsmStub

--- a/src/coreclr/vm/arm64/unixstubs.cpp
+++ b/src/coreclr/vm/arm64/unixstubs.cpp
@@ -2,4 +2,3 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "common.h"
-

--- a/src/coreclr/vm/arm64/unixstubs.cpp
+++ b/src/coreclr/vm/arm64/unixstubs.cpp
@@ -3,15 +3,3 @@
 
 #include "common.h"
 
-extern "C"
-{
-    void RedirectForThrowControl()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
-    void RedirectForThreadAbort()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-};

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -800,7 +800,11 @@ UINT_PTR ExceptionTracker::FinishSecondPass(
     {
         CopyOSContext(pThread->m_OSContext, pContextRecord);
         SetIP(pThread->m_OSContext, (PCODE)uResumePC);
+#if defined(TARGET_UNIX) && !(defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_ARM))
+        uAbortAddr = NULL;
+#else
         uAbortAddr = (UINT_PTR)COMPlusCheckForAbort(uResumePC);
+#endif
     }
 
     if (uAbortAddr)

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -800,11 +800,7 @@ UINT_PTR ExceptionTracker::FinishSecondPass(
     {
         CopyOSContext(pThread->m_OSContext, pContextRecord);
         SetIP(pThread->m_OSContext, (PCODE)uResumePC);
-#ifdef TARGET_UNIX
-        uAbortAddr = NULL;
-#else
         uAbortAddr = (UINT_PTR)COMPlusCheckForAbort(uResumePC);
-#endif
     }
 
     if (uAbortAddr)
@@ -833,7 +829,12 @@ UINT_PTR ExceptionTracker::FinishSecondPass(
         STRESS_LOG1(LF_EH, LL_INFO10, "resume under control: ip: %p\n", uResumePC);
 
 #ifdef TARGET_AMD64
+#ifdef TARGET_UNIX
+        pContextRecord->Rdi = uResumePC;
+        pContextRecord->Rsi = GetIP(pThread->GetAbortContext());
+#else
         pContextRecord->Rcx = uResumePC;
+#endif
 #elif defined(TARGET_ARM) || defined(TARGET_ARM64)
         // On ARM & ARM64, we save off the original PC in Lr. This is the same as done
         // in HandleManagedFault for H/W generated exceptions.

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -3956,7 +3956,9 @@ ThrowControlForThread(
     STRESS_LOG0(LF_SYNC, LL_INFO100, "ThrowControlForThread Aborting\n");
 
     // Here we raise an exception.
+    INSTALL_MANAGED_EXCEPTION_DISPATCHER
     RaiseComPlusException();
+    UNINSTALL_MANAGED_EXCEPTION_DISPATCHER
 }
 
 #if defined(FEATURE_HIJACK) && !defined(TARGET_UNIX)

--- a/src/libraries/System.Runtime/tests/System/Runtime/ControlledExecutionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/ControlledExecutionTests.cs
@@ -97,13 +97,6 @@ namespace System.Runtime.Tests
                     _caughtException = true;
                 }
 
-                if (!PlatformDetection.IsWindows)
-                {
-                    // Rethrowing a ThreadAbortException at the end of catch blocks is not implemented, so force it
-                    // here by calling native code (https://github.com/dotnet/runtime/issues/72703).
-                    Thread.Sleep(0);
-                }
-
                 _finishedExecution = true;
             }
         }


### PR DESCRIPTION
After the catch handler for ThreadAbortException exits, the
exception needs to be rethrown immediately. This was not
implemented on Unix and this change makes that work on 
Unix amd64, arm64 and arm.

Close #72703 