### PR TITLE
Fix Activity Baggage logging scope

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactoryScopeProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactoryScopeProvider.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Extensions.Logging
             }
         }
 
-        private sealed class ActivityBaggageLogScopeWrapper : IEnumerable<KeyValuePair<string, string?>>
+        private sealed class ActivityBaggageLogScopeWrapper : IEnumerable<KeyValuePair<string, object?>>
         {
             private readonly IEnumerable<KeyValuePair<string, string?>> _items;
 
@@ -231,15 +231,9 @@ namespace Microsoft.Extensions.Logging
                 _items = items;
             }
 
-            public IEnumerator<KeyValuePair<string, string?>> GetEnumerator()
-            {
-                return _items.GetEnumerator();
-            }
+            public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => new BaggageEnumerator(_items.GetEnumerator());
 
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return _items.GetEnumerator();
-            }
+            IEnumerator IEnumerable.GetEnumerator() => new BaggageEnumerator(_items.GetEnumerator());
 
             public override string ToString()
             {
@@ -268,6 +262,26 @@ namespace Microsoft.Extensions.Logging
                     _stringBuilder.Clear();
                     return result;
                 }
+            }
+
+            private struct BaggageEnumerator : IEnumerator<KeyValuePair<string, object?>>
+            {
+                private readonly IEnumerator<KeyValuePair<string, string?>> _enumerator;
+
+                public BaggageEnumerator(IEnumerator<KeyValuePair<string, string?>> enumerator)
+                {
+                    _enumerator = enumerator;
+                }
+
+                public KeyValuePair<string, object?> Current => new KeyValuePair<string, object?>(_enumerator.Current.Key, _enumerator.Current.Value);
+
+                object? IEnumerator.Current => Current;
+
+                public void Dispose() => _enumerator.Dispose();
+
+                public bool MoveNext() => _enumerator.MoveNext();
+
+                public void Reset() => _enumerator.Reset();
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerFactoryTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerFactoryTest.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Text;
 using System.Diagnostics;
 using System.Collections.Generic;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerFactoryTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerFactoryTest.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 using System.Text;
 using System.Diagnostics;
 using System.Collections.Generic;
+using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
@@ -407,6 +409,46 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
+        public void BaggageFormattedOutput()
+        {
+            var loggerProvider = new ExternalScopeLoggerWithFormatterProvider();
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .Configure(o => o.ActivityTrackingOptions = ActivityTrackingOptions.TraceId | ActivityTrackingOptions.Baggage | ActivityTrackingOptions.Tags)
+                    .AddProvider(loggerProvider);
+            });
+
+            var logger = loggerFactory.CreateLogger("Logger");
+
+            Activity activity = new Activity("ScopeActivity");
+            activity.Start();
+
+            activity.AddTag("Tag1", "1");
+            activity.AddBaggage("Baggage1", "1");
+
+            using (logger.BeginScope("Scope1"))
+            {
+                activity.AddTag("Tag2", "2");
+                activity.AddBaggage("Baggage2", "2");
+                logger.LogInformation("Inside Scope Info!");
+            }
+            activity.Stop();
+
+            string [] loggerOutput = new string[]
+            {
+                $"Inside Scope Info!",
+                $"[TraceId, {activity.GetTraceId()}]",
+                $"[Tag1, 1]",
+                $"[Tag2, 2]",
+                $"[Baggage2, 2]",
+                $"[Baggage1, 1]",
+                $"Scope1",
+            };
+            Assert.Equal(loggerOutput, loggerProvider.LogText);
+        }
+
+        [Fact]
         public void CallsSetScopeProvider_OnSupportedProviders()
         {
             var loggerProvider = new ExternalScopeLoggerProvider();
@@ -572,6 +614,53 @@ namespace Microsoft.Extensions.Logging.Test
             {
                 return true;
             }
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                BeginScopeCalledTimes++;
+                return null;
+            }
+        }
+
+        // Support formatting IEnumerable<KeyValuePair<string, object?>> scopes
+        private class ExternalScopeLoggerWithFormatterProvider : ILoggerProvider, ISupportExternalScope, ILogger
+        {
+            public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+            {
+                ScopeProvider = scopeProvider;
+            }
+
+            public IExternalScopeProvider ScopeProvider { get; set; }
+
+            public int BeginScopeCalledTimes { get; set; }
+
+            public List<string> LogText { get; set; } = new List<string>();
+
+            public void Dispose() { }
+
+            public ILogger CreateLogger(string categoryName) => this;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                LogText.Add(formatter(state, exception));
+
+                ScopeProvider.ForEachScope((scope, builder) =>
+                {
+                    if (scope is IEnumerable<KeyValuePair<string, object>> scopeItems)
+                    {
+                        foreach (KeyValuePair<string, object> item in scopeItems)
+                        {
+                            builder.Add(item.ToString());
+                        }
+                    }
+                    else
+                    {
+                        builder.Add(scope.ToString());
+                    }
+                }, LogText);
+            }
+
+            public bool IsEnabled(LogLevel logLevel) => true;
 
             public IDisposable BeginScope<TState>(TState state)
             {


### PR DESCRIPTION
Fixes #90071

When we enable `Activity.Baggage` logging, we currently log it as a scope object that implements `IEnumerable<KeyValuePair<string, string?>>`. The problem is that many logger providers don't support scopes of this type, causing them to use the `ToString()` method instead of properly enumerating the items and logging them correctly. To address this issue, we are making a fix by changing the baggage scope object to implement `IEnumerable<KeyValuePair<string, object?>>`. This change will ensure compatibility with most logger providers, allowing them to enumerate the baggage items and log each entry separately as intended.