### PR TITLE
[wasm][debugger] Avoid step out if JMC is enabled before runtime is ready

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -244,7 +244,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     {
                         if (JustMyCode)
                         {
-                            if (!Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context))
+                            if (!Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context) || !context.IsRuntimeReady)
                                 return false;
                             //avoid pausing when justMyCode is enabled and it's a wasm function
                             if (args?["callFrames"]?[0]?["scopeChain"]?[0]?["type"]?.Value<string>()?.Equals("wasm-expression-stack") == true)


### PR DESCRIPTION
Fixing side effect of #89741