### PR TITLE
[Browser][hybrid] Fix tests for NodeJS.

### DIFF
--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedDayNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedDayNames.cs
@@ -37,7 +37,10 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, new string[] { "রবি", "সোম", "মঙ্গল", "বুধ", "বৃহস্পতি", "শুক্র", "শনি" } };
             yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, new string[] { "dg.", "dl.", "dt.", "dc.", "dj.", "dv.", "ds." } };
             yield return new object[] { new CultureInfo("cs-CZ").DateTimeFormat, new string[] { "ne", "po", "út", "st", "čt", "pá", "so" } };
-            yield return new object[] { new CultureInfo("da-DK").DateTimeFormat, new string[] { "søn.", "man.", "tirs.", "ons.", "tors.", "fre.", "lør." } };
+            string[] dannishDays = PlatformDetection.IsNodeJS ?
+                new string[] { "søn", "man", "tir", "ons", "tor", "fre", "lør" } :
+                new string[] { "søn.", "man.", "tirs.", "ons.", "tors.", "fre.", "lør." };
+            yield return new object[] { new CultureInfo("da-DK").DateTimeFormat, dannishDays };
             yield return new object[] { new CultureInfo("de-DE").DateTimeFormat, new string[] { "So", "Mo", "Di", "Mi", "Do", "Fr", "Sa" } };
             yield return new object[] { new CultureInfo("el-GR").DateTimeFormat, new string[] { "Κυρ", "Δευ", "Τρί", "Τετ", "Πέμ", "Παρ", "Σάβ" } };
             yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, new string[] { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" } }; // should be with dots

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthGenitiveNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthGenitiveNames.cs
@@ -8,15 +8,20 @@ namespace System.Globalization.Tests
 {
     public class DateTimeFormatInfoAbbreviatedMonthGenitiveNames
     {
-
         public static IEnumerable<object[]> AbbreviatedMonthGenitiveNames_Get_TestData_HybridGlobalization()
         {
             // see the comments on the right to check the non-Hybrid result, if it differs
             yield return new object[] { new CultureInfo("ar-SA").DateTimeFormat, new string[] { "محرم", "صفر", "ربيع الأول", "ربيع الآخر", "جمادى الأولى", "جمادى الآخرة", "رجب", "شعبان", "رمضان", "شوال", "ذو القعدة", "ذو الحجة", "" } };
             yield return new object[] { new CultureInfo("am-ET").DateTimeFormat, new string[] { "ጃንዩ", "ፌብሩ", "ማርች", "ኤፕሪ", "ሜይ", "ጁን", "ጁላይ", "ኦገስ", "ሴፕቴ", "ኦክቶ", "ኖቬም", "ዲሴም", "" } };
             yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, new string[] { "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "" } }; //"яну", "фев", "март", "апр", "май", "юни", "юли", "авг", "сеп", "окт", "ное", "дек", ""
-            yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, new string[] { "জানু", "ফেব", "মার্চ", "এপ্রি", "মে", "জুন", "জুল", "আগ", "সেপ", "অক্টো", "নভে", "ডিসে", "" } }; // "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", ""
-            yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, new string[] { "জানু", "ফেব", "মার্চ", "এপ্রি", "মে", "জুন", "জুল", "আগ", "সেপ্টেঃ", "অক্টোঃ", "নভেঃ", "ডিসেঃ", "" } }; // "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", ""
+            yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat,
+                PlatformDetection.IsNodeJS ? // NodeJs responds like dotnet
+                    new string[] { "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", "" } :
+                    new string[] { "জানু", "ফেব", "মার্চ", "এপ্রি", "মে", "জুন", "জুল", "আগ", "সেপ", "অক্টো", "নভে", "ডিসে", "" } };
+            yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat,
+                PlatformDetection.IsNodeJS ? // NodeJs responds like dotnet
+                    new string[] { "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", "" } :
+                    new string[] { "জানু", "ফেব", "মার্চ", "এপ্রি", "মে", "জুন", "জুল", "আগ", "সেপ্টেঃ", "অক্টোঃ", "নভেঃ", "ডিসেঃ", "" } };
             yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, new string[] { "gen.", "febr.", "març", "abr.", "maig", "juny", "jul.", "ag.", "set.", "oct.", "nov.", "des.", "" } }; // "de gen.", "de febr.", "de març", "d’abr.", "de maig", "de juny", "de jul.", "d’ag.", "de set.", "d’oct.", "de nov.", "de des.", ""
             yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, new string[] { "gen.", "febr.", "març", "abr.", "maig", "juny", "jul.", "ag.", "set.", "oct.", "nov.", "des.", "" } };
             yield return new object[] { new CultureInfo("cs-CZ").DateTimeFormat, new string[] { "led", "úno", "bře", "dub", "kvě", "čvn", "čvc", "srp", "zář", "říj", "lis", "pro", "" } };
@@ -43,7 +48,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-BS").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-BW").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-BZ").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
-            yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "" } }; // "Jan.", "Feb.", "Mar.", "Apr.", "May", "Jun.", "Jul.", "Aug.", "Sep.", "Oct.", "Nov.", "Dec.", ""
+            yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", PlatformDetection.IsNodeJS ? "Sept" : "Sep", "Oct", "Nov", "Dec", "" } }; // "Jan.", "Feb.", "Mar.", "Apr.", "May", "Jun.", "Jul.", "Aug.", "Sep.", "Oct.", "Nov.", "Dec.", ""
             yield return new object[] { new CultureInfo("en-CC").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-CH").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-CK").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
@@ -153,7 +158,10 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("it-CH").DateTimeFormat, new string[] { "gen", "feb", "mar", "apr", "mag", "giu", "lug", "ago", "set", "ott", "nov", "dic", "" } };
             yield return new object[] { new CultureInfo("it-IT").DateTimeFormat, new string[] { "gen", "feb", "mar", "apr", "mag", "giu", "lug", "ago", "set", "ott", "nov", "dic", "" } };
             yield return new object[] { new CultureInfo("ja-JP").DateTimeFormat, new string[] { "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月", "" } };
-            yield return new object[] { new CultureInfo("kn-IN").DateTimeFormat, new string[] { "ಜನವರಿ", "ಫೆಬ್ರವರಿ", "ಮಾರ್ಚ್", "ಏಪ್ರಿ", "ಮೇ", "ಜೂನ್", "ಜುಲೈ", "ಆಗಸ್ಟ್", "ಸೆಪ್ಟೆಂ", "ಅಕ್ಟೋ", "ನವೆಂ", "ಡಿಸೆಂ", "" } }; //"ಜನವರಿ", "ಫೆಬ್ರವರಿ", "ಮಾರ್ಚ್", "ಏಪ್ರಿ", "ಮೇ", "ಜೂನ್", "ಜುಲೈ", "ಆಗ", "ಸೆಪ್ಟೆಂ", "ಅಕ್ಟೋ", "ನವೆಂ", "ಡಿಸೆಂ", ""
+            string[] kannadianMonths = PlatformDetection.IsNodeJS ? // NodeJs responds like dotnet
+                new string[] { "ಜನವರಿ", "ಫೆಬ್ರವರಿ", "ಮಾರ್ಚ್", "ಏಪ್ರಿ", "ಮೇ", "ಜೂನ್", "ಜುಲೈ", "ಆಗ", "ಸೆಪ್ಟೆಂ", "ಅಕ್ಟೋ", "ನವೆಂ", "ಡಿಸೆಂ", "" } :
+                new string[] { "ಜನವರಿ", "ಫೆಬ್ರವರಿ", "ಮಾರ್ಚ್", "ಏಪ್ರಿ", "ಮೇ", "ಜೂನ್", "ಜುಲೈ", "ಆಗಸ್ಟ್", "ಸೆಪ್ಟೆಂ", "ಅಕ್ಟೋ", "ನವೆಂ", "ಡಿಸೆಂ", "" };
+            yield return new object[] { new CultureInfo("kn-IN").DateTimeFormat, kannadianMonths };
             yield return new object[] { new CultureInfo("ko-KR").DateTimeFormat, new string[] { "1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월", "" } };
             yield return new object[] { new CultureInfo("lt-LT").DateTimeFormat, new string[] { "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "" } }; // "saus.", "vas.", "kov.", "bal.", "geg.", "birž.", "liep.", "rugp.", "rugs.", "spal.", "lapkr.", "gruod."
             yield return new object[] { new CultureInfo("lv-LV").DateTimeFormat, new string[] { "janv.", "febr.", "marts", "apr.", "maijs", "jūn.", "jūl.", "aug.", "sept.", "okt.", "nov.", "dec.", "" } };
@@ -164,9 +172,12 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("ms-SG").DateTimeFormat, new string[] { "Jan", "Feb", "Mac", "Apr", "Mei", "Jun", "Jul", "Ogo", "Sep", "Okt", "Nov", "Dis", "" } };
             yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, new string[] { "jan.", "feb.", "mar.", "apr.", "mai", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "des.", "" } };
             yield return new object[] { new CultureInfo("no-NO").DateTimeFormat, new string[] { "jan.", "feb.", "mar.", "apr.", "mai", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "des.", "" } };
-            yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" } }; // "jan.", "feb.", "mrt.", "apr.", "mei", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "dec.", ""
-            yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" } }; // "jan.", "feb.", "mrt.", "apr.", "mei", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "dec.", ""
-            yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" } }; // "jan.", "feb.", "mrt.", "apr.", "mei", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "dec.", ""
+            string[] dutchMonths = PlatformDetection.IsNodeJS ? // NodeJs responds like dotnet
+                new string[] { "jan.", "feb.", "mrt.", "apr.", "mei", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "dec.", "" } :
+                new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" };
+            yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, dutchMonths };
+            yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, dutchMonths };
+            yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, dutchMonths };
             yield return new object[] { new CultureInfo("pl-PL").DateTimeFormat, new string[] { "sty", "lut", "mar", "kwi", "maj", "cze", "lip", "sie", "wrz", "paź", "lis", "gru", "" } };
             yield return new object[] { new CultureInfo("pt-BR").DateTimeFormat, new string[] { "jan.", "fev.", "mar.", "abr.", "mai.", "jun.", "jul.", "ago.", "set.", "out.", "nov.", "dez.", "" } };
             yield return new object[] { new CultureInfo("pt-PT").DateTimeFormat, new string[] { "jan.", "fev.", "mar.", "abr.", "mai.", "jun.", "jul.", "ago.", "set.", "out.", "nov.", "dez.", "" } };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthNames.cs
@@ -11,8 +11,7 @@ namespace System.Globalization.Tests
         [Fact]
         public void AbbreviatedMonthNames_GetInvariantInfo_ReturnsExpected()
         {
-            Assert.Equal(new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "" },
-                DateTimeFormatInfo.InvariantInfo.AbbreviatedMonthNames);
+            Assert.Equal(new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "" }, DateTimeFormatInfo.InvariantInfo.AbbreviatedMonthNames);
         }
 
         [Fact]
@@ -35,8 +34,14 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("ar-SA").DateTimeFormat, new string[] { "محرم", "صفر", "ربيع الأول", "ربيع الآخر", "جمادى الأولى", "جمادى الآخرة", "رجب", "شعبان", "رمضان", "شوال", "ذو القعدة", "ذو الحجة", "" } };
             yield return new object[] { new CultureInfo("am-ET").DateTimeFormat, new string[] { "ጃንዩ", "ፌብሩ", "ማርች", "ኤፕሪ", "ሜይ", "ጁን", "ጁላይ", "ኦገስ", "ሴፕቴ", "ኦክቶ", "ኖቬም", "ዲሴም", "" } };
             yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, new string[] { "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "" } }; // "яну", "фев", "март", "апр", "май", "юни", "юли", "авг", "сеп", "окт", "ное", "дек", ""
-            yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, new string[] { "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", "" } }; // "জানুয়ারী", "ফেব্রুয়ারী", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", ""
-            yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, new string[] { "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেঃ", "অক্টোঃ", "নভেঃ", "ডিসেঃ", "" } }; // BUG. JS returns Genitive even though we expect Nominative; "জানুয়ারী", "ফেব্রুয়ারী", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", ""
+            yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, 
+                PlatformDetection.IsNodeJS ?
+                    new string[] { "জানুয়ারী", "ফেব্রুয়ারী", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", "" } :
+                    new string[] { "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", "" } }; // NodeJS responds like dotnet
+            yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 
+                PlatformDetection.IsNodeJS ?
+                    new string[] { "জানুয়ারী", "ফেব্রুয়ারী", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", "" } :
+                    new string[] { "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেঃ", "অক্টোঃ", "নভেঃ", "ডিসেঃ", "" } }; // BUG. JS returns Genitive even though we expect Nominative; NodeJS responds like dotnet
             yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, new string[] { "gen.", "febr.", "març", "abr.", "maig", "juny", "jul.", "ag.", "set.", "oct.", "nov.", "des.", "" } };
             yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, new string[] { "gen.", "febr.", "març", "abr.", "maig", "juny", "jul.", "ag.", "set.", "oct.", "nov.", "des.", "" } };
             yield return new object[] { new CultureInfo("cs-CZ").DateTimeFormat, new string[] { "led", "úno", "bře", "dub", "kvě", "čvn", "čvc", "srp", "zář", "říj", "lis", "pro", "" } };
@@ -55,7 +60,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-AI").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-AS").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "" } };
             yield return new object[] { new CultureInfo("en-AT").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
-            yield return new object[] { new CultureInfo("en-AU").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } };
+            yield return new object[] { new CultureInfo("en-AU").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", PlatformDetection.IsNodeJS ? "Sep" : "Sept", "Oct", "Nov", "Dec", "" } }; // v8/Browser responds like dotnet
             yield return new object[] { new CultureInfo("en-BB").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-BE").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-BI").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "" } };
@@ -63,7 +68,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-BS").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-BW").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-BZ").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
-            yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "" } }; // "Jan.", "Feb.", "Mar.", "Apr.", "May", "Jun.", "Jul.", "Aug.", "Sep.", "Oct.", "Nov.", "Dec.", ""
+            yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", PlatformDetection.IsNodeJS ? "Sept" : "Sep", "Oct", "Nov", "Dec", "" } }; // "Jan.", "Feb.", "Mar.", "Apr.", "May", "Jun.", "Jul.", "Aug.", "Sep.", "Oct.", "Nov.", "Dec.", ""
             yield return new object[] { new CultureInfo("en-CC").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-CH").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-CK").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
@@ -185,9 +190,12 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, new string[] { "jan", "feb", "mar", "apr", "mai", "jun", "jul", "aug", "sep", "okt", "nov", "des", "" } };
             yield return new object[] { new CultureInfo("no").DateTimeFormat, new string[] { "jan", "feb", "mar", "apr", "mai", "jun", "jul", "aug", "sep", "okt", "nov", "des", "" } };
             yield return new object[] { new CultureInfo("no-NO").DateTimeFormat, new string[] { "jan", "feb", "mar", "apr", "mai", "jun", "jul", "aug", "sep", "okt", "nov", "des", "" } };
-            yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" } };
-            yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" } };
-            yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" } };
+            string [] dutchMonths = PlatformDetection.IsNodeJS ?
+                new string [] { "jan.", "feb.", "mrt.", "apr.", "mei", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "dec.", ""} :
+                new string [] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" };
+            yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, dutchMonths };
+            yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, dutchMonths };
+            yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, dutchMonths };
             yield return new object[] { new CultureInfo("pl-PL").DateTimeFormat, new string[] { "sty", "lut", "mar", "kwi", "maj", "cze", "lip", "sie", "wrz", "paź", "lis", "gru", "" } };
             yield return new object[] { new CultureInfo("pt-BR").DateTimeFormat, new string[] { "jan.", "fev.", "mar.", "abr.", "mai.", "jun.", "jul.", "ago.", "set.", "out.", "nov.", "dez.", "" } };
             yield return new object[] { new CultureInfo("pt-PT").DateTimeFormat, new string[] { "jan.", "fev.", "mar.", "abr.", "mai.", "jun.", "jul.", "ago.", "set.", "out.", "nov.", "dez.", "" } };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoCalendarWeekRule.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoCalendarWeekRule.cs
@@ -176,9 +176,9 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("ms-BN").DateTimeFormat, CalendarWeekRule.FirstDay };
                 yield return new object[] { new CultureInfo("ms-MY").DateTimeFormat, CalendarWeekRule.FirstDay };
                 yield return new object[] { new CultureInfo("ms-SG").DateTimeFormat, CalendarWeekRule.FirstDay };
-                yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, CalendarWeekRule.FirstFourDayWeek };
+                yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, PlatformDetection.IsNodeJS ? CalendarWeekRule.FirstDay : CalendarWeekRule.FirstFourDayWeek }; // v8/Browser responds like dotnet
                 yield return new object[] { new CultureInfo("no-NO").DateTimeFormat, CalendarWeekRule.FirstFourDayWeek };
-                yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, CalendarWeekRule.FirstDay };
+                yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, PlatformDetection.IsNodeJS ? CalendarWeekRule.FirstFourDayWeek : CalendarWeekRule.FirstDay }; // v8/Browser responds like dotnet
                 yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, CalendarWeekRule.FirstFourDayWeek };
                 yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, CalendarWeekRule.FirstFourDayWeek };
                 yield return new object[] { new CultureInfo("pl-PL").DateTimeFormat, CalendarWeekRule.FirstFourDayWeek };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoDayNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoDayNames.cs
@@ -42,7 +42,10 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("es-419").DateTimeFormat, new string[] { "domingo", "lunes", "martes", "miércoles", "jueves", "viernes", "sábado" } };
             yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, new string[] { "domingo", "lunes", "martes", "miércoles", "jueves", "viernes", "sábado" } };
             yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, new string[] { "domingo", "lunes", "martes", "miércoles", "jueves", "viernes", "sábado" } };
-            yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, new string[] { "pühapäev", "esmaspäev", "teisipäev", "kolmapäev", "neljapäev", "reede", "laupäev" } };
+            yield return new object[] { new CultureInfo("et-EE").DateTimeFormat,
+                PlatformDetection.IsNodeJS ?
+                new string[] { "Pühapäev", "Esmaspäev", "Teisipäev", "Kolmapäev", "Neljapäev", "Reede", "Laupäev" } :
+                new string[] { "pühapäev", "esmaspäev", "teisipäev", "kolmapäev", "neljapäev", "reede", "laupäev" } };
             yield return new object[] { new CultureInfo("fa-IR").DateTimeFormat, new string[] { "یکشنبه", "دوشنبه", "سه‌شنبه", "چهارشنبه", "پنجشنبه", "جمعه", "شنبه" } };
             yield return new object[] { new CultureInfo("fi-FI").DateTimeFormat, new string[] { "sunnuntai", "maanantai", "tiistai", "keskiviikko", "torstai", "perjantai", "lauantai" } };
             yield return new object[] { new CultureInfo("fil-PH").DateTimeFormat, new string[] { "Linggo", "Lunes", "Martes", "Miyerkules", "Huwebes", "Biyernes", "Sabado" } };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoFirstDayOfWeek.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoFirstDayOfWeek.cs
@@ -42,7 +42,7 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("en-AI").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("en-AS").DateTimeFormat, DayOfWeek.Sunday };
                 yield return new object[] { new CultureInfo("en-AT").DateTimeFormat, DayOfWeek.Monday };
-                yield return new object[] { new CultureInfo("en-AU").DateTimeFormat, DayOfWeek.Monday }; // originally in ICU: Sunday, even though ISO 8601 states: Monday 
+                yield return new object[] { new CultureInfo("en-AU").DateTimeFormat, PlatformDetection.IsNodeJS ? DayOfWeek.Sunday : DayOfWeek.Monday }; // originally in ICU: Sunday, even though ISO 8601 states: Monday 
                 yield return new object[] { new CultureInfo("en-BB").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("en-BE").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("en-BI").DateTimeFormat, DayOfWeek.Monday };
@@ -194,13 +194,13 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("ta-LK").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("ta-MY").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("ta-SG").DateTimeFormat, DayOfWeek.Sunday };
-                yield return new object[] { new CultureInfo("te-IN").DateTimeFormat, DayOfWeek.Sunday };
+                yield return new object[] { new CultureInfo("te-IN").DateTimeFormat, PlatformDetection.IsNodeJS ? DayOfWeek.Monday : DayOfWeek.Sunday }; // Browser/V8 responds like dotnet
                 yield return new object[] { new CultureInfo("th-TH").DateTimeFormat, DayOfWeek.Sunday };
                 yield return new object[] { new CultureInfo("tr-CY").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("tr-TR").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("uk-UA").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, DayOfWeek.Monday };
-                yield return new object[] { new CultureInfo("zh-CN").DateTimeFormat, DayOfWeek.Monday  }; // DayOfWeek.Sunday
+                yield return new object[] { new CultureInfo("zh-CN").DateTimeFormat, PlatformDetection.IsNodeJS ? DayOfWeek.Sunday : DayOfWeek.Monday  }; // NodeJS responds like dotnet
                 yield return new object[] { new CultureInfo("zh-Hans-HK").DateTimeFormat, DayOfWeek.Sunday };
                 yield return new object[] { new CultureInfo("zh-SG").DateTimeFormat, DayOfWeek.Sunday };
                 yield return new object[] { new CultureInfo("zh-HK").DateTimeFormat, DayOfWeek.Sunday };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedEraName.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedEraName.cs
@@ -23,7 +23,7 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("am-ET").DateTimeFormat, 1, "ዓ/ም" };
                 yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, 1, "сл.Хр." };
                 yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, 1, "খৃষ্টাব্দ" };
-                yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 1, "খ্রিঃ" }; // খৃষ্টাব্দ
+                yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 1, PlatformDetection.IsNodeJS ? "খৃষ্টাব্দ" : "খ্রিঃ" }; // NodeJS responses like dotnet
                 yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, 1, "dC" };
                 yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, 1, "dC" };
                 yield return new object[] { new CultureInfo("cs-CZ").DateTimeFormat, 1, "n.l." };
@@ -140,8 +140,9 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("en-ZM").DateTimeFormat, 1, "A" }; // AD
                 yield return new object[] { new CultureInfo("en-ZW").DateTimeFormat, 1, "A" }; // AD
                 yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, 1, "d. C." };
-                yield return new object[] { new CultureInfo("es-419").DateTimeFormat, 1, "d.C." }; // d. C.
-                yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, 1, "d.C." }; // d. C.
+                string spanishEra = PlatformDetection.IsNodeJS ? "d. C." : "d.C."; // NodeJS responses like dotnet
+                yield return new object[] { new CultureInfo("es-419").DateTimeFormat, 1, spanishEra };
+                yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, 1, spanishEra };
                 yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, 1, "pKr" };
                 yield return new object[] { new CultureInfo("fa-IR").DateTimeFormat, 1, "ه.ش" }; // ه‍.ش.
                 yield return new object[] { new CultureInfo("fi-FI").DateTimeFormat, 1, "jKr" };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEraName.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEraName.cs
@@ -12,7 +12,7 @@ namespace System.Globalization.Tests
         {
             yield return new object[] { DateTimeFormatInfo.InvariantInfo, 1, "A.D." };
             yield return new object[] { DateTimeFormatInfo.InvariantInfo, 0, "A.D." };
-
+            
             if (!PlatformDetection.IsHybridGlobalizationOnBrowser)
             {
                 var enUSFormat = new CultureInfo("en-US").DateTimeFormat;
@@ -33,8 +33,9 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, 1, "сл.Хр." };
                 yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, 0, "খৃষ্টাব্দ" };
                 yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, 1, "খৃষ্টাব্দ" };
-                yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 0, "খ্রিঃ" };
-                yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 1, "খ্রিঃ" };
+                string bangladeshEra = PlatformDetection.IsNodeJS ? "খৃষ্টাব্দ" : "খ্রিঃ";
+                yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 0, bangladeshEra };
+                yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 1, bangladeshEra };
                 yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, 0, "dC" };
                 yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, 1, "dC" };
                 yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, 0, "dC" };
@@ -269,10 +270,11 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("en-US").DateTimeFormat, 1, "AD" };
                 yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, 0, "d. C." };
                 yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, 1, "d. C." };
-                yield return new object[] { new CultureInfo("es-419").DateTimeFormat, 0, "d.C." };
-                yield return new object[] { new CultureInfo("es-419").DateTimeFormat, 1, "d.C." };
-                yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, 0, "d.C." };
-                yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, 1, "d.C." };
+                string spanishEra = PlatformDetection.IsNodeJS ? "d. C." : "d.C.";
+                yield return new object[] { new CultureInfo("es-419").DateTimeFormat, 0, spanishEra };
+                yield return new object[] { new CultureInfo("es-419").DateTimeFormat, 1, spanishEra};
+                yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, 0, spanishEra };
+                yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, 1, spanishEra };
                 yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, 0, "pKr" };
                 yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, 1, "pKr" };
                 yield return new object[] { new CultureInfo("fa-IR").DateTimeFormat, 0, "ه.ش" }; // ه‍.ش.
@@ -387,8 +389,9 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("tr-TR").DateTimeFormat, 1, "MS" };
                 yield return new object[] { new CultureInfo("uk-UA").DateTimeFormat, 0, "н. е." };
                 yield return new object[] { new CultureInfo("uk-UA").DateTimeFormat, 1, "н. е." };
-                yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, 0, "CN" }; // sau CN
-                yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, 1, "CN" }; // sau CN
+                string vietnameseEra = PlatformDetection.IsNodeJS ? "Sau CN" : "CN"; // dotnet: sau CN
+                yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, 0, vietnameseEra };
+                yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, 1, vietnameseEra };
                 yield return new object[] { new CultureInfo("zh-CN").DateTimeFormat, 0, "公元" };
                 yield return new object[] { new CultureInfo("zh-CN").DateTimeFormat, 1, "公元" };
                 yield return new object[] { new CultureInfo("zh-Hans-HK").DateTimeFormat, 0, "公元" };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoNativeCalendarName.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoNativeCalendarName.cs
@@ -11,193 +11,197 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> NativeCalendarName_Get_TestData_HybridGlobalization()
         {
             // see the comments on the right to check the non-Hybrid result, in this collection it always differs
-            yield return new object[] { new CultureInfo("ar-SA").DateTimeFormat, "islamic-umalqura" }; // التقويم الإسلامي (أم القرى)
-            yield return new object[] { new CultureInfo("am-ET").DateTimeFormat, "gregory" }; // የግሪጎሪያን የቀን አቆጣጠር
-            yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, "gregory" }; // григориански календар
-            yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, "gregory" }; // গ্রিগোরিয়ান ক্যালেন্ডার
-            yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, "gregory" }; // গ্রিগোরিয়ান ক্যালেন্ডার
-            yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, "gregory" }; // calendari gregorià
-            yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, "gregory" }; // calendari gregorià
-            yield return new object[] { new CultureInfo("cs-CZ").DateTimeFormat, "gregory" }; // Gregoriánský kalendář
-            yield return new object[] { new CultureInfo("da-DK").DateTimeFormat, "gregory" }; // gregoriansk kalender
-            yield return new object[] { new CultureInfo("de-AT").DateTimeFormat, "gregory" }; // Gregorianischer Kalender
-            yield return new object[] { new CultureInfo("de-BE").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("de-CH").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("de-DE").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("de-IT").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("de-LI").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("de-LU").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("el-CY").DateTimeFormat, "gregory" }; // Γρηγοριανό ημερολόγιο
-            yield return new object[] { new CultureInfo("el-GR").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-AE").DateTimeFormat, "gregory" }; // Gregorian Calendar
-            yield return new object[] { new CultureInfo("en-AG").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-AI").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-AS").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-AT").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-AU").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-BB").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-BE").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-BI").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-BM").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-BS").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-BW").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-BZ").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-CC").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-CH").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-CK").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-CM").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-CX").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-CY").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-DE").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-DK").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-DM").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-ER").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-FI").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-FJ").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-FK").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-FM").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-GB").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-GD").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-GG").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-GH").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-GI").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-GM").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-GU").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-GY").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-HK").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-IE").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-IL").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-IM").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-IN").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-IO").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-JE").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-JM").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-KE").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-KI").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-KN").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-KY").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-LC").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-LR").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-LS").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-MG").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-MH").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-MO").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-MP").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-MS").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-MT").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-MU").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-MW").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-MY").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-NA").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-NF").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-NG").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-NL").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-NR").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-NU").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-NZ").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-PG").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-PH").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-PK").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-PN").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-PR").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-PW").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-RW").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-SB").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-SC").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-SD").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-SE").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-SG").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-SH").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-SI").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-SL").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-SS").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-SX").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-SZ").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-TC").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-TK").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-TO").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-TT").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-TV").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-TZ").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-UG").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-UM").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-US").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-VC").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-VG").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-VI").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-VU").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-WS").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-ZA").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-ZM").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-ZW").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("en-US").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("es-419").DateTimeFormat, "gregory" }; // calendario gregoriano
-            yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, "gregory" }; // Gregoriuse kalender
-            yield return new object[] { new CultureInfo("fa-IR").DateTimeFormat, "persian" }; // تقویم هجری شمسی
-            yield return new object[] { new CultureInfo("fi-FI").DateTimeFormat, "gregory" }; // gregoriaaninen kalenteri
-            yield return new object[] { new CultureInfo("fil-PH").DateTimeFormat, "gregory" }; // Gregorian na Kalendaryo
-            yield return new object[] { new CultureInfo("fr-BE").DateTimeFormat, "gregory" }; // calendrier grégorien
-            yield return new object[] { new CultureInfo("fr-CA").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("fr-CH").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("fr-FR").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("gu-IN").DateTimeFormat, "gregory" }; // ગ્રેગોરિઅન કેલેન્ડર
-            yield return new object[] { new CultureInfo("he-IL").DateTimeFormat, "gregory" }; // לוח השנה הגרגוריאני
-            yield return new object[] { new CultureInfo("hi-IN").DateTimeFormat, "gregory" }; // ग्रेगोरियन कैलेंडर"
-            yield return new object[] { new CultureInfo("hr-BA").DateTimeFormat, "gregory" }; // gregorijanski kalendar
-            yield return new object[] { new CultureInfo("hr-HR").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("hu-HU").DateTimeFormat, "gregory" }; // Gergely-naptár
-            yield return new object[] { new CultureInfo("id-ID").DateTimeFormat, "gregory" }; // Kalender Gregorian"
-            yield return new object[] { new CultureInfo("it-CH").DateTimeFormat, "gregory" }; // Calendario gregoriano
-            yield return new object[] { new CultureInfo("it-IT").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("ja-JP").DateTimeFormat, "gregory" }; // 西暦(グレゴリオ暦)
-            yield return new object[] { new CultureInfo("kn-IN").DateTimeFormat, "gregory" }; // ಗ್ರೆಗೋರಿಯನ್ ಕ್ಯಾಲೆಂಡರ್
-            yield return new object[] { new CultureInfo("ko-KR").DateTimeFormat, "gregory" }; // 양력
-            yield return new object[] { new CultureInfo("lt-LT").DateTimeFormat, "gregory" }; // Grigaliaus kalendorius
-            yield return new object[] { new CultureInfo("lv-LV").DateTimeFormat, "gregory" }; // Gregora kalendārs
-            yield return new object[] { new CultureInfo("ml-IN").DateTimeFormat, "gregory" }; // ഇംഗ്ലീഷ് കലണ്ടർ
-            yield return new object[] { new CultureInfo("mr-IN").DateTimeFormat, "gregory" }; // ग्रेगोरियन दिनदर्शिका
-            yield return new object[] { new CultureInfo("ms-BN").DateTimeFormat, "gregory" }; // Kalendar Gregory
-            yield return new object[] { new CultureInfo("ms-MY").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("ms-SG").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, "gregory" }; // gregoriansk kalender
-            yield return new object[] { new CultureInfo("no").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("no-NO").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, "gregory" }; // Gregoriaanse kalender
-            yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("pl-PL").DateTimeFormat, "gregory" }; // kalendarz gregoriański
-            yield return new object[] { new CultureInfo("pt-BR").DateTimeFormat, "gregory" }; // Calendário Gregoriano
-            yield return new object[] { new CultureInfo("pt-PT").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("ro-RO").DateTimeFormat, "gregory" }; // calendar gregory
-            yield return new object[] { new CultureInfo("ru-RU").DateTimeFormat, "gregory" }; // григорианский календарь
-            yield return new object[] { new CultureInfo("sk-SK").DateTimeFormat, "gregory" }; // gregoriánsky kalendár
-            yield return new object[] { new CultureInfo("sl-SI").DateTimeFormat, "gregory" }; // gregorijanski koledar
-            yield return new object[] { new CultureInfo("sr-Cyrl-RS").DateTimeFormat, "gregory" }; // грегоријански календар
-            yield return new object[] { new CultureInfo("sr-Latn-RS").DateTimeFormat, "gregory" }; // gregorijanski kalendar
-            yield return new object[] { new CultureInfo("sv-AX").DateTimeFormat, "gregory" }; // gregoriansk kalender
-            yield return new object[] { new CultureInfo("sv-SE").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("sw-CD").DateTimeFormat, "gregory" }; // Kalenda ya Kigregori
-            yield return new object[] { new CultureInfo("sw-KE").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("sw-TZ").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("sw-UG").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("ta-IN").DateTimeFormat, "gregory" }; // கிரிகோரியன் நாள்காட்டி
-            yield return new object[] { new CultureInfo("ta-LK").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("ta-MY").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("ta-SG").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("te-IN").DateTimeFormat, "gregory" };// గ్రేగోరియన్ క్యాలెండర్
-            yield return new object[] { new CultureInfo("th-TH").DateTimeFormat, "buddhist" }; // ปฏิทินพุทธ
-            yield return new object[] { new CultureInfo("tr-CY").DateTimeFormat, "gregory" }; // Miladi Takvim
-            yield return new object[] { new CultureInfo("tr-TR").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("uk-UA").DateTimeFormat, "gregory" }; // григоріанський календар
-            yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, "gregory" }; // Lịch Gregory
-            yield return new object[] { new CultureInfo("zh-CN").DateTimeFormat, "gregory" }; // 公历
-            yield return new object[] { new CultureInfo("zh-Hans-HK").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("zh-SG").DateTimeFormat, "gregory" };
-            yield return new object[] { new CultureInfo("zh-HK").DateTimeFormat, "gregory" }; // 公曆
-            yield return new object[] { new CultureInfo("zh-TW").DateTimeFormat, "gregory" };
+            string islamicName = PlatformDetection.IsNodeJS ? "UMALQURA" : "islamic-umalqura";
+            string gregorianName = PlatformDetection.IsNodeJS ? "GREGORIAN" : "gregory";
+            string persianName = PlatformDetection.IsNodeJS ? "PERSIAN" : "persian";
+            string bhuddistName = PlatformDetection.IsNodeJS ? "THAI" : "buddhist";
+            yield return new object[] { new CultureInfo("ar-SA").DateTimeFormat, islamicName }; // التقويم الإسلامي (أم القرى)
+            yield return new object[] { new CultureInfo("am-ET").DateTimeFormat, gregorianName }; // የግሪጎሪያን የቀን አቆጣጠር
+            yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, gregorianName }; // григориански календар
+            yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, gregorianName }; // গ্রিগোরিয়ান ক্যালেন্ডার
+            yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, gregorianName }; // গ্রিগোরিয়ান ক্যালেন্ডার
+            yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, gregorianName }; // calendari gregorià
+            yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, gregorianName }; // calendari gregorià
+            yield return new object[] { new CultureInfo("cs-CZ").DateTimeFormat, gregorianName }; // Gregoriánský kalendář
+            yield return new object[] { new CultureInfo("da-DK").DateTimeFormat, gregorianName }; // gregoriansk kalender
+            yield return new object[] { new CultureInfo("de-AT").DateTimeFormat, gregorianName }; // Gregorianischer Kalender
+            yield return new object[] { new CultureInfo("de-BE").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("de-CH").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("de-DE").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("de-IT").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("de-LI").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("de-LU").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("el-CY").DateTimeFormat, gregorianName }; // Γρηγοριανό ημερολόγιο
+            yield return new object[] { new CultureInfo("el-GR").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-AE").DateTimeFormat, gregorianName }; // Gregorian Calendar
+            yield return new object[] { new CultureInfo("en-AG").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-AI").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-AS").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-AT").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-AU").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-BB").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-BE").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-BI").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-BM").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-BS").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-BW").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-BZ").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-CC").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-CH").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-CK").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-CM").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-CX").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-CY").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-DE").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-DK").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-DM").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-ER").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-FI").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-FJ").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-FK").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-FM").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-GB").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-GD").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-GG").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-GH").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-GI").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-GM").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-GU").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-GY").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-HK").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-IE").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-IL").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-IM").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-IN").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-IO").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-JE").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-JM").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-KE").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-KI").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-KN").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-KY").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-LC").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-LR").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-LS").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-MG").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-MH").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-MO").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-MP").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-MS").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-MT").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-MU").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-MW").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-MY").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-NA").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-NF").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-NG").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-NL").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-NR").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-NU").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-NZ").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-PG").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-PH").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-PK").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-PN").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-PR").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-PW").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-RW").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-SB").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-SC").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-SD").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-SE").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-SG").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-SH").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-SI").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-SL").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-SS").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-SX").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-SZ").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-TC").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-TK").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-TO").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-TT").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-TV").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-TZ").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-UG").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-UM").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-US").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-VC").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-VG").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-VI").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-VU").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-WS").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-ZA").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-ZM").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-ZW").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("en-US").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("es-419").DateTimeFormat, gregorianName }; // calendario gregoriano
+            yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, gregorianName }; // Gregoriuse kalender
+            yield return new object[] { new CultureInfo("fa-IR").DateTimeFormat, persianName }; // تقویم هجری شمسی
+            yield return new object[] { new CultureInfo("fi-FI").DateTimeFormat, gregorianName }; // gregoriaaninen kalenteri
+            yield return new object[] { new CultureInfo("fil-PH").DateTimeFormat, gregorianName }; // Gregorian na Kalendaryo
+            yield return new object[] { new CultureInfo("fr-BE").DateTimeFormat, gregorianName }; // calendrier grégorien
+            yield return new object[] { new CultureInfo("fr-CA").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("fr-CH").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("fr-FR").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("gu-IN").DateTimeFormat, gregorianName }; // ગ્રેગોરિઅન કેલેન્ડર
+            yield return new object[] { new CultureInfo("he-IL").DateTimeFormat, gregorianName }; // לוח השנה הגרגוריאני
+            yield return new object[] { new CultureInfo("hi-IN").DateTimeFormat, gregorianName }; // ग्रेगोरियन कैलेंडर"
+            yield return new object[] { new CultureInfo("hr-BA").DateTimeFormat, gregorianName }; // gregorijanski kalendar
+            yield return new object[] { new CultureInfo("hr-HR").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("hu-HU").DateTimeFormat, gregorianName }; // Gergely-naptár
+            yield return new object[] { new CultureInfo("id-ID").DateTimeFormat, gregorianName }; // Kalender Gregorian"
+            yield return new object[] { new CultureInfo("it-CH").DateTimeFormat, gregorianName }; // Calendario gregoriano
+            yield return new object[] { new CultureInfo("it-IT").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("ja-JP").DateTimeFormat, gregorianName }; // 西暦(グレゴリオ暦)
+            yield return new object[] { new CultureInfo("kn-IN").DateTimeFormat, gregorianName }; // ಗ್ರೆಗೋರಿಯನ್ ಕ್ಯಾಲೆಂಡರ್
+            yield return new object[] { new CultureInfo("ko-KR").DateTimeFormat, gregorianName }; // 양력
+            yield return new object[] { new CultureInfo("lt-LT").DateTimeFormat, gregorianName }; // Grigaliaus kalendorius
+            yield return new object[] { new CultureInfo("lv-LV").DateTimeFormat, gregorianName }; // Gregora kalendārs
+            yield return new object[] { new CultureInfo("ml-IN").DateTimeFormat, gregorianName }; // ഇംഗ്ലീഷ് കലണ്ടർ
+            yield return new object[] { new CultureInfo("mr-IN").DateTimeFormat, gregorianName }; // ग्रेगोरियन दिनदर्शिका
+            yield return new object[] { new CultureInfo("ms-BN").DateTimeFormat, gregorianName }; // Kalendar Gregory
+            yield return new object[] { new CultureInfo("ms-MY").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("ms-SG").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, gregorianName }; // gregoriansk kalender
+            yield return new object[] { new CultureInfo("no").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("no-NO").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, gregorianName }; // Gregoriaanse kalender
+            yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("pl-PL").DateTimeFormat, gregorianName }; // kalendarz gregoriański
+            yield return new object[] { new CultureInfo("pt-BR").DateTimeFormat, gregorianName }; // Calendário Gregoriano
+            yield return new object[] { new CultureInfo("pt-PT").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("ro-RO").DateTimeFormat, gregorianName }; // calendar gregory
+            yield return new object[] { new CultureInfo("ru-RU").DateTimeFormat, gregorianName }; // григорианский календарь
+            yield return new object[] { new CultureInfo("sk-SK").DateTimeFormat, gregorianName }; // gregoriánsky kalendár
+            yield return new object[] { new CultureInfo("sl-SI").DateTimeFormat, gregorianName }; // gregorijanski koledar
+            yield return new object[] { new CultureInfo("sr-Cyrl-RS").DateTimeFormat, gregorianName }; // грегоријански календар
+            yield return new object[] { new CultureInfo("sr-Latn-RS").DateTimeFormat, gregorianName }; // gregorijanski kalendar
+            yield return new object[] { new CultureInfo("sv-AX").DateTimeFormat, gregorianName }; // gregoriansk kalender
+            yield return new object[] { new CultureInfo("sv-SE").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("sw-CD").DateTimeFormat, gregorianName }; // Kalenda ya Kigregori
+            yield return new object[] { new CultureInfo("sw-KE").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("sw-TZ").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("sw-UG").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("ta-IN").DateTimeFormat, gregorianName }; // கிரிகோரியன் நாள்காட்டி
+            yield return new object[] { new CultureInfo("ta-LK").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("ta-MY").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("ta-SG").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("te-IN").DateTimeFormat, gregorianName };// గ్రేగోరియన్ క్యాలెండర్
+            yield return new object[] { new CultureInfo("th-TH").DateTimeFormat, bhuddistName }; // ปฏิทินพุทธ
+            yield return new object[] { new CultureInfo("tr-CY").DateTimeFormat, gregorianName }; // Miladi Takvim
+            yield return new object[] { new CultureInfo("tr-TR").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("uk-UA").DateTimeFormat, gregorianName }; // григоріанський календар
+            yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, gregorianName }; // Lịch Gregory
+            yield return new object[] { new CultureInfo("zh-CN").DateTimeFormat, gregorianName }; // 公历
+            yield return new object[] { new CultureInfo("zh-Hans-HK").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("zh-SG").DateTimeFormat, gregorianName };
+            yield return new object[] { new CultureInfo("zh-HK").DateTimeFormat, gregorianName }; // 公曆
+            yield return new object[] { new CultureInfo("zh-TW").DateTimeFormat, gregorianName };
         }
         
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnBrowser))]

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortDatePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortDatePattern.cs
@@ -44,7 +44,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-BZ").DateTimeFormat, "dd/MM/yyyy" };
             yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, "yyyy-MM-dd" };
             yield return new object[] { new CultureInfo("en-CC").DateTimeFormat, "dd/MM/yyyy" };
-            yield return new object[] { new CultureInfo("en-CH").DateTimeFormat, "dd.MM.yyyy" }; // should be "dd/MM/yyyy"
+            yield return new object[] { new CultureInfo("en-CH").DateTimeFormat, PlatformDetection.IsNodeJS ? "dd/MM/yyyy" : "dd.MM.yyyy" }; // NodeJS responds like dotnet
             yield return new object[] { new CultureInfo("en-CK").DateTimeFormat, "dd/MM/yyyy" };
             yield return new object[] { new CultureInfo("en-CM").DateTimeFormat, "dd/MM/yyyy" };
             yield return new object[] { new CultureInfo("en-CX").DateTimeFormat, "dd/MM/yyyy" };


### PR DESCRIPTION
PR https://github.com/dotnet/runtime/pull/90145 revealed failures on Hybrid hosted on NodeJS. The differences in behavior should be removed once we update to node v20.

The reason for this PR might be unclear as it would seem better to fix the behavior then to change the tests. We have a few cases here:
- Differences in the API's responses between hosts are marginal e.g. "Sept" as September abbreviation instead of "Sep" and hardcoding the fix would be easy but adding additional performance overhead (a forest of if-cases) or adding a bunch of static data.
- Differences in the API's responses are big e.g. first day of the week. For some locales it's hard to define the first day of the week, e.g. see "en-AU" - in dotnet we originally return "Sunday" even though ISO 8601 suggests "Monday". Node and v8/browser are not in line with the decision either. Hardcoding is possible but we would rather inform users what JS function is used to fetch the response:
https://github.com/dotnet/runtime/blob/24f151365fe1a1795775f2ad0287aba8f14f40d0/docs/design/features/globalization-hybrid-mode.md?plain=1#L317
so that they would be conscious about the "FirstDayOfWeek" being directly bound to the host's answer to that JS function.
- Differences that are big and wrong. E.g. "bn-IN" `AbbreviatedMonthNames` returns abbreviated **genitive** name for browser/v8. Node behaves fine. We are aware of the buggy behavior but due to reasons from previous points we decide to keep uniform and fast preforming code, over fixing the individual host's implementations.