### PR TITLE
Update the event used for the tiered compilation background thread

### DIFF
--- a/src/coreclr/vm/tieredcompilation.cpp
+++ b/src/coreclr/vm/tieredcompilation.cpp
@@ -55,7 +55,7 @@ CrstStatic TieredCompilationManager::s_lock;
 #ifdef _DEBUG
 Thread *TieredCompilationManager::s_backgroundWorkerThread = nullptr;
 #endif
-CLREvent TieredCompilationManager::s_backgroundWorkAvailableEvent;
+CLREventStatic TieredCompilationManager::s_backgroundWorkAvailableEvent;
 bool TieredCompilationManager::s_isBackgroundWorkerRunning = false;
 bool TieredCompilationManager::s_isBackgroundWorkerProcessingWork = false;
 

--- a/src/coreclr/vm/tieredcompilation.h
+++ b/src/coreclr/vm/tieredcompilation.h
@@ -121,7 +121,7 @@ private:
 #ifdef _DEBUG
     static Thread *s_backgroundWorkerThread;
 #endif
-    static CLREvent s_backgroundWorkAvailableEvent;
+    static CLREventStatic s_backgroundWorkAvailableEvent;
     static bool s_isBackgroundWorkerRunning;
     static bool s_isBackgroundWorkerProcessingWork;
 #endif // !DACCESS_COMPILE


### PR DESCRIPTION
Updated the event to use `ClrEventStatic` instead of `ClrEvent`, as the former is intended for global variables and does not have a destructor. With the latter type there may be a possibility for races with the destructor in shutdown scenarios.

Fixes https://github.com/dotnet/runtime/issues/89749