### PR TITLE
Add log level and keyword tests for NativeRuntimeEventSource

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3403,6 +3403,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventpipe/enabledisable/**">
             <Issue> needs triage </Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/tracing/runtimeeventsource/nativeruntimelevelkeywords/**">
+            <Issue>needs triage</Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/Exceptions/ForeignThread/ForeignThreadExceptions/**">
             <Issue>needs triage</Issue>
         </ExcludeList>

--- a/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
+++ b/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using Tracing.Tests.Common;
 
 
-{// Copied from fix #86370 by @davmason:
+{// Copied from https://github.com/dotnet/runtime/pull/86370 by @davmason:
 
     // Access ArrayPool.Shared.Rent() before the test to avoid the deadlock reported
     // in https://github.com/dotnet/runtime/issues/86233. This is a real issue,

--- a/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
+++ b/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
@@ -1,27 +1,9 @@
-﻿//*
-#define GC_COLLECT
-//*/
-//*
-#define GC_FINALIZERS
-//*/
-//*
-#define GC_MEMORY_PRESSURE
-//*/
-/*
-#define LOCK_CONTENTION //BUG!? Possibly deadlocks Linux x64
-//*/
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Linq;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
-#if LOCK_CONTENTION
-using System.Threading;
-using System.Threading.Tasks;
-#endif //LOCK_CONTENTION
 
 using System.Buffers; // Copied from https://github.com/dotnet/runtime/pull/86370 by @davmason:
 {
@@ -33,130 +15,41 @@ using System.Buffers; // Copied from https://github.com/dotnet/runtime/pull/8637
     Console.WriteLine($"buffer length={localBuffer.Length}");
 }
 
-const EventKeywords keywords = EventKeywords.None
-#if GC_COLLECT || GC_FINALIZERS || GC_MEMORY_PRESSURE
-    | (EventKeywords)0x1
-#endif
-#if LOCK_CONTENTION
-    | (EventKeywords)0x4000
-#endif //LOCK_CONTENTION
-    ;
-using Listener informational = Listener.StartNew("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, keywords);
-using Listener verbose = Listener.StartNew("Microsoft-Windows-DotNETRuntime", EventLevel.Verbose, keywords);
-using Listener logAlways = Listener.StartNew("Microsoft-Windows-DotNETRuntime", EventLevel.LogAlways, keywords);
+Listener.NextLevel = EventLevel.Informational;
+using Listener informational = new();
 
-#if GC_COLLECT
-for (int i = 0; i < ushort.MaxValue; i++)
+Listener.NextLevel = EventLevel.Verbose;
+using Listener verbose = new();
+
+Listener.NextLevel = EventLevel.LogAlways;
+using Listener logAlways = new();
+
+Listener.Event gCStart_V2 = new(1, EventLevel.Informational, 0xf00000000001L, "GCStart_V2");
+Listener.Event gCAllocationTick_V4 = new(10, EventLevel.Verbose, 0xf00000000001L, "GCAllocationTick_V4");
+
+for (Stopwatch stopwatch = Stopwatch.StartNew(); stopwatch.Elapsed.TotalSeconds < 10d;)
 {
-    GC.KeepAlive(new());
-}
-GC.Collect();
-#endif //GC_COLLECT
-
-#if GC_FINALIZERS
-GC.WaitForPendingFinalizers();
-#endif //GC_FINALIZERS
-
-#if GC_MEMORY_PRESSURE
-GC.AddMemoryPressure(1L);
-GC.RemoveMemoryPressure(1L);
-#endif //GC_MEMORY_PRESSURE
-
-#if LOCK_CONTENTION
-for (int i = 1; i <= 0x40; i++)
-{
-    object lockObject = new();
-    Task task = new(() =>
+    for (int i = 0; i < 1000; i++)
     {
-        lock (lockObject)
-        {
-            Thread.Sleep(0);
-        }
-    });
-    lock (lockObject)
-    {
-        task.Start();
-        while (Monitor.LockContentionCount < i)
-        {
-            Thread.Sleep(0);
-        }
+        GC.KeepAlive(new());
     }
-    task.Wait();
+    GC.Collect();
+
+    if (informational.Contains(gCStart_V2) &&
+        verbose.Contains(gCAllocationTick_V4))
+    {
+        Console.WriteLine($"\n{nameof(stopwatch.Elapsed.TotalSeconds)} {stopwatch.Elapsed.TotalSeconds}");
+        break;
+    }
 }
-#endif //LOCK_CONTENTION
-
-informational.DumpEvents();
-verbose.DumpEvents();
-logAlways.DumpEvents();
-
-IEnumerable<Listener.Event> informationalEvents = new Listener.Event[]
-{
-#if GC_COLLECT
-
-#if false //BUG!? Shouldn’t events be consistent across all platforms?
-    new(1,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCStart_V2"),
-    new(2,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCEnd_V1"),// Linux only?
-    new(4,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCHeapStats_V2"),// Linux only?
-    new(35,  EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCTriggered"),
-    new(39,  EventLevel.Informational, (EventKeywords)0x0000F00003F00003, "GCDynamicEvent")// Linux arm64 only?,
-    new(202, EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCMarkWithType"),// Linux only?
-    new(204, EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCPerHeapHistory_V3"),// Linux only?
-    new(205, EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCGlobalHeapHistory_V4"),// Linux only?
-#endif
-
-    new(3,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCRestartEEEnd_V1"),
-    new(7,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCRestartEEBegin_V1"),
-    new(8,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCSuspendEEEnd_V1"),
-    new(9,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCSuspendEEBegin_V1"),
-#endif //GC_COLLECT
-#if GC_FINALIZERS
-    new(13,  EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCFinalizersEnd_V1"),
-    new(14,  EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCFinalizersBegin_V1"),
-#endif //GC_FINALIZERS
-#if LOCK_CONTENTION
-    new(81,  EventLevel.Informational, (EventKeywords)0x0000F00000004000, "ContentionStart_V1"),// Inconsistent name?
-
-#if false //BUG!? Shouldn’t events be consistent across all platforms?
-    new(90,  EventLevel.Informational, (EventKeywords)0x0000F00000004000, "ContentionLockCreated"),// Windows/Linux/osx64 only?
-#endif
-
-    new(91,  EventLevel.Informational, (EventKeywords)0x0000F00000004000, "ContentionStop_V1"),// Inconsistent name?
-#endif //LOCK_CONTENTION
-};
-IEnumerable<Listener.Event> verboseEvents = new Listener.Event[]
-{
-#if GC_COLLECT
-
-#if false //BUG!? Shouldn’t events be consistent across all platforms?
-    new(10,  EventLevel.Verbose,       (EventKeywords)0x0000F00000000001, "GCAllocationTick_V4"),// Linux only?
-    new(33,  EventLevel.Verbose,       (EventKeywords)0x0000F00000000001, "PinObjectAtGCTime"),// Linux only?
-#endif
-
-    new(29,  EventLevel.Verbose,       (EventKeywords)0x0000F00000000001, "FinalizeObject"),
-
-#endif //GC_COLLECT
-#if GC_MEMORY_PRESSURE
-    new(200, EventLevel.Verbose,       (EventKeywords)0x0000F00000000001, "IncreaseMemoryPressure"),
-    new(201, EventLevel.Verbose,       (EventKeywords)0x0000F00000000001, "DecreaseMemoryPressure"),
-#endif //GC_MEMORY_PRESSURE
-};
-IEnumerable<Listener.Event> allEvents = informationalEvents.Concat(verboseEvents);
-
 try
 {
-    // BUGS!?
-    // Build linux-arm64 Release AllSubsets_Mono_Minijit_RuntimeTests minijit - receves no events!
-    // Build linux-x64 Release AllSubsets_Mono_LLVMAot_RuntimeTests llvmaot - receves no events!
-    // Build osx-x64 Release AllSubsets_Mono_Interpreter_RuntimeTests monointerpreter - receves no events!
-    // Build osx-x64 Release AllSubsets_Mono_Minijit_RuntimeTests minijit - receves no events!
-    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-    {
-
-        ThrowIfEventsFound(informational, verboseEvents);
-        ThrowIfEventsNotFound(informational, informationalEvents);
-        ThrowIfEventsNotFound(verbose, allEvents);
-        ThrowIfEventsNotFound(logAlways, allEvents);
-    }
+    ThrowIfEvent(informational, gCStart_V2, false);
+    ThrowIfEvent(informational, gCAllocationTick_V4);
+    ThrowIfEvent(verbose, gCStart_V2, false);
+    ThrowIfEvent(verbose, gCAllocationTick_V4, false);
+    ThrowIfEvent(logAlways, gCStart_V2, false);
+    ThrowIfEvent(logAlways, gCAllocationTick_V4, false);
 }
 finally
 {
@@ -164,122 +57,67 @@ finally
     verbose.DumpEvents();
     logAlways.DumpEvents();
 }
-
 return 100;
 
-static void ThrowIfEventsFound(Listener listener, IEnumerable<Listener.Event> events)
+static void ThrowIfEvent(Listener listener, Listener.Event e, bool contains = true)
 {
-    foreach (Listener.Event e in events)
+    if (listener.Contains(e) == contains)
     {
-        if (listener.Contains(e))
-        {
-            throw new Exception($"{listener} contains {e}");
-        }
-    }
-}
-static void ThrowIfEventsNotFound(Listener listener, IEnumerable<Listener.Event> events)
-{
-    foreach (Listener.Event e in events)
-    {
-        if (!listener.Contains(e))
-        {
-            throw new Exception($"{listener} doesn't contain {e}");
-        }
+        throw new Exception($"{listener} {(contains ? "contains" : "doesn't contain")} {e}");
     }
 }
 
-internal sealed class Listener : EventListener, IReadOnlySet<Listener.Event>
+internal sealed class Listener : EventListener
 {
-    public string SourceName { get; private set; } = "";
-    public EventLevel Level { get; private set; } = default;
-    public EventKeywords Keywords { get; private set; } = default;
-    public int Count => events.Count;
+    public static string NextSourceName = "Microsoft-Windows-DotNETRuntime";
+    public static EventLevel NextLevel = EventLevel.LogAlways;
+    public static long NextKeywords = 1L;
 
-    private static string nextSourceName = "";
-    private static EventLevel nextLevel = default;
-    private static EventKeywords nextKeywords = default;
     private readonly ConcurrentDictionary<Event, int> events = new();
-    private readonly SortedSet<Event> keys = new();
+    private string sourceName = "";
+    private EventLevel level;
+    private long keywords;
 
-    public readonly struct Event : IComparable<Event>
+    public readonly record struct Event(int Id, EventLevel Level, long Keywords, string Name)
     {
-        public readonly int Id;
-        public readonly EventLevel Level;
-        public readonly EventKeywords Keywords;
-        public readonly string Name = "";
-        public Event(int id, EventLevel level, EventKeywords keywords, string name)
+        public override string ToString()
         {
-            Id = id;
-            Level = level;
-            Keywords = keywords;
-            Name = name;
+            return $"new({Id,3}, {nameof(EventLevel)}.{Level,-13}, 0x{Keywords:x12}L, \"{Name}\");";
         }
-        public int CompareTo(Event other) => Id - other.Id;
-
-        #region BUG!? Shouldn’t event names be consistent across all platforms?
-        public override bool Equals([NotNullWhen(true)] object? obj) => GetHashCode() == obj?.GetHashCode();
-        public override int GetHashCode() => (Id, Level, Keywords).GetHashCode();
-        #endregion
-
-        public override string ToString() => $"{GetType().Name}({Id}, {Level}, {Keywords:x}, {Name})";
     }
 
-    private Listener() => keys.UnionWith(events.Keys);
-
-    public static Listener StartNew(string sourceName, EventLevel level, EventKeywords keywords)
+    public bool Contains(Event e)
     {
-        nextSourceName = sourceName;
-        nextLevel = level;
-        nextKeywords = keywords;
-        return new();
+        return events.ContainsKey(e);
     }
     public void DumpEvents()
     {
-        Console.WriteLine($"\n{this} {Count}\n{{");
-        Span<char> chars = stackalloc char[0x80];
-        foreach (Event e in this)
+        Console.WriteLine($"\n{this}\n\\");
+        foreach (KeyValuePair<Event, int> e in events)
         {
-            chars.Fill(' ');
-            "    new(".TryCopyTo(chars);
-            $"{e.Id},".TryCopyTo(chars[8..]);
-            $"{e.Level.GetType().Name}.{e.Level},".TryCopyTo(chars[13..]);
-            $"({e.Keywords.GetType().Name})0x{e.Keywords:x}, \"{e.Name}\"),".TryCopyTo(chars[39..]);
-            Console.WriteLine(chars.TrimEnd(' ').ToString());
+            Console.WriteLine($"{e.Key} // {e.Value}");
         }
-        Console.WriteLine("};");
     }
-    public bool Contains(Event item) => Events.Contains(item);
-    public bool IsProperSubsetOf(IEnumerable<Event> other) => Events.IsProperSubsetOf(other);
-    public bool IsProperSupersetOf(IEnumerable<Event> other) => Events.IsProperSupersetOf(other);
-    public bool IsSubsetOf(IEnumerable<Event> other) => Events.IsSubsetOf(other);
-    public bool IsSupersetOf(IEnumerable<Event> other) => Events.IsSupersetOf(other);
-    public bool Overlaps(IEnumerable<Event> other) => Events.Overlaps(other);
-    public bool SetEquals(IEnumerable<Event> other) => Events.SetEquals(other);
-    public IEnumerator<Event> GetEnumerator() => Events.GetEnumerator();
-    IEnumerator IEnumerable.GetEnumerator() => Events.GetEnumerator();
-    public override string ToString() => $"{GetType().Name}({SourceName}, {Level}, {Keywords:x})";
+    public override string ToString()
+    {
+        return $"\"{sourceName}\": [{nameof(EventLevel)}.{level,-13}, 0x{keywords:x12}L] ({events.Count,3}, {events.Values.Sum()})";
+    }
 
     protected override void OnEventSourceCreated(EventSource source)
     {
-        if (string.IsNullOrEmpty(SourceName) && (source.Name == nextSourceName))
+        if (string.IsNullOrEmpty(sourceName) && (source.Name == NextSourceName))
         {
-            SourceName = source.Name;
-            Level = nextLevel;
-            Keywords = nextKeywords;
-            EnableEvents(source, Level, Keywords);
+            sourceName = source.Name;
+            level = NextLevel;
+            keywords = NextKeywords;
+            EnableEvents(source, level, (EventKeywords)keywords);
         }
     }
-    protected override void OnEventWritten(EventWrittenEventArgs e) => events[new(e.EventId, e.Level, e.Keywords, e.EventName ?? "")] = 0;
-
-    private IReadOnlySet<Event> Events
+    protected override void OnEventWritten(EventWrittenEventArgs e)
     {
-        get
+        events.AddOrUpdate(new(e.EventId, e.Level, (long)e.Keywords, e.EventName ?? ""), 1, (_, i) =>
         {
-            if (Count > keys.Count)
-            {
-                keys.UnionWith(events.Keys);
-            }
-            return keys;
-        }
+            return i + 1;
+        });
     }
 }

--- a/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
+++ b/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
@@ -123,6 +123,12 @@ internal sealed class GCListener : EventListener
     {
         return $"{GetType().Name}({sourceName}, {Level.GetType().Name}.{Level,-13}, {Events.Count,3});";
     }
+    public override void Dispose()
+    {
+        Console.WriteLine($"\n{this}\n\\\nDisposing...");
+        base.Dispose();
+        Console.WriteLine("Disposed");
+    }
 
     protected override void OnEventSourceCreated(EventSource source)
     {

--- a/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
+++ b/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Tracing.Tests.Common;
+
+
+
+const string SourceName = "Microsoft-Windows-DotNETRuntime";
+
+using Listener most = Listener.Create(SourceName, EventLevel.Verbose, EventKeywords.All);
+using Listener all1 = Listener.Create(SourceName, EventLevel.LogAlways, EventKeywords.All);
+using Listener all2 = Listener.Create(SourceName, EventLevel.LogAlways, EventKeywords.None);
+Stopwatch stopwatch = Stopwatch.StartNew();
+HashSet<Task> tasks = new();
+
+while (stopwatch.Elapsed.TotalSeconds < (39d / 10d))
+{
+    tasks.RemoveWhere(t => t.IsCompleted);
+    tasks.Add(Task.Run(() =>
+    {
+        Thread.Sleep(Random.Shared.Next().ToString().GetHashCode() & sbyte.MaxValue);
+    }));
+
+    string str = stopwatch.Elapsed.TotalNanoseconds.ToString();
+    GC.KeepAlive(str);
+    Thread.Sleep(str.GetHashCode() & sbyte.MaxValue);
+}
+GC.Collect();
+
+foreach (Task task in tasks)
+{
+    task.Wait();
+}
+Thread.Sleep(1000);
+
+bool LevelsPassed = most.IsSubsetOf(all1);
+bool KeywordsPassed = all1.SetEquals(all2);
+
+most.DumpEvents();
+all1.DumpEvents();
+all2.DumpEvents();
+Console.WriteLine($"\n{nameof(stopwatch.Elapsed.TotalSeconds)}\t{stopwatch.Elapsed.TotalSeconds}");
+
+Assert.True(nameof(LevelsPassed), LevelsPassed);
+Assert.True(nameof(KeywordsPassed), KeywordsPassed);
+
+return 100;
+
+
+
+internal sealed class Listener : EventListener, IReadOnlySet<string>
+{
+    public int Count => Invoke(_ => events.Count, 0);
+    public readonly string? SourceName = null;
+    public readonly EventLevel? Level = nextLevel;
+    public readonly EventKeywords? Keywords = nextKeywords;
+
+    private static string nextSourceName = "";
+    private static EventLevel nextLevel = default;
+    private static EventKeywords nextKeywords = default;
+    private readonly object eventsLock = new();
+    private readonly HashSet<string> events = new();
+
+    private Listener() => SourceName = nextSourceName;
+    public static Listener Create(string sourceName, EventLevel level, EventKeywords keywords)
+    {
+        nextSourceName = sourceName;
+        nextLevel = level;
+        nextKeywords = keywords;
+        return new();
+    }
+
+    public void DumpEvents()
+    {
+        Console.WriteLine($"\n{nameof(SourceName)}\t{SourceName}");
+        Console.WriteLine($"{nameof(Level)}\t\t{Level}");
+        Console.WriteLine($"{nameof(Keywords)}\t{Keywords}");
+        Console.WriteLine($"{nameof(Count)}\t\t{Count}");
+
+        foreach (string e in this)
+        {
+            Console.WriteLine(e);
+        }
+    }
+    public bool Contains(string item) => Invoke(events.Contains, item);
+    public bool IsProperSubsetOf(IEnumerable<string> other) => Invoke(events.IsProperSubsetOf, other);
+    public bool IsProperSupersetOf(IEnumerable<string> other) => Invoke(events.IsProperSupersetOf, other);
+    public bool IsSubsetOf(IEnumerable<string> other) => Invoke(events.IsSubsetOf, other);
+    public bool IsSupersetOf(IEnumerable<string> other) => Invoke(events.IsSupersetOf, other);
+    public bool Overlaps(IEnumerable<string> other) => Invoke(events.Overlaps, other);
+    public bool SetEquals(IEnumerable<string> other) => Invoke(events.SetEquals, other);
+    public IEnumerator<string> GetEnumerator() => Invoke(events.ToHashSet, EqualityComparer<string>.Default).GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    protected override void OnEventSourceCreated(EventSource source)
+    {
+        if (source.Name == (SourceName ?? nextSourceName))
+        {
+            EnableEvents(source, Level ?? nextLevel, Keywords ?? nextKeywords);
+        }
+    }
+    protected override void OnEventWritten(EventWrittenEventArgs e) => Invoke(events.Add, $"{e.EventId}\t\t{e.EventName}");
+    
+    private TResult Invoke<T, TResult>(Func<T, TResult> func, T t)
+    {
+        lock (eventsLock)
+        {
+            return func(t);
+        }
+    }
+}

--- a/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
+++ b/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
@@ -20,8 +20,7 @@ using GCListener verbose = GCListener.Create(EventLevel.Verbose);
 using GCListener logAlways = GCListener.Create(EventLevel.LogAlways);
 
 Stopwatch stopwatch = Stopwatch.StartNew();
-
-while (stopwatch.Elapsed.TotalSeconds < 3d)
+do
 {
     for (long i1 = 0, i2 = stopwatch.ElapsedMilliseconds; i1 < i2; i1++)
     {
@@ -30,12 +29,13 @@ while (stopwatch.Elapsed.TotalSeconds < 3d)
     GC.AddMemoryPressure(1L);
     GC.RemoveMemoryPressure(1L);
 
-    if ((informational.Events.Count > 0) &&
-        verbose.Events.Any(e => e.Level is EventLevel.Verbose))
+    if ((informational.Events.Count > 0) && verbose.Events.Any(e => e.Level is EventLevel.Verbose))
     {
         break;
     }
 }
+while (stopwatch.Elapsed.TotalSeconds <= 0.25d);
+
 informational.DumpEvents();
 verbose.DumpEvents();
 logAlways.DumpEvents();

--- a/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
+++ b/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
@@ -1,17 +1,28 @@
-﻿using System;
-using System.Buffers;
+﻿//*
+#define GC_COLLECT
+//*/
+//*
+#define GC_FINALIZERS
+//*/
+//*
+#define GC_MEMORY_PRESSURE
+//*/
+//*
+#define LOCK_CONTENTION
+//*/
+using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Linq;
+#if LOCK_CONTENTION
 using System.Threading;
 using System.Threading.Tasks;
-using Tracing.Tests.Common;
+#endif
 
-
-{// Copied from https://github.com/dotnet/runtime/pull/86370 by @davmason:
-
+using System.Buffers; // Copied from https://github.com/dotnet/runtime/pull/86370 by @davmason:
+{
     // Access ArrayPool.Shared.Rent() before the test to avoid the deadlock reported
     // in https://github.com/dotnet/runtime/issues/86233. This is a real issue,
     // but only seen if you have a short lived EventListener and create EventSources
@@ -19,107 +30,197 @@ using Tracing.Tests.Common;
     byte[] localBuffer = ArrayPool<byte>.Shared.Rent(10);
     Console.WriteLine($"buffer length={localBuffer.Length}");
 }
-const string SourceName = "Microsoft-Windows-DotNETRuntime";
 
-using Listener most = Listener.Create(SourceName, EventLevel.Verbose, EventKeywords.All);
-using Listener all1 = Listener.Create(SourceName, EventLevel.LogAlways, EventKeywords.All);
-using Listener all2 = Listener.Create(SourceName, EventLevel.LogAlways, EventKeywords.None);
-Stopwatch stopwatch = Stopwatch.StartNew();
-HashSet<Task> tasks = new();
+const EventKeywords keywords = EventKeywords.None
+#if GC_COLLECT || GC_FINALIZERS || GC_MEMORY_PRESSURE
+    | (EventKeywords)0x1
+#endif
+#if LOCK_CONTENTION
+    | (EventKeywords)0x4000
+#endif
+    ;
+using Listener informational = Listener.StartNew("Microsoft-Windows-DotNETRuntime", EventLevel.Informational, keywords);
+using Listener verbose = Listener.StartNew("Microsoft-Windows-DotNETRuntime", EventLevel.Verbose, keywords);
+using Listener logAlways = Listener.StartNew("Microsoft-Windows-DotNETRuntime", EventLevel.LogAlways, keywords);
 
-while (stopwatch.Elapsed.TotalSeconds < (39d / 10d))
-{
-    tasks.RemoveWhere(t => t.IsCompleted);
-    tasks.Add(Task.Run(() =>
-    {
-        Thread.Sleep(Random.Shared.Next().ToString().GetHashCode() & sbyte.MaxValue);
-    }));
-
-    string str = stopwatch.Elapsed.TotalNanoseconds.ToString();
-    GC.KeepAlive(str);
-    Thread.Sleep(str.GetHashCode() & sbyte.MaxValue);
-}
+#if GC_COLLECT
 GC.Collect();
+#endif
 
-foreach (Task task in tasks)
+#if GC_FINALIZERS
+GC.WaitForPendingFinalizers();
+#endif
+
+#if GC_MEMORY_PRESSURE
+GC.AddMemoryPressure(1L);
+GC.RemoveMemoryPressure(1L);
+#endif
+
+#if LOCK_CONTENTION
+for (int i = 1; i <= 0x40; i++)
 {
+    object lockObject = new();
+    Task task = new(() =>
+    {
+        lock (lockObject)
+        {
+            Thread.Sleep(0);
+        }
+    });
+    lock (lockObject)
+    {
+        task.Start();
+        while (Monitor.LockContentionCount < i)
+        {
+            Thread.Sleep(0);
+        }
+    }
     task.Wait();
 }
-Thread.Sleep(1000);
+#endif
 
-bool LevelsPassed = most.IsSubsetOf(all1);
-bool KeywordsPassed = all1.SetEquals(all2);
+informational.DumpEvents();
+verbose.DumpEvents();
+logAlways.DumpEvents();
 
-most.DumpEvents();
-all1.DumpEvents();
-all2.DumpEvents();
-Console.WriteLine($"\n{nameof(stopwatch.Elapsed.TotalSeconds)}\t{stopwatch.Elapsed.TotalSeconds}");
+IEnumerable<Listener.Event> informationalEvents = new Listener.Event[]
+{
+#if GC_COLLECT
+    new(1,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCStart_V2"),
+    new(2,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCEnd_V1"),
+    new(3,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCRestartEEEnd_V1"),
+    new(4,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCHeapStats_V2"),
+    new(7,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCRestartEEBegin_V1"),
+    new(8,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCSuspendEEEnd_V1"),
+    new(9,   EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCSuspendEEBegin_V1"),
+    new(35,  EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCTriggered"),
+    new(202, EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCMarkWithType"),
+    new(204, EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCPerHeapHistory_V3"),
+    new(205, EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCGlobalHeapHistory_V4"),
+#endif
+#if GC_FINALIZERS
+    new(13,  EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCFinalizersEnd_V1"),
+    new(14,  EventLevel.Informational, (EventKeywords)0x0000F00000000001, "GCFinalizersBegin_V1"),
+#endif
+#if LOCK_CONTENTION
+    new(81,  EventLevel.Informational, (EventKeywords)0x0000F00000004000, "ContentionStart_V1"),
+    new(91,  EventLevel.Informational, (EventKeywords)0x0000F00000004000, "ContentionStop_V1"),
+#endif
+};
+IEnumerable<Listener.Event> verboseEvents = new Listener.Event[]
+{
+#if GC_COLLECT
+    new(29,  EventLevel.Verbose,       (EventKeywords)0x0000F00000000001, "FinalizeObject"),
+#endif
+#if GC_MEMORY_PRESSURE
+    new(200, EventLevel.Verbose,       (EventKeywords)0x0000F00000000001, "IncreaseMemoryPressure"),
+    new(201, EventLevel.Verbose,       (EventKeywords)0x0000F00000000001, "DecreaseMemoryPressure"),
+#endif
+};
+IEnumerable<Listener.Event> allEvents = informationalEvents.Concat(verboseEvents);
 
-Assert.True(nameof(LevelsPassed), LevelsPassed);
-Assert.True(nameof(KeywordsPassed), KeywordsPassed);
+ThrowIfEventsFound(informational, verboseEvents);
+ThrowIfEventsNotFound(informational, informationalEvents);
+ThrowIfEventsNotFound(verbose, allEvents);
+ThrowIfEventsNotFound(logAlways, allEvents);
 
 return 100;
 
-
-
-internal sealed class Listener : EventListener, IReadOnlySet<string>
+static void ThrowIfEventsFound(Listener listener, IEnumerable<Listener.Event> events)
 {
-    public int Count => Invoke(_ => events.Count, 0);
-    public readonly string? SourceName = null;
-    public readonly EventLevel? Level = nextLevel;
-    public readonly EventKeywords? Keywords = nextKeywords;
+    foreach (Listener.Event e in events)
+    {
+        if (listener.Contains(e))
+        {
+            throw new Exception($"{listener} contains {e}");
+        }
+    }
+}
+static void ThrowIfEventsNotFound(Listener listener, IEnumerable<Listener.Event> events)
+{
+    foreach (Listener.Event e in events)
+    {
+        if (!listener.Contains(e))
+        {
+            throw new Exception($"{listener} doesn't contain {e}");
+        }
+    }
+}
+
+internal sealed class Listener : EventListener, IReadOnlySet<Listener.Event>
+{
+    public string SourceName { get; private set; } = "";
+    public EventLevel Level { get; private set; } = default;
+    public EventKeywords Keywords { get; private set; } = default;
+    public int Count => events.Count;
 
     private static string nextSourceName = "";
     private static EventLevel nextLevel = default;
     private static EventKeywords nextKeywords = default;
-    private readonly object eventsLock = new();
-    private readonly HashSet<string> events = new();
+    private readonly ConcurrentDictionary<Event, int> events = new();
+    private readonly HashSet<Event> keys = new();
 
-    private Listener() => SourceName = nextSourceName;
-    public static Listener Create(string sourceName, EventLevel level, EventKeywords keywords)
+    public readonly record struct Event(int Id, EventLevel Level, EventKeywords Keywords, string Name)
+    {
+        public override string ToString() => $"{GetType().Name}({Id}, {Level}, {Keywords:x}, {Name})";
+    }
+
+    private Listener() => keys.UnionWith(events.Keys);
+
+    public static Listener StartNew(string sourceName, EventLevel level, EventKeywords keywords)
     {
         nextSourceName = sourceName;
         nextLevel = level;
         nextKeywords = keywords;
         return new();
     }
-
     public void DumpEvents()
     {
-        Console.WriteLine($"\n{nameof(SourceName)}\t{SourceName}");
-        Console.WriteLine($"{nameof(Level)}\t\t{Level}");
-        Console.WriteLine($"{nameof(Keywords)}\t{Keywords}");
-        Console.WriteLine($"{nameof(Count)}\t\t{Count}");
-
-        foreach (string e in this)
+        Console.WriteLine($"\n{this} {Count}\n{{");
+        Span<char> chars = stackalloc char[0x80];
+        foreach (Event e in this)
         {
-            Console.WriteLine(e);
+            chars.Fill(' ');
+            "    new(".TryCopyTo(chars);
+            $"{e.Id},".TryCopyTo(chars[8..]);
+            $"{e.Level.GetType().Name}.{e.Level},".TryCopyTo(chars[13..]);
+            $"({e.Keywords.GetType().Name})0x{e.Keywords:x}, \"{e.Name}\"),".TryCopyTo(chars[39..]);
+            Console.WriteLine(chars.TrimEnd(' ').ToString());
         }
+        Console.WriteLine("};");
     }
-    public bool Contains(string item) => Invoke(events.Contains, item);
-    public bool IsProperSubsetOf(IEnumerable<string> other) => Invoke(events.IsProperSubsetOf, other);
-    public bool IsProperSupersetOf(IEnumerable<string> other) => Invoke(events.IsProperSupersetOf, other);
-    public bool IsSubsetOf(IEnumerable<string> other) => Invoke(events.IsSubsetOf, other);
-    public bool IsSupersetOf(IEnumerable<string> other) => Invoke(events.IsSupersetOf, other);
-    public bool Overlaps(IEnumerable<string> other) => Invoke(events.Overlaps, other);
-    public bool SetEquals(IEnumerable<string> other) => Invoke(events.SetEquals, other);
-    public IEnumerator<string> GetEnumerator() => Invoke(events.ToHashSet, EqualityComparer<string>.Default).GetEnumerator();
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    public bool Contains(Event item) => Events.Contains(item);
+    public bool IsProperSubsetOf(IEnumerable<Event> other) => Events.IsProperSubsetOf(other);
+    public bool IsProperSupersetOf(IEnumerable<Event> other) => Events.IsProperSupersetOf(other);
+    public bool IsSubsetOf(IEnumerable<Event> other) => Events.IsSubsetOf(other);
+    public bool IsSupersetOf(IEnumerable<Event> other) => Events.IsSupersetOf(other);
+    public bool Overlaps(IEnumerable<Event> other) => Events.Overlaps(other);
+    public bool SetEquals(IEnumerable<Event> other) => Events.SetEquals(other);
+    public IEnumerator<Event> GetEnumerator() => Events.OrderBy(e => e.Id).GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => Events.GetEnumerator();
+    public override string ToString() => $"{GetType().Name}({SourceName}, {Level}, {Keywords:x})";
 
     protected override void OnEventSourceCreated(EventSource source)
     {
-        if (source.Name == (SourceName ?? nextSourceName))
+        if (string.IsNullOrEmpty(SourceName) && (source.Name == nextSourceName))
         {
-            EnableEvents(source, Level ?? nextLevel, Keywords ?? nextKeywords);
+            SourceName = source.Name;
+            Level = nextLevel;
+            Keywords = nextKeywords;
+            EnableEvents(source, Level, Keywords);
         }
     }
-    protected override void OnEventWritten(EventWrittenEventArgs e) => Invoke(events.Add, $"{e.EventId}\t\t{e.EventName}");
+    protected override void OnEventWritten(EventWrittenEventArgs e) => events[new(e.EventId, e.Level, e.Keywords, e.EventName ?? "")] = 0;
 
-    private TResult Invoke<T, TResult>(Func<T, TResult> func, T t)
+    private IReadOnlySet<Event> Events
     {
-        lock (eventsLock)
+        get
         {
-            return func(t);
+            if (Count > keys.Count)
+            {
+                keys.UnionWith(events.Keys);
+            }
+            return keys;
         }
     }
 }

--- a/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
+++ b/src/tests/tracing/runtimeeventsource/NativeRuntimeLevelKeywords.cs
@@ -72,6 +72,7 @@ internal sealed class GCListener : EventListener
 
     private static EventLevel nextLevel;
     private readonly ConcurrentDictionary<string, (int id, EventLevel level)> events = new();
+    private bool eventsReceived = false;
 
     private GCListener()
     {
@@ -105,7 +106,7 @@ internal sealed class GCListener : EventListener
     }
     public override string ToString()
     {
-        return $"{nameof(GCListener)}({Level,-13}, {events.Count,2})";
+        return $"{nameof(GCListener)}({Level,-13}, {eventsReceived,-5}, {events.Count,2})";
     }
     public override void Dispose()
     {
@@ -124,5 +125,12 @@ internal sealed class GCListener : EventListener
     protected override void OnEventWritten(EventWrittenEventArgs e)
     {
         events.TryAdd(e.EventName ?? "", (e.EventId, e.Level));
+
+        if (eventsReceived)
+        {
+            return;
+        }
+        eventsReceived = true;
+        Console.WriteLine($"{this} Events Received");
     }
 }

--- a/src/tests/tracing/runtimeeventsource/nativeruntimelevelkeywords.csproj
+++ b/src/tests/tracing/runtimeeventsource/nativeruntimelevelkeywords.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- This test has a secondary thread with an infinite loop -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="NativeRuntimeLevelKeywords.cs" />
+    <ProjectReference Include="../common/common.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Tests are designed to catch possible regressions for ```EventLevel.LogAlways``` & ```EventKeywords.None``` after dotnet/runtime#89326.

```EventKeywords.None``` sould be equivalent to ```EventKeywords.All```.
```EventLevel.LogAlways``` sould be equivalent to or greater then ```EventLevel.Verbose```.