### PR TITLE
Rebaseline failing pri0 tests

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -22,6 +22,28 @@ namespace TestLibrary
                                                 ? isEnabled
                                                 : true);
 
+        private static volatile Tuple<bool> s_lazyNonZeroLowerBoundArraySupported;
+        public static bool IsNonZeroLowerBoundArraySupported
+        {
+            get
+            {
+                if (s_lazyNonZeroLowerBoundArraySupported == null)
+                {
+                    bool nonZeroLowerBoundArraysSupported = false;
+                    try
+                    {
+                        Array.CreateInstance(typeof(int), new int[] { 5 }, new int[] { 5 });
+                        nonZeroLowerBoundArraysSupported = true;
+                    }
+                    catch (PlatformNotSupportedException)
+                    {
+                    }
+                    s_lazyNonZeroLowerBoundArraySupported = Tuple.Create<bool>(nonZeroLowerBoundArraysSupported);
+                }
+                return s_lazyNonZeroLowerBoundArraySupported.Item1;
+            }
+        }
+
         static string _variant = Environment.GetEnvironmentVariable("DOTNET_RUNTIME_VARIANT");
 
         public static bool IsMonoLLVMAOT => _variant == "llvmaot";

--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -22,6 +22,8 @@ namespace TestLibrary
                                                 ? isEnabled
                                                 : true);
 
+        public static bool IsRareEnumsSupported => !Utilities.IsNativeAot;
+
         private static volatile Tuple<bool> s_lazyNonZeroLowerBoundArraySupported;
         public static bool IsNonZeroLowerBoundArraySupported
         {

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize/Serialize_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize/Serialize_r.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <AssemblyName>X86_Serialize_r</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Would have to translate Illegal instruction to PNSE -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize/Serialize_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize/Serialize_ro.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <AssemblyName>X86_Serialize_ro</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Would have to translate Illegal instruction to PNSE -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize_X64/Serialize.X64_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize_X64/Serialize.X64_r.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Would have to translate Illegal instruction to PNSE -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize_X64/Serialize.X64_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/X86/X86Serialize_X64/Serialize.X64_ro.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Would have to translate Illegal instruction to PNSE -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Embedded</DebugType>

--- a/src/tests/JIT/Intrinsics/MemoryMarshalGetArrayDataReference.cs
+++ b/src/tests/JIT/Intrinsics/MemoryMarshalGetArrayDataReference.cs
@@ -147,14 +147,17 @@ namespace MemoryMarshalGetArrayDataReferenceTest
             IsTrue(Unsafe.AreSame(ref Unsafe.As<byte, string>(ref MemoryMarshal.GetArrayDataReference(NoInline(testStringMdArray))), ref testStringMdArray[0, 0]));
             IsTrue(Unsafe.AreSame(ref Unsafe.As<byte, string>(ref ptrMd(NoInline(testStringMdArray))), ref testStringMdArray[0, 0]));
 
-            Array nonZeroArray = Array.CreateInstance(typeof(string), new [] { 1 }, new [] { -1 });
-            string test = "test";
-            nonZeroArray.SetValue(test, -1);
-            IsTrue(ReferenceEquals(Unsafe.As<byte, string>(ref MemoryMarshal.GetArrayDataReference(nonZeroArray)), test));
-            IsTrue(ReferenceEquals(Unsafe.As<byte, string>(ref ptrMd(nonZeroArray)), test));
+            if (TestLibrary.PlatformDetection.IsNonZeroLowerBoundArraySupported)
+            {
+                Array nonZeroArray = Array.CreateInstance(typeof(string), new [] { 1 }, new [] { -1 });
+                string test = "test";
+                nonZeroArray.SetValue(test, -1);
+                IsTrue(ReferenceEquals(Unsafe.As<byte, string>(ref MemoryMarshal.GetArrayDataReference(nonZeroArray)), test));
+                IsTrue(ReferenceEquals(Unsafe.As<byte, string>(ref ptrMd(nonZeroArray)), test));
 
-            IsTrue(ReferenceEquals(Unsafe.As<byte, string>(ref MemoryMarshal.GetArrayDataReference(NoInline(nonZeroArray))), test));
-            IsTrue(ReferenceEquals(Unsafe.As<byte, string>(ref ptrMd(NoInline(nonZeroArray))), test));
+                IsTrue(ReferenceEquals(Unsafe.As<byte, string>(ref MemoryMarshal.GetArrayDataReference(NoInline(nonZeroArray))), test));
+                IsTrue(ReferenceEquals(Unsafe.As<byte, string>(ref ptrMd(NoInline(nonZeroArray))), test));
+            }
 
             IsFalse(Unsafe.IsNullRef(ref MemoryMarshal.GetArrayDataReference((Array)new byte[0])));
             IsFalse(Unsafe.IsNullRef(ref MemoryMarshal.GetArrayDataReference((Array)new string[0])));

--- a/src/tests/JIT/Intrinsics/MemoryMarshalGetArrayDataReference_r.csproj
+++ b/src/tests/JIT/Intrinsics/MemoryMarshalGetArrayDataReference_r.csproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MemoryMarshalGetArrayDataReference.cs" />
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Intrinsics/MemoryMarshalGetArrayDataReference_ro.csproj
+++ b/src/tests/JIT/Intrinsics/MemoryMarshalGetArrayDataReference_ro.csproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MemoryMarshalGetArrayDataReference.cs" />
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/opt/Devirtualization/Comparer_get_Default.cs
+++ b/src/tests/JIT/opt/Devirtualization/Comparer_get_Default.cs
@@ -271,7 +271,7 @@ public class Program
                 Compare_Struct1_Nullable(null, null);
                 Compare_Struct2_Nullable(null, null);
 
-                if (PlatformDetection.IsRareEnumsSupported)
+                if (TestLibrary.PlatformDetection.IsRareEnumsSupported)
                 {
                     // workaround for: https://github.com/dotnet/roslyn/issues/68770
                     static T Bitcast<T>(long l) => Unsafe.As<long, T>(ref l);

--- a/src/tests/JIT/opt/Devirtualization/Comparer_get_Default.cs
+++ b/src/tests/JIT/opt/Devirtualization/Comparer_get_Default.cs
@@ -271,33 +271,36 @@ public class Program
                 Compare_Struct1_Nullable(null, null);
                 Compare_Struct2_Nullable(null, null);
 
-                // workaround for: https://github.com/dotnet/roslyn/issues/68770
-                static T Bitcast<T>(long l) => Unsafe.As<long, T>(ref l);
+                if (!TestLibrary.Utilities.IsNativeAot)
+                {
+                    // workaround for: https://github.com/dotnet/roslyn/issues/68770
+                    static T Bitcast<T>(long l) => Unsafe.As<long, T>(ref l);
 
-                var enumCharA = Bitcast<CharEnum>(a);
-                var enumCharB = Bitcast<CharEnum>(b);
-                Compare_Generic_Enum(enumCharA, enumCharB);
+                    var enumCharA = Bitcast<CharEnum>(a);
+                    var enumCharB = Bitcast<CharEnum>(b);
+                    Compare_Generic_Enum(enumCharA, enumCharB);
 
-                var enumBoolA = Bitcast<BoolEnum>(a);
-                var enumBoolB = Bitcast<BoolEnum>(b);
-                Compare_Generic_Enum(enumBoolA, enumBoolB);
+                    var enumBoolA = Bitcast<BoolEnum>(a);
+                    var enumBoolB = Bitcast<BoolEnum>(b);
+                    Compare_Generic_Enum(enumBoolA, enumBoolB);
 
-                var enumFloatA = Bitcast<FloatEnum>(a);
-                var enumFloatB = Bitcast<FloatEnum>(b);
-                Compare_Generic_Enum(enumFloatA, enumFloatB);
+                    var enumFloatA = Bitcast<FloatEnum>(a);
+                    var enumFloatB = Bitcast<FloatEnum>(b);
+                    Compare_Generic_Enum(enumFloatA, enumFloatB);
 
-                var enumDoubleA = Bitcast<DoubleEnum>(a);
-                var enumDoubleB = Bitcast<DoubleEnum>(b);
-                Compare_Generic_Enum(enumDoubleA, enumDoubleB);
-                Compare_Double_Enum(enumDoubleA, enumDoubleB);
+                    var enumDoubleA = Bitcast<DoubleEnum>(a);
+                    var enumDoubleB = Bitcast<DoubleEnum>(b);
+                    Compare_Generic_Enum(enumDoubleA, enumDoubleB);
+                    Compare_Double_Enum(enumDoubleA, enumDoubleB);
 
-                var enumIntPtrA = Bitcast<IntPtrEnum>(a);
-                var enumIntPtrB = Bitcast<IntPtrEnum>(b);
-                Compare_Generic_Enum(enumIntPtrA, enumIntPtrB);
+                    var enumIntPtrA = Bitcast<IntPtrEnum>(a);
+                    var enumIntPtrB = Bitcast<IntPtrEnum>(b);
+                    Compare_Generic_Enum(enumIntPtrA, enumIntPtrB);
 
-                var enumUIntPtrA = Bitcast<UIntPtrEnum>(a);
-                var enumUIntPtrB = Bitcast<UIntPtrEnum>(b);
-                Compare_Generic_Enum(enumUIntPtrA, enumUIntPtrB);
+                    var enumUIntPtrA = Bitcast<UIntPtrEnum>(a);
+                    var enumUIntPtrB = Bitcast<UIntPtrEnum>(b);
+                    Compare_Generic_Enum(enumUIntPtrA, enumUIntPtrB);
+                }
             }
         }
 

--- a/src/tests/JIT/opt/Devirtualization/Comparer_get_Default.cs
+++ b/src/tests/JIT/opt/Devirtualization/Comparer_get_Default.cs
@@ -271,7 +271,7 @@ public class Program
                 Compare_Struct1_Nullable(null, null);
                 Compare_Struct2_Nullable(null, null);
 
-                if (!TestLibrary.Utilities.IsNativeAot)
+                if (PlatformDetection.IsRareEnumsSupported)
                 {
                     // workaround for: https://github.com/dotnet/roslyn/issues/68770
                     static T Bitcast<T>(long l) => Unsafe.As<long, T>(ref l);

--- a/src/tests/JIT/opt/Devirtualization/Comparer_get_Default.csproj
+++ b/src/tests/JIT/opt/Devirtualization/Comparer_get_Default.csproj
@@ -7,5 +7,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="UncommonEnums.ilproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* We don't throw PNSE for unguarded HW intrinsic use. We could translate illegal instruction to PNSE but it feels too big of a hammer. We could do something more sophisticated such as disassemble the instruction and compare with "known problematic" ones. But it doesn't feel worth the effort.
* Non-zero lower bounds are not supported.
* Corner case weird enums like `enum Foo : double { }` are not supported.

Cc @dotnet/ilc-contrib 