### PR TITLE
[mono][aot] Use g_strcasecmp () to check whenever aot input assemblie…

### DIFF
--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -1414,7 +1414,7 @@ main_thread_handler (gpointer user_data)
 				MonoImage *img;
 
 				img = mono_image_open (main_args->argv [i], &status);
-				if (img && strcmp (img->name, assembly->image->name)) {
+				if (img && g_strcasecmp (img->name, assembly->image->name)) {
 					fprintf (stderr, "Error: Loaded assembly '%s' doesn't match original file name '%s'. Set MONO_PATH to the assembly's location.\n", assembly->image->name, img->name);
 					exit (1);
 				}


### PR DESCRIPTION
…s are loaded from the correct location.

Fixes https://github.com/dotnet/runtime/issues/90030.