### PR TITLE
Support `DllImportSearchPath.AssemblyDirectory` for NativeAOT applications

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.Windows.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.Windows.cs
@@ -24,7 +24,7 @@ namespace System.Runtime.InteropServices
                     goto exit;
                 }
 
-                int lastError = Marshal.GetLastWin32Error();
+                int lastError = Marshal.GetLastPInvokeError();
                 if (lastError != Interop.Errors.ERROR_INVALID_PARAMETER)
                 {
                     errorTracker.TrackErrorCode(lastError);
@@ -35,7 +35,7 @@ namespace System.Runtime.InteropServices
             hmod = Interop.Kernel32.LoadLibraryEx(libraryName, IntPtr.Zero, flags & 0xFF);
             if (hmod == IntPtr.Zero)
             {
-                errorTracker.TrackErrorCode(Marshal.GetLastWin32Error());
+                errorTracker.TrackErrorCode(Marshal.GetLastPInvokeError());
             }
 
         exit:

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
@@ -98,7 +98,7 @@ namespace System.Runtime.InteropServices
                 {
                     // Try to load the module alongside the assembly where the PInvoke was declared.
                     // For PInvokes where the DllImportSearchPath.AssemblyDirectory is specified, look next to the application.
-                    ret = LoadLibraryHelper(Path.Combine(AppContext.BaseDirectory, currLibNameVariation), dllImportSearchPathFlags, ref errorTracker);
+                    ret = LoadLibraryHelper(Path.Combine(AppContext.BaseDirectory, currLibNameVariation), loadWithAlteredPathFlags | dllImportSearchPathFlags, ref errorTracker);
                     if (ret != IntPtr.Zero)
                     {
                         return ret;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.cs
@@ -97,7 +97,12 @@ namespace System.Runtime.InteropServices
                 else if ((callingAssembly != null) && searchAssemblyDirectory)
                 {
                     // Try to load the module alongside the assembly where the PInvoke was declared.
-                    // This only makes sense in dynamic scenarios (JIT/interpreter), so leaving this out for now.
+                    // For PInvokes where the DllImportSearchPath.AssemblyDirectory is specified, look next to the application.
+                    ret = LoadLibraryHelper(Path.Combine(AppContext.BaseDirectory, currLibNameVariation), dllImportSearchPathFlags, ref errorTracker);
+                    if (ret != IntPtr.Zero)
+                    {
+                        return ret;
+                    }
                 }
 
                 ret = LoadLibraryHelper(currLibNameVariation, dllImportSearchPathFlags, ref errorTracker);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetThreadErrorMode.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetThreadErrorMode.cs
@@ -14,6 +14,7 @@ internal static partial class Interop
             uint dwNewMode,
             out uint lpOldMode);
 
-        internal const uint SEM_FAILCRITICALERRORS = 1;
+        internal const int SEM_FAILCRITICALERRORS = 0x00000001;
+        internal const int SEM_NOOPENFILEERRORBOX = 0x00008000;
     }
 }

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
@@ -39,6 +39,15 @@ public class DllImportSearchPathsTest
         Assert.Equal(3, sum);
     }
 
+    public static bool IsNativeAot => TestLibrary.Utilities.IsNativeAot;
+
+    [ConditionalFact(nameof(IsNativeAot))]
+    public static void AssemblyDirectoryAot_Found()
+    {
+        int sum = NativeLibraryPInvokeAot.Sum(1, 2);
+        Assert.Equal(3, sum);
+    }
+
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     public static void AssemblyDirectory_Fallback_Found()
@@ -68,5 +77,17 @@ public class NativeLibraryPInvoke
 
     [DllImport(NativeLibraryToLoad.Name)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
+    static extern int NativeSum(int arg1, int arg2);
+}
+
+public class NativeLibraryPInvokeAot
+{
+    public static int Sum(int a, int b)
+    {
+        return NativeSum(a, b);
+    }
+
+    [DllImport(NativeLibraryToLoad.Name + "-in-native")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32)]
     static extern int NativeSum(int arg1, int arg2);
 }

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
@@ -39,9 +39,7 @@ public class DllImportSearchPathsTest
         Assert.Equal(3, sum);
     }
 
-    public static bool IsNativeAot => TestLibrary.Utilities.IsNativeAot;
-
-    [ConditionalFact(nameof(IsNativeAot))]
+    [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void AssemblyDirectoryAot_Found()
     {
         int sum = NativeLibraryPInvokeAot.Sum(1, 2);
@@ -87,6 +85,9 @@ public class NativeLibraryPInvokeAot
         return NativeSum(a, b);
     }
 
+    // For NativeAOT, validate the case where the native library is next to the AOT application.
+    // The passing of DllImportSearchPath.System32 is done to ensure on Windows the runtime won't fallback
+    // and try to search the application directory by default.
     [DllImport(NativeLibraryToLoad.Name + "-in-native")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32)]
     static extern int NativeSum(int arg1, int arg2);

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
@@ -14,24 +14,24 @@
 
   <Target Name="SetUpSubdirectoryNative" AfterTargets="CopyNativeProjectBinaries">
     <ItemGroup>
-      <AssembliesToCopyNative Include="$(OutDir)/libNativeLibrary.*" />
-      <AssembliesToCopyNative Include="$(OutDir)/NativeLibrary.*" />
+      <NativeLibrariesToMove Include="$(OutDir)/libNativeLibrary.*" />
+      <NativeLibrariesToMove Include="$(OutDir)/NativeLibrary.*" />
     </ItemGroup>
-    <Move SourceFiles="@(AssembliesToCopyNative)" DestinationFiles="@(AssembliesToCopyNative -> '$(LibrarySubdirectory)/%(Filename)%(Extension)')"/>
+    <Move SourceFiles="@(NativeLibrariesToMove)" DestinationFiles="@(NativeLibrariesToMove -> '$(LibrarySubdirectory)/%(Filename)%(Extension)')"/>
   </Target>
 
   <Target Name="SetUpSubdirectoryManaged" AfterTargets="Build">
     <ItemGroup>
-      <AssembliesToCopyManaged Include="$(OutDir)/$(TargetName).dll" />
+      <AssembliesToCopy Include="$(OutDir)/$(TargetName).dll" />
     </ItemGroup>
-    <Copy SourceFiles="@(AssembliesToCopyManaged)" DestinationFiles="@(AssembliesToCopyManaged -> '$(LibrarySubdirectory)/%(Filename)%(Extension)')"/>
+    <Copy SourceFiles="@(AssembliesToCopy)" DestinationFiles="@(AssembliesToCopy -> '$(LibrarySubdirectory)/%(Filename)%(Extension)')"/>
   </Target>
 
   <Target Name="SetUpAOTDirectory" Condition="'$(TestBuildMode)' == 'nativeaot'" AfterTargets="Build">
     <ItemGroup>
-      <AssembliesToCopyAOT Include="$(LibrarySubdirectory)/libNativeLibrary.*" />
-      <AssembliesToCopyAOT Include="$(LibrarySubdirectory)/NativeLibrary.*" />
+      <NativeLibrariesToCopy Include="$(LibrarySubdirectory)/libNativeLibrary.*" />
+      <NativeLibrariesToCopy Include="$(LibrarySubdirectory)/NativeLibrary.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(AssembliesToCopyAOT)" DestinationFiles="@(AssembliesToCopyAOT -> '$(NativeOutputPath)/%(Filename)-in-native%(Extension)')" />
+    <Copy SourceFiles="@(NativeLibrariesToCopy)" DestinationFiles="@(NativeLibrariesToCopy -> '$(NativeOutputPath)/%(Filename)-in-native%(Extension)')" />
   </Target>
 </Project>

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
@@ -14,16 +14,24 @@
 
   <Target Name="SetUpSubdirectoryNative" AfterTargets="CopyNativeProjectBinaries">
     <ItemGroup>
-      <_FilesToMove Include="$(OutDir)/libNativeLibrary.*" />
-      <_FilesToMove Include="$(OutDir)/NativeLibrary.*" />
+      <AssembliesToCopyNative Include="$(OutDir)/libNativeLibrary.*" />
+      <AssembliesToCopyNative Include="$(OutDir)/NativeLibrary.*" />
     </ItemGroup>
-    <Move SourceFiles="@(_FilesToMove)" DestinationFiles="@(_FilesToMove -> '$(LibrarySubdirectory)/%(Filename)%(Extension)')"/>
+    <Move SourceFiles="@(AssembliesToCopyNative)" DestinationFiles="@(AssembliesToCopyNative -> '$(LibrarySubdirectory)/%(Filename)%(Extension)')"/>
   </Target>
 
   <Target Name="SetUpSubdirectoryManaged" AfterTargets="Build">
     <ItemGroup>
-      <_FilesToCopy Include="$(OutDir)/$(TargetName).dll" />
+      <AssembliesToCopyManaged Include="$(OutDir)/$(TargetName).dll" />
     </ItemGroup>
-    <Copy SourceFiles="@(_FilesToCopy)" DestinationFiles="@(_FilesToCopy -> '$(LibrarySubdirectory)/%(Filename)%(Extension)')"/>
+    <Copy SourceFiles="@(AssembliesToCopyManaged)" DestinationFiles="@(AssembliesToCopyManaged -> '$(LibrarySubdirectory)/%(Filename)%(Extension)')"/>
+  </Target>
+
+  <Target Name="SetUpAOTDirectory" Condition="'$(TestBuildMode)' == 'nativeaot'" AfterTargets="Build">
+    <ItemGroup>
+      <AssembliesToCopyAOT Include="$(LibrarySubdirectory)/libNativeLibrary.*" />
+      <AssembliesToCopyAOT Include="$(LibrarySubdirectory)/NativeLibrary.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(AssembliesToCopyAOT)" DestinationFiles="@(AssembliesToCopyAOT -> '$(NativeOutputPath)/%(Filename)-in-native%(Extension)')" />
   </Target>
 </Project>

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
@@ -189,6 +189,16 @@ public class NativeLibraryTests : IDisposable
             EXPECT(TryLoadLibrary_WithAssembly(libName, assemblyInSubdirectory, DllImportSearchPath.AssemblyDirectory));
         }
 
+        if (TestLibrary.Utilities.IsNativeAot)
+        {
+            // For NativeAOT, validate the case where the native library is next to the AOT application.
+            // The passing of DllImportSearchPath.System32 is done to ensure on Windows the runtime won't fallback
+            // and try to search the application directory by default.
+            string libNameAot = $"{NativeLibraryToLoad.Name}-in-native";
+            EXPECT(LoadLibrary_WithAssembly(libNameAot, assembly, DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32));
+            EXPECT(TryLoadLibrary_WithAssembly(libNameAot, assembly, DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.System32));
+        }
+
         if (OperatingSystem.IsWindows())
         {
             string currentDirectory = Environment.CurrentDirectory;

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
@@ -24,16 +24,24 @@
 
   <Target Name="SetUpSubdirectoryNative" AfterTargets="CopyNativeProjectBinaries">
     <ItemGroup>
-      <AssembliesToCopy Include="$(OutDir)/libNativeLibrary.*" />
-      <AssembliesToCopy Include="$(OutDir)/NativeLibrary.*" />
+      <AssembliesToCopyNative Include="$(OutDir)/libNativeLibrary.*" />
+      <AssembliesToCopyNative Include="$(OutDir)/NativeLibrary.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(AssembliesToCopy)" DestinationFiles="@(AssembliesToCopy -> '$(LibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
+    <Copy SourceFiles="@(AssembliesToCopyNative)" DestinationFiles="@(AssembliesToCopyNative -> '$(LibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
   </Target>
 
   <Target Name="SetUpSubdirectoryManaged" AfterTargets="Build">
     <ItemGroup>
-      <AssembliesToCopy Include="$(OutDir)/$(TargetName).dll" />
+      <AssembliesToCopyManaged Include="$(OutDir)/$(TargetName).dll" />
     </ItemGroup>
-    <Copy SourceFiles="@(AssembliesToCopy)" DestinationFiles="@(AssembliesToCopy -> '$(LibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
+    <Copy SourceFiles="@(AssembliesToCopyManaged)" DestinationFiles="@(AssembliesToCopyManaged -> '$(LibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
+  </Target>
+
+  <Target Name="SetUpAOTDirectory" Condition="'$(TestBuildMode)' == 'nativeaot'" AfterTargets="Build">
+    <ItemGroup>
+      <AssembliesToCopyAOT Include="$(OutDir)/libNativeLibrary.*" />
+      <AssembliesToCopyAOT Include="$(OutDir)/NativeLibrary.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(AssembliesToCopyAOT)" DestinationFiles="@(AssembliesToCopyAOT -> '$(NativeOutputPath)/%(Filename)-in-native%(Extension)')" />
   </Target>
 </Project>

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
@@ -24,24 +24,24 @@
 
   <Target Name="SetUpSubdirectoryNative" AfterTargets="CopyNativeProjectBinaries">
     <ItemGroup>
-      <AssembliesToCopyNative Include="$(OutDir)/libNativeLibrary.*" />
-      <AssembliesToCopyNative Include="$(OutDir)/NativeLibrary.*" />
+      <NativeLibrariesToCopy Include="$(OutDir)/libNativeLibrary.*" />
+      <NativeLibrariesToCopy Include="$(OutDir)/NativeLibrary.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(AssembliesToCopyNative)" DestinationFiles="@(AssembliesToCopyNative -> '$(LibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
+    <Copy SourceFiles="@(NativeLibrariesToCopy)" DestinationFiles="@(NativeLibrariesToCopy -> '$(LibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
   </Target>
 
   <Target Name="SetUpSubdirectoryManaged" AfterTargets="Build">
     <ItemGroup>
-      <AssembliesToCopyManaged Include="$(OutDir)/$(TargetName).dll" />
+      <AssembliesToCopy Include="$(OutDir)/$(TargetName).dll" />
     </ItemGroup>
-    <Copy SourceFiles="@(AssembliesToCopyManaged)" DestinationFiles="@(AssembliesToCopyManaged -> '$(LibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
+    <Copy SourceFiles="@(AssembliesToCopy)" DestinationFiles="@(AssembliesToCopy -> '$(LibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
   </Target>
 
   <Target Name="SetUpAOTDirectory" Condition="'$(TestBuildMode)' == 'nativeaot'" AfterTargets="Build">
     <ItemGroup>
-      <AssembliesToCopyAOT Include="$(OutDir)/libNativeLibrary.*" />
-      <AssembliesToCopyAOT Include="$(OutDir)/NativeLibrary.*" />
+      <NativeLibrariesToCopyAOT Include="$(OutDir)/libNativeLibrary.*" />
+      <NativeLibrariesToCopyAOT Include="$(OutDir)/NativeLibrary.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(AssembliesToCopyAOT)" DestinationFiles="@(AssembliesToCopyAOT -> '$(NativeOutputPath)/%(Filename)-in-native%(Extension)')" />
+    <Copy SourceFiles="@(NativeLibrariesToCopyAOT)" DestinationFiles="@(NativeLibrariesToCopyAOT -> '$(NativeOutputPath)/%(Filename)-in-native%(Extension)')" />
   </Target>
 </Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -778,9 +778,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/164</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/NativeLibrary/API/NativeLibraryTests/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/165</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/NativeLibrary/AssemblyLoadContext/ResolveUnmanagedDllTests/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/165</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/89874