### PR TITLE
Fix BinSkim scan in nightly validation

### DIFF
--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -1,6 +1,5 @@
 -SourceToolsList @("policheck","credscan")
 -ArtifactToolsList @("binskim")
--BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True")
 -TsaInstanceURL https://devdiv.visualstudio.com/
 -TsaProjectName DEVDIV
 -TsaNotificationEmail runtimerepo-infra@microsoft.com


### PR DESCRIPTION
My previous PR [Enabling BinSkim scan in nightly validation pipeline](https://github.com/dotnet/runtime/pull/89728) had a problem - `BinskimAdditionalRunConfigParams` is already specified in the yml templates which caused a error
This fixes it