### PR TITLE
[JIT] ARM64 vector right-shift must dead-code eliminate if the constant is zero.

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -5162,8 +5162,7 @@ void emitter::emitIns_R_R_I(
             assert(isVectorRegister(reg2));
             isRightShift = emitInsIsVectorRightShift(ins);
 
-            // temporarily commenting this out
-            //assert(!isRightShift || (imm != 0 && "instructions for vector right-shift do not allow zero as an immediate value"));
+            assert(!isRightShift || (imm != 0 && "instructions for vector right-shift do not allow zero as an immediate value"));
 
             if (insOptsAnyArrangement(opt))
             {

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -5162,7 +5162,8 @@ void emitter::emitIns_R_R_I(
             assert(isVectorRegister(reg2));
             isRightShift = emitInsIsVectorRightShift(ins);
 
-            assert(!isRightShift || (imm != 0 && "instructions for vector right-shift do not allow zero as an immediate value"));
+            // temporarily commenting this out
+            //assert(!isRightShift || (imm != 0 && "instructions for vector right-shift do not allow zero as an immediate value"));
 
             if (insOptsAnyArrangement(opt))
             {

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -5162,7 +5162,8 @@ void emitter::emitIns_R_R_I(
             assert(isVectorRegister(reg2));
             isRightShift = emitInsIsVectorRightShift(ins);
 
-            assert(!isRightShift || (imm != 0 && "instructions for vector right-shift do not allow zero as an immediate value"));
+            assert(!isRightShift ||
+                   (imm != 0 && "instructions for vector right-shift do not allow zero as an immediate value"));
 
             if (insOptsAnyArrangement(opt))
             {

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -5162,6 +5162,8 @@ void emitter::emitIns_R_R_I(
             assert(isVectorRegister(reg2));
             isRightShift = emitInsIsVectorRightShift(ins);
 
+            assert(!isRightShift || (imm != 0 && "instructions for vector right-shift do not allow zero as an immediate value"));
+
             if (insOptsAnyArrangement(opt))
             {
                 // Vector operation

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -344,7 +344,9 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
 
                     if (shiftAmount == 0)
                     {
-                        // TODO: Use emitIns_Mov instead, but it will still elide even if 'canSkip' is false.
+                        // TODO: Use emitIns_Mov instead.
+                        //       We do not use it currently because it will still elide the 'mov'
+                        //       even if 'canSkip' is false. We cannot elide the 'mov' here.
                         GetEmitter()->emitIns_R_R_R(INS_mov, emitTypeSize(node), targetReg, reg, reg);
                     }
                     else

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -335,8 +335,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
         {
             assert(hasImmediateOperand);
 
-            auto emitShift = [&](GenTree* op, regNumber reg)
-            {
+            auto emitShift = [&](GenTree* op, regNumber reg) {
                 HWIntrinsicImmOpHelper helper(this, op, node);
 
                 for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -335,29 +335,32 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
         {
             assert(hasImmediateOperand);
 
+            auto emitShift = [&](GenTree* op, regNumber reg) {
+                HWIntrinsicImmOpHelper helper(this, op, node);
+
+                for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())
+                {
+                    const int shiftAmount = helper.ImmValue();
+
+                    if (shiftAmount == 0)
+                    {
+                        GetEmitter()->emitIns_Mov(INS_mov, emitSize, targetReg, reg, /* canSkip */ false);
+                    }
+                    else
+                    {
+                        GetEmitter()->emitIns_R_R_I(ins, emitSize, targetReg, reg, shiftAmount, opt);
+                    }
+                }
+            };
+
             if (isRMW)
             {
                 GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
-
-                HWIntrinsicImmOpHelper helper(this, intrin.op3, node);
-
-                for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())
-                {
-                    const int shiftAmount = helper.ImmValue();
-
-                    GetEmitter()->emitIns_R_R_I(ins, emitSize, targetReg, op2Reg, shiftAmount, opt);
-                }
+                emitShift(intrin.op3, op2Reg);
             }
             else
             {
-                HWIntrinsicImmOpHelper helper(this, intrin.op2, node);
-
-                for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())
-                {
-                    const int shiftAmount = helper.ImmValue();
-
-                    GetEmitter()->emitIns_R_R_I(ins, emitSize, targetReg, op1Reg, shiftAmount, opt);
-                }
+                emitShift(intrin.op2, op1Reg);
             }
         }
         else

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -335,7 +335,8 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
         {
             assert(hasImmediateOperand);
 
-            auto emitShift = [&](GenTree* op, regNumber reg) {
+            auto emitShift = [&](GenTree* op, regNumber reg)
+            {
                 HWIntrinsicImmOpHelper helper(this, op, node);
 
                 for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -344,6 +344,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
 
                     if (shiftAmount == 0)
                     {
+                        // TODO: Use emitIns_Mov instead, but it will still elide even if 'canSkip' is false.
                         GetEmitter()->emitIns_R_R_R(INS_mov, emitTypeSize(node), targetReg, reg, reg);
                     }
                     else

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -344,7 +344,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
 
                     if (shiftAmount == 0)
                     {
-                        GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, reg, /* canSkip */ false);
+                        GetEmitter()->emitIns_R_R_R(INS_mov, emitTypeSize(node), targetReg, reg, reg);
                     }
                     else
                     {

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -344,7 +344,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
 
                     if (shiftAmount == 0)
                     {
-                        GetEmitter()->emitIns_Mov(INS_mov, emitSize, targetReg, reg, /* canSkip */ false);
+                        GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, reg, /* canSkip */ false);
                     }
                     else
                     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/89868

The vector right-shift instructions do not allow a zero immediate value in the encoding. See the [docs](https://developer.arm.com/documentation/dui0801/g/A64-SIMD-Vector-Instructions/USHR--vector-).

> shift
Is the right shift amount, in the range 1 to the element width in bits, and can be one of the values shown in Usage.