### PR TITLE
Add debug information to System.Diagnostics.Tracing ETW test to help track down intermittent failures

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
@@ -143,9 +143,18 @@ namespace BasicEventSourceTests
 
             ETWTraceEventSource source = new ETWTraceEventSource(fileName);
 
+            Dictionary<string, int> providers = new Dictionary<string, int>();
+            int eventCount = 0;
             var sawManifestData = false;
             source.Dynamic.All += (eventData) =>
             {
+                eventCount++;
+                if (!providers.ContainsKey(eventData.ProviderName))
+                {
+                    providers[eventData.ProviderName] = 0;
+                }
+                providers[eventData.ProviderName]++;
+
                 if (eventData.ProviderName.Equals("SimpleEventSource") && eventData.EventName.Equals("ManifestData"))
                 {
                     sawManifestData = true;
@@ -153,6 +162,18 @@ namespace BasicEventSourceTests
             };
             source.Process();
             //File.Delete(fileName);
+
+            if (!sawManifestData)
+            {
+                Console.WriteLine("Did not see ManifestData event from SimpleEventSource, test will fail. Additional info:");
+                Console.WriteLine($"    file name {fileName}");
+                Console.WriteLine($"    total event count {eventCount}");
+                Console.WriteLine($"    total providers {providers.Count}");
+                foreach (var provider in providers.Keys)
+                {
+                    Console.WriteLine($"        Provider name {provider} event count {providers[provider]}");
+                }
+            }
             return sawManifestData;
         }
     }


### PR DESCRIPTION
In #88027 we see a test fail in CI that I cannot reproduce locally. This PR adds some additional output to help track down what the issue is.