### PR TITLE
Add IgnoreForCI property to certain no-op test suites

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/AssemblyAttributes.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/AssemblyAttributes.cs
@@ -3,4 +3,4 @@
 
 using Xunit;
 
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/35970", TestRuntimes.Mono)]
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/35970", TestRuntimes.Mono)] // Note: remove IgnoreForCI from .csproj when reenabling

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/Microsoft.Extensions.Caching.Memory.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/Microsoft.Extensions.Caching.Memory.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <!-- ActiveIssue in AssemblyInfo.cs for Mono -->
+    <IgnoreForCI Condition="'$(RuntimeFlavor)' == 'Mono'">true</IgnoreForCI>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/FunctionalTests/Microsoft.Extensions.Hosting.Functional.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/FunctionalTests/Microsoft.Extensions.Hosting.Functional.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <!-- ActiveIssue in AssemblyInfo.cs -->
+    <IgnoreForCI>true</IgnoreForCI>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/FunctionalTests/Properties/AssemblyInfo.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/FunctionalTests/Properties/AssemblyInfo.cs
@@ -4,3 +4,4 @@
 using Xunit;
 
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/34090")] // Note: remove IgnoreForCI from .csproj when reenabling

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/FunctionalTests/ShutdownTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/FunctionalTests/ShutdownTests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34090")]
         [PlatformSpecific(TestPlatforms.Linux)]
         public async Task ShutdownTestRun()
         {
@@ -37,7 +36,6 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34090")]
         [PlatformSpecific(TestPlatforms.Linux)]
         public async Task ShutdownTestWaitForShutdown()
         {

--- a/src/libraries/System.ComponentModel.Composition/tests/AssemblyInfo.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Xunit;
 
-[assembly: ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)] // flaky tests
+[assembly: ActiveIssue("https://github.com/mono/mono/issues/16417", TestRuntimes.Mono)] // flaky tests. Note: remove IgnoreForCI from .csproj when reenabling

--- a/src/libraries/System.ComponentModel.Composition/tests/System.ComponentModel.Composition.Tests.csproj
+++ b/src/libraries/System.ComponentModel.Composition/tests/System.ComponentModel.Composition.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <!-- ActiveIssue in AssemblyInfo.cs for Mono -->
+    <IgnoreForCI Condition="'$(RuntimeFlavor)' == 'Mono'">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs"


### PR DESCRIPTION
A couple projects have all tests disabled, it makes no sense to send them to Helix to run 0 tests.