### PR TITLE
Pass through ComWrappers based objects to COM type descriptor

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace System.ComponentModel
@@ -1539,6 +1540,17 @@ namespace System.ComponentModel
 
                 if (type.IsCOMObject)
                 {
+                    type = ComObjectType;
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    && ComWrappers.TryGetComInstance(instance, out nint unknown))
+                {
+                    // ComObjectType uses the Windows Forms provided ComNativeDescriptor. It currently has hard Win32
+                    // API dependencies. Even though ComWrappers work with other platforms, restricting to Windows until
+                    // such time that the ComNativeDescriptor can handle basic COM types on other platforms.
+                    //
+                    // Tracked with https://github.com/dotnet/winforms/issues/9291
+                    Marshal.Release(unknown);
                     type = ComObjectType;
                 }
 


### PR DESCRIPTION
WinForms hosts the the COM type descriptor. It has been updated to work with ComWrappers based objects- adding the check for them in TypeDescriptor.

There are hard dependencies on Windows in the current implementation. We can potentially update to conditionalize these. https://github.com/dotnet/winforms/issues/9291 tracks.

There is no automated test as it would require adding a dependency upstream to WinForms.

cc: @ericstj @AaronRobinsonMSFT 