### PR TITLE
Serialize createdump core dump generation

### DIFF
--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -413,7 +413,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
 
     PROCNotifyProcessShutdown(IsRunningOnAlternateStack(context));
 
-    PROCCreateCrashDumpIfEnabled(code, siginfo);
+    PROCCreateCrashDumpIfEnabled(code, siginfo, true);
 }
 
 /*++
@@ -746,7 +746,7 @@ static void sigterm_handler(int code, siginfo_t *siginfo, void *context)
         DWORD val = 0;
         if (enableDumpOnSigTerm.IsSet() && enableDumpOnSigTerm.TryAsInteger(10, val) && val == 1)
         {
-            PROCCreateCrashDumpIfEnabled(code, siginfo);
+            PROCCreateCrashDumpIfEnabled(code, siginfo, false);
         }
         // g_pSynchronizationManager shouldn't be null if PAL is initialized.
         _ASSERTE(g_pSynchronizationManager != nullptr);

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -388,8 +388,15 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
     {
         if (signalRestarts)
         {
+            // Shutdown and create the core dump before we restore the signal to the default handler.
+            PROCNotifyProcessShutdown(IsRunningOnAlternateStack(context));
+
+            PROCCreateCrashDumpIfEnabled(code, siginfo, true);
+
             // Restore the original and restart h/w exception.
             restore_signal(code, action);
+
+            return;
         }
         else
         {

--- a/src/coreclr/pal/src/include/pal/process.h
+++ b/src/coreclr/pal/src/include/pal/process.h
@@ -178,10 +178,12 @@ Function:
 
 Parameters:
   signal - POSIX signal number
+  siginfo - POSIX signal info or nullptr
+  serialize - allow only one thread to generate core dump
 
 (no return value)
 --*/
-VOID PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo);
+VOID PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo, bool serialize);
 
 /*++
 Function:

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -1197,7 +1197,10 @@ ExitProcess(
            Update: [TODO] PROCSuspendOtherThreads has been removed. Can this
            code be changed? */
         WARN("termination already started from another thread; blocking.\n");
-        poll(NULL, 0, INFTIM);
+        while (true)
+        {
+            poll(NULL, 0, INFTIM);
+        }
     }
 
     /* ExitProcess may be called even if PAL is not initialized.
@@ -2205,9 +2208,10 @@ PROCCreateCrashDump(
             _ASSERTE(previousThreadId != currentThreadId);
 
             // The first thread generates the crash info and any other threads are blocked
-            poll(NULL, 0, INFTIM);
-
-            return false;
+            while (true)
+            {
+                poll(NULL, 0, INFTIM);
+            }
         }
     }
 
@@ -3246,7 +3250,10 @@ CorUnix::TerminateCurrentProcessNoExit(BOOL bTerminateUnconditionally)
            TerminateProcess won't call DllMain, so there's no danger to get
            caught in an infinite loop */
         WARN("termination already started from another thread; blocking.\n");
-        poll(NULL, 0, INFTIM);
+        while (true)
+        {
+            poll(NULL, 0, INFTIM);
+        }
     }
 
     /* Try to lock the initialization count to prevent multiple threads from

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2178,8 +2178,9 @@ PROCBuildCreateDumpCommandLine(
 Function:
   PROCCreateCrashDump
 
-  Creates crash dump of the process. Can be called from the
-  unhandled native exception handler.
+  Creates crash dump of the process. Can be called from the unhandled
+  native exception handler. Allows only one thread to generate the core
+  dump if serialize is true.
 
 Return:
   TRUE - succeeds, FALSE - fails
@@ -2188,10 +2189,27 @@ BOOL
 PROCCreateCrashDump(
     std::vector<const char*>& argv,
     LPSTR errorMessageBuffer,
-    INT cbErrorMessageBuffer)
+    INT cbErrorMessageBuffer,
+    bool serialize)
 {
     _ASSERTE(argv.size() > 0);
     _ASSERTE(errorMessageBuffer == nullptr || cbErrorMessageBuffer > 0);
+
+    if (serialize)
+    {
+        size_t currentThreadId = THREADSilentGetCurrentThreadId();
+        size_t previousThreadId = InterlockedCompareExchange(&g_crashingThreadId, currentThreadId, 0);
+        if (previousThreadId != 0)
+        {
+            // Should never reenter or recurse
+            _ASSERTE(previousThreadId != currentThreadId);
+
+            // The first thread generates the crash info and any other threads are blocked
+            poll(NULL, 0, INFTIM);
+
+            return false;
+        }
+    }
 
     int pipe_descs[2];
     if (pipe(pipe_descs) == -1)
@@ -2297,41 +2315,6 @@ PROCCreateCrashDump(
         }
     }
     return true;
-}
-
-/*++
-Function:
-  PROCSerializedCreateCrashDump
-
-  Creates crash dump of the process. Only allows one thread to generate the
-  core dump. Can be called from the unhandled native exception handler.
-
-Return:
-   nothing
---*/
-VOID
-PROCSerializedCreateCrashDump(
-    std::vector<const char*>& argv,
-    LPSTR errorMessageBuffer,
-    INT cbErrorMessageBuffer)
-{
-    _ASSERTE(argv.size() > 0);
-    _ASSERTE(errorMessageBuffer == nullptr || cbErrorMessageBuffer > 0);
-
-    size_t currentThreadId = THREADSilentGetCurrentThreadId();
-    size_t previousThreadId = InterlockedCompareExchange(&g_crashingThreadId, currentThreadId, 0);
-    if (previousThreadId == 0)
-    {
-        PROCCreateCrashDump(argv, errorMessageBuffer, cbErrorMessageBuffer);
-    }
-    else
-    {
-        // Should never reenter or recurse
-        _ASSERTE(previousThreadId != currentThreadId);
-
-        // The first thread generates the crash info and any other threads are blocked
-        Sleep(INFINITE);
-    }
 }
 
 /*++
@@ -2452,7 +2435,7 @@ PAL_GenerateCoreDump(
     BOOL result = PROCBuildCreateDumpCommandLine(argvCreateDump, &program, &pidarg, dumpName, nullptr, dumpType, flags);
     if (result)
     {
-        result = PROCCreateCrashDump(argvCreateDump, errorMessageBuffer, cbErrorMessageBuffer);
+        result = PROCCreateCrashDump(argvCreateDump, errorMessageBuffer, cbErrorMessageBuffer, false);
     }
     free(program);
     free(pidarg);
@@ -2532,14 +2515,7 @@ PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo, bool serialize)
             argv.push_back(nullptr);
         }
 
-        if (serialize)
-        {
-            PROCSerializedCreateCrashDump(argv, nullptr, 0);
-        }
-        else
-        {
-            PROCCreateCrashDump(argv, nullptr, 0);
-        }
+        PROCCreateCrashDump(argv, nullptr, 0, serialize);
 
         free(signalArg);
         free(crashThreadArg);

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2327,7 +2327,7 @@ PROCSerializedCreateCrashDump(
     else
     {
         // Should never reenter or recurse
-        _ASSERTE(previousThreadId != currentThreadId)
+        _ASSERTE(previousThreadId != currentThreadId);
 
         // The first thread generates the crash info and any other threads are blocked
         Sleep(INFINITE);


### PR DESCRIPTION
Only allow one thread at a time to generate a core dump.

Issue: https://github.com/dotnet/runtime/issues/82989