### PR TITLE
[wasm] WBT: Fix up AppTest tests to fix missed testing cases

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorRunOptions.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorRunOptions.cs
@@ -17,7 +17,8 @@ public record BlazorRunOptions
     Action<IConsoleMessage>? OnConsoleMessage = null,
     Action<string>? OnErrorMessage = null,
     string Config = "Debug",
-    string? ExtraArgs = null
+    string? ExtraArgs = null,
+    string QueryString = ""
 );
 
 public enum BlazorRunHost { DotnetRun, WebServer };

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
@@ -172,7 +172,7 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
                                     .WithWorkingDirectory(workingDirectory);
 
         await using var runner = new BrowserRunner(_testOutput);
-        var page = await runner.RunAsync(runCommand, runArgs, onConsoleMessage: OnConsoleMessage, onError: OnErrorMessage);
+        var page = await runner.RunAsync(runCommand, runArgs, onConsoleMessage: OnConsoleMessage, onError: OnErrorMessage, modifyBrowserUrl: browserUrl => browserUrl + runOptions.QueryString);
 
         _testOutput.WriteLine("Waiting for page to load");
         await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
@@ -193,7 +193,7 @@ public class BuildPublishTests : BlazorWasmTestBase
                 .ExecuteWithCapturedOutput("new razorclasslib")
                 .EnsureSuccessful();
 
-        string razorClassLibraryFileName = UseWebcil ? $"RazorClassLibrary{ProjectProviderBase.WebcilInWasmExtension}" : "RazorClassLibrary.dll";
+        string razorClassLibraryFileName = $"RazorClassLibrary{ProjectProviderBase.WasmAssemblyExtension}";
         AddItemsPropertiesToProject(wasmProjectFile, extraItems: @$"
             <ProjectReference Include=""..\\RazorClassLibrary\\RazorClassLibrary.csproj"" />
             <BlazorWebAssemblyLazyLoad Include=""{razorClassLibraryFileName}"" />

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -148,8 +148,7 @@ namespace Wasm.Build.Tests
                 buildType,
                 $"-bl:{logFilePath}",
                 $"-p:Configuration={config}",
-                "-nr:false",
-                !UseWebcil ? "-p:WasmEnableWebcil=false" : string.Empty,
+                "-nr:false"
             };
             commandLineArgs.AddRange(extraArgs);
 

--- a/src/mono/wasm/Wasm.Build.Tests/Common/BuildEnvironment.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Common/BuildEnvironment.cs
@@ -122,6 +122,12 @@ namespace Wasm.Build.Tests
             EnvVars["PATH"] = $"{sdkForWorkloadPath}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}";
             EnvVars["EM_WORKAROUND_PYTHON_BUG_34780"] = "1";
 
+            if (!UseWebcil)
+            {
+                // Default is 'true'
+                EnvVars["WasmEnableWebCil"] = "false";
+            }
+
             // helps with debugging
             EnvVars["WasmNativeStrip"] = "false";
 

--- a/src/mono/wasm/Wasm.Build.Tests/ProjectProviderBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/ProjectProviderBase.cs
@@ -21,7 +21,7 @@ namespace Wasm.Build.Tests;
 // For projects using WasmAppBuilder
 public abstract class ProjectProviderBase(ITestOutputHelper _testOutput, string? _projectDir)
 {
-    public const string WebcilInWasmExtension = ".wasm";
+    public static string WasmAssemblyExtension = BuildTestBase.s_buildEnv.UseWebcil ? ".wasm" : ".dll";
     protected const string s_dotnetVersionHashRegex = @"\.(?<version>[0-9]+\.[0-9]+\.[a-zA-Z0-9\.-]+)\.(?<hash>[a-zA-Z0-9]+)\.";
 
     private const string s_runtimePackPathPattern = "\\*\\* MicrosoftNetCoreAppRuntimePackDir : '([^ ']*)'";
@@ -390,6 +390,15 @@ public abstract class ProjectProviderBase(ITestOutputHelper _testOutput, string?
         Assert.True(File.Exists(bootJsonPath), $"Expected to find {bootJsonPath}");
 
         BootJsonData bootJson = ParseBootData(bootJsonPath);
+        string spcExpectedFilename = $"System.Private.CoreLib{WasmAssemblyExtension}";
+        string? spcActualFilename = bootJson.resources.assembly.Keys
+                                        .Where(a => Path.GetFileNameWithoutExtension(a) == "System.Private.CoreLib")
+                                        .SingleOrDefault();
+        if (spcActualFilename is null)
+            throw new XunitException($"Could not find an assembly named System.Private.CoreLib.* in {bootJsonPath}");
+        if (spcExpectedFilename != spcActualFilename)
+            throw new XunitException($"Expected to find {spcExpectedFilename} but found {spcActualFilename} in {bootJsonPath}");
+
         var bootJsonEntries = bootJson.resources.jsModuleNative.Keys
             .Union(bootJson.resources.jsModuleRuntime.Keys)
             .Union(bootJson.resources.jsModuleWorker?.Keys ?? Enumerable.Empty<string>())

--- a/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/AppTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/AppTestBase.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Xunit.Abstractions;
+using Wasm.Build.Tests.Blazor;
 
 namespace Wasm.Build.Tests.TestAppScenarios;
 
@@ -33,22 +34,14 @@ public abstract class AppTestBase : BlazorWasmTestBase
 
     protected void BuildProject(string configuration)
     {
-        CommandResult result = CreateDotNetCommand().ExecuteWithCapturedOutput("build", $"-bl:{GetBinLogFilePath()}", $"-p:Configuration={configuration}");
+        (CommandResult result, _) = BlazorBuild(new BlazorBuildOptions(Id, configuration));
         result.EnsureSuccessful();
     }
 
     protected void PublishProject(string configuration)
     {
-        CommandResult result = CreateDotNetCommand().ExecuteWithCapturedOutput("publish", $"-bl:{GetBinLogFilePath()}", $"-p:Configuration={configuration}");
+        (CommandResult result, _) = BlazorPublish(new BlazorBuildOptions(Id, configuration));
         result.EnsureSuccessful();
-    }
-
-    protected string GetBinLogFilePath(string suffix = null)
-    {
-        if (!string.IsNullOrEmpty(suffix))
-            suffix = "_" + suffix;
-
-        return Path.Combine(LogPath, $"{Id}{suffix}.binlog");
     }
 
     protected ToolCommand CreateDotNetCommand() => new DotNetCommand(s_buildEnv, _testOutput)
@@ -57,39 +50,25 @@ public abstract class AppTestBase : BlazorWasmTestBase
 
     protected async Task<RunResult> RunSdkStyleApp(RunOptions options)
     {
-        string runArgs = $"run -c {options.Configuration}";
-        string workingDirectory = _projectDir;
-
-        using var runCommand = new RunCommand(s_buildEnv, _testOutput)
-            .WithWorkingDirectory(workingDirectory);
-
-        var tcs = new TaskCompletionSource<int>();
-
-        List<string> testOutput = new();
-        List<string> consoleOutput = new();
-        Regex exitRegex = new Regex("WASM EXIT (?<exitCode>[0-9]+)$");
-
-        await using var runner = new BrowserRunner(_testOutput);
-
-        IPage page = null;
-
         string queryString = "?test=" + options.TestScenario;
         if (options.BrowserQueryString != null)
             queryString += "&" + string.Join("&", options.BrowserQueryString.Select(kvp => $"{kvp.Key}={kvp.Value}"));
 
-        page = await runner.RunAsync(runCommand, runArgs, onConsoleMessage: OnConsoleMessage, modifyBrowserUrl: url => 
-        {
-            url += queryString;
-            _testOutput.WriteLine($"Opening browser at {url}");
-            return url;
-        });
+        var tcs = new TaskCompletionSource<int>();
+        List<string> testOutput = new();
+        List<string> consoleOutput = new();
+        Regex exitRegex = new Regex("WASM EXIT (?<exitCode>[0-9]+)$");
+
+        BlazorRunOptions blazorRunOptions = new(
+                CheckCounter: false,
+                Config: options.Configuration,
+                OnConsoleMessage: OnConsoleMessage,
+                QueryString: queryString);
+
+        await BlazorRunForBuildWithDotnetRun(blazorRunOptions);
 
         void OnConsoleMessage(IConsoleMessage msg)
         {
-            if (EnvironmentVariables.ShowBuildOutput)
-                Console.WriteLine($"[{msg.Type}] {msg.Text}");
-
-            _testOutput.WriteLine($"[{msg.Type}] {msg.Text}");
             consoleOutput.Add(msg.Text);
 
             const string testOutputPrefix = "TestOutput -> ";
@@ -104,13 +83,13 @@ public abstract class AppTestBase : BlazorWasmTestBase
                 throw new Exception(msg.Text);
 
             if (options.OnConsoleMessage != null)
-                options.OnConsoleMessage(msg, page);
+                options.OnConsoleMessage(msg);
         }
 
-        TimeSpan timeout = TimeSpan.FromMinutes(2);
-        await Task.WhenAny(tcs.Task, Task.Delay(timeout));
-        if (!tcs.Task.IsCompleted)
-            throw new Exception($"Timed out after {timeout.TotalSeconds}s waiting for process to exit");
+        //TimeSpan timeout = TimeSpan.FromMinutes(2);
+        //await Task.WhenAny(tcs.Task, Task.Delay(timeout));
+        //if (!tcs.Task.IsCompleted)
+            //throw new Exception($"Timed out after {timeout.TotalSeconds}s waiting for process to exit");
 
         int wasmExitCode = tcs.Task.Result;
         if (options.ExpectedExitCode != null && wasmExitCode != options.ExpectedExitCode)
@@ -123,7 +102,7 @@ public abstract class AppTestBase : BlazorWasmTestBase
         string Configuration,
         string TestScenario,
         Dictionary<string, string> BrowserQueryString = null,
-        Action<IConsoleMessage, IPage> OnConsoleMessage = null,
+        Action<IConsoleMessage> OnConsoleMessage = null,
         int? ExpectedExitCode = 0
     );
 

--- a/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/SatelliteLoadingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/SatelliteLoadingTests.cs
@@ -27,6 +27,7 @@ public class SatelliteLoadingTests : AppTestBase
     public async Task LoadSatelliteAssembly()
     {
         CopyTestAsset("WasmBasicTestApp", "SatelliteLoadingTests");
+        BuildProject("Debug");
 
         var result = await RunSdkStyleApp(new(Configuration: "Debug", TestScenario: "SatelliteAssembliesTest"));
         Assert.Collection(

--- a/src/mono/wasm/Wasm.Build.Tests/TestMainJsProjectProvider.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/TestMainJsProjectProvider.cs
@@ -76,8 +76,7 @@ public class TestMainJsProjectProvider : ProjectProviderBase
             TestUtils.AssertFilesExist(assertOptions.BundleDir, new[] { "index.html" });
         TestUtils.AssertFilesExist(assertOptions.BundleDir, new[] { "run-v8.sh" }, expectToExist: assertOptions.HasV8Script);
 
-        string bundledMainAppAssembly =
-            BuildTestBase.UseWebcil ? $"{assertOptions.ProjectName}{WebcilInWasmExtension}" : $"{assertOptions.ProjectName}.dll";
+        string bundledMainAppAssembly = $"{assertOptions.ProjectName}{WasmAssemblyExtension}";
         TestUtils.AssertFilesExist(assertOptions.BinFrameworkDir, new[] { bundledMainAppAssembly });
     }
 

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -143,6 +143,8 @@
 
     <!-- by default, package assemblies as webcil -->
     <WasmEnableWebcil Condition="'$(WasmEnableWebcil)' == ''">true</WasmEnableWebcil>
+    <WasmAssemblyExtension Condition="'$(WasmEnableWebcil)' == 'true'">.wasm</WasmAssemblyExtension>
+    <WasmAssemblyExtension Condition="'$(WasmEnableWebcil)' != 'true'">.dll</WasmAssemblyExtension>
 
     <WasmRuntimeAssetsLocation Condition="'$(WasmRuntimeAssetsLocation)' == ''">_framework</WasmRuntimeAssetsLocation>
   </PropertyGroup>

--- a/src/mono/wasm/testassets/WasmBasicTestApp/WasmBasicTestApp.csproj
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/WasmBasicTestApp.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <BlazorWebAssemblyLazyLoad Include="System.Text.Json.wasm" />
+    <BlazorWebAssemblyLazyLoad Include="System.Text.Json$(WasmAssemblyExtension)" />
   </ItemGroup>
 </Project>

--- a/src/mono/wasm/testassets/WasmBasicTestApp/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/wwwroot/main.js
@@ -68,6 +68,7 @@ switch (testCase) {
 const { getAssemblyExports, getConfig, INTERNAL } = await dotnet.create();
 const config = getConfig();
 const exports = await getAssemblyExports(config.mainAssemblyName);
+const assemblyExtension = config.resources.assembly['System.Private.CoreLib.wasm'] !== undefined ? ".wasm" : ".dll";
 
 // Run the test case
 try {
@@ -78,7 +79,7 @@ try {
             break;
         case "LazyLoadingTest":
             if (params.get("loadRequiredAssembly") !== "false") {
-                await INTERNAL.loadLazyAssembly("System.Text.Json.wasm");
+                await INTERNAL.loadLazyAssembly(`System.Text.Json${assemblyExtension}`);
             }
             exports.LazyLoadingTest.Run();
             exit(0);


### PR DESCRIPTION
Currently, all the tests based on `AppTestBase` use their own methods to build, and run projects. This does not used the common API which does more like automatic binlogs, correctly respect webcil setting, assert the basic app bundle etc.

- Also, the tests were ignoring the no-webcil case and always ran with webcil enabled. Fixing this surfaced some other issues with hardcoded assembly file extensions.
- Add checks when asserting the basic appbundle for assembly extensions
- WasmApp.targets - add $(WasmAssemblyExtension)