### PR TITLE
Fix IsFixupPrecodeByASM and StubPrecode::IsStubPrecodeByASM

### DIFF
--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -662,7 +662,15 @@ BOOL StubPrecode::IsStubPrecodeByASM(PCODE addr)
             *(WORD*)(pInstr + 5) == *(WORD*)((BYTE*)StubPrecodeCode + 5) &&
             *(DWORD*)(pInstr + SYMBOL_VALUE(StubPrecodeCode_Target_Offset)) == (DWORD)(pInstr + GetStubCodePageSize() + offsetof(StubPrecodeData, Target));
 #else // TARGET_X86
-    return memcmp(pInstr, (void*)PCODEToPINSTR((PCODE)StubPrecodeCode), (BYTE*)StubPrecodeCode_End - (BYTE*)StubPrecodeCode) == 0;
+    BYTE *pTemplateInstr = (BYTE*)PCODEToPINSTR((PCODE)StubPrecodeCode);
+    BYTE *pTemplateInstrEnd = (BYTE*)PCODEToPINSTR((PCODE)StubPrecodeCode_End);
+    while ((pTemplateInstr < pTemplateInstrEnd) && (*pInstr == *pTemplateInstr))
+    {
+        pInstr++;
+        pTemplateInstr++;
+    }
+
+    return pTemplateInstr == pTemplateInstrEnd;
 #endif // TARGET_X86
 }
 
@@ -779,7 +787,15 @@ BOOL FixupPrecode::IsFixupPrecodeByASM(PCODE addr)
         *(WORD*)(pInstr + 11) == *(WORD*)((BYTE*)FixupPrecodeCode + 11) &&
         *(DWORD*)(pInstr + SYMBOL_VALUE(FixupPrecodeCode_PrecodeFixupThunk_Offset)) == (DWORD)(pInstr + GetStubCodePageSize() + offsetof(FixupPrecodeData, PrecodeFixupThunk));
 #else // TARGET_X86
-    return memcmp(pInstr, (void*)PCODEToPINSTR((PCODE)FixupPrecodeCode), (BYTE*)FixupPrecodeCode_End - (BYTE*)FixupPrecodeCode) == 0;
+    BYTE *pTemplateInstr = (BYTE*)PCODEToPINSTR((PCODE)FixupPrecodeCode);
+    BYTE *pTemplateInstrEnd = (BYTE*)PCODEToPINSTR((PCODE)FixupPrecodeCode_End);
+    while ((pTemplateInstr < pTemplateInstrEnd) && (*pInstr == *pTemplateInstr))
+    {
+        pInstr++;
+        pTemplateInstr++;
+    }
+
+    return pTemplateInstr == pTemplateInstrEnd;
 #endif // TARGET_X86
 }
 


### PR DESCRIPTION
These functions use memcmp that can internally be optimized by vectorization. It can thus read more bytes than necessary for the purpose of this function. In edge cases it can end up reading from unmapped memory and crashing with access violation.

The fix is to compare the data byte by byte and early out as soon as a mismatch is found.

Close #87012