### PR TITLE
Add `emitDispEmbBroadcastCount` to display the embedded broadcasted element count.

### DIFF
--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1541,6 +1541,12 @@ protected:
             _idEvexbContext = 1;
             assert(_idEvexbContext == 1);
         }
+        void idClearEvexbContext()
+        {
+            assert(_idEvexbContext == 1);
+            _idEvexbContext = 0;
+            assert(_idEvexbContext == 0);
+        }
 #endif
 
 #ifdef TARGET_ARMARCH
@@ -2107,6 +2113,7 @@ protected:
     void emitDispInsAddr(BYTE* code);
     void emitDispInsOffs(unsigned offs, bool doffs);
     void emitDispInsHex(instrDesc* id, BYTE* code, size_t sz);
+    void emitDispEmbBroadcastCount(instrDesc* id);
     void emitDispIns(instrDesc* id,
                      bool       isNew,
                      bool       doffs,

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1541,12 +1541,6 @@ protected:
             _idEvexbContext = 1;
             assert(_idEvexbContext == 1);
         }
-        void idClearEvexbContext()
-        {
-            assert(_idEvexbContext == 1);
-            _idEvexbContext = 0;
-            assert(_idEvexbContext == 0);
-        }
 #endif
 
 #ifdef TARGET_ARMARCH

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2060,6 +2060,7 @@ protected:
     unsigned emitGetInsCIargs(instrDesc* id);
 
     inline emitAttr emitGetMemOpSize(instrDesc* id) const;
+    inline emitAttr emitGetBaseMemOpSize(instrDesc*) const;
 
     // Return the argument count for a direct call "id".
     int emitGetInsCDinfo(instrDesc* id);
@@ -3755,21 +3756,15 @@ inline unsigned emitter::emitGetInsCIargs(instrDesc* id)
 //-----------------------------------------------------------------------------
 // emitGetMemOpSize: Get the memory operand size of instrDesc.
 //
-// Note: vextractf128 has a 128-bit output (register or memory) but a 256-bit input (register).
-// vinsertf128 is the inverse with a 256-bit output (register), a 256-bit input(register),
-// and a 128-bit input (register or memory).
-// Similarly, vextractf64x4 has a 256-bit output and 128-bit input and vinsertf64x4 the inverse
-// This method is mainly used for such instructions to return the appropriate memory operand
-// size, otherwise returns the regular operand size of the instruction.
+//  Note: there are cases when embedded broadcast is enabled, so the memory operand
+//  size is different from the intrinsic simd size, we will check here if emitter is
+//  emiting a embedded broadcast enabled instruction.
 
 //  Arguments:
 //       id - Instruction descriptor
 //
 emitAttr emitter::emitGetMemOpSize(instrDesc* id) const
 {
-
-    emitAttr    defaultSize = id->idOpSize();
-    instruction ins         = id->idIns();
     if (id->idIsEvexbContext())
     {
         // should have the assumption that Evex.b now stands for the embedded broadcast context.
@@ -3786,6 +3781,31 @@ emitAttr emitter::emitGetMemOpSize(instrDesc* id) const
                 unreached();
         }
     }
+    else
+    {
+        return emitGetBaseMemOpSize(id);
+    }
+}
+
+//-----------------------------------------------------------------------------
+// emitGetMemOpSize: Get the memory operand size of instrDesc.
+//
+// Note: vextractf128 has a 128-bit output (register or memory) but a 256-bit input (register).
+// vinsertf128 is the inverse with a 256-bit output (register), a 256-bit input(register),
+// and a 128-bit input (register or memory).
+// Similarly, vextractf64x4 has a 256-bit output and 128-bit input and vinsertf64x4 the inverse
+// This method is mainly used for such instructions to return the appropriate memory operand
+// size, otherwise returns the regular operand size of the instruction.
+
+//  Arguments:
+//       id - Instruction descriptor
+//
+emitAttr emitter::emitGetBaseMemOpSize(instrDesc* id) const
+{
+
+    emitAttr    defaultSize = id->idOpSize();
+    instruction ins         = id->idIns();
+
     switch (ins)
     {
         case INS_pextrb:

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -10722,6 +10722,20 @@ void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
     }
 }
 
+// emitDispEmbBroadcastCount: Display the tag where embedded broadcast is activated to show how many elements are broadcasted.
+//
+// Arguments:
+//   id - The instruction descriptor
+//
+void emitter::emitDispEmbBroadcastCount(instrDesc* id)
+{
+    ssize_t baseSize = GetInputSizeInBytes(id);
+    id->idClearEvexbContext();
+    ssize_t vectorSize = (ssize_t)emitGetMemOpSize(id);
+    id->idSetEvexbContext();
+    printf(" {1to%d}", vectorSize / baseSize);
+}
+
 //--------------------------------------------------------------------
 // emitDispIns: Dump the given instruction to jitstdout.
 //
@@ -11123,6 +11137,11 @@ void emitter::emitDispIns(
         {
             printf("%s, %s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), attr), sstr);
             emitDispAddrMode(id);
+            if(id->idIsEvexbContext())
+            {
+                // we should have the assumption that we are under embedded broadcast use case.
+                emitDispEmbBroadcastCount(id);
+            }
             break;
         }
 
@@ -11395,6 +11414,11 @@ void emitter::emitDispIns(
             printf("%s, %s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), attr), sstr);
             emitDispFrameRef(id->idAddr()->iiaLclVar.lvaVarNum(), id->idAddr()->iiaLclVar.lvaOffset(),
                              id->idDebugOnlyInfo()->idVarRefOffs, asmfm);
+            if(id->idIsEvexbContext())
+            {
+                // we should have the assumption that we are under embedded broadcast use case.
+                emitDispEmbBroadcastCount(id);
+            }
             break;
         }
 
@@ -11899,6 +11923,11 @@ void emitter::emitDispIns(
             printf("%s, %s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), attr), sstr);
             offs = emitGetInsDsp(id);
             emitDispClsVar(id->idAddr()->iiaFieldHnd, offs, ID_INFO_DSP_RELOC);
+            if(id->idIsEvexbContext())
+            {
+                // we should have the assumption that we are under embedded broadcast use case.
+                emitDispEmbBroadcastCount(id);
+            }
             break;
         }
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -11141,6 +11141,7 @@ void emitter::emitDispIns(
                 break;
             }
             emitDispEmbBroadcastCount(id);
+            break;
         }
 
         case IF_RRD_ARD_RRD:
@@ -11417,6 +11418,7 @@ void emitter::emitDispIns(
                 break;
             }
             emitDispEmbBroadcastCount(id);
+            break;
         }
 
         case IF_RWR_RRD_SRD_CNS:

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -10730,6 +10730,10 @@ void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 //
 void emitter::emitDispEmbBroadcastCount(instrDesc* id)
 {
+    if (!id->idIsEvexbContext())
+    {
+        return;
+    }
     ssize_t baseSize   = GetInputSizeInBytes(id);
     ssize_t vectorSize = (ssize_t)emitGetBaseMemOpSize(id);
     printf(" {1to%d}", vectorSize / baseSize);
@@ -11136,10 +11140,6 @@ void emitter::emitDispIns(
         {
             printf("%s, %s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), attr), sstr);
             emitDispAddrMode(id);
-            if (!id->idIsEvexbContext())
-            {
-                break;
-            }
             emitDispEmbBroadcastCount(id);
             break;
         }
@@ -11413,10 +11413,6 @@ void emitter::emitDispIns(
             printf("%s, %s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), attr), sstr);
             emitDispFrameRef(id->idAddr()->iiaLclVar.lvaVarNum(), id->idAddr()->iiaLclVar.lvaOffset(),
                              id->idDebugOnlyInfo()->idVarRefOffs, asmfm);
-            if (!id->idIsEvexbContext())
-            {
-                break;
-            }
             emitDispEmbBroadcastCount(id);
             break;
         }
@@ -11922,10 +11918,6 @@ void emitter::emitDispIns(
             printf("%s, %s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), attr), sstr);
             offs = emitGetInsDsp(id);
             emitDispClsVar(id->idAddr()->iiaFieldHnd, offs, ID_INFO_DSP_RELOC);
-            if (!id->idIsEvexbContext())
-            {
-                break;
-            }
             emitDispEmbBroadcastCount(id);
             break;
         }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -10722,17 +10722,16 @@ void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
     }
 }
 
-// emitDispEmbBroadcastCount: Display the tag where embedded broadcast is activated to show how many elements are broadcasted.
+// emitDispEmbBroadcastCount: Display the tag where embedded broadcast is activated to show how many elements are
+// broadcasted.
 //
 // Arguments:
 //   id - The instruction descriptor
 //
 void emitter::emitDispEmbBroadcastCount(instrDesc* id)
 {
-    ssize_t baseSize = GetInputSizeInBytes(id);
-    id->idClearEvexbContext();
-    ssize_t vectorSize = (ssize_t)emitGetMemOpSize(id);
-    id->idSetEvexbContext();
+    ssize_t baseSize   = GetInputSizeInBytes(id);
+    ssize_t vectorSize = (ssize_t)emitGetBaseMemOpSize(id);
     printf(" {1to%d}", vectorSize / baseSize);
 }
 
@@ -11137,12 +11136,11 @@ void emitter::emitDispIns(
         {
             printf("%s, %s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), attr), sstr);
             emitDispAddrMode(id);
-            if(id->idIsEvexbContext())
+            if (!id->idIsEvexbContext())
             {
-                // we should have the assumption that we are under embedded broadcast use case.
-                emitDispEmbBroadcastCount(id);
+                break;
             }
-            break;
+            emitDispEmbBroadcastCount(id);
         }
 
         case IF_RRD_ARD_RRD:
@@ -11414,12 +11412,11 @@ void emitter::emitDispIns(
             printf("%s, %s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), attr), sstr);
             emitDispFrameRef(id->idAddr()->iiaLclVar.lvaVarNum(), id->idAddr()->iiaLclVar.lvaOffset(),
                              id->idDebugOnlyInfo()->idVarRefOffs, asmfm);
-            if(id->idIsEvexbContext())
+            if (!id->idIsEvexbContext())
             {
-                // we should have the assumption that we are under embedded broadcast use case.
-                emitDispEmbBroadcastCount(id);
+                break;
             }
-            break;
+            emitDispEmbBroadcastCount(id);
         }
 
         case IF_RWR_RRD_SRD_CNS:
@@ -11923,11 +11920,11 @@ void emitter::emitDispIns(
             printf("%s, %s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), attr), sstr);
             offs = emitGetInsDsp(id);
             emitDispClsVar(id->idAddr()->iiaFieldHnd, offs, ID_INFO_DSP_RELOC);
-            if(id->idIsEvexbContext())
+            if (!id->idIsEvexbContext())
             {
-                // we should have the assumption that we are under embedded broadcast use case.
-                emitDispEmbBroadcastCount(id);
+                break;
             }
+            emitDispEmbBroadcastCount(id);
             break;
         }
 


### PR DESCRIPTION
# Description 

JitDisasm doesn't include embedded broadcast syntax in disassembly.
 Eg.
`vaddps   zmm0, zmm0, dword ptr [reloc @RWD00]`

This PR will add the missing tag with the broadcasted element count, so the new disassembly will look like:

`vaddps   zmm0, zmm0, dword ptr [reloc @RWD00] {1to16}`