### PR TITLE
Ignore some tests on macOS only due to small stack size

### DIFF
--- a/src/tests/JIT/jit64/opt/cse/HugeArray1.csproj
+++ b/src/tests/JIT/jit64/opt/cse/HugeArray1.csproj
@@ -3,6 +3,10 @@
     <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <GCStressIncompatible>true</GCStressIncompatible>
+
+    <!-- The test is too complex to compile on macOS where secondary threads have small stack size by default
+         and that is not enough for Roslyn, see https://github.com/dotnet/runtime/issues/87879 -->
+    <DisableProjectBuild Condition="'$(HostOS)' != 'osx'">true</DisableProjectBuild>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/jit64/opt/cse/HugeArray1.csproj
+++ b/src/tests/JIT/jit64/opt/cse/HugeArray1.csproj
@@ -6,7 +6,7 @@
 
     <!-- The test is too complex to compile on macOS where secondary threads have small stack size by default
          and that is not enough for Roslyn, see https://github.com/dotnet/runtime/issues/87879 -->
-    <DisableProjectBuild Condition="'$(HostOS)' != 'osx'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(HostOS)' == 'osx'">true</DisableProjectBuild>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/jit64/opt/cse/hugeSimpleExpr1.csproj
+++ b/src/tests/JIT/jit64/opt/cse/hugeSimpleExpr1.csproj
@@ -7,7 +7,7 @@
 
     <!-- The test is too complex to compile on macOS where secondary threads have small stack size by default
          and that is not enough for Roslyn, see https://github.com/dotnet/runtime/issues/87879 -->
-    <DisableProjectBuild Condition="'$(HostOS)' != 'osx'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(HostOS)' == 'osx'">true</DisableProjectBuild>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/jit64/opt/cse/hugeSimpleExpr1.csproj
+++ b/src/tests/JIT/jit64/opt/cse/hugeSimpleExpr1.csproj
@@ -4,8 +4,10 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Timeout on Arm64 -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <!-- Issue: https://github.com/dotnet/runtime/issues/87879 -->
-    <DisableProjectBuild>true</DisableProjectBuild>
+
+    <!-- The test is too complex to compile on macOS where secondary threads have small stack size by default
+         and that is not enough for Roslyn, see https://github.com/dotnet/runtime/issues/87879 -->
+    <DisableProjectBuild Condition="'$(HostOS)' != 'osx'">true</DisableProjectBuild>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/jit64/opt/rngchk/RngchkStress2_o.csproj
+++ b/src/tests/JIT/jit64/opt/rngchk/RngchkStress2_o.csproj
@@ -5,7 +5,7 @@
 
     <!-- The test is too complex to compile on macOS where secondary threads have small stack size by default
          and that is not enough for Roslyn, see https://github.com/dotnet/runtime/issues/87879 -->
-    <DisableProjectBuild Condition="'$(HostOS)' != 'osx'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(HostOS)' == 'osx'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="RngchkStress2.cs" />

--- a/src/tests/JIT/jit64/opt/rngchk/RngchkStress2_o.csproj
+++ b/src/tests/JIT/jit64/opt/rngchk/RngchkStress2_o.csproj
@@ -2,8 +2,10 @@
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
-    <!-- Issue: https://github.com/dotnet/runtime/issues/87879 -->
-    <DisableProjectBuild>true</DisableProjectBuild>
+
+    <!-- The test is too complex to compile on macOS where secondary threads have small stack size by default
+         and that is not enough for Roslyn, see https://github.com/dotnet/runtime/issues/87879 -->
+    <DisableProjectBuild Condition="'$(HostOS)' != 'osx'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="RngchkStress2.cs" />


### PR DESCRIPTION
Rationale: https://github.com/dotnet/runtime/issues/87879#issuecomment-1667717261

This PR enables these tests back on non-macOS platforms + disables HugeArray1 on macOS since it hits the same issue too (e.g. in https://github.com/dotnet/runtime/runs/15626705312)