### PR TITLE
Fix deadlock in EventPipeEventDispatcher

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2075,6 +2075,9 @@
   <data name="EventSource_ChannelTypeDoesNotMatchEventChannelValue" xml:space="preserve">
     <value>Channel {0} does not match event channel value {1}.</value>
   </data>
+  <data name="EventSource_CouldNotEnableEventPipe" xml:space="preserve">
+    <value>Failed to open an EventPipe session for NativeRuntimeEventSource.</value>
+  </data>
   <data name="EventSource_DataDescriptorsOutOfRange" xml:space="preserve">
     <value>Data descriptors are out of range.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventDispatcher.cs
@@ -131,6 +131,7 @@ namespace System.Diagnostics.Tracing
         private void StartDispatchTask(ulong sessionID, DateTime syncTimeUtc, long syncTimeQPC, long timeQPCFrequency)
         {
             Debug.Assert(Monitor.IsEntered(m_dispatchControlLock));
+            Debug.Assert(sessionID != 0);
 
             m_dispatchTaskCancellationSource = new CancellationTokenSource();
             Task? previousDispatchTask = m_dispatchTask;
@@ -151,6 +152,7 @@ namespace System.Diagnostics.Tracing
 
         private unsafe void DispatchEventsToEventListeners(ulong sessionID, DateTime syncTimeUtc, long syncTimeQPC, long timeQPCFrequency, Task? previousDispatchTask, CancellationToken token)
         {
+            Debug.Assert(sessionID != 0);
             previousDispatchTask?.Wait(CancellationToken.None);
 
             // Struct to fill with the call to GetNextEvent.
@@ -178,7 +180,7 @@ namespace System.Diagnostics.Tracing
                 {
                     if (!eventsReceived)
                     {
-                        EventPipeInternal.WaitForSessionSignal(m_sessionID, Timeout.Infinite);
+                        EventPipeInternal.WaitForSessionSignal(sessionID, Timeout.Infinite);
                     }
 
                     Thread.Sleep(10);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventDispatcher.cs
@@ -143,6 +143,7 @@ namespace System.Diagnostics.Tracing
 
             if (m_dispatchTask != null)
             {
+                Debug.Assert(m_dispatchTaskCancellationSource != null);
                 m_dispatchTaskCancellationSource?.Cancel();
                 EventPipeInternal.SignalSession(m_sessionID);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -4078,7 +4078,6 @@ namespace System.Diagnostics.Tracing
 
 #if FEATURE_PERFTRACING
             // Remove the listener from the EventPipe dispatcher. EventCommand.Update with enable==false removes it.
-            // Have to send outside of EventListenersLock, or we risk deadlocks.
             EventPipeEventDispatcher.Instance.SendCommand(this, EventCommand.Update, false, EventLevel.LogAlways, (EventKeywords)0);
 #endif // FEATURE_PERFTRACING
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -4075,6 +4075,12 @@ namespace System.Diagnostics.Tracing
                 }
                 Validate();
             }
+
+#if FEATURE_PERFTRACING
+            // Remove the listener from the EventPipe dispatcher. EventCommand.Update with enable==false removes it.
+            // Have to send outside of EventListenersLock, or we risk deadlocks.
+            EventPipeEventDispatcher.Instance.SendCommand(this, EventCommand.Update, false, EventLevel.LogAlways, (EventKeywords)0);
+#endif // FEATURE_PERFTRACING
         }
         // We don't expose a Dispose(bool), because the contract is that you don't have any non-syncronous
         // 'cleanup' associated with this object
@@ -4391,11 +4397,6 @@ namespace System.Diagnostics.Tracing
                     }
                 }
             }
-
-#if FEATURE_PERFTRACING
-            // Remove the listener from the EventPipe dispatcher.
-            EventPipeEventDispatcher.Instance.RemoveEventListener(listenerToRemove);
-#endif // FEATURE_PERFTRACING
         }
 
 

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -665,7 +665,7 @@ disable_helper (EventPipeSessionID id)
 		ep_provider_callback_data_queue_fini (provider_callback_data_queue);
 
 #ifdef EP_CHECKED_BUILD
-		if (ep_volatile_load_number_of_sessions () == 0)
+		if (ep_volatile_load_number_of_sessions () == 0 && ep_volatile_load_eventpipe_state () != EP_STATE_SHUTTING_DOWN)
 			EP_ASSERT (ep_rt_providers_validate_all_disabled ());
 #endif
 

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -1432,7 +1432,9 @@ ep_shutdown (void)
 
 	for (uint32_t i = 0; i < EP_MAX_NUMBER_OF_SESSIONS; ++i) {
 		EventPipeSession *session = ep_volatile_load_session (i);
-		if (session)
+		// Do not shut down listener sessions on shutdown, the processing thread will
+		// still be trying to process events in the background until the process is torn down
+		if (session && session->session_type != EP_SESSION_TYPE_LISTENER)
 			ep_disable ((EventPipeSessionID)session);
 	}
 


### PR DESCRIPTION
Fixes #86838

In EventPipeEventDispatcher we currently wait on the session to close synchronously before updating the configuration, this can lead to a deadlock if the dispatcher thread tries to call back in to EventSource apis (as described in #86838).

This change fixes the deadlock by making stopping the session asynchronous, and moving the call to update EventPipeEventDispatcher outside of the EventListenersLock in EventListener.Dispose.

This is the test program I used to recreate the deadlock. It would reliably hit the deadlock within a minute before, and can run for hours without a deadlock after

```
// See https://aka.ms/new-console-template for more information
using System.Diagnostics;
using System.Diagnostics.Tracing;
using System.Reflection.Emit;

Console.WriteLine("Hello, World!");

List<Thread> threads = new List<Thread>();
DateTime lastUpdate = DateTime.Now;

threads.Add(new Thread(() =>
{
    while (true)
    {
        RuntimeEventListener listener = new RuntimeEventListener();
        Thread.Sleep(100);
        listener.Dispose();

        lastUpdate = DateTime.Now;
        Console.Write('.');
    }
}));

threads.ForEach(x => x.Start());

while (true)
{
    // create some GC events
    GC.Collect();
    GC.Collect();

    Thread.Sleep(1000);
    if ((DateTime.Now - lastUpdate) > TimeSpan.FromSeconds(10))
    {
        Console.WriteLine("Deadlock!");
        Debugger.Launch();
        Debugger.Break();
    }
}

[EventSource(Name = "SampleEventSource")]
class SampleEventSource : EventSource
{

}

class RuntimeEventListener : EventListener
{
    protected override void OnEventSourceCreated(EventSource eventSource)
    {
        base.OnEventSourceCreated(eventSource);

        if (eventSource.Name.Equals("Microsoft-Windows-DotNETRuntime"))
        {
            EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)0x11);
        }
    }

    protected override void OnEventWritten(EventWrittenEventArgs eventData)
    {
        base.OnEventWritten(eventData);

        Console.Write("!");
        using (SampleEventSource testSource = new SampleEventSource())
        {
            testSource.Write("OneEvent");
        }
    }
}
```

As part of this fix we discovered a latent bug in EventPipeEventDispatcher as described in #90052. We are too close to releasing .net 8 to make this kind of change so the work will happen in a later release.