### PR TITLE
Trigger a rebuild if ILC command line changes

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -195,7 +195,6 @@ The .NET Foundation licenses this file to you under the MIT license.
   </Target>
 
   <Target Name="WriteIlcRspFileForCompilation"
-      Inputs="@(IlcCompileInput);@(RdXmlFile);@(TrimmerRootDescriptor)"
       Outputs="%(ManagedBinary.IlcRspFile)"
       DependsOnTargets="$(IlcCompileDependsOn)">
 


### PR DESCRIPTION
Incremental build wouldn't consider things like `OptimizationPreference` property changing as a thing that should trigger a rebuild. I feel like this is more a MSBuild bug, but it has been like this for a long time.

Turns out we can use `WriteIlcRspFileForCompilation` target as a sentinel:

* Run the target always. We only actually write out the file if it's different (`WriteOnlyWhenDifferent` is already set to `true`).
* ILC execution already specifies the RSP as one of its inputs. So if the RSP is more recent than the output, it will trigger a build.

Fixes #88725.

Cc @dotnet/ilc-contrib 