### PR TITLE
Debugger IPC creation failure should not abort coreclr startup

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -1939,7 +1939,7 @@ HRESULT Debugger::Startup(void)
         if (FAILED(hr))
         {
             ShutdownTransport();
-            ThrowHR(hr);
+            return S_OK; // we do not want debugger IPC to block runtime initialization
         }
     #endif // FEATURE_DBGIPC_TRANSPORT_VM
 

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -1939,6 +1939,7 @@ HRESULT Debugger::Startup(void)
         if (FAILED(hr))
         {
             ShutdownTransport();
+            LOG((LF_CORDB, LL_ERROR, "D::S: The debugger pipe failed to initialize in /tmp or $TMPDIR.\n"));
             return S_OK; // we do not want debugger IPC to block runtime initialization
         }
     #endif // FEATURE_DBGIPC_TRANSPORT_VM

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -1939,7 +1939,7 @@ HRESULT Debugger::Startup(void)
         if (FAILED(hr))
         {
             ShutdownTransport();
-            LOG((LF_CORDB, LL_ERROR, "D::S: The debugger pipe failed to initialize in /tmp or $TMPDIR.\n"));
+            STRESS_LOG0(LF_CORDB, LL_ERROR, "D::S: The debugger pipe failed to initialize in /tmp or $TMPDIR.\n");
             return S_OK; // we do not want debugger IPC to block runtime initialization
         }
     #endif // FEATURE_DBGIPC_TRANSPORT_VM


### PR DESCRIPTION
On Linux, the debugger creates 2 single-directional pipes in `/tmp` or `$TMPDIR`.  Today if we fail to create these pipes, coreclr init will fail with `Failed to create CoreCLR, HRESULT: 0x8007000E` as described in https://github.com/dotnet/runtime/issues/86259.  

We found that there are two places where the runtime creates pipes/domain sockets for diagnostics:
* [Diagnostics IPC](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnostic-port) - By default the 'listen' port is created in /tmp or `$TMPDIR` if the env variable is set.  It provides a transport for collecting memory dumps, starting an EventPipe tracing session, requesting a dump, ...  It is considered *non-fatal* if it doesn't start.  
* [Debugger Port](https://github.com/dotnet/runtime/blob/ddbce91b241bcf0d7f33d04d33520659addd6dd7/src/coreclr/debug/ee/debugger.cpp#L1813) - creates 2 pipes in /tmp or `$TMPDIR` if the variable is set in Debugger::Startup.  This is considered *fatal* if we can't create the port.  This is not only related to read only file systems or non-Linux file system mounts.  For example, if `$TMPDIR` is set to a Windows mount in WSL2, the pipe will also fail to be created.

This PR changes Debugger Port creation failure from fatal to non-fatal.  