### PR TITLE
make Https_MultipleRequests_TlsResumed test Linux specific

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -4302,7 +4302,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux)]
+        [PlatformSpecific(TestPlatforms.Linux)]
         public async Task Https_MultipleRequests_TlsResumed(bool useSocketHandler)
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>


### PR DESCRIPTION
this is new test introduced in #88214. Since  https://github.com/dotnet/runtime/issues/75434 manifest only on Linux I make the test also Linux specific. 
It _should_ on Windows as well - I could not reproduce the failures - but .NET is not in charge of the TLS resume and it is not what the fix & test is trying to guard. 

fixes #88979
 