### PR TITLE
Fix wasm perf setup

### DIFF
--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -69,7 +69,7 @@ jobs:
           npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
           $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 --engines=v8 &&
           find ~/.jsvu -ls &&
-          ~/.jsvu/v8 -e "console.log(`V8 version: ${this.version()}`)"
+          ~/.jsvu/engines/v8/v8 -e 'console.log(`V8 version: ${this.version()}`)'
     - ${{ if ne(parameters.runtimeType, 'wasm') }}:
       - HelixPreCommandsWasmOnLinux: echo
     - HelixPreCommandStemWindows: 'set ORIGPYPATH=%PYTHONPATH%;py -m pip install -U pip;py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install -U pip;py -3 -m pip install urllib3==1.26.15;py -3 -m pip install azure.storage.blob==12.0.0;py -3 -m pip install azure.storage.queue==12.0.0;set "PERFLAB_UPLOAD_TOKEN=$(HelixPerfUploadTokenValue)"'


### PR DESCRIPTION
* Fixes path to `v8` executable.
* Fixes bash expansion of `${this.version()}`.