### PR TITLE
Fix SocketsHttpHandler metrics test on Android

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -969,17 +969,17 @@ namespace System.Net.Http.Functional.Tests
         {
             RemoteExecutor.Invoke(static async Task () =>
             {
+                if (PlatformDetection.IsMobile)
+                {
+                    // Force the test to use SocketsHttpHandler
+                    AppContext.SetSwitch("System.Net.Http.UseNativeHttpHandler", false);
+                }
+
                 TaskCompletionSource clientWaitingTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 using HttpMetricsTest_DefaultMeter test = new(null);
                 await test.LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
                 {
-                    if (PlatformDetection.IsMobile)
-                    {
-                        // Force the test to use SocketsHttpHandler
-                        AppContext.SetSwitch("System.Net.Http.UseNativeHttpHandler", false);
-                    }
-
                     using MultiInstrumentRecorder recorder = new();
 
                     using (HttpClient client = test.CreateHttpClient())

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -974,6 +974,12 @@ namespace System.Net.Http.Functional.Tests
                 using HttpMetricsTest_DefaultMeter test = new(null);
                 await test.LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
                 {
+                    if (PlatformDetection.IsMobile)
+                    {
+                        // Force the test to use SocketsHttpHandler
+                        AppContext.SetSwitch("System.Net.Http.UseNativeHttpHandler", false);
+                    }
+
                     using MultiInstrumentRecorder recorder = new();
 
                     using (HttpClient client = test.CreateHttpClient())


### PR DESCRIPTION
Saw failures like these in a few `runtime-extra-platforms` runs.
My guess is the test ended up using the mobile platform handler instead of `SocketsHttpHandler`.

```
Assert.Collection() Failure
Collection: [http.client.active_requests=1 [url.scheme=http, server.address=127.0.0.1, server.port=42873, http.request.method=GET], http.client.active_requests=-1 [url.scheme=http, server.address=127.0.0.1, server.port=42873, http.request.method=GET], http.client.request.duration=0.0143246 [url.scheme=http, server.address=127.0.0.1, server.port=42873, http.request.method=GET, http.response.status_code=200, network.protocol.version=1.1]]
Expected item count: 11
Actual item count:   3
   at System.Net.Http.Functional.Tests.HttpMetricsTest.<>c__DisplayClass19_0.<<AllSocketsHttpHandlerCounters_Success_Recorded>b__0>d.MoveNext() in /_/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs:line 618
--- End of stack trace from previous location ---
   at System.Threading.Tasks.TaskTimeoutExtensions.GetRealException(Task task) in /_/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs:line 120
--- End of stack trace from previous location ---
   at System.Threading.Tasks.TaskTimeoutExtensions.WhenAllOrAnyFailed(Task[] tasks) in /_/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs:line 90
   at System.Net.Test.Common.LoopbackServerFactory.<>c__DisplayClass6_0.<<CreateClientAndServerAsync>b__0>d.MoveNext() in /_/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs:line 44
--- End of stack trace from previous location ---
   at System.Net.Test.Common.LoopbackServer.CreateServerAsync(Func`2 funcAsync, Options options) in /_/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs:line 107
   at System.Net.Http.Functional.Tests.HttpMetricsTest.AllSocketsHttpHandlerCounters_Success_Recorded() in /_/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs:line 575
```