### PR TITLE
Remove spurious assertion check causing .NET Core crashes

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -2142,6 +2142,7 @@ namespace System.Text
             // jumps as much as possible in the optimistic case of "all ASCII". If we see non-ASCII
             // data, we jump out of the hot paths to targets at the end of the method.
 
+            // Commented out to workaround https://github.com/dotnet/runtime/issues/90265
             // Debug.Assert(Vector256.IsHardwareAccelerated, "Vector256 is required.");
             Debug.Assert(BitConverter.IsLittleEndian, "This implementation assumes little-endian.");
             Debug.Assert(elementCount >= 2 * Vector256.Size);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -2142,7 +2142,6 @@ namespace System.Text
             // jumps as much as possible in the optimistic case of "all ASCII". If we see non-ASCII
             // data, we jump out of the hot paths to targets at the end of the method.
 
-            Debug.Assert(Vector256.IsHardwareAccelerated, "Vector256 is required.");
             Debug.Assert(BitConverter.IsLittleEndian, "This implementation assumes little-endian.");
             Debug.Assert(elementCount >= 2 * Vector256.Size);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -2142,7 +2142,7 @@ namespace System.Text
             // jumps as much as possible in the optimistic case of "all ASCII". If we see non-ASCII
             // data, we jump out of the hot paths to targets at the end of the method.
 
-    // Debug.Assert(Vector256.IsHardwareAccelerated, "Vector256 is required.");
+            // Debug.Assert(Vector256.IsHardwareAccelerated, "Vector256 is required.");
             Debug.Assert(BitConverter.IsLittleEndian, "This implementation assumes little-endian.");
             Debug.Assert(elementCount >= 2 * Vector256.Size);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -2142,6 +2142,7 @@ namespace System.Text
             // jumps as much as possible in the optimistic case of "all ASCII". If we see non-ASCII
             // data, we jump out of the hot paths to targets at the end of the method.
 
+    // Debug.Assert(Vector256.IsHardwareAccelerated, "Vector256 is required.");
             Debug.Assert(BitConverter.IsLittleEndian, "This implementation assumes little-endian.");
             Debug.Assert(elementCount >= 2 * Vector256.Size);
 


### PR DESCRIPTION
I started this investigation based on heads-up from Rich Lander who hit the issue in a PR run. Thanks to help from Jan Vorlicek I have been able to repro the issue and I discussed it with Tanner Gooding who proposed this fix - removing the superfluous assertion check duplicating an upfront check in the method NarrowUtf16ToAscii before calling into the intrinsified version.

I sincerely admit I'm not an expert in the field of instruction set extensions and I have driven this investigation mostly because David Wrighton is OOF on parental leave for the entire month of August so I'm trying to make sure we ship .NET 8 in the best possible quality; I'll be more than happy for any suggestions for improvements or any other feedback.

Thanks

Tomas

/cc @dotnet/crossgen-contrib @davidwrighton @richlander 