### PR TITLE
Improvements to Banned APIs

### DIFF
--- a/src/tools/illink/src/linker/BannedSymbols.txt
+++ b/src/tools/illink/src/linker/BannedSymbols.txt
@@ -1,12 +1,12 @@
 T:Mono.Cecil.Cil.ILProcessor;Use LinkerILProcessor instead
-M:Mono.Cecil.TypeReference.Resolve();Use LinkContext.Resolve and LinkContext.TryResolve helpers instead
+M:Mono.Cecil.TypeReference.Resolve();Use LinkContext.Resolve and LinkContext.TryResolve helpers or BannedApiExtensions.Resolve and BannedApiExtensions.TryResolve instead
 P:Mono.Cecil.MethodReference.Parameters;Use an extension method from MethodReferenceExtensions instead
 P:Mono.Cecil.MethodReference.HasParameters;Use an extension method from MethodReference.HasMetadataParameters() instead
-M:Mono.Cecil.MethodReference.Resolve();Use LinkContext.Resolve and LinkContext.TryResolve helpers instead
-M:Mono.Cecil.ExportedType.Resolve();Use LinkContext.Resolve and LinkContext.TryResolve helpers instead
+M:Mono.Cecil.MethodReference.Resolve();Use LinkContext.Resolve and LinkContext.TryResolve helpers or BannedApiExtensions.Resolve and BannedApiExtensions.TryResolve instead
+M:Mono.Cecil.ExportedType.Resolve();Use LinkContext.Resolve and LinkContext.TryResolve helpers or BannedApiExtensions.Resolve and BannedApiExtensions.TryResolve instead
 P:Mono.Collections.Generic.Collection`1{Mono.Cecil.ParameterDefinition}.Item(System.Int32); use x
 P:Mono.Cecil.ParameterDefinitionCollection.Item(System.Int32); use x
-P:Mono.Cecil.Cil.MethodBody.Instructions;Use LinkContext.MethodBodyInstructionProvider instead
-P:Mono.Cecil.Cil.MethodBody.ExceptionHandlers;Use LinkContext.MethodBodyInstructionProvider instead
-P:Mono.Cecil.Cil.MethodBody.Variables;Use LinkContext.MethodBodyInstructionProvider instead
+P:Mono.Cecil.Cil.MethodBody.Instructions;Use LinkContext.GetMethodIL or BannedApiExtensions.Instructions(Mono.Linker.LinkContext) instead
+P:Mono.Cecil.Cil.MethodBody.ExceptionHandlers;Use LinkContext.GetMethodIL or BannedApiExtensions.ExceptionHandlers(Mono.Linker.LinkContext) instead
+P:Mono.Cecil.Cil.MethodBody.Variables;Use LinkContext.GetMethodIL or BannedApiExtensions.Variables(Mono.Linker.LinkContext) instead
 M:Mono.Linker.Steps.ILProvider/MethodIL.Create;Use ILProvider GetMethodIL instead

--- a/src/tools/illink/src/linker/CompatibilitySuppressions.xml
+++ b/src/tools/illink/src/linker/CompatibilitySuppressions.xml
@@ -195,6 +195,12 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Mono.Linker.BannedApiExtensions</Target>
+    <Left>ref/net8.0/illink.dll</Left>
+    <Right>lib/net8.0/illink.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Mono.Linker.BCL</Target>
     <Left>ref/net8.0/illink.dll</Left>
     <Right>lib/net8.0/illink.dll</Right>
@@ -382,6 +388,12 @@
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Mono.Linker.LinkerFatalErrorException</Target>
+    <Left>ref/net8.0/illink.dll</Left>
+    <Right>lib/net8.0/illink.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Mono.Linker.LinkerILProcessor</Target>
     <Left>ref/net8.0/illink.dll</Left>
     <Right>lib/net8.0/illink.dll</Right>
   </Suppression>

--- a/src/tools/illink/src/linker/Linker.Dataflow/CompilerGeneratedState.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/CompilerGeneratedState.cs
@@ -146,7 +146,7 @@ namespace Mono.Linker.Dataflow
 				// Discover calls or references to lambdas or local functions. This includes
 				// calls to local functions, and lambda assignments (which use ldftn).
 				if (method.Body != null) {
-					foreach (var instruction in _context.GetMethodIL (method).Instructions) {
+					foreach (var instruction in method.Body.Instructions (_context)) {
 						switch (instruction.OpCode.OperandType) {
 						case OperandType.InlineMethod: {
 								MethodDefinition? referencedMethod = _context.TryResolve ((MethodReference) instruction.Operand);

--- a/src/tools/illink/src/linker/Linker/BannedApiExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/BannedApiExtensions.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Collections.Generic;
+
+namespace Mono.Linker;
+
+/// <summary>
+/// Extension methods to help make working with banned apis easier and more discoverable
+/// </summary>
+public static class BannedApiExtensions
+{
+	public static Collection<Instruction> Instructions (this MethodBody body, LinkContext context)
+		=> context.GetMethodIL(body.Method).Instructions;
+
+	public static Collection<ExceptionHandler> ExceptionHandlers (this MethodBody body, LinkContext context)
+		=> context.GetMethodIL (body.Method).ExceptionHandlers;
+
+	public static Collection<VariableDefinition> Variables (this MethodBody body, LinkContext context)
+		=> context.GetMethodIL(body.Method).Variables;
+
+	public static MethodIL GetMethodIL (this MethodDefinition method, LinkContext context)
+		=> context.GetMethodIL (method);
+
+	public static MethodIL GetMethodIL (this MethodBody body, LinkContext context)
+		=> context.GetMethodIL (body);
+
+	public static MethodDefinition? Resolve (this MethodReference method, LinkContext context)
+		=> context.Resolve (method);
+
+	public static MethodDefinition? TryResolve (this MethodReference method, LinkContext context)
+		=> context.TryResolve (method);
+
+	public static TypeDefinition? Resolve (this TypeReference type, LinkContext context)
+		=> context.Resolve (type);
+
+	public static TypeDefinition? TryResolve (this TypeReference type, LinkContext context)
+		=> context.TryResolve (type);
+
+	public static TypeDefinition? Resolve (this ExportedType type, LinkContext context)
+		=> context.Resolve (type);
+
+	public static TypeDefinition? TryResolve (this ExportedType type, LinkContext context)
+		=> context.TryResolve (type);
+
+	public static LinkerILProcessor GetLinkerILProcessor (this MethodBody body)
+		=> new (body);
+}

--- a/src/tools/illink/src/linker/Linker/LinkerILProcessor.cs
+++ b/src/tools/illink/src/linker/Linker/LinkerILProcessor.cs
@@ -8,7 +8,7 @@ using Mono.Cecil.Cil;
 namespace Mono.Linker
 {
 #pragma warning disable RS0030
-	sealed class LinkerILProcessor
+	public sealed class LinkerILProcessor
 	{
 		readonly ILProcessor _ilProcessor;
 
@@ -127,13 +127,5 @@ namespace Mono.Linker
 			}
 		}
 #pragma warning disable RS0030
-	}
-
-	static class ILProcessorExtensions
-	{
-		public static LinkerILProcessor GetLinkerILProcessor (this MethodBody body)
-		{
-			return new LinkerILProcessor (body);
-		}
 	}
 }


### PR DESCRIPTION
I'm working on turning on the banned api analyzer in UnityLinker and I found some things that I think help streamline working with banned apis.

* Some of the suggested alternatives look like they were out of date.  I fixed these to give the correct suggestion.

* I added a `BannedApiExtensions` class to house extension methods for working with banned apis.  I think this will help with discoverability.

* Having to write `Context.` to get to things that are on cecil objects feels cumbersome and hard to discover.  I added extension methods for many of the banned apis.

* I moved `GetLinkerILProcessor` to `BannedApiExtensions` and made it public

* I made `LinkerILProcessor` public so that we can access it if necessary.

* I changed a few things to use the extension methods in `BannedApiExtensions` so that some usages existed.  I didn't go so far as to convert everything over to the extension methods.  I didn't think that would be desired.  I'm happy to standardize everything if that is desired.