### PR TITLE
[wasm] Fix startup without emcc -g option

### DIFF
--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -457,7 +457,14 @@ function replace_linker_placeholders(
 ) {
     // the output from emcc contains wrappers for these linker imports which add overhead,
     //  but now we have what we need to replace them with the actual functions
-    const env = imports.env;
+    // By default the imports all live inside of 'env', but emscripten minification will rename it, typically to 'a'.
+    // See the entry for '-g' in https://emscripten.org/docs/tools_reference/emcc.html and
+    // https://github.com/emscripten-core/emscripten/blob/e929196ccaaddd5f0a2afce19cce4e4213c5590b/test/optimizer/test-js-optimizer-minifyGlobals-output.js#L51
+    const env = imports.env || imports.a;
+    if (!env) {
+        mono_log_warn("WARNING: Neither imports.env or imports.a were present when instantiating the wasm module. This likely indicates an emscripten configuration issue.");
+        return;
+    }
     for (const k in realFunctions) {
         const v = realFunctions[k];
         if (typeof (v) !== "function")

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -457,7 +457,7 @@ function replace_linker_placeholders(
 ) {
     // the output from emcc contains wrappers for these linker imports which add overhead,
     //  but now we have what we need to replace them with the actual functions
-    // By default the imports all live inside of 'env', but emscripten minification could rename to 'a'.
+    // By default the imports all live inside of 'env', but emscripten minification could rename it to 'a'.
     // See https://github.com/emscripten-core/emscripten/blob/c5d1a856592b788619be11bbdc1dd119dec4e24c/src/preamble.js#L933-L936
     const env = imports.env || imports.a;
     if (!env) {

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -457,9 +457,8 @@ function replace_linker_placeholders(
 ) {
     // the output from emcc contains wrappers for these linker imports which add overhead,
     //  but now we have what we need to replace them with the actual functions
-    // By default the imports all live inside of 'env', but emscripten minification will rename it, typically to 'a'.
-    // See the entry for '-g' in https://emscripten.org/docs/tools_reference/emcc.html and
-    // https://github.com/emscripten-core/emscripten/blob/e929196ccaaddd5f0a2afce19cce4e4213c5590b/test/optimizer/test-js-optimizer-minifyGlobals-output.js#L51
+    // By default the imports all live inside of 'env', but emscripten minification could rename to 'a'.
+    // See https://github.com/emscripten-core/emscripten/blob/c5d1a856592b788619be11bbdc1dd119dec4e24c/src/preamble.js#L933-L936
     const env = imports.env || imports.a;
     if (!env) {
         mono_log_warn("WARNING: Neither imports.env or imports.a were present when instantiating the wasm module. This likely indicates an emscripten configuration issue.");


### PR DESCRIPTION
In some configurations emscripten will minify the name of the module containing all of our imports, changing it from the hard-coded "env" to something else (typically "a"). This PR updates the startup code to check that second location and then if neither one is present, continue operating in a degraded mode with a warning.

cc @radical @pavelsavara 