### PR TITLE
Report exception type name in Http metrics

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
@@ -150,8 +150,7 @@ namespace System.Net.Http.Metrics
                     HttpRequestError.ResponseEnded => "response_ended",
                     HttpRequestError.ConfigurationLimitExceeded => "configuration_limit_exceeded",
 
-                    // Fall back to the exception type name
-                    HttpRequestError.Unknown => null,
+                    // Fall back to the exception type name (including for HttpRequestError.Unknown).
                     _ => null
                 };
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
@@ -132,14 +132,11 @@ namespace System.Net.Http.Metrics
 
         private static string GetErrorReason(Exception exception)
         {
-            if (exception is OperationCanceledException)
-            {
-                return "cancellation";
-            }
-            else if (exception is HttpRequestException e)
+            if (exception is HttpRequestException e)
             {
                 Debug.Assert(Enum.GetValues<HttpRequestError>().Length == 12, "We need to extend the mapping in case new values are added to HttpRequestError.");
-                return e.HttpRequestError switch
+
+                string? errorReason = e.HttpRequestError switch
                 {
                     HttpRequestError.NameResolutionError => "name_resolution_error",
                     HttpRequestError.ConnectionError => "connection_error",
@@ -152,10 +149,19 @@ namespace System.Net.Http.Metrics
                     HttpRequestError.InvalidResponse => "invalid_response",
                     HttpRequestError.ResponseEnded => "response_ended",
                     HttpRequestError.ConfigurationLimitExceeded => "configuration_limit_exceeded",
-                    _ => "_OTHER"
+
+                    // Fall back to the exception type name
+                    HttpRequestError.Unknown => null,
+                    _ => null
                 };
+
+                if (errorReason is not null)
+                {
+                    return errorReason;
+                }
             }
-            return "_OTHER";
+
+            return exception.GetType().Name;
         }
 
         private static string GetProtocolVersionString(Version httpVersion) => (httpVersion.Major, httpVersion.Minor) switch

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -31,7 +31,7 @@ namespace System.Net.Http.Functional.Tests
         private async Task AssertProtocolErrorAsync(Task task, ProtocolErrors errorCode)
         {
             HttpRequestException outerEx = await Assert.ThrowsAsync<HttpRequestException>(() => task);
-            _output.WriteLine(outerEx.InnerException.Message);
+            _output.WriteLine($"Outer exception: {outerEx}");
             Assert.Equal(HttpRequestError.HttpProtocolError, outerEx.HttpRequestError);
             HttpProtocolException protocolEx = Assert.IsType<HttpProtocolException>(outerEx.InnerException);
             Assert.Equal(HttpRequestError.HttpProtocolError, protocolEx.HttpRequestError);


### PR DESCRIPTION
Fixes #90182

Instead of special-casing `OperationCanceledException` and falling back to "_OTHER", report the exception type name.

cc: @lmolkova