### PR TITLE
Use generated version files when printing/tracing host version info

### DIFF
--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -6,8 +6,6 @@
 
     <_BuildNativeTargetOS>$(TargetOS)</_BuildNativeTargetOS>
     <_BuildNativeTargetOS Condition="'$(TargetsLinuxBionic)' == 'true'">linux-bionic</_BuildNativeTargetOS>
-    <BuildRuntimeDependsOn>GetPgoDataPackagePath;GetProductVersions</BuildRuntimeDependsOn>
-    <BuildRuntimeDependsOn Condition="'$(EnableSourceControlManagerQueries)' == 'true'">$(BuildRuntimeDependsOn);InitializeSourceControlInformationFromSourceControlManager</BuildRuntimeDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +19,7 @@
   <Import Project="$(RepositoryEngineeringDir)nativepgo.targets" />
 
   <Target Name="BuildRuntime"
-          DependsOnTargets="$(BuildRuntimeDependsOn)"
+          DependsOnTargets="GetPgoDataPackagePath"
           BeforeTargets="Build">
     <ItemGroup>
       <_CMakeArgs Include="$(CMakeArgs)" />
@@ -52,9 +50,6 @@
       <_CoreClrBuildArg Condition="'$(HostCrossOS)' != ''" Include="-hostos $(HostCrossOS)" />
       <_CoreClrBuildArg Include="-outputrid $(OutputRID)" />
       <_CoreClrBuildArg Condition="'$(BuildSubdirectory)' != ''" Include="-subdir $(BuildSubdirectory)" />
-
-      <_CoreClrBuildArg Include="-cmakeargs &quot;-DCLI_CMAKE_COMMIT_HASH=$([MSBuild]::ValueOrDefault('$(SourceRevisionId)', 'N/A'))&quot;" />
-      <_CoreClrBuildArg Include="-cmakeargs &quot;-DCLI_CMAKE_HOST_VER=$(HostVersion)&quot;" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(ClrFullNativeBuild)' != 'true'">

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -6,6 +6,8 @@
 
     <_BuildNativeTargetOS>$(TargetOS)</_BuildNativeTargetOS>
     <_BuildNativeTargetOS Condition="'$(TargetsLinuxBionic)' == 'true'">linux-bionic</_BuildNativeTargetOS>
+    <BuildRuntimeDependsOn>GetPgoDataPackagePath;GetProductVersions</BuildRuntimeDependsOn>
+    <BuildRuntimeDependsOn Condition="'$(EnableSourceControlManagerQueries)' == 'true'">$(BuildRuntimeDependsOn);InitializeSourceControlInformationFromSourceControlManager</BuildRuntimeDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,7 +21,7 @@
   <Import Project="$(RepositoryEngineeringDir)nativepgo.targets" />
 
   <Target Name="BuildRuntime"
-          DependsOnTargets="GetPgoDataPackagePath"
+          DependsOnTargets="$(BuildRuntimeDependsOn)"
           BeforeTargets="Build">
     <ItemGroup>
       <_CMakeArgs Include="$(CMakeArgs)" />
@@ -50,6 +52,9 @@
       <_CoreClrBuildArg Condition="'$(HostCrossOS)' != ''" Include="-hostos $(HostCrossOS)" />
       <_CoreClrBuildArg Include="-outputrid $(OutputRID)" />
       <_CoreClrBuildArg Condition="'$(BuildSubdirectory)' != ''" Include="-subdir $(BuildSubdirectory)" />
+
+      <_CoreClrBuildArg Include="-cmakeargs &quot;-DCLI_CMAKE_COMMIT_HASH=$([MSBuild]::ValueOrDefault('$(SourceRevisionId)', 'N/A'))&quot;" />
+      <_CoreClrBuildArg Include="-cmakeargs &quot;-DCLI_CMAKE_HOST_VER=$(HostVersion)&quot;" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(ClrFullNativeBuild)' != 'true'">

--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -77,7 +77,7 @@ namespace
         pal::string_t msg = _X("Architecture: ");
         msg.append(get_current_arch_name());
         msg.append(_X("\n")
-            _X("App host version: ") _STRINGIFY(COMMON_HOST_PKG_VER) _X("\n\n"));
+            _X("App host version: ") _STRINGIFY(HOST_VERSION) _X("\n\n"));
         return msg;
     }
 
@@ -305,7 +305,7 @@ namespace
                     details = get_apphost_details_message();
                     url = get_download_url();
                     url.append(_X("&apphost_version="));
-                    url.append(_STRINGIFY(COMMON_HOST_PKG_VER));
+                    url.append(_STRINGIFY(HOST_VERSION));
                 }
             }
 

--- a/src/native/corehost/build.cmd
+++ b/src/native/corehost/build.cmd
@@ -38,10 +38,6 @@ if /i [%1] == [arm64]       (set __BuildArch=arm64&&shift&goto Arg_Loop)
 if /i [%1] == [portable]    (set __PortableBuild=1&&shift&goto Arg_Loop)
 if /i [%1] == [outputrid]   (set __OutputRid=%2&&shift&&shift&goto Arg_Loop)
 if /i [%1] == [toolsetDir]  (set "__ToolsetDir=%2"&&shift&&shift&goto Arg_Loop)
-if /i [%1] == [hostver]     (set __HostVersion=%2&&shift&&shift&goto Arg_Loop)
-if /i [%1] == [apphostver]  (set __AppHostVersion=%2&&shift&&shift&goto Arg_Loop)
-if /i [%1] == [fxrver]      (set __HostFxrVersion=%2&&shift&&shift&goto Arg_Loop)
-if /i [%1] == [policyver]   (set __HostPolicyVersion=%2&&shift&&shift&goto Arg_Loop)
 if /i [%1] == [commit]      (set __CommitSha=%2&&shift&&shift&goto Arg_Loop)
 
 if /i [%1] == [configureonly] (set __ConfigureOnly=1&&shift&goto Arg_Loop)
@@ -107,8 +103,7 @@ for /f "delims=-" %%i in ("%__OutputRid%") do set __HostFallbackOS=%%i
 :: The "win" host build is Windows 10 compatible
 if "%__HostFallbackOS%" == "win"       (set __HostFallbackOS=win10)
 
-set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCLI_CMAKE_HOST_VER=%__HostVersion%" "-DCLI_CMAKE_COMMON_HOST_VER=%__AppHostVersion%" "-DCLI_CMAKE_HOST_FXR_VER=%__HostFxrVersion%"
-set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCLI_CMAKE_HOST_POLICY_VER=%__HostPolicyVersion%" "-DCLI_CMAKE_PKG_RID=%cm_BaseRid%" "-DCLI_CMAKE_FALLBACK_OS=%__HostFallbackOS%" "-DCLI_CMAKE_COMMIT_HASH=%__CommitSha%"
+set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCLI_CMAKE_PKG_RID=%cm_BaseRid%" "-DCLI_CMAKE_FALLBACK_OS=%__HostFallbackOS%" "-DCLI_CMAKE_COMMIT_HASH=%__CommitSha%"
 set __ExtraCmakeParams=%__ExtraCmakeParams% "-DRUNTIME_FLAVOR=%__RuntimeFlavor% "
 set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCLI_CMAKE_RESOURCE_DIR=%__ResourcesDir%" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%"
 

--- a/src/native/corehost/build.sh
+++ b/src/native/corehost/build.sh
@@ -32,26 +32,6 @@ __commit_hash=
 handle_arguments() {
 
     case "$1" in
-        hostver|-hostver)
-            __host_ver="$2"
-            __ShiftArgs=1
-            ;;
-
-        apphostver|-apphostver)
-            __apphost_ver="$2"
-            __ShiftArgs=1
-            ;;
-
-        fxrver|-fxrver)
-            __fxr_ver="$2"
-            __ShiftArgs=1
-            ;;
-
-        policyver|-policyver)
-            __policy_ver="$2"
-            __ShiftArgs=1
-            ;;
-
         commithash|-commithash)
             __commit_hash="$2"
             __ShiftArgs=1
@@ -79,8 +59,7 @@ __IntermediatesDir="$__RootBinDir/obj/$__OutputRid.$__BuildType"
 
 export __BinDir __IntermediatesDir __RuntimeFlavor
 
-__CMakeArgs="-DCLI_CMAKE_HOST_VER=\"$__host_ver\" -DCLI_CMAKE_COMMON_HOST_VER=\"$__apphost_ver\" -DCLI_CMAKE_HOST_FXR_VER=\"$__fxr_ver\" $__CMakeArgs"
-__CMakeArgs="-DCLI_CMAKE_HOST_POLICY_VER=\"$__policy_ver\" -DCLI_CMAKE_PKG_RID=\"$__OutputRid\" -DCLI_CMAKE_FALLBACK_OS=\"$__HostFallbackOS\" -DCLI_CMAKE_COMMIT_HASH=\"$__commit_hash\" $__CMakeArgs"
+__CMakeArgs="-DCLI_CMAKE_PKG_RID=\"$__OutputRid\" -DCLI_CMAKE_FALLBACK_OS=\"$__HostFallbackOS\" -DCLI_CMAKE_COMMIT_HASH=\"$__commit_hash\" $__CMakeArgs"
 __CMakeArgs="-DRUNTIME_FLAVOR=\"$__RuntimeFlavor\" $__CMakeArgs"
 __CMakeArgs="-DFEATURE_DISTRO_AGNOSTIC_SSL=$__PortableBuild $__CMakeArgs"
 

--- a/src/native/corehost/common.cmake
+++ b/src/native/corehost/common.cmake
@@ -13,6 +13,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/)
 include_directories(${CMAKE_CURRENT_LIST_DIR}/)
 include_directories(${CMAKE_CURRENT_LIST_DIR}/../)
 include_directories(${CMAKE_CURRENT_LIST_DIR}/hostmisc)
+include_directories(${CLR_ARTIFACTS_OBJ_DIR}) # Generated version files
 
 set(RESOURCES)
 if (CLR_CMAKE_TARGET_WIN32)

--- a/src/native/corehost/corehost.cpp
+++ b/src/native/corehost/corehost.cpp
@@ -19,7 +19,6 @@
 #endif
 
 #define CURHOST_TYPE    _X("apphost")
-#define CUREXE_PKG_VER  COMMON_HOST_PKG_VER
 #define CURHOST_EXE
 
 /**
@@ -80,7 +79,6 @@ bool is_exe_enabled_for_execution(pal::string_t* app_dll)
 
 #elif !defined(FEATURE_LIBHOST)
 #define CURHOST_TYPE    _X("dotnet")
-#define CUREXE_PKG_VER  HOST_PKG_VER
 #define CURHOST_EXE
 #endif
 
@@ -91,10 +89,10 @@ void need_newer_framework_error(const pal::string_t& dotnet_root, const pal::str
         INSTALL_OR_UPDATE_NET_ERROR_MESSAGE,
         host_path.c_str(),
         get_current_arch_name(),
-        _STRINGIFY(COMMON_HOST_PKG_VER),
+        _STRINGIFY(HOST_VERSION),
         dotnet_root.c_str(),
         get_download_url().c_str(),
-        _STRINGIFY(COMMON_HOST_PKG_VER));
+        _STRINGIFY(HOST_VERSION));
 }
 
 #if defined(CURHOST_EXE)
@@ -294,7 +292,7 @@ int main(const int argc, const pal::char_t* argv[])
 
     if (trace::is_enabled())
     {
-        trace::info(_X("--- Invoked %s [version: %s, commit hash: %s] main = {"), CURHOST_TYPE, _STRINGIFY(CUREXE_PKG_VER), _STRINGIFY(REPO_COMMIT_HASH));
+        trace::info(_X("--- Invoked %s [version: %s] main = {"), CURHOST_TYPE, get_host_version_description().c_str());
         for (int i = 0; i < argc; ++i)
         {
             trace::info(_X("%s"), argv[i]);

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -76,7 +76,7 @@
 
       <_CoreHostUnixTargetOS>$(TargetOS)</_CoreHostUnixTargetOS>
       <_CoreHostUnixTargetOS Condition="'$(TargetsLinuxBionic)' == 'true'">linux-bionic</_CoreHostUnixTargetOS>
-      <BuildArgs>$(Configuration) $(TargetArchitecture) -apphostver "$(AppHostVersion)" -hostver "$(HostVersion)" -fxrver "$(HostResolverVersion)" -policyver "$(HostPolicyVersion)" -commithash "$([MSBuild]::ValueOrDefault('$(SourceRevisionId)', 'N/A'))" -os $(_CoreHostUnixTargetOS)</BuildArgs>
+      <BuildArgs>$(Configuration) $(TargetArchitecture) -commithash "$([MSBuild]::ValueOrDefault('$(SourceRevisionId)', 'N/A'))" -os $(_CoreHostUnixTargetOS)</BuildArgs>
       <BuildArgs>$(BuildArgs) -cmakeargs "-DVERSION_FILE_PATH=$(NativeVersionFile)"</BuildArgs>
       <BuildArgs Condition="'$(ConfigureOnly)' == 'true'">$(BuildArgs) -configureonly</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' != 'true'">$(BuildArgs) -portablebuild=false</BuildArgs>
@@ -139,7 +139,7 @@
     <PropertyGroup>
       <BuildScript>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'build.cmd'))</BuildScript>
 
-      <BuildArgs>$(Configuration) $(TargetArchitecture) apphostver $(AppHostVersion) hostver $(HostVersion) fxrver $(HostResolverVersion) policyver $(HostPolicyVersion) commit $([MSBuild]::ValueOrDefault('$(SourceRevisionId)', 'N/A')) outputrid $(OutputRID)</BuildArgs>
+      <BuildArgs>$(Configuration) $(TargetArchitecture) commit $([MSBuild]::ValueOrDefault('$(SourceRevisionId)', 'N/A')) outputrid $(OutputRID)</BuildArgs>
       <BuildArgs Condition="'$(ConfigureOnly)' == 'true'">$(BuildArgs) configureonly</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' == 'true'">$(BuildArgs) portable</BuildArgs>
       <BuildArgs Condition="'$(IncrementalNativeBuild)' == 'true'">$(BuildArgs) incremental-native-build</BuildArgs>

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -4,11 +4,16 @@
     Add basic project properties for NuGet restore, needed to import the SourceLink MSBuild tool
     package's targets into the build.
   -->
+  <Import Project="$(RepositoryEngineeringDir)versioning.targets" />
+
   <PropertyGroup>
     <IncrementalNativeBuild Condition="'$(IncrementalNativeBuild)' == ''">true</IncrementalNativeBuild>
-    <BuildCoreHostDependsOn>GetProductVersions;GenerateNativeVersionFile</BuildCoreHostDependsOn>
+    <BuildCoreHostDependsOn>GetProductVersions;GenerateRuntimeVersionFile</BuildCoreHostDependsOn>
     <BuildCoreHostDependsOn Condition="'$(EnableSourceControlManagerQueries)' == 'true'">$(BuildCoreHostDependsOn);InitializeSourceControlInformationFromSourceControlManager</BuildCoreHostDependsOn>
     <IntermediateOutputRootPath>$(ArtifactsObjDir)$(OutputRID).$(Configuration)\</IntermediateOutputRootPath>
+    <!-- Global location for version files -->
+    <NativeVersionFile Condition="$([MSBuild]::IsOsPlatform(Windows))">$(ArtifactsObjDir)_version.h</NativeVersionFile>
+    <NativeVersionFile Condition="!$([MSBuild]::IsOsPlatform(Windows))">$(ArtifactsObjDir)_version.c</NativeVersionFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/native/corehost/fxr/command_line.cpp
+++ b/src/native/corehost/fxr/command_line.cpp
@@ -285,7 +285,7 @@ void command_line::print_muxer_info(const pal::string_t &dotnet_root, const pal:
     pal::string_t commit = _STRINGIFY(REPO_COMMIT_HASH);
     trace::println(_X("\n")
         _X("Host:\n")
-        _X("  Version:      ") _STRINGIFY(HOST_FXR_PKG_VER) _X("\n")
+        _X("  Version:      ") _STRINGIFY(HOST_VERSION) _X("\n")
         _X("  Architecture: ") _STRINGIFY(CURRENT_ARCH_NAME) _X("\n")
         _X("  Commit:       %s\n")
         _X("  RID:          %s"),

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -21,7 +21,8 @@ namespace
     void trace_hostfxr_entry_point(const pal::char_t *entry_point)
     {
         trace::setup();
-        trace::info(_X("--- Invoked %s [version: %s, commit hash: %s]"), entry_point, _STRINGIFY(HOST_FXR_PKG_VER), _STRINGIFY(REPO_COMMIT_HASH));
+        if (trace::is_enabled())
+            trace::info(_X("--- Invoked %s [version: %s]"), entry_point, get_host_version_description().c_str());
     }
 }
 
@@ -440,7 +441,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_dotnet_environment_info(
     const hostfxr_dotnet_environment_info environment_info
     {
         sizeof(hostfxr_dotnet_environment_info),
-        _STRINGIFY(HOST_FXR_PKG_VER),
+        _STRINGIFY(HOST_VERSION),
         _STRINGIFY(REPO_COMMIT_HASH),
         environment_sdk_infos.size(),
         (environment_sdk_infos.empty()) ? nullptr : &environment_sdk_infos[0],

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -21,7 +21,7 @@ namespace
     void trace_hostfxr_entry_point(const pal::char_t *entry_point)
     {
         trace::setup();
-        trace::info(_X("--- Invoked %s [commit hash: %s]"), entry_point, _STRINGIFY(REPO_COMMIT_HASH));
+        trace::info(_X("--- Invoked %s [version: %s, commit hash: %s]"), entry_point, _STRINGIFY(HOST_FXR_PKG_VER), _STRINGIFY(REPO_COMMIT_HASH));
     }
 }
 

--- a/src/native/corehost/fxr_resolver.cpp
+++ b/src/native/corehost/fxr_resolver.cpp
@@ -115,10 +115,10 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
             INSTALL_NET_ERROR_MESSAGE,
             host_path.c_str(),
             get_current_arch_name(),
-            _STRINGIFY(COMMON_HOST_PKG_VER),
+            _STRINGIFY(HOST_VERSION),
             _X("Not found"),
             get_download_url().c_str(),
-            _STRINGIFY(COMMON_HOST_PKG_VER));
+            _STRINGIFY(HOST_VERSION));
         return false;
     }
 

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -4,6 +4,11 @@
 #include "utils.h"
 #include "trace.h"
 #include "bundle/info.h"
+#if defined(TARGET_WINDOWS)
+#include <_version.h>
+#else
+#include <_version.c>
+#endif
 
 bool library_exists_in_dir(const pal::string_t& lib_dir, const pal::string_t& lib_name, pal::string_t* p_lib_path)
 {
@@ -469,6 +474,26 @@ pal::string_t get_download_url(const pal::char_t* framework_name, const pal::cha
     url.append(os);
 
     return url;
+}
+
+pal::string_t get_host_version_description()
+{
+#if defined(TARGET_WINDOWS)
+    return _STRINGIFY(VER_PRODUCTVERSION_STR);
+#else
+    pal::string_t info {_STRINGIFY(HOST_VERSION)};
+
+    // sccsid is @(#)Version <file_version> [@Commit: <commit_hash>]
+    // Get the commit portion if available
+    char* commit_maybe = ::strchr(&sccsid[STRING_LENGTH("@(#)Version ")], '@');
+    if (commit_maybe != nullptr)
+    {
+        info.append(" ");
+        info.append(commit_maybe);
+    }
+
+    return info;
+#endif
 }
 
 pal::string_t to_lower(const pal::char_t* in) {

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -7,6 +7,8 @@
 #include "pal.h"
 #include "trace.h"
 #include <type_traits>
+#include <runtime_version.h>
+#include <minipal/utils.h>
 
 #if defined(_WIN32)
 #define DOTNET_CORE_INSTALL_PREREQUISITES_URL _X("https://go.microsoft.com/fwlink/?linkid=798306")
@@ -46,6 +48,11 @@
 #define DOTNET_ROOT_ENV_VAR _X("DOTNET_ROOT")
 
 #define SDK_DOTNET_DLL _X("dotnet.dll")
+
+#define _TEXT(x) #x
+#define _QUOTE(x) _TEXT(x)
+
+#define HOST_VERSION _QUOTE(RuntimeProductVersion)
 
 bool ends_with(const pal::string_t& value, const pal::string_t& suffix, bool match_case);
 bool starts_with(const pal::string_t& value, const pal::string_t& prefix, bool match_case);
@@ -111,6 +118,8 @@ pal::string_t get_dotnet_root_from_fxr_path(const pal::string_t& fxr_path);
 // Get a download URL for a specific framework and version
 // If no framework is specified, a download URL for the runtime is returned
 pal::string_t get_download_url(const pal::char_t* framework_name = nullptr, const pal::char_t* framework_version = nullptr);
+
+pal::string_t get_host_version_description();
 
 pal::string_t to_lower(const pal::char_t* in);
 pal::string_t to_upper(const pal::char_t* in);

--- a/src/native/corehost/hostpolicy/hostpolicy.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy.cpp
@@ -287,12 +287,9 @@ int HOSTPOLICY_CALLTYPE run_app(const int argc, const pal::char_t *argv[])
 
 void trace_hostpolicy_entrypoint_invocation(const pal::string_t& entryPointName)
 {
-    trace::info(_X("--- Invoked hostpolicy [commit hash: %s] [%s,%s,%s][%s] %s = {"),
-        _STRINGIFY(REPO_COMMIT_HASH),
-        _STRINGIFY(HOST_POLICY_PKG_NAME),
+    trace::info(_X("--- Invoked hostpolicy [version: %s, commit hash: %s] %s = {"),
         _STRINGIFY(HOST_POLICY_PKG_VER),
-        _STRINGIFY(HOST_POLICY_PKG_REL_DIR),
-        get_current_arch_name(),
+        _STRINGIFY(REPO_COMMIT_HASH),
         entryPointName.c_str());
 }
 

--- a/src/native/corehost/hostpolicy/hostpolicy.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy.cpp
@@ -287,10 +287,8 @@ int HOSTPOLICY_CALLTYPE run_app(const int argc, const pal::char_t *argv[])
 
 void trace_hostpolicy_entrypoint_invocation(const pal::string_t& entryPointName)
 {
-    trace::info(_X("--- Invoked hostpolicy [version: %s, commit hash: %s] %s = {"),
-        _STRINGIFY(HOST_POLICY_PKG_VER),
-        _STRINGIFY(REPO_COMMIT_HASH),
-        entryPointName.c_str());
+    if (trace::is_enabled())
+        trace::info(_X("--- Invoked hostpolicy [version: %s] %s = {"), get_host_version_description().c_str(), entryPointName.c_str());
 }
 
 //

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -184,7 +184,7 @@ int hostpolicy_context_t::initialize(const hostpolicy_init_t &hostpolicy_init, c
     if (breadcrumbs_enabled)
     {
         pal::string_t policy_name = _STRINGIFY(HOST_POLICY_PKG_NAME);
-        pal::string_t policy_version = _STRINGIFY(HOST_POLICY_PKG_VER);
+        pal::string_t policy_version = _STRINGIFY(HOST_VERSION);
 
         // Always insert the hostpolicy that the code is running on.
         breadcrumbs.insert(policy_name);

--- a/src/native/corehost/setup.cmake
+++ b/src/native/corehost/setup.cmake
@@ -1,17 +1,27 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 
+if("${CLI_CMAKE_COMMIT_HASH}" STREQUAL "")
+    message(FATAL_ERROR "Commit hash needs to be specified to build the host")
+else()
+    add_definitions(-DREPO_COMMIT_HASH="${CLI_CMAKE_COMMIT_HASH}")
+endif()
+
+if("${CLI_CMAKE_HOST_VER}" STREQUAL "")
+    message(FATAL_ERROR "Host version is not specified")
+else()
+    add_definitions(-DHOST_PKG_VER="${CLI_CMAKE_HOST_VER}")
+    # All versions are the same in single-file.
+    if(CLR_SINGLE_FILE_HOST_ONLY)
+        add_definitions(-DCOMMON_HOST_PKG_VER="${CLI_CMAKE_HOST_VER}")
+        add_definitions(-DHOST_POLICY_PKG_VER="${CLI_CMAKE_HOST_VER}")
+        add_definitions(-DHOST_FXR_PKG_VER="${CLI_CMAKE_HOST_VER}")
+    endif()
+endif()
+
 if(CLR_SINGLE_FILE_HOST_ONLY)
-    # CLR partition builds only the single file host where hosting components are all statically linked.
-    # the versioning information is irrelevant and may only come up in tracing.
-    # so we will use "static"
-    add_definitions(-DHOST_POLICY_PKG_VER="static")
-    add_definitions(-DHOST_FXR_PKG_VER="static")
-    add_definitions(-DHOST_PKG_VER="static")
-    add_definitions(-DCOMMON_HOST_PKG_VER="static")
     add_definitions(-DHOST_POLICY_PKG_NAME="static")
     add_definitions(-DHOST_POLICY_PKG_REL_DIR="static")
-    add_definitions(-DREPO_COMMIT_HASH="static")
 else()
     if("${CLI_CMAKE_HOST_POLICY_VER}" STREQUAL "")
         message(FATAL_ERROR "Host policy version is not specified")
@@ -23,12 +33,6 @@ else()
         message(FATAL_ERROR "Host FXR version is not specified")
     else()
         add_definitions(-DHOST_FXR_PKG_VER="${CLI_CMAKE_HOST_FXR_VER}")
-    endif()
-
-    if("${CLI_CMAKE_HOST_VER}" STREQUAL "")
-        message(FATAL_ERROR "Dotnet host version is not specified")
-    else()
-        add_definitions(-DHOST_PKG_VER="${CLI_CMAKE_HOST_VER}")
     endif()
 
     if("${CLI_CMAKE_COMMON_HOST_VER}" STREQUAL "")

--- a/src/native/corehost/setup.cmake
+++ b/src/native/corehost/setup.cmake
@@ -1,46 +1,14 @@
 # Licensed to the .NET Foundation under one or more agreements.
 # The .NET Foundation licenses this file to you under the MIT license.
 
-if("${CLI_CMAKE_COMMIT_HASH}" STREQUAL "")
-    message(FATAL_ERROR "Commit hash needs to be specified to build the host")
-else()
-    add_definitions(-DREPO_COMMIT_HASH="${CLI_CMAKE_COMMIT_HASH}")
-endif()
-
-if("${CLI_CMAKE_HOST_VER}" STREQUAL "")
-    message(FATAL_ERROR "Host version is not specified")
-else()
-    add_definitions(-DHOST_PKG_VER="${CLI_CMAKE_HOST_VER}")
-    # All versions are the same in single-file.
-    if(CLR_SINGLE_FILE_HOST_ONLY)
-        add_definitions(-DCOMMON_HOST_PKG_VER="${CLI_CMAKE_HOST_VER}")
-        add_definitions(-DHOST_POLICY_PKG_VER="${CLI_CMAKE_HOST_VER}")
-        add_definitions(-DHOST_FXR_PKG_VER="${CLI_CMAKE_HOST_VER}")
-    endif()
-endif()
-
 if(CLR_SINGLE_FILE_HOST_ONLY)
+    # CLR partition builds only the single file host where hosting components are all statically linked.
+    # the versioning information is irrelevant and may only come up in tracing.
+    # so we will use "static"
     add_definitions(-DHOST_POLICY_PKG_NAME="static")
     add_definitions(-DHOST_POLICY_PKG_REL_DIR="static")
+    add_definitions(-DREPO_COMMIT_HASH="static")
 else()
-    if("${CLI_CMAKE_HOST_POLICY_VER}" STREQUAL "")
-        message(FATAL_ERROR "Host policy version is not specified")
-    else()
-        add_definitions(-DHOST_POLICY_PKG_VER="${CLI_CMAKE_HOST_POLICY_VER}")
-    endif()
-
-    if("${CLI_CMAKE_HOST_FXR_VER}" STREQUAL "")
-        message(FATAL_ERROR "Host FXR version is not specified")
-    else()
-        add_definitions(-DHOST_FXR_PKG_VER="${CLI_CMAKE_HOST_FXR_VER}")
-    endif()
-
-    if("${CLI_CMAKE_COMMON_HOST_VER}" STREQUAL "")
-        message(FATAL_ERROR "Common host version is not specified")
-    else()
-        add_definitions(-DCOMMON_HOST_PKG_VER="${CLI_CMAKE_COMMON_HOST_VER}")
-    endif()
-
     if("${CLI_CMAKE_PKG_RID}" STREQUAL "")
         message(FATAL_ERROR "A minimum supported package rid is not specified (ex: win7-x86 or ubuntu.14.04-x64, osx.10.12-x64, rhel.7-x64)")
     else()


### PR DESCRIPTION
Use generated version files when printing/tracing host version info.
- Use `VER_PRODUCTVERSION_STR` / `sccsid` from generated `_version.(h|c)` for version and commit info (for tracing)
- Use `RuntimeProductVersion` for version from header generated by `GenerateRuntimeVersionFile` 
- Remove `HOST_*_PKG_VER` defines and script arguments for passing that info around

Fixes https://github.com/dotnet/runtime/issues/80961

Host traces will have:
```
--- Invoked apphost [version: 8.0.0-dev @Commit: c088228be355eef650fbde9593122e21b2b124aa] main = {
--- Invoked hostfxr_main_bundle_startupinfo [version: 8.0.0-dev @Commit: c088228be355eef650fbde9593122e21b2b124aa]
--- Invoked hostpolicy [version: 8.0.0-dev @Commit: c088228be355eef650fbde9593122e21b2b124aa] corehost_main = {
```