### PR TITLE
Use highest thread priority in linux

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1052,8 +1052,8 @@ bool GCToOSInterface::BoostThreadPriority()
     pthread_t thread_t = pthread_self();
     struct sched_param params;
     // Use max priority minus 1, in order to avoid need for elevated privileges
-    params.sched_priority = sched_get_priority_max(SCHED_FIFO) - 1;
-    return !!pthread_setschedparam(thread_t, SCHED_FIFO, &params);
+    params.sched_priority = sched_get_priority_max(SCHED_RR) - 1;
+    return !!pthread_setschedparam(thread_t, SCHED_RR, &params);
 #else // __APPLE__
     // [LOCALGC TODO] Thread priority for macos
     return false;

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1053,7 +1053,7 @@ bool GCToOSInterface::BoostThreadPriority()
     struct sched_param params;
     // Use max priority minus 1, in order to avoid need for elevated privileges
     params.sched_priority = sched_get_priority_max(SCHED_RR) - 1;
-    return !!pthread_setschedparam(thread_t, SCHED_RR, &params);
+    return !pthread_setschedparam(thread_t, SCHED_RR, &params);
 #else // __APPLE__
     // [LOCALGC TODO] Thread priority for macos
     return false;


### PR DESCRIPTION
Trying to fix #49317

I believe the fact that it is not clearly communicated that the gc in other envs besides windows **doesn't** run in high priority have made a lot of teams to try to debug issues produced by this fact.

Same facts as this https://github.com/dotnet/runtime/pull/89682 applies for the author.