### PR TITLE
[iOS] Generate unique class name for MonoDeadLetter

### DIFF
--- a/src/mono/mono/utils/mono-threads-mach-helper.c
+++ b/src/mono/mono/utils/mono-threads-mach-helper.c
@@ -15,11 +15,8 @@
 #include <stdio.h>
 #include <objc/runtime.h>
 #include <objc/message.h>
-#include <mono/metadata/metadata.h>
 #include <mono/utils/mono-compiler.h>
-#include <mono/utils/mono-error-internals.h>
 #include <mono/utils/mono-publib.h>
-#include <mono/utils/mono-rand.h>
 
 /*
  * We cannot include mono-threads.h as this includes io-layer internal types
@@ -30,8 +27,6 @@ void mono_threads_init_dead_letter (void);
 void mono_threads_install_dead_letter (void);
 MONO_API void
 mono_thread_info_detach (void);
-
-static char* generate_partial_unique_classname (void);
 
 static Class nsobject, nsthread, mono_dead_letter_class;
 static SEL dealloc, release, currentThread, threadDictionary, init, alloc, objectForKey, setObjectForKey;
@@ -127,12 +122,7 @@ mono_threads_init_dead_letter (void)
 	setObjectForKey = sel_registerName ("setObject:forKey:");
 	objectForKey = sel_registerName ("objectForKey:");
 
-	
-	char *partial_class_name;
-	partial_class_name = generate_partial_unique_classname ();
-
-	char *class_name = g_strconcat ("MonoDeadLetter", partial_class_name, (const char *)NULL);
-	g_free(partial_class_name);
+	char *class_name = g_strdup_printf ("MonoDeadLetter%p", &"MonoDeadLetter");
 
 	// Define the dead letter class
 	// The class name needs to be unique in the event different runtimes are loaded into the same process.
@@ -152,24 +142,6 @@ mono_threads_init_dead_letter (void)
 
 	id_objc_msgSend (mono_dead_letter_key, retain);
 	id_objc_msgSend (pool, release);
-}
-
-static char *
-generate_partial_unique_classname ()
-{
-	guint8 partial_class_name [16];
-	gpointer rand_handle;
-	ERROR_DECL (error);
-
-	mono_rand_open ();
-	rand_handle = mono_rand_init (NULL, 0);
-
-	mono_rand_try_get_bytes (&rand_handle, (guint8*) partial_class_name, 16, error);
-	mono_error_assert_ok (error);
-
-	mono_rand_close (rand_handle);
-
-	return mono_guid_to_string_minimal ((guint8*) partial_class_name);
 }
 
 #else

--- a/src/native/libs/System.Native/pal_autoreleasepool.m
+++ b/src/native/libs/System.Native/pal_autoreleasepool.m
@@ -3,27 +3,35 @@
 
 #include "pal_autoreleasepool.h"
 #include <Foundation/Foundation.h>
+#include <objc/runtime.h>
 
-@interface PlaceholderObject : NSObject
-- (void)noop:(id)_;
-@end
-
-@implementation PlaceholderObject : NSObject
-- (void)noop:(id)_
+static void noop_release(id self, SEL _cmd)
 {
     [self release];
 }
-@end
 
 void EnsureNSThreadIsMultiThreaded(void)
 {
     if (![NSThread isMultiThreaded])
     {
+        NSString *placeholderClassName = @"PlaceholderObject";
+        NSString *uuidClassName = [[NSUUID UUID] UUIDString];
+        const char* className = [[placeholderClassName stringByAppendingString:uuidClassName] UTF8String];
+
+        // For the overwhelming majority of all cases, there will only ever be one runtime at a time in a process. However,
+        // for library mode both in NativeAOT and Mono, more than one library can be used. Therefore, 
+        // the placeholder class needs to be registered at runtime and its name unique in the event (unlikely as it may be)
+        // this is called more than once. 
+        Class defPlaceholderObject = objc_allocateClassPair([NSObject class], className, 0);
+        class_addMethod(defPlaceholderObject, @selector(noop:), (IMP)noop_release, "v@:");
+        objc_registerClassPair(defPlaceholderObject);
+
+        id placeholderObject = [[defPlaceholderObject alloc] init];
+
         // Start another no-op thread with the NSThread APIs to get NSThread into multithreaded mode.
         // The NSAutoReleasePool APIs can't be used on secondary threads until NSThread is in multithreaded mode.
         // See https://developer.apple.com/documentation/foundation/nsautoreleasepool for more information.
-        PlaceholderObject* placeholderObject = [[PlaceholderObject alloc] init];
-
+        //
         // We need to use detachNewThreadSelector to put NSThread into multithreaded mode.
         // We can't use detachNewThreadWithBlock since it doesn't change NSThread into multithreaded mode for some reason.
         // See https://developer.apple.com/documentation/foundation/nswillbecomemultithreadednotification for more information.

--- a/src/native/libs/System.Native/pal_autoreleasepool.m
+++ b/src/native/libs/System.Native/pal_autoreleasepool.m
@@ -5,11 +5,6 @@
 #include <Foundation/Foundation.h>
 #include <objc/runtime.h>
 
-static void noop_release(id self, SEL _cmd)
-{
-    [self release];
-}
-
 void EnsureNSThreadIsMultiThreaded(void)
 {
     if (![NSThread isMultiThreaded])

--- a/src/native/libs/System.Native/pal_autoreleasepool.m
+++ b/src/native/libs/System.Native/pal_autoreleasepool.m
@@ -14,20 +14,6 @@ void EnsureNSThreadIsMultiThreaded(void)
 {
     if (![NSThread isMultiThreaded])
     {
-        NSString *placeholderClassName = @"PlaceholderObject";
-        NSString *uuidClassName = [[NSUUID UUID] UUIDString];
-        const char* className = [[placeholderClassName stringByAppendingString:uuidClassName] UTF8String];
-
-        // For the overwhelming majority of all cases, there will only ever be one runtime at a time in a process. However,
-        // for library mode both in NativeAOT and Mono, more than one library can be used. Therefore, 
-        // the placeholder class needs to be registered at runtime and its name unique in the event (unlikely as it may be)
-        // this is called more than once. 
-        Class defPlaceholderObject = objc_allocateClassPair([NSObject class], className, 0);
-        class_addMethod(defPlaceholderObject, @selector(noop:), (IMP)noop_release, "v@:");
-        objc_registerClassPair(defPlaceholderObject);
-
-        id placeholderObject = [[defPlaceholderObject alloc] init];
-
         // Start another no-op thread with the NSThread APIs to get NSThread into multithreaded mode.
         // The NSAutoReleasePool APIs can't be used on secondary threads until NSThread is in multithreaded mode.
         // See https://developer.apple.com/documentation/foundation/nsautoreleasepool for more information.
@@ -35,7 +21,9 @@ void EnsureNSThreadIsMultiThreaded(void)
         // We need to use detachNewThreadSelector to put NSThread into multithreaded mode.
         // We can't use detachNewThreadWithBlock since it doesn't change NSThread into multithreaded mode for some reason.
         // See https://developer.apple.com/documentation/foundation/nswillbecomemultithreadednotification for more information.
-        [NSThread detachNewThreadSelector:@selector(noop:) toTarget:placeholderObject withObject:nil];
+        id placeholderObject = [[NSMutableString alloc] init];		
+        [NSThread detachNewThreadSelector:@selector(appendString:) toTarget:placeholderObject withObject:@""];
+        [placeholderObject release];
     }
     assert([NSThread isMultiThreaded]);
 }


### PR DESCRIPTION
In library mode, it is possible to have multiple shared libraries (runtimes) loaded in the same process. On iOS, we have a small bit of objc to make sure we know when threads die so we can properly detach the runtime. Unfortunately, the class name we use is not unique and results in a crash when calling into a 2nd library.

This change makes the class name partially unique to avoid such a circumstance.