### PR TITLE
Integrate keyed DI with HttpClientFactory

### DIFF
--- a/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
@@ -164,9 +164,24 @@ namespace Microsoft.Extensions.Http
 
                 void Configure(HttpMessageHandlerBuilder b)
                 {
-                    for (int i = 0; i < options.HttpMessageHandlerBuilderActions.Count; i++)
+                    if (options.MergedToHandlerBuilderActions)
                     {
-                        options.HttpMessageHandlerBuilderActions[i](b);
+                        for (int i = 0; i < options.HttpMessageHandlerBuilderActions.Count; i++)
+                        {
+                            options.HttpMessageHandlerBuilderActions[i](b);
+                        }
+                    }
+                    else
+                    {
+                        for (int i = 0; i < options.PrimaryHandlerActions.Count; i++)
+                        {
+                            options.PrimaryHandlerActions[i](b);
+                        }
+
+                        for (int i = 0; i < options.AdditionalHandlersActions.Count; i++)
+                        {
+                            options.AdditionalHandlersActions[i](b);
+                        }
                     }
 
                     // Logging is added separately in the end. But for now it should be still possible to override it via filters...

--- a/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpMessageHandlerBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpMessageHandlerBuilder.cs
@@ -36,16 +36,8 @@ namespace Microsoft.Extensions.Http
             {
                 if (_primaryHandler is null && !PrimaryHandlerIsSet)
                 {
-                    _primaryHandler =
-#if NET5_0_OR_GREATER
-                        SocketsHttpHandler.IsSupported
-                            // There's a lot of erroneous usecases when a client gets captured by a singleton.
-                            // This should make the default case better by preventing the loss of DNS changes.
-                            ? new SocketsHttpHandler() { PooledConnectionLifetime = HttpClientFactoryOptions.DefaultHandlerLifetime }
-                            : new HttpClientHandler();
-#else
-                        new HttpClientHandler();
-#endif
+                    _primaryHandler = new HttpClientHandler();
+                    PrimaryHandlerIsSet = true;
                 }
                 return _primaryHandler!;
             }

--- a/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
-                options.HttpMessageHandlerBuilderActions.Add(b => b.AdditionalHandlers.Add(configureHandler()));
+                options.AddAdditionalHandlersAction(b => b.AdditionalHandlers.Add(configureHandler()));
             });
 
             return builder;
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
-                options.HttpMessageHandlerBuilderActions.Add(b => b.AdditionalHandlers.Add(configureHandler(b.Services)));
+                options.AddAdditionalHandlersAction(b => b.AdditionalHandlers.Add(configureHandler(b.Services)));
             });
 
             return builder;
@@ -133,7 +133,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
-                options.HttpMessageHandlerBuilderActions.Add(b =>
+                options.AddAdditionalHandlersAction(b =>
                 {
                     THandler? handler = null;
                     if (b.Services is IKeyedServiceProvider keyedProvider)
@@ -167,7 +167,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
-                options.HttpMessageHandlerBuilderActions.Add(b => b.PrimaryHandler = configureHandler());
+                options.AddPrimaryHandlerAction(b => b.PrimaryHandler = configureHandler(), updatesExistingHandler: false);
             });
 
             return builder;
@@ -197,7 +197,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
-                options.HttpMessageHandlerBuilderActions.Add(b => b.PrimaryHandler = configureHandler(b.Services));
+                options.AddPrimaryHandlerAction(b => b.PrimaryHandler = configureHandler(b.Services), updatesExistingHandler: false);
             });
 
             return builder;
@@ -225,7 +225,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
-                options.HttpMessageHandlerBuilderActions.Add(b =>
+                options.AddPrimaryHandlerAction(b =>
                 {
                     THandler? handler = null;
                     if (b.Services is IKeyedServiceProvider keyedProvider)
@@ -235,7 +235,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     handler ??= b.Services.GetRequiredService<THandler>();
 
                     b.PrimaryHandler = handler;
-                });
+                },
+                updatesExistingHandler: false);
             });
 
             return builder;
@@ -261,7 +262,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
-                options.HttpMessageHandlerBuilderActions.Add(b => configureHandler(b.PrimaryHandler, b.Services));
+                options.AddPrimaryHandlerAction(b => configureHandler(b.PrimaryHandler, b.Services), updatesExistingHandler: true);
             });
 
             return builder;
@@ -308,7 +309,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
-                options.HttpMessageHandlerBuilderActions.Add(b =>
+                options.AddPrimaryHandlerAction(b =>
                 {
                     SocketsHttpHandler? handler = null;
 
@@ -322,7 +323,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     configureHandler?.Invoke(handler, b.Services);
                     b.PrimaryHandler = handler;
-                });
+                },
+                updatesExistingHandler: true);
             });
 
             return builder;
@@ -696,7 +698,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
-                options.HttpMessageHandlerBuilderActions.Add(b => configureAdditionalHandlers(b.AdditionalHandlers, b.Services));
+                options.AddAdditionalHandlersAction(b => configureAdditionalHandlers(b.AdditionalHandlers, b.Services));
             });
 
             return builder;

--- a/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(name);
 
             AddHttpClient(services);
+            services.AddKeyedHttpClient(name);
 
             return new DefaultHttpClientBuilder(services, name);
         }
@@ -133,6 +134,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(configureClient);
 
             AddHttpClient(services);
+            services.AddKeyedHttpClient(name);
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
@@ -163,6 +165,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(configureClient);
 
             AddHttpClient(services);
+            services.AddKeyedHttpClient(name);
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
@@ -200,6 +203,8 @@ namespace Microsoft.Extensions.DependencyInjection
             AddHttpClient(services);
 
             string name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            services.AddKeyedHttpClient(name);
+
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.AddTypedClientCore<TClient>(validateSingleType: true);
             return builder;
@@ -241,6 +246,8 @@ namespace Microsoft.Extensions.DependencyInjection
             AddHttpClient(services);
 
             string name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            services.AddKeyedHttpClient(name);
+
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.AddTypedClientCore<TClient, TImplementation>(validateSingleType: true);
             return builder;
@@ -279,8 +286,10 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(name);
 
             AddHttpClient(services);
+            services.AddKeyedHttpClient(name);
 
             var builder = new DefaultHttpClientBuilder(services, name);
+
             builder.AddTypedClientCore<TClient>(validateSingleType: false); // Name was explicitly provided.
             return builder;
         }
@@ -323,6 +332,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(name);
 
             AddHttpClient(services);
+            services.AddKeyedHttpClient(name);
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.AddTypedClientCore<TClient, TImplementation>(validateSingleType: false); // name was explicitly provided
@@ -362,6 +372,8 @@ namespace Microsoft.Extensions.DependencyInjection
             AddHttpClient(services);
 
             string name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            services.AddKeyedHttpClient(name);
+
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
             builder.AddTypedClientCore<TClient>(validateSingleType: true);
@@ -401,6 +413,8 @@ namespace Microsoft.Extensions.DependencyInjection
             AddHttpClient(services);
 
             string name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            services.AddKeyedHttpClient(name);
+
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
             builder.AddTypedClientCore<TClient>(validateSingleType: true);
@@ -445,6 +459,8 @@ namespace Microsoft.Extensions.DependencyInjection
             AddHttpClient(services);
 
             string name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            services.AddKeyedHttpClient(name);
+
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
             builder.AddTypedClientCore<TClient, TImplementation>(validateSingleType: true);
@@ -489,6 +505,8 @@ namespace Microsoft.Extensions.DependencyInjection
             AddHttpClient(services);
 
             string name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            services.AddKeyedHttpClient(name);
+
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
             builder.AddTypedClientCore<TClient, TImplementation>(validateSingleType: true);
@@ -530,6 +548,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(configureClient);
 
             AddHttpClient(services);
+            services.AddKeyedHttpClient(name);
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
@@ -572,6 +591,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(configureClient);
 
             AddHttpClient(services);
+            services.AddKeyedHttpClient(name);
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
@@ -619,6 +639,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(configureClient);
 
             AddHttpClient(services);
+            services.AddKeyedHttpClient(name);
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
@@ -666,6 +687,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(configureClient);
 
             AddHttpClient(services);
+            services.AddKeyedHttpClient(name);
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
@@ -706,6 +728,8 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(factory);
 
             string name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            services.AddKeyedHttpClient(name);
+
             return AddHttpClient<TClient, TImplementation>(services, name, factory);
         }
 
@@ -746,6 +770,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(factory);
 
             AddHttpClient(services);
+            services.AddKeyedHttpClient(name);
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.AddTypedClient<TClient>(factory);
@@ -785,6 +810,8 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(factory);
 
             string name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            services.AddKeyedHttpClient(name);
+
             return AddHttpClient<TClient, TImplementation>(services, name, factory);
         }
 
@@ -823,10 +850,29 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(factory);
 
             AddHttpClient(services);
+            services.AddKeyedHttpClient(name);
 
             var builder = new DefaultHttpClientBuilder(services, name);
             builder.AddTypedClient<TClient>(factory);
             return builder;
+        }
+
+        private static IServiceCollection AddKeyedHttpClient(this IServiceCollection services, string name)
+        {
+            services.AddKeyedTransient<HttpClient>(name, KeyedCreateClient)
+                .AddKeyedTransient<HttpMessageHandler>(name, KeyedCreateHandler);
+
+            return services;
+        }
+
+        private static HttpClient KeyedCreateClient(IServiceProvider services, object? key)
+        {
+            return services.GetRequiredService<IHttpClientFactory>().CreateClient((string?)key ?? string.Empty);
+        }
+
+        private static HttpMessageHandler KeyedCreateHandler(IServiceProvider services, object? key)
+        {
+            return services.GetRequiredService<IHttpMessageHandlerFactory>().CreateHandler((string?)key ?? string.Empty);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Http/src/HttpClientFactoryOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/HttpClientFactoryOptions.cs
@@ -19,9 +19,8 @@ namespace Microsoft.Extensions.Http
         //
         // IMPORTANT: MinimumHandlerLifetime is used in a resource string. Update the resource if this changes.
         internal static readonly TimeSpan MinimumHandlerLifetime = TimeSpan.FromSeconds(1);
-        internal static readonly TimeSpan DefaultHandlerLifetime = TimeSpan.FromMinutes(2);
 
-        private TimeSpan _handlerLifetime = DefaultHandlerLifetime;
+        private TimeSpan _handlerLifetime = TimeSpan.FromMinutes(2);
 
         /// <summary>
         /// Gets a list of operations used to configure an <see cref="HttpMessageHandlerBuilder"/>.

--- a/src/libraries/Microsoft.Extensions.Http/src/HttpClientFactoryOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/HttpClientFactoryOptions.cs
@@ -16,10 +16,11 @@ namespace Microsoft.Extensions.Http
     {
         // Establishing a minimum lifetime helps us avoid some possible destructive cases.
         //
-        // IMPORTANT: This is used in a resource string. Update the resource if this changes.
+        // IMPORTANT: MinimumHandlerLifetime is used in a resource string. Update the resource if this changes.
         internal static readonly TimeSpan MinimumHandlerLifetime = TimeSpan.FromSeconds(1);
+        internal static readonly TimeSpan DefaultHandlerLifetime = TimeSpan.FromMinutes(2);
 
-        private TimeSpan _handlerLifetime = TimeSpan.FromMinutes(2);
+        private TimeSpan _handlerLifetime = DefaultHandlerLifetime;
 
         /// <summary>
         /// Gets a list of operations used to configure an <see cref="HttpMessageHandlerBuilder"/>.

--- a/src/libraries/Microsoft.Extensions.Http/src/HttpMessageHandlerBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/HttpMessageHandlerBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.Http
     /// a transient service. Callers should retrieve a new instance for each <see cref="HttpMessageHandler"/> to
     /// be created. Implementors should expect each instance to be used a single time.
     /// </remarks>
-    public abstract class HttpMessageHandlerBuilder
+    public abstract class HttpMessageHandlerBuilder : IPrimaryHandlerBuilder, IAdditionalHandlersBuilder
     {
         /// <summary>
         /// Gets or sets the name of the <see cref="HttpClient"/> being created.
@@ -117,5 +117,22 @@ namespace Microsoft.Extensions.Http
 
             return next;
         }
+    }
+
+    internal interface IHandlerBuilder
+    {
+        [DisallowNull]
+        string? Name { get; set; }
+        IServiceProvider Services { get; }
+    }
+
+    internal interface IPrimaryHandlerBuilder : IHandlerBuilder
+    {
+        HttpMessageHandler PrimaryHandler { get; set; }
+    }
+
+    internal interface IAdditionalHandlersBuilder : IHandlerBuilder
+    {
+        IList<DelegatingHandler> AdditionalHandlers { get; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DefaultHttpMessageHandlerBuilderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DefaultHttpMessageHandlerBuilderTest.cs
@@ -21,14 +21,20 @@ namespace Microsoft.Extensions.Http
         // Testing this because it's an important design detail. If someone wants to globally replace the handler
         // they can do so by replacing this service. It's important that the Factory isn't the one to instantiate
         // the handler. The factory has no defaults - it only applies options.
-        [Fact] 
+        [Fact]
         public void Ctor_SetsPrimaryHandler()
         {
             // Arrange & Act
             var builder = new DefaultHttpMessageHandlerBuilder(Services);
 
             // Act
+#if NET5_0_OR_GREATER
+            HttpMessageHandler _ = SocketsHttpHandler.IsSupported
+                ? Assert.IsType<SocketsHttpHandler>(builder.PrimaryHandler)
+                : Assert.IsType<HttpClientHandler>(builder.PrimaryHandler);
+#else
             Assert.IsType<HttpClientHandler>(builder.PrimaryHandler);
+#endif
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DefaultHttpMessageHandlerBuilderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DefaultHttpMessageHandlerBuilderTest.cs
@@ -27,14 +27,8 @@ namespace Microsoft.Extensions.Http
             // Arrange & Act
             var builder = new DefaultHttpMessageHandlerBuilder(Services);
 
-            // Act
-#if NET5_0_OR_GREATER
-            HttpMessageHandler _ = SocketsHttpHandler.IsSupported
-                ? Assert.IsType<SocketsHttpHandler>(builder.PrimaryHandler)
-                : Assert.IsType<HttpClientHandler>(builder.PrimaryHandler);
-#else
+            // Assert
             Assert.IsType<HttpClientHandler>(builder.PrimaryHandler);
-#endif
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DependencyInjection/HttpClientKeyedRegistrationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DependencyInjection/HttpClientKeyedRegistrationTest.cs
@@ -1,0 +1,260 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Http.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Xunit;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public class HttpClientKeyedRegistrationTest
+    {
+        [Fact]
+        public void HttpClient_ResolvedAsKeyedService_Success()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddHttpClient("test", c => c.BaseAddress = new Uri("http://example.com"));
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            var client = services.GetRequiredKeyedService<HttpClient>("test");
+
+            Assert.Equal(new Uri("http://example.com"), client.BaseAddress);
+        }
+
+        [Fact]
+        public void HttpClient_ResolvedAsKeyedService_AbsentClient()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddHttpClient("test");
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            var client = services.GetKeyedService<HttpClient>("absent");
+
+            Assert.Null(client);
+        }
+        [Fact]
+        public void HttpMessageHandler_ResolvedAsKeyedService_Success()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddHttpClient("test")
+                .ConfigurePrimaryHttpMessageHandler(() => new TestMessageHandler());
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            var handler = services.GetRequiredKeyedService<HttpMessageHandler>("test");
+            while (handler is DelegatingHandler dh)
+            {
+                handler = dh.InnerHandler;
+            }
+
+            Assert.IsType<TestMessageHandler>(handler);
+        }
+
+        [Fact]
+        public void HttpMessageHandler_ResolvedAsKeyedService_AbsentHandler()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddHttpClient("test");
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            var handler = services.GetKeyedService<HttpMessageHandler>("absent");
+
+            Assert.Null(handler);
+        }
+
+        [Fact]
+        public void HttpClient_InjectedAsKeyedService_Success()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddHttpClient("test", c => c.BaseAddress = new Uri("http://example.com"));
+            serviceCollection.AddSingleton<KeyedClientTestService>();
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            var testService = services.GetRequiredService<KeyedClientTestService>();
+
+            Assert.Equal(new Uri("http://example.com"), testService.HttpClient.BaseAddress);
+        }
+
+        [Fact]
+        public void AdditionalHandler_InjectedAsKeyedService_Success()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddKeyedTransient<KeyedDelegatingHandler>(KeyedService.AnyKey);
+            serviceCollection.AddHttpClient("test")
+                .AddHttpMessageHandler<KeyedDelegatingHandler>();
+            serviceCollection.AddHttpClient("test2")
+                .AddHttpMessageHandler<KeyedDelegatingHandler>();
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            ValidateHandler("test");
+            ValidateHandler("test2");
+
+            void ValidateHandler(string clientName)
+            {
+                var handler = services.GetRequiredKeyedService<HttpMessageHandler>(clientName);
+                while (handler is DelegatingHandler dh)
+                {
+                    if (dh is KeyedDelegatingHandler)
+                    {
+                        break;
+                    }
+                    handler = dh.InnerHandler;
+                }
+
+                var keyedHandler = Assert.IsType<KeyedDelegatingHandler>(handler);
+                Assert.Equal(clientName, keyedHandler.Key);
+            }
+        }
+
+        [Fact]
+        public void PrimaryHandler_InjectedAsKeyedService_Success()
+        {
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddKeyedTransient<BaseKeyedHandler, KeyedPrimaryHandler>("test");
+            serviceCollection.AddKeyedTransient<BaseKeyedHandler, OtherKeyedPrimaryHandler>("other-implementation");
+            serviceCollection.AddTransient<BaseKeyedHandler>(_ => new KeyedPrimaryHandler("non-keyed-fallback"));
+
+            serviceCollection.AddHttpClient("test")
+                .ConfigurePrimaryHttpMessageHandler<BaseKeyedHandler>();
+            serviceCollection.AddHttpClient("other-implementation")
+                .ConfigurePrimaryHttpMessageHandler<BaseKeyedHandler>();
+            serviceCollection.AddHttpClient("non-keyed")
+                .ConfigurePrimaryHttpMessageHandler<BaseKeyedHandler>();
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            var handler = services.GetRequiredKeyedService<HttpMessageHandler>("test");
+            while (handler is DelegatingHandler dh)
+            {
+                handler = dh.InnerHandler;
+            }
+            var keyedHandler = Assert.IsType<KeyedPrimaryHandler>(handler);
+            Assert.Equal("test", keyedHandler.Key);
+
+            var otherHandler = services.GetRequiredService<IHttpMessageHandlerFactory>().CreateHandler("other-implementation");
+            while (otherHandler is DelegatingHandler odh)
+            {
+                otherHandler = odh.InnerHandler;
+            }
+            var otherKeyedHandler = Assert.IsType<OtherKeyedPrimaryHandler>(otherHandler);
+            Assert.Equal("{ \"key\": \"other-implementation\" }", otherKeyedHandler.Key);
+
+            var fallbackHandler = services.GetRequiredKeyedService<HttpMessageHandler>("non-keyed");
+            while (fallbackHandler is DelegatingHandler fdh)
+            {
+                fallbackHandler = fdh.InnerHandler;
+            }
+            var nonKeyedHandler = Assert.IsType<KeyedPrimaryHandler>(fallbackHandler);
+            Assert.Equal("non-keyed-fallback", nonKeyedHandler.Key);
+        }
+
+        [Fact]
+        public async Task HttpClientLogger_InjectedAsKeyedService_Success()
+        {
+            var sink = new TestSink();
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging();
+            serviceCollection.AddSingleton<ILoggerFactory>(new TestLoggerFactory(sink, enabled: true));
+            serviceCollection.AddTransient<TestMessageHandler>();
+            serviceCollection.AddKeyedSingleton<KeyedHttpClientLogger>(KeyedService.AnyKey);
+
+            serviceCollection.AddHttpClient("FirstClient")
+                .ConfigurePrimaryHttpMessageHandler<TestMessageHandler>()
+                .RemoveAllLoggers()
+                .AddLogger<KeyedHttpClientLogger>();
+
+            serviceCollection.AddHttpClient("SecondClient")
+                .ConfigurePrimaryHttpMessageHandler<TestMessageHandler>()
+                .RemoveAllLoggers()
+                .AddLogger<KeyedHttpClientLogger>();
+
+            var services = serviceCollection.BuildServiceProvider();
+            var factory = services.GetRequiredService<IHttpClientFactory>();
+
+            var client1 = factory.CreateClient("FirstClient");
+            var client2 = factory.CreateClient("SecondClient");
+
+            _ = await client1.GetAsync(new Uri("http://example.com"));
+            Assert.Equal(2, sink.Writes.Count);
+            Assert.Equal(2, sink.Writes.Count(w => w.LoggerName == typeof(KeyedHttpClientLogger).FullName + ".FirstClient"));
+
+            _ = await client2.GetAsync(new Uri("http://example.com"));
+            Assert.Equal(4, sink.Writes.Count);
+            Assert.Equal(2, sink.Writes.Count(w => w.LoggerName == typeof(KeyedHttpClientLogger).FullName + ".SecondClient"));
+        }
+
+        internal class KeyedClientTestService
+        {
+            public KeyedClientTestService([FromKeyedServices("test")] HttpClient httpClient)
+            {
+                HttpClient = httpClient;
+            }
+
+            public HttpClient HttpClient { get; }
+        }
+
+        internal class KeyedDelegatingHandler : DelegatingHandler
+        {
+            public string Key { get; }
+
+            public KeyedDelegatingHandler([ServiceKey] string key)
+            {
+                Key = key;
+            }
+        }
+
+        internal abstract class BaseKeyedHandler : TestMessageHandler
+        {
+            public string Key { get; protected set; }
+        }
+
+        internal class KeyedPrimaryHandler : BaseKeyedHandler
+        {
+            public KeyedPrimaryHandler([ServiceKey] string key)
+            {
+                Key = key;
+            }
+        }
+
+        internal class OtherKeyedPrimaryHandler : BaseKeyedHandler
+        {
+            public OtherKeyedPrimaryHandler([ServiceKey] string key)
+            {
+                Key = "{ \"key\": \"" + key + "\" }";
+            }
+        }
+
+        internal class KeyedHttpClientLogger : IHttpClientLogger
+        {
+            private readonly ILogger _logger;
+            public KeyedHttpClientLogger(ILoggerFactory loggerFactory, [ServiceKey] string key)
+            {
+                _logger = loggerFactory.CreateLogger(typeof(KeyedHttpClientLogger).FullName + "." + key);
+            }
+
+            public object? LogRequestStart(HttpRequestMessage request)
+            {
+                _logger.LogInformation("LogRequestStart");
+                return null;
+            }
+
+            public void LogRequestStop(object? context, HttpRequestMessage request, HttpResponseMessage response, TimeSpan elapsed)
+                => _logger.LogInformation("LogRequestStop");
+
+            public void LogRequestFailed(object? context, HttpRequestMessage request, HttpResponseMessage? response, Exception exception,TimeSpan elapsed)
+                => _logger.LogInformation("LogRequestFailed");
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/SocketsHttpHandlerConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/SocketsHttpHandlerConfigurationTest.cs
@@ -40,13 +40,10 @@ namespace Microsoft.Extensions.Http
             var messageHandlerFactory = services.GetRequiredService<IHttpMessageHandlerFactory>();
 
             var defaultPrimaryHandlerChain = messageHandlerFactory.CreateHandler("DefaultPrimaryHandler");
-            var useSocketsHttpHandlerChain = messageHandlerFactory.CreateHandler("UseSocketsHttpHandler");
+            var socketsHttpHandlerChain = messageHandlerFactory.CreateHandler("UseSocketsHttpHandler");
 
-            var defaultPrimaryHandler = Assert.IsType<SocketsHttpHandler>(GetPrimaryHandler(defaultPrimaryHandlerChain));
-            var useSocketsHttpHandler = Assert.IsType<SocketsHttpHandler>(GetPrimaryHandler(useSocketsHttpHandlerChain));
-
-            Assert.Equal(HttpClientFactoryOptions.DefaultHandlerLifetime, defaultPrimaryHandler.PooledConnectionLifetime); // opinionated default
-            Assert.Equal(Timeout.InfiniteTimeSpan, useSocketsHttpHandler.PooledConnectionLifetime); // clear unconfigured instance
+            Assert.IsType<HttpClientHandler>(GetPrimaryHandler(defaultPrimaryHandlerChain));
+            Assert.IsType<SocketsHttpHandler>(GetPrimaryHandler(socketsHttpHandlerChain));
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/SocketsHttpHandlerConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/SocketsHttpHandlerConfigurationTest.cs
@@ -33,17 +33,20 @@ namespace Microsoft.Extensions.Http
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddHttpClient("DefaultPrimaryHandler");
 
-            serviceCollection.AddHttpClient("SocketsHttpHandler")
+            serviceCollection.AddHttpClient("UseSocketsHttpHandler")
                 .UseSocketsHttpHandler();
 
             var services = serviceCollection.BuildServiceProvider();
             var messageHandlerFactory = services.GetRequiredService<IHttpMessageHandlerFactory>();
 
             var defaultPrimaryHandlerChain = messageHandlerFactory.CreateHandler("DefaultPrimaryHandler");
-            var socketsHttpHandlerChain = messageHandlerFactory.CreateHandler("SocketsHttpHandler");
+            var useSocketsHttpHandlerChain = messageHandlerFactory.CreateHandler("UseSocketsHttpHandler");
 
-            Assert.IsType<HttpClientHandler>(GetPrimaryHandler(defaultPrimaryHandlerChain));
-            Assert.IsType<SocketsHttpHandler>(GetPrimaryHandler(socketsHttpHandlerChain));
+            var defaultPrimaryHandler = Assert.IsType<SocketsHttpHandler>(GetPrimaryHandler(defaultPrimaryHandlerChain));
+            var useSocketsHttpHandler = Assert.IsType<SocketsHttpHandler>(GetPrimaryHandler(useSocketsHttpHandlerChain));
+
+            Assert.Equal(HttpClientFactoryOptions.DefaultHandlerLifetime, defaultPrimaryHandler.PooledConnectionLifetime); // opinionated default
+            Assert.Equal(Timeout.InfiniteTimeSpan, useSocketsHttpHandler.PooledConnectionLifetime); // clear unconfigured instance
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]


### PR DESCRIPTION
1. `HttpClient` (and `HttpMessageHandler` chain) are registered as _keyed transients_ with client name as the key
2. Generic parameters from `AddHttpMessageHandler`, `ConfigurePrimaryHttpMessageHandler` and `AddLogger` overloads are resolved as keyed by client name if possible, otherwise fall back to ordinary resolve
3. Reduced unnecessary primary handler allocations

_Transient_ lifetime was chosen to make this
```c#
var client1 = services.GetRequiredKeyedService<HttpClient>(name);
var client2 = services.GetRequiredKeyedService<HttpClient>(name); // new instance
```
functionally equivalent to this
```c#
var client1 = factory.CreateClient(name);
var client2 = factory.CreateClient(name); // new instance
```
Especially if needed to use in singletons.
I've considered scoped lifetime, but it would be too confusing with typed clients being transient and named clients created by factory being essentially transient.

_Scenarios made possible by (1):_

Constructor injection with the attribute (can substitute Typed clients):
```c#
class KeyedClientTestService
{
    public KeyedClientTestService([FromKeyedServices("test")] HttpClient httpClient)
    {
        HttpClient = httpClient;
    }
```

Resolving by name directly from service provider (needed when name is not a compile-time constant):
```c#
var client = services.GetRequiredKeyedService<HttpClient>(name);
// or
var handler = services.GetRequiredKeyedService<HttpMessageHandler>(name);
```

_Scenarios made possible by (2):_

Registering different implementations per name
```c#
serviceCollection.AddKeyedSingleton<BaseLogger, FirstClientLogger>("FirstClient");
serviceCollection.AddKeyedSingleton<BaseLogger, SecondClientLogger>("SecondClient");

serviceCollection.AddHttpClient("FirstClient")
    .AddLogger<BaseLogger>(); // will use FirstClientLogger

serviceCollection.AddHttpClient("SecondClient")
    .AddLogger<BaseLogger>(); // will use SecondClientLogger
```

Easy access to client name from implementation
```c#
serviceCollection.AddKeyedSingleton<KeyedHttpClientLogger>(KeyedService.AnyKey); // registered only once

serviceCollection.AddHttpClient("FirstClient")
    .AddLogger<KeyedHttpClientLogger>(); // "KeyedHttpClientLogger.FirstClient" category

serviceCollection.AddHttpClient("SecondClient")
    .AddLogger<KeyedHttpClientLogger>(); // "KeyedHttpClientLogger.SecondClient" category

class KeyedHttpClientLogger : IHttpClientLogger
{
    private readonly ILogger _logger;
    public KeyedHttpClientLogger(ILoggerFactory loggerFactory, [ServiceKey] string key)
    {
        _logger = loggerFactory.CreateLogger(nameof(KeyedHttpClientLogger) + "." + key);
    }
```

Fixes #89755