### PR TITLE
[wasm][debugger] Support calling `get_Item` passing decimal, float or double as parameter.

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -680,11 +680,11 @@ namespace Microsoft.WebAssembly.Diagnostics
                     TypeCode = ElementType.Char;
                     break;
                 case ConstantTypeCode.Byte:
-                    Value = (int)value[0];
+                    Value = (uint)value[0];
                     TypeCode = ElementType.U1;
                     break;
                 case ConstantTypeCode.SByte:
-                    Value = (uint)value[0];
+                    Value = (int)value[0];
                     TypeCode = ElementType.I1;
                     break;
                 case ConstantTypeCode.Int16:

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -358,6 +358,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public int KickOffMethod { get; }
         internal bool IsCompilerGenerated { get; }
         private AsyncScopeDebugInformation[] _asyncScopes { get; set; }
+        private static SignatureTypeProvider _signatureTypeProvider = new();
 
         public MethodInfo(AssemblyInfo assembly, string methodName, int methodToken, TypeInfo type, MethodAttributes attrs)
         {
@@ -436,6 +437,11 @@ namespace Microsoft.WebAssembly.Diagnostics
             if (_parametersInfo != null)
                 return _parametersInfo;
 
+            var signature = methodDef.Signature;
+            var sigReader = Assembly.asmMetadataReader.GetBlobReader(signature);
+            var decoder = new SignatureDecoder<ElementType, object>(_signatureTypeProvider, Assembly.asmMetadataReader, genericContext: null);
+            var methodSignature = decoder.DecodeMethodSignature(ref sigReader);
+
             var paramsHandles = methodDef.GetParameters().ToArray();
             var paramsCnt = paramsHandles.Length;
             var paramsInfo = new ParameterInfo[paramsCnt];
@@ -447,7 +453,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 var isOptional = parameter.Attributes.HasFlag(ParameterAttributes.Optional) && parameter.Attributes.HasFlag(ParameterAttributes.HasDefault);
                 if (!isOptional)
                 {
-                    paramsInfo[i] = new ParameterInfo(paramName);
+                    paramsInfo[i] = new ParameterInfo(paramName, methodSignature.ParameterTypes[i]);
                     continue;
                 }
                 var constantHandle = parameter.GetDefaultValue();
@@ -653,7 +659,11 @@ namespace Microsoft.WebAssembly.Diagnostics
         public ElementType? TypeCode { get; init; }
 
         public object Value { get; init; }
-
+        public ParameterInfo(string name, ElementType type)
+        {
+            Name = name;
+            TypeCode = type;
+        }
         public ParameterInfo(string name, ConstantTypeCode? typeCode = null, byte[] value = null)
         {
             Name = name;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
@@ -365,7 +365,7 @@ internal sealed class JObjectValueCreator
     public bool TryGetValueTypeById(int valueTypeId, out ValueTypeClass vt) => _valueTypes.TryGetValue(valueTypeId, out vt);
     public PointerValue GetPointerValue(int pointerId) => _pointerValues.TryGetValue(pointerId, out PointerValue pv) ? pv : null;
 
-    private static JObject CreateJObjectForNumber<T>(T value) => Create(value, "number", value.ToString(), writable: true);
+    private static JObject CreateJObjectForNumber<T>(T value) => Create(value, "number", value.ToString(), writable: true, className: typeof(T).Name);
 
     private static JObject CreateJObjectForChar(int value)
     {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -545,17 +545,17 @@ namespace Microsoft.WebAssembly.Diagnostics
             }
         }
 
-        private static bool CheckParametersCompatibility(ElementType? typeCode, JObject value)
+        private static bool CheckParametersCompatibility(ElementType? paramTypeCode, JObject value)
         {
-            if (!typeCode.HasValue)
+            if (!paramTypeCode.HasValue)
                 return true;
-            var parameterType = value["type"]?.Value<string>();
-            var parameterClassName = value["className"]?.Value<string>();
+            var argumentType = value["type"]?.Value<string>();
+            var argumentClassName = value["className"]?.Value<string>();
 
-            switch (typeCode.Value)
+            switch (paramTypeCode.Value)
             {
                 case ElementType.Object:
-                    if (parameterType != "object")
+                    if (argumentType != "object")
                         return false;
                     break;
                 case ElementType.I2:
@@ -566,25 +566,27 @@ namespace Microsoft.WebAssembly.Diagnostics
                 case ElementType.U2:
                 case ElementType.U4:
                 case ElementType.U8:
-                    if (parameterType != "number")
+                    if (argumentType != "number")
                         return false;
-                    if (parameterType == "object")
+                    if (argumentType == "object")
                         return false;
                     break;
                 case ElementType.Char:
-                    if (parameterType != "string" && parameterType != "symbol")
+                    if (argumentType != "string" && argumentType != "symbol")
+                        return false;
+                    if (argumentType == "object")
                         return false;
                     break;
                 case ElementType.Boolean:
-                    if (parameterType == "boolean")
+                    if (argumentType == "boolean")
                         return true;
-                    if (parameterType == "number" && (parameterClassName == "Single" || parameterClassName == "Double"))
+                    if (argumentType == "number" && (argumentClassName == "Single" || argumentClassName == "Double"))
                         return false;
-                    if (parameterType == "object")
+                    if (argumentType == "object")
                         return false;
                     break;
                 case ElementType.String:
-                    if (parameterType != "string")
+                    if (argumentType != "string")
                         return false;
                     break;
                 default:

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -587,7 +587,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         {
             switch (type)
             {
-                case ElementType.U1:
+                case ElementType.I1:
                 case ElementType.I2:
                 case ElementType.I4:
                     Write((ElementType)type, (int)value);
@@ -604,7 +604,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         intBoolVal = (bool)value ? 1 : 0;
                     Write((ElementType)type, intBoolVal);
                     return true;
-                case ElementType.I1:
+                case ElementType.U1:
                 case ElementType.U2:
                 case ElementType.U4:
                     Write((ElementType)type, (uint)value);
@@ -722,12 +722,34 @@ namespace Microsoft.WebAssembly.Diagnostics
                 case "number":
                 {
                     var expected = expectedType is not null ? expectedType.Value : ElementType.I4;
-                    if (expected == ElementType.R4)
-                        Write(expected, objValue["value"].Value<float>());
-                    else if (expected == ElementType.R8)
-                        Write(expected, objValue["value"].Value<double>());
-                    else
-                        Write(expected, objValue["value"].Value<int>());
+                    switch (expected)
+                    {
+                        case ElementType.I1:
+                        case ElementType.I2:
+                        case ElementType.I4:
+                            Write(expected, objValue["value"].Value<int>());
+                            break;
+                        case ElementType.U1:
+                        case ElementType.U2:
+                        case ElementType.U4:
+                            Write(expected, objValue["value"].Value<uint>());
+                            break;
+                        case ElementType.I8:
+                            Write(expected, objValue["value"].Value<long>());
+                            break;
+                        case ElementType.U8:
+                            Write(expected, objValue["value"].Value<ulong>());
+                            break;
+                        case ElementType.R4:
+                            Write(expected, objValue["value"].Value<float>());
+                            break;
+                        case ElementType.R8:
+                            Write(expected, objValue["value"].Value<double>());
+                            break;
+                        default:
+                            objValue["value"].Value<int>();
+                            break;
+                    };
                     return true;
                 }
                 case "symbol":

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -715,14 +715,19 @@ namespace Microsoft.WebAssembly.Diagnostics
             return false;
         }
 
-        public async Task<bool> WriteJsonValue(JObject objValue, MonoSDBHelper SdbHelper, CancellationToken token)
+        public async Task<bool> WriteJsonValue(JObject objValue, MonoSDBHelper SdbHelper, ElementType? expectedType, CancellationToken token)
         {
             switch (objValue["type"].Value<string>())
             {
                 case "number":
                 {
-                    // FixMe: what if the number is not int but single/double?
-                    Write(ElementType.I4, objValue["value"].Value<int>());
+                    var expected = expectedType is not null ? expectedType.Value : ElementType.I4;
+                    if (expected == ElementType.R4)
+                        Write(expected, objValue["value"].Value<float>());
+                    else if (expected == ElementType.R8)
+                        Write(expected, objValue["value"].Value<double>());
+                    else
+                        Write(expected, objValue["value"].Value<int>());
                     return true;
                 }
                 case "symbol":

--- a/src/mono/wasm/debugger/BrowserDebugProxy/SignatureTypeProvider.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/SignatureTypeProvider.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.WebAssembly.Diagnostics;
+
+namespace Microsoft.WebAssembly.Diagnostics
+{
+    internal sealed class SignatureTypeProvider : ISignatureTypeProvider<ElementType, object>
+    {
+        public ElementType GetPrimitiveType(PrimitiveTypeCode typeCode)
+            => typeCode switch
+            {
+                PrimitiveTypeCode.Boolean => ElementType.Boolean,
+                PrimitiveTypeCode.Byte => ElementType.U1,
+                PrimitiveTypeCode.Char => ElementType.Char,
+                PrimitiveTypeCode.Double => ElementType.R8,
+                PrimitiveTypeCode.Int16 => ElementType.I2,
+                PrimitiveTypeCode.Int32 => ElementType.I4,
+                PrimitiveTypeCode.Int64 => ElementType.I8,
+                PrimitiveTypeCode.IntPtr => ElementType.Ptr,
+                PrimitiveTypeCode.Object => ElementType.Object,
+                PrimitiveTypeCode.SByte => ElementType.I1,
+                PrimitiveTypeCode.Single => ElementType.R4,
+                PrimitiveTypeCode.String => ElementType.String,
+                PrimitiveTypeCode.TypedReference => ElementType.ValueType,
+                PrimitiveTypeCode.UInt16 => ElementType.U2,
+                PrimitiveTypeCode.UInt32 => ElementType.U4,
+                PrimitiveTypeCode.UInt64 => ElementType.U8,
+                PrimitiveTypeCode.UIntPtr => ElementType.Ptr,
+                PrimitiveTypeCode.Void => ElementType.Void,
+                _ => ElementType.End,
+            };
+
+        ElementType ISignatureTypeProvider<ElementType, object>.GetFunctionPointerType(MethodSignature<ElementType> signature) => ElementType.FnPtr;
+        ElementType ISignatureTypeProvider<ElementType, object>.GetModifiedType(ElementType modifier, ElementType unmodifiedType, bool isRequired) => ElementType.Object;
+        ElementType ISignatureTypeProvider<ElementType, object>.GetPinnedType(ElementType elementType) => ElementType.Object;
+        ElementType IConstructedTypeProvider<ElementType>.GetArrayType(ElementType elementType, ArrayShape shape) => ElementType.Array;
+        ElementType IConstructedTypeProvider<ElementType>.GetByReferenceType(ElementType elementType) => ElementType.Object;
+        ElementType IConstructedTypeProvider<ElementType>.GetGenericInstantiation(ElementType genericType, ImmutableArray<ElementType> typeArguments) => ElementType.Object;
+        ElementType IConstructedTypeProvider<ElementType>.GetPointerType(ElementType elementType) => ElementType.Ptr;
+        ElementType ISZArrayTypeProvider<ElementType>.GetSZArrayType(ElementType elementType) => ElementType.SzArray;
+        ElementType ISignatureTypeProvider<ElementType, object>.GetGenericMethodParameter(object genericContext, int index) => ElementType.Object;
+        ElementType ISignatureTypeProvider<ElementType, object>.GetGenericTypeParameter(object genericContext, int index) => ElementType.Object;
+        ElementType ISignatureTypeProvider<ElementType, object>.GetTypeFromSpecification(MetadataReader reader, object genericContext, TypeSpecificationHandle handle, byte rawTypeKind) => ElementType.Object;
+        ElementType ISimpleTypeProvider<ElementType>.GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => ElementType.Object;
+        ElementType ISimpleTypeProvider<ElementType>.GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => ElementType.Object;
+    }
+}

--- a/src/mono/wasm/debugger/BrowserDebugProxy/SignatureTypeProvider.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/SignatureTypeProvider.cs
@@ -10,7 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 
-namespace Microsoft.WebAssembly.Diagnostics
+namespace Microsoft.WebAssembly.Diagnostics;
 {
     internal sealed class SignatureTypeProvider : ISignatureTypeProvider<ElementType, object>
     {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/SignatureTypeProvider.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/SignatureTypeProvider.cs
@@ -11,45 +11,44 @@ using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 
 namespace Microsoft.WebAssembly.Diagnostics;
-{
-    internal sealed class SignatureTypeProvider : ISignatureTypeProvider<ElementType, object>
-    {
-        public ElementType GetPrimitiveType(PrimitiveTypeCode typeCode)
-            => typeCode switch
-            {
-                PrimitiveTypeCode.Boolean => ElementType.Boolean,
-                PrimitiveTypeCode.Byte => ElementType.U1,
-                PrimitiveTypeCode.Char => ElementType.Char,
-                PrimitiveTypeCode.Double => ElementType.R8,
-                PrimitiveTypeCode.Int16 => ElementType.I2,
-                PrimitiveTypeCode.Int32 => ElementType.I4,
-                PrimitiveTypeCode.Int64 => ElementType.I8,
-                PrimitiveTypeCode.IntPtr => ElementType.Ptr,
-                PrimitiveTypeCode.Object => ElementType.Object,
-                PrimitiveTypeCode.SByte => ElementType.I1,
-                PrimitiveTypeCode.Single => ElementType.R4,
-                PrimitiveTypeCode.String => ElementType.String,
-                PrimitiveTypeCode.TypedReference => ElementType.ValueType,
-                PrimitiveTypeCode.UInt16 => ElementType.U2,
-                PrimitiveTypeCode.UInt32 => ElementType.U4,
-                PrimitiveTypeCode.UInt64 => ElementType.U8,
-                PrimitiveTypeCode.UIntPtr => ElementType.Ptr,
-                PrimitiveTypeCode.Void => ElementType.Void,
-                _ => ElementType.End,
-            };
 
-        ElementType ISignatureTypeProvider<ElementType, object>.GetFunctionPointerType(MethodSignature<ElementType> signature) => ElementType.FnPtr;
-        ElementType ISignatureTypeProvider<ElementType, object>.GetModifiedType(ElementType modifier, ElementType unmodifiedType, bool isRequired) => ElementType.Object;
-        ElementType ISignatureTypeProvider<ElementType, object>.GetPinnedType(ElementType elementType) => ElementType.Object;
-        ElementType IConstructedTypeProvider<ElementType>.GetArrayType(ElementType elementType, ArrayShape shape) => ElementType.Array;
-        ElementType IConstructedTypeProvider<ElementType>.GetByReferenceType(ElementType elementType) => ElementType.Object;
-        ElementType IConstructedTypeProvider<ElementType>.GetGenericInstantiation(ElementType genericType, ImmutableArray<ElementType> typeArguments) => ElementType.Object;
-        ElementType IConstructedTypeProvider<ElementType>.GetPointerType(ElementType elementType) => ElementType.Ptr;
-        ElementType ISZArrayTypeProvider<ElementType>.GetSZArrayType(ElementType elementType) => ElementType.SzArray;
-        ElementType ISignatureTypeProvider<ElementType, object>.GetGenericMethodParameter(object genericContext, int index) => ElementType.Object;
-        ElementType ISignatureTypeProvider<ElementType, object>.GetGenericTypeParameter(object genericContext, int index) => ElementType.Object;
-        ElementType ISignatureTypeProvider<ElementType, object>.GetTypeFromSpecification(MetadataReader reader, object genericContext, TypeSpecificationHandle handle, byte rawTypeKind) => ElementType.Object;
-        ElementType ISimpleTypeProvider<ElementType>.GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => ElementType.Object;
-        ElementType ISimpleTypeProvider<ElementType>.GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => ElementType.Object;
-    }
+internal sealed class SignatureTypeProvider : ISignatureTypeProvider<ElementType, object>
+{
+    public ElementType GetPrimitiveType(PrimitiveTypeCode typeCode)
+        => typeCode switch
+        {
+            PrimitiveTypeCode.Boolean => ElementType.Boolean,
+            PrimitiveTypeCode.Byte => ElementType.U1,
+            PrimitiveTypeCode.Char => ElementType.Char,
+            PrimitiveTypeCode.Double => ElementType.R8,
+            PrimitiveTypeCode.Int16 => ElementType.I2,
+            PrimitiveTypeCode.Int32 => ElementType.I4,
+            PrimitiveTypeCode.Int64 => ElementType.I8,
+            PrimitiveTypeCode.IntPtr => ElementType.Ptr,
+            PrimitiveTypeCode.Object => ElementType.Object,
+            PrimitiveTypeCode.SByte => ElementType.I1,
+            PrimitiveTypeCode.Single => ElementType.R4,
+            PrimitiveTypeCode.String => ElementType.String,
+            PrimitiveTypeCode.TypedReference => ElementType.ValueType,
+            PrimitiveTypeCode.UInt16 => ElementType.U2,
+            PrimitiveTypeCode.UInt32 => ElementType.U4,
+            PrimitiveTypeCode.UInt64 => ElementType.U8,
+            PrimitiveTypeCode.UIntPtr => ElementType.Ptr,
+            PrimitiveTypeCode.Void => ElementType.Void,
+            _ => ElementType.End,
+        };
+
+    ElementType ISignatureTypeProvider<ElementType, object>.GetFunctionPointerType(MethodSignature<ElementType> signature) => ElementType.FnPtr;
+    ElementType ISignatureTypeProvider<ElementType, object>.GetModifiedType(ElementType modifier, ElementType unmodifiedType, bool isRequired) => ElementType.Object;
+    ElementType ISignatureTypeProvider<ElementType, object>.GetPinnedType(ElementType elementType) => ElementType.Object;
+    ElementType IConstructedTypeProvider<ElementType>.GetArrayType(ElementType elementType, ArrayShape shape) => ElementType.Array;
+    ElementType IConstructedTypeProvider<ElementType>.GetByReferenceType(ElementType elementType) => ElementType.Object;
+    ElementType IConstructedTypeProvider<ElementType>.GetGenericInstantiation(ElementType genericType, ImmutableArray<ElementType> typeArguments) => ElementType.Object;
+    ElementType IConstructedTypeProvider<ElementType>.GetPointerType(ElementType elementType) => ElementType.Ptr;
+    ElementType ISZArrayTypeProvider<ElementType>.GetSZArrayType(ElementType elementType) => ElementType.SzArray;
+    ElementType ISignatureTypeProvider<ElementType, object>.GetGenericMethodParameter(object genericContext, int index) => ElementType.Object;
+    ElementType ISignatureTypeProvider<ElementType, object>.GetGenericTypeParameter(object genericContext, int index) => ElementType.Object;
+    ElementType ISignatureTypeProvider<ElementType, object>.GetTypeFromSpecification(MetadataReader reader, object genericContext, TypeSpecificationHandle handle, byte rawTypeKind) => ElementType.Object;
+    ElementType ISimpleTypeProvider<ElementType>.GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => ElementType.Object;
+    ElementType ISimpleTypeProvider<ElementType>.GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => ElementType.Object;
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -659,12 +659,10 @@ namespace DebuggerTests
                     ("f[longString]", TBool(true)),
                     ("f[aBool]", TString("True")),
                     ("f[aChar]", TString("res_9")),
-                    ("f[shortString]", TBool(false))
-                    // ("f[aFloat]", TNumber(1)),
-                    // ("f[aDouble]", TNumber(2)),
-
-                    // FixMe: https://github.com/dotnet/runtime/issues/76014
-                    // ("f[aDecimal]", TNumber(3)) // object
+                    ("f[shortString]", TBool(false)),
+                    ("f[aFloat]", TNumber(1)),
+                    ("f[aDouble]", TNumber(2)),
+                    ("f[aDecimal]", TNumber(3)) // object
                 );
             });
 


### PR DESCRIPTION
Fixes #76014 