### PR TITLE
[wasm] Fix condition to use latest chrome for testing

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -178,6 +178,7 @@ jobs:
       include:
       - eng/Version.Details.xml
       - eng/Versions.props
+        eng/testing/ProvisioningVersions.props
       - eng/testing/scenarios/BuildWasmAppsJobsList.txt
       - eng/testing/workloads-testing.targets
       - src/installer/pkg/sfx/Microsoft.NETCore.App/*

--- a/eng/testing/ProvisioningVersions.props
+++ b/eng/testing/ProvisioningVersions.props
@@ -45,6 +45,8 @@
     <!-- To use a specific version, set ChromeFindLatestAvailableVersion=false,
          and set the version, and revisions in the propertygroup below -->
     <!--<ChromeFindLatestAvailableVersion>false</ChromeFindLatestAvailableVersion>-->
+
+    <ChromeFindLatestAvailableVersion Condition="'$(ChromeFindLatestAvailableVersion)' == ''">true</ChromeFindLatestAvailableVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Use specific version of chrome" Condition="'$(ChromeFindLatestAvailableVersion)' != 'true' and $([MSBuild]::IsOSPlatform('linux'))">

--- a/src/mono/wasm/runtime/marshal.ts
+++ b/src/mono/wasm/runtime/marshal.ts
@@ -331,7 +331,10 @@ export class ManagedError extends Error implements IDisposable {
 
     getSuperStack() {
         if (this.superStack) {
-            return this.superStack.value;
+            if (this.superStack.value !== undefined)
+                return this.superStack.value;
+            if (this.superStack.get !== undefined)
+                return this.superStack.get.call(this);
         }
         return super.stack; // this works on FF
     }


### PR DESCRIPTION
The condition to pick the latest version was incorrect, thus we have still been using the previous version `113`, instead of the latest `115`.

Also:
- trigger Wasm.Build.Tests when `ProvisioningVersions.props` changes.
- generating stack traces broke with the latest chrome update (`115.*`), which is fixed here