### PR TITLE
Expose the RequiresLocationAttribute

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -842,6 +842,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\PreserveBaseOverridesAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RefSafetyRulesAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RequiredMemberAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RequiresLocationAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RuntimeCompatibilityAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RuntimeFeature.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RuntimeFeature.NonNativeAot.cs" Condition="'$(FeatureNativeAot)' != 'true'" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RequiresLocationAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RequiresLocationAttribute.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved for use by a compiler for tracking metadata.
+    /// This attribute should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    public sealed class RequiresLocationAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute.</summary>
+        public RequiresLocationAttribute()
+        {
+        }
+    }
+}

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13042,6 +13042,12 @@ namespace System.Runtime.CompilerServices
     {
         public RequiredMemberAttribute() { }
     }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter, Inherited=false)]
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    public sealed partial class RequiresLocationAttribute : System.Attribute
+    {
+        public RequiresLocationAttribute() { }
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly, AllowMultiple=false)]
     public sealed partial class ReferenceAssemblyAttribute : System.Attribute
     {

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/AttributesTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/AttributesTests.cs
@@ -393,5 +393,11 @@ namespace System.Runtime.CompilerServices.Tests
             Assert.Equal("feature2", attr2.FeatureName);
             Assert.True(attr2.IsOptional);
         }
+
+        [Fact]
+        public static void RequiresLocationAttributeTests()
+        {
+            new RequiresLocationAttribute();
+        }
     }
 }


### PR DESCRIPTION
This resolves https://github.com/dotnet/runtime/issues/85910. It is necessary to avoid potential downstream issues with the use of the attribute as a `modreq` in `virtual members` and `function pointers`.