### PR TITLE
Use current runtime version in ILLink.Tasks package

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -274,9 +274,10 @@
   <Target Name="AddBuildOutputToToolsPackage">
     <ItemGroup>
       <!-- Include build outputs in the package under tools directory. -->
-      <TfmSpecificPackageFile Include="$(OutputPath)**"
-                              Exclude="$(OutputPath)publish\**;
-                                       $(OutputPath)"
+      <_BuildOutputPackageFile Include="$(OutputPath)**"
+                               Exclude="$(OutputPath)publish\**;
+                                        $(OutputPath)" />
+      <TfmSpecificPackageFile Include="@(_BuildOutputPackageFile)"
                               PackagePath="tools/$(TargetFramework)/%(RecursiveDir)%(FileName)%(Extension)" />
       <TfmSpecificDebugSymbolsFile Include="@(TfmSpecificPackageFile->WithMetadataValue('Extension', '.pdb'))"
                                    TargetPath="/%(TfmSpecificPackageFile.PackagePath)/%(Filename)%(Extension)"

--- a/eng/testing/linker/SupportFiles/Directory.Build.props
+++ b/eng/testing/linker/SupportFiles/Directory.Build.props
@@ -1,13 +1,4 @@
 <Project>
-
-  <!-- Use live illink bits. It is necessary to both import the package props and override
-       the tasks assembly, because the live package props in the build output do not use
-       the same layout as the NuGet package. -->
-  <Import Project="$(ToolsILLinkDir)$(NetCoreAppToolCurrent)/build/Microsoft.NET.ILLink.Tasks.props" />
-  <PropertyGroup>
-    <ILLinkTasksAssembly>$(ToolsILLinkDir)$(NetCoreAppToolCurrent)/ILLink.Tasks.dll</ILLinkTasksAssembly>
-  </PropertyGroup>
-
   <PropertyGroup>
     <SkipConfigureTrimming>true</SkipConfigureTrimming>
     <PublishTrimmed>true</PublishTrimmed>

--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -1,12 +1,10 @@
-<Project>
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- Needed for PublishTrimmed -->
     <NetCoreAppToolCurrent>{NetCoreAppToolCurrent}</NetCoreAppToolCurrent>
     <ToolsILLinkDir>{ToolsILLinkDir}</ToolsILLinkDir>
   </PropertyGroup>
-
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <!-- Use live illink bits. It is necessary to both import the package props and override
        the tasks assembly, because the live package props in the build output do not use
@@ -93,7 +91,5 @@
   </Target>
 
   <Import Project="{NativeSanitizersTargets}" />
-
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
 </Project>

--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -8,6 +8,16 @@
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
+  <!-- Use live illink bits. It is necessary to both import the package props and override
+       the tasks assembly, because the live package props in the build output do not use
+       the same layout as the NuGet package. -->
+  <!-- This must be done after the usual nuget props imports, to override the implicitly referenced
+       Microsoft.NET.ILLink.Tasks.props from the SDK. -->
+  <Import Project="$(ToolsILLinkDir)$(NetCoreAppToolCurrent)/build/Microsoft.NET.ILLink.Tasks.props" />
+  <PropertyGroup>
+    <ILLinkTasksAssembly>$(ToolsILLinkDir)$(NetCoreAppToolCurrent)/ILLink.Tasks.dll</ILLinkTasksAssembly>
+  </PropertyGroup>
+
   <PropertyGroup>
     <TargetFramework>{TargetFramework}</TargetFramework>
     <OutputType>Exe</OutputType>

--- a/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -26,6 +26,20 @@
     <EnableSingleFileAnalyzer>false</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
+  <!-- Include the illink.runtimeconfig.pack.json file (which depends on the runtimeversion being built)
+       as illink.runtime.config.json in the package, instead of the original illink.runtime.config.json. -->
+  <Target Name="FixPackageRuntimeConfigPath"
+          AfterTargets="AddBuildOutputToToolsPackage"
+          Condition="'$(TargetFramework)' == '$(NetCoreAppToolCurrent)'">
+    <ItemGroup>
+      <TfmSpecificPackageFile Remove="@(TfmSpecificPackageFile)"
+                              Condition="$([System.String]::Copy('%(Identity)').EndsWith('.runtimeconfig.json'))" />
+      <TfmSpecificPackageFile
+        Condition="$([System.String]::Copy('%(TfmSpecificPackageFile.PackagePath)').EndsWith('.pack.json'))"
+        PackagePath="$([System.String]::Copy(%(TfmSpecificPackageFile.PackagePath)).Substring(0, $([MSBuild]::Subtract($([System.String]::Copy('%(TfmSpecificPackageFile.PackagePath)').Length), 10)))).json" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <!-- Note: 'build/Microsoft.NET.ILLink.targets' should not match the package name, because we don't want the targets
          to be imported by nuget. The SDK will import them in the right order. -->

--- a/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <!-- Include the illink.runtimeconfig.pack.json file (which depends on the runtimeversion being built)
-       as illink.runtime.config.json in the package, instead of the original illink.runtime.config.json. -->
+       as illink.runtimeconfig.json in the package, instead of the original illink.runtimeconfig.json. -->
   <Target Name="FixPackageRuntimeConfigPath"
           AfterTargets="AddBuildOutputToToolsPackage"
           Condition="'$(TargetFramework)' == '$(NetCoreAppToolCurrent)'">

--- a/src/tools/illink/src/linker/Mono.Linker.csproj
+++ b/src/tools/illink/src/linker/Mono.Linker.csproj
@@ -24,6 +24,43 @@
     <DefineConstants>$(DefineConstants);ILLINK</DefineConstants>
   </PropertyGroup>
 
+  <Target Name="_ComputePackRuntimeConfigFilePath">
+    <PropertyGroup>
+      <PackRuntimeConfigFilePath>$([System.IO.Path]::ChangeExtension($(ProjectRuntimeConfigFilePath), pack.json))</PackRuntimeConfigFilePath>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Generate a runtimeconfig.pack.json file that has the runtime version replaced by version of dotnet/runtime being built.
+       This will be the version used by the ILLink.Tasks package. -->
+  <Target Name="GeneratePackageRuntimeConfig" AfterTargets="GenerateBuildRuntimeConfigurationFiles"
+          DependsOnTargets="_ComputePackRuntimeConfigFilePath"
+          Condition="'$(TargetFramework)' == '$(NetCoreAppToolCurrent)'">
+    <PropertyGroup>
+      <_RuntimeConfigContents>$([System.IO.File]::ReadAllText('$(ProjectRuntimeConfigFilePath)'))</_RuntimeConfigContents>
+      <ReplacementPattern>"version": ".*"</ReplacementPattern>
+      <ReplacementString>"version": "$(Version)"</ReplacementString>
+      <_NewRuntimeConfigContents>$([System.Text.RegularExpressions.Regex]::Replace($(_RuntimeConfigContents), $(ReplacementPattern), $(ReplacementString)))</_NewRuntimeConfigContents>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(PackRuntimeConfigFilePath)"
+                      Lines="$(_NewRuntimeConfigContents)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
+  </Target>
+
+  <!-- Ensure that the pack.json file flows to ILLink.Tasks so that it can be included in the package.
+       The original runtimeconfig.json file (included by default) is also needed so that projects which use
+       the ILLink.Tasks build output can run illink using the LKG SDK. -->
+  <Target Name="AddPackageRuntimeConfigToCopyItemsForReferencingProjects"
+          DependsOnTargets="_ComputePackRuntimeConfigFilePath"
+          AfterTargets="AddDepsJsonAndRuntimeConfigToCopyItemsForReferencingProjects">
+    <ItemGroup>
+      <AllItemsFullPathWithTargetPath Include="$(PackRuntimeConfigFilePath)"
+                                      TargetPath="$([System.IO.Path]::GetFileName($(PackRuntimeConfigFilePath)))"
+                                      CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+  </Target>
+
   <!-- The default pack logic will include the implementation assembly in lib.
        This also adds the reference assembly under ref. -->
   <Target Name="_AddReferenceAssemblyToPackage" DependsOnTargets="ResolveProjectReferences">


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/90015

The ILLink.Tasks package should have a runtimeconfig.json that matches the runtime version bundled with the SDK that references it. This used to be done by stomping the runtime version in the dotnet/sdk build, but ILLink.Tasks is no longer bundled with the SDK so we need to do this ourselves.

Tests that use live ILLink bits need to continue working with the SDK specified in global.json, so this preserves the existing illink.runtimeconfig.json in the build output, but defines an additional illink.runtimeconfig.pack.json file that uses the current runtime version. The pack.json file is included in the package (with the name illink.runtimeconfig.json) instead of the original.

This includes a fix for https://github.com/dotnet/runtime/pull/88929 - we weren't actually using live illink for tests due to an ordering issue that I introduced in response to feedback on the PR. @ViktorHofer the Directory.Build.props is imported too early (before the nuget props that this is trying to override) so I think we need to import Microsoft.NET.ILLink.props directly from the project file - but let me know if you can see a better solution.