### PR TITLE
Improve duplicate assembly resolving

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -98,12 +98,6 @@ namespace Mono.Linker.Steps
 
 			if (File.Exists (fileName)) {
 				assembly = Context.Resolver.GetAssembly (fileName);
-				AssemblyDefinition? loaded = Context.GetLoadedAssembly (assembly.Name.Name);
-
-				// The same assembly could be already loaded if there are multiple inputs pointing to same file
-				if (loaded != null)
-					return loaded;
-
 				Context.Resolver.CacheAssembly (assembly);
 				return assembly;
 			}

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/CommandLineTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/CommandLineTests.g.cs
@@ -22,6 +22,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task DuplicateRootAssembly ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task InvalidArguments ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/DuplicateRootAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/DuplicateRootAssembly.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CommandLine;
+
+[SetupLinkerArgument ("-a", "test.exe", "entrypoint")]
+[SetupLinkerArgument ("-a", "../input/test.exe", "entrypoint")]
+public class DuplicateRootAssembly
+{
+	public static void Main ()
+	{
+
+	}
+}


### PR DESCRIPTION
`GetAssembly` opens a new assembly and stream every time it is called and keeps them open for the duration of the run.

`RootAssemblyFile.LoadAssemblyFile` sort of handled an already loaded assembly, but it left a new `AssemblyDefinition` instance and `MemoryStream` open every time it happened.

`CacheAssembly` was easy to make a mistake with.   Forget to do the delicate dance that `RootAssemblyFile.LoadAssemblyFile` goes to already loaded assemblies and you can easily overwrite an already cached assembly.  Guard against mistakes rather than quitely overwriting the assembly that was already cached.

Why force callers of `CacheAssembly` to check if something is cached already?  Handle that case internally.

With these changes the logic in `RootAssemblyFile.LoadAssemblyFile` is simplified and an extra copy of the assembly is no longer left open in the scenario where an assembly is specified multiple times.