### PR TITLE
Mark XxHash64.Complete as noinline

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.State.cs
@@ -66,6 +66,7 @@ namespace System.IO.Hashing
                 return acc;
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             internal readonly uint Complete(int length, ReadOnlySpan<byte> remaining)
             {
                 uint acc = _hadFullStripe ? Converge() : _smallAcc;

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.State.cs
@@ -66,7 +66,6 @@ namespace System.IO.Hashing
                 return acc;
             }
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
             internal readonly uint Complete(int length, ReadOnlySpan<byte> remaining)
             {
                 uint acc = _hadFullStripe ? Converge() : _smallAcc;

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
@@ -97,6 +97,9 @@ namespace System.IO.Hashing
                 return acc;
             }
 
+            // Inliner may decide to inline this method into HashToUInt64() with help of PGO and
+            // can run out of "time budget" producing non-inlined simple calls such as Span.Slice.
+            // TODO: Remove NoInlining when https://github.com/dotnet/runtime/issues/85531 is fixed.
             [MethodImpl(MethodImplOptions.NoInlining)]
             internal readonly ulong Complete(long length, ReadOnlySpan<byte> remaining)
             {

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs
@@ -97,6 +97,7 @@ namespace System.IO.Hashing
                 return acc;
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             internal readonly ulong Complete(long length, ReadOnlySpan<byte> remaining)
             {
                 ulong acc = _hadFullStripe ? Converge() : _smallAcc;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/90090

```cs
public static IEnumerable<byte[]> TestData()
{
    yield return "aadwejkadjgb8c27tr874c3/./[}|P{OP&^&$%^^TGERfgea"u8.ToArray();
}

[Benchmark]
[ArgumentsSource(nameof(TestData))]
public byte[] XxHash64_(byte[] data) => XxHash64.Hash(data);
```
|    Method |                   Toolchain |        data |         Mean |
|---------- |---------------------------- |------------ |-------------:|
| XxHash64_ |      \Core_Root\corerun.exe |    Byte[48] |    **11.322 ns** |
| XxHash64_ | \Core_Root_base\corerun.exe |    Byte[48] |    30.245 ns |

_Temp_ workaround for the [inliner's budget problem](https://github.com/dotnet/runtime/issues/85531). It seems to decide to inline [this](https://github.com/EgorBo/runtime-1/blob/4f51f81d90e188cb8f22bb4567dec2a351d0d0dd/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.State.cs#L101-L139) function because it's on a hot path + PGO + it has multiple recognizeable intrinsics and looks like it mistakenly recognized foldable expressions here. Actually, it does make code faster if we inline it, but, since we [run out of budget](https://github.com/dotnet/runtime/issues/90090#issuecomment-1667871147), we give up on inlining simple things such as `Span.Slice` and that makes perf worse. No impact on large inputs as the main work is done in [this loop](https://github.com/dotnet/runtime/blob/5730c2098b2fe3f18c0d43303eecc6b96823274e/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs#L246-L250) and Complete is called as the last iteration so only small inputs are affected..

It's not an issue for `XxHash32` where `Complete()` is 2x simpler and is inlined just fine. `XxHash128` is not affected as well due to a different structure of code, although, it hit a similiar issue in the past.