### PR TITLE
Fixed Enumerator variable null check

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs
@@ -689,27 +689,24 @@ namespace Internal.TypeSystem
 
             public bool MoveNext()
             {
-                if (_sentinel != null)
+                if ((_sentinel != null) && (_hashtableContentsToEnumerate != null))
                 {
-                    if ((_hashtableContentsToEnumerate != null) && (_index < _hashtableContentsToEnumerate.Length))
+                    for (; _index < _hashtableContentsToEnumerate.Length; _index++)
                     {
-                        for (; _index < _hashtableContentsToEnumerate.Length; _index++)
+                        if ((_hashtableContentsToEnumerate[_index] != null) && (_hashtableContentsToEnumerate[_index] != _sentinel))
                         {
-                            if ((_hashtableContentsToEnumerate[_index] != null) && (_hashtableContentsToEnumerate[_index] != _sentinel))
-                            {
-                                _current = _hashtableContentsToEnumerate[_index];
-                                _index++;
-                                return true;
-                            }
+                            _current = _hashtableContentsToEnumerate[_index];
+                            _index++;
+                            return true;
                         }
                     }
-                }
 
-                if ((_index == _hashtableContentsToEnumerate.Length) && _sentinel != null)
-                {
-                    _current = _sentinel;
-                    _index++;
-                    return true;
+                    if (_index == _hashtableContentsToEnumerate.Length)
+                    {
+                        _current = _sentinel;
+                        _index++;
+                        return true;
+                    }
                 }
 
                 _current = default(TValue);


### PR DESCRIPTION
Fixed error when _hashtableContentsToEnumerate is null. 
Error will always appear when this variable is null when using 'Length' property. 

Also reduced nesting.

The error was detected using the Svace analyzer maded by ISP RAS.