### PR TITLE
Add Fact

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
@@ -213,6 +213,7 @@ namespace ComInterfaceGenerator.Tests
             Assert.Equal(1, obj.ReturnPreserveSig().i);
         }
 
+        [Fact]
         public void ICollectionMarshallingFails()
         {
             Type hrExceptionType = SystemFindsComCalleeException() ? typeof(MarshallingFailureException) : typeof(Exception);


### PR DESCRIPTION
A mistake in a merge from main led to a missed [Fact] attribute, causing a build failure.