### PR TITLE
[PERF] Setup scheduled once a day runs rather than constant runs 

### DIFF
--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -1,27 +1,27 @@
 jobs:
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+# - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
 
-  # build mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - linux_x64
+#   # build mono
+#   - template: /eng/pipelines/common/platform-matrix.yml
+#     parameters:
+#       jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+#       runtimeFlavor: mono
+#       buildConfig: release
+#       platforms:
+#       - linux_x64
 
-  # build coreclr and libraries
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      buildConfig: release
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
+#   # build coreclr and libraries
+#   - template: /eng/pipelines/common/platform-matrix.yml
+#     parameters:
+#       jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+#       buildConfig: release
+#       platforms:
+#       - linux_x64
+#       jobParameters:
+#         testGroup: perf
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public')) }}: # notin(variables['Build.Reason'], 'Schedule') # Temporarily remove schedule filter since we are now running on schedule runs (Same for above schedule section)
 
   # build coreclr and libraries
   - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -21,7 +21,7 @@ jobs:
 #       jobParameters:
 #         testGroup: perf
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public')) }}: # notin(variables['Build.Reason'], 'Schedule') # Temporarily remove schedule filter since we are now running on schedule runs (Same for above schedule section)
+- ${{ if ne(variables['System.TeamProject'], 'public') }}: # notin(variables['Build.Reason'], 'Schedule') # Temporarily remove schedule filter since we are now running on schedule runs (Same for above schedule section)
 
   # build coreclr and libraries
   - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -23,13 +23,13 @@ variables:
 
 # Run at 10:00AM () every night to give plenty of time to rerun if errors occur
 schedules:
-- cron: "00 10 * * *"
-  displayName: Every day at 10:00AM UTC (3AM PDT)
-  branches:
-    include:
-    - main
-  always: true
-  batch: true
+  - cron: "00 10 * * *"
+    displayName: Every day at 10:00AM UTC (3AM PDT)
+    branches:
+      include:
+      - main
+    always: true
+    batch: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -41,9 +41,9 @@ extends:
       - template: /eng/pipelines/coreclr/perf-wasm-jobs.yml
         parameters:
           collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
-          ${{ and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
-            runProfile: 'non-v8'
-          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
+          # ${{ and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+          #   runProfile: 'non-v8'
+          ${{ if ne(variables['System.TeamProject'], 'public') }}: # , notin(variables['Build.Reason'], 'Schedule')
             runProfile: 'v8'
 
       - template: /eng/pipelines/coreclr/perf-non-wasm-jobs.yml

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -1,8 +1,9 @@
+
 trigger:
   batch: true
   branches:
     include:
-    - main
+    #- main # Temporarily disable trigger while the ubuntu queue is backed up
     - release/*
   paths:
     include:
@@ -20,20 +21,15 @@ trigger:
 variables:
   - template: /eng/pipelines/common/variables.yml
 
-#
-# For the 'schedule' case, only wasm/jsc perf jobs are run.
-# And the rest are build jobs - wasm, mono, coreclr, and libraries.
-#
-# Since, we are not running *any* perf jobs, none of these builds are needed,
-# thus the whole scheduled run can be disabled.
-#
-#schedules:
-#- cron: "30 2 * * *"
-  #displayName: Every night at 2:30AM
-  #branches:
-    #include:
-    #- main
-  #always: true
+# Run at 10:00AM () every night to give plenty of time to rerun if errors occur
+schedules:
+- cron: "00 10 * * *"
+  displayName: Every day at 10:00AM UTC (3AM PDT)
+  branches:
+    include:
+    - main
+  always: true
+  batch: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml


### PR DESCRIPTION
Setup scheduled once a day runs rather than constant runs to help keep our queues under control during version upgrades.
Manually triggered run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2235134&view=results. Everything should match what the schedule will run (also shows no yaml formatting problems).