### PR TITLE
Fix NoLinkedOuput having the wrong base attribute type.

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/NoLinkedOutputAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/NoLinkedOutputAttribute.cs
@@ -6,7 +6,7 @@ using System;
 namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 {
 	[AttributeUsage (AttributeTargets.Class)]
-	public class NoLinkedOutputAttribute : Attribute
+	public class NoLinkedOutputAttribute : BaseExpectedLinkedBehaviorAttribute
 	{
 		public NoLinkedOutputAttribute () { }
 	}


### PR DESCRIPTION
This led to `[NoLinkedOutput]` being left in the `input` assembly