### PR TITLE
Change LoadDomainInfo to honor requested LDAP port

### DIFF
--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
@@ -2419,7 +2419,7 @@ namespace System.DirectoryServices.AccountManagement
 
             // Pull the requested port number
             Uri ldapUri = new Uri(this.ctxBase.Path);
-            int port = ldapUri.Port != -1 ? ldapUri.Port : (ldapUri.Scheme.ToUpper() == "LDAPS" ? 636 : 389);
+            int port = ldapUri.Port != -1 ? ldapUri.Port : (ldapUri.Scheme.ToUpperInvariant() == "LDAPS" ? 636 : 389);
 
             string dnsDomainName = "";
 

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
@@ -2417,9 +2417,13 @@ namespace System.DirectoryServices.AccountManagement
             // From that, we can build the DNS Domain Name
             this.dnsHostName = ADUtils.GetServerName(this.ctxBase);
 
+            // Pull the requested port number
+            Uri ldapUri = new Uri(this.ctxBase.Path);
+            int port = ldapUri.Port != -1 ? ldapUri.Port : (ldapUri.Scheme.ToUpper() == "LDAPS" ? 636 : 389);
+
             string dnsDomainName = "";
 
-            using (DirectoryEntry rootDse = new DirectoryEntry("LDAP://" + this.dnsHostName + "/rootDse", "", "", AuthenticationTypes.Anonymous))
+            using (DirectoryEntry rootDse = new DirectoryEntry("LDAP://" + this.dnsHostName + ":" + port + "/rootDse", "", "", AuthenticationTypes.Anonymous))
             {
                 this.defaultNamingContext = (string)rootDse.Properties["defaultNamingContext"][0];
                 this.contextBasePartitionDN = this.defaultNamingContext;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/65894

LoadDomainInfo builds an LDAP Uri that ignores the requested port.  If LDAPS/636 is requested, traffic still goes to 389 for this request.  For environments where port 389 is blocked, this causes calls such as GroupPrincipal.GetMembers() to fail when the group is Domain Local or Universal.  We do not seem to call LoadDomainInfo for Global groups.

This PR will use the specified port for the call, 389 if no port is specified, or 636 if LDAPS is specified.