### PR TITLE
Align V512 reads in IndexOf.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Packed.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Packed.cs
@@ -332,8 +332,8 @@ namespace System
                                 // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
                                 short *pTwoVectorsAwayFromEnd = pSearchSpace + (length - (2 * Vector512<short>.Count));
 
-                                Vector512<short> source0 = Vector512.LoadUnsafe(ref currentSearchSpace);
-                                Vector512<short> source1 = Vector512.LoadUnsafe(ref currentSearchSpace, (nuint)Vector512<short>.Count);
+                                Vector512<short> source0 = Vector512.Load(pCurrentSearchSpace);
+                                Vector512<short> source1 = Vector512.Load(pCurrentSearchSpace + Vector512<short>.Count);
                                 Vector512<byte> packedSource = PackSources(source0, source1);
 
                                 if (HasMatch<TNegator>(packedValue, packedSource))
@@ -359,7 +359,7 @@ namespace System
                                 }
                             }
 
-                            // We have 1-32 characters remaining. Process the first and last vector in the search space.
+                            // We have 1-64 characters remaining. Process the first and last vector in the search space.
                             // They may overlap, but we'll handle that in the index calculation if we do get a match.
                             {
                                 short *pOneVectorAwayFromEnd = pSearchSpace + (length - Vector512<short>.Count);
@@ -1242,7 +1242,7 @@ namespace System
         {
             ulong notEqualsElements = FixUpPackedVector512Result(equals).ExtractMostSignificantBits();
             int index = BitOperations.TrailingZeroCount(notEqualsElements);
-            return index + (int)((nuint)(current - searchSpace) / sizeof(short));
+            return index + (int)(((nuint)current - (nuint)searchSpace) / sizeof(short));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1301,7 +1301,7 @@ namespace System
                 current0 = current1;
                 offsetInVector -= Vector512<short>.Count;
             }
-            return offsetInVector + (int)((nuint)(current0 - searchSpace) / sizeof(short));
+            return offsetInVector + (int)(((nuint)current0 - (nuint)searchSpace) / sizeof(short));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
We see some nice performance improvement when we align the reads for the `char` version of `IndexOf`, and may see similar improvements for the `char` version of `IndexOfAny` (working on that at the moment).

`Vector256` is with `DOTNET_EnableAVX512F=0`, `Vector512-Base` is with `DOTNET_EnableAVX512F=1` without my changes, and `Vector512-Diff` is with my changes.

![image](https://github.com/dotnet/runtime/assets/91913526/d40c39be-41d7-4495-9465-36e58edd3e4a)

where `CharIndexOf` is

![image](https://github.com/dotnet/runtime/assets/91913526/97894528-f8ee-4923-a88f-b91f8408d16c)

We applied to same optimization to `char` `IndexOfAny`

![image](https://github.com/dotnet/runtime/assets/91913526/429d6858-611d-402a-9d2b-e5ee76d0a88d)

where `CharIndexOfAny` is

![image](https://github.com/dotnet/runtime/assets/91913526/7d59198e-8019-4375-ace3-944ae11fed4c)

