### PR TITLE
Fix build race condition in ILLink.Tasks

### DIFF
--- a/eng/testing/linker/SupportFiles/Directory.Build.props
+++ b/eng/testing/linker/SupportFiles/Directory.Build.props
@@ -3,7 +3,7 @@
   <!-- Use live illink bits. It is necessary to both import the package props and override
        the tasks assembly, because the live package props in the build output do not use
        the same layout as the NuGet package. -->
-  <Import Project="$(ToolsILLinkDir)build/Microsoft.NET.ILLink.Tasks.props" />
+  <Import Project="$(ToolsILLinkDir)$(NetCoreAppToolCurrent)/build/Microsoft.NET.ILLink.Tasks.props" />
   <PropertyGroup>
     <ILLinkTasksAssembly>$(ToolsILLinkDir)$(NetCoreAppToolCurrent)/ILLink.Tasks.dll</ILLinkTasksAssembly>
   </PropertyGroup>

--- a/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -30,9 +30,9 @@
     <!-- Note: 'build/Microsoft.NET.ILLink.targets' should not match the package name, because we don't want the targets
          to be imported by nuget. The SDK will import them in the right order. -->
     <Content Include="**\*.props;**\*.targets" Pack="true" PackagePath="%(RecursiveDir)%(Filename)%(Extension)"
-             CopyToOutputDirectory="PreserveNewest" TargetPath="../%(RecursiveDir)%(Filename)%(Extension)" />
+             CopyToOutputDirectory="PreserveNewest" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" />
     <Content Include="..\ILLink.RoslynAnalyzer\build\**\*.props" Pack="true" PackagePath="build/%(RecursiveDir)%(Filename)%(Extension)"
-             CopyToOutputDirectory="PreserveNewest" TargetPath="../build/%(RecursiveDir)%(Filename)%(Extension)" />
+             CopyToOutputDirectory="PreserveNewest" TargetPath="build/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Avoid copying props/targets to the same output location for different TFMs. Instead copy them to the build output in a TFM-specific directory, and import the targets from that directory when needed. Should fix https://github.com/dotnet/runtime/issues/89941.