### PR TITLE
Improve performance in DI

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -560,9 +560,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         /// <returns>Not <b>null</b> if <b>throwIfCallSiteNotFound</b> is true</returns>
         private ServiceCallSite[]? CreateArgumentCallSites(
-#pragma warning disable IDE0060 // Remove unused parameter
             ServiceIdentifier serviceIdentifier,
-#pragma warning restore IDE0060 // Remove unused parameter
             Type implementationType,
             CallSiteChain callSiteChain,
             ParameterInfo[] parameters,

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -67,9 +67,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         ValidateTrimmingAnnotations(serviceType, serviceTypeGenericArguments, implementationType, implementationTypeGenericArguments);
                     }
                 }
-                else if (!descriptor.HasImplementationInstance() && !descriptor.HasImplementationFactory())
+                else if (descriptor.TryGetImplementationType(out Type? implementationType))
                 {
-                    Type? implementationType = descriptor.GetImplementationType();
                     Debug.Assert(implementationType != null);
 
                     if (implementationType.IsGenericTypeDefinition ||

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -272,8 +272,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private static void AddCacheKey(ILEmitResolverBuilderContext argument, ServiceCacheKey key)
         {
-            Debug.Assert(key.ServiceIdentifier != null);
-            var id = key.ServiceIdentifier.Value;
+            var id = key.ServiceIdentifier;
 
             // new ServiceCacheKey(key.ServiceKey, key.type, key.slot)
             AddConstant(argument, id.ServiceKey);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ResultCache.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ResultCache.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public ResultCache(ServiceLifetime lifetime, ServiceIdentifier serviceIdentifier, int slot)
         {
-            Debug.Assert(lifetime == ServiceLifetime.Transient);
-
             switch (lifetime)
             {
                 case ServiceLifetime.Singleton:

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ResultCache.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ResultCache.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             Key = cacheKey;
         }
 
-        public ResultCache(ServiceLifetime lifetime, ServiceIdentifier? serviceIdentifier, int slot)
+        public ResultCache(ServiceLifetime lifetime, ServiceIdentifier serviceIdentifier, int slot)
         {
-            Debug.Assert(lifetime == ServiceLifetime.Transient || serviceIdentifier != null);
+            Debug.Assert(lifetime == ServiceLifetime.Transient);
 
             switch (lifetime)
             {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCacheKey.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceCacheKey.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         /// <summary>
         /// Type of service being cached
         /// </summary>
-        public ServiceIdentifier? ServiceIdentifier { get; }
+        public ServiceIdentifier ServiceIdentifier { get; }
 
         /// <summary>
         /// Reverse index of the service when resolved in <c>IEnumerable&lt;Type&gt;</c> where default instance gets slot 0.
@@ -32,7 +32,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             Slot = slot;
         }
 
-        public ServiceCacheKey(ServiceIdentifier? type, int slot)
+        public ServiceCacheKey(ServiceIdentifier type, int slot)
         {
             ServiceIdentifier = type;
             Slot = slot;
@@ -51,7 +51,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             unchecked
             {
-                return ((ServiceIdentifier?.GetHashCode() ?? 23) * 397) ^ Slot;
+                return (ServiceIdentifier.GetHashCode() * 397) ^ Slot;
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceDescriptorExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceDescriptorExtensions.cs
@@ -35,5 +35,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 ? serviceDescriptor.KeyedImplementationType
                 : serviceDescriptor.ImplementationType;
         }
+
+        public static bool TryGetImplementationType(this ServiceDescriptor serviceDescriptor, out Type? type)
+        {
+            type = GetImplementationType(serviceDescriptor);
+            return type != null;
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceIdentifier.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceIdentifier.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
             unchecked
             {
-                return ((ServiceType?.GetHashCode() ?? 23) * 397) ^ ServiceKey.GetHashCode();
+                return (ServiceType.GetHashCode() * 397) ^ ServiceKey.GetHashCode();
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
@@ -789,7 +789,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             Assert.Equal(expectedLocation, callSite.Cache.Location);
             Assert.Equal(0, callSite.Cache.Key.Slot);
-            Assert.Equal(typeof(IEnumerable<FakeService>), callSite.Cache.Key.ServiceIdentifier.Value.ServiceType);
+            Assert.Equal(typeof(IEnumerable<FakeService>), callSite.Cache.Key.ServiceIdentifier.ServiceType);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]


### PR DESCRIPTION
Related issue: #89104 

This PR manage to get some perf back, for example here are the results from `TimeToFirstService` tests on my machine:

**Mode: Dynamic**
|                        Type |                                 Method | Toolchain |         Mean |      Error |      StdDev |       Median |          Min |          Max |   Gen0 |   Gen1 | Allocated |
|---------------------------- |--------------------------------------- |-----------|-------------:|-----------:|------------:|-------------:|-------------:|-------------:|-------:|-------:|----------:|
|          TimeToFirstService |                          BuildProvider | before    |   753.182 ns |  8.1624 ns |   7.2357 ns |   753.700 ns |   739.973 ns |   764.742 ns | 0.4668 | 0.0091 |    6128 B |
|          TimeToFirstService |                              Transient | before    | 1,850.161 ns | 13.2022 ns |  11.7034 ns | 1,848.994 ns | 1,819.342 ns | 1,870.730 ns | 0.5957 | 0.0147 |    7832 B |
|          TimeToFirstService |                                 Scoped | before    | 2,254.959 ns | 99.2547 ns | 106.2014 ns | 2,216.799 ns | 2,147.805 ns | 2,440.183 ns | 0.6297 |      - |    8592 B |
|          TimeToFirstService |                              Singleton | before    | 1,814.500 ns | 35.9730 ns |  30.0391 ns | 1,826.555 ns | 1,768.116 ns | 1,861.855 ns | 0.5689 |      - |    7752 B |
|          TimeToFirstService |                          BuildProvider | after     |   735.550 ns |  7.7966 ns |   6.9115 ns |   735.079 ns |   724.098 ns |   750.727 ns | 0.4637 | 0.0087 |    6064 B |
|          TimeToFirstService |                              Transient | after     | 1,450.943 ns | 13.5098 ns |  11.9761 ns | 1,448.951 ns | 1,434.024 ns | 1,472.397 ns | 0.5851 | 0.0116 |    7720 B |
|          TimeToFirstService |                                 Scoped | after     | 1,628.323 ns | 29.2638 ns |  25.9416 ns | 1,623.571 ns | 1,587.373 ns | 1,681.996 ns | 0.6397 | 0.0129 |    8424 B |
|          TimeToFirstService |                              Singleton | after     | 1,479.134 ns | 10.9894 ns |  10.2795 ns | 1,479.818 ns | 1,461.227 ns | 1,497.052 ns | 0.5824 | 0.0118 |    7640 B |

**Mode: Expressions**
|                        Type |                                 Method | Toolchain |         Mean |      Error |      StdDev |       Median |          Min |          Max |   Gen0 |   Gen1 | Allocated |
|---------------------------- |--------------------------------------- |-----------|-------------:|-----------:|------------:|-------------:|-------------:|-------------:|-------:|-------:|----------:|
|          TimeToFirstService |                          BuildProvider | before    |   748.165 ns | 10.0476 ns |   8.9070 ns |   748.712 ns |   734.724 ns |   768.351 ns | 0.4687 | 0.0089 |    6128 B |
|          TimeToFirstService |                              Transient | before    | 1,727.041 ns | 19.5083 ns |  18.2481 ns | 1,723.208 ns | 1,703.159 ns | 1,765.775 ns | 0.5993 | 0.0139 |    7832 B |
|          TimeToFirstService |                                 Scoped | before    | 2,085.410 ns | 20.9439 ns |  19.5910 ns | 2,081.465 ns | 2,052.385 ns | 2,124.829 ns | 0.6511 | 0.0165 |    8592 B |
|          TimeToFirstService |                              Singleton | before    | 1,714.011 ns |  8.9126 ns |   7.9008 ns | 1,712.218 ns | 1,701.574 ns | 1,725.505 ns | 0.5909 | 0.0139 |    7752 B |
|          TimeToFirstService |                          BuildProvider | after     |   704.607 ns |  7.6209 ns |   6.7558 ns |   706.088 ns |   693.590 ns |   713.942 ns | 0.4627 | 0.0084 |    6064 B |
|          TimeToFirstService |                              Transient | after     | 1,464.115 ns | 16.4037 ns |  15.3440 ns | 1,461.208 ns | 1,445.253 ns | 1,492.207 ns | 0.5855 | 0.0117 |    7720 B |
|          TimeToFirstService |                                 Scoped | after     | 1,655.321 ns | 19.3172 ns |  17.1242 ns | 1,651.134 ns | 1,637.538 ns | 1,692.870 ns | 0.6400 | 0.0129 |    8424 B |
|          TimeToFirstService |                              Singleton | after     | 1,477.645 ns | 20.9259 ns |  19.5741 ns | 1,472.233 ns | 1,454.302 ns | 1,517.361 ns | 0.5799 | 0.0118 |    7640 B |

**Mode: ILEmit**
|                        Type |                                 Method | Toolchain |         Mean |      Error |      StdDev |       Median |          Min |          Max |   Gen0 |   Gen1 | Allocated |
|---------------------------- |--------------------------------------- |-----------|--------------:|-----------:|------------:|-------------:|-------------:|-------------:|-------:|-------:|----------:|
|          TimeToFirstService |                          BuildProvider | before    |    747.465 ns |  8.3819 ns |   7.8404 ns |   745.817 ns |   736.959 ns |   762.628 ns | 0.4659 | 0.0090 |    6128 B |
|          TimeToFirstService |                              Transient | before    |  1,850.115 ns | 29.8682 ns |  27.9388 ns | 1,845.605 ns | 1,802.040 ns | 1,889.587 ns | 0.5952 | 0.0147 |    7832 B |
|          TimeToFirstService |                                 Scoped | before    |  2,071.536 ns | 16.4799 ns |  15.4153 ns | 2,075.149 ns | 2,046.785 ns | 2,104.762 ns | 0.6574 | 0.0164 |    8592 B |
|          TimeToFirstService |                              Singleton | before    |  1,729.107 ns | 21.5811 ns |  20.1870 ns | 1,727.140 ns | 1,696.679 ns | 1,773.935 ns | 0.5896 | 0.0137 |    7752 B |
|          TimeToFirstService |                          BuildProvider |  after    |    710.039 ns |  8.3128 ns |   7.7758 ns |   709.738 ns |   695.468 ns |   723.130 ns | 0.4631 | 0.0085 |    6064 B |
|          TimeToFirstService |                              Transient |  after    |  1,600.915 ns | 17.8740 ns |  14.9256 ns | 1,599.622 ns | 1,581.591 ns | 1,638.828 ns | 0.5888 | 0.0128 |    7720 B |
|          TimeToFirstService |                                 Scoped |  after    |  1,634.161 ns | 16.9376 ns |  15.0147 ns | 1,639.237 ns | 1,607.226 ns | 1,654.997 ns | 0.6430 | 0.0130 |    8424 B |
|          TimeToFirstService |                              Singleton |  after    |  1,497.916 ns | 14.4069 ns |  13.4762 ns | 1,496.076 ns | 1,476.665 ns | 1,522.015 ns | 0.5790 | 0.0118 |    7640 B |

**Mode: Runtime**
|                        Type |                                 Method | Toolchain |         Mean |      Error |      StdDev |       Median |          Min |          Max |   Gen0 |   Gen1 | Allocated |
|---------------------------- |--------------------------------------- |-----------|--------------:|-----------:|------------:|-------------:|-------------:|-------------:|-------:|-------:|----------:|
|          TimeToFirstService |                          BuildProvider | before    |    762.557 ns |  7.6228 ns |   7.1304 ns |   764.343 ns |   753.039 ns |   776.406 ns | 0.4675 | 0.0091 |    6128 B |
|          TimeToFirstService |                              Transient | before    |  1,865.525 ns | 18.0385 ns |  15.9907 ns | 1,862.359 ns | 1,846.681 ns | 1,899.738 ns | 0.5963 | 0.0149 |    7832 B |
|          TimeToFirstService |                                 Scoped | before    |  2,072.554 ns | 17.1927 ns |  16.0821 ns | 2,068.519 ns | 2,054.988 ns | 2,100.529 ns | 0.6532 | 0.0165 |    8592 B |
|          TimeToFirstService |                              Singleton | before    |  1,741.121 ns | 13.3652 ns |  12.5018 ns | 1,743.684 ns | 1,721.771 ns | 1,764.339 ns | 0.5902 | 0.0139 |    7752 B |
|          TimeToFirstService |                          BuildProvider |  after    |    702.085 ns |  9.2328 ns |   8.6364 ns |   700.056 ns |   687.292 ns |   717.406 ns | 0.4622 | 0.0085 |    6064 B |
|          TimeToFirstService |                              Transient |  after    |  1,478.332 ns | 20.7039 ns |  19.3664 ns | 1,474.176 ns | 1,450.284 ns | 1,516.376 ns | 0.5850 | 0.0117 |    7720 B |
|          TimeToFirstService |                                 Scoped |  after    |  1,629.725 ns | 13.7779 ns |  12.2137 ns | 1,626.608 ns | 1,613.067 ns | 1,655.360 ns | 0.6392 | 0.0129 |    8424 B |
|          TimeToFirstService |                              Singleton |  after    |  1,507.486 ns | 17.7877 ns |  15.7684 ns | 1,505.385 ns | 1,486.664 ns | 1,544.344 ns | 0.5839 | 0.0122 |    7640 B |
