### PR TITLE
Serialize createdump core dump generation

### DIFF
--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -413,7 +413,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
 
     PROCNotifyProcessShutdown(IsRunningOnAlternateStack(context));
 
-    PROCCreateCrashDumpIfEnabled(code, siginfo);
+    PROCCreateCrashDumpIfEnabled(code, siginfo, true);
 }
 
 /*++
@@ -746,7 +746,7 @@ static void sigterm_handler(int code, siginfo_t *siginfo, void *context)
         DWORD val = 0;
         if (enableDumpOnSigTerm.IsSet() && enableDumpOnSigTerm.TryAsInteger(10, val) && val == 1)
         {
-            PROCCreateCrashDumpIfEnabled(code, siginfo);
+            PROCCreateCrashDumpIfEnabled(code, siginfo, false);
         }
         // g_pSynchronizationManager shouldn't be null if PAL is initialized.
         _ASSERTE(g_pSynchronizationManager != nullptr);

--- a/src/coreclr/pal/src/include/pal/process.h
+++ b/src/coreclr/pal/src/include/pal/process.h
@@ -178,10 +178,12 @@ Function:
 
 Parameters:
   signal - POSIX signal number
+  siginfo - POSIX signal info or nullptr
+  serialize - allow only one thread to generate core dump
 
 (no return value)
 --*/
-VOID PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo);
+VOID PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo, bool serialize);
 
 /*++
 Function:

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2205,7 +2205,7 @@ PROCCreateCrashDump(
             _ASSERTE(previousThreadId != currentThreadId);
 
             // The first thread generates the crash info and any other threads are blocked
-            SleepEx(INFINITE, FALSE);
+            poll(NULL, 0, INFTIM);
 
             return false;
         }

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2327,7 +2327,7 @@ PROCSerializedCreateCrashDump(
     else
     {
         // Should never reenter or recurse
-        _ASSERTE(previousThreadId != currentThreadId)
+        _ASSERTE(previousThreadId != currentThreadId);
 
         // The first thread generates the crash info and any other threads are blocked
         Sleep(INFINITE);


### PR DESCRIPTION
Only allow one thread at a time to generate a core dump.

Issue: https://github.com/dotnet/runtime/issues/82989