### PR TITLE
Adjust DNS metrics

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -24,13 +24,13 @@ namespace System.Net
             {
                 name = NameResolutionPal.GetHostName();
             }
-            catch when (LogFailure(startingTimestamp))
+            catch when (LogFailure(string.Empty, startingTimestamp))
             {
                 Debug.Fail("LogFailure should return false");
                 throw;
             }
 
-            NameResolutionTelemetry.Log.AfterResolution(startingTimestamp, successful: true);
+            NameResolutionTelemetry.Log.AfterResolution(string.Empty, startingTimestamp, successful: true);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, name);
             return name;
@@ -395,13 +395,13 @@ namespace System.Net
                         Aliases = aliases
                     };
             }
-            catch when (LogFailure(startingTimestamp))
+            catch when (LogFailure(hostName, startingTimestamp))
             {
                 Debug.Fail("LogFailure should return false");
                 throw;
             }
 
-            NameResolutionTelemetry.Log.AfterResolution(startingTimestamp, successful: true);
+            NameResolutionTelemetry.Log.AfterResolution(hostName, startingTimestamp, successful: true);
 
             return result;
         }
@@ -435,13 +435,13 @@ namespace System.Net
                 }
                 Debug.Assert(name != null);
             }
-            catch when (LogFailure(startingTimestamp))
+            catch when (LogFailure(address, startingTimestamp))
             {
                 Debug.Fail("LogFailure should return false");
                 throw;
             }
 
-            NameResolutionTelemetry.Log.AfterResolution(startingTimestamp, successful: true);
+            NameResolutionTelemetry.Log.AfterResolution(address, startingTimestamp, successful: true);
 
             // Do the forward lookup to get the IPs for that host name
             startingTimestamp = NameResolutionTelemetry.Log.BeforeResolution(name);
@@ -465,13 +465,13 @@ namespace System.Net
                         AddressList = addresses
                     };
             }
-            catch when (LogFailure(startingTimestamp))
+            catch when (LogFailure(name, startingTimestamp))
             {
                 Debug.Fail("LogFailure should return false");
                 throw;
             }
 
-            NameResolutionTelemetry.Log.AfterResolution(startingTimestamp, successful: true);
+            NameResolutionTelemetry.Log.AfterResolution(name, startingTimestamp, successful: true);
 
             // One of three things happened:
             // 1. Success.
@@ -603,7 +603,7 @@ namespace System.Net
                 }
                 finally
                 {
-                    NameResolutionTelemetry.Log.AfterResolution(startingTimestamp, successful: result is not null);
+                    NameResolutionTelemetry.Log.AfterResolution(hostName, startingTimestamp, successful: result is not null);
                 }
             }
         }
@@ -628,9 +628,9 @@ namespace System.Net
             }
         }
 
-        private static bool LogFailure(long? startingTimestamp)
+        private static bool LogFailure(object hostNameOrAddress, long? startingTimestamp)
         {
-            NameResolutionTelemetry.Log.AfterResolution(startingTimestamp, successful: false);
+            NameResolutionTelemetry.Log.AfterResolution(hostNameOrAddress, startingTimestamp, successful: false);
             return false;
         }
 

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
@@ -12,42 +12,15 @@ namespace System.Net
     {
         private static readonly Meter s_meter = new("System.Net.NameResolution");
 
-        private static readonly Counter<long> s_lookupsRequestedCounter = s_meter.CreateCounter<long>(
-            name: "dns-lookups-requested",
-            description: "Number of DNS lookups requested.");
+        private static readonly Histogram<double> s_lookupDuration = s_meter.CreateHistogram<double>(
+            name: "dns.lookups.duration",
+            description: "Measures the time take to perform a DNS lookup.");
 
-        public static bool IsEnabled() => s_lookupsRequestedCounter.Enabled;
+        public static bool IsEnabled() => s_lookupDuration.Enabled;
 
-        public static void BeforeResolution(object hostNameOrAddress, out string? host)
+        public static void AfterResolution(TimeSpan duration, string hostName)
         {
-            if (s_lookupsRequestedCounter.Enabled)
-            {
-                host = GetHostnameFromStateObject(hostNameOrAddress);
-
-                s_lookupsRequestedCounter.Add(1, KeyValuePair.Create("hostname", (object?)host));
-            }
-            else
-            {
-                host = null;
-            }
-        }
-
-        public static string GetHostnameFromStateObject(object hostNameOrAddress)
-        {
-            Debug.Assert(hostNameOrAddress is not null);
-
-            string host = hostNameOrAddress switch
-            {
-                string h => h,
-                KeyValuePair<string, AddressFamily> t => t.Key,
-                IPAddress a => a.ToString(),
-                KeyValuePair<IPAddress, AddressFamily> t => t.Key.ToString(),
-                _ => null!
-            };
-
-            Debug.Assert(host is not null, $"Unknown hostNameOrAddress type: {hostNameOrAddress.GetType().Name}");
-
-            return host;
+            s_lookupDuration.Record(duration.TotalSeconds, KeyValuePair.Create("dns.question.name", (object?)hostName));
         }
     }
 }

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
@@ -14,6 +14,7 @@ namespace System.Net
 
         private static readonly Histogram<double> s_lookupDuration = s_meter.CreateHistogram<double>(
             name: "dns.lookups.duration",
+            unit: "s",
             description: "Measures the time take to perform a DNS lookup.");
 
         public static bool IsEnabled() => s_lookupDuration.Enabled;

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
@@ -15,7 +15,7 @@ namespace System.Net
         private static readonly Histogram<double> s_lookupDuration = s_meter.CreateHistogram<double>(
             name: "dns.lookups.duration",
             unit: "s",
-            description: "Measures the time take to perform a DNS lookup.");
+            description: "Measures the time taken to perform a DNS lookup.");
 
         public static bool IsEnabled() => s_lookupDuration.Enabled;
 

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
@@ -1,8 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using System.Net.Sockets;
 using System.Threading;
 
 namespace System.Net
@@ -60,18 +62,15 @@ namespace System.Net
         [NonEvent]
         public long BeforeResolution(object hostNameOrAddress)
         {
-            // System.Diagnostics.Metrics part
-            NameResolutionMetrics.BeforeResolution(hostNameOrAddress, out string? host);
-
-            // System.Diagnostics.Tracing part
-            if (IsEnabled())
+            bool telemetryEnabled = IsEnabled();
+            if (telemetryEnabled)
             {
                 Interlocked.Increment(ref _lookupsRequested);
                 Interlocked.Increment(ref _currentLookups);
 
                 if (IsEnabled(EventLevel.Informational, EventKeywords.None))
                 {
-                    host ??= NameResolutionMetrics.GetHostnameFromStateObject(hostNameOrAddress);
+                    string host = GetHostnameFromStateObject(hostNameOrAddress);
 
                     ResolutionStart(host);
                 }
@@ -79,19 +78,25 @@ namespace System.Net
                 return Stopwatch.GetTimestamp();
             }
 
-            return 0;
+            return telemetryEnabled || NameResolutionMetrics.IsEnabled() ? Stopwatch.GetTimestamp() : 0;
         }
 
         [NonEvent]
-        public void AfterResolution(long? startingTimestamp, bool successful)
+        public void AfterResolution(object hostNameOrAddress, long? startingTimestamp, bool successful)
         {
             Debug.Assert(startingTimestamp.HasValue);
+            if (startingTimestamp == 0)
+            {
+                return;
+            }
 
-            if (startingTimestamp != 0)
+            TimeSpan duration = Stopwatch.GetElapsedTime(startingTimestamp.Value);
+
+            if (IsEnabled())
             {
                 Interlocked.Decrement(ref _currentLookups);
 
-                _lookupsDuration?.WriteMetric(Stopwatch.GetElapsedTime(startingTimestamp.Value).TotalMilliseconds);
+                _lookupsDuration?.WriteMetric(duration.TotalMilliseconds);
 
                 if (IsEnabled(EventLevel.Informational, EventKeywords.None))
                 {
@@ -103,6 +108,29 @@ namespace System.Net
                     ResolutionStop();
                 }
             }
+
+            if (NameResolutionMetrics.IsEnabled())
+            {
+                NameResolutionMetrics.AfterResolution(duration, GetHostnameFromStateObject(hostNameOrAddress));
+            }
+        }
+
+        private static string GetHostnameFromStateObject(object hostNameOrAddress)
+        {
+            Debug.Assert(hostNameOrAddress is not null);
+
+            string host = hostNameOrAddress switch
+            {
+                string h => h,
+                KeyValuePair<string, AddressFamily> t => t.Key,
+                IPAddress a => a.ToString(),
+                KeyValuePair<IPAddress, AddressFamily> t => t.Key.ToString(),
+                _ => null!
+            };
+
+            Debug.Assert(host is not null, $"Unknown hostNameOrAddress type: {hostNameOrAddress.GetType().Name}");
+
+            return host;
         }
     }
 }

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
@@ -62,8 +62,7 @@ namespace System.Net
         [NonEvent]
         public long BeforeResolution(object hostNameOrAddress)
         {
-            bool telemetryEnabled = IsEnabled();
-            if (telemetryEnabled)
+            if (IsEnabled())
             {
                 Interlocked.Increment(ref _lookupsRequested);
                 Interlocked.Increment(ref _currentLookups);
@@ -78,7 +77,7 @@ namespace System.Net
                 return Stopwatch.GetTimestamp();
             }
 
-            return telemetryEnabled || NameResolutionMetrics.IsEnabled() ? Stopwatch.GetTimestamp() : 0;
+            return NameResolutionMetrics.IsEnabled() ? Stopwatch.GetTimestamp() : 0;
         }
 
         [NonEvent]

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/MetricsTest.cs
@@ -14,7 +14,7 @@ namespace System.Net.NameResolution.Tests
 {
     public class MetricsTest
     {
-        private const string DnsLookupsRequested = "dns-lookups-requested";
+        private const string DnsLookupDuration = "dns.lookups.duration";
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public static void ResolveValidHostName_MetricsRecorded()
@@ -23,7 +23,7 @@ namespace System.Net.NameResolution.Tests
             {
                 const string ValidHostName = "localhost";
 
-                using var recorder = new InstrumentRecorder<long>(DnsLookupsRequested);
+                using var recorder = new InstrumentRecorder<double>(DnsLookupDuration);
 
                 await Dns.GetHostEntryAsync(ValidHostName);
                 await Dns.GetHostAddressesAsync(ValidHostName);
@@ -34,10 +34,10 @@ namespace System.Net.NameResolution.Tests
                 Dns.EndGetHostEntry(Dns.BeginGetHostEntry(ValidHostName, null, null));
                 Dns.EndGetHostAddresses(Dns.BeginGetHostAddresses(ValidHostName, null, null));
 
-                long[] measurements = GetMeasurementsForHostname(recorder, ValidHostName);
+                double[] measurements = GetMeasurementsForHostname(recorder, ValidHostName);
 
                 Assert.Equal(6, measurements.Length);
-                Assert.All(measurements, m => Assert.Equal(1, m));
+                Assert.All(measurements, m => Assert.True(m > double.Epsilon));
             }).Dispose();
         }
 
@@ -46,7 +46,7 @@ namespace System.Net.NameResolution.Tests
         {
             const string InvalidHostName = $"invalid...example.com...{nameof(ResolveInvalidHostName_MetricsRecorded)}";
 
-            using var recorder = new InstrumentRecorder<long>(DnsLookupsRequested);
+            using var recorder = new InstrumentRecorder<double>(DnsLookupDuration);
 
             await Assert.ThrowsAnyAsync<SocketException>(async () => await Dns.GetHostEntryAsync(InvalidHostName));
             await Assert.ThrowsAnyAsync<SocketException>(async () => await Dns.GetHostAddressesAsync(InvalidHostName));
@@ -57,17 +57,17 @@ namespace System.Net.NameResolution.Tests
             Assert.ThrowsAny<SocketException>(() => Dns.EndGetHostEntry(Dns.BeginGetHostEntry(InvalidHostName, null, null)));
             Assert.ThrowsAny<SocketException>(() => Dns.EndGetHostAddresses(Dns.BeginGetHostAddresses(InvalidHostName, null, null)));
 
-            long[] measurements = GetMeasurementsForHostname(recorder, InvalidHostName);
+            double[] measurements = GetMeasurementsForHostname(recorder, InvalidHostName);
 
             Assert.Equal(6, measurements.Length);
-            Assert.All(measurements, m => Assert.Equal(1, m));
+            Assert.All(measurements, m => Assert.True(m > double.Epsilon));
         }
 
-        private static long[] GetMeasurementsForHostname(InstrumentRecorder<long> recorder, string hostname)
+        private static double[] GetMeasurementsForHostname(InstrumentRecorder<double> recorder, string hostname)
         {
             return recorder
                 .GetMeasurements()
-                .Where(m => m.Tags.ToArray().Any(t => t.Key == "hostname" && t.Value is string hostnameTag && hostnameTag == hostname))
+                .Where(m => m.Tags.ToArray().Any(t => t.Key == "dns.question.name" && t.Value is string hostnameTag && hostnameTag == hostname))
                 .Select(m => m.Value)
                 .ToArray();
         }


### PR DESCRIPTION
Adjust DNS metrics according to [dotnet-dns-metrics.md](https://github.com/lmolkova/semantic-conventions/blob/dotnet8-metrics/docs/dotnet/dotnet-dns-metrics.md) from https://github.com/lmolkova/semantic-conventions/pull/1 .

This is a semantical change, since we are recording lookup duration instead of lookups requested. The total number of lookups can be derived though unfinished requests will not count. /cc @davidfowl

Contributes to #89093.