### PR TITLE
Fix stack overflow handling on Unix

### DIFF
--- a/src/coreclr/pal/src/exception/seh.cpp
+++ b/src/coreclr/pal/src/exception/seh.cpp
@@ -109,7 +109,7 @@ SEHCleanup()
 {
     TRACE("Cleaning up SEH\n");
 
-    SEHCleanupSignals();
+    SEHCleanupSignals(false /* isChildProcess */);
 }
 
 /*++

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -275,11 +275,13 @@ void SEHCleanupSignals(bool isChildProcess)
         restore_signal(SIGFPE, &g_previous_sigfpe);
         restore_signal(SIGBUS, &g_previous_sigbus);
         restore_signal(SIGABRT, &g_previous_sigabrt);
+#if !HAVE_MACH_EXCEPTIONS
         // Do not restore the sigsegv when stack overflow was hit on a thread,
         // since all other sigsegvs have to wait in the handler until the process
         // dies.
         // If it is called by a forked child though, restore the sigsegv unconditionally
         if (isChildProcess || (g_stackOverflowHandlerStack != 0)) 
+#endif
         {
             restore_signal(SIGSEGV, &g_previous_sigsegv);
         }

--- a/src/coreclr/pal/src/include/pal/signal.hpp
+++ b/src/coreclr/pal/src/include/pal/signal.hpp
@@ -112,9 +112,11 @@ Function :
     SEHCleanupSignals
 
     Restore default signal handlers
+Parameters :
+    isChildProcess - indicates that it is called from a child process fork
 
-    (no parameters, no return value)
+    (no return value)
 --*/
-void SEHCleanupSignals();
+void SEHCleanupSignals(bool isChildProcess);
 
 #endif /* _PAL_SIGNAL_HPP_ */

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2229,7 +2229,7 @@ PROCCreateCrashDump(
         if (g_createdumpCallback != nullptr)
         {
             // Remove the signal handlers inherited from the runtime process
-            SEHCleanupSignals();
+            SEHCleanupSignals(true /* isChildProcess */);
 
             // Call the statically linked createdump code
             g_createdumpCallback(argv.size(), argv.data());
@@ -2524,7 +2524,7 @@ PROCAbort(int signal, siginfo_t* siginfo)
 
     // Restore all signals; the SIGABORT handler to prevent recursion and
     // the others to prevent multiple core dumps from being generated.
-    SEHCleanupSignals();
+    SEHCleanupSignals(false /* isChildProcess */);
 
     // Abort the process after waiting for the core dump to complete
     abort();

--- a/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
+++ b/src/tests/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
@@ -25,6 +25,7 @@ namespace TestStackOverflow
             testProcess.StartInfo.Arguments = $"{Path.Combine(s_currentPath, "..", testName, $"{testName}.dll")} {testArgs}";
             testProcess.StartInfo.UseShellExecute = false;
             testProcess.StartInfo.RedirectStandardError = true;
+            testProcess.StartInfo.Environment.Add("DOTNET_DbgEnableMiniDump", "0");
             bool endOfStackTrace = false;
             testProcess.ErrorDataReceived += (sender, line) => 
             {

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -86,9 +86,6 @@
 
     <!-- All Unix targets  on CoreCLR Runtime -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' != 'true' and '$(RuntimeFlavor)' == 'coreclr' ">
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/stackoverflow/stackoverflowtester/*">
-            <Issue>https://github.com/dotnet/runtime/issues/46175</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
             <Issue>https://github.com/dotnet/runtime/issues/80666</Issue>
         </ExcludeList>


### PR DESCRIPTION
There was a race between cleaning up signal handlers at process abort and multiple threads failing with stack overflow at the same time.
When a process exits due to a stack overflow, we should not restore the SIGSEGV handler so that all other threads failing due to the same condition just wait until the process abort completes.

Close #46175