### PR TITLE
[release/7.0-staging][wasm] runtime: Fix creating the stack trace for a ManagedError

### DIFF
--- a/eng/testing/ProvisioningVersions.props
+++ b/eng/testing/ProvisioningVersions.props
@@ -9,9 +9,10 @@
     the same snapshot might not be available in both of them.
   -->
   <PropertyGroup Condition="'$(BrowserHost)' != 'windows'">
-    <ChromiumRevision>972765</ChromiumRevision>
-    <ChromiumUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/$(ChromiumRevision)/chrome-linux.zip</ChromiumUrl>
-    <ChromeDriverUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/$(ChromiumRevision)/chromedriver_linux64.zip</ChromeDriverUrl>
+    <ChromiumRevision>1148114</ChromiumRevision>
+    <!-- 115.0.5790.170 -->
+    <ChromiumUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1148123/chrome-linux.zip</ChromiumUrl>
+    <ChromeDriverUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1148123/chromedriver_linux64.zip</ChromeDriverUrl>
     <ChromiumDirName>chrome-linux</ChromiumDirName>
     <ChromeDriverDirName>chromedriver_linux64</ChromeDriverDirName>
     <ChromiumBinaryName>chrome</ChromiumBinaryName>
@@ -21,9 +22,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BrowserHost)' == 'windows'">
-    <ChromiumRevision>972766</ChromiumRevision>
-    <ChromiumUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/$(ChromiumRevision)/chrome-win.zip</ChromiumUrl>
-    <ChromeDriverUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/$(ChromiumRevision)/chromedriver_win32.zip</ChromeDriverUrl>
+    <ChromiumRevision>1148114</ChromiumRevision>
+    <!-- 115.0.5790.170 -->
+    <ChromiumUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1148119/chrome-win.zip</ChromiumUrl>
+    <ChromeDriverUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1148119/chromedriver_win32.zip</ChromeDriverUrl>
     <ChromiumDirName>chrome-win</ChromiumDirName>
     <ChromeDriverDirName>chromedriver_win32</ChromeDriverDirName>
     <ChromiumBinaryName>chrome.exe</ChromiumBinaryName>

--- a/src/mono/wasm/runtime/marshal.ts
+++ b/src/mono/wasm/runtime/marshal.ts
@@ -327,7 +327,10 @@ export class ManagedError extends Error implements IDisposable {
 
     getSuperStack() {
         if (this.superStack) {
-            return this.superStack.value;
+            if (this.superStack.value !== undefined)
+                return this.superStack.value;
+            if (this.superStack.get !== undefined)
+                return this.superStack.get.call(this);
         }
         return super.stack; // this works on FF
     }


### PR DESCRIPTION
Backport of a fix from https://github.com/dotnet/runtime/pull/89890

cc @kg

## Customer impact

With the latest stable version of chrome (`115.*`), some of the errors thrown for exceptions can be missing the original exception message, and the native stack. This fixes the issue.

### Details

With the latest chrome (`115.*`) the following code in `runtime/marshal.ts` fails because `this.superStack.value` is no longer available:

```js
    getSuperStack() {
        if (this.superStack) {
            return this.superStack.value;
        }
        return super.stack; // this works on FF
    }
```

This causes the final error to not have the original managed error message, and also have a `"undefined"` at the end of the string.

Truncated error missing the native part of the stack, and the message:
```
   at System.Runtime.InteropServices.JavaScript.Tests.JavaScriptTestHelper.ThrowFromJSExport(String message)
   at System.Runtime.InteropServices.JavaScript.Tests.JavaScriptTestHelper.__Wrapper_ThrowFromJSExport_271731536(JSMarshalerArgument* __arguments_buffer)
undefined
```

With the fix:
```
   at System.Runtime.InteropServices.JavaScript.Tests.JavaScriptTestHelper.ThrowFromJSExport(String message)
   at System.Runtime.InteropServices.JavaScript.Tests.JavaScriptTestHelper.__Wrapper_ThrowFromJSExport_817705034(JSMarshalerArgument* __arguments_buffer)
Error: -t-e-s-t-
    at sr (http://127.0.0.1:60345/_framework/dotnet.runtime.js:3:33284)
    at Br (http://127.0.0.1:60345/_framework/dotnet.runtime.js:3:42679)
    at http://127.0.0.1:60345/_framework/dotnet.runtime.js:3:40825
    at Module.catch1stack (http://127.0.0.1:60345/JavaScriptTestHelper.mjs:132:9)
    at http://127.0.0.1:60345/_framework/dotnet.runtime.js:3:36627
    at mr (http://127.0.0.1:60345/_framework/dotnet.runtime.js:3:37821)
    at do_icall (http://127.0.0.1:60345/_framework/dotnet.native.wasm:wasm-function[221]:0x19711)
    at do_icall_wrapper (http://127.0.0.1:60345/_framework/dotnet.native.wasm:wasm-function[108]:0x157bc)
    at mono_interp_exec_method (http://127.0.0.1:60345/_framework/dotnet.native.wasm:wasm-function[101]:0x9c92)
    at interp_runtime_invoke (http://127.0.0.1:60345/_framework/dotnet.native.wasm:wasm-function[141]:0x16cd7)
```

Thanks to @kg for the fix.

(cherry picked from commit 89f6429fcf8a065971dd1a0646c4a8b98d0d2116)

## Testing

This has been tested with manual, and automated tests on `main`. FIXME: Testing pending on 7.0-staging

## Risk

Low. This fixes a regression in behavior caused by a new chrome update.