### PR TITLE
Fixing COM Aggregation and XAML reference tracking on .NET AOT

### DIFF
--- a/src/coreclr/nativeaot/Directory.Build.props
+++ b/src/coreclr/nativeaot/Directory.Build.props
@@ -56,6 +56,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <FeatureComWrappers>true</FeatureComWrappers>
+    <DefineConstants Condition="'$(FeatureComWrappers)' == 'true'">FEATURE_COMWRAPPERS;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <FeatureObjCMarshal>false</FeatureObjCMarshal>

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -60,14 +60,14 @@ namespace System.Runtime
 
         // Force a garbage collection.
         [RuntimeExport("RhCollect")]
-        internal static void RhCollect(int generation, InternalGCCollectionMode mode)
+        internal static void RhCollect(int generation, InternalGCCollectionMode mode, bool lowMemoryP = false)
         {
-            RhpCollect(generation, mode);
+            RhpCollect(generation, mode, lowMemoryP);
         }
 
         [DllImport(Redhawk.BaseName)]
         [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static extern void RhpCollect(int generation, InternalGCCollectionMode mode);
+        private static extern void RhpCollect(int generation, InternalGCCollectionMode mode, bool lowMemoryP);
 
         [RuntimeExport("RhGetGcTotalMemory")]
         internal static long RhGetGcTotalMemory()

--- a/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
@@ -128,6 +128,11 @@ COOP_PINVOKE_HELPER(int32_t, RhSetGcLatencyMode, (int32_t newLatencyMode))
     return GCHeapUtilities::GetGCHeap()->SetGcLatencyMode(newLatencyMode);
 }
 
+COOP_PINVOKE_HELPER(FC_BOOL_RET, RhIsPromoted, (OBJECTREF obj))
+{
+    FC_RETURN_BOOL(GCHeapUtilities::GetGCHeap()->IsPromoted(obj));
+}
+
 COOP_PINVOKE_HELPER(FC_BOOL_RET, RhIsServerGc, ())
 {
     FC_RETURN_BOOL(GCHeapUtilities::IsServerHeap());

--- a/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
@@ -25,7 +25,7 @@
 #include "threadstore.inl"
 #include "thread.inl"
 
-EXTERN_C NATIVEAOT_API void __cdecl RhpCollect(uint32_t uGeneration, uint32_t uMode)
+EXTERN_C NATIVEAOT_API void __cdecl RhpCollect(uint32_t uGeneration, uint32_t uMode, UInt32_BOOL lowMemoryP)
 {
     // This must be called via p/invoke rather than RuntimeImport to make the stack crawlable.
 
@@ -35,7 +35,7 @@ EXTERN_C NATIVEAOT_API void __cdecl RhpCollect(uint32_t uGeneration, uint32_t uM
     pCurThread->DisablePreemptiveMode();
 
     ASSERT(!pCurThread->IsDoNotTriggerGcSet());
-    GCHeapUtilities::GetGCHeap()->GarbageCollect(uGeneration, FALSE, uMode);
+    GCHeapUtilities::GetGCHeap()->GarbageCollect(uGeneration, lowMemoryP, uMode);
 
     pCurThread->EnablePreemptiveMode();
 }

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -989,15 +989,19 @@ bool GCToEEInterface::EagerFinalized(Object* obj)
     // Managed code should not be running.
     ASSERT(GCHeapUtilities::GetGCHeap()->IsGCInProgressHelper());
 
-    // the lowermost 1 bit is reserved for storing additional info about the handle
-    const uintptr_t HandleTagBits = 1;
+    // the lowermost 2 bits are reserved for storing additional info about the handle
+    // we can use these bits because handle is at least 4 byte aligned
+    const uintptr_t HandleTagBits = 3;
 
     WeakReference* weakRefObj = (WeakReference*)obj;
     OBJECTHANDLE handle = (OBJECTHANDLE)(weakRefObj->m_taggedHandle & ~HandleTagBits);
-    _ASSERTE((weakRefObj->m_taggedHandle & 2) == 0);
-    HandleType handleType = (weakRefObj->m_taggedHandle & 1) ? HandleType::HNDTYPE_WEAK_LONG : HandleType::HNDTYPE_WEAK_SHORT;
+    HandleType handleType = (weakRefObj->m_taggedHandle & 2) ?
+        HandleType::HNDTYPE_STRONG :
+        (weakRefObj->m_taggedHandle & 1) ?
+        HandleType::HNDTYPE_WEAK_LONG :
+        HandleType::HNDTYPE_WEAK_SHORT;
     // keep the bit that indicates whether this reference was tracking resurrection, clear the rest.
-    weakRefObj->m_taggedHandle &= HandleTagBits;
+    weakRefObj->m_taggedHandle &= (uintptr_t)1;
     GCHandleUtilities::GetGCHandleManager()->DestroyHandleOfType(handle, handleType);
     return true;
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -210,6 +210,7 @@
     <Compile Include="System\Runtime\InteropServices\Marshal.NativeAot.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal.Com.cs" Condition="'$(FeatureCominterop)' == 'true'" />
     <Compile Include="System\Runtime\InteropServices\MemoryMarshal.NativeAot.cs" />
+    <Compile Include="System\Runtime\InteropServices\TrackerObjectManager.NativeAot.cs" Condition="'$(FeatureComWrappers)' == 'true'" />    
     <Compile Include="System\Runtime\InteropServices\ObjectiveCMarshal.NativeAot.cs" Condition="'$(FeatureObjCMarshal)' == 'true'" />
     <Compile Include="System\Runtime\InteropServices\UnsafeGCHandle.cs" />
     <Compile Include="System\Runtime\Intrinsics\X86\X86Base.NativeAot.cs" Condition="'$(SupportsX86Intrinsics)' == 'true'" />
@@ -273,6 +274,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.CoGetApartmentType.cs">
       <Link>Interop\Windows\Ole32\Interop.CoGetApartmentType.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.CoGetContextToken.cs">
+      <Link>Interop\Windows\Ole32\Interop.CoGetContextToken.cs</Link>
+    </Compile>    
     <Compile Include="$(CommonPath)\Interop\Windows\OleAut32\Interop.VariantClear.cs">
       <Link>Interop\Windows\OleAut32\Interop.VariantClear.cs</Link>
     </Compile>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ComAwareWeakReference.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ComAwareWeakReference.NativeAot.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 #if FEATURE_COMINTEROP || FEATURE_COMWRAPPERS
 
@@ -11,85 +10,47 @@ namespace System
 {
     internal sealed partial class ComAwareWeakReference
     {
-        private static readonly Guid IID_IInspectable = new Guid(0xAF86E2E0, 0xB12D, 0x4c6a, 0x9C, 0x5A, 0xD7, 0xAA, 0x65, 0x10, 0x1E, 0x90);
-        private static readonly Guid IID_IWeakReferenceSource = new Guid(0x00000038, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
+        // We don't want to consult ComWrappers if no RCW objects have been created.
+        // In addition we don't want a direct reference to ComWrappers to allow for better
+        // trimming.  So we instead make use of delegates that ComWrappers registers when
+        // it is used.
+        private static unsafe delegate*<IntPtr, long, object?> ComWeakRefToObjectCallback;
+        private static unsafe delegate*<object, bool> PossiblyComObjectCallback;
+        private static unsafe delegate*<object, long*, IntPtr> ObjectToComWeakRefCallback;
 
-        // We don't want to consult the ComWrappers if no RCW objects have been created.
-        // So we instead use this variable which is set by ComWrappers to determine
-        // whether RCW objects have been created before consulting it as part of PossiblyComObject.
-        internal static bool ComWrappersRcwInitialized;
-
-        internal static object? ComWeakRefToObject(IntPtr pComWeakRef, long wrapperId)
+        internal static unsafe void InitializeCallbacks(
+            delegate*<IntPtr, long, object?> comWeakRefToObject,
+            delegate*<object, bool> possiblyComObject,
+            delegate*<object, long*, IntPtr> objectToComWeakRef)
         {
-            if (wrapperId == 0)
-            {
-                return null;
-            }
+            // PossiblyComObjectCallback is initialized last to avoid any potential races
+            // where functions are being called while initialization is happening.
+            ComWeakRefToObjectCallback = comWeakRefToObject;
+            ObjectToComWeakRefCallback = objectToComWeakRef;
+            PossiblyComObjectCallback = possiblyComObject;
+        }
 
-            // Using the IWeakReference*, get ahold of the target native COM object's IInspectable*.  If this resolve fails or
-            // returns null, then we assume that the underlying native COM object is no longer alive, and thus we cannot create a
-            // new RCW for it.
-            if (IWeakReference.Resolve(pComWeakRef, IID_IInspectable, out IntPtr targetPtr) == HResults.S_OK &&
-                targetPtr != IntPtr.Zero)
-            {
-                using ComHolder target = new ComHolder(targetPtr);
-                if (Marshal.QueryInterface(target.Ptr, in ComWrappers.IID_IUnknown, out IntPtr targetIdentityPtr) == HResults.S_OK)
-                {
-                    using ComHolder targetIdentity = new ComHolder(targetIdentityPtr);
-                    return ComWrappers.GetOrCreateObjectFromWrapper(wrapperId, targetIdentity.Ptr);
-                }
-            }
-
-            return null;
+        internal static unsafe object? ComWeakRefToObject(IntPtr pComWeakRef, long wrapperId)
+        {
+            return ComWeakRefToObjectCallback != null ? ComWeakRefToObjectCallback(pComWeakRef, wrapperId) : null;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe bool PossiblyComObject(object target)
         {
-            return ComWrappersRcwInitialized && ComWrappers.IsRcwObject(target);
+            return PossiblyComObjectCallback != null ? PossiblyComObjectCallback(target) : false;
         }
 
-        internal static IntPtr ObjectToComWeakRef(object target, out long wrapperId)
+        internal static unsafe IntPtr ObjectToComWeakRef(object target, out long wrapperId)
         {
-            if (ComWrappers.TryGetComInstanceForIID(
-                target,
-                IID_IWeakReferenceSource,
-                out IntPtr weakReferenceSourcePtr,
-                out bool isAggregated,
-                out wrapperId))
+            wrapperId = 0;
+            if (ObjectToComWeakRefCallback != null)
             {
-                // If the RCW is an aggregated RCW, then the managed object cannot be recreated from the IUnknown
-                // as the outer IUnknown wraps the managed object. In this case, don't create a weak reference backed
-                // by a COM weak reference.
-                using ComHolder weakReferenceSource = new ComHolder(weakReferenceSourcePtr);
-                if (!isAggregated && IWeakReferenceSource.GetWeakReference(weakReferenceSource.Ptr, out IntPtr weakReference) == HResults.S_OK)
-                {
-                    return weakReference;
-                }
+                fixed (long* id = &wrapperId)
+                    return ObjectToComWeakRefCallback(target, id);
             }
 
-            wrapperId = 0;
             return IntPtr.Zero;
-        }
-    }
-
-    // Wrapper for IWeakReference
-    internal static unsafe class IWeakReference
-    {
-        public static int Resolve(IntPtr pThis, Guid guid, out IntPtr inspectable)
-        {
-            fixed (IntPtr* inspectablePtr = &inspectable)
-                return (*(delegate* unmanaged<IntPtr, Guid*, IntPtr*, int>**)pThis)[3](pThis, &guid, inspectablePtr);
-        }
-    }
-
-    // Wrapper for IWeakReferenceSource
-    internal static unsafe class IWeakReferenceSource
-    {
-        public static int GetWeakReference(IntPtr pThis, out IntPtr weakReference)
-        {
-            fixed (IntPtr* weakReferencePtr = &weakReference)
-                return (*(delegate* unmanaged<IntPtr, IntPtr*, int>**)pThis)[3](pThis, weakReferencePtr);
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ComAwareWeakReference.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ComAwareWeakReference.NativeAot.cs
@@ -14,17 +14,15 @@ namespace System
         // In addition we don't want a direct reference to ComWrappers to allow for better
         // trimming.  So we instead make use of delegates that ComWrappers registers when
         // it is used.
-        private static unsafe volatile delegate*<IntPtr, long, object?> s_comWeakRefToObjectCallback;
-        private static unsafe volatile delegate*<object, bool> s_possiblyComObjectCallback;
-        private static unsafe volatile delegate*<object, out long, IntPtr> s_objectToComWeakRefCallback;
+        private static unsafe delegate*<IntPtr, long, object?> s_comWeakRefToObjectCallback;
+        private static unsafe delegate*<object, bool> s_possiblyComObjectCallback;
+        private static unsafe delegate*<object, out long, IntPtr> s_objectToComWeakRefCallback;
 
         internal static unsafe void InitializeCallbacks(
             delegate*<IntPtr, long, object?> comWeakRefToObject,
             delegate*<object, bool> possiblyComObject,
             delegate*<object, out long, IntPtr> objectToComWeakRef)
         {
-            // PossiblyComObjectCallback is initialized last to avoid any potential race
-            // conditions where functions are being called while initialization is happening.
             s_comWeakRefToObjectCallback = comWeakRefToObject;
             s_objectToComWeakRefCallback = objectToComWeakRef;
             s_possiblyComObjectCallback = possiblyComObject;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ComAwareWeakReference.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ComAwareWeakReference.NativeAot.cs
@@ -2,32 +2,94 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 #if FEATURE_COMINTEROP || FEATURE_COMWRAPPERS
-
-#pragma warning disable IDE0060
 
 namespace System
 {
     internal sealed partial class ComAwareWeakReference
     {
+        private static readonly Guid IID_IInspectable = new Guid(0xAF86E2E0, 0xB12D, 0x4c6a, 0x9C, 0x5A, 0xD7, 0xAA, 0x65, 0x10, 0x1E, 0x90);
+        private static readonly Guid IID_IWeakReferenceSource = new Guid(0x00000038, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
+
+        // We don't want to consult the ComWrappers if no RCW objects have been created.
+        // So we instead use this variable which is set by ComWrappers to determine
+        // whether RCW objects have been created before consulting it as part of PossiblyComObject.
+        internal static bool ComWrappersRcwInitialized;
+
         internal static object? ComWeakRefToObject(IntPtr pComWeakRef, long wrapperId)
         {
-            // NativeAOT support for COM WeakReference is NYI
-            throw new NotImplementedException();
+            if (wrapperId == 0)
+            {
+                return null;
+            }
+
+            // Using the IWeakReference*, get ahold of the target native COM object's IInspectable*.  If this resolve fails or
+            // returns null, then we assume that the underlying native COM object is no longer alive, and thus we cannot create a
+            // new RCW for it.
+            if (IWeakReference.Resolve(pComWeakRef, IID_IInspectable, out IntPtr targetPtr) == HResults.S_OK &&
+                targetPtr != IntPtr.Zero)
+            {
+                using ComHolder target = new ComHolder(targetPtr);
+                if (Marshal.QueryInterface(target.Ptr, in ComWrappers.IID_IUnknown, out IntPtr targetIdentityPtr) == HResults.S_OK)
+                {
+                    using ComHolder targetIdentity = new ComHolder(targetIdentityPtr);
+                    return ComWrappers.GetOrCreateObjectFromWrapper(wrapperId, targetIdentity.Ptr);
+                }
+            }
+
+            return null;
         }
 
-        internal static bool PossiblyComObject(object target)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe bool PossiblyComObject(object target)
         {
-            // NativeAOT support for COM WeakReference is NYI
-            return false;
+            return ComWrappersRcwInitialized && ComWrappers.IsRcwObject(target);
         }
 
         internal static IntPtr ObjectToComWeakRef(object target, out long wrapperId)
         {
-            // NativeAOT support for COM WeakReference is NYI
+            if (ComWrappers.TryGetComInstanceForIID(
+                target,
+                IID_IWeakReferenceSource,
+                out IntPtr weakReferenceSourcePtr,
+                out bool isAggregated,
+                out wrapperId))
+            {
+                // If the RCW is an aggregated RCW, then the managed object cannot be recreated from the IUnknown
+                // as the outer IUnknown wraps the managed object. In this case, don't create a weak reference backed
+                // by a COM weak reference.
+                using ComHolder weakReferenceSource = new ComHolder(weakReferenceSourcePtr);
+                if (!isAggregated && IWeakReferenceSource.GetWeakReference(weakReferenceSource.Ptr, out IntPtr weakReference) == HResults.S_OK)
+                {
+                    return weakReference;
+                }
+            }
+
             wrapperId = 0;
-            return 0;
+            return IntPtr.Zero;
+        }
+    }
+
+    // Wrapper for IWeakReference
+    internal static unsafe class IWeakReference
+    {
+        public static int Resolve(IntPtr pThis, Guid guid, out IntPtr inspectable)
+        {
+            fixed (IntPtr* inspectablePtr = &inspectable)
+                return (*(delegate* unmanaged<IntPtr, Guid*, IntPtr*, int>**)pThis)[3](pThis, &guid, inspectablePtr);
+        }
+    }
+
+    // Wrapper for IWeakReferenceSource
+    internal static unsafe class IWeakReferenceSource
+    {
+        public static int GetWeakReference(IntPtr pThis, out IntPtr weakReference)
+        {
+            fixed (IntPtr* weakReferencePtr = &weakReference)
+                return (*(delegate* unmanaged<IntPtr, IntPtr*, int>**)pThis)[3](pThis, weakReferencePtr);
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -518,6 +518,14 @@ namespace System.Runtime.InteropServices
 
             public IntPtr TrackerObject => (_trackerObject == IntPtr.Zero || _trackerObjectDisconnected == 1) ? IntPtr.Zero : _trackerObject;
 
+            static NativeObjectWrapper()
+            {
+                // Set to true to indicate we have RCW objects created
+                // which enables the weak reference support to consult
+                // ComWrappers when weak references are created for RCWs.
+                ComAwareWeakReference.ComWrappersRcwInitialized = true;
+            }
+
             public NativeObjectWrapper(IntPtr externalComObject, IntPtr inner, ComWrappers comWrappers, object comProxy, CreateObjectFlags flags)
             {
                 _externalComObject = externalComObject;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -490,7 +490,7 @@ namespace System.Runtime.InteropServices
             internal readonly bool _fromTrackerRuntime;
             private IntPtr _trackerObject;
             private readonly bool _releaseTrackerObject;
-            private int _trackerObjectDisconnected;
+            private int _trackerObjectDisconnected; // Atomic boolean, so using int.
 
             internal readonly IntPtr _contextToken;
 
@@ -506,7 +506,7 @@ namespace System.Runtime.InteropServices
                 // We have a separate handle tracking resurrection as we want to make sure
                 // we clean up the NativeObjectWrapper only after the RCW has been finalized
                 // due to it can access the native object in the finalizer. At the same time,
-                // we want other callers which are using _proxyHandle such as the rcw cache to
+                // we want other callers which are using _proxyHandle such as the RCW cache to
                 // see the object as not alive once it is eligible for finalization.
                 _proxyHandleTrackingResurrection = GCHandle.Alloc(comProxy, GCHandleType.WeakTrackResurrection);
 
@@ -1184,7 +1184,7 @@ namespace System.Runtime.InteropServices
                     }
                 }
             }
-            catch (Exception)
+            catch
             {
                 // Report that we failed while walking.
                 TrackerObjectManager.s_IsGlobalPeggingOn = true;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -534,10 +534,7 @@ namespace System.Runtime.InteropServices
                     }
                 }
 
-                if (Interop.Ole32.CoGetContextToken(out _contextToken) != 0)
-                {
-                    _contextToken = 0;
-                }
+                _contextToken = GetContextToken();
 
                 // If this is an aggregation scenario and the identity object
                 // is a managed object wrapper, we need to call Release() to
@@ -1146,7 +1143,7 @@ namespace System.Runtime.InteropServices
                 throw new NotSupportedException(SR.InvalidOperation_ComInteropRequireComWrapperInstance);
             }
 
-            Interop.Ole32.CoGetContextToken(out IntPtr contextToken);
+            IntPtr contextToken = GetContextToken();
 
             List<object> objects = new List<object>();
             foreach (GCHandle weakNativeObjectWrapperHandle in s_nativeObjectWrapperCache)
@@ -1432,6 +1429,16 @@ namespace System.Runtime.InteropServices
             vftbl[7] = (IntPtr)(delegate* unmanaged<IntPtr, long, int>)&ComWrappers.IReferenceTrackerHost_AddMemoryPressure;
             vftbl[8] = (IntPtr)(delegate* unmanaged<IntPtr, long, int>)&ComWrappers.IReferenceTrackerHost_RemoveMemoryPressure;
             return (IntPtr)vftbl;
+        }
+
+        private static IntPtr GetContextToken()
+        {
+#if TARGET_WINDOWS
+            Interop.Ole32.CoGetContextToken(out IntPtr contextToken);
+            return contextToken;
+#else
+            return IntPtr.Zero;
+#endif
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -1170,7 +1170,7 @@ namespace System.Runtime.InteropServices
         {
             if (s_globalInstanceForTrackerSupport == null)
             {
-                throw new NotSupportedException(SR.InvalidOperation_ComInteropRequireComWrapperInstance);
+                throw new NotSupportedException(SR.InvalidOperation_ComInteropRequireComWrapperTrackerInstance);
             }
 
             object obj = s_globalInstanceForTrackerSupport.GetOrCreateObjectForComInstance(externalComObject, CreateObjectFlags.TrackerObject);
@@ -1181,7 +1181,7 @@ namespace System.Runtime.InteropServices
         {
             if (s_globalInstanceForTrackerSupport == null)
             {
-                throw new NotSupportedException(SR.InvalidOperation_ComInteropRequireComWrapperInstance);
+                throw new NotSupportedException(SR.InvalidOperation_ComInteropRequireComWrapperTrackerInstance);
             }
 
             IntPtr contextToken = GetContextToken();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -1236,9 +1236,9 @@ namespace System.Runtime.InteropServices
 
         internal static void DetachNonPromotedObjects()
         {
-            for (int idx = 0; idx < s_nativeObjectWrapperCache.Count; idx++)
+            foreach (GCHandle weakNativeObjectWrapperHandle in s_nativeObjectWrapperCache)
             {
-                NativeObjectWrapper? nativeObjectWrapper = Unsafe.As<NativeObjectWrapper?>(s_nativeObjectWrapperCache[idx].Target);
+                NativeObjectWrapper? nativeObjectWrapper = Unsafe.As<NativeObjectWrapper?>(weakNativeObjectWrapperHandle.Target);
                 if (nativeObjectWrapper != null &&
                     nativeObjectWrapper.TrackerObject != IntPtr.Zero &&
                     !RuntimeImports.RhIsPromoted(nativeObjectWrapper._proxyHandle.Target))

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -1563,20 +1563,19 @@ namespace System.Runtime.InteropServices
             return null;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe bool PossiblyComObject(object target)
         {
             return s_rcwTable.TryGetValue(target, out _);
         }
 
-        private static unsafe IntPtr ObjectToComWeakRef(object target, long* wrapperId)
+        private static unsafe IntPtr ObjectToComWeakRef(object target, out long wrapperId)
         {
             if (TryGetComInstanceForIID(
                 target,
                 IID_IWeakReferenceSource,
                 out IntPtr weakReferenceSourcePtr,
                 out bool isAggregated,
-                out *wrapperId))
+                out wrapperId))
             {
                 // If the RCW is an aggregated RCW, then the managed object cannot be recreated from the IUnknown
                 // as the outer IUnknown wraps the managed object. In this case, don't create a weak reference backed
@@ -1588,7 +1587,6 @@ namespace System.Runtime.InteropServices
                 }
             }
 
-            *wrapperId = 0;
             return IntPtr.Zero;
         }
     }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Threading;
-using static System.Runtime.InteropServices.ComWrappers;
 
 namespace System.Runtime.InteropServices
 {
@@ -27,7 +26,6 @@ namespace System.Runtime.InteropServices
         internal static IntPtr DefaultIUnknownVftblPtr { get; } = CreateDefaultIUnknownVftbl();
         internal static IntPtr TaggedImplVftblPtr { get; } = CreateTaggedImplVftbl();
         internal static IntPtr DefaultIReferenceTrackerTargetVftblPtr { get; } = CreateDefaultIReferenceTrackerTargetVftbl();
-        internal static IntPtr DefaultIReferenceTrackerHostVftblPtr { get; } = CreateDefaultIReferenceTrackerHostVftbl();
 
         internal static readonly Guid IID_IUnknown = new Guid(0x00000000, 0x0000, 0x0000, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46);
         internal static readonly Guid IID_IReferenceTrackerTarget = new Guid(0x64bd43f8, 0xbfee, 0x4ec4, 0xb7, 0xeb, 0x29, 0x35, 0x15, 0x8d, 0xae, 0x21);
@@ -49,13 +47,12 @@ namespace System.Runtime.InteropServices
 
         internal static bool TryGetComInstanceForIID(object obj, Guid iid, out IntPtr unknown, out bool isAggregated, out long wrapperId)
         {
-            unknown = IntPtr.Zero;
-            isAggregated = false;
-            wrapperId = 0;
-
             if (obj == null
                 || !s_rcwTable.TryGetValue(obj, out NativeObjectWrapper? wrapper))
             {
+                unknown = IntPtr.Zero;
+                isAggregated = false;
+                wrapperId = 0;
                 return false;
             }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
@@ -185,7 +185,7 @@ namespace System.Runtime.InteropServices
                 return;
             }
 
-            Debug.Assert(s_HasTrackingStarted == false);
+            Debug.Assert(!s_HasTrackingStarted);
             Debug.Assert(s_IsGlobalPeggingOn);
 
             s_HasTrackingStarted = true;
@@ -269,7 +269,6 @@ namespace System.Runtime.InteropServices
         {
             DetachNonPromotedObjects();
         }
-
     }
 
     // Wrapper for IReferenceTrackerManager
@@ -344,15 +343,10 @@ namespace System.Runtime.InteropServices
         [UnmanagedCallersOnly]
         private static unsafe int IFindReferenceTargetsCallback_QueryInterface(IntPtr pThis, Guid* guid, IntPtr* ppObject)
         {
-            if (pThis == IntPtr.Zero)
-            {
-                return HResults.E_POINTER;
-            }
-
             if (*guid == IID_IFindReferenceTargetsCallback || *guid == IID_IUnknown)
             {
                 *ppObject = pThis;
-                return 0;
+                return HResults.S_OK;
             }
             else
             {
@@ -389,10 +383,10 @@ namespace System.Runtime.InteropServices
 
         internal static unsafe IntPtr CreateFindReferenceTargetsCallback()
         {
-            IntPtr wrapperMem = (IntPtr)NativeMemory.Alloc(2 * (nuint)sizeof(IntPtr));
-            *(IntPtr*)(wrapperMem) = CreateDefaultIFindReferenceTargetsCallbackVftbl();
-            *(IntPtr*)(wrapperMem + sizeof(IntPtr)) = wrapperMem;
-            return wrapperMem;
+            IntPtr* wrapperMem = (IntPtr*)NativeMemory.Alloc(2 * (nuint)sizeof(IntPtr));
+            wrapperMem[0] = CreateDefaultIFindReferenceTargetsCallbackVftbl();
+            wrapperMem[1] = (IntPtr)wrapperMem;
+            return (IntPtr)wrapperMem;
         }
     }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -11,7 +10,7 @@ using static System.Runtime.InteropServices.ComWrappers;
 namespace System.Runtime.InteropServices
 {
     // Defined in windows.ui.xaml.hosting.referencetracker.h.
-    enum XAML_REFERENCETRACKER_DISCONNECT
+    internal enum XAML_REFERENCETRACKER_DISCONNECT
     {
         // Indicates the disconnect is during a suspend and a GC can be trigger.
         XAML_REFERENCETRACKER_DISCONNECT_SUSPEND = 0x00000001

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
@@ -452,7 +452,11 @@ namespace System.Runtime.InteropServices
             if (_pHandles == null)
             {
                 _capacity = DefaultCapacity;
+#if TARGET_WINDOWS
                 _pHandles = (IntPtr*)Interop.Ucrtbase.calloc((nuint)_capacity, (nuint)sizeof(IntPtr));
+#else
+                _pHandles = (IntPtr*)Interop.Sys.Calloc((nuint)_capacity, (nuint)sizeof(IntPtr));
+#endif
 
                 return _pHandles != null;
             }
@@ -506,7 +510,11 @@ namespace System.Runtime.InteropServices
             }
 
             // Shrink the size of the memory
+#if TARGET_WINDOWS
             IntPtr* pNewHandles = (IntPtr*)Interop.Ucrtbase.realloc(_pHandles, (nuint)(newCapacity * sizeof(IntPtr)));
+#else
+            IntPtr* pNewHandles = (IntPtr*)Interop.Sys.Realloc(_pHandles, (nuint)(newCapacity * sizeof(IntPtr)));
+#endif
             if (pNewHandles == null)
                 return false;
 
@@ -519,7 +527,11 @@ namespace System.Runtime.InteropServices
         private bool Grow()
         {
             int newCapacity = _capacity * 2;
+#if TARGET_WINDOWS
             IntPtr* pNewHandles = (IntPtr*)Interop.Ucrtbase.realloc(_pHandles, (nuint)(newCapacity * sizeof(IntPtr)));
+#else
+            IntPtr* pNewHandles = (IntPtr*)Interop.Sys.Realloc(_pHandles, (nuint)(newCapacity * sizeof(IntPtr)));
+#endif
             if (pNewHandles == null)
                 return false;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
@@ -1,0 +1,302 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.Marshalling;
+using System.Threading;
+using static System.Runtime.InteropServices.ComWrappers;
+
+namespace System.Runtime.InteropServices
+{
+    // Defined in windows.ui.xaml.hosting.referencetracker.h.
+    enum XAML_REFERENCETRACKER_DISCONNECT
+    {
+        // Indicates the disconnect is during a suspend and a GC can be trigger.
+        XAML_REFERENCETRACKER_DISCONNECT_SUSPEND = 0x00000001
+    };
+
+    internal struct HostServices
+    {
+        internal static IntPtr s_globalHostServices = CreateHostServices();
+
+        private static unsafe IntPtr CreateHostServices()
+        {
+            IntPtr wrapperMem = (IntPtr)NativeMemory.Alloc(
+                (nuint)sizeof(HostServices) + (nuint)sizeof(IntPtr) + (nuint)sizeof(HostServices*));
+
+            *(IntPtr*)(wrapperMem + sizeof(HostServices)) = ComWrappers.DefaultIReferenceTrackerHostVftblPtr;
+            *(IntPtr*)(wrapperMem + sizeof(HostServices) + sizeof(IntPtr)) = wrapperMem;
+            return wrapperMem;
+        }
+
+        public static void DisconnectUnusedReferenceSources(uint flags)
+        {
+            if ((((XAML_REFERENCETRACKER_DISCONNECT)flags) & XAML_REFERENCETRACKER_DISCONNECT.XAML_REFERENCETRACKER_DISCONNECT_SUSPEND) != 0)
+            {
+                // In CoreCLR, low_memory_p is also set to true which it isn't here in AOT currently via this code path.
+                // If that ends up being needed, a new export would need to be added to achieve that.
+                GC.Collect(2, GCCollectionMode.Optimized, true);
+            }
+            else
+            {
+                GC.Collect();
+            }
+        }
+
+        public static void ReleaseDisconnectedReferenceSources()
+        {
+            GC.WaitForPendingFinalizers();
+        }
+
+        public static void NotifyEndOfReferenceTrackingOnThread()
+        {
+            ComWrappers.ReleaseExternalObjectsFromCurrentThread();
+        }
+
+        // Creates a proxy object (managed object wrapper) that points to the given IUnknown.
+        // The proxy represents the following:
+        //   1. Has a managed reference pointing to the external object
+        //      and therefore forms a cycle that can be resolved by GC.
+        //   2. Forwards data binding requests.
+        //
+        // For example:
+        //
+        // Grid <---- NoCW             Grid <-------- NoCW
+        // | ^                         |              ^
+        // | |             Becomes     |              |
+        // v |                         v              |
+        // Rectangle                  Rectangle ----->Proxy
+        //
+        // Arguments
+        //   obj        - An IUnknown* where a NoCW points to (Grid, in this case)
+        //                    Notes:
+        //                    1. We can either create a new NoCW or get back an old one from the cache.
+        //                    2. This obj could be a regular tracker runtime object for data binding.
+        //  ppNewReference  - The IReferenceTrackerTarget* for the proxy created
+        //                    The tracker runtime will call IReferenceTrackerTarget to establish a reference.
+        //
+        public static void GetTrackerTarget(IntPtr punk, out IntPtr ppNewReference)
+        {
+            if (punk == IntPtr.Zero)
+            {
+                throw new ArgumentException();
+            }
+
+            if (Marshal.QueryInterface(punk, in ComWrappers.IID_IUnknown, out nint ppv) != 0)
+            {
+                throw new InvalidCastException();
+            }
+
+            IntPtr trackerTarget = ComWrappers.GetOrCreateTrackerTarget(ppv);
+            if (Marshal.QueryInterface(trackerTarget, in ComWrappers.IID_IReferenceTrackerTarget, out ppNewReference) != 0)
+            {
+                throw new InvalidCastException();
+            }
+        }
+
+        public static void AddMemoryPressure(long bytesAllocated)
+        {
+            GC.AddMemoryPressure(bytesAllocated);
+        }
+
+        public static void RemoveMemoryPressure(long bytesAllocated)
+        {
+            GC.RemoveMemoryPressure(bytesAllocated);
+        }
+    }
+
+    internal static class TrackerObjectManager
+    {
+        internal static volatile IntPtr s_TrackerManager;
+        internal static volatile bool s_HasTrackingStarted;
+        internal static volatile bool s_IsGlobalPeggingOn = true;
+
+        // Indicates if walking the external objects is needed.
+        // (i.e. Have any IReferenceTracker instances been found?)
+        public static bool ShouldWalkExternalObjects()
+        {
+            return s_TrackerManager != IntPtr.Zero;
+        }
+
+        // Called when an IReferenceTracker instance is found.
+        public static void OnIReferenceTrackerFound(IntPtr referenceTracker)
+        {
+            Debug.Assert(referenceTracker != IntPtr.Zero);
+            if (s_TrackerManager != IntPtr.Zero)
+            {
+                return;
+            }
+
+            IReferenceTracker.GetReferenceTrackerManager(referenceTracker, out IntPtr referenceTrackerManager);
+
+            // Attempt to set the tracker instance.
+            // If set, the ownership of referenceTrackerManager has been transferred
+            if (Interlocked.CompareExchange(ref s_TrackerManager, referenceTrackerManager, IntPtr.Zero) == IntPtr.Zero)
+            {
+                IReferenceTrackerManager.SetReferenceTrackerHost(s_TrackerManager, HostServices.s_globalHostServices);
+            }
+            else
+            {
+                Marshal.Release(referenceTrackerManager);
+            }
+        }
+
+        // Called after wrapper has been created.
+        public static void AfterWrapperCreated(IntPtr referenceTracker)
+        {
+            Debug.Assert(referenceTracker != IntPtr.Zero);
+
+            // Notify tracker runtime that we've created a new wrapper for this object.
+            // To avoid surprises, we should notify them before we fire the first AddRefFromTrackerSource.
+            IReferenceTracker.ConnectFromTrackerSource(referenceTracker);
+
+            // Send out AddRefFromTrackerSource callbacks to notify tracker runtime we've done AddRef()
+            // for certain interfaces. We should do this *after* we made a AddRef() because we should never
+            // be in a state where report refs > actual refs
+            IReferenceTracker.AddRefFromTrackerSource(referenceTracker); // IUnknown
+            IReferenceTracker.AddRefFromTrackerSource(referenceTracker); // IReferenceTracker
+        }
+
+        // Called before wrapper is about to be finalized (the same lifetime as short weak handle).
+        public static void BeforeWrapperFinalized(IntPtr referenceTracker)
+        {
+            Debug.Assert(referenceTracker != IntPtr.Zero);
+
+            // Notify tracker runtime that we are about to finalize a wrapper
+            // (same timing as short weak handle) for this object.
+            // They need this information to disconnect weak refs and stop firing events,
+            // so that they can avoid resurrecting the object.
+            IReferenceTracker.DisconnectFromTrackerSource(referenceTracker);
+        }
+
+        // Begin the reference tracking process for external objects.
+        public static void BeginReferenceTracking(/*InteropLibImports::RuntimeCallContext* cxt*/)
+        {
+            // Debug.Assert(cxt != IntPtr.Zero);
+            if (!ShouldWalkExternalObjects())
+            {
+                return;
+            }
+
+            Debug.Assert(s_HasTrackingStarted == false);
+            Debug.Assert(s_IsGlobalPeggingOn);
+
+            s_HasTrackingStarted = true;
+
+            // Let the tracker runtime know we are about to walk external objects so that
+            // they can lock their reference cache. Note that the tracker runtime doesn't need to
+            // unpeg all external objects at this point and they can do the pegging/unpegging.
+            // in FindTrackerTargetsCompleted.
+            Debug.Assert(s_TrackerManager != IntPtr.Zero);
+            IReferenceTrackerManager.ReferenceTrackingStarted(s_TrackerManager);
+
+            // From this point, the tracker runtime decides whether a target
+            // should be pegged or not as the global pegging flag is now off.
+            s_IsGlobalPeggingOn = false;
+
+            // Time to walk the external objects
+            WalkExternalTrackerObjects(cxt);
+        }
+
+        private static void WalkExternalTrackerObjects()
+        {
+            bool walkFailed = false;
+
+        }
+
+        // End the reference tracking process for external object.
+        public static void EndReferenceTracking()
+        {
+            if (!s_HasTrackingStarted || !ShouldWalkExternalObjects())
+            {
+                return;
+            }
+
+            // Let the tracker runtime know the external object walk is done and they need to:
+            // 1. Unpeg all managed object wrappers (mow) if the (mow) needs to be unpegged
+            //       (i.e. when the (mow) is only reachable by other external tracker objects).
+            // 2. Peg all mows if the mow needs to be pegged (i.e. when the above condition is not true)
+            // 3. Unlock reference cache when they are done.
+            Debug.Assert(s_TrackerManager != IntPtr.Zero);
+            IReferenceTrackerManager.ReferenceTrackingCompleted(s_TrackerManager);
+
+            s_IsGlobalPeggingOn = true;
+            s_HasTrackingStarted = false;
+        }
+    }
+
+    // Wrapper for IReferenceTrackerManager
+    internal static unsafe class IReferenceTrackerManager
+    {
+        public static void ReferenceTrackingStarted(IntPtr pThis)
+        {
+            Marshal.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)pThis)[3](pThis));
+        }
+
+        public static void FindTrackerTargetsCompleted(IntPtr pThis, bool walkFailed)
+        {
+            Marshal.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, bool, int>**)pThis)[4](pThis, walkFailed));
+        }
+
+        public static void ReferenceTrackingCompleted(IntPtr pThis)
+        {
+            Marshal.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)pThis)[5](pThis));
+        }
+
+        public static void SetReferenceTrackerHost(IntPtr pThis, IntPtr referenceTrackerHost)
+        {
+            Marshal.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int>**)pThis)[6](pThis, referenceTrackerHost));
+        }
+    }
+
+    // Wrapper for IReferenceTracker
+    internal static unsafe class IReferenceTracker
+    {
+        public static void ConnectFromTrackerSource(IntPtr pThis)
+        {
+            Marshal.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)pThis)[3](pThis));
+        }
+
+        public static void DisconnectFromTrackerSource(IntPtr pThis)
+        {
+            Marshal.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)pThis)[4](pThis));
+        }
+
+        public static void FindTrackerTargets(IntPtr pThis, IntPtr findReferenceTargetsCallback)
+        {
+            Marshal.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int>**)pThis)[5](pThis, findReferenceTargetsCallback));
+        }
+
+        public static void GetReferenceTrackerManager(IntPtr pThis, out IntPtr referenceTrackerManager)
+        {
+            fixed (IntPtr* ptr = &referenceTrackerManager)
+                Marshal.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>**)pThis)[6](pThis, ptr));
+        }
+
+        public static void AddRefFromTrackerSource(IntPtr pThis)
+        {
+            Marshal.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)pThis)[7](pThis));
+        }
+
+        public static void ReleaseFromTrackerSource(IntPtr pThis)
+        {
+            Marshal.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)pThis)[8](pThis));
+        }
+
+        public static void PegFromTrackerSource(IntPtr pThis)
+        {
+            Marshal.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, int>**)pThis)[9](pThis));
+        }
+    }
+
+    // Wrapper for IReferenceTracker
+    internal static unsafe class IFindReferenceTargetsCallback
+    {
+        public static void FoundTrackerTarget(IntPtr pThis, IntPtr referenceTrackerTarget)
+        {
+            Marshal.ThrowExceptionForHR((*(delegate* unmanaged[Stdcall]<IntPtr, IntPtr, int>**)pThis)[3](pThis, referenceTrackerTarget));
+        }
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -129,6 +129,10 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhSetGcLatencyMode")]
         internal static extern int RhSetGcLatencyMode(GCLatencyMode newLatencyMode);
 
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhIsPromoted")]
+        internal static extern bool RhIsPromoted(object obj);
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhIsServerGc")]
         internal static extern bool RhIsServerGc();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -65,7 +65,7 @@ namespace System.Runtime
         // Force a garbage collection.
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhCollect")]
-        internal static extern void RhCollect(int generation, InternalGCCollectionMode mode);
+        internal static extern void RhCollect(int generation, InternalGCCollectionMode mode, bool lowMemoryP = false);
 
         // Mark an object instance as already finalized.
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -297,7 +297,7 @@ namespace System.Runtime
         // Allocate handle for dependent handle case where a secondary can be set at the same time.
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhpHandleAllocDependent")]
-        private static extern IntPtr RhpHandleAllocDependent(object primary, object secondary);
+        internal static extern IntPtr RhpHandleAllocDependent(object primary, object secondary);
 
         internal static IntPtr RhHandleAllocDependent(object primary, object secondary)
         {

--- a/src/libraries/Common/src/Interop/Windows/Ole32/Interop.CoGetContextToken.cs
+++ b/src/libraries/Common/src/Interop/Windows/Ole32/Interop.CoGetContextToken.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Ole32
+    {
+        internal static unsafe int CoGetContextToken(out IntPtr token)
+        {
+            fixed (IntPtr* pToken = &token)
+            {
+                return CoGetContextToken(pToken);
+            }
+        }
+
+        [LibraryImport(Libraries.Ole32)]
+        internal static unsafe partial int CoGetContextToken(IntPtr* pToken);
+    }
+}

--- a/src/libraries/Common/src/Interop/Windows/Ole32/Interop.CoGetContextToken.cs
+++ b/src/libraries/Common/src/Interop/Windows/Ole32/Interop.CoGetContextToken.cs
@@ -8,15 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Ole32
     {
-        internal static unsafe int CoGetContextToken(out IntPtr token)
-        {
-            fixed (IntPtr* pToken = &token)
-            {
-                return CoGetContextToken(pToken);
-            }
-        }
-
         [LibraryImport(Libraries.Ole32)]
-        internal static unsafe partial int CoGetContextToken(IntPtr* pToken);
+        internal static unsafe partial int CoGetContextToken(out IntPtr pToken);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -4181,6 +4181,9 @@
   <data name="InvalidOperation_ComInteropRequireComWrapperInstance" xml:space="preserve">
     <value>COM Interop requires ComWrapper instance registered for marshalling.</value>
   </data>
+  <data name="InvalidOperation_ComInteropRequireComWrapperTrackerInstance" xml:space="preserve">
+    <value>COM Interop requires ComWrapper instance registered for reference tracker support.</value>
+  </data>
   <data name="ArgumentOutOfRange_NotGreaterThanBufferLength" xml:space="preserve">
     <value>Must not be greater than the length of the buffer.</value>
   </data>

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -927,7 +927,6 @@ namespace ComWrappersTests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/85137", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public void ValidateAggregationWithComObject()
         {
@@ -944,7 +943,6 @@ namespace ComWrappersTests
             Assert.Equal(0, allocTracker.GetCount());
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/85137", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public void ValidateAggregationWithReferenceTrackerObject()
         {


### PR DESCRIPTION
There were blocks put in place in AOT for COM aggregation and XAML reference tracking wasn't implemented.  This PR adds support for both of them by porting the CoreCLR native code that existed to C# for AOT support.  With these changes, the ComWrappers API tests and weak reference tests all pass.

Fixes #89713
Fixes #85137