### PR TITLE
[mono] Add LLVM-AOT support to the sample app

### DIFF
--- a/src/mono/sample/HelloWorld/HelloWorld.csproj
+++ b/src/mono/sample/HelloWorld/HelloWorld.csproj
@@ -18,7 +18,6 @@
 
     <ItemGroup>
       <AotInputAssemblies Include="$(PublishDir)\*.dll" />
-      <ReferenceAssembliesForPGO Include="$(PublishDir)\*.dll" />
     </ItemGroup>
 
     <MonoAOTCompiler
@@ -31,11 +30,9 @@
       CompiledMethodsOutputDirectory="$(CompiledMethodsOutputDirectory)"
       IntermediateOutputPath="$(IntermediateOutputPath)"
       UseAotDataFile="$(UseAotDataFile)"
-      CacheFilePath="$(IntermediateOutputPath)aot_compiler_cache.json"
-      NetTracePath="$(NetTracePath)"
-      PgoBinaryPath="$(PgoBinaryPath)"
-      ReferenceAssembliesForPGO="@(ReferenceAssembliesForPGO)"
-      MibcProfilePath="$(MibcProfilePath)">
+      MibcProfilePath="$(MibcProfilePath)"
+      UseLLVM="$(MonoEnableLLVM)"
+      LLVMPath="$(MonoAotCrossDir)">
       <Output TaskParameter="CompiledAssemblies" ItemName="BundleAssemblies" />
     </MonoAOTCompiler>
   </Target>

--- a/src/mono/sample/HelloWorld/Makefile
+++ b/src/mono/sample/HelloWorld/Makefile
@@ -6,11 +6,10 @@ MONO_CONFIG?=Debug
 MONO_ARCH?=$(shell . $(TOP)eng/native/init-os-and-arch.sh && echo $${arch})
 TARGET_OS?=$(shell . $(TOP)eng/native/init-os-and-arch.sh && echo $${os})
 AOT?=false
+USE_LLVM?=false
 StripILCode?=false
 CompiledMethodsOutputDirectory?= #<path-to-a-writable-directory>
 
-#NET_TRACE_PATH=<path-to-trace-of-sample>
-#PGO_BINARY_PATH=<path-to-dotnet-pgo-executable>
 #MIBC_PROFILE_PATH=<path-to-mibc-for-sample>
 
 MONO_ENV_OPTIONS ?=
@@ -20,11 +19,11 @@ publish:
 	-c $(MONO_CONFIG) \
 	-r $(TARGET_OS)-$(MONO_ARCH) \
 	/p:RunAOTCompilation=$(AOT) \
+	/p:MonoEnableLLVM=$(USE_LLVM) \
 	/p:StripILCode=$(StripILCode) \
 	/p:CompiledMethodsOutputDirectory=$(CompiledMethodsOutputDirectory) \
-	'/p:NetTracePath="$(NET_TRACE_PATH)"' \
-	'/p:PgoBinaryPath="$(PGO_BINARY_PATH)"' \
-	'/p:MibcProfilePath="$(MIBC_PROFILE_PATH)"'
+	'/p:MibcProfilePath="$(MIBC_PROFILE_PATH)"' \
+	/bl
 
 run: publish
 	DOTNET_DebugWriteToStdErr=1 \


### PR DESCRIPTION
This PR adds LLVM-AOT support to the sample app.

Fixes https://github.com/dotnet/runtime/issues/81696