### PR TITLE
Avoid extra `Array.Copy` in `List<T>.Insert(Range)` when the list is full

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -489,10 +489,12 @@ namespace System.Collections.Generic
 
             T[] newItems = new T[newCapacity];
             if (indexToInsert != 0)
-                Array.Copy(_items, newItems, indexToInsert);
+                Array.Copy(_items, newItems, length: indexToInsert);
 
             if (_size != indexToInsert)
+            {
                 Array.Copy(_items, indexToInsert, newItems, indexToInsert + insertionCount, _size - indexToInsert);
+            }
 
             _items = newItems;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -477,7 +477,7 @@ namespace System.Collections.Generic
         private void GrowForInsertion(int capacity, int indexToInsert, int insertionCount = 1)
         {
             Debug.Assert(_items.Length < capacity);
-            Debug.Assert(insertionCount <= 0)
+            Debug.Assert(insertionCount <= 0);
             Debug.Assert((uint)_size + insertionCount > capacity);
             Debug.Assert((uint)_size + insertionCount > Array.MaxLength);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -466,20 +466,19 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
-        /// Increase the capacity of this list to at least the specified <paramref name="capacity"/>.
-        /// This method is specifically for insertion, to avoid 1 extra array copy.
-        /// It also copies data to their after-insertion positions.
-        /// You should only call this method when Count + insertionCount > Capacity
+        /// Enlarge this list so it may contain at least <paramref name="insertionCount"/> more elements
+        /// And copy data to their after-insertion positions.
+        /// This method is specifically for insertion, as it avoids 1 extra array copy.
+        /// You should only call this method when Count + insertionCount > Capacity.
         /// </summary>
-        /// <param name="capacity">The minimum capacity to ensure.</param>
-        /// <param name="indexToInsert">Index where the element will be.</param>
+        /// <param name="indexToInsert">Index of the first insertion.</param>
         /// <param name="insertionCount">How many elements will be inserted.</param>
-        private void GrowForInsertion(int capacity, int indexToInsert, int insertionCount = 1)
+        private void GrowForInsertion(int indexToInsert, int insertionCount = 1)
         {
-            Debug.Assert(_items.Length < capacity);
             Debug.Assert(insertionCount > 0);
-            Debug.Assert((uint)_size + insertionCount <= capacity);
             Debug.Assert((uint)_size + insertionCount <= Array.MaxLength);
+
+            int capacity = checked(_size + insertionCount);
 
             // Follow the same logic from Grow(capacity)
 
@@ -773,7 +772,7 @@ namespace System.Collections.Generic
             }
             if (_size == _items.Length)
             {
-                GrowForInsertion(_size + 1, index);
+                GrowForInsertion(index, 1);
             }
             else if (index < _size)
             {
@@ -822,7 +821,7 @@ namespace System.Collections.Generic
                 {
                     if (_items.Length - _size < count)
                     {
-                        GrowForInsertion(checked(_size + count), index, count);
+                        GrowForInsertion(index, count);
                     }
                     else if (index < _size)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -477,9 +477,9 @@ namespace System.Collections.Generic
         private void GrowForInsertion(int capacity, int indexToInsert, int insertionCount = 1)
         {
             Debug.Assert(_items.Length < capacity);
-            Debug.Assert(insertionCount <= 0);
-            Debug.Assert((uint)_size + insertionCount > capacity);
-            Debug.Assert((uint)_size + insertionCount > Array.MaxLength);
+            Debug.Assert(insertionCount > 0);
+            Debug.Assert((uint)_size + insertionCount <= capacity);
+            Debug.Assert((uint)_size + insertionCount <= Array.MaxLength);
 
             // Follow the same logic from Grow(capacity)
 
@@ -822,9 +822,9 @@ namespace System.Collections.Generic
                 {
                     if (_items.Length - _size < count)
                     {
-                        Grow(checked(_size + count));
+                        GrowForInsertion(checked(_size + count), index, count);
                     }
-                    if (index < _size)
+                    else if (index < _size)
                     {
                         Array.Copy(_items, index, _items, index + count, _size - index);
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -476,7 +476,6 @@ namespace System.Collections.Generic
         private void GrowForInsertion(int indexToInsert, int insertionCount = 1)
         {
             Debug.Assert(insertionCount > 0);
-            Debug.Assert((uint)_size + insertionCount <= Array.MaxLength);
 
             int capacity = checked(_size + insertionCount);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -470,7 +470,8 @@ namespace System.Collections.Generic
         /// This method is specifically for insertion, to avoid 1 extra array copy.
         /// </summary>
         /// <param name="capacity">The minimum capacity to ensure.</param>
-        private void GrowForInsert(int capacity, int indexToInsert)
+        /// <param name="indexToInsert">Index where the element will be.</param>
+        private void GrowForInsertion(int capacity, int indexToInsert)
         {
             Debug.Assert(_items.Length < capacity);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -784,7 +784,7 @@ namespace System.Collections.Generic
             }
             if (_size == _items.Length)
             {
-                GrowForInsert(_size + 1, index);
+                GrowForInsertion(_size + 1, index);
             }
             else if (index < _size)
             {


### PR DESCRIPTION
Originally there are 3 `Array.Copy` during `List<T>.Insert` when `Capacity` is maxed out. Avoid one extra copy with a modified `Grow`.

[Microbenchmark in following comments.](https://github.com/dotnet/runtime/pull/90089#issuecomment-1667807944) `List<T>.InsertRange` also benefits from similar patterns. Performance is ~20% better for best cases.

Fix #89915