### PR TITLE
[browser] fix order of libraryInitializers execution

### DIFF
--- a/src/mono/sample/wasm/browser-advanced/main.js
+++ b/src/mono/sample/wasm/browser-advanced/main.js
@@ -30,6 +30,13 @@ try {
         // 'withModuleConfig' is internal lower level API 
         // here we show how emscripten could be further configured
         // It is preferred to use specific 'with***' methods instead in all other cases.
+        .withConfig({
+            resources: {
+                modulesAfterConfigLoaded: {
+                    "advanced-sample.lib.module.js": ""
+                }
+            }
+        })
         .withModuleConfig({
             configSrc: "./blazor.boot.json",
             onConfigLoaded: (config) => {
@@ -38,9 +45,6 @@ try {
                 // config is loaded and could be tweaked before the rest of the runtime startup sequence
                 config.environmentVariables["MONO_LOG_LEVEL"] = "debug";
                 config.browserProfilerOptions = {};
-                config.resources.modulesAfterConfigLoaded = {
-                    "advanced-sample.lib.module.js": ""
-                }
             },
             preInit: () => { console.log('user code Module.preInit'); },
             preRun: () => { console.log('user code Module.preRun'); },

--- a/src/mono/wasm/runtime/loader/config.ts
+++ b/src/mono/wasm/runtime/loader/config.ts
@@ -228,6 +228,9 @@ export async function mono_wasm_load_config(module: DotnetModuleInternal): Promi
 
         normalizeConfig();
 
+        await importLibraryInitializers(loaderHelpers.config.resources?.modulesAfterConfigLoaded);
+        await invokeLibraryInitializers("onRuntimeConfigLoaded", [loaderHelpers.config]);
+
         if (module.onConfigLoaded) {
             try {
                 await module.onConfigLoaded(loaderHelpers.config, exportedRuntimeAPI);
@@ -239,8 +242,6 @@ export async function mono_wasm_load_config(module: DotnetModuleInternal): Promi
             }
         }
 
-        await importLibraryInitializers(loaderHelpers.config.resources?.modulesAfterConfigLoaded);
-        await invokeLibraryInitializers("onRuntimeConfigLoaded", [loaderHelpers.config]);
         normalizeConfig();
 
         loaderHelpers.afterConfigLoaded.promise_control.resolve(loaderHelpers.config);

--- a/src/mono/wasm/runtime/loader/config.ts
+++ b/src/mono/wasm/runtime/loader/config.ts
@@ -228,6 +228,7 @@ export async function mono_wasm_load_config(module: DotnetModuleInternal): Promi
 
         normalizeConfig();
 
+        // scripts need to be loaded before onConfigLoaded because Blazor calls `beforeStart` export in onConfigLoaded
         await importLibraryInitializers(loaderHelpers.config.resources?.modulesAfterConfigLoaded);
         await invokeLibraryInitializers("onRuntimeConfigLoaded", [loaderHelpers.config]);
 


### PR DESCRIPTION
To fix `Microsoft.AspNetCore.Components.E2ETest.Tests.JsInitializersTest.InitializersWork` Blazor E2E test 
[Build](https://github.com/dotnet/aspnetcore/pull/49884/checks?check_run_id=15721281120)

Blazor expects that scripts are already loaded when we call `onConfigLoaded` event.