### PR TITLE
[HTTP/2] Forward innerException's HttpRequestError to retryable HttpRequestException

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -2205,7 +2205,7 @@ namespace System.Net.Http
 
         [DoesNotReturn]
         private static void ThrowRetry(string message, Exception? innerException = null) =>
-            throw new HttpRequestException(HttpRequestError.Unknown, message, innerException, RequestRetryType.RetryOnConnectionFailure);
+            throw new HttpRequestException((innerException as HttpIOException)?.HttpRequestError ?? HttpRequestError.Unknown, message, innerException, RequestRetryType.RetryOnConnectionFailure);
 
         private static Exception GetRequestAbortedException(Exception? innerException = null) =>
             innerException as HttpIOException ?? new IOException(SR.net_http_request_aborted, innerException);


### PR DESCRIPTION
If we are doing a retry because of a protocol error, or some other `HttpIOException`, we should forward the error code to the retryable `HttpRequestException` in case it surfaces to the user. With this, surfacing `HttpRequestError.Unknown` should be very rare in HTTP/2, most likely indicating a bug.

(Sort-of) contributes to #89097.