### PR TITLE
Make {u}int/{u}long/n{u}int.CompareTo branch-free

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -63,13 +63,9 @@ namespace System
                 return 1;
             }
 
-            // NOTE: Cannot use return (_value - value) as this causes a wrap
-            // around in cases where _value - value > MaxValue.
             if (value is int i)
             {
-                if (m_value < i) return -1;
-                if (m_value > i) return 1;
-                return 0;
+                return CompareTo(i);
             }
 
             throw new ArgumentException(SR.Arg_MustBeInt32);
@@ -77,11 +73,9 @@ namespace System
 
         public int CompareTo(int value)
         {
-            // NOTE: Cannot use return (_value - value) as this causes a wrap
-            // around in cases where _value - value > MaxValue.
-            if (m_value < value) return -1;
-            if (m_value > value) return 1;
-            return 0;
+            int gt = (m_value > value) ? 1 : 0;
+            int lt = (m_value < value) ? 1 : 0;
+            return gt - lt;
         }
 
         public override bool Equals([NotNullWhen(true)] object? obj)

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -60,13 +60,9 @@ namespace System
                 return 1;
             }
 
-            // Need to use compare because subtraction will wrap
-            // to positive for very large neg numbers, etc.
             if (value is long i)
             {
-                if (m_value < i) return -1;
-                if (m_value > i) return 1;
-                return 0;
+                return CompareTo(i);
             }
 
             throw new ArgumentException(SR.Arg_MustBeInt64);
@@ -74,11 +70,9 @@ namespace System
 
         public int CompareTo(long value)
         {
-            // Need to use compare because subtraction will wrap
-            // to positive for very large neg numbers, etc.
-            if (m_value < value) return -1;
-            if (m_value > value) return 1;
-            return 0;
+            int gt = (m_value > value) ? 1 : 0;
+            int lt = (m_value < value) ? 1 : 0;
+            return gt - lt;
         }
 
         public override bool Equals([NotNullWhen(true)] object? obj)

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -195,9 +195,9 @@ namespace System
 
         public int CompareTo(nint value)
         {
-            if (_value < value) return -1;
-            if (_value > value) return 1;
-            return 0;
+            int gt = (_value > value) ? 1 : 0;
+            int lt = (_value < value) ? 1 : 0;
+            return gt - lt;
         }
 
         [NonVersionable]

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -57,13 +57,9 @@ namespace System
                 return 1;
             }
 
-            // Need to use compare because subtraction will wrap
-            // to positive for very large neg numbers, etc.
             if (value is uint i)
             {
-                if (m_value < i) return -1;
-                if (m_value > i) return 1;
-                return 0;
+                return CompareTo(i);
             }
 
             throw new ArgumentException(SR.Arg_MustBeUInt32);
@@ -71,11 +67,9 @@ namespace System
 
         public int CompareTo(uint value)
         {
-            // Need to use compare because subtraction will wrap
-            // to positive for very large neg numbers, etc.
-            if (m_value < value) return -1;
-            if (m_value > value) return 1;
-            return 0;
+            int gt = (m_value > value) ? 1 : 0;
+            int lt = (m_value < value) ? 1 : 0;
+            return gt - lt;
         }
 
         public override bool Equals([NotNullWhen(true)] object? obj)

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -57,13 +57,9 @@ namespace System
                 return 1;
             }
 
-            // Need to use compare because subtraction will wrap
-            // to positive for very large neg numbers, etc.
             if (value is ulong i)
             {
-                if (m_value < i) return -1;
-                if (m_value > i) return 1;
-                return 0;
+                return CompareTo(i);
             }
 
             throw new ArgumentException(SR.Arg_MustBeUInt64);
@@ -71,11 +67,9 @@ namespace System
 
         public int CompareTo(ulong value)
         {
-            // Need to use compare because subtraction will wrap
-            // to positive for very large neg numbers, etc.
-            if (m_value < value) return -1;
-            if (m_value > value) return 1;
-            return 0;
+            int gt = (m_value > value) ? 1 : 0;
+            int lt = (m_value < value) ? 1 : 0;
+            return gt - lt;
         }
 
         public override bool Equals([NotNullWhen(true)] object? obj)

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -191,9 +191,9 @@ namespace System
 
         public int CompareTo(nuint value)
         {
-            if (_value < value) return -1;
-            if (_value > value) return 1;
-            return 0;
+            int gt = (_value > value) ? 1 : 0;
+            int lt = (_value < value) ? 1 : 0;
+            return gt - lt;
         }
 
         [NonVersionable]


### PR DESCRIPTION
Utilize C# compiler's recent `(b ? 1 : 0)` optimization to avoid branching in CompareTo.

We've talked about doing this in the past, as part of discussing the aforementioned compiler optimization, so I'm not sure if it just fell through the cracks or if we decided against doing it.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[HideColumns("Error", "StdDev", "Median", "RatioSD")]
public partial class Tests
{
    private static readonly Random s_rand = new Random();

    [Benchmark]
    public int CompareConst() => 0.CompareTo(-1);

    [Benchmark]
    [Arguments(0, 0)]
    [Arguments(0, 1)]
    [Arguments(1, 0)]
    public int ComparePredictable(int x, int y) => x.CompareTo(y);

    private int _y = int.MaxValue / 2;

    [Benchmark]
    public int CompareRandom() => s_rand.Next().CompareTo(_y);
}
```

|                      Method |         Toolchain | x | y |      Mean | Ratio |
|---------------------------- |------------------ |-- |-- |----------:|------:|
|                CompareConst | \main\corerun.exe | ? | ? | 0.0096 ns |     ? |
|                CompareConst |   \pr\corerun.exe | ? | ? | 0.0030 ns |     ? |
|                             |                   |   |   |           |       |
|               CompareRandom | \main\corerun.exe | ? | ? | 6.2326 ns |  1.00 |
|               CompareRandom |   \pr\corerun.exe | ? | ? | 1.9093 ns |  0.31 |
|                             |                   |   |   |           |       |
|          ComparePredictable | \main\corerun.exe | 0 | 0 | 0.0003 ns |     ? |
|          ComparePredictable |   \pr\corerun.exe | 0 | 0 | 0.0057 ns |     ? |
|                             |                   |   |   |           |       |
|          ComparePredictable | \main\corerun.exe | 0 | 1 | 0.0313 ns |     ? |
|          ComparePredictable |   \pr\corerun.exe | 0 | 1 | 0.0028 ns |     ? |
|                             |                   |   |   |           |       |
|          ComparePredictable | \main\corerun.exe | 1 | 0 | 0.0009 ns |     ? |
|          ComparePredictable |   \pr\corerun.exe | 1 | 0 | 0.0000 ns |     ? |

```
// * Warnings *
ZeroMeasurement
  Tests.CompareConst: Toolchain=\main\corerun.exe                -> The method duration is indistinguishable from the empty method duration
  Tests.CompareConst: Toolchain=\pr\corerun.exe                  -> The method duration is indistinguishable from the empty method duration
  Tests.ComparePredictable: Toolchain=\main\corerun.exe          -> The method duration is indistinguishable from the empty method duration
  Tests.ComparePredictable: Toolchain=\pr\corerun.exe            -> The method duration is indistinguishable from the empty method duration
  Tests.ComparePredictable: Toolchain=\main\corerun.exe          -> The method duration is indistinguishable from the empty method duration
  Tests.ComparePredictable: Toolchain=\pr\corerun.exe            -> The method duration is indistinguishable from the empty method duration
  Tests.ComparePredictable: Toolchain=\main\corerun.exe          -> The method duration is indistinguishable from the empty method duration
  Tests.ComparePredictable: Toolchain=\pr\corerun.exe            -> The method duration is indistinguishable from the empty method duration
```

```assembly
; Tests.CompareConst()
       mov       eax,1
       ret
; Total bytes of code 6

; Tests.ComparePredictable(Int32, Int32)
       xor       eax,eax
       cmp       edx,r8d
       setg      al
       xor       ecx,ecx
       cmp       edx,r8d
       setl      cl
       sub       eax,ecx
       ret
; Total bytes of code 19

; Tests.CompareRandom()
       push      rbx
       sub       rsp,20
       mov       rbx,rcx
       mov       rcx,180BB801E68
       mov       rcx,[rcx]
       mov       rcx,[rcx+8]
       mov       rax,offset MT_System.Random+XoshiroImpl
       cmp       [rcx],rax
       jne       short M00_L01
       call      qword ptr [7FFE9D302860]; System.Random+XoshiroImpl.Next()
M00_L00:
       mov       ecx,[rbx+8]
       xor       edx,edx
       cmp       eax,ecx
       setg      dl
       setl      al
       movzx     eax,al
       sub       edx,eax
       mov       eax,edx
       add       rsp,20
       pop       rbx
       ret
M00_L01:
       mov       rax,[rcx]
       mov       rax,[rax+40]
       call      qword ptr [rax+28]
       jmp       short M00_L00
; Total bytes of code 84
```