### PR TITLE
Apply mitigations for a recent STJ performance regression

### DIFF
--- a/src/libraries/System.Text.Json/src/System/ReflectionExtensions.cs
+++ b/src/libraries/System.Text.Json/src/System/ReflectionExtensions.cs
@@ -43,20 +43,20 @@ namespace System.Text.Json.Reflection
         private static bool HasJsonConstructorAttribute(ConstructorInfo constructorInfo)
             => constructorInfo.GetCustomAttribute<JsonConstructorAttribute>() != null;
 
-        public static bool HasRequiredMemberAttribute(this ICustomAttributeProvider memberInfo)
+        public static bool HasRequiredMemberAttribute(this MemberInfo memberInfo)
         {
             // For compiler related attributes we should only look at full type name rather than trying to do something different for version when attribute was introduced.
             // I.e. library is targeting netstandard2.0 with polyfilled attributes and is being consumed by an app targeting net7.0 or greater.
-            return memberInfo.HasCustomAttributeWithName("System.Runtime.CompilerServices.RequiredMemberAttribute", inherit: true);
+            return memberInfo.HasCustomAttributeWithName("System.Runtime.CompilerServices.RequiredMemberAttribute", inherit: false);
         }
 
-        public static bool HasSetsRequiredMembersAttribute(this ICustomAttributeProvider memberInfo)
+        public static bool HasSetsRequiredMembersAttribute(this MemberInfo memberInfo)
         {
             // See comment for HasRequiredMemberAttribute for why we need to always only look at full name
-            return memberInfo.HasCustomAttributeWithName("System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute", inherit: true);
+            return memberInfo.HasCustomAttributeWithName("System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute", inherit: false);
         }
 
-        private static bool HasCustomAttributeWithName(this ICustomAttributeProvider memberInfo, string fullName, bool inherit)
+        private static bool HasCustomAttributeWithName(this MemberInfo memberInfo, string fullName, bool inherit)
         {
             foreach (object attribute in memberInfo.GetCustomAttributes(inherit))
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Helpers.cs
@@ -85,20 +85,17 @@ namespace System.Text.Json.Serialization.Metadata
             // Walk the type hierarchy starting from the current type up to the base type(s)
             foreach (Type currentType in typeInfo.Type.GetSortedTypeHierarchy())
             {
-                if (currentType == JsonTypeInfo.ObjectType)
+                if (currentType == JsonTypeInfo.ObjectType ||
+                    currentType == typeof(ValueType))
                 {
-                    // Don't process any members for typeof(object)
+                    // Don't process any members for typeof(object) or System.ValueType
                     break;
                 }
-
-                // Compiler adds RequiredMemberAttribute to type if any of the members are marked with 'required' keyword.
-                bool shouldCheckMembersForRequiredMemberAttribute =
-                    !constructorHasSetsRequiredMembersAttribute && currentType.HasRequiredMemberAttribute();
 
                 AddMembersDeclaredBySuperType(
                     typeInfo,
                     currentType,
-                    shouldCheckMembersForRequiredMemberAttribute,
+                    constructorHasSetsRequiredMembersAttribute,
                     ref state);
             }
 
@@ -113,7 +110,7 @@ namespace System.Text.Json.Serialization.Metadata
         private static void AddMembersDeclaredBySuperType(
             JsonTypeInfo typeInfo,
             Type currentType,
-            bool shouldCheckMembersForRequiredMemberAttribute,
+            bool constructorHasSetsRequiredMembersAttribute,
             ref JsonTypeInfo.PropertyHierarchyResolutionState state)
         {
             Debug.Assert(!typeInfo.IsReadOnly);
@@ -124,6 +121,10 @@ namespace System.Text.Json.Serialization.Metadata
                 BindingFlags.Public |
                 BindingFlags.NonPublic |
                 BindingFlags.DeclaredOnly;
+
+            // Compiler adds RequiredMemberAttribute to type if any of the members are marked with 'required' keyword.
+            bool shouldCheckMembersForRequiredMemberAttribute =
+                !constructorHasSetsRequiredMembersAttribute && currentType.HasRequiredMemberAttribute();
 
             foreach (PropertyInfo propertyInfo in currentType.GetProperties(BindingFlags))
             {


### PR DESCRIPTION
Fix #89794. Mitigates a necessary performance regression introduced by #89418.

|             Method |  Branch |     Mean |    Error |   StdDev |   Median |      Min |      Max | Ratio | MannWhitney(3%) | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|------------------- |------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|---------------- |--------:|-------:|----------:|------------:|
| NewCustomConverter | main | 28.87 us | 9.279 us | 9.529 us | 23.93 us | 23.44 us | 54.01 us |  1.00 |            Base |    0.00 | 0.2841 |   9.11 KB |        1.00 |
| NewCustomConverter | PR | 19.51 us | 1.547 us | 1.519 us | 18.96 us | 18.18 us | 24.38 us |  0.71 |          Faster |    0.15 | 0.2490 |   7.87 KB |        0.86 |