### PR TITLE
make it throw InvalidTypeLibraryException if type library is empty file

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/ComHost/ComHost.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ComHost/ComHost.cs
@@ -62,6 +62,7 @@ namespace Microsoft.NET.HostModel.ComHost
                             byte[] tlbFileBytes = File.ReadAllBytes(typeLibrary.Value);
                             if (tlbFileBytes.Length == 0)
                                 throw new InvalidTypeLibraryException(typeLibrary.Value);
+
                             updater.AddResource(tlbFileBytes, "typelib", (IntPtr)typeLibrary.Key);
                         }
                         catch (FileNotFoundException ex)

--- a/src/installer/managed/Microsoft.NET.HostModel/ComHost/ComHost.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ComHost/ComHost.cs
@@ -11,7 +11,6 @@ namespace Microsoft.NET.HostModel.ComHost
 {
     public class ComHost
     {
-        private const int E_INVALIDARG = unchecked((int)0x80070057);
         // These need to match RESOURCEID_CLSIDMAP and RESOURCETYPE_CLSIDMAP defined in comhost.h.
         private const int ClsidmapResourceId = 64;
         private const int ClsidmapResourceType = 1024;
@@ -61,15 +60,13 @@ namespace Microsoft.NET.HostModel.ComHost
                         try
                         {
                             byte[] tlbFileBytes = File.ReadAllBytes(typeLibrary.Value);
+                            if (tlbFileBytes.Length == 0)
+                                throw new InvalidTypeLibraryException(typeLibrary.Value);
                             updater.AddResource(tlbFileBytes, "typelib", (IntPtr)typeLibrary.Key);
                         }
                         catch (FileNotFoundException ex)
                         {
                             throw new TypeLibraryDoesNotExistException(typeLibrary.Value, ex);
-                        }
-                        catch (HResultException hr) when (hr.Win32HResult == E_INVALIDARG)
-                        {
-                            throw new InvalidTypeLibraryException(typeLibrary.Value, hr);
                         }
                     }
                 }


### PR DESCRIPTION


Implements @elinor-fung's suggestion.

https://github.com/dotnet/sdk/pull/34522#issuecomment-1670664709

> For the `GivenThatWeWantToBuildAComServerLibrary.It_fails_when_typelib_is_invalid` [failure on the Windows leg](https://dev.azure.com/dnceng-public/public/_build/results?buildId=367479&view=ms.vss-test-web.build-test-results-tab&runId=7778042&resultId=103381&paneView=debug), I think we should update `ComHost` in runtime to just check for the byte count being 0 and throw throw `InvalidTypeLibraryException` - it was relying on the Win32 UpdateResource function failing with E_INVALIDARG for that case (which will now never happen): https://github.com/dotnet/runtime/blob/main/src/installer/managed/Microsoft.NET.HostModel/ComHost/ComHost.cs#L70-L73

