### PR TITLE
Enable support for generic methods with IDIC

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -714,7 +714,6 @@ PTR_MethodTable InterfaceInfo_t::GetApproxMethodTable(Module * pContainingModule
     // we call GetInterfaceImplementation on the object and call GetMethodDescForInterfaceMethod
     // with whatever type it returns.
     if (pServerMT->IsIDynamicInterfaceCastable()
-        && !pItfMD->HasMethodInstantiation()
         && !TypeHandle(pServerMT).CanCastTo(ownerType)) // we need to make sure object doesn't implement this interface in a natural way
     {
         TypeHandle implTypeHandle;

--- a/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
+++ b/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
@@ -30,6 +30,7 @@ namespace IDynamicInterfaceCastableTests
     public interface ITestGeneric<in T, out U>
     {
         U ReturnArg(T t);
+        V DoubleGenericArg<V>(V t);
     }
 
     public interface IDirectlyImplemented
@@ -140,6 +141,21 @@ namespace IDynamicInterfaceCastableTests
 
             return Unsafe.As<T, U>(ref t);
         }
+
+        V ITestGeneric<T, U>.DoubleGenericArg<V>(V v)
+        {
+            if (v is int i)
+            {
+                i *= 2;
+                return Unsafe.As<int, V>(ref i);
+            }
+            else if (v is string s)
+            {
+                s += s;
+                return Unsafe.As<string, V>(ref s);
+            }
+            throw new Exception("Unable to double");
+        }
     }
 
     [DynamicInterfaceCastableImplementation]
@@ -148,6 +164,21 @@ namespace IDynamicInterfaceCastableTests
         int ITestGeneric<int, int>.ReturnArg(int i)
         {
             return i;
+        }
+
+        V ITestGeneric<int, int>.DoubleGenericArg<V>(V v)
+        {
+            if (v is int i)
+            {
+                i *= 2;
+                return Unsafe.As<int, V>(ref i);
+            }
+            else if (v is string s)
+            {
+                s += s;
+                return Unsafe.As<string, V>(ref s);
+            }
+            throw new Exception("Unable to double");
         }
     }
 
@@ -373,6 +404,8 @@ namespace IDynamicInterfaceCastableTests
             Assert.Equal(expectedInt, testInt.ReturnArg(42));
             Assert.Equal(expectedStr, testStr.ReturnArg(expectedStr));
             Assert.Equal(expectedStr, testVar.ReturnArg(expectedStr));
+            Assert.Equal(expectedInt * 2, testInt.DoubleGenericArg<int>(42));
+            Assert.Equal(expectedStr + expectedStr, testStr.DoubleGenericArg<string>("str"));
 
             Console.WriteLine(" -- Validate delegate call");
             Func<int, int> funcInt = new Func<int, int>(testInt.ReturnArg);

--- a/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
+++ b/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
@@ -146,11 +146,13 @@ namespace IDynamicInterfaceCastableTests
         {
             if (v is int i)
             {
+                Assert.True(typeof(V) == typeof(int));
                 i *= 2;
                 return Unsafe.As<int, V>(ref i);
             }
             else if (v is string s)
             {
+                Assert.True(typeof(V) == typeof(string));
                 s += s;
                 return Unsafe.As<string, V>(ref s);
             }
@@ -170,11 +172,13 @@ namespace IDynamicInterfaceCastableTests
         {
             if (v is int i)
             {
+                Assert.True(typeof(V) == typeof(int));
                 i *= 2;
                 return Unsafe.As<int, V>(ref i);
             }
             else if (v is string s)
             {
+                Assert.True(typeof(V) == typeof(string));
                 s += s;
                 return Unsafe.As<string, V>(ref s);
             }
@@ -404,8 +408,14 @@ namespace IDynamicInterfaceCastableTests
             Assert.Equal(expectedInt, testInt.ReturnArg(42));
             Assert.Equal(expectedStr, testStr.ReturnArg(expectedStr));
             Assert.Equal(expectedStr, testVar.ReturnArg(expectedStr));
+
+            Console.WriteLine(" -- Validate generic method call");
             Assert.Equal(expectedInt * 2, testInt.DoubleGenericArg<int>(42));
+            Assert.Equal(expectedStr + expectedStr, testInt.DoubleGenericArg<string>("str"));
+            Assert.Equal(expectedInt * 2, testStr.DoubleGenericArg<int>(42));
             Assert.Equal(expectedStr + expectedStr, testStr.DoubleGenericArg<string>("str"));
+            Assert.Equal(expectedInt * 2, testVar.DoubleGenericArg<int>(42));
+            Assert.Equal(expectedStr + expectedStr, testVar.DoubleGenericArg<string>("str"));
 
             Console.WriteLine(" -- Validate delegate call");
             Func<int, int> funcInt = new Func<int, int>(testInt.ReturnArg);


### PR DESCRIPTION
Fixes #88964

Create tests to validate scenario.

Support for NativeAOT is still blocked - see https://github.com/dotnet/runtime/issues/72909.