### PR TITLE
Make [In] the default for blittable arrays that are pinned

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceAnalyzer.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Interop.Analyzers
             String
         }
 
-        private sealed record TrackedMarshallingInfo(TrackedMarshallingInfoAnnotation TrackingAnnotation, MarshallingInfo InnerInfo): MarshallingInfo;
+        private sealed record TrackedMarshallingInfo(TrackedMarshallingInfoAnnotation TrackingAnnotation, MarshallingInfo InnerInfo) : MarshallingInfo;
 
         private sealed class TrackingStringMarshallingInfoProvider : ITypeBasedMarshallingInfoProvider
         {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ByValueMarshalKindSupportDescriptor.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ByValueMarshalKindSupportDescriptor.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Interop
             InOutSupport: ByValueMarshalKindSupport.Supported, InOutSupportDetails: null);
 
         /// <summary>
-        /// A default <see cref="ByValueMarshalKindSupportDescriptor"/> for pinned by value parameters. [In] is not allowed. [In, Out] is the default and unnecessary. [Out] is allowed.
+        /// A default <see cref="ByValueMarshalKindSupportDescriptor"/> for pinned parameters. [In] is allowed, but unnecessary. Out is allowed.
         /// </summary>
         public static readonly ByValueMarshalKindSupportDescriptor PinnedParameter = new ByValueMarshalKindSupportDescriptor(
             InSupport: ByValueMarshalKindSupport.Unnecessary, InSupportDetails: SR.InAttributeOnlyIsDefault,

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ByValueMarshalKindSupportDescriptor.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ByValueMarshalKindSupportDescriptor.cs
@@ -34,9 +34,9 @@ namespace Microsoft.Interop
         /// A default <see cref="ByValueMarshalKindSupportDescriptor"/> for pinned by value parameters. [In] is not allowed. [In, Out] is the default and unnecessary. [Out] is allowed.
         /// </summary>
         public static readonly ByValueMarshalKindSupportDescriptor PinnedParameter = new ByValueMarshalKindSupportDescriptor(
-            InSupport: ByValueMarshalKindSupport.NotSupported, InSupportDetails: SR.InAttributeOnlyNotSupportedOnPinnedParameters,
+            InSupport: ByValueMarshalKindSupport.Unnecessary, InSupportDetails: SR.InAttributeOnlyIsDefault,
             OutSupport: ByValueMarshalKindSupport.Supported, OutSupportDetails: null,
-            InOutSupport: ByValueMarshalKindSupport.Unnecessary, InOutSupportDetails: SR.PinnedMarshallingIsInOutByDefault);
+            InOutSupport: ByValueMarshalKindSupport.Supported, InOutSupportDetails: null);
 
         /// <summary>
         /// Returns the support for the ByValueContentsMarshalKind, and if it is not <see cref="ByValueMarshalKindSupport.Supported"/>, diagnostic is not null

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
@@ -142,15 +142,6 @@ namespace Microsoft.Interop
         private static string PinnedIdentifier(string identifier) => $"{identifier}__pinned";
         public ByValueMarshalKindSupport SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, TypePositionInfo info, StubCodeContext context, out GeneratorDiagnostic? diagnostic)
         {
-            // Maybe should be done in the CharMarshallerFactory, but complexity and interdependence bleeds in if you do that
-            if (IsPinningPathSupported(info, context) && info.RefKind == RefKind.In)
-            {
-                diagnostic = new GeneratorDiagnostic.NotSupported(info, context)
-                {
-                    NotSupportedDetails = SR.InRefKindIsNotSupportedOnPinnedParameters
-                };
-                return ByValueMarshalKindSupport.NotSupported;
-            }
             return ByValueMarshalKindSupportDescriptor.Default.GetSupport(marshalKind, info, context, out diagnostic);
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomTypeMarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomTypeMarshallingGenerator.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Interop
         {
             return
             info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out)
-                && _byValueContentsMarshallingSupport.GetSupport(info.ByValueContentsMarshalKind, info, context, out _) == ByValueMarshalKindSupport.Supported
+                && _byValueContentsMarshallingSupport.GetSupport(info.ByValueContentsMarshalKind, info, context, out _) != ByValueMarshalKindSupport.NotSupported
                 && !info.IsByRef
                 && !_isPinned;
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/IMarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/IMarshallingGeneratorFactory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Runtime.InteropServices;
-using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Interop
 {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StaticPinnableManagedValueMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StaticPinnableManagedValueMarshaller.cs
@@ -105,14 +105,6 @@ namespace Microsoft.Interop
 
         public ByValueMarshalKindSupport SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, TypePositionInfo info, StubCodeContext context, out GeneratorDiagnostic? diagnostic)
         {
-            if (marshalKind is ByValueContentsMarshalKind.In)
-            {
-                diagnostic = new GeneratorDiagnostic.NotSupported(info, context)
-                {
-                    NotSupportedDetails = SR.InAttributeOnlyNotSupportedOnPinnedParameters
-                };
-                return ByValueMarshalKindSupport.NotSupported;
-            }
             return ByValueMarshalKindSupportDescriptor.PinnedParameter.GetSupport(marshalKind, info, context, out diagnostic);
         }
     }

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
@@ -79,13 +79,7 @@ namespace ComInterfaceGenerator.Tests
             Assert.Equal(data, value);
             obj.SwapArray(ref data, data.Length);
             obj.PassIn(in data, data.Length);
-        }
-
-        [Fact]
-        public void IIntArray_Failing()
-        {
-            var obj = CreateWrapper<IIntArrayImpl, IIntArray>();
-            int[] data = new int[] { 1, 2, 3 };
+            data = new int[] { 1, 2, 3 };
             obj.Double(data, data.Length);
             Assert.True(data is [2, 4, 6]);
         }

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
@@ -82,7 +82,6 @@ namespace ComInterfaceGenerator.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/89265")]
         public void IIntArray_Failing()
         {
             var obj = CreateWrapper<IIntArrayImpl, IIntArray>();

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/CompileFails.cs
@@ -746,14 +746,12 @@ namespace ComInterfaceGenerator.Unit.Tests
                     .WithLocation(0)
                     .WithArguments(SR.InAttributeOnlyNotSupportedOnPinnedParameters, paramName);
             yield return new object[] { ID(), codeSnippets.ByValueMarshallingOfType(inAttribute + constElementCount, "int[]", paramNameWithLocation), new DiagnosticResult[] {
-                inAttributeNotSupportedOnPinnedParameter
+                inAttributeIsDefaultDiagnostic
             }};
-            // blittable arrays don't support [In] only. Different diagnostics are issued because we can pin in one direction (managed->unmanaged)
-            // but not the other direction.
             yield return new object[] {
                 ID(),
                 codeSnippets.ByValueMarshallingOfType(inAttribute + constElementCount, "char[]", paramNameWithLocation, (StringMarshalling.Utf16, null)),
-                new DiagnosticResult[] { inAttributeNotSupportedOnPinnedParameter, inAttributeIsDefaultDiagnostic }
+                new DiagnosticResult[] { inAttributeIsDefaultDiagnostic }
             };
 
             // bools that are marshalled into a new array are in by default
@@ -782,12 +780,12 @@ namespace ComInterfaceGenerator.Unit.Tests
             yield return new object[] {
                 ID(),
                 codeSnippets.ByValueMarshallingOfType(inAttribute + outAttribute + constElementCount, "int[]", paramNameWithLocation),
-                new DiagnosticResult[] { inOutAttributeIsDefaultDiagnostic }
+                new DiagnosticResult[] { }
             };
             yield return new object[] {
                 ID(),
                 codeSnippets.ByValueMarshallingOfType(inAttribute + outAttribute + constElementCount, "char[]", paramNameWithLocation, (StringMarshalling.Utf16, null)),
-                new DiagnosticResult[] { inOutAttributeIsDefaultDiagnostic }
+                new DiagnosticResult[] { }
             };
 
             yield return new object[] {

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CompileFails.cs
@@ -832,11 +832,12 @@ namespace LibraryImportGenerator.UnitTests
                     .WithLocation(1)
                     .WithArguments("ref return", "Basic.RefReadonlyReturn()"),
             } };
-            yield return new object[] { ID(), CodeSnippets.ByValueParameterWithModifier<int[]>("In"), new[]
+            yield return new object[] { ID(), CodeSnippets.ByValueParameterWithModifier<int[]>("{|#10:In|}"), new[]
             {
-                VerifyCS.Diagnostic(GeneratorDiagnostics.ParameterTypeNotSupportedWithDetails)
+                VerifyCS.Diagnostic(GeneratorDiagnostics.UnnecessaryParameterMarshallingInfo)
                     .WithLocation(0)
-                    .WithArguments(SR.InAttributeOnlyNotSupportedOnPinnedParameters, "p")
+                    .WithLocation(10)
+                    .WithArguments("[In] and [Out] attributes", "p", SR.InAttributeOnlyIsDefault)
             } };
         }
 

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Interop.UnitTests;
 using Xunit;
+using GeneratorDiagnostics = Microsoft.Interop.GeneratorDiagnostics;
 using VerifyCS = Microsoft.Interop.UnitTests.Verifiers.CSharpSourceGeneratorVerifier<Microsoft.Interop.LibraryImportGenerator>;
 
 namespace LibraryImportGenerator.UnitTests
@@ -752,7 +753,7 @@ namespace LibraryImportGenerator.UnitTests
             yield return new object[] { ID(), CodeSnippets.ByValueParameterWithModifier<int[]>("{|#10:In|}, {|#11:Out|}"), new DiagnosticResult[] { } };
 
             yield return new object[] { ID(), CodeSnippets.ByValueParameterWithModifier<int[]>("{|#10:In|}"), new DiagnosticResult[] {
-                VerifyCS.Diagnostic(Microsoft.Interop.GeneratorDiagnostics.UnnecessaryParameterMarshallingInfo)
+                VerifyCS.Diagnostic(GeneratorDiagnostics.UnnecessaryParameterMarshallingInfo)
                     .WithLocation(0)
                     .WithLocation(10)
                     .WithArguments("[In] and [Out] attributes", "p", SR.InAttributeOnlyIsDefault)

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -17,7 +17,6 @@ using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Interop.UnitTests;
 using Xunit;
-using GeneratorDiagnostics = Microsoft.Interop.GeneratorDiagnostics;
 using VerifyCS = Microsoft.Interop.UnitTests.Verifiers.CSharpSourceGeneratorVerifier<Microsoft.Interop.LibraryImportGenerator>;
 
 namespace LibraryImportGenerator.UnitTests
@@ -750,13 +749,13 @@ namespace LibraryImportGenerator.UnitTests
             // Blittable array
             yield return new object[] { ID(), CodeSnippets.ByValueParameterWithModifier<int[]>("{|#10:Out|}"), new DiagnosticResult[] { } };
 
-            yield return new object[] { ID(), CodeSnippets.ByValueParameterWithModifier<int[]>("{|#10:In|}, {|#11:Out|}"), new[]
-            {
-                VerifyCS.Diagnostic(GeneratorDiagnostics.UnnecessaryParameterMarshallingInfo)
+            yield return new object[] { ID(), CodeSnippets.ByValueParameterWithModifier<int[]>("{|#10:In|}, {|#11:Out|}"), new DiagnosticResult[] { } };
+
+            yield return new object[] { ID(), CodeSnippets.ByValueParameterWithModifier<int[]>("{|#10:In|}"), new DiagnosticResult[] {
+                VerifyCS.Diagnostic(Microsoft.Interop.GeneratorDiagnostics.UnnecessaryParameterMarshallingInfo)
                     .WithLocation(0)
                     .WithLocation(10)
-                    .WithLocation(11)
-                    .WithArguments("[In] and [Out] attributes", "p", SR.PinnedMarshallingIsInOutByDefault)
+                    .WithArguments("[In] and [Out] attributes", "p", SR.InAttributeOnlyIsDefault)
             } };
         }
 

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessPinnableCollectionBlittableElements.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatelessPinnableCollectionBlittableElements.cs
@@ -1,0 +1,156 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface]
+    [Guid("3BBB0C99-7D6C-4AD1-BE4C-ACB4C2127F02")]
+    internal partial interface IStatelessPinnableCollectionBlittableElements
+    {
+        void Method(
+            [MarshalUsing(CountElementName = nameof(size))] StatelessPinnableCollection<int> p,
+            int size);
+
+        void MethodIn(
+            [MarshalUsing(CountElementName = nameof(size))] in StatelessPinnableCollection<int> pIn,
+            in int size);
+
+        void MethodRef(
+            [MarshalUsing(CountElementName = nameof(size))] ref StatelessPinnableCollection<int> pRef,
+            int size);
+
+        void MethodOut(
+            [MarshalUsing(CountElementName = nameof(size))] out StatelessPinnableCollection<int> pOut,
+            out int size);
+
+        [return: MarshalUsing(CountElementName = nameof(size))]
+        StatelessPinnableCollection<int> Return(int size);
+
+        [PreserveSig]
+        [return: MarshalUsing(CountElementName = nameof(size))]
+        StatelessPinnableCollection<int> ReturnPreserveSig(int size);
+    }
+
+    [NativeMarshalling(typeof(StatelessPinnableCollectionMarshaller<,>))]
+    internal class StatelessPinnableCollection<T> where T : unmanaged
+    {
+    }
+
+    internal unsafe struct StatelessPinnableCollectionNative<T> where T : unmanaged
+    {
+        public static explicit operator StatelessPinnableCollectionNative<T>(void* ptr) => new StatelessPinnableCollectionNative<T>();
+        public static explicit operator void*(StatelessPinnableCollectionNative<T> ptr) => (void*)null;
+    }
+
+
+    [ContiguousCollectionMarshaller]
+    [CustomMarshaller(typeof(StatelessPinnableCollection<>), MarshalMode.ManagedToUnmanagedIn, typeof(StatelessPinnableCollectionMarshaller<,>.ManagedToUnmanaged))]
+    [CustomMarshaller(typeof(StatelessPinnableCollection<>), MarshalMode.UnmanagedToManagedOut, typeof(StatelessPinnableCollectionMarshaller<,>.ManagedToUnmanaged))]
+    [CustomMarshaller(typeof(StatelessPinnableCollection<>), MarshalMode.ElementIn, typeof(StatelessPinnableCollectionMarshaller<,>.ManagedToUnmanaged))]
+    [CustomMarshaller(typeof(StatelessPinnableCollection<>), MarshalMode.ManagedToUnmanagedOut, typeof(StatelessPinnableCollectionMarshaller<,>.UnmanagedToManaged))]
+    [CustomMarshaller(typeof(StatelessPinnableCollection<>), MarshalMode.UnmanagedToManagedIn, typeof(StatelessPinnableCollectionMarshaller<,>.UnmanagedToManaged))]
+    [CustomMarshaller(typeof(StatelessPinnableCollection<>), MarshalMode.ElementOut, typeof(StatelessPinnableCollectionMarshaller<,>.UnmanagedToManaged))]
+    [CustomMarshaller(typeof(StatelessPinnableCollection<>), MarshalMode.UnmanagedToManagedRef, typeof(StatelessPinnableCollectionMarshaller<,>.Bidirectional))]
+    [CustomMarshaller(typeof(StatelessPinnableCollection<>), MarshalMode.ManagedToUnmanagedRef, typeof(StatelessPinnableCollectionMarshaller<,>.Bidirectional))]
+    [CustomMarshaller(typeof(StatelessPinnableCollection<>), MarshalMode.ElementRef, typeof(StatelessPinnableCollectionMarshaller<,>.Bidirectional))]
+    internal static unsafe class StatelessPinnableCollectionMarshaller<T, TUnmanagedElement>
+        where T : unmanaged
+        where TUnmanagedElement : unmanaged
+    {
+        internal static class Bidirectional
+        {
+            public static StatelessPinnableCollectionNative<T> AllocateContainerForUnmanagedElements(StatelessPinnableCollection<T> managed, out int numElements)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static StatelessPinnableCollection<T> AllocateContainerForManagedElements(StatelessPinnableCollectionNative<T> unmanaged, int numElements)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static ReadOnlySpan<T> GetManagedValuesSource(StatelessPinnableCollection<T> managed)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static Span<TUnmanagedElement> GetUnmanagedValuesDestination(StatelessPinnableCollectionNative<T> unmanaged, int numElements)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(StatelessPinnableCollectionNative<T> unmanaged, int numElements)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static Span<T> GetManagedValuesDestination(StatelessPinnableCollection<T> managed)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static ref StatelessPinnableCollectionNative<T> GetPinnableReference(StatelessPinnableCollection<T> managed)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void Free(StatelessPinnableCollectionNative<T> unmanaged) { }
+        }
+
+        internal static class ManagedToUnmanaged
+        {
+            public static StatelessPinnableCollectionNative<T> AllocateContainerForUnmanagedElements(StatelessPinnableCollection<T> managed, out int numElements)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static ReadOnlySpan<T> GetManagedValuesSource(StatelessPinnableCollection<T> managed)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static Span<TUnmanagedElement> GetUnmanagedValuesDestination(StatelessPinnableCollectionNative<T> unmanaged, int numElements)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static ref StatelessPinnableCollectionNative<T> GetPinnableReference(StatelessPinnableCollection<T> managed)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void Free(StatelessPinnableCollectionNative<T> unmanaged) => throw new NotImplementedException();
+        }
+
+        internal static class UnmanagedToManaged
+        {
+            public static StatelessPinnableCollection<T> AllocateContainerForManagedElements(StatelessPinnableCollectionNative<T> unmanaged, int numElements)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(StatelessPinnableCollectionNative<T> unmanaged, int numElements)
+            {
+                throw new NotImplementedException();
+            }
+
+            // Should be removed: https://github.com/dotnet/runtime/issues/89885
+            public static Span<TUnmanagedElement> GetUnmanagedValuesDestination(StatelessPinnableCollectionNative<T> unmanaged, int numElements)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static Span<T> GetManagedValuesDestination(StatelessPinnableCollection<T> managed)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static void Free(StatelessPinnableCollectionNative<T> unmanaged) => throw new NotImplementedException();
+
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/89265

The default for arrays of blittable elements and pinned parameters is now [In], and [In,Out] will not be considered unnecessary information. The change in CustomTypeMarshallingGenerator.cs makes it so that parameters with [In,Out] will actually marshal back to the caller in the unmanaged to managed stubs