### PR TITLE
JIT: don't dead store OSR exposed locals

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -356,6 +356,12 @@ void Compiler::lvaInitTypeRef()
                 {
                     lvaSetVarAddrExposed(lclNum DEBUGARG(AddressExposedReason::OSR_EXPOSED));
                 }
+
+                // Ensure that ref counts for exposed OSR locals take into account
+                // that some of the refs might be in the Tier0 parts of the method
+                // that get trimmed away.
+                //
+                varDsc->lvImplicitlyReferenced = 1;
             }
         }
     }

--- a/src/tests/JIT/opt/OSR/Runtime_89666.cs
+++ b/src/tests/JIT/opt/OSR/Runtime_89666.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+public class Runtime_89666
+{
+    public static int Main()
+    {
+        byte[] a1 = new byte[100_000];
+        byte[] a2 = new byte[100_000];
+
+        Problem(a1.Length, a1);
+        Problem(a2.Length, a2);
+
+        for (int i = 0; i < a1.Length; i++)
+        {
+            if (a1[i] != a2[i])
+            {
+                Console.WriteLine($"Found diff at {i}: {a1[i]} != {a2[i]}");
+                return -1;
+            }
+        }
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Problem(int n, byte[] a)
+    {
+        Random random = new Random(1);
+        int value = 0;
+        Span<byte> span = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref value, 1));
+        for (int i = 0; i < n; i++)
+        {
+            // This write must be kept in the OSR method
+            value = random.Next();
+            Write(span, i, a);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Write(Span<byte> s, int i, byte[] a)
+    {
+        a[i] = s[0];
+    }
+}

--- a/src/tests/JIT/opt/OSR/Runtime_89666.csproj
+++ b/src/tests/JIT/opt/OSR/Runtime_89666.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TC_OnStackReplacement" Value="1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #89743 to 7.0.

## Customer Impact

Fixes customer reported issue #89666. 

Methods with loops might unexpectedly start running incorrectly after some time, because the runtime/JIT transitioned execution to a new native version via OSR, and in some rare cases the OSR method will not properly update a local variable.

## Testing

Verified test from #89666 case fixed, added new test based on the underlying problem. SPMI screening of this fix in main showed minimal diffs and no instances of the problem.

## Risk

Low, targeted fix for OSR that disable some optimizations.

The local var ref count for OSR locals can be misleading, since some of the appearances may be in the "tier0" parts of the methods and won't be visible once we trim the OSR method down to just the part we're going to compile.

Fix by giving OSR-exposed locals an implicit ref count; this prevents the JIT from inferring that a store to a local is not needed because the stored value cannot be read.