### PR TITLE
Fix CompositeChangeToken & CancellationTokenSource deadlock

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/src/CompositeChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/CompositeChangeToken.cs
@@ -131,6 +131,11 @@ namespace Microsoft.Extensions.Primitives
 
             lock (compositeChangeTokenState._callbackLock)
             {
+                if (compositeChangeTokenState._cancellationTokenSource.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 try
                 {
                     compositeChangeTokenState._cancellationTokenSource.Cancel();

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/Microsoft.Extensions.Primitives.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/Microsoft.Extensions.Primitives.Tests.csproj
@@ -14,4 +14,9 @@
     <ProjectReference Include="..\src\Microsoft.Extensions.Primitives.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs"
+             Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixes #43438

If you have two cancellation callbacks that are calling `CancellationTokenRegistration.Dispose` on each other, then ["by design"](https://github.com/dotnet/runtime/issues/43438#issuecomment-709441446) this results in a deadlock. Example:

```cs
var cts1 = new CancellationTokenSource();
var cts2 = new CancellationTokenSource();
IDisposable? reg1 = null;
var reg2 = cts2.Token.Register(() => reg1?.Dispose());
reg1 = cts1.Token.Register(reg2.Dispose);
Task.Run(cts1.Cancel);
cts2.Cancel(); // Deadlock
```

Therefore code like this should be avoided. However, in `Microsoft.Extensions.Primitives.CompositeChangeToken` code like this exists. Now it becomes easy to get a deadlock:

```cs
var cts1 = new CancellationTokenSource();
var cts2 = new CancellationTokenSource();
var t1 = new CancellationChangeToken(cts1.Token);
var t2 = new CancellationChangeToken(cts2.Token);
var composite = new CompositeChangeToken(new[] { t1, t2 });
composite.RegisterChangeCallback(_ => { }, null);
Task.Run(cts1.Cancel);
cts2.Cancel(); // Deadlock
```

In this PR we make a minor modification to the `CompositeChangeToken.OnChange` method so that this last deadlock is no longer possible. The idea is to return early from this method if another thread is running or has already ran the method. This makes sure the potential `CancellationTokenRegistration.Dispose` calls are done by a single thread, preventing the deadlock.

The modification has three noticable effects:

1. The above deadlock is no longer possible.
2. The `IDisposable`s returned from `IChangeToken.RegisterChangeCallback` for the `IChangeToken`s that make up the `CompositeChangeToken` are now called at most once. This seems like a good thing and non-breaking.
3. The callback that `CompositeChangeToken` registers on its `IChangeToken`s can now complete before it has unregistered itself. The unregistering still takes place, but a few moments later.

I _think_ this last effect doesn't break anything. The old behavior is not documented anywhere and there are no failing unit tests. Also, the callback doesn't do anything the second time it is called, so as far as the callback is concerned it doesn't matter how long it is registered.

Should this third effect be detrimental then with [some more modifications to `CompositeChangeToken.OnChange`](https://github.com/rdragon/runtime/compare/issue-43438...rdragon:runtime:issue-43438-alt) it can be avoided. However, these extra modifications do cause one memory allocation per callback.