### PR TITLE
Abort host startup before the next phase

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -62,8 +62,8 @@ namespace Microsoft.Extensions.Hosting.Internal
 
         /// <summary>
         /// Order:
-        ///  IHostLifetime.WaitForStartAsync (can abort chain)
-        ///  Services.GetService{IStartupValidator}().Validate() (can abort chain)
+        ///  IHostLifetime.WaitForStartAsync
+        ///  Services.GetService{IStartupValidator}().Validate()
         ///  IHostedLifecycleService.StartingAsync
         ///  IHostedService.Start
         ///  IHostedLifecycleService.StartedAsync
@@ -123,11 +123,11 @@ namespace Microsoft.Extensions.Hosting.Internal
                     await ForeachService(_hostedLifecycleServices, token, concurrent, abortOnFirstException, exceptions,
                         (service, token) => service.StartingAsync(token)).ConfigureAwait(false);
 
-                    // We do not abort on exceptions from StartingAsync.
+                    // Exceptions in StartingAsync cause startup to be aborted.
+                    LogAndRethrow();
                 }
 
                 // Call StartAsync().
-                // We do not abort on exceptions from StartAsync.
                 await ForeachService(_hostedServices, token, concurrent, abortOnFirstException, exceptions,
                     async (service, token) =>
                     {
@@ -139,14 +139,17 @@ namespace Microsoft.Extensions.Hosting.Internal
                         }
                     }).ConfigureAwait(false);
 
+                // Exceptions in StartAsync cause startup to be aborted.
+                LogAndRethrow();
+
                 // Call StartedAsync().
-                // We do not abort on exceptions from StartedAsync.
                 if (_hostedLifecycleServices is not null)
                 {
                     await ForeachService(_hostedLifecycleServices, token, concurrent, abortOnFirstException, exceptions,
                         (service, token) => service.StartedAsync(token)).ConfigureAwait(false);
                 }
 
+                // Exceptions in StartedAsync cause startup to be aborted.
                 LogAndRethrow();
 
                 // Call IHostApplicationLifetime.Started
@@ -329,7 +332,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             {
                 // The beginning synchronous portions of the implementations are run serially in registration order for
                 // performance since it is common to return Task.Completed as a noop.
-                // Any subsequent asynchronous portions are grouped together run concurrently.
+                // Any subsequent asynchronous portions are grouped together and run concurrently.
                 List<Task>? tasks = null;
 
                 foreach (T service in services)
@@ -354,6 +357,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                     }
                     else
                     {
+                        // The task encountered an await; add it to a list to run concurrently.
                         tasks ??= new();
                         tasks.Add(Task.Run(() => task, token));
                     }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Stop.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.Stop.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Extensions.Hosting.Tests
         [InlineData(false)]
         public async Task StopPhasesException(bool throwAfterAsyncCall)
         {
-            ExceptionImpl impl = new(throwAfterAsyncCall: throwAfterAsyncCall, throwOnStartup: false, throwOnShutdown: true);
+            ExceptionImpl impl = new(throwAfterAsyncCall: throwAfterAsyncCall, throwOnShutdown: true);
             var hostBuilder = CreateHostBuilder(services =>
             {
                 services.AddHostedService((token) => impl);

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/LifecycleTests.cs
@@ -180,23 +180,35 @@ namespace Microsoft.Extensions.Hosting.Tests
             public bool StopCalled = false;
             public bool StoppedCalled = false;
 
-            public bool ThrowOnStartup;
+            public bool ThrowOnStarting;
+            public bool ThrowOnStart;
+            public bool ThrowOnStarted;
             public bool ThrowOnShutdown;
 
             public ExceptionImpl(
                 bool throwAfterAsyncCall,
-                bool throwOnStartup,
                 bool throwOnShutdown)
             {
                 _throwAfterAsyncCall = throwAfterAsyncCall;
-                ThrowOnStartup = throwOnStartup;
                 ThrowOnShutdown = throwOnShutdown;
+            }
+
+            public ExceptionImpl(
+                bool throwAfterAsyncCall,
+                bool throwOnStarting,
+                bool throwOnStart,
+                bool throwOnStarted)
+            {
+                _throwAfterAsyncCall = throwAfterAsyncCall;
+                ThrowOnStarting = throwOnStarting;
+                ThrowOnStart = throwOnStart;
+                ThrowOnStarted = throwOnStarted;
             }
 
             public async Task StartingAsync(CancellationToken cancellationToken)
             {
                 StartingCalled = true;
-                if (ThrowOnStartup)
+                if (ThrowOnStarting)
                 {
                     if (_throwAfterAsyncCall)
                     {
@@ -210,7 +222,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             public async Task StartAsync(CancellationToken cancellationToken)
             {
                 StartCalled = true;
-                if (ThrowOnStartup)
+                if (ThrowOnStart)
                 {
                     if (_throwAfterAsyncCall)
                     {
@@ -224,7 +236,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             public async Task StartedAsync(CancellationToken cancellationToken)
             {
                 StartedCalled = true;
-                if (ThrowOnStartup)
+                if (ThrowOnStarted)
                 {
                     if (_throwAfterAsyncCall)
                     {


### PR DESCRIPTION
Change host startup behavior so that the startup aborts before the next phase (Starting, Start and Started) if there are any exceptions.

This makes more sense than the previous behavior of gathering all exceptions in Starting, Start, Started and then abort after Started -- e.g. if an exception occurs in Starting then Start and Started were still run in the previous behavior.

Shutdown, however, will continue to have the same semantics where exceptions are gathered in Stopping, Stop and Stopped. This is to ensure all shutdown code is called.

Fixes https://github.com/dotnet/runtime/issues/88603