### PR TITLE
[ComInterfaceGenerator] Add test COM interfaces

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/ArrayMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/ArrayMarshalling.cs
@@ -3,13 +3,8 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-using System.Text;
-using System.Threading.Tasks;
 using SharedTypes.ComInterfaces;
 using static System.Runtime.InteropServices.ComWrappers;
 
@@ -53,7 +48,7 @@ namespace NativeExports.ComInterfaceGenerator
                 if (obj is ImplementingObject)
                 {
                     ComInterfaceEntry* comInterfaceEntry = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ImplementingObject), sizeof(ComInterfaceEntry));
-                    comInterfaceEntry->IID = new Guid(IGetIntArray._guid);
+                    comInterfaceEntry->IID = new Guid(IGetIntArray.IID);
                     comInterfaceEntry->Vtable = (nint)GetIntArrayVTable;
                     count = 1;
                     return comInterfaceEntry;

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/GetAndSetInt.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/GetAndSetInt.cs
@@ -3,15 +3,8 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-using System.Runtime.InteropServices.ObjectiveC;
-using System.Text;
-using System.Threading.Tasks;
 using SharedTypes.ComInterfaces;
 using static System.Runtime.InteropServices.ComWrappers;
 
@@ -55,7 +48,7 @@ namespace NativeExports.ComInterfaceGenerator
                 if (obj is ImplementingObject)
                 {
                     ComInterfaceEntry* comInterfaceEntry = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ImplementingObject), sizeof(ComInterfaceEntry));
-                    comInterfaceEntry->IID = new Guid(IGetAndSetInt._guid);
+                    comInterfaceEntry->IID = new Guid(IGetAndSetInt.IID);
                     comInterfaceEntry->Vtable = (nint)s_comInterface1VTable;
                     count = 1;
                     return comInterfaceEntry;

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/StringMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/StringMarshalling.cs
@@ -3,199 +3,195 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
-using System.Text;
-using System.Threading.Tasks;
 using SharedTypes.ComInterfaces;
 using static System.Runtime.InteropServices.ComWrappers;
 
 namespace NativeExports.ComInterfaceGenerator
 {
-	public unsafe class StringMarshalling
-	{
-		[UnmanagedCallersOnly(EntryPoint = "new_utf8_marshalling")]
-		public static void* CreateUtf8ComObject()
-		{
-			MyComWrapper cw = new();
-			var myObject = new Utf8Implementation();
-			nint ptr = cw.GetOrCreateComInterfaceForObject(myObject, CreateComInterfaceFlags.None);
+    public unsafe class StringMarshalling
+    {
+        [UnmanagedCallersOnly(EntryPoint = "new_utf8_marshalling")]
+        public static void* CreateUtf8ComObject()
+        {
+            MyComWrapper cw = new();
+            var myObject = new Utf8Implementation();
+            nint ptr = cw.GetOrCreateComInterfaceForObject(myObject, CreateComInterfaceFlags.None);
 
-			return (void*)ptr;
-		}
+            return (void*)ptr;
+        }
 
-		[UnmanagedCallersOnly(EntryPoint = "new_utf16_marshalling")]
-		public static void* CreateUtf16ComObject()
-		{
-			MyComWrapper cw = new();
-			var myObject = new Utf16Implementation();
-			nint ptr = cw.GetOrCreateComInterfaceForObject(myObject, CreateComInterfaceFlags.None);
+        [UnmanagedCallersOnly(EntryPoint = "new_utf16_marshalling")]
+        public static void* CreateUtf16ComObject()
+        {
+            MyComWrapper cw = new();
+            var myObject = new Utf16Implementation();
+            nint ptr = cw.GetOrCreateComInterfaceForObject(myObject, CreateComInterfaceFlags.None);
 
-			return (void*)ptr;
-		}
+            return (void*)ptr;
+        }
 
-		class MyComWrapper : ComWrappers
-		{
-			static void* _s_comInterface1VTable = null;
-			static void* _s_comInterface2VTable = null;
-			static void* S_Utf8VTable
-			{
-				get
-				{
-					if (_s_comInterface1VTable != null)
-						return _s_comInterface1VTable;
-					void** vtable = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(GetAndSetInt), sizeof(void*) * 5);
-					GetIUnknownImpl(out var fpQueryInterface, out var fpAddReference, out var fpRelease);
-					vtable[0] = (void*)fpQueryInterface;
-					vtable[1] = (void*)fpAddReference;
-					vtable[2] = (void*)fpRelease;
-					vtable[3] = (delegate* unmanaged<void*, byte**, int>)&Utf8Implementation.ABI.GetStringUtf8;
-					vtable[4] = (delegate* unmanaged<void*, byte*, int>)&Utf8Implementation.ABI.SetStringUtf8;
-					_s_comInterface1VTable = vtable;
-					return _s_comInterface1VTable;
-				}
-			}
-			static void* S_Utf16VTable
-			{
-				get
-				{
-					if (_s_comInterface2VTable != null)
-						return _s_comInterface2VTable;
-					void** vtable = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(GetAndSetInt), sizeof(void*) * 5);
-					GetIUnknownImpl(out var fpQueryInterface, out var fpAddReference, out var fpRelease);
-					vtable[0] = (void*)fpQueryInterface;
-					vtable[1] = (void*)fpAddReference;
-					vtable[2] = (void*)fpRelease;
-					vtable[3] = (delegate* unmanaged<void*, ushort**, int>)&Utf16Implementation.ABI.GetStringUtf16;
-					vtable[4] = (delegate* unmanaged<void*, ushort*, int>)&Utf16Implementation.ABI.SetStringUtf16;
-					_s_comInterface2VTable = vtable;
-					return _s_comInterface2VTable;
-				}
-			}
+        class MyComWrapper : ComWrappers
+        {
+            static void* _s_comInterface1VTable = null;
+            static void* _s_comInterface2VTable = null;
+            static void* S_Utf8VTable
+            {
+                get
+                {
+                    if (_s_comInterface1VTable != null)
+                        return _s_comInterface1VTable;
+                    void** vtable = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(GetAndSetInt), sizeof(void*) * 5);
+                    GetIUnknownImpl(out var fpQueryInterface, out var fpAddReference, out var fpRelease);
+                    vtable[0] = (void*)fpQueryInterface;
+                    vtable[1] = (void*)fpAddReference;
+                    vtable[2] = (void*)fpRelease;
+                    vtable[3] = (delegate* unmanaged<void*, byte**, int>)&Utf8Implementation.ABI.GetStringUtf8;
+                    vtable[4] = (delegate* unmanaged<void*, byte*, int>)&Utf8Implementation.ABI.SetStringUtf8;
+                    _s_comInterface1VTable = vtable;
+                    return _s_comInterface1VTable;
+                }
+            }
+            static void* S_Utf16VTable
+            {
+                get
+                {
+                    if (_s_comInterface2VTable != null)
+                        return _s_comInterface2VTable;
+                    void** vtable = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(GetAndSetInt), sizeof(void*) * 5);
+                    GetIUnknownImpl(out var fpQueryInterface, out var fpAddReference, out var fpRelease);
+                    vtable[0] = (void*)fpQueryInterface;
+                    vtable[1] = (void*)fpAddReference;
+                    vtable[2] = (void*)fpRelease;
+                    vtable[3] = (delegate* unmanaged<void*, ushort**, int>)&Utf16Implementation.ABI.GetStringUtf16;
+                    vtable[4] = (delegate* unmanaged<void*, ushort*, int>)&Utf16Implementation.ABI.SetStringUtf16;
+                    _s_comInterface2VTable = vtable;
+                    return _s_comInterface2VTable;
+                }
+            }
 
-			protected override ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
-			{
-				if (obj is IUTF8Marshalling)
-				{
-					ComInterfaceEntry* comInterfaceEntry = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Utf8Implementation), sizeof(ComInterfaceEntry));
-					comInterfaceEntry->IID = new Guid(IUTF8Marshalling._guid);
-					comInterfaceEntry->Vtable = (nint)S_Utf8VTable;
-					count = 1;
-					return comInterfaceEntry;
-				}
-				else if (obj is IUTF16Marshalling)
-				{
-					ComInterfaceEntry* comInterfaceEntry = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Utf16Implementation), sizeof(ComInterfaceEntry));
-					comInterfaceEntry->IID = new Guid(IUTF16Marshalling._guid);
-					comInterfaceEntry->Vtable = (nint)S_Utf16VTable;
-					count = 1;
-					return comInterfaceEntry;
-				}
-				count = 0;
-				return null;
-			}
+            protected override ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
+            {
+                if (obj is IUTF8Marshalling)
+                {
+                    ComInterfaceEntry* comInterfaceEntry = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Utf8Implementation), sizeof(ComInterfaceEntry));
+                    comInterfaceEntry->IID = new Guid(IUTF8Marshalling.IID);
+                    comInterfaceEntry->Vtable = (nint)S_Utf8VTable;
+                    count = 1;
+                    return comInterfaceEntry;
+                }
+                else if (obj is IUTF16Marshalling)
+                {
+                    ComInterfaceEntry* comInterfaceEntry = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Utf16Implementation), sizeof(ComInterfaceEntry));
+                    comInterfaceEntry->IID = new Guid(IUTF16Marshalling.IID);
+                    comInterfaceEntry->Vtable = (nint)S_Utf16VTable;
+                    count = 1;
+                    return comInterfaceEntry;
+                }
+                count = 0;
+                return null;
+            }
 
-			protected override object? CreateObject(nint externalComObject, CreateObjectFlags flags) => throw new NotImplementedException();
-			protected override void ReleaseObjects(IEnumerable objects) => throw new NotImplementedException();
-		}
+            protected override object? CreateObject(nint externalComObject, CreateObjectFlags flags) => throw new NotImplementedException();
+            protected override void ReleaseObjects(IEnumerable objects) => throw new NotImplementedException();
+        }
 
-		class Utf8Implementation : IUTF8Marshalling
-		{
-			string _data = "Hello, World!";
+        class Utf8Implementation : IUTF8Marshalling
+        {
+            string _data = "Hello, World!";
 
-			string IUTF8Marshalling.GetString()
-			{
-				return _data;
-			}
-			void IUTF8Marshalling.SetString(string x)
-			{
-				_data = x;
-			}
+            string IUTF8Marshalling.GetString()
+            {
+                return _data;
+            }
+            void IUTF8Marshalling.SetString(string x)
+            {
+                _data = x;
+            }
 
-			// Provides function pointers in the COM format to use in COM VTables
-			public static class ABI
-			{
-				[UnmanagedCallersOnly]
-				public static int GetStringUtf8(void* @this, byte** value)
-				{
-					try
-					{
-						string currValue = ComInterfaceDispatch.GetInstance<IUTF8Marshalling>((ComInterfaceDispatch*)@this).GetString();
-						*value = Utf8StringMarshaller.ConvertToUnmanaged(currValue);
-						return 0;
-					}
-					catch (Exception e)
-					{
-						return e.HResult;
-					}
-				}
+            // Provides function pointers in the COM format to use in COM VTables
+            public static class ABI
+            {
+                [UnmanagedCallersOnly]
+                public static int GetStringUtf8(void* @this, byte** value)
+                {
+                    try
+                    {
+                        string currValue = ComInterfaceDispatch.GetInstance<IUTF8Marshalling>((ComInterfaceDispatch*)@this).GetString();
+                        *value = Utf8StringMarshaller.ConvertToUnmanaged(currValue);
+                        return 0;
+                    }
+                    catch (Exception e)
+                    {
+                        return e.HResult;
+                    }
+                }
 
-				[UnmanagedCallersOnly]
-				public static int SetStringUtf8(void* @this, byte* newValue)
-				{
-					try
-					{
-						string value = Utf8StringMarshaller.ConvertToManaged(newValue);
-						ComInterfaceDispatch.GetInstance<IUTF8Marshalling>((ComInterfaceDispatch*)@this).SetString(value);
-						return 0;
-					}
-					catch (Exception e)
-					{
-						return e.HResult;
-					}
-				}
-			}
-		}
+                [UnmanagedCallersOnly]
+                public static int SetStringUtf8(void* @this, byte* newValue)
+                {
+                    try
+                    {
+                        string value = Utf8StringMarshaller.ConvertToManaged(newValue);
+                        ComInterfaceDispatch.GetInstance<IUTF8Marshalling>((ComInterfaceDispatch*)@this).SetString(value);
+                        return 0;
+                    }
+                    catch (Exception e)
+                    {
+                        return e.HResult;
+                    }
+                }
+            }
+        }
 
-		class Utf16Implementation : IUTF16Marshalling
-		{
-			string _data = "Hello, World!";
+        class Utf16Implementation : IUTF16Marshalling
+        {
+            string _data = "Hello, World!";
 
-			string IUTF16Marshalling.GetString()
-			{
-				return _data;
-			}
-			void IUTF16Marshalling.SetString(string x)
-			{
-				_data = x;
-			}
+            string IUTF16Marshalling.GetString()
+            {
+                return _data;
+            }
+            void IUTF16Marshalling.SetString(string x)
+            {
+                _data = x;
+            }
 
-			// Provides function pointers in the COM format to use in COM VTables
-			public static class ABI
-			{
-				[UnmanagedCallersOnly]
-				public static int GetStringUtf16(void* @this, ushort** value)
-				{
-					try
-					{
-						string currValue = ComInterfaceDispatch.GetInstance<IUTF16Marshalling>((ComInterfaceDispatch*)@this).GetString();
-						*value = Utf16StringMarshaller.ConvertToUnmanaged(currValue);
-						return 0;
-					}
-					catch (Exception e)
-					{
-						return e.HResult;
-					}
-				}
+            // Provides function pointers in the COM format to use in COM VTables
+            public static class ABI
+            {
+                [UnmanagedCallersOnly]
+                public static int GetStringUtf16(void* @this, ushort** value)
+                {
+                    try
+                    {
+                        string currValue = ComInterfaceDispatch.GetInstance<IUTF16Marshalling>((ComInterfaceDispatch*)@this).GetString();
+                        *value = Utf16StringMarshaller.ConvertToUnmanaged(currValue);
+                        return 0;
+                    }
+                    catch (Exception e)
+                    {
+                        return e.HResult;
+                    }
+                }
 
-				[UnmanagedCallersOnly]
-				public static int SetStringUtf16(void* @this, ushort* newValue)
-				{
-					try
-					{
-						string value = Utf16StringMarshaller.ConvertToManaged(newValue);
-						ComInterfaceDispatch.GetInstance<IUTF16Marshalling>((ComInterfaceDispatch*)@this).SetString(value);
-						return 0;
-					}
-					catch (Exception e)
-					{
-						return e.HResult;
-					}
-				}
-			}
-		}
-	}
+                [UnmanagedCallersOnly]
+                public static int SetStringUtf16(void* @this, ushort* newValue)
+                {
+                    try
+                    {
+                        string value = Utf16StringMarshaller.ConvertToManaged(newValue);
+                        ComInterfaceDispatch.GetInstance<IUTF16Marshalling>((ComInterfaceDispatch*)@this).SetString(value);
+                        return 0;
+                    }
+                    catch (Exception e)
+                    {
+                        return e.HResult;
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/StringMarshallingOverride.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/StringMarshallingOverride.cs
@@ -3,13 +3,9 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
-using System.Text;
-using System.Threading.Tasks;
 using SharedTypes.ComInterfaces;
 using static System.Runtime.InteropServices.ComWrappers;
 
@@ -76,9 +72,9 @@ namespace NativeExports.ComInterfaceGenerator
                 if (obj is IStringMarshallingOverrideDerived)
                 {
                     ComInterfaceEntry* comInterfaceEntry = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Implementation), sizeof(ComInterfaceEntry) * 2);
-                    comInterfaceEntry[0].IID = new Guid(IStringMarshallingOverrideDerived._guid);
+                    comInterfaceEntry[0].IID = new Guid(IStringMarshallingOverrideDerived.IID);
                     comInterfaceEntry[0].Vtable = (nint)S_DerivedVTable;
-                    comInterfaceEntry[1].IID = new Guid(IStringMarshallingOverride._guid);
+                    comInterfaceEntry[1].IID = new Guid(IStringMarshallingOverride.IID);
                     comInterfaceEntry[1].Vtable = (nint)S_VTable;
                     count = 2;
                     return comInterfaceEntry;
@@ -86,7 +82,7 @@ namespace NativeExports.ComInterfaceGenerator
                 if (obj is IStringMarshallingOverride)
                 {
                     ComInterfaceEntry* comInterfaceEntry = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Implementation), sizeof(ComInterfaceEntry));
-                    comInterfaceEntry->IID = new Guid(IStringMarshallingOverride._guid);
+                    comInterfaceEntry->IID = new Guid(IStringMarshallingOverride.IID);
                     comInterfaceEntry->Vtable = (nint)S_VTable;
                     count = 1;
                     return comInterfaceEntry;

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IArrayOfStatelessElements.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IArrayOfStatelessElements.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("F4963CBF-10AF-460B-8495-107782187705")]
+    internal partial interface IArrayOfStatelessElements
+    {
+        void Method([MarshalUsing(CountElementName = nameof(size))] StatelessType[] param, int size);
+        void MethodIn([MarshalUsing(CountElementName = nameof(size))] in StatelessType[] param, int size);
+        void MethodOut([MarshalUsing(CountElementName = nameof(size))] out StatelessType[] param, int size);
+        void MethodRef([MarshalUsing(CountElementName = nameof(size))] ref StatelessType[] param, int size);
+        void MethodContentsIn([MarshalUsing(CountElementName = nameof(size))][In] StatelessType[] param, int size);
+        void MethodContentsOut([MarshalUsing(CountElementName = nameof(size))][Out] StatelessType[] param, int size);
+        void MethodContentsInOut([MarshalUsing(CountElementName = nameof(size))][In, Out] StatelessType[] param, int size);
+    }
+
+    [GeneratedComClass]
+    internal partial class ArrayOfStatelessElements : IArrayOfStatelessElements
+    {
+        public void Method(StatelessType[] param, int size)
+        {
+        }
+        public void MethodContentsIn(StatelessType[] param, int size)
+        {
+            // We should be able to modify the contents and the caller shouldn't see it
+            for (int i = 0; i < size; i++)
+            {
+                param[i] = new StatelessType() { I = param[i].I * 2 };
+            }
+        }
+        public void MethodContentsInOut(StatelessType[] param, int size)
+        {
+            for (int i = 0; i < size; i++)
+            {
+                param[i] = new StatelessType() { I = param[i].I * 2 };
+            }
+        }
+        public void MethodContentsOut(StatelessType[] param, int size)
+        {
+            for (int i = 0; i < size; i++)
+            {
+                param[i] = new StatelessType() { I = i };
+            }
+        }
+        public void MethodIn(in StatelessType[] param, int size)
+        {
+            // We should be able to modify the contents and the caller shouldn't see it
+            for (int i = 0; i < size; i++)
+            {
+                param[i] = new StatelessType() { I = param[i].I * 2 };
+            }
+        }
+        public void MethodOut(out StatelessType[] param, int size)
+        {
+            param = new StatelessType[size];
+            for (int i = 0; i < size; i++)
+            {
+                param[i] = new StatelessType() { I = i };
+            }
+        }
+        public void MethodRef(ref StatelessType[] param, int size)
+        {
+            for (int i = 0; i < size; i++)
+            {
+                param[i] = new StatelessType() { I = param[i].I * 2 };
+            }
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IBool.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IBool.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("5A9D3ED6-CC17-4FB9-8F82-0070489B7213")]
+    internal partial interface IBool
+    {
+        [return: MarshalAs(UnmanagedType.I1)]
+        bool Get();
+        void Set([MarshalAs(UnmanagedType.I1)] bool value);
+    }
+
+    [GeneratedComClass]
+    internal partial class IBoolImpl : IBool
+    {
+        bool _data;
+        public bool Get() => _data;
+        public void Set(bool value) => _data = value;
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/ICustomStringMarshallingUtf16.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/ICustomStringMarshallingUtf16.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices.Marshalling;
 
 namespace SharedTypes.ComInterfaces
 {
-    [Guid(_guid)]
+    [Guid(IID)]
     [GeneratedComInterface(StringMarshalling = StringMarshalling.Custom, StringMarshallingCustomType = typeof(Utf16StringMarshaller))]
     internal partial interface ICustomStringMarshallingUtf16
     {
@@ -15,6 +15,6 @@ namespace SharedTypes.ComInterfaces
 
         public void SetString(string value);
 
-        public const string _guid = "E11D5F3E-DD57-41A6-A59E-7D110551A760";
+        public const string IID = "E11D5F3E-DD57-41A6-A59E-7D110551A760";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IDerived.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IDerived.cs
@@ -2,22 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
 namespace SharedTypes.ComInterfaces
 {
     [GeneratedComInterface]
-    [Guid(_guid)]
+    [Guid(IID)]
     internal partial interface IDerived : IGetAndSetInt
     {
         void SetName([MarshalUsing(typeof(Utf16StringMarshaller))] string name);
 
-        [return:MarshalUsing(typeof(Utf16StringMarshaller))]
+        [return: MarshalUsing(typeof(Utf16StringMarshaller))]
         string GetName();
 
-        internal new const string _guid = "7F0DB364-3C04-4487-9193-4BB05DC7B654";
+        internal new const string IID = "7F0DB364-3C04-4487-9193-4BB05DC7B654";
     }
 
     [GeneratedComClass]

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IEmpty.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IEmpty.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices.Marshalling;
 namespace SharedTypes.ComInterfaces
 {
     [GeneratedComInterface]
-    [Guid(_guid)]
+    [Guid(IID)]
     internal partial interface IEmpty
     {
-        public const string _guid = "95D19F50-F2D8-4E61-884B-0A9162EA4646";
+        public const string IID = "95D19F50-F2D8-4E61-884B-0A9162EA4646";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IFloat.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IFloat.cs
@@ -8,20 +8,18 @@ using System.Runtime.InteropServices.Marshalling;
 namespace SharedTypes.ComInterfaces
 {
     [GeneratedComInterface]
-    [Guid(IID)]
-    internal partial interface IGetAndSetInt
+    [Guid("9FA4A8A9-2D8F-48A8-B6FB-B44B5F1B9FB6")]
+    internal partial interface IFloat
     {
-        int GetInt();
-
-        public void SetInt(int x);
-
-        public const string IID = "2c3f9903-b586-46b1-881b-adfce9af47b1";
+        float Get();
+        void Set(float value);
     }
+
     [GeneratedComClass]
-    internal partial class GetAndSetInt : IGetAndSetInt
+    internal partial class IFloatImpl : IFloat
     {
-        int _data = 0;
-        public int GetInt() => _data;
-        public void SetInt(int x) => _data = x;
+        float _data;
+        public float Get() => _data;
+        public void Set(float value) => _data = value;
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IGetIntArray.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IGetIntArray.cs
@@ -8,12 +8,12 @@ using System.Runtime.InteropServices.Marshalling;
 namespace SharedTypes.ComInterfaces
 {
     [GeneratedComInterface]
-    [Guid(_guid)]
+    [Guid(IID)]
     internal partial interface IGetIntArray
     {
         [return: MarshalUsing(ConstantElementCount = 10)]
         int[] GetInts();
 
-        public const string _guid = "7D802A0A-630A-4C8E-A21F-771CC9031FB9";
+        public const string IID = "7D802A0A-630A-4C8E-A21F-771CC9031FB9";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IInt.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IInt.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("EE6D1F2A-3418-4317-A87C-35488F6546AB")]
+    internal partial interface IInt
+    {
+        public int Get();
+        public void Set(int value);
+        public void SwapRef(ref int value);
+        public void GetOut(out int value);
+        public void SetIn(in int value);
+    }
+
+    [GeneratedComClass]
+    internal partial class IIntImpl : IInt
+    {
+        int _data;
+
+        public int Get() => _data;
+
+        public void Set(int value) => _data = value;
+
+        public void SetIn(in int value)
+        {
+            _data = value;
+        }
+
+        public void GetOut(out int value)
+        {
+            value = _data;
+        }
+
+        public void SwapRef(ref int value)
+        {
+            var tmp = _data;
+            _data = value;
+            value = tmp;
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IIntArray.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IIntArray.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("9FA4A8A9-3D8F-48A8-B6FB-B45B5F1B9FB6")]
+    internal partial interface IIntArray
+    {
+        [return: MarshalUsing(CountElementName = nameof(size))]
+        int[] GetReturn(out int size);
+        int GetOut([MarshalUsing(CountElementName = MarshalUsingAttribute.ReturnsCountValue)] out int[] array);
+        void SetContents([MarshalUsing(CountElementName = nameof(size))] int[] array, int size);
+        void FillAscending([Out][MarshalUsing(CountElementName = nameof(size))] int[] array, int size);
+        void Double([In, Out][MarshalUsing(CountElementName = nameof(size))] int[] array, int size);
+        void PassIn([MarshalUsing(CountElementName = nameof(size))] in int[] array, int size);
+        void SwapArray([MarshalUsing(CountElementName = nameof(size))] ref int[] array, int size);
+    }
+
+    [GeneratedComClass]
+    internal partial class IIntArrayImpl : IIntArray
+    {
+        int[] _data;
+        public int[] GetReturn(out int size)
+        {
+            size = _data.Length;
+            return _data;
+        }
+        public int GetOut(out int[] array)
+        {
+            array = _data;
+            return array.Length;
+        }
+        public void SetContents(int[] array, int size)
+        {
+            _data = new int[size];
+            array.CopyTo(_data, 0);
+        }
+
+        public void FillAscending(int[] array, int size)
+        {
+            for (int i = 0; i < size; i++)
+            {
+                array[i] = i;
+            }
+        }
+        public void Double(int[] array, int size)
+        {
+            for (int i = 0; i < size; i++)
+            {
+                array[i] = array[i] * 2;
+            }
+
+        }
+
+        public void PassIn([MarshalUsing(CountElementName = "size")] in int[] array, int size)
+        {
+            _data = new int[size];
+            array.CopyTo(_data, 0);
+        }
+        public void SwapArray([MarshalUsing(CountElementName = "size")] ref int[] array, int size)
+        {
+            var temp = _data;
+            _data = array;
+            array = temp;
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IInterface.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IInterface.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("A4857398-06FB-4A6E-81DB-35461BE999C5")]
+    internal partial interface IInterface
+    {
+        public IInt Get();
+        public void SetInt(IInt value);
+        public void SwapRef(ref IInt value);
+        public void GetOut(out IInt value);
+        public void InInt(in IInt value);
+    }
+
+    [GeneratedComClass]
+    internal partial class IInterfaceImpl : IInterface
+    {
+        IInt _data = new IIntImpl();
+
+        IInt IInterface.Get() => _data;
+
+        void IInterface.InInt(in IInt value)
+        {
+            var i = value.Get();
+        }
+
+        void IInterface.GetOut(out IInt value)
+        {
+            value = _data;
+        }
+
+        void IInterface.SwapRef(ref IInt value)
+        {
+            var tmp = _data;
+            _data = value;
+            value = tmp;
+        }
+
+        void IInterface.SetInt(IInt value)
+        {
+            int x = value.Get();
+            value.Set(x);
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IJaggedIntArray.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IJaggedIntArray.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("9FA4A8A9-3D8F-48A8-B6FB-B45B5F1B9FB6")]
+    internal partial interface IJaggedIntArray
+    {
+        [return: MarshalUsing(CountElementName = nameof(length)),
+            MarshalUsing(ElementIndirectionDepth = 1, CountElementName = nameof(widths))]
+        int[][] Get(
+            [MarshalUsing(CountElementName = nameof(length))]
+            out int[] widths,
+            out int length);
+
+        int Get2(
+            [MarshalUsing(CountElementName = MarshalUsingAttribute.ReturnsCountValue),
+            MarshalUsing(ElementIndirectionDepth = 1, CountElementName = nameof(widths))]
+            out int[][] array,
+            [MarshalUsing(CountElementName = MarshalUsingAttribute.ReturnsCountValue)]
+            out int[] widths);
+
+        void Set(
+            [MarshalUsing(CountElementName = nameof(length)),
+            MarshalUsing(ElementIndirectionDepth = 1, CountElementName = nameof(widths))]
+            int[][] array,
+            [MarshalUsing(CountElementName = nameof(length))]
+            int[] widths,
+            int length);
+    }
+
+    [GeneratedComClass]
+    internal partial class IJaggedIntArrayImpl : IJaggedIntArray
+    {
+        int[][] _data = new int[][] { new int[] { 1, 2, 3 }, new int[] { 4, 5 }, new int[] { 6, 7, 8, 9 } };
+        int[] _widths = new int[] { 3, 2, 4 };
+        public int[][] Get(out int[] widths, out int length)
+        {
+            widths = _widths;
+            length = _data.Length;
+            return _data;
+        }
+        public int Get2(out int[][] array, out int[] widths)
+        {
+            array = _data;
+            widths = _widths;
+            return array.Length;
+        }
+        public void Set(int[][] array, int[] widths, int length)
+        {
+            _data = array;
+            _widths = widths;
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IRefStrings.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IRefStrings.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
@@ -9,15 +8,11 @@ namespace SharedTypes.ComInterfaces
 {
     [GeneratedComInterface(StringMarshalling = System.Runtime.InteropServices.StringMarshalling.Utf8)]
     [Guid(IID)]
-    internal partial interface IStringMarshallingOverride
+    internal partial interface IRefStrings
     {
         public const string IID = "5146B7DB-0588-469B-B8E5-B38090A2FC15";
-        string StringMarshallingUtf8(string input);
-
-        [return: MarshalAs(UnmanagedType.LPWStr)]
-        string MarshalAsLPWString([MarshalAs(UnmanagedType.LPWStr)] string input);
-
-        [return: MarshalUsing(typeof(Utf16StringMarshaller))]
-        string MarshalUsingUtf16([MarshalUsing(typeof(Utf16StringMarshaller))] string input);
+        void RefString(ref string value);
+        void InString(in string value);
+        void OutString(out string value);
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/ISafeHandles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/ISafeHandles.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Microsoft.Win32.SafeHandles;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface(Options = ComInterfaceOptions.ComObjectWrapper), Guid("0A52B77C-E08B-4274-A1F4-1A2BF2C07E60")]
+    internal partial interface ISafeFileHandle
+    {
+        void Method(SafeFileHandle p);
+        void MethodIn(in SafeFileHandle p);
+        void MethodOut(out SafeFileHandle p);
+        void MethodRef(ref SafeFileHandle p);
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulCallerAllocatedBuffer.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulCallerAllocatedBuffer.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("4731FA5D-C103-4A22-87A1-58DCEDD4A9B3")]
+    internal partial interface IStatefulCallerAllocatedBufferMarshalling
+    {
+        void Method(StatefulCallerAllocatedBufferType param);
+        void MethodIn(in StatefulCallerAllocatedBufferType param);
+        void MethodOut(out StatefulCallerAllocatedBufferType param);
+        void MethodRef(ref StatefulCallerAllocatedBufferType param);
+        StatefulCallerAllocatedBufferType Return();
+        [PreserveSig]
+        StatefulCallerAllocatedBufferType ReturnPreserveSig();
+    }
+
+    [NativeMarshalling(typeof(StatefulCallerAllocatedBufferTypeMarshaller))]
+    internal class StatefulCallerAllocatedBufferType
+    {
+    }
+
+    [CustomMarshaller(typeof(StatefulCallerAllocatedBufferType), MarshalMode.Default, typeof(StatefulCallerAllocatedBufferTypeMarshaller))]
+    internal struct StatefulCallerAllocatedBufferTypeMarshaller
+    {
+        public static int BufferSize => 64;
+
+        public void FromManaged(StatefulCallerAllocatedBufferType managed, Span<byte> buffer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public nint ToUnmanaged()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void FromUnmanaged(nint unmanaged)
+        {
+            throw new NotImplementedException();
+        }
+
+        public StatefulCallerAllocatedBufferType ToManaged()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Free()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulCollectionBlittableElement.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulCollectionBlittableElement.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface(), Guid("0A52B77C-E08B-4274-A1F4-1A2BF2C07E60")]
+    partial interface IStatefulCollectionBlittableElement
+    {
+        void Method(
+            [MarshalUsing(CountElementName = nameof(size))] StatefulCollection<int> p,
+            int size);
+        void MethodIn(
+            [MarshalUsing(CountElementName = nameof(size))] in StatefulCollection<int> pIn,
+            in int size);
+        void MethodRef(
+            [MarshalUsing(CountElementName = nameof(size))] ref StatefulCollection<int> pRef,
+            int size);
+        void MethodOut(
+            [MarshalUsing(CountElementName = nameof(size))] out StatefulCollection<int> pOut,
+            out int size);
+        [return: MarshalUsing(CountElementName = nameof(size))]
+        StatefulCollection<int> Return(int size);
+        [PreserveSig]
+        [return: MarshalUsing(CountElementName = nameof(size))]
+        StatefulCollection<int> ReturnPreserveSig(int size);
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulCollectionStatelessElement.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulCollectionStatelessElement.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface(), Guid("0A52B77C-E08B-4274-A1F4-1A2BF2C07E60")]
+    partial interface IStatefulCollectionStatelessElement
+    {
+        void Method(
+            [MarshalUsing(CountElementName = nameof(size))] StatefulCollection<StatelessType> p,
+            int size);
+        void MethodIn(
+            [MarshalUsing(CountElementName = nameof(size))] in StatefulCollection<StatelessType> pIn,
+            in int size);
+        void MethodRef(
+            [MarshalUsing(CountElementName = nameof(size))] ref StatefulCollection<StatelessType> pRef,
+            int size);
+        void MethodOut(
+            [MarshalUsing(CountElementName = nameof(size))] out StatefulCollection<StatelessType> pOut,
+            out int size);
+        [return: MarshalUsing(CountElementName = nameof(size))]
+        StatefulCollection<StatelessType> Return(int size);
+        [PreserveSig]
+        [return: MarshalUsing(CountElementName = nameof(size))]
+        StatefulCollection<StatelessType> ReturnPreserveSig(int size);
+    }
+
+    [NativeMarshalling(typeof(StatefulCollectionMarshaller<,>))]
+    internal class StatefulCollection<T>
+    {
+    }
+
+    [ContiguousCollectionMarshaller]
+    [CustomMarshaller(typeof(StatefulCollection<>), MarshalMode.Default, typeof(StatefulCollectionMarshaller<,>.Default))]
+    static unsafe class StatefulCollectionMarshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+    {
+        public ref struct Default
+        {
+            public byte* ToUnmanaged() => throw null;
+            public System.ReadOnlySpan<T> GetManagedValuesSource() => throw null;
+            public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() => throw null;
+
+            public void FromUnmanaged(byte* value) => throw null;
+            public System.Span<T> GetManagedValuesDestination(int numElements) => throw null;
+            public System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements) => throw null;
+
+            public void Free() => throw null;
+
+            public void FromManaged(StatefulCollection<T> managed) => throw null;
+
+            public StatefulCollection<T> ToManaged() => throw null;
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulFinallyMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulFinallyMarshalling.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("4731FA5D-C103-4A22-87A1-58DCEDD4A9B3")]
+    internal partial interface IStatefulFinallyMarshalling
+    {
+        void Method(StatefulFinallyType param);
+        void MethodIn(in StatefulFinallyType param);
+        void MethodOut(out StatefulFinallyType param);
+        void MethodRef(ref StatefulFinallyType param);
+        StatefulFinallyType Return();
+        [PreserveSig]
+        StatefulFinallyType ReturnPreserveSig();
+    }
+
+    [NativeMarshalling(typeof(StatefulFinallyTypeMarshaller))]
+    internal class StatefulFinallyType
+    {
+    }
+
+    [CustomMarshaller(typeof(StatefulFinallyType), MarshalMode.Default, typeof(StatefulFinallyTypeMarshaller))]
+    internal struct StatefulFinallyTypeMarshaller
+    {
+        public void FromManaged(StatefulFinallyType managed)
+        {
+            throw new NotImplementedException();
+        }
+
+        public nint ToUnmanaged()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void FromUnmanaged(nint unmanaged)
+        {
+            throw new NotImplementedException();
+        }
+
+        public StatefulFinallyType ToManagedFinally()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Free()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulMarshalling.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("4731FA5D-C103-4A22-87A1-58DCEDD4A9B3")]
+    internal partial interface IStatefulMarshalling
+    {
+        void Method(StatefulType param);
+        void MethodIn(in StatefulType param);
+        void MethodOut(out StatefulType param);
+        void MethodRef(ref StatefulType param);
+        StatefulType Return();
+        [PreserveSig]
+        StatefulType ReturnPreserveSig();
+    }
+
+    [NativeMarshalling(typeof(StatefulTypeMarshaller))]
+    internal class StatefulType
+    {
+    }
+
+    [CustomMarshaller(typeof(StatefulType), MarshalMode.Default, typeof(StatefulTypeMarshaller))]
+    internal struct StatefulTypeMarshaller
+    {
+        public void FromManaged(StatefulType managed)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public nint ToUnmanaged()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void FromUnmanaged(nint unmanaged)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public StatefulType ToManaged()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Free()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void OnInvoked() { }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulPinnedMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulPinnedMarshalling.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("4731FA5D-C103-4A22-87A1-58DCEDD4A9B3")]
+    internal partial interface IStatefulPinnedMarshalling
+    {
+        void Method(StatefulPinnedType param);
+        void MethodIn(in StatefulPinnedType param);
+        void MethodOut(out StatefulPinnedType param);
+        void MethodRef(ref StatefulPinnedType param);
+        StatefulPinnedType Return();
+        [PreserveSig]
+        StatefulPinnedType ReturnPreserveSig();
+    }
+
+    [NativeMarshalling(typeof(StatefulPinnedTypeMarshaller))]
+    internal class StatefulPinnedType
+    {
+    }
+
+    [CustomMarshaller(typeof(StatefulPinnedType), MarshalMode.Default, typeof(StatefulPinnedTypeMarshaller))]
+    internal struct StatefulPinnedTypeMarshaller
+    {
+
+        public static int BufferSize => 64;
+        public ref int GetPinnableReference() => throw new System.NotImplementedException();
+        public void FromManaged(StatefulPinnedType managed, Span<byte> buffer)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public nint ToUnmanaged()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void FromUnmanaged(nint unmanaged)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public StatefulPinnedType ToManaged()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Free()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void OnInvoked() { }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessCallerAllocateBufferMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessCallerAllocateBufferMarshalling.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("4732FA5D-C105-4A23-87A7-58DCEDD4A9B3")]
+    internal partial interface IStatelessCallerAllocateBufferMarshalling
+    {
+        void Method([MarshalUsing(CountElementName = nameof(size))] StatelessCallerAllocatedBufferType param, int size);
+        void MethodIn([MarshalUsing(CountElementName = nameof(size))] in StatelessCallerAllocatedBufferType param, int size);
+        void MethodOut([MarshalUsing(CountElementName = nameof(size))] out StatelessCallerAllocatedBufferType param, int size);
+        void MethodRef([MarshalUsing(CountElementName = nameof(size))] ref StatelessCallerAllocatedBufferType param, int size);
+        StatelessCallerAllocatedBufferType Return();
+        [PreserveSig]
+        StatelessCallerAllocatedBufferType ReturnPreserveSig();
+    }
+
+    [GeneratedComClass]
+    internal partial class StatelessCallerAllocatedBufferMarshalling : IStatelessCallerAllocateBufferMarshalling
+    {
+        public void Method([MarshalUsing(CountElementName = "size")] StatelessCallerAllocatedBufferType param, int size) { }
+        public void MethodIn([MarshalUsing(CountElementName = "size")] in StatelessCallerAllocatedBufferType param, int size) { }
+        public void MethodOut([MarshalUsing(CountElementName = "size")] out StatelessCallerAllocatedBufferType param, int size) { param = new StatelessCallerAllocatedBufferType { I = 42 }; }
+        public void MethodRef([MarshalUsing(CountElementName = "size")] ref StatelessCallerAllocatedBufferType param, int size) { param = new StatelessCallerAllocatedBufferType { I = 200 }; }
+        public StatelessCallerAllocatedBufferType Return() => throw new NotImplementedException();
+        public StatelessCallerAllocatedBufferType ReturnPreserveSig() => throw new NotImplementedException();
+    }
+
+    [NativeMarshalling(typeof(StatelessCallerAllocatedBufferTypeMarshaller))]
+    internal class StatelessCallerAllocatedBufferType
+    {
+        public int I;
+    }
+
+    [CustomMarshaller(typeof(StatelessCallerAllocatedBufferType), MarshalMode.Default, typeof(StatelessCallerAllocatedBufferTypeMarshaller))]
+    internal static class StatelessCallerAllocatedBufferTypeMarshaller
+    {
+        public static int FreeCount { get; private set; }
+        public static int BufferSize => 64;
+        public static nint ConvertToUnmanaged(StatelessCallerAllocatedBufferType managed, Span<byte> buffer) => managed.I;
+
+        public static StatelessCallerAllocatedBufferType ConvertToManaged(nint unmanaged) => new StatelessCallerAllocatedBufferType { I = (int)unmanaged };
+
+        public static void Free(nint unmanaged) => FreeCount++;
+
+        public static nint ConvertToUnmanaged(StatelessCallerAllocatedBufferType managed) => managed.I;
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessCollectionBlittableElement.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessCollectionBlittableElement.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface(), Guid("0A52B77C-E08B-4274-A1F4-1A2BF2C07E60")]
+    partial interface IStatelessCollectionBlittableElement
+    {
+        void Method(
+            [MarshalUsing(CountElementName = nameof(size))] StatelessCollection<int> p,
+            int size);
+        void MethodIn(
+            [MarshalUsing(CountElementName = nameof(size))] in StatelessCollection<int> pIn,
+            in int size);
+        void MethodRef(
+            [MarshalUsing(CountElementName = nameof(size))] ref StatelessCollection<int> pRef,
+            int size);
+        void MethodOut(
+            [MarshalUsing(CountElementName = nameof(size))] out StatelessCollection<int> pOut,
+            out int size);
+        [return: MarshalUsing(CountElementName = nameof(size))]
+        StatelessCollection<int> Return(int size);
+        [PreserveSig]
+        [return: MarshalUsing(CountElementName = nameof(size))]
+        StatelessCollection<int> ReturnPreserveSig(int size);
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessCollectionStatelessElement.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessCollectionStatelessElement.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface(), Guid("0A52B77C-E08B-4274-A1F4-1A2BF2C07E60")]
+    partial interface IStatelessCollectionStatelessElement
+    {
+        void Method(
+            [MarshalUsing(CountElementName = nameof(size))] StatelessCollection<StatelessType> p,
+            int size);
+
+        void MethodIn(
+            [MarshalUsing(CountElementName = nameof(size))] in StatelessCollection<StatelessType> pIn,
+            in int size);
+
+        void MethodRef(
+            [MarshalUsing(CountElementName = nameof(size))] ref StatelessCollection<StatelessType> pRef,
+            int size);
+
+        void MethodOut(
+            [MarshalUsing(CountElementName = nameof(size))] out StatelessCollection<StatelessType> pOut,
+            out int size);
+
+        [return: MarshalUsing(CountElementName = nameof(size))]
+        StatelessCollection<StatelessType> Return(int size);
+
+        [PreserveSig]
+        [return: MarshalUsing(CountElementName = nameof(size))]
+        StatelessCollection<StatelessType> ReturnPreserveSig(int size);
+    }
+
+    [NativeMarshalling(typeof(StatelessCollectionMarshaller<,>))]
+    internal class StatelessCollection<T>
+    {
+    }
+
+    [ContiguousCollectionMarshaller]
+    [CustomMarshaller(typeof(StatelessCollection<>), MarshalMode.Default, typeof(StatelessCollectionMarshaller<,>.Default))]
+    internal static unsafe class StatelessCollectionMarshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+    {
+        internal static class Default
+        {
+            public static nint AllocateContainerForUnmanagedElements(StatelessCollection<T> managed, out int numElements)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public static StatelessCollection<T> AllocateContainerForManagedElements(nint unmanaged, int numElements)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public static System.ReadOnlySpan<T> GetManagedValuesSource(StatelessCollection<T> managed)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(nint unmanaged, int numElements)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(nint unmanaged, int numElements)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public static System.Span<T> GetManagedValuesDestination(StatelessCollection<T> managed)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public static void Free(nint unmanaged) { }
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessFinallyMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessFinallyMarshalling.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("4732FA5D-C105-4A26-87A7-58DCEDD4A9B3")]
+    internal partial interface IStatelessFinallyMarshalling
+    {
+        void Method([MarshalUsing(CountElementName = nameof(size))] StatelessFinallyType param, int size);
+        void MethodIn([MarshalUsing(CountElementName = nameof(size))] in StatelessFinallyType param, int size);
+        void MethodOut([MarshalUsing(CountElementName = nameof(size))] out StatelessFinallyType param, int size);
+        void MethodRef([MarshalUsing(CountElementName = nameof(size))] ref StatelessFinallyType param, int size);
+        StatelessFinallyType Return();
+        [PreserveSig]
+        StatelessFinallyType ReturnPreserveSig();
+    }
+
+    [GeneratedComClass]
+    internal partial class StatelessFinallyMarshalling : IStatelessFinallyMarshalling
+    {
+        public void Method([MarshalUsing(CountElementName = "size")] StatelessFinallyType param, int size) { }
+        public void MethodIn([MarshalUsing(CountElementName = "size")] in StatelessFinallyType param, int size) { }
+        public void MethodOut([MarshalUsing(CountElementName = "size")] out StatelessFinallyType param, int size) { param = new StatelessFinallyType { I = 42 }; }
+        public void MethodRef([MarshalUsing(CountElementName = "size")] ref StatelessFinallyType param, int size) { param = new StatelessFinallyType { I = 200 }; }
+        public StatelessFinallyType Return() => throw new NotImplementedException();
+        public StatelessFinallyType ReturnPreserveSig() => throw new NotImplementedException();
+    }
+
+    [NativeMarshalling(typeof(StatelessFinallyTypeMarshaller))]
+    internal class StatelessFinallyType
+    {
+        public int I;
+    }
+
+    [CustomMarshaller(typeof(StatelessFinallyType), MarshalMode.Default, typeof(StatelessFinallyTypeMarshaller))]
+    internal static class StatelessFinallyTypeMarshaller
+    {
+        public static int FreeCount { get; private set; }
+        public static nint ConvertToUnmanaged(StatelessFinallyType managed) => managed.I;
+
+        public static StatelessFinallyType ConvertToManagedFinally(nint unmanaged) => new StatelessFinallyType { I = (int)unmanaged };
+
+        public static void Free(nint unmanaged) => FreeCount++;
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessMarshalling.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("4732FA5D-C105-4A23-87A7-58DCEDD4A9B3")]
+    internal partial interface IStatelessMarshalling
+    {
+        void Method([MarshalUsing(CountElementName = nameof(size))] StatelessType param, int size);
+        void MethodIn([MarshalUsing(CountElementName = nameof(size))] in StatelessType param, int size);
+        void MethodOut([MarshalUsing(CountElementName = nameof(size))] out StatelessType param, int size);
+        void MethodRef([MarshalUsing(CountElementName = nameof(size))] ref StatelessType param, int size);
+        StatelessType Return();
+        [PreserveSig]
+        StatelessType ReturnPreserveSig();
+    }
+
+    [GeneratedComClass]
+    internal partial class StatelessMarshalling : IStatelessMarshalling
+    {
+        public void Method([MarshalUsing(CountElementName = "size")] StatelessType param, int size) { }
+        public void MethodIn([MarshalUsing(CountElementName = "size")] in StatelessType param, int size) { }
+        public void MethodOut([MarshalUsing(CountElementName = "size")] out StatelessType param, int size) { param = new StatelessType { I = 42 }; }
+        public void MethodRef([MarshalUsing(CountElementName = "size")] ref StatelessType param, int size) { param = new StatelessType { I = 200 }; }
+        public StatelessType Return() => throw new NotImplementedException();
+        public StatelessType ReturnPreserveSig() => throw new NotImplementedException();
+    }
+
+    [NativeMarshalling(typeof(StatelessTypeMarshaller))]
+    internal class StatelessType
+    {
+        public int I;
+    }
+
+    [CustomMarshaller(typeof(StatelessType), MarshalMode.Default, typeof(StatelessTypeMarshaller))]
+    internal static class StatelessTypeMarshaller
+    {
+        public static int FreeCount { get; private set; }
+        public static nint ConvertToUnmanaged(StatelessType managed) => managed.I;
+
+        public static StatelessType ConvertToManaged(nint unmanaged) => new StatelessType { I = (int)unmanaged };
+
+        public static void Free(nint unmanaged) => FreeCount++;
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessPinnedMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessPinnedMarshalling.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("4732FA5D-C105-4A23-87A7-58DCEDD4A9B3")]
+    internal partial interface IStatelessPinnedMarshalling
+    {
+        void Method([MarshalUsing(CountElementName = nameof(size))] StatelessPinnedType param, int size);
+        void MethodIn([MarshalUsing(CountElementName = nameof(size))] in StatelessPinnedType param, int size);
+        void MethodOut([MarshalUsing(CountElementName = nameof(size))] out StatelessPinnedType param, int size);
+        void MethodRef([MarshalUsing(CountElementName = nameof(size))] ref StatelessPinnedType param, int size);
+        StatelessPinnedType Return();
+        [PreserveSig]
+        StatelessPinnedType ReturnPreserveSig();
+    }
+
+    [GeneratedComClass]
+    internal partial class StatelessPinnedMarshalling : IStatelessPinnedMarshalling
+    {
+        public void Method([MarshalUsing(CountElementName = "size")] StatelessPinnedType param, int size) { }
+        public void MethodIn([MarshalUsing(CountElementName = "size")] in StatelessPinnedType param, int size) { }
+        public void MethodOut([MarshalUsing(CountElementName = "size")] out StatelessPinnedType param, int size) { param = new StatelessPinnedType { I = 42 }; }
+        public void MethodRef([MarshalUsing(CountElementName = "size")] ref StatelessPinnedType param, int size) { param = new StatelessPinnedType { I = 200 }; }
+        public StatelessPinnedType Return() => throw new NotImplementedException();
+        public StatelessPinnedType ReturnPreserveSig() => throw new NotImplementedException();
+    }
+
+    [NativeMarshalling(typeof(StatelessPinnedTypeMarshaller))]
+    internal class StatelessPinnedType
+    {
+        public int I;
+    }
+
+    internal struct StatelessPinnedStruct
+    {
+        public int I;
+    }
+
+    [CustomMarshaller(typeof(StatelessPinnedType), MarshalMode.Default, typeof(StatelessPinnedTypeMarshaller))]
+    internal static class StatelessPinnedTypeMarshaller
+    {
+        public static int FreeCount { get; private set; }
+        public static nint ConvertToUnmanaged(StatelessPinnedType managed) => managed.I;
+
+        public static StatelessPinnedType ConvertToManaged(nint unmanaged) => new StatelessPinnedType { I = (int)unmanaged };
+
+        static StatelessPinnedStruct _field;
+        public static ref StatelessPinnedStruct GetPinnableReference(StatelessPinnedType unmanaged)
+        {
+            _field = new StatelessPinnedStruct() { I = unmanaged.I };
+            return ref _field;
+        }
+
+        public static void Free(nint unmanaged) => FreeCount++;
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStringMarshallingOverrideDerived.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStringMarshallingOverrideDerived.cs
@@ -2,20 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices.Marshalling;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace SharedTypes.ComInterfaces
 {
     [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf8)]
-    [Guid(_guid)]
+    [Guid(IID)]
     internal partial interface IStringMarshallingOverrideDerived : IStringMarshallingOverride
     {
-        public new const string _guid = "3AFFE3FD-D11E-4195-8250-0C73321977A0";
+        public new const string IID = "3AFFE3FD-D11E-4195-8250-0C73321977A0";
         string StringMarshallingUtf8_2(string input);
 
         [return: MarshalAs(UnmanagedType.LPWStr)]

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IUTF16Marshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IUTF16Marshalling.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices.Marshalling;
 
 namespace SharedTypes.ComInterfaces
 {
-    [Guid(_guid)]
+    [Guid(IID)]
     [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
     internal partial interface IUTF16Marshalling
     {
@@ -15,6 +15,6 @@ namespace SharedTypes.ComInterfaces
 
         public void SetString(string value);
 
-        public const string _guid = "E11D5F3E-DD57-41A6-A59E-7D110551A760";
+        public const string IID = "E11D5F3E-DD57-41A6-A59E-7D110551A760";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IUTF8Marshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IUTF8Marshalling.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices.Marshalling;
 
 namespace SharedTypes.ComInterfaces
 {
-    [Guid(_guid)]
+    [Guid(IID)]
     [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf8)]
     internal partial interface IUTF8Marshalling
     {
@@ -15,6 +15,6 @@ namespace SharedTypes.ComInterfaces
 
         public void SetString(string value);
 
-        public const string _guid = "E11D5F3E-DD57-41A6-A59E-7D110551A760";
+        public const string IID = "E11D5F3E-DD57-41A6-A59E-7D110551A760";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/MarshallingFails/ICollectionMarshallingFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/MarshallingFails/ICollectionMarshallingFails.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces.MarshallingFails
+{
+    [GeneratedComInterface]
+    [Guid("A4857395-06FB-4A6E-81DB-35461BE999C5")]
+    internal partial interface ICollectionMarshallingFails
+    {
+        [return: MarshalUsing(ConstantElementCount = 10)]
+        [return: MarshalUsing(typeof(ThrowOn4thElementMarshalled), ElementIndirectionDepth = 1)]
+        public int[] GetConstSize();
+
+        [return: MarshalUsing(CountElementName = nameof(size))]
+        [return: MarshalUsing(typeof(ThrowOn4thElementMarshalled), ElementIndirectionDepth = 1)]
+        public int[] Get(out int size);
+
+        public void Set(
+            [MarshalUsing(CountElementName = nameof(size))]
+            [MarshalUsing(typeof(ThrowOn4thElementMarshalled), ElementIndirectionDepth = 1)]
+            int[] value, int size);
+    }
+
+    [GeneratedComClass]
+    internal partial class ICollectionMarshallingFailsImpl : ICollectionMarshallingFails
+    {
+        int[] _data = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        public int[] Get(out int size)
+        {
+            size = _data.Length;
+            return _data;
+        }
+
+        [return: MarshalUsing(ConstantElementCount = 10), MarshalUsing(typeof(ThrowOn4thElementMarshalled), ElementIndirectionDepth = 1)]
+        public int[] GetConstSize() => new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+        public void Set(int[] value, int size)
+        {
+            _data = new int[size];
+            value.CopyTo(_data, 0);
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/MarshallingFails/IJaggedIntArrayMarshallingFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/MarshallingFails/IJaggedIntArrayMarshallingFails.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces.MarshallingFails
+{
+    [GeneratedComInterface]
+    [Guid("9FA4A8A9-3D8F-48A8-B6FB-B45B5F1B9FB6")]
+    internal partial interface IJaggedIntArrayMarshallingFails
+    {
+        [return: MarshalUsing(CountElementName = nameof(length)),
+            MarshalUsing(ElementIndirectionDepth = 1, CountElementName = nameof(widths)),
+            MarshalUsing(typeof(ThrowOn4thElementMarshalled), ElementIndirectionDepth = 2)]
+        int[][] Get(
+            [MarshalUsing(CountElementName = nameof(length))]
+            out int[] widths,
+            out int length);
+
+        int Get2(
+            [MarshalUsing(CountElementName = MarshalUsingAttribute.ReturnsCountValue),
+            MarshalUsing(ElementIndirectionDepth = 1, CountElementName = nameof(widths)),
+            MarshalUsing(typeof(ThrowOn4thElementMarshalled), ElementIndirectionDepth = 2)]
+            out int[][] array,
+            [MarshalUsing(CountElementName = MarshalUsingAttribute.ReturnsCountValue)]
+            out int[] widths);
+
+        [return: MarshalUsing(ConstantElementCount = 10),
+            MarshalUsing(ElementIndirectionDepth = 1, ConstantElementCount = 10),
+            MarshalUsing(typeof(ThrowOn4thElementMarshalled), ElementIndirectionDepth = 2)]
+        int[][] GetConstSize();
+
+        void Set(
+            [MarshalUsing(CountElementName = nameof(length)),
+            MarshalUsing(ElementIndirectionDepth = 1, CountElementName = nameof(widths)),
+            MarshalUsing(typeof(ThrowOn4thElementMarshalled), ElementIndirectionDepth = 2)]
+            int[][] array,
+            [MarshalUsing(CountElementName = nameof(length))]
+            int[] widths,
+            int length);
+    }
+
+    [GeneratedComClass]
+    internal partial class IJaggedIntArrayMarshallingFailsImpl : IJaggedIntArrayMarshallingFails
+    {
+        int[][] _data = new int[][] { new int[] { 1, 2, 3 }, new int[] { 4, 5 }, new int[] { 6, 7, 8, 9 } };
+        int[] _widths = new int[] { 3, 2, 4 };
+        public int[][] Get(out int[] widths, out int length)
+        {
+            widths = _widths;
+            length = _data.Length;
+            return _data;
+        }
+        public int Get2(out int[][] array, out int[] widths)
+        {
+            array = _data;
+            widths = _widths;
+            return array.Length;
+        }
+
+        [return: MarshalUsing(ConstantElementCount = 10), MarshalUsing(ElementIndirectionDepth = 1, ConstantElementCount = 10), MarshalUsing(typeof(ThrowOn4thElementMarshalled), ElementIndirectionDepth = 2)]
+        public int[][] GetConstSize()
+        {
+            int[][] values = new int[10][];
+            for (int i = 0; i < 10; i++)
+            {
+                values[i] = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            }
+            return values;
+        }
+
+        public void Set(int[][] array, int[] widths, int length)
+        {
+            _data = array;
+            _widths = widths;
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/MarshallingFails/IStringArrayMarshallingFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/MarshallingFails/IStringArrayMarshallingFails.cs
@@ -57,7 +57,7 @@ namespace SharedTypes.ComInterfaces.MarshallingFails
             if (++_marshalledCount == ThrowOnNthMarshalledElement)
             {
                 _marshalledCount = 0;
-                throw new ArgumentException("This marshaller throws on the Nth element marshalled where N = " + ThrowOnNthMarshalledElement);
+                throw new MarshallingFailureException("This marshaller throws on the Nth element marshalled where N = " + ThrowOnNthMarshalledElement);
             }
             return (nint)Utf8StringMarshaller.ConvertToUnmanaged(managed);
         }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/MarshallingFails/MarshallingFailureException.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/MarshallingFails/MarshallingFailureException.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace SharedTypes.ComInterfaces.MarshallingFails
+{
+    internal class MarshallingFailureException : Exception
+    {
+        public MarshallingFailureException() : base() { }
+        public MarshallingFailureException(string message) : base(message) { }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/MarshallingFails/ThrowOn4thElementMarshalled.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/MarshallingFails/ThrowOn4thElementMarshalled.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces.MarshallingFails
+{
+    [CustomMarshaller(typeof(int), MarshalMode.ElementIn, typeof(ThrowOn4thElementMarshalled))]
+    [CustomMarshaller(typeof(int), MarshalMode.ElementOut, typeof(ThrowOn4thElementMarshalled))]
+    internal static class ThrowOn4thElementMarshalled
+    {
+        static int _marshalledCount = 0;
+        static int _unmarshalledCount = 0;
+        public static int FreeCount { get; private set; }
+        public static nint ConvertToUnmanaged(int managed)
+        {
+            if (_marshalledCount++ == 3)
+            {
+                _marshalledCount = 0;
+                throw new MarshallingFailureException("The element was the 4th element (with 0-based index 3)");
+            }
+            return managed;
+        }
+
+        public static int ConvertToManaged(nint unmanaged)
+        {
+            if (_unmarshalledCount++ == 3)
+            {
+                _unmarshalledCount = 0;
+                throw new MarshallingFailureException("The element was the 4th element (with 0-based index 3)");
+            }
+            return (int)unmanaged;
+        }
+        public static void Free(nint unmanaged) => ++FreeCount;
+    }
+
+}


### PR DESCRIPTION
Moves the changes to the test types from https://github.com/dotnet/runtime/pull/89583 to a separate PR. All changes are to the tests, no changes to the source generator.