### PR TITLE
What is the expected behavior when a reference is missing?

### DIFF
--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/ReferencesTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/ReferencesTests.g.cs
@@ -58,6 +58,18 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task MissingReferenceInUnusedCodePath ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
+		public Task MissingReferenceInUsedCodePath ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task ReferencesAreRemovedWhenAllUsagesAreRemoved ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Metadata/DeleteBeforeAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Metadata/DeleteBeforeAttribute.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+/// <summary>
+/// Deletes a file before the linker is ran
+/// </summary>
+[AttributeUsage (AttributeTargets.Class)]
+public class DeleteBeforeAttribute : BaseMetadataAttribute
+{
+	public DeleteBeforeAttribute (string fileName)
+	{
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Dependencies/MissingAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Dependencies/MissingAssembly.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Mono.Linker.Tests.Cases.References.Dependencies;
+
+public class MissingAssembly
+{
+	
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/MissingReferenceInUnusedCodePath.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/MissingReferenceInUnusedCodePath.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.References.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.References;
+
+[ExpectNonZeroExitCode (1)]
+[NoLinkedOutput]
+[SetupCompileBefore ("missing.dll", new[] { "Dependencies/MissingAssembly.cs" })]
+[DeleteBefore ("missing.dll")]
+public class MissingReferenceInUnusedCodePath
+{
+	public static void Main ()
+	{
+	}
+
+	private static void UnusedPath ()
+	{
+		typeof (MissingAssembly).ToString ();
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/MissingReferenceInUsedCodePath.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/MissingReferenceInUsedCodePath.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.References.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.References;
+
+[ExpectNonZeroExitCode (1)]
+[NoLinkedOutput]
+[SetupCompileBefore ("missing.dll", new[] { "Dependencies/MissingAssembly.cs" })]
+[DeleteBefore ("missing.dll")]
+public class MissingReferenceInUsedCodePath
+{
+	public static void Main ()
+	{
+		typeof (MissingAssembly).ToString ();
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadataProvider.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadataProvider.cs
@@ -152,6 +152,13 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				.Select (GetSourceAndRelativeDestinationValue);
 		}
 
+		public IEnumerable<string> GetDeleteBefore ()
+		{
+			return _testCaseTypeDefinition.CustomAttributes
+				.Where (attr => attr.AttributeType.Name == nameof (DeleteBeforeAttribute))
+				.Select (attr => (string)attr.ConstructorArguments[0].Value);
+		}
+
 		public virtual IEnumerable<NPath> GetExtraLinkerReferences ()
 		{
 			var netcoreappDir = Path.GetDirectoryName (typeof (object).Assembly.Location);

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseSandbox.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseSandbox.cs
@@ -159,6 +159,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			foreach (var res in metadataProvider.GetLinkAttributesFiles ()) {
 				res.Source.FileMustExist ().Copy (InputDirectory.Combine (res.DestinationFileName));
 			}
+
+			foreach (var delete in metadataProvider.GetDeleteBefore ())
+				InputDirectory.Combine (delete).FileMustExist ().Delete ();
 		}
 
 		private static NPath GetExpectationsAssemblyPath ()


### PR DESCRIPTION
I've been fighting with some tests in our UnityLinker suite that verify our behavior when a reference is missing.  What I need to know to get unblocked is what the design intend is of illink.  I've had a hard time figuring out what the excepted behavior is.  The `TryResolve` calls and `probing` logic in `AssemblyResolver` lead me to believe there are times when an unresolved assembly shouldn't be treated as an error.   However, after porting some of our tests to ilink's suite I see that an unresolved reference is fatal regardless of whether or not it's in a used code path.

Here are the two tests.

`MissingReferenceInUsedCodePath` - This test passes as expected.  An exit code of 1 is returned.

`MissingReferenceInUnusedCodePath` - This test is where I'm unclear what the expected behavior is.  Should the linker fail or pass in this case?  Currently it fails.   `DiscoverDynamicCastableImplementationInterfaces` triggers a resolve failure which leads to the linker failing.  `SweepAssemblyReferences` also leads to a resolve failure.

@vitek-karas @marek-safar  ?