### PR TITLE
[HTTP Metrics] Shorter version tags

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
@@ -161,8 +161,8 @@ namespace System.Net.Http.Metrics
         {
             (1, 0) => "1.0",
             (1, 1) => "1.1",
-            (2, 0) => "2.0",
-            (3, 0) => "3.0",
+            (2, 0) => "2",
+            (3, 0) => "3",
             _ => httpVersion.ToString()
         };
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -47,8 +47,8 @@ namespace System.Net.Http
                 // While requests may report HTTP/1.0 as the protocol, we treat all HTTP/1.X connections as HTTP/1.1.
                 string protocol =
                     this is HttpConnection ? "1.1" :
-                    this is Http2Connection ? "2.0" :
-                    "3.0";
+                    this is Http2Connection ? "2" :
+                    "3";
 
                 _connectionMetrics = new ConnectionMetrics(
                     metrics,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/SocketsHttpHandlerMetrics.cs
@@ -34,8 +34,8 @@ namespace System.Net.Http.Metrics
                 tags.Add("network.protocol.version", versionMajor switch
                 {
                     1 => "1.1",
-                    2 => "2.0",
-                    _ => "3.0"
+                    2 => "2",
+                    _ => "3"
                 });
 
                 tags.Add("url.scheme", pool.IsSecure ? "https" : "http");

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -63,6 +63,13 @@ namespace System.Net.Http.Functional.Tests
             VerifyTag(tags, "server.port", uri.Port);
         }
 
+        private static string? GetVersionString(Version? version) => version == null ? null : version.Major switch
+        {
+            1 => "1.1",
+            2 => "2",
+            _ => "3"
+        };
+
         protected static void VerifyRequestDuration(Measurement<double> measurement,
             Uri uri,
             Version? protocolVersion,
@@ -75,7 +82,7 @@ namespace System.Net.Http.Functional.Tests
             double measurement,
             KeyValuePair<string, object?>[] tags,
             Uri uri,
-            Version? protocol,
+            Version? protocolVersion,
             int? statusCode,
             string method = "GET",
             string[] acceptedErrorReasons = null)
@@ -84,7 +91,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.InRange(measurement, double.Epsilon, 60);
             VerifySchemeHostPortTags(tags, uri);
             VerifyTag(tags, "http.request.method", method);
-            VerifyTag(tags, "network.protocol.version", protocol?.ToString());
+            VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
             VerifyTag(tags, "http.response.status_code", statusCode);
             if (acceptedErrorReasons == null)
             {
@@ -113,7 +120,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(InstrumentNames.OpenConnections, actualName);
             Assert.Equal(expectedValue, Assert.IsType<long>(measurement));
             VerifySchemeHostPortTags(tags, uri);
-            VerifyTag(tags, "network.protocol.version", protocolVersion.ToString());
+            VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
             VerifyTag(tags, "http.connection.state", state);
             VerifySocketAddress(tags);
         }
@@ -124,7 +131,7 @@ namespace System.Net.Http.Functional.Tests
             double value = Assert.IsType<double>(measurement);
             Assert.InRange(value, double.Epsilon, 60);
             VerifySchemeHostPortTags(tags, uri);
-            VerifyTag(tags, "network.protocol.version", protocolVersion.ToString());
+            VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
             VerifySocketAddress(tags);
         }
 
@@ -134,7 +141,7 @@ namespace System.Net.Http.Functional.Tests
             double value = Assert.IsType<double>(measurement);
             Assert.InRange(value, double.Epsilon, 60);
             VerifySchemeHostPortTags(tags, uri);
-            VerifyTag(tags, "network.protocol.version", protocolVersion.ToString());
+            VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
             VerifyTag(tags, "http.request.method", method);
         }
 


### PR DESCRIPTION
This is addressing https://github.com/dotnet/runtime/pull/89809#discussion_r1283541867.

We need to omit minor version from the version tag values to conform to our own spec and to be consistent with aspnet.

Closes #89093.