### PR TITLE
[mono] Update runtimeFlavor property for Mono AOT perf jobs

### DIFF
--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -293,7 +293,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
       buildConfig: release
-      runtimeFlavor: aot
+      runtimeFlavor: mono
       platforms:
       - linux_x64
       jobParameters:

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -158,7 +158,7 @@ extends:
           parameters:
             jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
             buildConfig: release
-            runtimeFlavor: aot
+            runtimeFlavor: mono
             platforms:
             - linux_arm64
             jobParameters:


### PR DESCRIPTION
This PR updates the `runtimeFlavor` property for Mono AOT performance jobs.