### PR TITLE
Recover some lost EH performance on Unix amd64

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -598,14 +598,13 @@ if (CLR_CMAKE_HOST_UNIX)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-stringop-overflow>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-restrict>)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-stringop-truncation>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-class-memaccess>)
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0)
       # this warning is only reported by g++ 11 in debug mode when building
       # src/coreclr/vm/stackingallocator.h. It is a false-positive, fixed in g++ 12.
       # see: https://github.com/dotnet/runtime/pull/69188#issuecomment-1136764770
       add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-placement-new>)
-
-      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-class-memaccess>)
     endif()
 
     if (CMAKE_CXX_COMPILER_ID)

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -6539,7 +6539,7 @@ HRESULT Debugger::LaunchDebuggerForUser(Thread * pThread, EXCEPTION_POINTERS * p
 // once and leave them set without the risk of clobbering something we care about.
 JIT_DEBUG_INFO   Debugger::s_DebuggerLaunchJitInfo = {0};
 EXCEPTION_RECORD Debugger::s_DebuggerLaunchJitInfoExceptionRecord = {0};
-CONTEXT          Debugger::s_DebuggerLaunchJitInfoContext = {0};
+CONTEXT          Debugger::s_DebuggerLaunchJitInfoContext = {};
 
 //----------------------------------------------------------------------------
 //

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -1531,6 +1531,14 @@ typedef struct _XMM_SAVE_AREA32 {
 
 typedef struct DECLSPEC_ALIGN(16) _CONTEXT {
 
+    _CONTEXT() = default;
+    _CONTEXT(const _CONTEXT& ctx)
+    {
+        *this = ctx;
+    }
+
+    _CONTEXT& operator=(const _CONTEXT& ctx);
+
     //
     // Register parameter home addresses.
     //

--- a/src/coreclr/pal/src/exception/seh-unwind.cpp
+++ b/src/coreclr/pal/src/exception/seh-unwind.cpp
@@ -939,7 +939,7 @@ RaiseException(IN DWORD dwExceptionCode,
     }
 
     // Capture the context of RaiseException.
-    ZeroMemory(contextRecord, sizeof(CONTEXT));
+    new (contextRecord) CONTEXT();
     contextRecord->ContextFlags = CONTEXT_FULL;
     CONTEXT_CaptureContext(contextRecord);
 

--- a/src/coreclr/pal/src/exception/seh-unwind.cpp
+++ b/src/coreclr/pal/src/exception/seh-unwind.cpp
@@ -939,7 +939,7 @@ RaiseException(IN DWORD dwExceptionCode,
     }
 
     // Capture the context of RaiseException.
-    new (contextRecord) CONTEXT();
+    ZeroMemory(contextRecord, sizeof(CONTEXT));
     contextRecord->ContextFlags = CONTEXT_FULL;
     CONTEXT_CaptureContext(contextRecord);
 

--- a/src/coreclr/pal/src/thread/context.cpp
+++ b/src/coreclr/pal/src/thread/context.cpp
@@ -29,7 +29,6 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD); // some headers have code with asserts, so do
 #endif
 #include <errno.h>
 #include <unistd.h>
-#include <new>
 
 extern PGET_GCMARKER_EXCEPTION_CODE g_getGcMarkerExceptionCode;
 
@@ -496,7 +495,7 @@ CONTEXT_GetThreadContext(
             ERROR("GetThreadContext on a thread other than the current "
                   "thread is returning TRUE\n");
             flags = lpContext->ContextFlags;
-            new (lpContext) CONTEXT();
+            memset(lpContext, 0, sizeof(*lpContext));
             lpContext->ContextFlags = flags;
             ret = TRUE;
             goto EXIT;

--- a/src/coreclr/pal/src/thread/context.cpp
+++ b/src/coreclr/pal/src/thread/context.cpp
@@ -29,6 +29,7 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD); // some headers have code with asserts, so do
 #endif
 #include <errno.h>
 #include <unistd.h>
+#include <new>
 
 extern PGET_GCMARKER_EXCEPTION_CODE g_getGcMarkerExceptionCode;
 

--- a/src/coreclr/pal/src/thread/context.cpp
+++ b/src/coreclr/pal/src/thread/context.cpp
@@ -495,7 +495,7 @@ CONTEXT_GetThreadContext(
             ERROR("GetThreadContext on a thread other than the current "
                   "thread is returning TRUE\n");
             flags = lpContext->ContextFlags;
-            memset(lpContext, 0, sizeof(*lpContext));
+            new (lpContext) CONTEXT();
             lpContext->ContextFlags = flags;
             ret = TRUE;
             goto EXIT;

--- a/src/coreclr/pal/src/thread/context.cpp
+++ b/src/coreclr/pal/src/thread/context.cpp
@@ -1898,7 +1898,7 @@ CONTEXT& CONTEXT::operator=(const CONTEXT& ctx)
     }
     else
     {
-        copySize = offsetof(CONTEXT, Ymm0H);
+        copySize = offsetof(CONTEXT, XStateFeaturesMask);
     }
 
     memcpy(this, &ctx, copySize);

--- a/src/coreclr/pal/src/thread/context.cpp
+++ b/src/coreclr/pal/src/thread/context.cpp
@@ -1880,3 +1880,29 @@ DBG_FlushInstructionCache(
 #endif
     return TRUE;
 }
+
+#ifdef HOST_AMD64
+CONTEXT& CONTEXT::operator=(const CONTEXT& ctx)
+{
+    size_t copySize;
+    if (ctx.ContextFlags & CONTEXT_XSTATE & CONTEXT_AREA_MASK)
+    {
+        if ((ctx.XStateFeaturesMask & XSTATE_MASK_AVX512) == XSTATE_MASK_AVX512)
+        {
+            copySize = sizeof(CONTEXT);
+        }
+        else
+        {
+            copySize = offsetof(CONTEXT, KMask0);
+        }
+    }
+    else
+    {
+        copySize = offsetof(CONTEXT, Ymm0H);
+    }
+
+    memcpy(this, &ctx, copySize);
+
+    return *this;
+}
+#endif // HOST_AMD64

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -1286,7 +1286,7 @@ bool FixNonvolatileRegisters(UINT_PTR  uOriginalSP,
     }
     CONTRACTL_END;
 
-    CONTEXT _ctx = {0};
+    CONTEXT _ctx = {};
 
     // Ctor will initialize it to NULL
     REGDISPLAY regdisp;


### PR DESCRIPTION
Few months ago, a change to enable AVX512 on Unix was merged in. That change has enlarged the CONTEXT structure significantly and it was found that it has caused 6..17% regressions in exception handling microbenchmarks.

This change gets some of the lost performance back by adding custom copy constructor and assignment operator to the CONTEXT structure and preventing copying of the AVX / AVX512 stuff if the source context doesn't have it. I have observed 3..9% gain on my machine.

Close #84308