### PR TITLE
Exclude NETFramework targets file during source build

### DIFF
--- a/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+++ b/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
@@ -50,7 +50,8 @@ System.Resources.Extensions.PreserializedResourceWriter</PackageDescription>
 
   <Target Name="GeneratePackageTargetsFile" 
           Inputs="$(MSBuildAllProjects)"
-          Outputs="$(SuggestedBindingRedirectsPackageFile)">
+          Outputs="$(SuggestedBindingRedirectsPackageFile)"
+          Condition="'$(NetFrameworkMinimum)' != ''">
     <PropertyGroup>
       <SuggestedBindingRedirectsPackageFileContent><![CDATA[<Project>
   <!-- ResolveAssemblyReferences will never see the assembly reference embedded in the resources type,


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/89208