### PR TITLE
Reenable properties disabled in illink.targets

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -2,11 +2,6 @@
 
   <PropertyGroup>
     <IsTrimmable Condition="'$(IsTrimmable)' == ''">true</IsTrimmable>
-    <!-- Don't use SDK's trimming functionality. 
-         TODO: Remove this once we build using preview 6 SDK. -->
-    <_IsTrimmingEnabled>false</_IsTrimmingEnabled>
-    <!-- Same fix for preview 6 SDK. -->
-    <_RequiresILLinkPack>false</_RequiresILLinkPack>
     <PrepareResourcesDependsOn>_EmbedILLinkXmls;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
     <TargetsTriggeredByCompilation Condition="'$(DesignTimeBuild)' != 'true'">$(TargetsTriggeredByCompilation);ILLinkTrimAssembly</TargetsTriggeredByCompilation>
 


### PR DESCRIPTION
We're now using a preview6 SDK.