### PR TITLE
Change www.microsoft.com to www.github.com in test

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -78,7 +78,7 @@ namespace System.Net.Security.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls12))]
         [OuterLoop("Uses external servers")]
         [InlineData("api.nuget.org")]
-        [InlineData("www.microsoft.com.")]
+        [InlineData("www.github.com.")]
         [InlineData("")]
         public async Task DefaultConnect_EndToEnd_Ok(string host)
         {


### PR DESCRIPTION
Fixes #89779. The change to use www.github.com was done after discussion with @wfurt.

Grepping the source code shows that we are using https://microsoft.com on other places as well, but so far they did not turn up in a CI report as failures, so I would prefer to do them as we encounter them.