### PR TITLE
Update prepare-artifacts.proj

### DIFF
--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -81,9 +81,6 @@
       <AssetManifestFilename>Manifest.xml</AssetManifestFilename>
       <AssetManifestFile>$(ArtifactsLogDir)AssetManifest/$(AssetManifestFilename)</AssetManifestFile>
 
-      <!-- Create temp dir to store generated asset manifest, per Arcade guidance. -->
-      <TempWorkingDir>$(ArtifactsObjDir)TempWorkingDir\$([System.Guid]::NewGuid())\</TempWorkingDir>
-
       <ProductVersionTxtContents Condition="'$(StabilizePackageVersion)'=='true'">$(ProductionVersion)</ProductVersionTxtContents>
       <ProductVersionTxtContents Condition="'$(StabilizePackageVersion)'!='true'">$(ProductVersion)</ProductVersionTxtContents>
     </PropertyGroup>
@@ -158,16 +155,7 @@
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       IsStableBuild="$(IsStableBuild)"
-      AssetManifestPath="$(AssetManifestFile)"
-      PublishingVersion ="3" />
-
-    <!-- Copy the generated manifest to the build's artifacts -->
-    <Copy SourceFiles="$(AssetManifestFile)" DestinationFolder="$(TempWorkingDir)" />
-
-    <Message Importance="High" Text="Uploading $(AssetManifestFilename) to pipeline" />
-    <Message
-      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(TempWorkingDir)$(AssetManifestFilename)"
-      Importance="High" />
+      AssetManifestPath="$(AssetManifestFile)" />
 
     <Message Importance="High" Text="Complete!" />
   </Target>

--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -159,7 +159,6 @@
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       IsStableBuild="$(IsStableBuild)"
       AssetManifestPath="$(AssetManifestFile)"
-      AssetsTemporaryDirectory="$(TempWorkingDir)"
       PublishingVersion ="3" />
 
     <!-- Copy the generated manifest to the build's artifacts -->


### PR DESCRIPTION
Don't pass AssetsTemporaryDirectory.
I noticed in our build logs:
```
It's no longer necessary to specify a value for the AssetsTemporaryDirectory property. Please consider patching your code to not use it.
```

https://dev.azure.com/dnceng/internal/_build/results?buildId=2233645&view=logs&j=4d50a8bf-a143-51c7-5cc8-defff437e23b&t=0b0b242f-bbcb-57b5-fe9f-26dc042642ec

See https://github.com/dotnet/arcade/blame/19a7052872ccc1b676191b4cc85954bf61484ef3/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToAzureDevOpsArtifacts.cs#L88C48-L88C63.