### PR TITLE
Move ThrowForHR to start of NotifyForSuccessFulInvoke

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ManagedToNativeVTableMethodGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ManagedToNativeVTableMethodGenerator.cs
@@ -171,6 +171,8 @@ namespace Microsoft.Interop
             }
             tryStatements.Add(statements.Pin.CastArray<FixedStatementSyntax>().NestFixedStatements(fixedBlock));
 
+            tryStatements.AddRange(statements.NotifyForSuccessfulInvoke);
+
             // <invokeSucceeded> = true;
             if (!statements.GuaranteedUnmarshal.IsEmpty)
             {
@@ -178,8 +180,6 @@ namespace Microsoft.Interop
                     IdentifierName(InvokeSucceededIdentifier),
                     LiteralExpression(SyntaxKind.TrueLiteralExpression))));
             }
-
-            tryStatements.AddRange(statements.NotifyForSuccessfulInvoke);
 
             // Keep the this object alive across the native call, similar to how we handle marshalling managed delegates.
             // We do this right after the NotifyForSuccessfulInvoke phase as that phase is where the delegate objects are kept alive.

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ManagedHResultExceptionMarshallerFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ManagedHResultExceptionMarshallerFactory.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Interop
             {
                 Debug.Assert(info.MarshallingAttributeInfo is ManagedHResultExceptionMarshallingInfo);
 
-                if (context.CurrentStage != StubCodeContext.Stage.Unmarshal)
+                if (context.CurrentStage != StubCodeContext.Stage.NotifyForSuccessfulInvoke)
                 {
                     yield break;
                 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
@@ -45,10 +45,9 @@ namespace Microsoft.Interop
     /// </summary>
     public sealed record TypePositionInfo(ManagedTypeInfo ManagedType, MarshallingInfo MarshallingAttributeInfo)
     {
-        public const int UnsetIndex = ExceptionIndex + 1;
-        public const int ReturnIndex = ExceptionIndex + 2;
-        // Make ExceptionIndex the min so that it is always the first to be dealt with in each stage
-        public const int ExceptionIndex = int.MinValue;
+        public const int UnsetIndex = int.MinValue;
+        public const int ReturnIndex = UnsetIndex + 1;
+        public const int ExceptionIndex = UnsetIndex + 2;
 
         public static bool IsSpecialIndex(int index)
         {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
@@ -45,9 +45,10 @@ namespace Microsoft.Interop
     /// </summary>
     public sealed record TypePositionInfo(ManagedTypeInfo ManagedType, MarshallingInfo MarshallingAttributeInfo)
     {
-        public const int UnsetIndex = int.MinValue;
-        public const int ReturnIndex = UnsetIndex + 1;
-        public const int ExceptionIndex = UnsetIndex + 2;
+        public const int UnsetIndex = ExceptionIndex + 1;
+        public const int ReturnIndex = ExceptionIndex + 2;
+        // Make ExceptionIndex the min so that it is always the first to be dealt with in each stage
+        public const int ExceptionIndex = int.MinValue;
 
         public static bool IsSpecialIndex(int index)
         {


### PR DESCRIPTION
As discussed offline, `__invokeSucceeded` needs to represent the concept of "the call didn't error", not "the call physically succeeded" to be correct in COM methods.
The assignment to `__invokeSucceeded` is moved below `NotifyForSuccessfulInvoke`, and the call to `ThrowForHR` is moved to `NotifyForSuccessfulInvoke` from `Marshal`.