### PR TITLE
[ocsp stapling] reject incorrect http response if the status code is not 2xx

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
+++ b/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
@@ -180,6 +180,11 @@ namespace System.Net.Http
                     while (true)
                     {
                         int statusCode = (int)responseStatusCodeProp.GetValue(responseMessage)!;
+                        if (statusCode < 200 || statusCode >= 300)
+                        {
+                            return null;
+                        }
+
                         object responseHeaders = responseHeadersProp.GetValue(responseMessage)!;
                         Uri? location = (Uri?)responseHeadersLocationProp.GetValue(responseHeaders);
                         redirectUri = GetUriForRedirect((Uri)requestUriProp.GetValue(requestMessage)!, statusCode, location, out hasRedirect);


### PR DESCRIPTION
Draft a possible fix for https://github.com/dotnet/runtime/issues/89907