### PR TITLE
Fix mono's Wsingle-bit-bitfield-constant-conversion

### DIFF
--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -223,7 +223,7 @@ enum {
 	/* added by metadata-update after class was created;
 	 * not in MonoClassEventInfo array - don't do ptr arithmetic */
 	MONO_EVENT_META_FLAG_FROM_UPDATE = 0x00010000,
-	
+
 	MONO_EVENT_META_FLAG_MASK = 0x00010000,
 };
 
@@ -504,11 +504,11 @@ struct _MonoGenericContainer {
 	int type_argc    : 29; // Per the ECMA spec, this value is capped at 16 bits
 	/* If true, we're a generic method, otherwise a generic type definition. */
 	/* Invariant: parent != NULL => is_method */
-	int is_method     : 1;
+	gint is_method     : 1;
 	/* If true, this container has no associated class/method and only the image is known. This can happen:
 	   1. For the special anonymous containers kept by MonoImage.
 	   2. When user code creates a generic parameter via SRE, but has not yet set an owner. */
-	int is_anonymous : 1;
+	gint is_anonymous : 1;
 	/* Our type parameters. If this is a special anonymous container (case 1, above), this field is not valid, use mono_metadata_create_anon_gparam ()  */
 	MonoGenericParamFull *type_params;
 };

--- a/src/mono/mono/metadata/image-internals.h
+++ b/src/mono/mono/metadata/image-internals.h
@@ -10,14 +10,14 @@
 #include <mono/metadata/loader-internals.h>
 
 typedef struct {
-	gboolean dont_care_about_cli : 1;
-	gboolean dont_care_about_pecoff : 1;
+	guint dont_care_about_cli : 1;
+	guint dont_care_about_pecoff : 1;
 } MonoImageLoadOptions;
 
 typedef struct {
 	MonoImageLoadOptions load_options;
-	int not_executable : 1;
-	int metadata_only : 1;
+	guint not_executable : 1;
+	guint metadata_only : 1;
 } MonoImageOpenOptions;
 
 MonoImage*

--- a/src/mono/mono/metadata/jit-info.h
+++ b/src/mono/mono/metadata/jit-info.h
@@ -106,8 +106,8 @@ typedef struct
 	MonoDwarfLocListEntry *locations;
 	gint32 this_offset;
 	guint8 this_reg;
-	guint32 has_this:1;
-	guint32 this_in_reg:1;
+	guint has_this:1;
+	guint this_in_reg:1;
 } MonoGenericJitInfo;
 
 /*
@@ -197,26 +197,26 @@ struct _MonoJitInfo {
 	guint32     unwind_info;
 	int         code_size;
 	guint32     num_clauses:15;
-	guint32    has_generic_jit_info:1;
-	guint32    has_try_block_holes:1;
-	guint32    has_arch_eh_info:1;
-	guint32    has_thunk_info:1;
-	guint32    has_unwind_info:1;
-	guint32    from_aot:1;
-	guint32    from_llvm:1;
-	guint32    dbg_attrs_inited:1;
-	guint32    dbg_hidden:1;
+	guint    has_generic_jit_info:1;
+	guint    has_try_block_holes:1;
+	guint    has_arch_eh_info:1;
+	guint    has_thunk_info:1;
+	guint    has_unwind_info:1;
+	guint    from_aot:1;
+	guint    from_llvm:1;
+	guint    dbg_attrs_inited:1;
+	guint    dbg_hidden:1;
 	/* Whenever this jit info was loaded in async context */
-	guint32    async:1;
-	guint32    dbg_step_through:1;
-	guint32    dbg_non_user_code:1;
+	guint    async:1;
+	guint    dbg_step_through:1;
+	guint    dbg_non_user_code:1;
 	/*
 	 * Whenever this jit info refers to a trampoline.
 	 * d.tramp_info contains additional data in this case.
 	 */
-	guint32    is_trampoline:1;
+	guint    is_trampoline:1;
 	/* Whenever this jit info refers to an interpreter method */
-	guint32    is_interp:1;
+	guint    is_interp:1;
 
 	/* FIXME: Embed this after the structure later*/
 	gpointer    gc_info; /* Currently only used by SGen */

--- a/src/mono/mono/metadata/jit-info.h
+++ b/src/mono/mono/metadata/jit-info.h
@@ -106,8 +106,8 @@ typedef struct
 	MonoDwarfLocListEntry *locations;
 	gint32 this_offset;
 	guint8 this_reg;
-	gboolean has_this:1;
-	gboolean this_in_reg:1;
+	guint32 has_this:1;
+	guint32 this_in_reg:1;
 } MonoGenericJitInfo;
 
 /*
@@ -197,26 +197,26 @@ struct _MonoJitInfo {
 	guint32     unwind_info;
 	int         code_size;
 	guint32     num_clauses:15;
-	gboolean    has_generic_jit_info:1;
-	gboolean    has_try_block_holes:1;
-	gboolean    has_arch_eh_info:1;
-	gboolean    has_thunk_info:1;
-	gboolean    has_unwind_info:1;
-	gboolean    from_aot:1;
-	gboolean    from_llvm:1;
-	gboolean    dbg_attrs_inited:1;
-	gboolean    dbg_hidden:1;
+	guint32    has_generic_jit_info:1;
+	guint32    has_try_block_holes:1;
+	guint32    has_arch_eh_info:1;
+	guint32    has_thunk_info:1;
+	guint32    has_unwind_info:1;
+	guint32    from_aot:1;
+	guint32    from_llvm:1;
+	guint32    dbg_attrs_inited:1;
+	guint32    dbg_hidden:1;
 	/* Whenever this jit info was loaded in async context */
-	gboolean    async:1;
-	gboolean    dbg_step_through:1;
-	gboolean    dbg_non_user_code:1;
+	guint32    async:1;
+	guint32    dbg_step_through:1;
+	guint32    dbg_non_user_code:1;
 	/*
 	 * Whenever this jit info refers to a trampoline.
 	 * d.tramp_info contains additional data in this case.
 	 */
-	gboolean    is_trampoline:1;
+	guint32    is_trampoline:1;
 	/* Whenever this jit info refers to an interpreter method */
-	gboolean    is_interp:1;
+	guint32    is_interp:1;
 
 	/* FIXME: Embed this after the structure later*/
 	gpointer    gc_info; /* Currently only used by SGen */

--- a/src/mono/mono/mini/interp/transform.h
+++ b/src/mono/mono/mini/interp/transform.h
@@ -133,18 +133,18 @@ struct _InterpBasicBlock {
 	SeqPoint **pred_seq_points;
 	guint num_pred_seq_points;
 
-	int reachable : 1;
+	guint reachable : 1;
 	// This block has special semantics and it shouldn't be optimized away
-	int eh_block : 1;
-	int dead: 1;
+	guint eh_block : 1;
+	guint dead: 1;
 	// If patchpoint is set we will store mapping information between native offset and bblock index within
 	// InterpMethod. In the unoptimized method we will map from native offset to the bb_index while in the
 	// optimized method we will map the bb_index to the corresponding native offset.
-	int patchpoint_data: 1;
-	int emit_patchpoint: 1;
+	guint patchpoint_data: 1;
+	guint emit_patchpoint: 1;
 	// used by jiterpreter
-	int backwards_branch_target: 1;
-	int contains_call_instruction: 1;
+	guint backwards_branch_target: 1;
+	guint contains_call_instruction: 1;
 };
 
 struct _InterpCallInfo {
@@ -260,16 +260,16 @@ typedef struct
 	int inline_depth;
 	int patchpoint_data_n;
 	int *patchpoint_data;
-	int has_localloc : 1;
+	guint has_localloc : 1;
 	// If method compilation fails due to certain limits being exceeded, we disable inlining
 	// and retry compilation.
-	int disable_inlining : 1;
+	guint disable_inlining : 1;
 	// If the current method (inlined_method) has the aggressive inlining attribute, we no longer
 	// bail out of inlining when having to generate certain opcodes (like call, throw).
-	int aggressive_inlining : 1;
-	int optimized : 1;
-	int has_invalid_code : 1;
-	int has_inlined_one_call : 1;
+	guint aggressive_inlining : 1;
+	guint optimized : 1;
+	guint has_invalid_code : 1;
+	guint has_inlined_one_call : 1;
 } TransformData;
 
 #define STACK_TYPE_I4 0

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -1239,9 +1239,9 @@ typedef struct {
 	guint            emulate_long_shift_opts : 1;
 	guint            have_objc_get_selector : 1;
 	guint            have_generalized_imt_trampoline : 1;
-	gboolean         have_op_tailcall_membase : 1;
-	gboolean         have_op_tailcall_reg : 1;
-	gboolean         have_volatile_non_param_register : 1;
+	guint         have_op_tailcall_membase : 1;
+	guint         have_op_tailcall_reg : 1;
+	guint         have_volatile_non_param_register : 1;
 	guint            have_init_mrgctx : 1;
 	guint            gshared_supported : 1;
 	guint            ilp32 : 1;

--- a/src/mono/mono/utils/mono-codeman.c
+++ b/src/mono/mono/utils/mono-codeman.c
@@ -84,18 +84,18 @@ struct _CodeChunk {
 	CodeChunk *next;
 	int pos;
 	int size;
-	unsigned int reserved: 8;
+	gint reserved: 8;
 	/* this number of bytes is available to resolve addresses far in memory */
-	unsigned int bsize: 24;
+	gint bsize: 24;
 };
 
 struct _MonoCodeManager {
 	CodeChunk *current;
 	CodeChunk *full;
 	CodeChunk *last;
-	int dynamic : 1;
-	int read_only : 1;
-	int no_exec : 1;
+	guint dynamic : 1;
+	guint read_only : 1;
+	guint no_exec : 1;
 };
 
 #define ALIGN_INT(val,alignment) (((val) + (alignment - 1)) & ~(alignment - 1))


### PR DESCRIPTION
Warnings are of the form:

> warning: implicit truncation from 'int' to a one-bit wide bit-field changes value from 1 to -1 [-Wsingle-bit-bitfield-constant-conversion]
 
reported on linux-x64 build (with cc: clang 17 rc1).