### PR TITLE
Fix analyzer warning that is breaking the build

### DIFF
--- a/src/tasks/MobileBuildTasks/Apple/AppleProject.cs
+++ b/src/tasks/MobileBuildTasks/Apple/AppleProject.cs
@@ -121,9 +121,8 @@ namespace Microsoft.Apple.Build
                 }
                 else
                 {
-                    if (!libDirs.Contains(rootPath))
+                    if (libDirs.Add(rootPath))
                     {
-                        libDirs.Add(rootPath);
                         ret.Append($"-L {rootPath} ");
                     }
                     ret.Append($"-l{libName} ");


### PR DESCRIPTION
Currently failing with error:
```
error CA1868: Do not guard 'HashSet.Add(string)' with 'HashSet.Contains(string)' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1868)
```