### PR TITLE
Apply objc_msgsend fix to src/mono too and fix build on earlier Xcode

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -949,6 +949,15 @@ if(CLR_CMAKE_HOST_ALPINE_LINUX)
   # larger than the initial committed stack size.
   add_definitions(-DENSURE_PRIMARY_STACK_SIZE)
 endif()
+
+if(CLR_CMAKE_HOST_APPLE)
+  # TODO: this is already set by configurecompiler.cmake, remove this once mono uses that
+  check_c_compiler_flag(-fno-objc-msgsend-selector-stubs COMPILER_SUPPORTS_FNO_OBJC_MSGSEND_SELECTOR_STUBS)
+  if(COMPILER_SUPPORTS_FNO_OBJC_MSGSEND_SELECTOR_STUBS)
+    set(CLR_CMAKE_COMMON_OBJC_FLAGS "${CLR_CMAKE_COMMON_OBJC_FLAGS} -fno-objc-msgsend-selector-stubs")
+  endif()
+endif()
+
 ### End of OS specific checks
 
 include_directories("${CLR_SRC_NATIVE_DIR}")

--- a/src/mono/mono/mini/CMakeLists.txt
+++ b/src/mono/mono/mini/CMakeLists.txt
@@ -67,18 +67,24 @@ if(HAVE_SYS_ICU)
       entrypoints.c
       ${pal_icushim_sources_base})
 
+  addprefix(icu_shim_sources "${ICU_SHIM_PATH}" "${icu_shim_sources_base}")
+
   if (TARGET_DARWIN)
-    set(icu_shim_sources_base
-        ${icu_shim_sources_base}
+    set(icu_shim_darwin_sources_base
         pal_locale.m
         pal_collation.m
         pal_casing.m
         pal_calendarData.m)
+
+    addprefix(icu_shim_darwin_sources "${ICU_SHIM_PATH}" "${icu_shim_darwin_sources_base}")
+    set(icu_shim_sources ${icu_shim_sources} ${icu_shim_darwin_sources})
   endif()
 
-  addprefix(icu_shim_sources "${ICU_SHIM_PATH}" "${icu_shim_sources_base}")
   set_source_files_properties(${icu_shim_sources} PROPERTIES COMPILE_DEFINITIONS OSX_ICU_LIBRARY_PATH="${OSX_ICU_LIBRARY_PATH}")
   set_source_files_properties(${icu_shim_sources} PROPERTIES COMPILE_FLAGS "-I\"${ICU_INCLUDEDIR}\" -I\"${CLR_SRC_NATIVE_DIR}/libs/System.Globalization.Native/\" -I\"${CLR_SRC_NATIVE_DIR}/libs/Common/\" ${ICU_FLAGS}")
+  if(TARGET_DARWIN)
+    set_property(SOURCE ${icu_shim_darwin_sources} APPEND_STRING PROPERTY COMPILE_FLAGS "${CLR_CMAKE_COMMON_OBJC_FLAGS}")
+  endif()
   if(TARGET_WIN32)
       set_source_files_properties(${icu_shim_sources} PROPERTIES LANGUAGE CXX)
   endif()

--- a/src/native/libs/System.Globalization.Native/CMakeLists.txt
+++ b/src/native/libs/System.Globalization.Native/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 
 if (CLR_CMAKE_TARGET_APPLE)
     set(NATIVEGLOBALIZATION_SOURCES ${NATIVEGLOBALIZATION_SOURCES} pal_locale.m pal_collation.m pal_casing.m pal_calendarData.m)
-    set_source_files_properties(pal_locale.m pal_collation.m pal_casing.m pal_calendarData.m PROPERTIES COMPILE_FLAGS ${CLR_CMAKE_COMMON_OBJC_FLAGS})
+    set_source_files_properties(pal_locale.m pal_collation.m pal_casing.m pal_calendarData.m PROPERTIES COMPILE_FLAGS "${CLR_CMAKE_COMMON_OBJC_FLAGS}")
 endif()
 
 # time zone names are filtered out of icu data for the browser and associated functionality is disabled

--- a/src/native/libs/System.Native/CMakeLists.txt
+++ b/src/native/libs/System.Native/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 
 if (CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
     list (APPEND NATIVE_SOURCES pal_environment.m)
-    set_source_files_properties(pal_environment.m PROPERTIES COMPILE_FLAGS ${CLR_CMAKE_COMMON_OBJC_FLAGS})
+    set_source_files_properties(pal_environment.m PROPERTIES COMPILE_FLAGS "${CLR_CMAKE_COMMON_OBJC_FLAGS}")
 else()
     list (APPEND NATIVE_SOURCES pal_environment.c)
 endif()
@@ -83,20 +83,20 @@ endif()
 if (CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
     set(NATIVE_SOURCES ${NATIVE_SOURCES}
         pal_datetime.m)
-    set_source_files_properties(pal_datetime.m PROPERTIES COMPILE_FLAGS ${CLR_CMAKE_COMMON_OBJC_FLAGS})
+    set_source_files_properties(pal_datetime.m PROPERTIES COMPILE_FLAGS "${CLR_CMAKE_COMMON_OBJC_FLAGS}")
 endif()
 
 if (CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
     set(NATIVE_SOURCES ${NATIVE_SOURCES}
         pal_log.m
         pal_searchpath.m)
-    set_source_files_properties(pal_log.m pal_searchpath.m PROPERTIES COMPILE_FLAGS ${CLR_CMAKE_COMMON_OBJC_FLAGS})
+    set_source_files_properties(pal_log.m pal_searchpath.m PROPERTIES COMPILE_FLAGS "${CLR_CMAKE_COMMON_OBJC_FLAGS}")
 elseif (CLR_CMAKE_TARGET_OSX)
     list (APPEND NATIVE_SOURCES
         pal_searchpath.m
         pal_console.c
         pal_log.c)
-    set_source_files_properties(pal_searchpath.m PROPERTIES COMPILE_FLAGS ${CLR_CMAKE_COMMON_OBJC_FLAGS})
+    set_source_files_properties(pal_searchpath.m PROPERTIES COMPILE_FLAGS "${CLR_CMAKE_COMMON_OBJC_FLAGS}")
 elseif (CLR_CMAKE_TARGET_WASI)
     list (APPEND NATIVE_SOURCES
         pal_searchpath.c
@@ -112,7 +112,7 @@ endif ()
 if (CLR_CMAKE_TARGET_MACCATALYST)
     set(NATIVE_SOURCES ${NATIVE_SOURCES}
         pal_iossupportversion.m)
-    set_source_files_properties(pal_iossupportversion.m PROPERTIES COMPILE_FLAGS ${CLR_CMAKE_COMMON_OBJC_FLAGS})
+    set_source_files_properties(pal_iossupportversion.m PROPERTIES COMPILE_FLAGS "${CLR_CMAKE_COMMON_OBJC_FLAGS}")
 else ()
     list (APPEND NATIVE_SOURCES
         pal_iossupportversion.c)


### PR DESCRIPTION
We were missing the objc_msgsend fix from https://github.com/dotnet/runtime/pull/89932 in the mono build.

Also fix an issue where CMake would complain about wrong number of arguments when CLR_CMAKE_COMMON_OBJC_FLAGS is empty, we need put the variable in quotes.