### PR TITLE
Cleanup work

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -249,7 +249,7 @@ extends:
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
-              testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing/eventpipe/config;tracing/eventpipe/diagnosticport;tracing/eventpipe/reverse;tracing/eventpipe/processenvironment;tracing/eventpipe/simpleruntimeeventvalidation;tracing/eventpipe/processinfo2;" test tracing/eventcounter/runtimecounters.csproj /p:BuildNativeAotFrameworkObjects=true'
+              testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing/eventpipe;tracing/eventcounter;" /p:BuildNativeAotFrameworkObjects=true'
               liveLibrariesBuildConfig: Release
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             extraVariablesTemplates:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -243,7 +243,7 @@ extends:
           - name: timeoutPerTestCollectionInMinutes
             value: 180
           jobParameters:
-            timeoutInMinutes: 120
+            timeoutInMinutes: 180
             nameSuffix: NativeAOT
             buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -249,7 +249,7 @@ extends:
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
-              testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing/eventpipe;tracing/eventcounter;" /p:BuildNativeAotFrameworkObjects=true'
+              testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing;" /p:BuildNativeAotFrameworkObjects=true'
               liveLibrariesBuildConfig: Release
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             extraVariablesTemplates:

--- a/src/coreclr/nativeaot/Runtime/eventpipe/dotnetruntime.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/dotnetruntime.cpp
@@ -3122,6 +3122,7 @@ void InitDotNETRuntime(void)
     EventPipeEventThreadPoolWorkerThreadAdjustmentStats = EventPipeAdapter::AddEvent(EventPipeProviderDotNETRuntime,56,65536,0,EP_EVENT_LEVEL_VERBOSE,true);
     EventPipeEventThreadPoolIOEnqueue = EventPipeAdapter::AddEvent(EventPipeProviderDotNETRuntime,63,2147549184,0,EP_EVENT_LEVEL_VERBOSE,true);
     EventPipeEventThreadPoolIODequeue = EventPipeAdapter::AddEvent(EventPipeProviderDotNETRuntime,64,2147549184,0,EP_EVENT_LEVEL_VERBOSE,true);
+    EventPipeEventThreadPoolIOPack = EventPipeAdapter::AddEvent(EventPipeProviderDotNETRuntime,65,65536,0,EP_EVENT_LEVEL_VERBOSE,true);
     EventPipeEventThreadPoolWorkingThreadCount = EventPipeAdapter::AddEvent(EventPipeProviderDotNETRuntime,60,65536,0,EP_EVENT_LEVEL_VERBOSE,true);
     EventPipeEventGCAllocationTick_V4 = EventPipeAdapter::AddEvent(EventPipeProviderDotNETRuntime,10,1,4,EP_EVENT_LEVEL_VERBOSE,true);
     EventPipeEventGCHeapStats_V2 = EventPipeAdapter::AddEvent(EventPipeProviderDotNETRuntime,4,1,2,EP_EVENT_LEVEL_INFORMATIONAL,false);

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.cpp
@@ -846,11 +846,6 @@ ep_rt_thread_id_t ep_rt_aot_thread_get_id (ep_rt_thread_handle_t thread_handle)
     return thread_handle->GetPalThreadIdForLogging();
 }
 
-bool ep_rt_aot_thread_has_started (ep_rt_thread_handle_t thread_handle)
-{
-    return thread_handle != NULL;
-}
-
 #ifdef EP_CHECKED_BUILD
 
 void ep_rt_aot_lock_requires_lock_held (const ep_rt_lock_handle_t *lock)

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.cpp
@@ -834,9 +834,21 @@ ep_rt_thread_handle_t ep_rt_aot_thread_get_handle (void)
     return ThreadStore::GetCurrentThreadIfAvailable();
 }
 
+ep_rt_thread_handle_t ep_rt_aot_thread_get_handle_for_streaming (void)
+{
+    // This is expensive but need a valid thread that will only be used by EventPipe
+    ThreadStore::AttachCurrentThread();
+    return ThreadStore::GetCurrentThread();
+}
+
 ep_rt_thread_id_t ep_rt_aot_thread_get_id (ep_rt_thread_handle_t thread_handle)
 {
     return thread_handle->GetPalThreadIdForLogging();
+}
+
+bool ep_rt_aot_thread_has_started (ep_rt_thread_handle_t thread_handle)
+{
+    return thread_handle != NULL && thread_handle->IsInitialized ();
 }
 
 #ifdef EP_CHECKED_BUILD

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.cpp
@@ -834,7 +834,7 @@ ep_rt_thread_handle_t ep_rt_aot_thread_get_handle (void)
     return ThreadStore::GetCurrentThreadIfAvailable();
 }
 
-ep_rt_thread_handle_t ep_rt_aot_thread_get_handle_for_streaming (void)
+ep_rt_thread_handle_t ep_rt_aot_setup_thread (void)
 {
     // This is expensive but need a valid thread that will only be used by EventPipe
     ThreadStore::AttachCurrentThread();
@@ -848,7 +848,7 @@ ep_rt_thread_id_t ep_rt_aot_thread_get_id (ep_rt_thread_handle_t thread_handle)
 
 bool ep_rt_aot_thread_has_started (ep_rt_thread_handle_t thread_handle)
 {
-    return thread_handle != NULL && thread_handle->IsInitialized ();
+    return thread_handle != NULL;
 }
 
 #ifdef EP_CHECKED_BUILD

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
@@ -726,10 +726,9 @@ EP_RT_DEFINE_THREAD_FUNC (ep_rt_thread_aot_start_session_or_sampling_thread)
 
     ep_rt_thread_params_t* thread_params = reinterpret_cast<ep_rt_thread_params_t *>(data);
 
-    // The session and sampling threads both assert that the incoming thread handle is
-    // non-null, but do not necessarily rely on it otherwise; just pass a meaningless non-null
-    // value until testing shows that a meaningful value is needed.
-    thread_params->thread = reinterpret_cast<ep_rt_thread_handle_t>(1);
+    // We will create a new thread. cannot call ep_rt_aot_thread_get_handle since that will return null
+    extern ep_rt_thread_handle_t ep_rt_aot_thread_get_handle_for_streaming (void);
+    thread_params->thread = ep_rt_aot_thread_get_handle_for_streaming ();
 
     size_t result = thread_params->thread_func (thread_params);
     delete thread_params;
@@ -793,15 +792,7 @@ ep_rt_current_processor_get_number (void)
 {
     STATIC_CONTRACT_NOTHROW;
 
-#ifndef TARGET_UNIX
-    extern uint32_t *_ep_rt_aot_proc_group_offsets;
-    if (_ep_rt_aot_proc_group_offsets) {
-        // PROCESSOR_NUMBER proc;
-        // GetCurrentProcessorNumberEx (&proc);
-        // return _ep_rt_aot_proc_group_offsets [proc.Group] + proc.Number;
-        // PalDebugBreak();
-    }
-#endif
+    // Follows the mono implementation
     return 0xFFFFFFFF;
 }
 
@@ -1588,10 +1579,8 @@ bool
 ep_rt_thread_has_started (ep_rt_thread_handle_t thread_handle)
 {
     STATIC_CONTRACT_NOTHROW;
-    // shipping criteria: no EVENTPIPE-NATIVEAOT-TODO left in the codebase
-    // TODO: Implement thread creation/management if needed
-    // return thread_handle != NULL && thread_handle->HasStarted ();
-    return true;
+    extern bool ep_rt_aot_thread_has_started (ep_rt_thread_handle_t thread_handle);
+    return ep_rt_aot_thread_has_started(thread_handle);
 }
 
 static

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
@@ -727,8 +727,8 @@ EP_RT_DEFINE_THREAD_FUNC (ep_rt_thread_aot_start_session_or_sampling_thread)
     ep_rt_thread_params_t* thread_params = reinterpret_cast<ep_rt_thread_params_t *>(data);
 
     // We will create a new thread. cannot call ep_rt_aot_thread_get_handle since that will return null
-    extern ep_rt_thread_handle_t ep_rt_aot_thread_get_handle_for_streaming (void);
-    thread_params->thread = ep_rt_aot_thread_get_handle_for_streaming ();
+    extern ep_rt_thread_handle_t ep_rt_aot_setup_thread (void);
+    thread_params->thread = ep_rt_aot_setup_thread ();
 
     size_t result = thread_params->thread_func (thread_params);
     delete thread_params;

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
@@ -1579,8 +1579,7 @@ bool
 ep_rt_thread_has_started (ep_rt_thread_handle_t thread_handle)
 {
     STATIC_CONTRACT_NOTHROW;
-    extern bool ep_rt_aot_thread_has_started (ep_rt_thread_handle_t thread_handle);
-    return ep_rt_aot_thread_has_started(thread_handle);
+    return thread_handle != NULL;
 }
 
 static

--- a/src/coreclr/nativeaot/Runtime/eventpipeinternal.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipeinternal.cpp
@@ -163,7 +163,7 @@ EXTERN_C NATIVEAOT_API int __cdecl RhEventPipeInternal_EventActivityIdControl(ui
 {
     int retVal = 0;
     ep_rt_thread_activity_id_handle_t activityIdHandle = ep_thread_get_activity_id_handle ();
-    if (pThread == NULL || pActivityId == NULL)
+    if (activityIdHandle == NULL || pActivityId == NULL)
     {
         retVal = 1;
     }
@@ -175,12 +175,12 @@ EXTERN_C NATIVEAOT_API int __cdecl RhEventPipeInternal_EventActivityIdControl(ui
         {
         case ActivityControlCode::EVENT_ACTIVITY_CONTROL_GET_ID:
 
-            ep_rt_thread_get_activity_id (pThread, reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
+            ep_rt_thread_get_activity_id (activityIdHandle, reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
             break;
 
         case ActivityControlCode::EVENT_ACTIVITY_CONTROL_SET_ID:
 
-            ep_rt_thread_set_activity_id (pThread, reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
+            ep_rt_thread_set_activity_id (activityIdHandle, reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
             break;
 
         case ActivityControlCode::EVENT_ACTIVITY_CONTROL_CREATE_ID:
@@ -190,17 +190,17 @@ EXTERN_C NATIVEAOT_API int __cdecl RhEventPipeInternal_EventActivityIdControl(ui
 
         case ActivityControlCode::EVENT_ACTIVITY_CONTROL_GET_SET_ID:
 
-            ep_rt_thread_get_activity_id (pThread, reinterpret_cast<uint8_t *>(&currentActivityId), EP_ACTIVITY_ID_SIZE);
-            ep_rt_thread_set_activity_id (pThread, reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
+            ep_rt_thread_get_activity_id (activityIdHandle, reinterpret_cast<uint8_t *>(&currentActivityId), EP_ACTIVITY_ID_SIZE);
+            ep_rt_thread_set_activity_id (activityIdHandle, reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
             *pActivityId = currentActivityId;
 
             break;
 
         case ActivityControlCode::EVENT_ACTIVITY_CONTROL_CREATE_SET_ID:
 
-            ep_rt_thread_get_activity_id (pThread, reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
+            ep_rt_thread_get_activity_id (activityIdHandle, reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
             ep_rt_create_activity_id(reinterpret_cast<uint8_t *>(&currentActivityId), EP_ACTIVITY_ID_SIZE);
-            ep_rt_thread_set_activity_id (pThread, reinterpret_cast<uint8_t *>(&currentActivityId), EP_ACTIVITY_ID_SIZE);
+            ep_rt_thread_set_activity_id (activityIdHandle, reinterpret_cast<uint8_t *>(&currentActivityId), EP_ACTIVITY_ID_SIZE);
             break;
 
         default:

--- a/src/coreclr/nativeaot/Runtime/eventpipeinternal.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipeinternal.cpp
@@ -148,9 +148,65 @@ EXTERN_C NATIVEAOT_API void __cdecl RhEventPipeInternal_DeleteProvider(intptr_t 
     }
 }
 
+enum class ActivityControlCode
+{
+    EVENT_ACTIVITY_CONTROL_GET_ID = 1,
+    EVENT_ACTIVITY_CONTROL_SET_ID = 2,
+    EVENT_ACTIVITY_CONTROL_CREATE_ID = 3,
+    EVENT_ACTIVITY_CONTROL_GET_SET_ID = 4,
+    EVENT_ACTIVITY_CONTROL_CREATE_SET_ID = 5
+};
+
 EXTERN_C NATIVEAOT_API int __cdecl RhEventPipeInternal_EventActivityIdControl(uint32_t controlCode, GUID *pActivityId)
 {
-    return 0;
+    int retVal = 0;
+    EventPipeThread *pThread = ep_rt_thread_get_or_create();
+    if (pThread == NULL || pActivityId == NULL)
+    {
+        retVal = 1;
+    }
+    else
+    {
+        ActivityControlCode activityControlCode = (ActivityControlCode)controlCode;
+        GUID currentActivityId;
+        switch (activityControlCode)
+        {
+        case ActivityControlCode::EVENT_ACTIVITY_CONTROL_GET_ID:
+
+            ep_rt_thread_get_activity_id (pThread, reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
+            break;
+
+        case ActivityControlCode::EVENT_ACTIVITY_CONTROL_SET_ID:
+
+            ep_rt_thread_set_activity_id (pThread, reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
+            break;
+
+        case ActivityControlCode::EVENT_ACTIVITY_CONTROL_CREATE_ID:
+
+            ep_rt_create_activity_id(reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
+            break;
+
+        case ActivityControlCode::EVENT_ACTIVITY_CONTROL_GET_SET_ID:
+
+            ep_rt_thread_get_activity_id (pThread, reinterpret_cast<uint8_t *>(&currentActivityId), EP_ACTIVITY_ID_SIZE);
+            ep_rt_thread_set_activity_id (pThread, reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
+            *pActivityId = currentActivityId;
+
+            break;
+
+        case ActivityControlCode::EVENT_ACTIVITY_CONTROL_CREATE_SET_ID:
+
+            ep_rt_thread_get_activity_id (pThread, reinterpret_cast<uint8_t *>(pActivityId), EP_ACTIVITY_ID_SIZE);
+            ep_rt_create_activity_id(reinterpret_cast<uint8_t *>(&currentActivityId), EP_ACTIVITY_ID_SIZE);
+            ep_rt_thread_set_activity_id (pThread, reinterpret_cast<uint8_t *>(&currentActivityId), EP_ACTIVITY_ID_SIZE);
+            break;
+
+        default:
+            retVal = 1;
+        }
+    }
+
+    return retVal;
 }
 
 EXTERN_C NATIVEAOT_API void __cdecl RhEventPipeInternal_WriteEventData(

--- a/src/coreclr/nativeaot/Runtime/eventpipeinternal.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipeinternal.cpp
@@ -160,7 +160,7 @@ enum class ActivityControlCode
 EXTERN_C NATIVEAOT_API int __cdecl RhEventPipeInternal_EventActivityIdControl(uint32_t controlCode, GUID *pActivityId)
 {
     int retVal = 0;
-    EventPipeThread *pThread = ep_rt_thread_get_or_create();
+    ep_rt_thread_activity_id_handle_t activityIdHandle = ep_thread_get_activity_id_handle ();
     if (pThread == NULL || pActivityId == NULL)
     {
         retVal = 1;

--- a/src/coreclr/nativeaot/Runtime/eventpipeinternal.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipeinternal.cpp
@@ -148,6 +148,8 @@ EXTERN_C NATIVEAOT_API void __cdecl RhEventPipeInternal_DeleteProvider(intptr_t 
     }
 }
 
+// All the runtime redefine this enum, should move to commmon code.
+// https://github.com/dotnet/runtime/issues/87069
 enum class ActivityControlCode
 {
     EVENT_ACTIVITY_CONTROL_GET_ID = 1,

--- a/src/coreclr/nativeaot/Runtime/eventtrace_gcheap.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_gcheap.cpp
@@ -34,13 +34,15 @@
 
 BOOL ETW::GCLog::ShouldWalkHeapObjectsForEtw()
 {
-    // @TODO:
+    // @TODO: until the below issue is fixed correctly
+    // https://github.com/dotnet/runtime/issues/88491
     return FALSE;
 }
 
 BOOL ETW::GCLog::ShouldWalkHeapRootsForEtw()
 {
-    // @TODO:
+    // @TODO: until the below issue is fixed correctly
+    // https://github.com/dotnet/runtime/issues/88491
     return FALSE;
 }
 

--- a/src/coreclr/nativeaot/Runtime/eventtrace_gcheap.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_gcheap.cpp
@@ -34,18 +34,14 @@
 
 BOOL ETW::GCLog::ShouldWalkHeapObjectsForEtw()
 {
-    LIMITED_METHOD_CONTRACT;
-    return RUNTIME_PROVIDER_CATEGORY_ENABLED(
-        TRACE_LEVEL_INFORMATION,
-        CLR_GCHEAPDUMP_KEYWORD);
+    // @TODO:
+    return FALSE;
 }
 
 BOOL ETW::GCLog::ShouldWalkHeapRootsForEtw()
 {
-    LIMITED_METHOD_CONTRACT;
-    return RUNTIME_PROVIDER_CATEGORY_ENABLED(
-        TRACE_LEVEL_INFORMATION,
-        CLR_GCHEAPDUMP_KEYWORD);
+    // @TODO:
+    return FALSE;
 }
 
 BOOL ETW::GCLog::ShouldTrackMovementForEtw()

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1042,9 +1042,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/reflection/SetValue/TrySetReadonlyStaticField/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/200</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventactivityidcontrol/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventlistener/EventListenerThreadPool/**">
             <Issue>https://github.com/dotnet/runtime/issues/83051: Waiting for PR_88894 to be merged</Issue>
         </ExcludeList>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1042,74 +1042,20 @@
         <ExcludeList Include="$(XunitTestBinBase)/reflection/SetValue/TrySetReadonlyStaticField/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/200</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/eventcounter/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/gh53564/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/incrementingeventcounter/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/incrementingpollingcounter/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/pollingcounter/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/regression-25709/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventcounter/regression-46938/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventactivityidcontrol/**">
             <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventlistener/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/bigevent/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/buffersize/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/enabledisable/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventlistener/EventListenerThreadPool/**">
+            <Issue>https://github.com/dotnet/runtime/issues/83051: Waiting for PR_88894 to be merged</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/gcdump/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/pauseonstart/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/processenvironment/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/processinfo/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/processinfo2/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/processinfo3/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/providervalidation/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/reverseouter/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051: not supported in net8</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/rundownvalidation/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/83051: not supported in net8</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/runtimeeventsource/**">
-            <Issue>https://github.com/dotnet/runtime/issues/83051</Issue>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/runtimeeventsource/nativeruntimeeventsource/**">
+            <Issue>https://github.com/dotnet/runtime/issues/90021</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b426654/b426654/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/208</Issue>

--- a/src/tests/tracing/eventactivityidcontrol/eventactivityidcontrol.csproj
+++ b/src/tests/tracing/eventactivityidcontrol/eventactivityidcontrol.csproj
@@ -10,4 +10,7 @@
     <Compile Include="EventActivityIdControl.cs" />
     <ProjectReference Include="../common/common.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TestBuildMode)' == 'nativeaot'">
+    <RdXmlFile Include="rd.xml" />
+  </ItemGroup>  
 </Project>

--- a/src/tests/tracing/eventactivityidcontrol/rd.xml
+++ b/src/tests/tracing/eventactivityidcontrol/rd.xml
@@ -1,0 +1,9 @@
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Application>
+    <Assembly Name="System.Private.CoreLib">
+      <Type Name="System.Diagnostics.Tracing.EventPipeEventProvider">
+        <Method Name="EventActivityIdControl" />
+      </Type>
+    </Assembly>
+  </Application>
+</Directives>

--- a/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.csproj
+++ b/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.csproj
@@ -11,5 +11,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
+    <ProjectReference Include="$(TestSourceDir)Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
+++ b/src/tests/tracing/eventpipe/processinfo3/processinfo3.cs
@@ -158,7 +158,9 @@ namespace Tracing.Tests.ProcessInfoValidation
                 // /path/to/corerun /path/to/processinfo.dll
                 // or
                 // "C:\path\to\CoreRun.exe" C:\path\to\processinfo.dll
-                string currentProcessCommandLine = $"{currentProcess.MainModule.FileName} {System.Reflection.Assembly.GetExecutingAssembly().Location}";
+                string currentProcessCommandLine = TestLibrary.Utilities.IsSingleFile
+                    ? currentProcess.MainModule.FileName
+                    : $"{currentProcess.MainModule.FileName} {System.Reflection.Assembly.GetExecutingAssembly().Location}";
                 string receivedCommandLine = NormalizeCommandLine(commandLine);
                 Utils.Assert(currentProcessCommandLine.Equals(receivedCommandLine, StringComparison.OrdinalIgnoreCase), $"CommandLine must match current process. Expected: {currentProcessCommandLine}, Received: {receivedCommandLine} (original: {commandLine})");
             }

--- a/src/tests/tracing/eventpipe/processinfo3/processinfo3.csproj
+++ b/src/tests/tracing/eventpipe/processinfo3/processinfo3.csproj
@@ -15,5 +15,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/common.csproj" />
+    <ProjectReference Include="$(TestSourceDir)Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Miscellaneous cleanup work: Implements `ep_rt_aot_thread_has_started`, `RhEventPipeInternal_EventActivityIdControl` that allows per-thread activity ID, generating a valid thread handle for `streaming_thread`  in `EventPipe` (`EventPipe` calls `ep_rt_aot_thread_has_started` which will cause issues unless its a valid thread handle now), not handling events related to GCHeapDumpKeyword and TypeKeyword (until issue #88491 is fixed correctly), and expanding testing.