### PR TITLE
[wasm] WBT: Use project ids that are safe for use as identifiers

### DIFF
--- a/src/mono/wasi/Wasi.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasi/Wasi.Build.Tests/BuildTestBase.cs
@@ -637,6 +637,8 @@ namespace Wasm.Build.Tests
                 _buildContext.RemoveFromCache(_projectDir, keepDir: s_skipProjectCleanup);
         }
 
+        public static string GetRandomId() => TestUtils.FixupSymbolName(Path.GetRandomFileName());
+
         private static string GetEnvironmentVariableOrDefault(string envVarName, string defaultValue)
         {
             string? value = Environment.GetEnvironmentVariable(envVarName);

--- a/src/mono/wasi/Wasi.Build.Tests/WasiTemplateTests.cs
+++ b/src/mono/wasi/Wasi.Build.Tests/WasiTemplateTests.cs
@@ -25,7 +25,7 @@ public class WasiTemplateTests : BuildTestBase
     [InlineData("Release")]
     public void ConsoleBuildThenPublish(string config)
     {
-        string id = $"{config}_{Path.GetRandomFileName()}";
+        string id = $"{config}_{GetRandomId()}";
         string projectFile = CreateWasmTemplateProject(id, "wasiconsole");
         string projectName = Path.GetFileNameWithoutExtension(projectFile);
         File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_simpleMainWithArgs);
@@ -88,7 +88,7 @@ public class WasiTemplateTests : BuildTestBase
     [MemberData(nameof(TestDataForConsolePublishAndRun))]
     public void ConsolePublishAndRunForSingleFileBundle(string config, bool relinking, bool invariantTimezone)
     {
-        string id = $"{config}_{Path.GetRandomFileName()}";
+        string id = $"{config}_{GetRandomId()}";
         string projectFile = CreateWasmTemplateProject(id, "wasiconsole");
         string projectName = Path.GetFileNameWithoutExtension(projectFile);
         File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_simpleMainWithArgs);

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/AppsettingsTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/AppsettingsTests.cs
@@ -21,7 +21,7 @@ public class AppsettingsTests : BlazorWasmTestBase
     [Fact]
     public async Task FileInVfs()
     {
-        string id = $"blazor_{Path.GetRandomFileName()}";
+        string id = $"blazor_{GetRandomId()}";
         string projectFile = CreateWasmTemplateProject(id, "blazorwasm");
 
         string projectDirectory = Path.GetDirectoryName(projectFile)!;

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
@@ -27,7 +27,7 @@ public class BuildPublishTests : BlazorWasmTestBase
     [InlineData("Release")]
     public async Task DefaultTemplate_WithoutWorkload(string config)
     {
-        string id = $"blz_no_workload_{config}_{Path.GetRandomFileName()}_{s_unicodeChar}";
+        string id = $"blz_no_workload_{config}_{GetRandomId()}_{s_unicodeChar}";
         CreateBlazorWasmTemplateProject(id);
 
         BlazorBuild(new BlazorBuildOptions(id, config));
@@ -45,8 +45,8 @@ public class BuildPublishTests : BlazorWasmTestBase
         // disable relinking tests for Unicode: github.com/emscripten-core/emscripten/issues/17817
         // [ActiveIssue("https://github.com/dotnet/runtime/issues/83497")]
         string id = config == "Release" ?
-            $"blz_no_aot_{config}_{Path.GetRandomFileName()}" :
-            $"blz_no_aot_{config}_{Path.GetRandomFileName()}_{s_unicodeChar}";
+            $"blz_no_aot_{config}_{GetRandomId()}" :
+            $"blz_no_aot_{config}_{GetRandomId()}_{s_unicodeChar}";
         CreateBlazorWasmTemplateProject(id);
 
         BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.FromRuntimePack));
@@ -68,7 +68,7 @@ public class BuildPublishTests : BlazorWasmTestBase
     [InlineData("Release", true)]
     public void DefaultTemplate_CheckFingerprinting(string config, bool expectFingerprintOnDotnetJs)
     {
-        string id = $"blz_checkfingerprinting_{config}_{Path.GetRandomFileName()}";
+        string id = $"blz_checkfingerprinting_{config}_{GetRandomId()}";
 
         CreateBlazorWasmTemplateProject(id);
 
@@ -172,7 +172,7 @@ public class BuildPublishTests : BlazorWasmTestBase
     [Fact]
     public void BugRegression_60479_WithRazorClassLib()
     {
-        string id = $"blz_razor_lib_top_{Path.GetRandomFileName()}";
+        string id = $"blz_razor_lib_top_{GetRandomId()}";
         InitBlazorWasmProjectDir(id);
 
         string wasmProjectDir = Path.Combine(_projectDir!, "wasm");
@@ -227,7 +227,7 @@ public class BuildPublishTests : BlazorWasmTestBase
     [InlineData("Release")]
     public async Task BlazorBuildRunTest(string config)
     {
-        string id = $"blazor_{config}_{Path.GetRandomFileName()}";
+        string id = $"blazor_{config}_{GetRandomId()}";
         string projectFile = CreateWasmTemplateProject(id, "blazorwasm");
 
         BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.FromRuntimePack));
@@ -241,7 +241,7 @@ public class BuildPublishTests : BlazorWasmTestBase
     [InlineData("Release", true)]
     public async Task BlazorPublishRunTest(string config, bool aot)
     {
-        string id = $"blazor_{config}_{Path.GetRandomFileName()}";
+        string id = $"blazor_{config}_{GetRandomId()}";
         string projectFile = CreateWasmTemplateProject(id, "blazorwasm");
         if (aot)
             AddItemsPropertiesToProject(projectFile, "<RunAOTCompilation>true</RunAOTCompilation>");

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/CleanTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/CleanTests.cs
@@ -25,7 +25,7 @@ public class CleanTests : BlazorWasmTestBase
     [InlineData("Release")]
     public void Blazor_BuildThenClean_NativeRelinking(string config)
     {
-        string id = Path.GetRandomFileName();
+        string id = GetRandomId();
 
         InitBlazorWasmProjectDir(id);
         string projectFile = CreateBlazorWasmTemplateProject(id);
@@ -63,7 +63,7 @@ public class CleanTests : BlazorWasmTestBase
 
     private void Blazor_BuildNativeNonNative_ThenCleanTest(string config, bool firstBuildNative)
     {
-        string id = Path.GetRandomFileName();
+        string id = GetRandomId();
 
         InitBlazorWasmProjectDir(id);
         string projectFile = CreateBlazorWasmTemplateProject(id);

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
@@ -24,7 +24,7 @@ public class MiscTests : BlazorWasmTestBase
     [InlineData("Release", false)]
     public void NativeBuild_WithDeployOnBuild_UsedByVS(string config, bool nativeRelink)
     {
-        string id = $"blz_deploy_on_build_{config}_{nativeRelink}_{Path.GetRandomFileName()}";
+        string id = $"blz_deploy_on_build_{config}_{nativeRelink}_{GetRandomId()}";
         string projectFile = CreateProjectWithNativeReference(id);
         string extraProperties = config == "Debug"
                                     ? ("<EmccLinkOptimizationFlag>-O1</EmccLinkOptimizationFlag>" +
@@ -57,7 +57,7 @@ public class MiscTests : BlazorWasmTestBase
     [InlineData("Release")]
     public void DefaultTemplate_AOT_InProjectFile(string config)
     {
-        string id = $"blz_aot_prj_file_{config}_{Path.GetRandomFileName()}";
+        string id = $"blz_aot_prj_file_{config}_{GetRandomId()}";
         string projectFile = CreateBlazorWasmTemplateProject(id);
 
         string extraProperties = config == "Debug"

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests2.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests2.cs
@@ -51,7 +51,7 @@ public class MiscTests2 : BlazorWasmTestBase
 
     private CommandResult PublishForRequiresWorkloadTest(string config, string extraItems="", string extraProperties="")
     {
-        string id = $"needs_workload_{config}_{Path.GetRandomFileName()}";
+        string id = $"needs_workload_{config}_{GetRandomId()}";
         CreateBlazorWasmTemplateProject(id);
 
         AddItemsPropertiesToProject(Path.Combine(_projectDir!, $"{id}.csproj"),

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/NativeRefTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/NativeRefTests.cs
@@ -23,7 +23,7 @@ public class NativeTests : BlazorWasmTestBase
     [ActiveIssue("https://github.com/dotnet/runtime/issues/82725")]
     public void WithNativeReference_AOTInProjectFile(string config)
     {
-        string id = $"blz_nativeref_aot_{config}_{Path.GetRandomFileName()}";
+        string id = $"blz_nativeref_aot_{config}_{GetRandomId()}";
         string projectFile = CreateProjectWithNativeReference(id);
         string extraProperties = config == "Debug"
                                     ? ("<EmccLinkOptimizationFlag>-O1</EmccLinkOptimizationFlag>" +
@@ -45,7 +45,7 @@ public class NativeTests : BlazorWasmTestBase
     [ActiveIssue("https://github.com/dotnet/runtime/issues/82725")]
     public void WithNativeReference_AOTOnCommandLine(string config)
     {
-        string id = $"blz_nativeref_aot_{config}_{Path.GetRandomFileName()}";
+        string id = $"blz_nativeref_aot_{config}_{GetRandomId()}";
         string projectFile = CreateProjectWithNativeReference(id);
         string extraProperties = config == "Debug"
                                     ? ("<EmccLinkOptimizationFlag>-O1</EmccLinkOptimizationFlag>" +
@@ -66,7 +66,7 @@ public class NativeTests : BlazorWasmTestBase
     [InlineData("Release")]
     public void BlazorWasm_CanRunMonoAOTCross_WithNoTrimming(string config)
     {
-        string id = $"blazorwasm_{config}_aot_{Path.GetRandomFileName()}";
+        string id = $"blazorwasm_{config}_aot_{GetRandomId()}";
         CreateBlazorWasmTemplateProject(id);
 
         // We don't want to emcc compile, and link ~180 assemblies!

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/NoopNativeRebuildTest.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/NoopNativeRebuildTest.cs
@@ -23,7 +23,7 @@ namespace Wasm.Build.Tests.Blazor
         [InlineData("Release")]
         public void BlazorNoopRebuild(string config)
         {
-            string id = $"blz_rebuild_{config}_{Path.GetRandomFileName()}";
+            string id = $"blz_rebuild_{config}_{GetRandomId()}";
             string projectFile = CreateBlazorWasmTemplateProject(id);
             AddItemsPropertiesToProject(projectFile, extraProperties: "<WasmBuildNative>true</WasmBuildNative>");
 
@@ -50,7 +50,7 @@ namespace Wasm.Build.Tests.Blazor
         [InlineData("Release")]
         public void BlazorOnlyLinkRebuild(string config)
         {
-            string id = $"blz_relink_{config}_{Path.GetRandomFileName()}";
+            string id = $"blz_relink_{config}_{GetRandomId()}";
             string projectFile = CreateBlazorWasmTemplateProject(id);
             AddItemsPropertiesToProject(projectFile, extraProperties: "<WasmBuildNative>true</WasmBuildNative>");
 

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleMultiThreadedTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleMultiThreadedTests.cs
@@ -26,7 +26,7 @@ public class SimpleMultiThreadedTests : BlazorWasmTestBase
     // [InlineData("Release")]
     // public async Task BlazorBuildRunTest(string config)
     // {
-    //     string id = $"blazor_mt_{config}_{Path.GetRandomFileName()}";
+    //     string id = $"blazor_mt_{config}_{GetRandomId()}";
     //     string projectFile = CreateWasmTemplateProject(id, "blazorwasm");
 
     //     AddItemsPropertiesToProject(projectFile, "<WasmEnableThreads>true</WasmEnableThreads>");
@@ -44,7 +44,7 @@ public class SimpleMultiThreadedTests : BlazorWasmTestBase
     // [InlineData("Release", true)]
     public async Task BlazorPublishRunTest(string config, bool aot)
     {
-        string id = $"blazor_mt_{config}_{Path.GetRandomFileName()}";
+        string id = $"blazor_mt_{config}_{GetRandomId()}";
         string projectFile = CreateWasmTemplateProject(id, "blazorwasm");
         AddItemsPropertiesToProject(projectFile, "<WasmEnableThreads>true</WasmEnableThreads>");
         // if (aot)

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -576,35 +576,7 @@ namespace Wasm.Build.Tests
                 _buildContext.RemoveFromCache(_projectDir, keepDir: s_skipProjectCleanup);
         }
 
-        public static string GetRandomId() => FixupSymbolName(Path.GetRandomFileName());
-
-        public static string FixupSymbolName(string name)
-        {
-            UTF8Encoding utf8 = new();
-            byte[] bytes = utf8.GetBytes(name);
-            StringBuilder sb = new();
-
-            foreach (byte b in bytes)
-            {
-                if ((b >= (byte)'0' && b <= (byte)'9') ||
-                    (b >= (byte)'a' && b <= (byte)'z') ||
-                    (b >= (byte)'A' && b <= (byte)'Z') ||
-                    (b == (byte)'_'))
-                {
-                    sb.Append((char)b);
-                }
-                else if (s_charsToReplace.Contains((char)b))
-                {
-                    sb.Append('_');
-                }
-                else
-                {
-                    sb.Append($"_{b:X}_");
-                }
-            }
-
-            return sb.ToString();
-        }
+        public static string GetRandomId() => TestUtils.FixupSymbolName(Path.GetRandomFileName());
 
         internal BuildPaths GetBuildPaths(BuildArgs buildArgs, bool forPublish = true)
         {

--- a/src/mono/wasm/Wasm.Build.Tests/Common/HelperExtensions.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Common/HelperExtensions.cs
@@ -93,11 +93,11 @@ namespace Wasm.Build.Tests
         {
             IEnumerable<object?> hostsEnumerable = hosts.Enumerate();
             if (hosts == RunHost.None)
-                return data.Select(d => d.Append((object?) Path.GetRandomFileName()));
+                return data.Select(d => d.Append((object?) BuildTestBase.GetRandomId()));
 
             return data.SelectMany(d =>
             {
-                string runId = Path.GetRandomFileName();
+                string runId = BuildTestBase.GetRandomId();
                 return hostsEnumerable.Select(o =>
                         d.Append((object?)o)
                          .Append((object?)runId));

--- a/src/mono/wasm/Wasm.Build.Tests/Common/TestUtils.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Common/TestUtils.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Xunit;
 using Xunit.Sdk;
 
@@ -81,5 +82,34 @@ public static class TestUtils
         throw new AssertActualExpectedException(
             expected, actual,
             $"[{label}]\n");
+    }
+
+    private static readonly char[] s_charsToReplace = new[] { '.', '-', '+' };
+    public static string FixupSymbolName(string name)
+    {
+        UTF8Encoding utf8 = new();
+        byte[] bytes = utf8.GetBytes(name);
+        StringBuilder sb = new();
+
+        foreach (byte b in bytes)
+        {
+            if ((b >= (byte)'0' && b <= (byte)'9') ||
+                (b >= (byte)'a' && b <= (byte)'z') ||
+                (b >= (byte)'A' && b <= (byte)'Z') ||
+                (b == (byte)'_'))
+            {
+                sb.Append((char)b);
+            }
+            else if (s_charsToReplace.Contains((char)b))
+            {
+                sb.Append('_');
+            }
+            else
+            {
+                sb.Append($"_{b:X}_");
+            }
+        }
+
+        return sb.ToString();
     }
 }

--- a/src/mono/wasm/Wasm.Build.Tests/NonWasmTemplateBuildTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NonWasmTemplateBuildTests.cs
@@ -98,7 +98,7 @@ public class NonWasmTemplateBuildTests : TestMainJsTestBase
                                      string? directoryBuildTargets = null,
                                      bool shouldRun = true)
     {
-        string id = $"nonwasm_{targetFramework}_{config}_{Path.GetRandomFileName()}";
+        string id = $"nonwasm_{targetFramework}_{config}_{GetRandomId()}";
         InitPaths(id);
         InitProjectDir(_projectDir);
 

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/NativeBuildTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/NativeBuildTests.cs
@@ -22,7 +22,7 @@ namespace Wasm.Build.Templates.Tests
         [InlineData(false)]
         public void BuildWithUndefinedNativeSymbol(bool allowUndefined)
         {
-            string id = $"UndefinedNativeSymbol_{(allowUndefined ? "allowed" : "disabled")}_{Path.GetRandomFileName()}";
+            string id = $"UndefinedNativeSymbol_{(allowUndefined ? "allowed" : "disabled")}_{GetRandomId()}";
 
             string code = @"
                 using System;
@@ -67,7 +67,7 @@ namespace Wasm.Build.Templates.Tests
         [InlineData("Release")]
         public void ProjectWithDllImportsRequiringMarshalIlGen_ArrayTypeParameter(string config)
         {
-            string id = $"dllimport_incompatible_{Path.GetRandomFileName()}";
+            string id = $"dllimport_incompatible_{GetRandomId()}";
             string projectPath = CreateWasmTemplateProject(id, template: "wasmconsole");
 
             string nativeSourceFilename = "incompatible_type.c";

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTests.cs
@@ -86,7 +86,7 @@ namespace Wasm.Build.Tests
         [InlineData("Release")]
         public void BrowserBuildThenPublish(string config)
         {
-            string id = $"browser_{config}_{Path.GetRandomFileName()}";
+            string id = $"browser_{config}_{GetRandomId()}";
             string projectFile = CreateWasmTemplateProject(id, "wasmbrowser");
             string projectName = Path.GetFileNameWithoutExtension(projectFile);
 
@@ -131,7 +131,7 @@ namespace Wasm.Build.Tests
         [InlineData("Release")]
         public void ConsoleBuildThenPublish(string config)
         {
-            string id = $"{config}_{Path.GetRandomFileName()}";
+            string id = $"{config}_{GetRandomId()}";
             string projectFile = CreateWasmTemplateProject(id, "wasmconsole");
             string projectName = Path.GetFileNameWithoutExtension(projectFile);
 
@@ -196,7 +196,7 @@ namespace Wasm.Build.Tests
 
         private void ConsoleBuildAndRun(string config, bool relinking, string extraNewArgs, string expectedTFM)
         {
-            string id = $"{config}_{Path.GetRandomFileName()}";
+            string id = $"{config}_{GetRandomId()}";
             string projectFile = CreateWasmTemplateProject(id, "wasmconsole", extraNewArgs);
             string projectName = Path.GetFileNameWithoutExtension(projectFile);
 
@@ -262,7 +262,7 @@ namespace Wasm.Build.Tests
 
         private async Task BrowserRunTwiceWithAndThenWithoutBuildAsync(string config, string extraProperties = "", bool runOutsideProjectDirectory = false)
         {
-            string id = $"browser_{config}_{Path.GetRandomFileName()}";
+            string id = $"browser_{config}_{GetRandomId()}";
             string projectFile = CreateWasmTemplateProject(id, "wasmbrowser");
 
             UpdateBrowserMainJs(DefaultTargetFramework);
@@ -295,7 +295,7 @@ namespace Wasm.Build.Tests
 
         private Task ConsoleRunWithAndThenWithoutBuildAsync(string config, string extraProperties = "", bool runOutsideProjectDirectory = false)
         {
-            string id = $"console_{config}_{Path.GetRandomFileName()}";
+            string id = $"console_{config}_{GetRandomId()}";
             string projectFile = CreateWasmTemplateProject(id, "wasmconsole");
 
             UpdateProgramCS();
@@ -358,7 +358,7 @@ namespace Wasm.Build.Tests
         [MemberData(nameof(TestDataForConsolePublishAndRun))]
         public void ConsolePublishAndRun(string config, bool aot, bool relinking)
         {
-            string id = $"{config}_{Path.GetRandomFileName()}";
+            string id = $"{config}_{GetRandomId()}";
             string projectFile = CreateWasmTemplateProject(id, "wasmconsole");
             string projectName = Path.GetFileNameWithoutExtension(projectFile);
 
@@ -416,7 +416,7 @@ namespace Wasm.Build.Tests
         public async Task BrowserBuildAndRun(string extraNewArgs, string targetFramework, string runtimeAssetsRelativePath)
         {
             string config = "Debug";
-            string id = $"browser_{config}_{Path.GetRandomFileName()}";
+            string id = $"browser_{config}_{GetRandomId()}";
             CreateWasmTemplateProject(id, "wasmbrowser", extraNewArgs);
 
             UpdateBrowserMainJs(targetFramework, runtimeAssetsRelativePath);

--- a/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/AppTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/AppTestBase.cs
@@ -25,7 +25,7 @@ public abstract class AppTestBase : BlazorWasmTestBase
 
     protected void CopyTestAsset(string assetName, string generatedProjectNamePrefix = null)
     {
-        Id = $"{generatedProjectNamePrefix ?? assetName}_{Path.GetRandomFileName()}";
+        Id = $"{generatedProjectNamePrefix ?? assetName}_{GetRandomId()}";
         InitBlazorWasmProjectDir(Id);
 
         LogPath = Path.Combine(s_buildEnv.LogRootPath, Id);

--- a/src/mono/wasm/Wasm.Build.Tests/WasmNativeDefaultsTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmNativeDefaultsTests.cs
@@ -93,7 +93,7 @@ namespace Wasm.Build.Tests
                                         insertAtEnd: printValueTarget);
 
             (_, string output) = BuildProject(buildArgs,
-                                                id: Path.GetRandomFileName(),
+                                                id: GetRandomId(),
                                                 new BuildProjectOptions(
                                                     InitProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_mainReturns42),
                                                     DotnetWasmFromRuntimePack: dotnetWasmFromRuntimePack,

--- a/src/mono/wasm/Wasm.Build.Tests/WasmSIMDTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmSIMDTests.cs
@@ -107,7 +107,7 @@ namespace Wasm.Build.Tests
         [InlineData("Release", /*aot*/false, /*publish*/true)]
         public void BuildWithSIMDNeedsWorkload(string config, bool aot, bool publish)
         {
-            string id = Path.GetRandomFileName();
+            string id = GetRandomId();
             string projectName = $"simd_no_workload_{config}_aot_{aot}";
             BuildArgs buildArgs = new
             (


### PR DESCRIPTION
For every test project, a random id is used which is
`Path.GetRandomFileName()`. In some cases this `id` gets used in a
generated C/C# source file, and that can cause failures.

For example the following fails with:

```
blz_checkfingerprinting_Release_zqkzgkui.ref/Program.cs(3,48): error CS1001: Identifier expected [/root/helix/work/workitem/e/wbt/blz_checkfingerprinting_Release_zqkzgkui.ref/blz_checkfingerprinting_Release_zqkzgkui.ref.csproj]
blz_checkfingerprinting_Release_zqkzgkui.ref/Program.cs(3,48): error CS1002: ; expected [/root/helix/work/workitem/e/wbt/blz_checkfingerprinting_Release_zqkzgkui.ref/blz_checkfingerprinting_Release_zqkzgkui.ref.csproj]
blz_checkfingerprinting_Release_zqkzgkui.ref/Program.cs(3,51): error CS1031: Type expected [/root/helix/work/workitem/e/wbt/blz_checkfingerprinting_Release_zqkzgkui.ref/blz_checkfingerprinting_Release_zqkzgkui.ref.csproj]
```

because the id, `blz_checkfingerprinting_Release_zqkzgkui.ref`, was used
as a namespace (line 3).

```
using Microsoft.AspNetCore.Components.Web;
using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
using blz_checkfingerprinting_Release_zqkzgkui.ref;
```

Fix up the generated random ids to make them safer. The code is taken
from `WasmAppBuilder/ManagedToNativeGenerator.cs`.

Fixes https://github.com/dotnet/runtime/issues/86533 .
