### PR TITLE
Add additional filter capabilities to dotnet-pgo tool.

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
+++ b/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
@@ -45,10 +45,10 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             new("--exclude-events-before") { DefaultValueFactory = _ => Double.MinValue, Description = "Exclude data from events before specified time. Time is specified as milliseconds from the start of the trace" };
         public CliOption<double> ExcludeEventsAfter { get; } =
             new("--exclude-events-after") { DefaultValueFactory = _ => Double.MaxValue, Description = "Exclude data from events after specified time. Time is specified as milliseconds from the start of the trace" };
-        public CliOption<string> ExcludeEventsBeforeMethod { get; } =
-            new("--exclude-events-before-method") { DefaultValueFactory = _ => string.Empty, Description = "Exclude data from events before observing a specific method. Method is matched using a regular expression" };
-        public CliOption<string> ExcludeEventsAfterMethod { get; } =
-            new("--exclude-events-after-method") { DefaultValueFactory = _ => string.Empty, Description = "Exclude data from events after observing a specific method. Method is matched using a regular expression" };
+        public CliOption<string> ExcludeEventsBeforeJittingMethod { get; } =
+            new("--exclude-events-before-jitting-method") { DefaultValueFactory = _ => string.Empty, Description = "Exclude data from events before observing a specific method getting jitted. Method is matched using a regular expression" };
+        public CliOption<string> ExcludeEventsAfterJittingMethod { get; } =
+            new("--exclude-events-after-jitting-method") { DefaultValueFactory = _ => string.Empty, Description = "Exclude data from events after observing a specific method getting jitted. Method is matched using a regular expression" };
         public CliOption<string> IncludeMethods { get; } =
             new("--include-methods") { DefaultValueFactory = _ => string.Empty, Description = "Include methods matching regular expression" };
         public CliOption<string> ExcludeMethods { get; } =
@@ -107,8 +107,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                 ClrInstanceId,
                 ExcludeEventsBefore,
                 ExcludeEventsAfter,
-                ExcludeEventsBeforeMethod,
-                ExcludeEventsAfterMethod,
+                ExcludeEventsBeforeJittingMethod,
+                ExcludeEventsAfterJittingMethod,
                 IncludeMethods,
                 ExcludeMethods,
                 AutomaticReferences,

--- a/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
+++ b/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
@@ -46,13 +46,13 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         public CliOption<double> ExcludeEventsAfter { get; } =
             new("--exclude-events-after") { DefaultValueFactory = _ => Double.MaxValue, Description = "Exclude data from events after specified time. Time is specified as milliseconds from the start of the trace" };
         public CliOption<string> ExcludeEventsBeforeJittingMethod { get; } =
-            new("--exclude-events-before-jitting-method") { DefaultValueFactory = _ => string.Empty, Description = "Exclude data from events before observing a specific method getting jitted. Method is matched using a regular expression" };
+            new("--exclude-events-before-jitting-method") { DefaultValueFactory = _ => string.Empty, Description = "Exclude data from events before observing a specific method getting jitted. Method is matched using a regular expression against the method name. Note that the method name is formatted the same as in PerfView which includes typed parameters." };
         public CliOption<string> ExcludeEventsAfterJittingMethod { get; } =
-            new("--exclude-events-after-jitting-method") { DefaultValueFactory = _ => string.Empty, Description = "Exclude data from events after observing a specific method getting jitted. Method is matched using a regular expression" };
+            new("--exclude-events-after-jitting-method") { DefaultValueFactory = _ => string.Empty, Description = "Exclude data from events after observing a specific method getting jitted. Method is matched using a regular expression against the method name. Note that the method name is formatted the same as in PerfView which includes typed parameters." };
         public CliOption<string> IncludeMethods { get; } =
-            new("--include-methods") { DefaultValueFactory = _ => string.Empty, Description = "Include methods matching regular expression" };
+            new("--include-methods") { DefaultValueFactory = _ => string.Empty, Description = "Include methods with names matching regular expression. Note that the method names are formatted the same as in PerfView which includes typed parameters." };
         public CliOption<string> ExcludeMethods { get; } =
-            new("--exclude-methods") { DefaultValueFactory = _ => string.Empty, Description = "Exclude methods matching regular expression" };
+            new("--exclude-methods") { DefaultValueFactory = _ => string.Empty, Description = "Exclude methods with names matching regular expression. Note that the method names are formatted the same as in PerfView which includes typed parameters." };
         public CliOption<bool> Compressed { get; } =
             new("--compressed") { DefaultValueFactory = _ => true, Description = "Generate compressed mibc" };
         public CliOption<int> DumpWorstOverlapGraphs { get; } =

--- a/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
+++ b/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
@@ -45,6 +45,14 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             new("--exclude-events-before") { DefaultValueFactory = _ => Double.MinValue, Description = "Exclude data from events before specified time. Time is specified as milliseconds from the start of the trace" };
         public CliOption<double> ExcludeEventsAfter { get; } =
             new("--exclude-events-after") { DefaultValueFactory = _ => Double.MaxValue, Description = "Exclude data from events after specified time. Time is specified as milliseconds from the start of the trace" };
+        public CliOption<string> ExcludeEventsBeforeMethod { get; } =
+            new("--exclude-events-before-method") { DefaultValueFactory = _ => string.Empty, Description = "Exclude data from events before observing a specific method. Method is matched using a regular expression" };
+        public CliOption<string> ExcludeEventsAfterMethod { get; } =
+            new("--exclude-events-after-method") { DefaultValueFactory = _ => string.Empty, Description = "Exclude data from events after observing a specific method. Method is matched using a regular expression" };
+        public CliOption<string> IncludeMethods { get; } =
+            new("--include-methods") { DefaultValueFactory = _ => string.Empty, Description = "Include methods matching regular expression" };
+        public CliOption<string> ExcludeMethods { get; } =
+            new("--exclude-methods") { DefaultValueFactory = _ => string.Empty, Description = "Exclude methods matching regular expression" };
         public CliOption<bool> Compressed { get; } =
             new("--compressed") { DefaultValueFactory = _ => true, Description = "Generate compressed mibc" };
         public CliOption<int> DumpWorstOverlapGraphs { get; } =
@@ -99,6 +107,10 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                 ClrInstanceId,
                 ExcludeEventsBefore,
                 ExcludeEventsAfter,
+                ExcludeEventsBeforeMethod,
+                ExcludeEventsAfterMethod,
+                IncludeMethods,
+                ExcludeMethods,
                 AutomaticReferences,
                 _verbosity,
                 Compressed,

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -1367,6 +1367,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             PrintWarning($"Skipped R2REntryPoint {methodNameFromEventDirectly} due to ClrInstanceID of {e.ClrInstanceID}");
                             continue;
                         }
+
                         MethodDesc method = null;
                         string extraWarningText = null;
                         bool failedDueToNonloadableModule = false;
@@ -1460,6 +1461,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         string retArg = e.MethodSignature.Substring(0, parenIndex);
                         string paramsArgs = e.MethodSignature.Substring(parenIndex);
                         string methodNameFromEventDirectly = retArg + e.MethodNamespace + "." + e.MethodName + paramsArgs;
+
                         if (e.ClrInstanceID != clrInstanceId)
                         {
                             if (!_command.Warnings)

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -1401,7 +1401,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             break;
                         }
 
-                        if (PassesMethodFilter(includeMethods, excludeMethods, methodNameFromEventDirectly))
+                        string perfviewMethodName = e.MethodNamespace + "." + e.MethodName + paramsArgs;
+                        if (PassesMethodFilter(includeMethods, excludeMethods, perfviewMethodName))
                         {
                             methodsToAttemptToPrepare.Add((int)e.EventIndex, new ProcessedMethodData(e.TimeStampRelativeMSec, method, "R2RLoad"));
                         }
@@ -1433,13 +1434,15 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             continue;
                         }
 
-                        string methodAsString = method.ToString();
-                        if (e.TimeStampRelativeMSec > excludeEventsBefore && excludeEventsBeforeJittingMethod != null && excludeEventsBeforeJittingMethod.IsMatch(methodAsString))
+                        int parenIndex = e.MethodSignature.IndexOf('(');
+                        string paramsArgs = e.MethodSignature.Substring(parenIndex);
+                        string perfviewMethodName = e.MethodNamespace + "." + e.MethodName + paramsArgs;
+                        if (e.TimeStampRelativeMSec > excludeEventsBefore && excludeEventsBeforeJittingMethod != null && excludeEventsBeforeJittingMethod.IsMatch(perfviewMethodName))
                         {
                             excludeEventsBefore = e.TimeStampRelativeMSec;
                         }
 
-                        if (e.TimeStampRelativeMSec < excludeEventsAfter && excludeEventsAfterJittingMethod != null && excludeEventsAfterJittingMethod.IsMatch(methodAsString))
+                        if (e.TimeStampRelativeMSec < excludeEventsAfter && excludeEventsAfterJittingMethod != null && excludeEventsAfterJittingMethod.IsMatch(perfviewMethodName))
                         {
                             excludeEventsAfter = e.TimeStampRelativeMSec;
                         }
@@ -1504,7 +1507,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             break;
                         }
 
-                        if (PassesMethodFilter(includeMethods, excludeMethods, methodNameFromEventDirectly))
+                        string perfviewMethodName = e.MethodNamespace + "." + e.MethodName + paramsArgs;
+                        if (PassesMethodFilter(includeMethods, excludeMethods, perfviewMethodName))
                         {
                             methodsToAttemptToPrepare.Add((int)e.EventIndex, new ProcessedMethodData(e.TimeStampRelativeMSec, method, "JitStart"));
                         }
@@ -1861,16 +1865,16 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             return 0;
         }
 
-        private static bool PassesMethodFilter(Regex? includeMethods, Regex? excludeMethods, string methodNameFromEventDirectly)
+        private static bool PassesMethodFilter(Regex includeMethods, Regex excludeMethods, string methodName)
         {
             if (includeMethods != null || excludeMethods != null)
             {
-                if (includeMethods != null && !includeMethods.IsMatch(methodNameFromEventDirectly))
+                if (includeMethods != null && !includeMethods.IsMatch(methodName))
                 {
                     return false;
                 }
 
-                if (excludeMethods != null && excludeMethods.IsMatch(methodNameFromEventDirectly))
+                if (excludeMethods != null && excludeMethods.IsMatch(methodName))
                 {
                     return false;
                 }


### PR DESCRIPTION
Mono adopted PGO in .net7 as a replacement for a solution called profiled AOT in mono/mono, primarly used by Android SDK. In the replaced solution there was a concept of a "stop trigger", meaning that the user could collect methods up to a stop trigger (a method name) meaning that the profiled AOT image would only include methods up to that point and nothing more.

When using EventPipe and nettrace there is limited ability to get the same fine grained control over what methods that ends up in the nettrace file. dotnet-monitor includes ways to stop tracing if it hits for example a specific method, but due to the nature of EventPipe, there could still be additional methods added to the trace when closing session. dotnet-trace currently don't offer any ability to do something similar, but if implemented, it would probably come with similar limitations as dotnet-monitor.

Adding better filter capabilities to dotnet-pgo would add additional capabilities, giving users more control on what methods that gets included into the generated mibc file. That would give Mono's profiled AOT better control to include methods up to a stop trigger.

dotnet-pgo already had capabilities to include events based on timestamp interval. This commit extends that to select the lower/upper timestamp based on a regular expression matching methods. This commit also adds additional filter capabilities to include/exclude methods based on regular expressions, giving better control on what methods to include/exclude in the generated mibc file.

The additional filter capabilities could be used by Android SDK to replace the stop trigger features used in old profiled AOT solution. Android team could then profile the startup of a MAUI application and use generated nettrace file with dotnet-pgo passing in `--exclude-events-after-method .*Main.* --exclude-methods .*Main.*`, to include methods up to executing Main method in the generated mibc file.

The new filter capabilities also add ways to create a mibc file only including/exclude methods from a specific assemblies, namespaces or a combination of all.