### PR TITLE
Disable failing outerloop tests and fix a build issue in MonoAOTCompiler

### DIFF
--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskRunSyncTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskRunSyncTests.cs
@@ -524,6 +524,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/89921", typeof(PlatformDetection), nameof(PlatformDetection.IsAlpine), nameof(PlatformDetection.IsMonoRuntime))]
         [OuterLoop]
         public static void TaskRunSyncTest15()
         {
@@ -541,6 +542,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/89921", typeof(PlatformDetection), nameof(PlatformDetection.IsAlpine), nameof(PlatformDetection.IsMonoRuntime))]
         [OuterLoop]
         public static void TaskRunSyncTest17()
         {
@@ -550,6 +552,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/89921", typeof(PlatformDetection), nameof(PlatformDetection.IsAlpine), nameof(PlatformDetection.IsMonoRuntime))]
         [OuterLoop]
         public static void TaskRunSyncTest18()
         {
@@ -558,6 +561,7 @@ namespace System.Threading.Tasks.Tests
             test.RealRun();
         }
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/89921", typeof(PlatformDetection), nameof(PlatformDetection.IsAlpine), nameof(PlatformDetection.IsMonoRuntime))]
         [OuterLoop]
         public static void TaskRunSyncTest19()
         {
@@ -567,6 +571,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/89921", typeof(PlatformDetection), nameof(PlatformDetection.IsAlpine), nameof(PlatformDetection.IsMonoRuntime))]
         [OuterLoop]
         public static void TaskRunSyncTest20()
         {
@@ -591,6 +596,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/89921", typeof(PlatformDetection), nameof(PlatformDetection.IsAlpine), nameof(PlatformDetection.IsMonoRuntime))]
         [OuterLoop]
         public static void TaskRunSyncTest23()
         {

--- a/src/libraries/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs
@@ -211,6 +211,7 @@ namespace System.Threading.Tasks.Tests
 
         [Fact]
         [OuterLoop]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/89921", typeof(PlatformDetection), nameof(PlatformDetection.IsAlpine), nameof(PlatformDetection.IsMonoRuntime))]
         public static void RunSynchronizationContextTaskSchedulerTests()
         {
             // Remember the current SynchronizationContext, so that we can restore it

--- a/src/tasks/AndroidAppBuilder/Templates/monodroid.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid.c
@@ -367,7 +367,7 @@ Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_
     for (int i = 0; i < args_len; ++i)
     {
         jstring j_arg = (*env)->GetObjectArrayElement(env, j_args, i);
-        managed_argv[i + 1] = (*env)->GetStringUTFChars(env, j_arg, NULL);
+        managed_argv[i + 1] = (char*)((*env)->GetStringUTFChars(env, j_arg, NULL));
     }
 
     int res = mono_droid_runtime_init (executable, managed_argc, managed_argv, current_local_time);

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -1106,7 +1106,8 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
                 {
                     writer.WriteLine($"extern void *{symbol};");
                 }
-                writer.WriteLine("void register_aot_modules ()");
+                writer.WriteLine("void register_aot_modules (void);");
+                writer.WriteLine("void register_aot_modules (void)");
                 writer.WriteLine("{");
                 foreach (var symbol in symbols)
                 {
@@ -1142,6 +1143,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
                     writer.WriteLine($"extern void *{symbol};");
                 }
 
+                writer.WriteLine("void register_aot_modules (void);");
                 writer.WriteLine("void register_aot_modules (void)");
                 writer.WriteLine("{");
                 foreach (var symbol in symbols)


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/89921 for the test failures.

Additionally, the Android build was failing while compiling an AOT test due to this error:

```
/__w/1/s/artifacts/bin/Android.Device_Emulator.Aot.Test/Release/net8.0/android-x64/AppBundle/modules.c:51:6: error: no previous prototype for function 'register_aot_modules' [-Werror,-Wmissing-prototypes]
void register_aot_modules ()
     ^
```

This is because we turned on `-Werror=missing-prototypes` in https://github.com/dotnet/runtime/pull/89197 but the MonoAOTCompiler didn't emit a function prototype in modules.c

Fixes https://github.com/dotnet/runtime/issues/89566