### PR TITLE
Make test `HugeField2` optimization sensitive for ARM32

### DIFF
--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -5524,8 +5524,8 @@ BYTE* emitter::emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i)
                 }
                 else
                 {
-                    assert(distVal >= CALL_DIST_MAX_NEG);
-                    assert(distVal <= CALL_DIST_MAX_POS);
+                    if ((distVal < CALL_DIST_MAX_NEG) || (distVal > CALL_DIST_MAX_POS))
+                        IMPL_LIMITATION("Method is too large");
 
                     if (distVal < 0)
                         code |= 1 << 26;

--- a/src/tests/JIT/jit64/opt/cse/HugeField2.csproj
+++ b/src/tests/JIT/jit64/opt/cse/HugeField2.csproj
@@ -4,6 +4,9 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- This test generates a lot of codegen and doesn't play nice with JitStress modes for ARM32 due to size limitations.
+         See https://github.com/dotnet/runtime/issues/88621 -->
+    <JitOptimizationSensitive Condition="'$(TargetArchitecture)' == 'arm'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/88621 by disabling the test for JitStress modes on arm32. 

This isn't the only test that has JitStress modes disabled due to limitations on arm32, see [`hugeexpr1`](https://github.com/dotnet/runtime/blob/main/src/tests/JIT/jit64/opt/cse/hugeexpr1.csproj).