### PR TITLE
[NativeAOT] Do not suppress inlining of random threadstatics

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -724,12 +724,6 @@ namespace ILCompiler
                         if (t.ConvertToCanonForm(CanonicalFormKind.Specific) != t)
                             continue;
 
-#if DEBUG
-                        // do not inline storage for some types in debug - for test coverage
-                        if (i % 8 == 0)
-                            continue;
-#endif
-
                         types.Add(t);
 
                         // N.B. for ARM32, we would need to deal with > PointerSize alignments.


### PR DESCRIPTION
Fixes: #89993

When we did not have a way to disable inlining of threadstatic storage, suppressing inlining of a fraction of threadstatic variables in Checked/Debug builds made sense from code coverage and testing point of view.  
Now that we have a compiler switch to disable inlining and have entire platform combinations that do not inline, the value of such instrumentation is not high.

On the other hand, it could result in issues like #89993
The culprit is that there is at least one variable `ThreadStatics.t_inlinedThreadStaticBase` that we assume to always participate in inlining (if there is inlining at all). The variable caches inlined threadstatic storage and assumes that mere accessing the variable will initiaize the cache. That will not be guaranteed if the variable itself is not on inlined plan.

We could, in theory, just ensure that we do not bump `t_inlinedThreadStaticBase` off the inlining plan as a part of random selection, but it seems better to stop doing that entirely.