### PR TITLE
Escape both CR and LF in IL disassembler

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/ILDisassembler.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/ILDisassembler.cs
@@ -156,6 +156,8 @@ namespace Internal.IL
                     sb.Append("\\\"");
                 else if (s[i] == '\n')
                     sb.Append("\\n");
+                else if (s[i] == '\r')
+                    sb.Append("\\r");
                 else
                     sb.Append(s[i]);
             }


### PR DESCRIPTION
Noticed this because lines were off with `--ildump`.

Cc @dotnet/ilc-contrib 