### PR TITLE
Create temp directory for SuperPMI JIT when running crossgen2 collections

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -659,7 +659,8 @@ class SuperPMICollect:
             # Therefore, we produce a copy of the JIT binary for SuperPMI to use. 
             jit_name_ext = os.path.splitext(jit_name)[1]
             jit_name_without_ext = os.path.splitext(jit_name)[0]
-            self.superpmi_jit_path = os.path.join(coreclr_args.core_root, jit_name_without_ext + "_superpmi." + jit_name_ext)
+            self.superpmi_jit_path_temp_dir = tempfile.TemporaryDirectory()
+            self.superpmi_jit_path = os.path.join(self.superpmi_jit_path_temp_dir.name, jit_name_without_ext + "_superpmi" + jit_name_ext)
             shutil.copyfile(self.jit_path, self.superpmi_jit_path)
         else:
             self.superpmi_jit_path = self.jit_path
@@ -790,7 +791,7 @@ class SuperPMICollect:
 
         # Cleanup the copy of the JIT binary.
         if self.coreclr_args.crossgen2 and not self.coreclr_args.skip_cleanup:
-            os.remove(self.superpmi_jit_path)
+            self.superpmi_jit_path_temp_dir.cleanup()
 
         return passed
 

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -665,7 +665,6 @@ class SuperPMICollect:
                 shutil.copyfile(self.jit_path, self.superpmi_jit_path)
             except Exception:
                 # Fallback to original JIT path if we are not able to make a copy.
-                self.superpmi_jit_path.cleanup()
                 self.superpmi_jit_path = self.jit_path
         else:
             self.superpmi_jit_path = self.jit_path

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -659,7 +659,7 @@ class SuperPMICollect:
             # Therefore, we produce a copy of the JIT binary for SuperPMI to use. 
             jit_name_ext = os.path.splitext(jit_name)[1]
             jit_name_without_ext = os.path.splitext(jit_name)[0]
-            self.superpmi_jit_path_temp_dir = tempfile.TemporaryDirectory()
+            self.superpmi_jit_path_temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
             try:
                 self.superpmi_jit_path = os.path.join(self.superpmi_jit_path_temp_dir.name, jit_name_without_ext + "_superpmi" + jit_name_ext)
                 shutil.copyfile(self.jit_path, self.superpmi_jit_path)

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -665,6 +665,8 @@ class SuperPMICollect:
         else:
             self.superpmi_jit_path = self.jit_path
 
+        logging.info("SuperPMI JIT Path: %s", self.superpmi_jit_path)
+
         self.superpmi_path = determine_superpmi_tool_path(coreclr_args)
         self.mcs_path = determine_mcs_tool_path(coreclr_args)
 

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -660,8 +660,13 @@ class SuperPMICollect:
             jit_name_ext = os.path.splitext(jit_name)[1]
             jit_name_without_ext = os.path.splitext(jit_name)[0]
             self.superpmi_jit_path_temp_dir = tempfile.TemporaryDirectory()
-            self.superpmi_jit_path = os.path.join(self.superpmi_jit_path_temp_dir.name, jit_name_without_ext + "_superpmi" + jit_name_ext)
-            shutil.copyfile(self.jit_path, self.superpmi_jit_path)
+            try:
+                self.superpmi_jit_path = os.path.join(self.superpmi_jit_path_temp_dir.name, jit_name_without_ext + "_superpmi" + jit_name_ext)
+                shutil.copyfile(self.jit_path, self.superpmi_jit_path)
+            except Exception:
+                # Fallback to original JIT path if we are not able to make a copy.
+                self.superpmi_jit_path.cleanup()
+                self.superpmi_jit_path = self.jit_path
         else:
             self.superpmi_jit_path = self.jit_path
 

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -750,7 +750,6 @@ class SuperPMICollect:
                         self.superpmi_jit_path = os.path.join(self.temp_location, jit_name_without_ext + "_superpmi" + jit_name_ext)
                         shutil.copyfile(self.jit_path, self.superpmi_jit_path)
                     except Exception:
-                        logging.info(self.superpmi_jit_path)
                         # Fallback to original JIT path if we are not able to make a copy.
                         self.superpmi_jit_path = self.jit_path
                 else:

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -659,9 +659,8 @@ class SuperPMICollect:
             # Therefore, we produce a copy of the JIT binary for SuperPMI to use. 
             jit_name_ext = os.path.splitext(jit_name)[1]
             jit_name_without_ext = os.path.splitext(jit_name)[0]
-            self.superpmi_jit_path_temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
             try:
-                self.superpmi_jit_path = os.path.join(self.superpmi_jit_path_temp_dir.name, jit_name_without_ext + "_superpmi" + jit_name_ext)
+                self.superpmi_jit_path = os.path.join(self.temp_location, jit_name_without_ext + "_superpmi" + jit_name_ext)
                 shutil.copyfile(self.jit_path, self.superpmi_jit_path)
             except Exception:
                 # Fallback to original JIT path if we are not able to make a copy.
@@ -794,10 +793,6 @@ class SuperPMICollect:
 
         if passed:
             logging.info("Generated MCH file: %s", self.final_mch_file)
-
-        # Cleanup the copy of the JIT binary.
-        if self.coreclr_args.crossgen2 and not self.coreclr_args.skip_cleanup:
-            self.superpmi_jit_path_temp_dir.cleanup()
 
         return passed
 

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -654,21 +654,6 @@ class SuperPMICollect:
 
         jit_name = get_jit_name(coreclr_args)
         self.jit_path = os.path.join(coreclr_args.core_root, jit_name)
-        if coreclr_args.crossgen2:
-            # There are issues when running SuperPMI and crossgen2 when using the same JIT binary. 
-            # Therefore, we produce a copy of the JIT binary for SuperPMI to use. 
-            jit_name_ext = os.path.splitext(jit_name)[1]
-            jit_name_without_ext = os.path.splitext(jit_name)[0]
-            try:
-                self.superpmi_jit_path = os.path.join(self.temp_location, jit_name_without_ext + "_superpmi" + jit_name_ext)
-                shutil.copyfile(self.jit_path, self.superpmi_jit_path)
-            except Exception:
-                # Fallback to original JIT path if we are not able to make a copy.
-                self.superpmi_jit_path = self.jit_path
-        else:
-            self.superpmi_jit_path = self.jit_path
-
-        logging.info("SuperPMI JIT Path: %s", self.superpmi_jit_path)
 
         self.superpmi_path = determine_superpmi_tool_path(coreclr_args)
         self.mcs_path = determine_mcs_tool_path(coreclr_args)
@@ -754,6 +739,24 @@ class SuperPMICollect:
                 self.base_mch_file = os.path.join(temp_location, "base.mch")
 
                 self.temp_location = temp_location
+
+                if self.coreclr_args.crossgen2:
+                    jit_name = os.path.basename(self.jit_path)
+                    # There are issues when running SuperPMI and crossgen2 when using the same JIT binary. 
+                    # Therefore, we produce a copy of the JIT binary for SuperPMI to use. 
+                    jit_name_ext = os.path.splitext(jit_name)[1]
+                    jit_name_without_ext = os.path.splitext(jit_name)[0]
+                    try:
+                        self.superpmi_jit_path = os.path.join(self.temp_location, jit_name_without_ext + "_superpmi" + jit_name_ext)
+                        shutil.copyfile(self.jit_path, self.superpmi_jit_path)
+                    except Exception:
+                        logging.info(self.superpmi_jit_path)
+                        # Fallback to original JIT path if we are not able to make a copy.
+                        self.superpmi_jit_path = self.jit_path
+                else:
+                    self.superpmi_jit_path = self.jit_path
+
+                logging.info("SuperPMI JIT Path: %s", self.superpmi_jit_path)
 
                 # If we have passed temp_dir, then we have a few flags we need
                 # to check to see where we are in the collection process. Note that this


### PR DESCRIPTION
Should resolve https://github.com/dotnet/runtime/issues/89851.

This re-uses the temporary directory for SuperPMI collections to store a copy of the JIT binary when doing crossgen2 SuperPMI collections. If this fails, it will fallback to the original JIT binary.