### PR TITLE
Don't have getVectorTByteLength() return 0 for the time being

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8741,7 +8741,10 @@ private:
         }
         else
         {
-            return 0;
+            // TODO: We should be returning 0 here, but there are a number of
+            // places that don't quite get handled correctly in that scenario
+
+            return XMM_REGSIZE_BYTES;
         }
 #elif defined(TARGET_ARM64)
         if (compExactlyDependsOn(InstructionSet_VectorT128))
@@ -8750,7 +8753,10 @@ private:
         }
         else
         {
-            return 0;
+            // TODO: We should be returning 0 here, but there are a number of
+            // places that don't quite get handled correctly in that scenario
+
+            return FP_REGSIZE_BYTES;
         }
 #else
         assert(!"getVectorTByteLength() unimplemented on target arch");


### PR DESCRIPTION
This resolves #87515, resolves #87511, resolves #87388

The proper fix for this is tracked by https://github.com/dotnet/runtime/issues/87502, but for the time being we'll continue matching what we did in .NET Core 2.0 through .NET 7