### PR TITLE
Reserve FOH segments in ExecutionAllocator and properly report them to debugger

### DIFF
--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -18,6 +18,7 @@
 #include "typestring.h"
 #include "daccess.h"
 #include "binder.h"
+#include "frozenobjectheap.h"
 #include "runtimeinfo.h"
 
 #ifdef FEATURE_COMWRAPPERS
@@ -347,6 +348,13 @@ HRESULT ClrDataAccess::EnumMemoryRegionsWorkerHeap(IN CLRDataEnumMemoryFlags fla
 
     // now dump the memory get dragged in by using DAC API implicitly.
     m_dumpStats.m_cbImplicitly = m_instances.DumpAllInstances(m_enumMemCb);
+
+    // Dump all frozen segments used by FrozenObjectHeapManager
+    PTR_FrozenObjectHeapManager fohManager = SystemDomain::GetFrozenObjectHeapManager();
+    if (fohManager != NULL)
+    {
+        CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED(fohManager->EnumMemoryRegions(flags); )
+    }
 
     // Do not let any remaining implicitly enumerated memory leak out.
     Flush();

--- a/src/coreclr/inc/dacvars.h
+++ b/src/coreclr/inc/dacvars.h
@@ -107,6 +107,7 @@ DEFINE_DACVAR(PTR_GcDacVars, dac__g_gcDacGlobals, g_gcDacGlobals)
 
 DEFINE_DACVAR(PTR_AppDomain, AppDomain__m_pTheAppDomain, AppDomain::m_pTheAppDomain)
 DEFINE_DACVAR(PTR_SystemDomain, SystemDomain__m_pSystemDomain, SystemDomain::m_pSystemDomain)
+DEFINE_DACVAR(PTR_FrozenObjectHeapManager, SystemDomain__m_pFrozenObjectHeapManager, SystemDomain::m_pFrozenObjectHeapManager)
 
 #ifdef FEATURE_INTEROP_DEBUGGING
 DEFINE_DACVAR(DWORD, dac__g_debuggerWordTLSIndex, g_debuggerWordTLSIndex)

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -76,6 +76,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     formattype.cpp
     fptrstubs.cpp
     frames.cpp
+    frozenobjectheap.cpp
     gctoclreventsink.cpp
     gcheaputilities.cpp
     gchandleutilities.cpp
@@ -320,7 +321,6 @@ set(VM_SOURCES_WKS
     fcall.cpp
     fieldmarshaler.cpp
     finalizerthread.cpp
-    frozenobjectheap.cpp
     gccover.cpp
     gcenv.ee.static.cpp
     gcenv.ee.common.cpp

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -88,6 +88,7 @@ static const WCHAR DEFAULT_DOMAIN_FRIENDLY_NAME[] = W("DefaultDomain");
 
 SPTR_IMPL(AppDomain, AppDomain, m_pTheAppDomain);
 SPTR_IMPL(SystemDomain, SystemDomain, m_pSystemDomain);
+SPTR_IMPL(FrozenObjectHeapManager, SystemDomain, m_pFrozenObjectHeapManager);
 
 #ifndef DACCESS_COMPILE
 
@@ -98,7 +99,6 @@ int                 BaseDomain::m_iNumberOfProcessors = 0;
 
 // System Domain Statics
 GlobalStringLiteralMap*  SystemDomain::m_pGlobalStringLiteralMap = NULL;
-FrozenObjectHeapManager* SystemDomain::m_FrozenObjectHeapManager = NULL;
 
 DECLSPEC_ALIGN(16)
 static BYTE         g_pSystemDomainMemory[sizeof(SystemDomain)];
@@ -1208,7 +1208,7 @@ void SystemDomain::LazyInitFrozenObjectsHeap()
     CONTRACTL_END;
 
     NewHolder<FrozenObjectHeapManager> pFoh(new FrozenObjectHeapManager());
-    if (InterlockedCompareExchangeT<FrozenObjectHeapManager*>(&m_FrozenObjectHeapManager, pFoh, nullptr) == nullptr)
+    if (InterlockedCompareExchangeT<FrozenObjectHeapManager*>(&m_pFrozenObjectHeapManager, pFoh, nullptr) == nullptr)
     {
         pFoh.SuppressRelease();
     }

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -32,6 +32,7 @@
 #endif
 
 #include "tieredcompilation.h"
+#include "frozenobjectheap.h"
 
 #include "codeversion.h"
 
@@ -2452,13 +2453,19 @@ public:
     static FrozenObjectHeapManager* GetFrozenObjectHeapManager()
     {
         WRAPPER_NO_CONTRACT;
-        if (m_FrozenObjectHeapManager == NULL)
+        if (m_pFrozenObjectHeapManager == NULL)
         {
             LazyInitFrozenObjectsHeap();
         }
-        return m_FrozenObjectHeapManager;
+        return m_pFrozenObjectHeapManager;
     }
-#endif // DACCESS_COMPILE
+#else // DACCESS_COMPILE
+    static PTR_FrozenObjectHeapManager GetFrozenObjectHeapManager()
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        return m_pFrozenObjectHeapManager;
+    }
+#endif // !DACCESS_COMPILE
 
 #if defined(FEATURE_COMINTEROP_APARTMENT_SUPPORT)
     static Thread::ApartmentState GetEntryPointThreadAptState(IMDInternalImport* pScope, mdMethodDef mdMethod);
@@ -2598,7 +2605,8 @@ private:
     {
         STANDARD_VM_CONTRACT;
 
-        m_pDelayedUnloadListOfLoaderAllocators=NULL;
+        m_pDelayedUnloadListOfLoaderAllocators = NULL;
+        m_pFrozenObjectHeapManager = NULL;
 
         m_GlobalAllocator.Init(this);
     }
@@ -2627,8 +2635,8 @@ private:
     static CrstStatic       m_SystemDomainCrst;
 
     static GlobalStringLiteralMap *m_pGlobalStringLiteralMap;
-    static FrozenObjectHeapManager *m_FrozenObjectHeapManager;
 #endif // DACCESS_COMPILE
+    SPTR_DECL(FrozenObjectHeapManager, m_pFrozenObjectHeapManager);
 
 public:
     //****************************************************************************************

--- a/src/coreclr/vm/common.h
+++ b/src/coreclr/vm/common.h
@@ -97,6 +97,8 @@
 #include <daccess.h>
 
 typedef VPTR(class LoaderAllocator)     PTR_LoaderAllocator;
+typedef DPTR(class FrozenObjectHeapManager) PTR_FrozenObjectHeapManager;
+typedef DPTR(class FrozenObjectSegment) PTR_FrozenObjectSegment;
 typedef VPTR(class AppDomain)           PTR_AppDomain;
 typedef DPTR(class ArrayBase)           PTR_ArrayBase;
 typedef DPTR(class Assembly)            PTR_Assembly;

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -66,7 +66,7 @@ Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t 
         {
             m_FirstSegment = new FrozenObjectSegment(FOH_SEGMENT_DEFAULT_SIZE);
             m_CurrentSegment = m_FirstSegment;
-            _ASSERT(m_CurrentSegment->GetNextSegment() == nullptr);
+            _ASSERT(m_CurrentSegment->m_NextSegment == nullptr);
         }
 
         obj = m_CurrentSegment->TryAllocateObject(type, objectSize);

--- a/src/coreclr/vm/profilingenumerators.cpp
+++ b/src/coreclr/vm/profilingenumerators.cpp
@@ -106,21 +106,16 @@ BOOL ProfilerObjectEnum::Init()
     FrozenObjectHeapManager* foh = SystemDomain::GetFrozenObjectHeapManager();
     CrstHolder ch(&foh->m_Crst);
 
-    const unsigned segmentsCount = foh->m_FrozenSegments.GetCount();
-    FrozenObjectSegment** segments = foh->m_FrozenSegments.GetElements();
-    if (segments != nullptr)
+    PTR_FrozenObjectSegment curr = foh->m_FirstSegment;
+    while (curr != nullptr)
     {
-        for (unsigned segmentIdx = 0; segmentIdx < segmentsCount; segmentIdx++)
+        Object* currentObj = curr->GetFirstObject();
+        while (currentObj != nullptr)
         {
-            const FrozenObjectSegment* segment = segments[segmentIdx];
-
-            Object* currentObj = segment->GetFirstObject();
-            while (currentObj != nullptr)
-            {
-                *m_elements.Append() = reinterpret_cast<size_t>(currentObj);
-                currentObj = segment->GetNextObject(currentObj);
-            }
+            *m_elements.Append() = reinterpret_cast<size_t>(currentObj);
+            currentObj = curr->GetNextObject(currentObj);
         }
+        curr = curr->m_NextSegment;
     }
     return TRUE;
 }


### PR DESCRIPTION
I've checked `dotnet-dump collect --type Heap` + `dumpheap` that all the frozen objects are properly included and can be enumerated.


This should allow jit to use relocs (mainly, for boxed statics), e.g.:
```csharp
static DateTime Date { get; set; }
```
Codegen for getter (same for setter):
Previously (after https://github.com/dotnet/runtime/pull/77737):
```asm
; Assembly listing for method get_Date()
       48B8901762B29D020000 mov      rax, 0x29DB2621790
       488B00               mov      rax, qword ptr [rax]
       C3                   ret
; Total bytes of code 14
```
New codegen:
```asm

; Assembly listing for method get_Date()
       488B0571E41000       mov      rax, qword ptr [(reloc 0x7fff54fc17b8)]
       C3                   ret
; Total bytes of code 8
```