### PR TITLE
[RISC-V][JIT] Fix assetion in System.Threading.LowLevelLifoSemaphore.Wait

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -3749,6 +3749,24 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
             emit->emitLoadImmediate(EA_PTRSIZE, REG_RA, imm);
             regs = (int)REG_RA << 5;
         }
+        else
+        {
+            if (cmpSize == EA_4BYTE)
+            {
+                regNumber tmpRegOp1 = rsGetRsvdReg();
+                assert(regOp1 != tmpRegOp1);
+                if (cond.IsUnsigned())
+                {
+                    emit->emitIns_R_R_I(INS_slli, EA_8BYTE, tmpRegOp1, regOp1, 32);
+                    emit->emitIns_R_R_I(INS_srli, EA_8BYTE, tmpRegOp1, tmpRegOp1, 32);
+                }
+                else
+                {
+                    emit->emitIns_R_R_I(INS_addiw, EA_8BYTE, tmpRegOp1, regOp1, 0);
+                }
+                regOp1 = tmpRegOp1;
+            }
+        }
 
         switch (cond.GetCode())
         {

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -5219,8 +5219,7 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
             }
 
             // Pick a register to store intermediate values in for the to-stack
-            // copy. It must not conflict with addrReg. We try to prefer an
-            // argument register since those can always use thumb encoding.
+            // copy. It must not conflict with addrReg.
             valueReg = treeNode->GetRegNumByIdx(0);
             if (valueReg == addrReg)
             {
@@ -5230,7 +5229,6 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
                 }
                 else
                 {
-                    // Prefer argument register that can always use thumb encoding.
                     valueReg = treeNode->GetRegNumByIdx(1);
                 }
             }
@@ -7210,7 +7208,7 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
     }
 #endif
 
-    // On LA we push the FP (frame-pointer) here along with all other callee saved registers
+    // On RISCV64 we push the FP (frame-pointer) here along with all other callee saved registers
     if (isFramePointerUsed())
     {
         rsPushRegs |= RBM_FPBASE;
@@ -7884,7 +7882,7 @@ void CodeGen::genFnPrologCalleeRegArgs()
                     // the struct is a split struct.
                     assert(varDsc->GetArgReg() == REG_ARG_LAST && varDsc->GetOtherArgReg() == REG_STK);
 
-                    // For the LA's ABI, the split struct arg will be passed via `A7` and a stack slot on caller.
+                    // For the RISCV64's ABI, the split struct arg will be passed via `A7` and a stack slot on caller.
                     // But if the `A7` is stored on stack on the callee side, the whole split struct should be
                     // stored continuous on the stack on the callee side.
                     // So, after we save `A7` on the stack in prolog, it has to copy the stack slot of the split struct

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -6350,7 +6350,7 @@ bool IsIPInMarkedJitHelper(UINT_PTR uControlPc)
     CHECK_RANGE(JIT_WriteBarrier)
     CHECK_RANGE(JIT_CheckedWriteBarrier)
     CHECK_RANGE(JIT_ByRefWriteBarrier)
-#if !defined(TARGET_ARM64) && !defined(TARGET_LOONGARCH64) && !(TARGET_RISCV64)
+#if !defined(TARGET_ARM64) && !defined(TARGET_LOONGARCH64) && !defined(TARGET_RISCV64)
     CHECK_RANGE(JIT_StackProbe)
 #endif // !TARGET_ARM64 && !TARGET_LOONGARCH64 && !TARGET_RISCV64
 #else

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -384,7 +384,7 @@ extern "C"
     void STDCALL JIT_MemCpy(void *dest, const void *src, SIZE_T count);
 
     void STDMETHODCALLTYPE JIT_ProfilerEnterLeaveTailcallStub(UINT_PTR ProfilerHandle);
-#if !defined(TARGET_ARM64) && !defined(TARGET_LOONGARCH64) && !(TARGET_RISCV64)
+#if !defined(TARGET_ARM64) && !defined(TARGET_LOONGARCH64) && !defined(TARGET_RISCV64)
     void STDCALL JIT_StackProbe();
 #endif // TARGET_ARM64
 };


### PR DESCRIPTION
Fixes assertions in the below tests. These fail only on CHECKED build.
```
./JIT/Directed/debugging/debuginfo/tester/tester.sh
./JIT/Performance/CodeQuality/BenchmarksGame/binarytrees/binarytrees-6/binarytrees-6.sh
./JIT/Performance/CodeQuality/Roslyn/CscBench/CscBench.sh
./JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314/b425314.sh
./JIT/superpmi/superpmicollect/CscBench/CscBench.sh
```

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov @tomeksowi