### PR TITLE
Improve zlib defenses on mono

### DIFF
--- a/src/native/external/zlib.cmake
+++ b/src/native/external/zlib.cmake
@@ -31,7 +31,7 @@ set(ZLIB_SOURCES_BASE
 
 # enable custom zlib allocator
 add_definitions(-DMY_ZCALLOC)
-if(CLR_CMAKE_HOST_WIN32)
+if(HOST_WIN32 OR CLR_CMAKE_TARGET_WIN32)
     set(ZLIB_SOURCES_BASE ${ZLIB_SOURCES_BASE} ../../libs/System.IO.Compression.Native/zlib_allocator_win.c)
 else()
     set(ZLIB_SOURCES_BASE ${ZLIB_SOURCES_BASE} ../../libs/System.IO.Compression.Native/zlib_allocator_unix.c)


### PR DESCRIPTION
Improvement to https://github.com/dotnet/runtime/pull/84604. See also https://github.com/dotnet/runtime/pull/89532#issuecomment-1660911628.

Mono doesn't define the same CMAKE variables as coreclr, so mono was picking up the Unix-style defenses, even when producing a Windows compilation unit. This change allows both mono and coreclr to pick up the same protections.

This pattern is based on the existing file:

https://github.com/dotnet/runtime/blob/d099f075e45d2aa6007a22b71b45a08758559f80/src/native/eventpipe/CMakeLists.txt#L98-L101.