### PR TITLE
List unsupported architectures in area-owners

### DIFF
--- a/docs/area-owners.json
+++ b/docs/area-owners.json
@@ -1,6 +1,20 @@
 {
   "architectures": [
     {
+      "lead": "",
+      "owners": [
+        ""
+      ],
+      "label": "arch-mips64"
+    },
+    {
+      "lead": "",
+      "owners": [
+        ""
+      ],
+      "label": "arch-s390x"
+    },
+    {
       "lead": "lewing",
       "owners": [
         "BrzVlad",


### PR DESCRIPTION
Driving some queries off this file and it's better to list these as having no owners.