### PR TITLE
Try Vector128 before Vector

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -109,6 +109,10 @@ namespace System.Text
             {
                 return GetIndexOfFirstNonAsciiByte_Intrinsified(pBuffer, bufferLength);
             }
+            else if (Vector128.IsHardwareAccelerated)
+            {
+                return GetIndexOfFirstNonAsciiByte_Vector(pBuffer, bufferLength);
+            }
             else
             {
                 return GetIndexOfFirstNonAsciiByte_Default(pBuffer, bufferLength);


### PR DESCRIPTION
After https://github.com/dotnet/runtime/pull/88532 The code prefers Vector512/Vector256/AdvSimd but then falls back to Vector rather than Vector128 which is implemented in the _Vector method

(I didn't actually check the Vector128 path closely)