### PR TITLE
only slice SocketAddress on success operation

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -476,7 +476,10 @@ namespace System.Net.Sockets
                     else
                     {
                         bool result = SocketPal.TryCompleteReceiveFrom(context._socket, Buffer.Span, null, Flags, SocketAddress.Span, out int socketAddressLen, out BytesTransferred, out ReceivedFlags, out ErrorCode);
-                        SocketAddress = SocketAddress.Slice(0, socketAddressLen);
+                        if (ErrorCode == SocketError.Success)
+                        {
+                            SocketAddress = SocketAddress.Slice(0, socketAddressLen);
+                        }
                         return result;
                     }
                 }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -475,12 +475,12 @@ namespace System.Net.Sockets
                     }
                     else
                     {
-                        bool result = SocketPal.TryCompleteReceiveFrom(context._socket, Buffer.Span, null, Flags, SocketAddress.Span, out int socketAddressLen, out BytesTransferred, out ReceivedFlags, out ErrorCode);
-                        if (ErrorCode == SocketError.Success)
+                        bool completed = SocketPal.TryCompleteReceiveFrom(context._socket, Buffer.Span, null, Flags, SocketAddress.Span, out int socketAddressLen, out BytesTransferred, out ReceivedFlags, out ErrorCode);
+                        if (completed && ErrorCode == SocketError.Success)
                         {
                             SocketAddress = SocketAddress.Slice(0, socketAddressLen);
                         }
-                        return result;
+                        return completed;
                     }
                 }
             }
@@ -511,7 +511,7 @@ namespace System.Net.Sockets
             protected override bool DoTryComplete(SocketAsyncContext context)
             {
                 bool completed = SocketPal.TryCompleteReceiveFrom(context._socket, default(Span<byte>), Buffers, Flags, SocketAddress.Span, out int socketAddressLen, out BytesTransferred, out ReceivedFlags, out ErrorCode);
-                if (ErrorCode == SocketError.Success)
+                if (completed && ErrorCode == SocketError.Success)
                 {
                     SocketAddress = SocketAddress.Slice(0, socketAddressLen);
                 }
@@ -545,7 +545,7 @@ namespace System.Net.Sockets
             protected override bool DoTryComplete(SocketAsyncContext context)
             {
                 bool completed = SocketPal.TryCompleteReceiveFrom(context._socket, new Span<byte>(BufferPtr, Length), null, Flags, SocketAddress.Span, out int socketAddressLen, out BytesTransferred, out ReceivedFlags, out ErrorCode);
-                if (ErrorCode == SocketError.Success)
+                if (completed && ErrorCode == SocketError.Success)
                 {
                     SocketAddress = SocketAddress.Slice(0, socketAddressLen);
                 }
@@ -572,7 +572,7 @@ namespace System.Net.Sockets
             protected override bool DoTryComplete(SocketAsyncContext context)
             {
                 bool completed = SocketPal.TryCompleteReceiveMessageFrom(context._socket, Buffer.Span, Buffers, Flags, SocketAddress, out int socketAddressLen, IsIPv4, IsIPv6, out BytesTransferred, out ReceivedFlags, out IPPacketInformation, out ErrorCode);
-                if (ErrorCode == SocketError.Success)
+                if (completed && ErrorCode == SocketError.Success)
                 {
                     SocketAddress = SocketAddress.Slice(0, socketAddressLen);
                 }
@@ -602,7 +602,7 @@ namespace System.Net.Sockets
             protected override bool DoTryComplete(SocketAsyncContext context)
             {
                 bool completed = SocketPal.TryCompleteReceiveMessageFrom(context._socket, new Span<byte>(BufferPtr, Length), null, Flags, SocketAddress!, out int socketAddressLen, IsIPv4, IsIPv6, out BytesTransferred, out ReceivedFlags, out IPPacketInformation, out ErrorCode);
-                if (ErrorCode == SocketError.Success)
+                if (completed && ErrorCode == SocketError.Success)
                 {
                     SocketAddress = SocketAddress.Slice(0, socketAddressLen);
                 }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -368,10 +368,7 @@ namespace System.Net.Sockets
 
         private void UpdateReceivedSocketAddress(SocketAddress socketAddress)
         {
-            if (_socketAddressSize > 0)
-            {
-                socketAddress.Size = _socketAddressSize;
-            }
+            socketAddress.Size = _socketAddressSize;
         }
 
         partial void FinishOperationReceiveMessageFrom();

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -152,7 +152,7 @@ namespace System.Net.Sockets
                     Count = (UIntPtr)buffer.Length
                 };
 
-                Debug.Assert(socketAddress.Length != 0 || rawSocketAddress == null);
+                Debug.Assert(socketAddress.Length != 0 || sockAddr == null);
 
                 var messageHeader = new Interop.Sys.MessageHeader {
                     SocketAddress = sockAddr,

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -152,6 +152,11 @@ namespace System.Net.Sockets
                     Count = (UIntPtr)buffer.Length
                 };
 
+                if (socketAddress.Length == 0)
+                {
+                    Debug.Assert(sockAddr == null);
+                }
+
                 var messageHeader = new Interop.Sys.MessageHeader {
                     SocketAddress = sockAddr,
                     SocketAddressLen = socketAddress.Length,
@@ -468,7 +473,6 @@ namespace System.Net.Sockets
         private static unsafe int SysReceiveMessageFrom(SafeSocketHandle socket, SocketFlags flags, Span<byte> buffer, Span<byte> socketAddress, out int socketAddressLen, bool isIPv4, bool isIPv6, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
         {
             Debug.Assert(socket.IsSocket);
-            Debug.Assert(socketAddress != null, "Expected non-null socketAddress");
 
             int cmsgBufferLen = Interop.Sys.GetControlMessageBufferSize(Convert.ToInt32(isIPv4), Convert.ToInt32(isIPv6));
             byte* cmsgBuffer = stackalloc byte[cmsgBufferLen];
@@ -483,6 +487,11 @@ namespace System.Net.Sockets
                     Base = b,
                     Count = (UIntPtr)buffer.Length
                 };
+
+                if (socketAddress.Length == 0)
+                {
+                    Debug.Assert(rawSocketAddress == null);
+                }
 
                 messageHeader = new Interop.Sys.MessageHeader {
                     SocketAddress = rawSocketAddress,
@@ -1234,7 +1243,7 @@ namespace System.Net.Sockets
             }
             else
             {
-                if (!TryCompleteReceiveFrom(handle, buffers, socketFlags, null, out int _, out bytesTransferred, out _, out errorCode))
+                if (!TryCompleteReceiveFrom(handle, buffers, socketFlags, Span<byte>.Empty, out int _, out bytesTransferred, out _, out errorCode))
                 {
                     errorCode = SocketError.WouldBlock;
                 }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -152,10 +152,7 @@ namespace System.Net.Sockets
                     Count = (UIntPtr)buffer.Length
                 };
 
-                if (socketAddress.Length == 0)
-                {
-                    Debug.Assert(sockAddr == null);
-                }
+                Debug.Assert(socketAddress.Length != 0 || rawSocketAddress == null);
 
                 var messageHeader = new Interop.Sys.MessageHeader {
                     SocketAddress = sockAddr,
@@ -488,10 +485,7 @@ namespace System.Net.Sockets
                     Count = (UIntPtr)buffer.Length
                 };
 
-                if (socketAddress.Length == 0)
-                {
-                    Debug.Assert(rawSocketAddress == null);
-                }
+                Debug.Assert(socketAddress.Length != 0 || rawSocketAddress == null);
 
                 messageHeader = new Interop.Sys.MessageHeader {
                     SocketAddress = rawSocketAddress,


### PR DESCRIPTION
This is regression from https://github.com/dotnet/runtime/pull/88970.
When the SocketPal.TryCompleteReceiveFrom fails e.g. no data yet, we should not Slice the SocketAddress because on next round we would not have buffer to receive to.  (as we do in case just bellow)
This was added to avoid tracking SocketAddressLength as separate parameter. 

Change is UpdateReceivedSocketAddress is small cleanup as we do not need to special case it any more. 

fixes #90125
