### PR TITLE
Put HasNativeCodeReJITAware into GetFunctionAddress

### DIFF
--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -1253,17 +1253,6 @@ public:
         /* [out] */ union STUB_BUF* outBuffer,
         /* [out] */ ULONG32* outFlags);
 
-    DebuggerJitInfo* GetDebuggerJitInfo(MethodDesc* methodDesc,
-                                        TADDR addr)
-    {
-        if (g_pDebugger)
-        {
-            return g_pDebugger->GetJitInfo(methodDesc, (PBYTE)addr, NULL);
-        }
-
-        return NULL;
-    }
-
     HRESULT GetMethodExtents(MethodDesc* methodDesc,
                              METH_EXTENTS** extents);
     HRESULT GetMethodVarInfo(MethodDesc* methodDesc,

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -5225,7 +5225,7 @@ EnumMethodInstances::Next(ClrDataAccess* dac,
         }
     }
 
-    if (!m_methodIter.Current()->HasNativeCodeReJITAware())
+    if (!m_methodIter.Current()->HasNativeCodeAnyVersion())
     {
         goto NextMethod;
     }
@@ -5243,7 +5243,7 @@ EnumMethodInstances::CdStart(MethodDesc* methodDesc,
                              CLRDATA_ENUM* handle)
 {
     if (!methodDesc->HasClassOrMethodInstantiation() &&
-        !(methodDesc->HasNativeCodeReJITAware()))
+        !(methodDesc->HasNativeCodeAnyVersion()))
     {
         *handle = 0;
         return S_FALSE;

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -5225,7 +5225,7 @@ EnumMethodInstances::Next(ClrDataAccess* dac,
         }
     }
 
-    if (!(g_pEEInterface->GetFunctionAddress(m_methodIter.Current()) != NULL))
+    if (!m_methodIter.Current()->HasNativeCodeReJITAware())
     {
         goto NextMethod;
     }
@@ -5243,7 +5243,7 @@ EnumMethodInstances::CdStart(MethodDesc* methodDesc,
                              CLRDATA_ENUM* handle)
 {
     if (!methodDesc->HasClassOrMethodInstantiation() &&
-        !(g_pEEInterface->GetFunctionAddress(methodDesc) != NULL))
+        !(methodDesc->HasNativeCodeReJITAware()))
     {
         *handle = 0;
         return S_FALSE;

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -5225,7 +5225,7 @@ EnumMethodInstances::Next(ClrDataAccess* dac,
         }
     }
 
-    if (!m_methodIter.Current()->HasNativeCodeReJITAware())
+    if (!(g_pEEInterface->GetFunctionAddress(m_methodIter.Current()) != NULL))
     {
         goto NextMethod;
     }
@@ -5243,7 +5243,7 @@ EnumMethodInstances::CdStart(MethodDesc* methodDesc,
                              CLRDATA_ENUM* handle)
 {
     if (!methodDesc->HasClassOrMethodInstantiation() &&
-        !methodDesc->HasNativeCodeReJITAware())
+        !(g_pEEInterface->GetFunctionAddress(methodDesc) != NULL))
     {
         *handle = 0;
         return S_FALSE;

--- a/src/coreclr/debug/di/breakpoint.cpp
+++ b/src/coreclr/debug/di/breakpoint.cpp
@@ -216,6 +216,7 @@ HRESULT CordbFunctionBreakpoint::Activate(BOOL fActivate)
         {
             pEvent->BreakpointData.nativeCodeMethodDescToken =
                 (m_code.GetValue()->AsNativeCode())->GetVMNativeCodeMethodDescToken().ToLsPtr();
+            pEvent->BreakpointData.codeStartAddress = (m_code.GetValue()->AsNativeCode())->GetAddress();
         }
 
         // Note: we're sending a two-way event, so it blocks here

--- a/src/coreclr/debug/di/breakpoint.cpp
+++ b/src/coreclr/debug/di/breakpoint.cpp
@@ -211,6 +211,7 @@ HRESULT CordbFunctionBreakpoint::Activate(BOOL fActivate)
         if (codeIsIL)
         {
             pEvent->BreakpointData.nativeCodeMethodDescToken = pEvent->BreakpointData.nativeCodeMethodDescToken.NullPtr();
+            pEvent->BreakpointData.codeStartAddress = 0;
         }
         else
         {

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -1247,7 +1247,7 @@ bool DebuggerController::BindPatch(DebuggerControllerPatch *patch,
             startAddr = (CORDB_ADDRESS_TYPE *) CORDB_ADDRESS_TO_PTR(patch->GetDJI()->m_addrOfCode);
             _ASSERTE(startAddr != NULL);
         }
-        //We  should never be calling this function with both a NULL startAddr and a DJI that doesn't have code.
+        //We should never be calling this function with both a NULL startAddr and a DJI that doesn't have code.
         _ASSERTE(startAddr != NULL);
     }
 

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -1249,6 +1249,7 @@ bool DebuggerController::BindPatch(DebuggerControllerPatch *patch,
         }
         if (startAddr == NULL)
         {
+            _ASSERTE(startAddr == NULL);
             // Should not be trying to place patches on MethodDecs's for stubs.
             // These stubs will never get jitted.
             CONSISTENCY_CHECK_MSGF(!pMD->IsWrapperStub(), ("Can't place patch at stub md %p, %s::%s",

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -1247,27 +1247,8 @@ bool DebuggerController::BindPatch(DebuggerControllerPatch *patch,
             startAddr = (CORDB_ADDRESS_TYPE *) CORDB_ADDRESS_TO_PTR(patch->GetDJI()->m_addrOfCode);
             _ASSERTE(startAddr != NULL);
         }
-        if (startAddr == NULL)
-        {
-            _ASSERTE(startAddr == NULL);
-            // Should not be trying to place patches on MethodDecs's for stubs.
-            // These stubs will never get jitted.
-            CONSISTENCY_CHECK_MSGF(!pMD->IsWrapperStub(), ("Can't place patch at stub md %p, %s::%s",
-                                   pMD, pMD->m_pszDebugClassName, pMD->m_pszDebugMethodName));
-
-            startAddr = (CORDB_ADDRESS_TYPE *)g_pEEInterface->GetFunctionAddress(pMD);
-            //
-            // Code is not available yet to patch.  The prestub should
-            // notify us when it is executed.
-            //
-            if (startAddr == NULL)
-            {
-                LOG((LF_CORDB, LL_INFO10000,
-                    "DC::BP: Patch at 0x%zx not bindable yet.\n", patch->offset));
-
-                return false;
-            }
-        }
+        //We  should never be calling this function with both a NULL startAddr and a DJI that doesn't have code.
+        _ASSERTE(startAddr != NULL);
     }
 
     _ASSERTE(!g_pEEInterface->IsStub((const BYTE *)startAddr));
@@ -8656,7 +8637,7 @@ bool DebuggerFuncEvalComplete::SendEvent(Thread *thread, bool fIpChanged)
 // DebuggerEnCBreakpoint constructor - creates and activates a new EnC breakpoint
 //
 // Arguments:
-//    offset        - native offset in the function to place the patch
+//    offset        - IL offset in the function to place the patch
 //    jitInfo       - identifies the function in which the breakpoint is being placed
 //    fTriggerType  - breakpoint type: either REMAP_PENDING or REMAP_COMPLETE
 //    pAppDomain    - the breakpoint applies to the specified AppDomain only

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -2832,6 +2832,8 @@ HRESULT Debugger::GetILToNativeMapping(PCODE pNativeCodeStartAddress, ULONG32 cM
     }
     CONTRACTL_END;
 
+    _ASSERTE(pNativeCodeStartAddress != NULL);
+
 #ifdef PROFILING_SUPPORTED
     // At this point, we're pulling in the debugger.
     if (!HasLazyData())
@@ -2998,6 +3000,7 @@ HRESULT Debugger::GetILToNativeMappingIntoArrays(
     _ASSERTE(pcMap != NULL);
     _ASSERTE(prguiILOffset != NULL);
     _ASSERTE(prguiNativeOffset != NULL);
+    _ASSERTE(pNativeCodeStartAddress != NULL);
 
     // Any caller of GetILToNativeMappingIntoArrays had better call
     // InitializeLazyDataIfNecessary first!
@@ -5402,28 +5405,6 @@ void Debugger::ReleaseAllRuntimeThreads(AppDomain *pAppDomain)
     g_pEEInterface->ResumeFromDebug(pAppDomain);
 }
 
-// Given a method, get's its EnC version number. 1 if the method is not EnCed.
-// Note that MethodDescs are reused between versions so this will give us
-// the most recent EnC number.
-int Debugger::GetMethodEncNumber(MethodDesc * pMethod)
-{
-    CONTRACTL
-    {
-        THROWS;
-        GC_NOTRIGGER;
-    }
-    CONTRACTL_END;
-
-    DebuggerJitInfo * dji = GetLatestJitInfoFromMethodDesc(pMethod);
-    if (dji == NULL)
-    {
-        // If there's no DJI, couldn't have been EnCed.
-        return 1;
-    }
-    return (int) dji->m_encVersion;
-}
-
-
 bool Debugger::IsJMCMethod(Module* pModule, mdMethodDef tkMethod)
 {
     CONTRACTL
@@ -6210,25 +6191,6 @@ void Debugger::LockAndSendEnCRemapCompleteEvent(MethodDesc *pMD)
     Thread *thread = g_pEEInterface->GetThread();
     // Note that the debugger lock is reentrant, so we may or may not hold it already.
     SENDIPCEVENT_BEGIN(this, thread);
-
-    EX_TRY
-    {
-        // Ensure the DJI for the latest version of this method has been pre-created.
-        // It's not clear whether this is necessary or not, but it shouldn't hurt since
-        // we're going to need to create it anyway since we'll be debugging inside it.
-        DebuggerJitInfo *dji = g_pDebugger->GetLatestJitInfoFromMethodDesc(pMD);
-        (void)dji; //prevent "unused variable" error from GCC
-        _ASSERTE( dji != NULL );
-    }
-    EX_CATCH
-    {
-        // GetLatestJitInfo could throw on OOM, but the debugger isn't resiliant to OOM.
-        // I'm not aware of any other legitimate reason why it may throw, so we'll ASSERT
-        // if it fails.
-        _ASSERTE(!"Unexpected exception from Debugger::GetLatestJitInfoFromMethodDesc on EnC remap complete");
-    }
-    EX_END_CATCH(RethrowTerminalExceptions);
-
     // Send an EnC remap complete event to the Right Side.
     DebuggerIPCEvent* ipce = m_pRCThread->GetIPCEventSendBuffer();
     InitIPCEvent(ipce,
@@ -7856,6 +7818,7 @@ void Debugger::FirstChanceManagedExceptionCatcherFound(Thread *pThread,
     // Implements DebugInterface
     // Call by EE/exception. Must be on managed thread
     _ASSERTE(GetThreadNULLOk() != NULL);
+    _ASSERTE(pMethodAddr != NULL);
 
     // Quick check.
     if (!CORDebuggerAttached())
@@ -12616,7 +12579,7 @@ DWORD Debugger::GetThreadIdHelper(Thread *pThread)
 // does not own the memory provided via vars outparameter.
 //-----------------------------------------------------------------------------
 void Debugger::GetVarInfo(MethodDesc *       fd,   // [IN] method of interest
-                    void *DebuggerVersionToken,    // [IN] which edit version
+                    CORDB_ADDRESS nativeCodeAddress,    // [IN] which edit version
                     SIZE_T *           cVars,      // [OUT] size of 'vars'
                     const ICorDebugInfo::NativeVarInfo **vars     // [OUT] map telling where local vars are stored
                     )
@@ -12628,7 +12591,7 @@ void Debugger::GetVarInfo(MethodDesc *       fd,   // [IN] method of interest
     }
     CONTRACTL_END;
 
-    DebuggerJitInfo * ji = (DebuggerJitInfo *)DebuggerVersionToken;
+    DebuggerJitInfo * ji = g_pDebugger->GetJitInfo(fd, (const BYTE *)nativeCodeAddress);
 
     // If we didn't supply a DJI, then we're asking for the most recent version.
     if (ji == NULL)

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -10452,7 +10452,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
             DebuggerJitInfo * pDJI =  NULL;
             if ((pMethodDesc != NULL) && (pDMI != NULL))
             {
-                pDJI = pDMI->FindOrCreateInitAndAddJitInfo(pMethodDesc, NULL /* startAddr */);
+                pDJI = pDMI->FindOrCreateInitAndAddJitInfo(pMethodDesc, pEvent->BreakpointData.codeStartAddress);
             }
 
             {

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -10452,7 +10452,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
             DebuggerJitInfo * pDJI =  NULL;
             if ((pMethodDesc != NULL) && (pDMI != NULL))
             {
-                pDJI = pDMI->FindOrCreateInitAndAddJitInfo(pMethodDesc, pEvent->BreakpointData.codeStartAddress);
+                pDJI = pDMI->FindOrCreateInitAndAddJitInfo(pMethodDesc, dac_cast<PCODE>(pEvent->BreakpointData.codeStartAddress));
             }
 
             {

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -13982,6 +13982,7 @@ bool Debugger::GetILOffsetFromNative (MethodDesc *pFunc, const BYTE *pbAddr,
     DebuggerJitInfo *jitInfo = methodInfo->FindOrCreateInitAndAddJitInfo(pFunc, methodStartAddress);
     if (jitInfo == NULL)
     {
+
         return false;
     }
 

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -10452,7 +10452,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
             DebuggerJitInfo * pDJI =  NULL;
             if ((pMethodDesc != NULL) && (pDMI != NULL))
             {
-                pDJI = pDMI->FindOrCreateInitAndAddJitInfo(pMethodDesc, dac_cast<PCODE>(pEvent->BreakpointData.codeStartAddress));
+                pDJI = pDMI->FindOrCreateInitAndAddJitInfo(pMethodDesc, PINSTRToPCODE(dac_cast<TADDR>(pEvent->BreakpointData.codeStartAddress)));
             }
 
             {

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -13982,7 +13982,6 @@ bool Debugger::GetILOffsetFromNative (MethodDesc *pFunc, const BYTE *pbAddr,
     DebuggerJitInfo *jitInfo = methodInfo->FindOrCreateInitAndAddJitInfo(pFunc, methodStartAddress);
     if (jitInfo == NULL)
     {
-
         return false;
     }
 

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -12915,6 +12915,11 @@ HRESULT Debugger::UpdateFunction(MethodDesc* pMD, SIZE_T encVersion)
 
     // For each offset in the IL->Native map, set a new EnC breakpoint on the
     // ones that we know could be remap points.
+
+    // Depending on which DJI was picked, the code might compute different IL offsets. The JIT may not guarantee it produces
+    // the same set of sequence points for every generic instantiation.
+    // Inside ENCSequencePointHelper there is logic that skips IL offsets that map to the same native offset.
+    // Its possible that one version of the code maps two IL offsets to the same native offset but another version of the code maps them to different offsets.
     PTR_DebuggerILToNativeMap seqMap = pJitInfo->GetSequenceMap();
     for (unsigned int i = 0; i < pJitInfo->GetSequenceMapCount(); i++)
     {

--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -1933,8 +1933,6 @@ public:
 
     bool IsJMCMethod(Module* pModule, mdMethodDef tkMethod);
 
-    int GetMethodEncNumber(MethodDesc * pMethod);
-
 
     bool FirstChanceManagedException(Thread *pThread, SIZE_T currentIP, SIZE_T currentSP);
 
@@ -1980,7 +1978,7 @@ public:
 #endif // EnC_SUPPORTED
 
     void GetVarInfo(MethodDesc *       fd,         // [IN] method of interest
-                    void *DebuggerVersionToken,    // [IN] which edit version
+                    CORDB_ADDRESS nativeCodeAddress,    // [IN] which edit version
                     SIZE_T *           cVars,      // [OUT] size of 'vars'
                     const ICorDebugInfo::NativeVarInfo **vars     // [OUT] map telling where local vars are stored
                     );

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1566,7 +1566,6 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
     }
     CONTRACTL_END;
     _ASSERTE(fd != NULL);
-
     // The debugger doesn't track Lightweight-codegen methods b/c they have no metadata.
     if (fd->IsDynamicMethod())
     {
@@ -1579,10 +1578,7 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
         if (startAddr == NULL)
         {
             startAddr = fd->GetNativeCodeReJITAware();
-            if (startAddr == NULL)
-            {
-                return NULL;
-            }
+            _ASSERTE(startAddr != NULL);
         }
     }
     else
@@ -1646,7 +1642,7 @@ DebuggerJitInfo *DebuggerMethodInfo::CreateInitAndAddJitInfo(NativeCodeVersion n
 
     _ASSERTE(fd != NULL);
 
-    // May or may-not be jitted, that's why we passed in the start addr & size explicitly.    
+    // May or may-not be jitted, that's why we passed in the start addr & size explicitly.
     _ASSERTE(startAddr != NULL);
 
     *jitInfoWasCreated = FALSE;

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1575,12 +1575,7 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
     if (startAddr == NULL)
     {
         startAddr = g_pEEInterface->GetFunctionAddress(fd);
-        //Test failure requires the below workaround, not sure how startAddr could be null
-        if (startAddr == NULL)
-        {
-            startAddr = fd->GetNativeCodeAnyVersion();
-            _ASSERTE(startAddr != NULL);
-        }
+        _ASSERTE(startAddr != NULL);
     }
     else
     {

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1576,16 +1576,17 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
 
     if (startAddr == NULL)
     {
-        // This will grab the start address for the current code version.
+        //Not any longer!!!!// This will grab the start address for the current code version.
         startAddr = g_pEEInterface->GetFunctionAddress(fd);
-        if (startAddr == NULL)
-        {
-            startAddr = fd->GetNativeCodeReJITAware();
-            if (startAddr == NULL)
-            {
-                return NULL;
-            }
-        }
+        // startAddr = g_pEEInterface->GetNativeCodeReJITAware(fd);
+        // if (startAddr == NULL)
+        // {
+        //     // startAddr = fd->GetFunctionAddress();
+        //     // if (startAddr == NULL)
+        //     // {
+        //     //     return NULL;
+        //     // }
+        // }
     }
     else
     {

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1576,17 +1576,7 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
 
     if (startAddr == NULL)
     {
-        //Not any longer!!!!// This will grab the start address for the current code version.
         startAddr = g_pEEInterface->GetFunctionAddress(fd);
-        // startAddr = g_pEEInterface->GetNativeCodeReJITAware(fd);
-        // if (startAddr == NULL)
-        // {
-        //     // startAddr = fd->GetFunctionAddress();
-        //     // if (startAddr == NULL)
-        //     // {
-        //     //     return NULL;
-        //     // }
-        // }
     }
     else
     {

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1577,7 +1577,7 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
         startAddr = g_pEEInterface->GetFunctionAddress(fd);
         if (startAddr == NULL)
         {
-            startAddr = fd->GetNativeCodeReJITAware();
+            startAddr = fd->GetNativeCodeAnyVersion();
             _ASSERTE(startAddr != NULL);
         }
     }

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1575,6 +1575,7 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
     if (startAddr == NULL)
     {
         startAddr = g_pEEInterface->GetFunctionAddress(fd);
+        //Test failure requires the below workaround, not sure how startAddr could be null
         if (startAddr == NULL)
         {
             startAddr = fd->GetNativeCodeAnyVersion();

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1565,7 +1565,6 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
         GC_NOTRIGGER;
     }
     CONTRACTL_END;
-
     _ASSERTE(fd != NULL);
 
     // The debugger doesn't track Lightweight-codegen methods b/c they have no metadata.
@@ -1577,6 +1576,14 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
     if (startAddr == NULL)
     {
         startAddr = g_pEEInterface->GetFunctionAddress(fd);
+        if (startAddr == NULL)
+        {
+            startAddr = fd->GetNativeCodeReJITAware();
+            if (startAddr == NULL)
+            {
+                return NULL;
+            }
+        }
     }
     else
     {
@@ -1639,7 +1646,7 @@ DebuggerJitInfo *DebuggerMethodInfo::CreateInitAndAddJitInfo(NativeCodeVersion n
 
     _ASSERTE(fd != NULL);
 
-    // May or may-not be jitted, that's why we passed in the start addr & size explicitly.
+    // May or may-not be jitted, that's why we passed in the start addr & size explicitly.    
     _ASSERTE(startAddr != NULL);
 
     *jitInfoWasCreated = FALSE;

--- a/src/coreclr/debug/inc/dbgipcevents.h
+++ b/src/coreclr/debug/inc/dbgipcevents.h
@@ -2011,6 +2011,7 @@ struct MSLAYOUT DebuggerIPCEvent
             SIZE_T       offset;
             SIZE_T       encVersion;
             LSPTR_METHODDESC  nativeCodeMethodDescToken; // points to the MethodDesc if !isIL
+            CORDB_ADDRESS codeStartAddress;
         } BreakpointData;
 
         struct MSLAYOUT

--- a/src/coreclr/vm/dbginterface.h
+++ b/src/coreclr/vm/dbginterface.h
@@ -203,7 +203,7 @@ public:
 
     // Get debugger variable information for a specific version of a method
     virtual     void GetVarInfo(MethodDesc *       fd,         // [IN] method of interest
-                                void *DebuggerVersionToken,    // [IN] which edit version
+                                CORDB_ADDRESS nativeCodeAddress,    // [IN] which edit version
                                 SIZE_T *           cVars,      // [OUT] size of 'vars'
                                 const ICorDebugInfo::NativeVarInfo **vars     // [OUT] map telling where local vars are stored
                                 ) = 0;
@@ -261,11 +261,6 @@ public:
     ) = 0;
 
     virtual bool IsJMCMethod(Module* pModule, mdMethodDef tkMethod) = 0;
-
-    // Given a method, get's its EnC version number. 1 if the method is not EnCed.
-    // Note that MethodDescs are reused between versions so this will give us
-    // the most recent EnC number.
-    virtual int GetMethodEncNumber(MethodDesc * pMethod) = 0;
 
     virtual void SendLogSwitchSetting (int iLevel,
                                        int iReason,

--- a/src/coreclr/vm/eedbginterfaceimpl.cpp
+++ b/src/coreclr/vm/eedbginterfaceimpl.cpp
@@ -631,7 +631,32 @@ PCODE EEDbgInterfaceImpl::GetFunctionAddress(MethodDesc *pFD)
     }
     CONTRACTL_END;
 
-    return pFD->GetNativeCode();
+    //return pFD->GetNativeCode();
+        WRAPPER_NO_CONTRACT;
+    SUPPORTS_DAC;
+
+    PCODE pDefaultCode = pFD->GetNativeCode();
+    if (pDefaultCode != NULL)
+    {
+        return pDefaultCode;
+    }
+
+    {
+        Module *pModule = pFD->GetModule();
+        CodeVersionManager *pCodeVersionManager = pModule->GetCodeVersionManager();
+        CodeVersionManager::LockHolder codeVersioningLockHolder;
+        ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(PTR_MethodDesc(pFD));
+        if (!ilVersion.IsDefaultVersion())
+        {
+            NativeCodeVersion activeNativeCodeVersion = ilVersion.GetActiveNativeCodeVersion(PTR_MethodDesc(pFD));
+            if (!activeNativeCodeVersion.IsNull())
+            {
+                return activeNativeCodeVersion.GetNativeCode();
+            }
+        }
+
+        return NULL;
+    }
 }
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/eedbginterfaceimpl.cpp
+++ b/src/coreclr/vm/eedbginterfaceimpl.cpp
@@ -630,33 +630,7 @@ PCODE EEDbgInterfaceImpl::GetFunctionAddress(MethodDesc *pFD)
         SUPPORTS_DAC;
     }
     CONTRACTL_END;
-
-    //return pFD->GetNativeCode();
-        WRAPPER_NO_CONTRACT;
-    SUPPORTS_DAC;
-
-    PCODE pDefaultCode = pFD->GetNativeCode();
-    if (pDefaultCode != NULL)
-    {
-        return pDefaultCode;
-    }
-
-    {
-        Module *pModule = pFD->GetModule();
-        CodeVersionManager *pCodeVersionManager = pModule->GetCodeVersionManager();
-        CodeVersionManager::LockHolder codeVersioningLockHolder;
-        ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(PTR_MethodDesc(pFD));
-        if (!ilVersion.IsDefaultVersion())
-        {
-            NativeCodeVersion activeNativeCodeVersion = ilVersion.GetActiveNativeCodeVersion(PTR_MethodDesc(pFD));
-            if (!activeNativeCodeVersion.IsNull())
-            {
-                return activeNativeCodeVersion.GetNativeCode();
-            }
-        }
-
-        return NULL;
-    }
+    return pFD->GetNativeCode();
 }
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/encee.cpp
+++ b/src/coreclr/vm/encee.cpp
@@ -804,8 +804,8 @@ NOINLINE void EditAndContinueModule::FixContextAndResume(
     // Get the var info which the codemanager will use for updating
     // enregistered variables correctly, or variables whose lifetimes differ
     // at the update point
-    g_pDebugInterface->GetVarInfo(pMD, oldDebuggerFuncHandle, &oldVarInfoCount, &pOldVarInfo);
-    g_pDebugInterface->GetVarInfo(pMD, NULL,                  &newVarInfoCount, &pNewVarInfo);
+    g_pDebugInterface->GetVarInfo(pMD, oldCodeInfo.GetCodeAddress(), &oldVarInfoCount, &pOldVarInfo);
+    g_pDebugInterface->GetVarInfo(pMD, newCodeInfo.GetCodeAddress(),                  &newVarInfoCount, &pNewVarInfo);
 
 #ifdef TARGET_X86
     // save the frame pointer as FixContextForEnC might step on it.

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -935,34 +935,6 @@ PCODE MethodDesc::GetNativeCode()
     return GetStableEntryPoint();
 }
 
-// PCODE MethodDesc::GetNativeCodeReJITAware()
-// {
-//     WRAPPER_NO_CONTRACT;
-//     SUPPORTS_DAC;
-
-//     PCODE pDefaultCode = GetNativeCode();
-//     if (pDefaultCode != NULL)
-//     {
-//         return pDefaultCode;
-//     }
-
-//     {
-//         CodeVersionManager *pCodeVersionManager = GetCodeVersionManager();
-//         CodeVersionManager::LockHolder codeVersioningLockHolder;
-//         ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(PTR_MethodDesc(this));
-//         if (!ilVersion.IsDefaultVersion())
-//         {
-//             NativeCodeVersion activeNativeCodeVersion = ilVersion.GetActiveNativeCodeVersion(PTR_MethodDesc(this));
-//             if (!activeNativeCodeVersion.IsNull())
-//             {
-//                 return activeNativeCodeVersion.GetNativeCode();
-//             }
-//         }
-
-//         return NULL;
-//     }
-// }
-
 //*******************************************************************************
 PTR_PCODE MethodDesc::GetAddrOfNativeCodeSlot()
 {

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -935,33 +935,33 @@ PCODE MethodDesc::GetNativeCode()
     return GetStableEntryPoint();
 }
 
-PCODE MethodDesc::GetNativeCodeReJITAware()
-{
-    WRAPPER_NO_CONTRACT;
-    SUPPORTS_DAC;
+// PCODE MethodDesc::GetNativeCodeReJITAware()
+// {
+//     WRAPPER_NO_CONTRACT;
+//     SUPPORTS_DAC;
 
-    PCODE pDefaultCode = GetNativeCode();
-    if (pDefaultCode != NULL)
-    {
-        return pDefaultCode;
-    }
+//     PCODE pDefaultCode = GetNativeCode();
+//     if (pDefaultCode != NULL)
+//     {
+//         return pDefaultCode;
+//     }
 
-    {
-        CodeVersionManager *pCodeVersionManager = GetCodeVersionManager();
-        CodeVersionManager::LockHolder codeVersioningLockHolder;
-        ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(PTR_MethodDesc(this));
-        if (!ilVersion.IsDefaultVersion())
-        {
-            NativeCodeVersion activeNativeCodeVersion = ilVersion.GetActiveNativeCodeVersion(PTR_MethodDesc(this));
-            if (!activeNativeCodeVersion.IsNull())
-            {
-                return activeNativeCodeVersion.GetNativeCode();
-            }
-        }
+//     {
+//         CodeVersionManager *pCodeVersionManager = GetCodeVersionManager();
+//         CodeVersionManager::LockHolder codeVersioningLockHolder;
+//         ILCodeVersion ilVersion = pCodeVersionManager->GetActiveILCodeVersion(PTR_MethodDesc(this));
+//         if (!ilVersion.IsDefaultVersion())
+//         {
+//             NativeCodeVersion activeNativeCodeVersion = ilVersion.GetActiveNativeCodeVersion(PTR_MethodDesc(this));
+//             if (!activeNativeCodeVersion.IsNull())
+//             {
+//                 return activeNativeCodeVersion.GetNativeCode();
+//             }
+//         }
 
-        return NULL;
-    }
-}
+//         return NULL;
+//     }
+// }
 
 //*******************************************************************************
 PTR_PCODE MethodDesc::GetAddrOfNativeCodeSlot()

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -934,7 +934,7 @@ PCODE MethodDesc::GetNativeCode()
     return GetStableEntryPoint();
 }
 
-PCODE MethodDesc::GetNativeCodeReJITAware()
+PCODE MethodDesc::GetNativeCodeAnyVersion()
 {
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1372,15 +1372,6 @@ public:
         return GetNativeCode() != NULL;
     }
 
-    // Perf warning: takes the CodeVersionManagerLock on every call
-    // BOOL HasNativeCodeReJITAware()
-    // {
-    //     LIMITED_METHOD_DAC_CONTRACT;
-    //     return GetFunctionAddress() != NULL;
-
-    //     // return GetNativeCodeReJITAware() != NULL;
-    // }
-
     BOOL SetNativeCodeInterlocked(PCODE addr, PCODE pExpected = NULL);
 
     PTR_PCODE GetAddrOfNativeCodeSlot();
@@ -1436,11 +1427,6 @@ public:
     //*******************************************************************************
     // Returns the address of the native code.
     PCODE GetNativeCode();
-
-    // Returns GetNativeCode() if it exists, but also checks to see if there
-    // is a non-default IL code version and returns that.
-    // Perf warning: takes the CodeVersionManagerLock on every call
-    //PCODE GetNativeCodeReJITAware();
 
 #if defined(FEATURE_JIT_PITCHING)
     bool IsPitchable();

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1372,6 +1372,14 @@ public:
         return GetNativeCode() != NULL;
     }
 
+    // Perf warning: takes the CodeVersionManagerLock on every call
+    BOOL HasNativeCodeReJITAware()
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+
+        return GetNativeCodeReJITAware() != NULL;
+    }
+
     BOOL SetNativeCodeInterlocked(PCODE addr, PCODE pExpected = NULL);
 
     PTR_PCODE GetAddrOfNativeCodeSlot();
@@ -1427,6 +1435,11 @@ public:
     //*******************************************************************************
     // Returns the address of the native code.
     PCODE GetNativeCode();
+
+    // Returns GetNativeCode() if it exists, but also checks to see if there
+    // is a non-default IL code version and returns that.
+    // Perf warning: takes the CodeVersionManagerLock on every call
+    PCODE GetNativeCodeReJITAware();
 
 #if defined(FEATURE_JIT_PITCHING)
     bool IsPitchable();

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1373,11 +1373,11 @@ public:
     }
 
     // Perf warning: takes the CodeVersionManagerLock on every call
-    BOOL HasNativeCodeReJITAware()
+    BOOL HasNativeCodeAnyVersion()
     {
         LIMITED_METHOD_DAC_CONTRACT;
 
-        return GetNativeCodeReJITAware() != NULL;
+        return GetNativeCodeAnyVersion() != NULL;
     }
 
     BOOL SetNativeCodeInterlocked(PCODE addr, PCODE pExpected = NULL);
@@ -1439,7 +1439,7 @@ public:
     // Returns GetNativeCode() if it exists, but also checks to see if there
     // is a non-default IL code version and returns that.
     // Perf warning: takes the CodeVersionManagerLock on every call
-    PCODE GetNativeCodeReJITAware();
+    PCODE GetNativeCodeAnyVersion();
 
 #if defined(FEATURE_JIT_PITCHING)
     bool IsPitchable();

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1373,12 +1373,13 @@ public:
     }
 
     // Perf warning: takes the CodeVersionManagerLock on every call
-    BOOL HasNativeCodeReJITAware()
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
+    // BOOL HasNativeCodeReJITAware()
+    // {
+    //     LIMITED_METHOD_DAC_CONTRACT;
+    //     return GetFunctionAddress() != NULL;
 
-        return GetNativeCodeReJITAware() != NULL;
-    }
+    //     // return GetNativeCodeReJITAware() != NULL;
+    // }
 
     BOOL SetNativeCodeInterlocked(PCODE addr, PCODE pExpected = NULL);
 
@@ -1439,7 +1440,7 @@ public:
     // Returns GetNativeCode() if it exists, but also checks to see if there
     // is a non-default IL code version and returns that.
     // Perf warning: takes the CodeVersionManagerLock on every call
-    PCODE GetNativeCodeReJITAware();
+    //PCODE GetNativeCodeReJITAware();
 
 #if defined(FEATURE_JIT_PITCHING)
     bool IsPitchable();

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1437,7 +1437,7 @@ public:
     PCODE GetNativeCode();
 
     // Returns GetNativeCode() if it exists, but also checks to see if there
-    // is a non-default IL code version and returns that.
+    // is a non-default code version that is populated with a code body and returns that.
     // Perf warning: takes the CodeVersionManagerLock on every call
     PCODE GetNativeCodeAnyVersion();
 


### PR DESCRIPTION
Went through many branches of the call tree to understand which changes needed to be made to ensure safe behavior when updating GetFunctionAddress to return possibly arbitrary nativeCode. 