### PR TITLE
[RISC-V] Add g_GCShadowEnd to JIT_WriteBarrier_Table

### DIFF
--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -46,7 +46,7 @@ LEAF_END GetCurrentSP, _TEXT
 // and each entry can be written atomically
 //
 WRITE_BARRIER_ENTRY JIT_UpdateWriteBarrierState
-    // a0-a7 will contain intended new state
+    // a0-a7 and t3 will contain intended new state
     // t0 will preserve skipEphemeralCheck
     // t2 will be used for pointers
 
@@ -64,30 +64,33 @@ WRITE_BARRIER_ENTRY JIT_UpdateWriteBarrierState
 #ifdef WRITE_BARRIER_CHECK
     lla  a2, g_GCShadow
     ld  a2, 0(a2)
-#endif
 
-#ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-    lla  a3, g_sw_ww_table
+    lla a3, g_GCShadowEnd
     ld  a3, 0(a3)
 #endif
 
-    lla  a4, g_ephemeral_low
+#ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
+    lla  a4, g_sw_ww_table
     ld  a4, 0(a4)
+#endif
 
-    lla  a5, g_ephemeral_high
+    lla  a5, g_ephemeral_low
     ld  a5, 0(a5)
+
+    lla  a6, g_ephemeral_high
+    ld  a6, 0(a6)
 
     beq  t0, zero, LOCAL_LABEL(EphemeralCheckEnabled)
 
-    ori  a4, zero, 0
-    addi  a5, zero, -1
+    ori  a5, zero, 0
+    addi  a6, zero, -1
 LOCAL_LABEL(EphemeralCheckEnabled):
 
-    lla  a6, g_lowest_address
-    ld  a6, 0(a6)
-
-    lla  a7, g_highest_address
+    lla  a7, g_lowest_address
     ld  a7, 0(a7)
+
+    lla  t3, g_highest_address
+    ld  t3, 0(t3)
 
     // Update wbs state
     lla  t2, JIT_WriteBarrier_Table_Loc
@@ -102,6 +105,7 @@ LOCAL_LABEL(EphemeralCheckEnabled):
     sd  a5, 40(t2)
     sd  a6, 48(t2)
     sd  a7, 56(t2)
+    sd  t3, 64(t2)
 
     EPILOG_RETURN
 
@@ -190,7 +194,6 @@ WRITE_BARRIER_END JIT_CheckedWriteBarrier
 //   t3  : trashed (incremented by 8 to implement JIT_ByRefWriteBarrier contract)
 //
 WRITE_BARRIER_ENTRY JIT_WriteBarrier
-
     // TODO: sync_release (runtime detection required)
     fence rw, rw
 
@@ -214,7 +217,7 @@ WRITE_BARRIER_ENTRY JIT_WriteBarrier
     add  t0, t6, t1
 
     // if (pShadow >= g_GCShadowEnd) goto end
-    lla  t6, g_GCShadowEnd
+    lla t6, wbs_GCShadowEnd
     ld  t6, 0(t6)
 
     slt  t6, t0, t6
@@ -306,6 +309,8 @@ wbs_card_table:
 wbs_card_bundle_table:
     .quad 0
 wbs_GCShadow:
+    .quad 0
+wbs_GCShadowEnd:
     .quad 0
 wbs_sw_ww_table:
     .quad 0


### PR DESCRIPTION
`lla` pseudo instruction which used for access to `g_GCShadowEnd` in `JIT_WriteBarrier` implemented via PC-relative addressing. But when `W^X` enabled, copy of `JIT_WriteBarrier` is being created and this PC-related addressing is not valid, which cause crash.

This change moves address of `g_GCShadowEnd` to `JIT_WriteBarrier_Table` like others variables used in Write Barrier.

Part of https://github.com/dotnet/runtime/issues/84834
cc @jakobbotsch @Maoni0 @wscho77 @HJLeee @JongHeonChoi @t-mustafin @clamp03 @gbalykov @tomeksowi