### PR TITLE
[RISC-V] Fix Shuffling Thunks part 1

### DIFF
--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -665,7 +665,7 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
         //
         // Code sequence to access thread local variable on linux/riscv64:
         //
-        //      mov targetReg, $tp, 0
+        //      mov targetReg, $tp
         //      ld rd, targetReg(cns)
         tlsValue = gtNewIconHandleNode(0, GTF_ICON_TLS_HDL);
 #else

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -171,7 +171,7 @@ public:
         // Shuffle float registers first
         if (m_currentFloatRegIndex < m_argLocDesc->m_cFloatReg)
         {
-#if defined(TARGET_LOONGARCH64)
+#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
             if ((m_argLocDesc->m_structFields & STRUCT_FLOAT_FIELD_SECOND) && (m_currentGenRegIndex < m_argLocDesc->m_cGenReg))
             {
                 // the first field is integer so just skip this.
@@ -190,7 +190,7 @@ public:
         // over a register we later need to shuffle down as well).
         if (m_currentGenRegIndex < m_argLocDesc->m_cGenReg)
         {
-#if defined(TARGET_LOONGARCH64)
+#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
             if (7 < (m_currentGenRegIndex + m_argLocDesc->m_idxGenReg))
             {
                 m_currentGenRegIndex++;

--- a/src/coreclr/vm/riscv64/cgencpu.h
+++ b/src/coreclr/vm/riscv64/cgencpu.h
@@ -368,9 +368,6 @@ public:
     void EmitSllImm(IntReg Xd, IntReg Xn, unsigned int value);
     void EmitLuImm(IntReg Xd, unsigned int value);
 
-    void EmitLoadStoreRegPairImm(DWORD flags, IntReg Xt1, IntReg Xt2, IntReg Xn, int offset=0);
-    void EmitLoadStoreRegPairImm(DWORD flags, FloatReg Ft1, FloatReg Ft2, IntReg Xn, int offset=0);
-
     void EmitLoadStoreRegImm(DWORD flags, IntReg Xt, IntReg Xn, int offset=0);
     void EmitLoadStoreRegImm(DWORD flags, FloatReg Ft, IntReg Xn, int offset=0);
 

--- a/src/coreclr/vm/riscv64/stubs.cpp
+++ b/src/coreclr/vm/riscv64/stubs.cpp
@@ -1114,7 +1114,7 @@ void StubLinkerCPU::EmitLoadStoreRegImm(DWORD flags, IntReg Xt, IntReg Xn, int o
         Emit32((DWORD)(0x00003003 | (Xt << 7) | (Xn << 15) | (offset << 20)));
     } else {
         // sd regNum, offset(Xn)
-        Emit32((DWORD)(0x00003023 | (Xt << 20) | (Xn << 15) | (offset & 0xF) << 7 | (((offset >> 4) & 0xFF) << 25)));
+        Emit32((DWORD)(0x00003023 | (Xt << 20) | (Xn << 15) | (offset & 0x1F) << 7 | (((offset >> 5) & 0x7F) << 25)));
     }
 }
 

--- a/src/coreclr/vm/riscv64/stubs.cpp
+++ b/src/coreclr/vm/riscv64/stubs.cpp
@@ -1106,44 +1106,6 @@ void StubLinkerCPU::EmitRet(IntReg Xn)
     Emit32((DWORD)(0x00000067 | (Xn << 15))); // jalr X0, 0(Xn)
 }
 
-void StubLinkerCPU::EmitLoadStoreRegPairImm(DWORD flags, IntReg Xt1, IntReg Xt2, IntReg Xn, int offset)
-{
-    _ASSERTE((-1024 <= offset) && (offset <= 1015));
-    _ASSERTE((offset & 7) == 0);
-
-    BOOL isLoad = flags & 1;
-    if (isLoad) {
-        // ld Xt1, offset(Xn));
-        Emit32((DWORD)(0x00003003 | (Xt1 << 7) | (Xn << 15) | (offset << 20)));
-        // ld Xt2, (offset+8)(Xn));
-        Emit32((DWORD)(0x00003003 | (Xt2 << 7) | (Xn << 15) | ((offset + 8) << 20)));
-    } else {
-        // sd Xt1, offset(Xn)
-        Emit32((DWORD)(0x00003023 | (Xt1 << 20) | (Xn << 15) | (offset & 0xF) << 7 | (((offset >> 4) & 0xFF) << 25)));
-        // sd Xt1, (offset + 8)(Xn)
-        Emit32((DWORD)(0x00003023 | (Xt2 << 20) | (Xn << 15) | ((offset + 8) & 0xF) << 7 | ((((offset + 8) >> 4) & 0xFF) << 25)));
-    }
-}
-
-void StubLinkerCPU::EmitLoadStoreRegPairImm(DWORD flags, FloatReg Ft1, FloatReg Ft2, IntReg Xn, int offset)
-{
-    _ASSERTE((-1024 <= offset) && (offset <= 1015));
-    _ASSERTE((offset & 7) == 0);
-
-    BOOL isLoad = flags & 1;
-    if (isLoad) {
-        // fld Ft, Xn, offset
-        Emit32((DWORD)(0x00003007 | (Xn << 15) | (Ft1 << 7) | (offset << 20)));
-        // fld Ft, Xn, offset + 8
-        Emit32((DWORD)(0x00003007 | (Xn << 15) | (Ft2 << 7) | ((offset + 8) << 20)));
-    } else {
-        // fsd Ft, offset(Xn)
-        Emit32((WORD)(0x00003027 | (Xn << 15) | (Ft1 << 20) | (offset & 0xF) << 7 | ((offset >> 4) & 0xFF)));
-        // fsd Ft, (offset + 8)(Xn)
-        Emit32((WORD)(0x00003027 | (Xn << 15) | (Ft2 << 20) | ((offset + 8) & 0xF) << 7 | (((offset + 8) >> 4) & 0xFF)));
-    }
-}
-
 void StubLinkerCPU::EmitLoadStoreRegImm(DWORD flags, IntReg Xt, IntReg Xn, int offset)
 {
     BOOL isLoad    = flags & 1;


### PR DESCRIPTION
[RISC-V] Fix failing cases with delegates passing a struct with 2 longs as argument (test16833.cs -> Test1MRB, Test2MRB, Test5MRB)

Fix emits a stack shuffle entry when we run out of general purpose registers, analogous to loongarch64.

Test2MRB fixed by correcting offset encoding while emitting sd instruction.

Part of #84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov @clamp03