### PR TITLE
Stop skipping tests in installer pipeline on linux_x64

### DIFF
--- a/eng/pipelines/installer/jobs/build-job.yml
+++ b/eng/pipelines/installer/jobs/build-job.yml
@@ -386,6 +386,7 @@ jobs:
           runtimeVariant: ${{ parameters.runtimeVariant }}
           isOfficialBuild: ${{ eq(parameters.isOfficialBuild, true) }}
           pgoType: ${{ parameters.pgoType }}
+          skipTests: ${{ eq(variables.SkipTests, true) }}
 
       - ${{ if ne(parameters.osGroup, 'windows') }}:
         - script: set -x && df -h

--- a/eng/pipelines/installer/jobs/build-job.yml
+++ b/eng/pipelines/installer/jobs/build-job.yml
@@ -86,18 +86,26 @@ jobs:
     - name: OfficialBuildArg
       value: ''
 
+    # Explicitly enable tests for linux even though it is a cross build using mariner
+    # They still work in this configuration and until they run on Helix, it is our only
+    # linux test coverage in the installer pipeline
     - name: SkipTests
       value: ${{ or(
         not(in(parameters.archType, 'x64', 'x86')),
         eq(parameters.runtimeFlavor, 'mono'),
         eq(parameters.isOfficialBuild, true),
-        eq(parameters.crossBuild, true),
+        and(
+          eq(parameters.crossBuild, true),
+          not(and(
+            eq(parameters.osGroup, 'linux'),
+            eq(parameters.osSubgroup, ''))
+          )),
         eq(parameters.pgoType, 'PGO')) }}
 
     - name: BuildAction
       value: -test
 
-    - ${{ if eq(or(not(in(parameters.archType, 'x64', 'x86')), eq(parameters.runtimeFlavor, 'mono'), eq(parameters.isOfficialBuild, true), eq(parameters.crossBuild, true), eq(parameters.pgoType, 'PGO')), true) }}:
+    - ${{ if eq(or(not(in(parameters.archType, 'x64', 'x86')), eq(parameters.runtimeFlavor, 'mono'), eq(parameters.isOfficialBuild, true), and(eq(parameters.crossBuild, true), not(and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, '')))), eq(parameters.pgoType, 'PGO')), true) }}:
       - name: BuildAction
         value: ''
 


### PR DESCRIPTION
- Explicitly enable tests in installer pipeline on linux_x64.
  - I think these ended up disabled after some infrastructure refactoring where we actually set the `crossBuild` parameter (before that, it was never set). Since these tests aren't on Helix yet, they are skipped for cross build - unfortunately, this means we have no tests running on linux. For linux_x64, they still work in this configuration, so this change enables tests in that configuration so that we have some linux coverage.
- Fix uploading of symbols/binaries for investigation on test failure
  - This relied on the `skipTests` parameter, which stopped being set after some infrastructure refactoring.

installer linux_x64 leg from this PR build: https://dev.azure.com/dnceng-public/public/_build/results?buildId=363131&view=logs&jobId=128f4634-3e62-52f1-6764-cb4c2b8330d4&j=c5f2201a-1517-53df-cad8-ae304147cc38&t=a15e3034-cc18-5a91-b9dd-0aaebf757d0c