### PR TITLE
[mono][ios] Disable failing eventpipe gcdump test on apple mobile platforms

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3956,7 +3956,7 @@
             <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/gcdump/**">
-            <Issue>needs triage</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/90012</Issue>
         </ExcludeList>
     </ItemGroup>
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3955,6 +3955,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/Regressions/v2.0-beta1/149926/149926/*">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/gcdump/**">
+            <Issue>needs triage</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetArchitecture)' == 'wasm' or '$(TargetsMobile)' == 'true'">


### PR DESCRIPTION
Fixes the failing gcdump test on the CI. The regression was potentially introduced in the https://github.com/dotnet/runtime/pull/89726 by enabling the test on apple mobile platforms.