### PR TITLE
Avoid looking for dynamically accessed members when none are requested.

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -964,7 +964,9 @@ namespace Mono.Linker.Steps
 					Context.LogWarning (ScopeStack.CurrentScope.Origin, DiagnosticId.NoMembersResolvedForMemberSignatureOrType, memberSignature, type.GetDisplayName ());
 					return;
 				}
-			} else if (dynamicDependency.MemberTypes != DynamicallyAccessedMemberTypes.None) {
+			} else if (dynamicDependency.MemberTypes == DynamicallyAccessedMemberTypes.None) {
+				return;
+			} else {
 				var memberTypes = dynamicDependency.MemberTypes;
 				members = type.GetDynamicallyAccessedMembers (Context, memberTypes);
 				if (!members.Any ()) {

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -964,7 +964,7 @@ namespace Mono.Linker.Steps
 					Context.LogWarning (ScopeStack.CurrentScope.Origin, DiagnosticId.NoMembersResolvedForMemberSignatureOrType, memberSignature, type.GetDisplayName ());
 					return;
 				}
-			} else {
+			} else if (dynamicDependency.MemberTypes != DynamicallyAccessedMemberTypes.None) {
 				var memberTypes = dynamicDependency.MemberTypes;
 				members = type.GetDynamicallyAccessedMembers (Context, memberTypes);
 				if (!members.Any ()) {


### PR DESCRIPTION
The purpose of this logic is to warn when no members can be found for a
DynamicDependency attribute.

However, it even warns when DynamicallyAccessedMemberTypes.None is specified
in the attribute, which seems a bit overeager, so change the logic to not warn
when DynamicallyAccessedMemberTypes.None is specified (nor try to mark any
members, because we're not supposed to mark any members).