### PR TITLE
[libs][Android] Reenable Trace_ClearTraceListeners_StopsWritingToDebugger test

### DIFF
--- a/src/libraries/System.Diagnostics.Debug/tests/DebugTestsUsingListeners.cs
+++ b/src/libraries/System.Diagnostics.Debug/tests/DebugTestsUsingListeners.cs
@@ -196,7 +196,6 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50570", TestPlatforms.Android)]
         public void Trace_ClearTraceListeners_StopsWritingToDebugger()
         {
             VerifyLogged(() => Debug.Write("pizza"), "pizza");


### PR DESCRIPTION
Removes unnecessary ActiveIssue discovered in https://github.com/dotnet/runtime/issues/50570#issuecomment-1671049438