### PR TITLE
Disable objc_msgSend stubs in clang

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -504,6 +504,17 @@ if (CLR_CMAKE_HOST_UNIX)
   # using twos-complement representation (this is normally undefined according to the C++ spec).
   add_compile_options(-fwrapv)
 
+  if(CLR_CMAKE_HOST_APPLE)
+    # Clang will by default emit objc_msgSend stubs in Xcode 14, which ld from earlier Xcodes doesn't understand.
+    # We disable this by passing -fno-objc-msgsend-selector-stubs to clang.
+    # We can probably remove this flag once we require developers to use Xcode 14.
+    # Ref: https://github.com/xamarin/xamarin-macios/issues/16223
+    check_c_compiler_flag(-fno-objc-msgsend-selector-stubs COMPILER_SUPPORTS_FNO_OBJC_MSGSEND_SELECTOR_STUBS)
+    if(COMPILER_SUPPORTS_FNO_OBJC_MSGSEND_SELECTOR_STUBS)
+      set(CLR_CMAKE_COMMON_OBJC_FLAGS "${CLR_CMAKE_COMMON_OBJC_FLAGS} -fno-objc-msgsend-selector-stubs")
+    endif()
+  endif()
+
   if(CLR_CMAKE_HOST_OSX OR CLR_CMAKE_HOST_MACCATALYST)
     # We cannot enable "stack-protector-strong" on OS X due to a bug in clang compiler (current version 7.0.2)
     add_compile_options(-fstack-protector)

--- a/src/native/libs/System.Globalization.Native/CMakeLists.txt
+++ b/src/native/libs/System.Globalization.Native/CMakeLists.txt
@@ -94,6 +94,7 @@ endif()
 
 if (CLR_CMAKE_TARGET_APPLE)
     set(NATIVEGLOBALIZATION_SOURCES ${NATIVEGLOBALIZATION_SOURCES} pal_locale.m pal_collation.m pal_casing.m)
+    set_source_files_properties(pal_locale.m pal_collation.m pal_casing.m PROPERTIES COMPILE_FLAGS ${CLR_CMAKE_COMMON_OBJC_FLAGS})
 endif()
 
 # time zone names are filtered out of icu data for the browser and associated functionality is disabled

--- a/src/native/libs/System.Native/CMakeLists.txt
+++ b/src/native/libs/System.Native/CMakeLists.txt
@@ -68,13 +68,14 @@ endif()
 
 if (CLR_CMAKE_TARGET_APPLE)
     list (APPEND NATIVE_SOURCES pal_autoreleasepool.m)
-    set_source_files_properties(pal_autoreleasepool.m PROPERTIES COMPILE_FLAGS -fno-objc-arc)
+    set_source_files_properties(pal_autoreleasepool.m PROPERTIES COMPILE_FLAGS "-fno-objc-arc ${CLR_CMAKE_COMMON_OBJC_FLAGS}")
 else()
     list (APPEND NATIVE_SOURCES pal_autoreleasepool.c)
 endif()
 
 if (CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
     list (APPEND NATIVE_SOURCES pal_environment.m)
+    set_source_files_properties(pal_environment.m PROPERTIES COMPILE_FLAGS ${CLR_CMAKE_COMMON_OBJC_FLAGS})
 else()
     list (APPEND NATIVE_SOURCES pal_environment.c)
 endif()
@@ -82,17 +83,20 @@ endif()
 if (CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
     set(NATIVE_SOURCES ${NATIVE_SOURCES}
         pal_datetime.m)
+    set_source_files_properties(pal_datetime.m PROPERTIES COMPILE_FLAGS ${CLR_CMAKE_COMMON_OBJC_FLAGS})
 endif()
 
 if (CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
     set(NATIVE_SOURCES ${NATIVE_SOURCES}
         pal_log.m
         pal_searchpath.m)
+    set_source_files_properties(pal_log.m pal_searchpath.m PROPERTIES COMPILE_FLAGS ${CLR_CMAKE_COMMON_OBJC_FLAGS})
 elseif (CLR_CMAKE_TARGET_OSX)
     list (APPEND NATIVE_SOURCES
         pal_searchpath.m
         pal_console.c
         pal_log.c)
+    set_source_files_properties(pal_searchpath.m PROPERTIES COMPILE_FLAGS ${CLR_CMAKE_COMMON_OBJC_FLAGS})
 elseif (CLR_CMAKE_TARGET_WASI)
     list (APPEND NATIVE_SOURCES
         pal_searchpath.c
@@ -108,6 +112,7 @@ endif ()
 if (CLR_CMAKE_TARGET_MACCATALYST)
     set(NATIVE_SOURCES ${NATIVE_SOURCES}
         pal_iossupportversion.m)
+    set_source_files_properties(pal_iossupportversion.m PROPERTIES COMPILE_FLAGS ${CLR_CMAKE_COMMON_OBJC_FLAGS})
 else ()
     list (APPEND NATIVE_SOURCES
         pal_iossupportversion.c)


### PR DESCRIPTION
Applies the same fix as https://github.com/xamarin/xamarin-macios/pull/16231.

We recently started seeing the same issue in our runtime builds, see https://github.com/dotnet/runtime/issues/89925. This is because the AzDO build machines use Xcode 14 now but the Helix machines are still using Xcode 13 so linking an Xcode-14-built static library fails.

This happens in e.g. libSystem.Native.a or libSystem.Globalization.Native.a (the two libraries where we're using Objective-C).

Fixes https://github.com/dotnet/runtime/issues/89925