### PR TITLE
Use `StoreAligned` not `Store` in WidenAsciiToUtf16

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -2472,7 +2472,7 @@ namespace System.Text
                     nuint finalOffsetWhereCanRunLoop = elementCount - (uint)Vector128<byte>.Count;
 
                     Vector128<byte> asciiVector = Vector128.Load(pAsciiBuffer + currentOffset);
-                    if (asciiVector.ExtractMostSignificantBits() == 0)
+                    if (!VectorContainsNonAsciiChar(asciiVector))
                     {
                         (Vector128<ushort> utf16LowVector, Vector128<ushort> utf16HighVector) = Vector128.Widen(asciiVector);
                         utf16LowVector.Store(pCurrentWriteAddress);
@@ -2490,7 +2490,7 @@ namespace System.Text
                         {
                             asciiVector = Vector128.Load(pAsciiBuffer + currentOffset);
 
-                            if (asciiVector.ExtractMostSignificantBits() != 0)
+                            if (VectorContainsNonAsciiChar(asciiVector))
                             {
                                 break;
                             }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -895,7 +895,7 @@ namespace System.Text
             // Only run the loop if we have at least two vectors we can pull out.
             if (Vector512.IsHardwareAccelerated && bufferLength >= 2 * (uint)Vector512<ushort>.Count)
             {
-                const uint SizeOfVector512InChars = Vector512.Size / sizeof(char);
+                const uint SizeOfVector512InChars = Vector512.Size / sizeof(ushort);
 
                 if (!VectorContainsNonAsciiChar(Vector512.Load((ushort*)pBuffer)))
                 {
@@ -931,7 +931,7 @@ namespace System.Text
             }
             else if (Vector256.IsHardwareAccelerated && bufferLength >= 2 * (uint)Vector256<ushort>.Count)
             {
-                const uint SizeOfVector256InChars = Vector256.Size / sizeof(char);
+                const uint SizeOfVector256InChars = Vector256.Size / sizeof(ushort);
 
                 if (!VectorContainsNonAsciiChar(Vector256.Load((ushort*)pBuffer)))
                 {
@@ -967,7 +967,7 @@ namespace System.Text
             }
             else if (Vector128.IsHardwareAccelerated && bufferLength >= 2 * (uint)Vector128<ushort>.Count)
             {
-                const uint SizeOfVector128InChars = Vector128.Size / sizeof(char); // JIT will make this a const
+                const uint SizeOfVector128InChars = Vector128.Size / sizeof(ushort); // JIT will make this a const
 
                 if (!VectorContainsNonAsciiChar(Vector128.Load((ushort*)pBuffer)))
                 {


### PR DESCRIPTION
## Description

This PR is to improve the in-loop `write` logic in `WidenAsciiToUtf16`, the major change is to replace `StoreAligned` with `Store` inside the loop to reduce the penalty caused by split loads.

We are open to adjusting the implementation style for either path. Perf number attached in the comments.