### PR TITLE
Put crossgen perf into "Ubuntu.1804.Amd64.Tiger.Perf".

### DIFF
--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -395,7 +395,7 @@ jobs:
         projectFile: crossgen_perf.proj
         runKind: crossgen_scenarios
         runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perftiger'
+        logicalmachine: 'perftiger_crossgen'
 
   # build mono runtime packs
   - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -47,9 +47,10 @@ $Queue = ""
 
 if ($Internal) {
     switch ($LogicalMachine) {
-        "perftiger" { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf"  }
-        "perfowl" { $Queue = "Windows.10.Amd64.20H2.Owl.Perf"  }
-        "perfsurf" { $Queue = "Windows.10.Arm64.Perf.Surf"  }
+        "perftiger" { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
+        "perftiger_crossgen" { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
+        "perfowl" { $Queue = "Windows.10.Amd64.20H2.Owl.Perf" }
+        "perfsurf" { $Queue = "Windows.10.Arm64.Perf.Surf" }
         "perfpixel4a" { $Queue = "Windows.10.Amd64.Pixel.Perf" }
         "perfampere" { $Queue = "Windows.Server.Arm64.Perf" }
         "cloudvm" { $Queue = "Windows.10.Amd64" }

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -285,6 +285,8 @@ if [[ "$internal" == true ]]; then
     else
         if [[ "$logical_machine" == "perfowl" ]]; then
             queue=Ubuntu.1804.Amd64.Owl.Perf
+        elif [[ "$logical_machine" == "perftiger_crossgen" ]]; then
+            queue=Ubuntu.1804.Amd64.Tiger.Perf
         else
             queue=Ubuntu.2204.Amd64.Tiger.Perf
         fi


### PR DESCRIPTION
* Because crossgen needs LTTng and perfcollect is not 22.04 compatible.
* Windows using same queue.