### PR TITLE
Improve test failure messages

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectNonZeroExitCodeAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/ExpectNonZeroExitCodeAttribute.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+[AttributeUsage (AttributeTargets.Class)]
+public class ExpectNonZeroExitCodeAttribute : BaseExpectedLinkedBehaviorAttribute
+{
+	public ExpectNonZeroExitCodeAttribute (int value)
+	{
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/InvalidArguments.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/InvalidArguments.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.CommandLine
 {
+	[ExpectNonZeroExitCode (1)]
 	[SetupLinkerArgument ("--verbose", "--invalidArgument")]
 	[LogContains ("Unrecognized command-line option")]
 	[NoLinkedOutput]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/FeatureSettings/FeatureSubstitutionsInvalid.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/FeatureSettings/FeatureSubstitutionsInvalid.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.FeatureSettings
 {
+	[ExpectNonZeroExitCode (1)]
 	[SetupLinkerSubstitutionFile ("FeatureSubstitutionsInvalid.xml")]
 	[SetupLinkerArgument ("--feature", "NoValueFeature", "true")]
 	[LogContains ("FeatureSubstitutionsInvalid.xml'. Feature 'NoValueFeature' does not specify a 'featurevalue' attribute")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/TypedArgumentsErrors.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/TypedArgumentsErrors.cs
@@ -4,6 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.LinkAttributes
 {
+	[ExpectNonZeroExitCode (1)]
 	[SetupLinkAttributesFile ("TypedArgumentsErrors.xml")]
 	[IgnoreLinkAttributes (false)]
 	[NoLinkedOutput]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Logging/CommonLogs.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Logging/CommonLogs.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Logging
 {
+	[ExpectNonZeroExitCode (1)]
 	[SetupCompileBefore ("LogStep.dll", new[] { "Dependencies/LogStep.cs" }, new[] { "illink.dll", "Mono.Cecil.dll" })]
 	[SetupLinkerArgument ("--custom-step", "Log.LogStep,LogStep.dll")]
 	[SetupLinkerArgument ("--verbose")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanDisableWarnAsError.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanDisableWarnAsError.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Warnings
 {
+	[ExpectNonZeroExitCode (1)]
 	[IgnoreTestCase ("Ignore in NativeAOT, see https://github.com/dotnet/runtime/issues/82447", IgnoredBy = Tool.NativeAot)]
 	[SkipKeptItemsValidation]
 	[SkipRemainingErrorsValidation]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanSingleWarnWithWarnAsError.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanSingleWarnWithWarnAsError.cs
@@ -5,6 +5,7 @@ using Mono.Linker.Tests.Cases.Warnings.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Warnings
 {
+	[ExpectNonZeroExitCode (1)]
 	[IgnoreTestCase ("Ignore in NativeAOT, see https://github.com/dotnet/runtime/issues/82447", IgnoredBy = Tool.NativeAot)]
 	[SkipKeptItemsValidation]
 	[SetupCompileBefore ("library.dll", new[] { typeof (TriggerWarnings_Lib) })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanWarnAsError.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanWarnAsError.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Warnings
 {
+	[ExpectNonZeroExitCode (1)]
 	[IgnoreTestCase ("Ignore in NativeAOT, see https://github.com/dotnet/runtime/issues/82447", IgnoredBy = Tool.NativeAot)]
 	[SkipKeptItemsValidation]
 	[SetupLinkerSubstitutionFile ("CanWarnAsErrorSubstitutions.xml")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/InvalidWarningVersion.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/InvalidWarningVersion.cs
@@ -3,6 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Warnings
 {
+	[ExpectNonZeroExitCode (1)]
 	[IgnoreTestCase ("Ignore in NativeAOT, see https://github.com/dotnet/runtime/issues/82447", IgnoredBy = Tool.NativeAot)]
 	[SetupLinkerArgument ("--verbose")]
 	[SetupLinkerArgument ("--warn", "invalid")]

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/LinkedTestCaseResult.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/LinkedTestCaseResult.cs
@@ -17,8 +17,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		public readonly ManagedCompilationResult CompilationResult;
 		public readonly LinkerTestLogger Logger;
 		public readonly LinkerCustomizations Customizations;
+		public readonly int ExitCode;
 
-		public LinkedTestCaseResult (TestCase testCase, NPath inputAssemblyPath, NPath outputAssemblyPath, NPath expectationsAssemblyPath, TestCaseSandbox sandbox, TestCaseMetadataProvider metadataProvider, ManagedCompilationResult compilationResult, LinkerTestLogger logger, LinkerCustomizations customizations)
+		public LinkedTestCaseResult (TestCase testCase, NPath inputAssemblyPath, NPath outputAssemblyPath, NPath expectationsAssemblyPath, TestCaseSandbox sandbox, TestCaseMetadataProvider metadataProvider, ManagedCompilationResult compilationResult, LinkerTestLogger logger, LinkerCustomizations customizations, int exitCode)
 		{
 			TestCase = testCase;
 			InputAssemblyPath = inputAssemblyPath;
@@ -29,6 +30,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			CompilationResult = compilationResult;
 			Logger = logger;
 			Customizations = customizations;
+			ExitCode = exitCode;
 		}
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestRunner.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestRunner.cs
@@ -109,9 +109,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			AddLinkOptions (sandbox, compilationResult, builder, metadataProvider);
 
 			LinkerTestLogger logger = new LinkerTestLogger ();
-			linker.Link (builder.ToArgs (), linkerCustomizations, logger);
+			var exitCode = linker.Link (builder.ToArgs (), linkerCustomizations, logger);
 
-			return new LinkedTestCaseResult (testCase, compilationResult.InputAssemblyPath, sandbox.OutputDirectory.Combine (compilationResult.InputAssemblyPath.FileName), compilationResult.ExpectationsAssemblyPath, sandbox, metadataProvider, compilationResult, logger, linkerCustomizations);
+			return new LinkedTestCaseResult (testCase, compilationResult.InputAssemblyPath, sandbox.OutputDirectory.Combine (compilationResult.InputAssemblyPath.FileName), compilationResult.ExpectationsAssemblyPath, sandbox, metadataProvider, compilationResult, logger, linkerCustomizations, exitCode);
 		}
 
 		protected virtual void AddLinkOptions (TestCaseSandbox sandbox, ManagedCompilationResult compilationResult, LinkerArgumentBuilder builder, TestCaseMetadataProvider metadataProvider)


### PR DESCRIPTION
I've noticed that there are more coding error scenarios where a test will fail and the failure that is hit is the failed to resolve "test.exe" error.  I don't fully have my head around which exceptions are being caught and logged but it seems like a lot more than there used to be.

Suffice it to say, when the only output from a test failure is about failing to resolve test.exe, that isn't particularly helpful when what actually happened is you had a mistake in your code and an exception was thrown.

With the linker now eating more exceptions and returning a non-zero exit code rather than throwing and crashing I think it's worth having the test framework fail with the messages from the linker if the exit code is non-zero.

For the tests that expect a non zero exit code, I added `ExpectNonZeroExitCodeAttribute`.