### PR TITLE
Support assignment to multiple refs in trim analyzer

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
@@ -10,7 +10,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 {
 	public readonly struct CapturedReferenceValue : IEquatable<CapturedReferenceValue>
 	{
-		public readonly IOperation? Reference;
+		public readonly IOperation Reference;
 
 		public CapturedReferenceValue (IOperation operation)
 		{
@@ -47,24 +47,5 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		public override int GetHashCode ()
 			=> Reference?.GetHashCode () ?? 0;
-	}
-
-
-	public struct CapturedReferenceLattice : ILattice<CapturedReferenceValue>
-	{
-		public CapturedReferenceValue Top => default;
-
-		public CapturedReferenceValue Meet (CapturedReferenceValue left, CapturedReferenceValue right)
-		{
-			if (left.Equals (right))
-				return left;
-			if (left.Reference == null)
-				return right;
-			if (right.Reference == null)
-				return left;
-			// Both non-null and different shouldn't happen.
-			// We assume that a flow capture can capture only a single property.
-			throw new InvalidOperationException ();
-		}
 	}
 }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LValueFlowCaptureProvider.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LValueFlowCaptureProvider.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable disable
+#nullable enable
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -15,7 +15,7 @@ using System.Diagnostics;
 
 namespace ILLink.RoslynAnalyzer.DataFlow
 {
-	// Copied from https://github.com/dotnet/roslyn/blob/c8ebc8682889b395fcb84c85bf4ff54577377d26/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/LValueFlowCaptureProvider.cs
+	// Adapted from https://github.com/dotnet/roslyn/blob/c8ebc8682889b395fcb84c85bf4ff54577377d26/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/LValueFlowCaptureProvider.cs
 	/// <summary>
 	/// Helper class to detect <see cref="IFlowCaptureOperation"/>s that are l-value captures.
 	/// L-value captures are essentially captures of a symbol's location/address.
@@ -38,6 +38,22 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 	/// </remarks>
 	internal static class LValueFlowCapturesProvider
 	{
+		static bool IsLValueFlowCapture (IFlowCaptureReferenceOperation flowCaptureReference, out IAssignmentOperation? assignment)
+		{
+			assignment = flowCaptureReference.Parent as IAssignmentOperation;
+			if (assignment?.Target == flowCaptureReference)
+				return true;
+
+			if (flowCaptureReference.Parent is IArrayElementReferenceOperation arrayAlementRef) {
+				assignment = arrayAlementRef.Parent as IAssignmentOperation;
+				if (assignment?.Target == arrayAlementRef)
+					return true;
+			}
+
+			assignment = null;
+			return flowCaptureReference.IsInLeftOfDeconstructionAssignment (out _);
+		}
+
 		public static ImmutableDictionary<CaptureId, FlowCaptureKind> CreateLValueFlowCaptures (ControlFlowGraph cfg)
 		{
 			// This method identifies flow capture reference operations that are target of an assignment
@@ -47,15 +63,13 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			// the flow graph. Specifically, for an ICoalesceOperation a flow capture acts
 			// as both an r-value and l-value flow capture.
 
-			ImmutableDictionary<CaptureId, FlowCaptureKind>.Builder lvalueFlowCaptureIdBuilder = null;
+			ImmutableDictionary<CaptureId, FlowCaptureKind>.Builder? lvalueFlowCaptureIdBuilder = null;
 			var rvalueFlowCaptureIds = new HashSet<CaptureId> ();
 
 			foreach (var flowCaptureReference in cfg.DescendantOperations<IFlowCaptureReferenceOperation> (OperationKind.FlowCaptureReference)) {
-				if (flowCaptureReference.Parent is IAssignmentOperation assignment &&
-					assignment.Target == flowCaptureReference ||
-					flowCaptureReference.IsInLeftOfDeconstructionAssignment (out _)) {
+				if (IsLValueFlowCapture (flowCaptureReference, out IAssignmentOperation? assignment)) {
 					lvalueFlowCaptureIdBuilder ??= ImmutableDictionary.CreateBuilder<CaptureId, FlowCaptureKind> ();
-					var captureKind = flowCaptureReference.Parent.IsAnyCompoundAssignment () || rvalueFlowCaptureIds.Contains (flowCaptureReference.Id)
+					var captureKind = assignment?.IsAnyCompoundAssignment () == true || rvalueFlowCaptureIds.Contains (flowCaptureReference.Id)
 						? FlowCaptureKind.LValueAndRValueCapture
 						: FlowCaptureKind.LValueCapture;
 					lvalueFlowCaptureIdBuilder.Add (flowCaptureReference.Id, captureKind);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateLattice.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateLattice.cs
@@ -43,22 +43,22 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		// Stores any operations which are captured by reference in a FlowCaptureOperation.
 		// Only stores captures which are assigned through. Captures of the values of operations
 		// are tracked as part of the dictionary of values, keyed by LocalKey.
-		public DefaultValueDictionary<CaptureId, CapturedReferenceValue> CapturedReferences;
+		public DefaultValueDictionary<CaptureId, ValueSet<CapturedReferenceValue>> CapturedReferences;
 
 		public LocalState (TValue defaultValue)
 			: this (new DefaultValueDictionary<LocalKey, TValue> (defaultValue),
-				new DefaultValueDictionary<CaptureId, CapturedReferenceValue> (default (CapturedReferenceValue)))
+				new DefaultValueDictionary<CaptureId, ValueSet<CapturedReferenceValue>> (default (ValueSet<CapturedReferenceValue>)))
 		{
 		}
 
-		public LocalState (DefaultValueDictionary<LocalKey, TValue> dictionary, DefaultValueDictionary<CaptureId, CapturedReferenceValue> capturedReferences)
+		public LocalState (DefaultValueDictionary<LocalKey, TValue> dictionary, DefaultValueDictionary<CaptureId, ValueSet<CapturedReferenceValue>> capturedReferences)
 		{
 			Dictionary = dictionary;
 			CapturedReferences = capturedReferences;
 		}
 
 		public LocalState (DefaultValueDictionary<LocalKey, TValue> dictionary)
-			: this (dictionary, new DefaultValueDictionary<CaptureId, CapturedReferenceValue> (default (CapturedReferenceValue)))
+			: this (dictionary, new DefaultValueDictionary<CaptureId, ValueSet<CapturedReferenceValue>> (default (ValueSet<CapturedReferenceValue>)))
 		{
 		}
 
@@ -83,12 +83,12 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		where TValueLattice : ILattice<TValue>
 	{
 		public readonly DictionaryLattice<LocalKey, TValue, TValueLattice> Lattice;
-		public readonly DictionaryLattice<CaptureId, CapturedReferenceValue, CapturedReferenceLattice> CapturedReferenceLattice;
+		public readonly DictionaryLattice<CaptureId, ValueSet<CapturedReferenceValue>, ValueSetLattice<CapturedReferenceValue>> CapturedReferenceLattice;
 
 		public LocalStateLattice (TValueLattice valueLattice)
 		{
 			Lattice = new DictionaryLattice<LocalKey, TValue, TValueLattice> (valueLattice);
-			CapturedReferenceLattice = new DictionaryLattice<CaptureId, CapturedReferenceValue, CapturedReferenceLattice> (default (CapturedReferenceLattice));
+			CapturedReferenceLattice = new DictionaryLattice<CaptureId, ValueSet<CapturedReferenceValue>, ValueSetLattice<CapturedReferenceValue>> (default (ValueSetLattice<CapturedReferenceValue>));
 			Top = new (Lattice.Top);
 		}
 

--- a/src/tools/illink/src/ILLink.Shared/DataFlow/ValueSet.cs
+++ b/src/tools/illink/src/ILLink.Shared/DataFlow/ValueSet.cs
@@ -132,6 +132,8 @@ namespace ILLink.Shared.DataFlow
 
 		public static implicit operator ValueSet<TValue> (TValue value) => new (value);
 
+		public bool HasMultipleValues => _values is EnumerableValues;
+
 		public override bool Equals (object? obj) => obj is ValueSet<TValue> other && Equals (other);
 
 		public bool Equals (ValueSet<TValue> other)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/MethodWithUnmanagedConstraint.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/MethodWithUnmanagedConstraint.cs
@@ -4,7 +4,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed
 {
 	[SetupCSharpCompilerToUse ("csc")]
-	[SetupCompileArgument ("/langversion:7.3")]
 	[SetupLinkerArgument ("--used-attrs-only", "true")]
 	public class MethodWithUnmanagedConstraint
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -35,6 +35,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			PointerDereference.Test ();
 			MultipleOutRefsToField.Test ();
+			SingleRefCapture.Test ();
 			MultipleRefCaptures.Test ();
 		}
 
@@ -190,6 +191,28 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
+		class SingleRefCapture
+		{
+			[Kept]
+			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
+			static void TestArrayElementReferenceAssignment ()
+			{
+				var arr1 = new Type[] { GetUnknownType () };
+				ref var local = ref arr1[0];
+				local = GetTypeWithPublicFields ();
+				arr1[0].RequiresAll ();
+			}
+
+			[Kept]
+			public static void Test ()
+			{
+				TestArrayElementReferenceAssignment ();
+			}
+		}
+
+		[Kept]
 		class MultipleRefCaptures
 		{
 			[Kept]
@@ -242,10 +265,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			[Kept]
-			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DataFlowTypeExtensions.RequiresAll))]
-			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicConstructors), nameof (DataFlowTypeExtensions.RequiresAll))]
-			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll))]
-			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicConstructors), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 			static void TestArrayElementReferenceAssignment (bool b = true)
 			{
 				var arr1 = new Type[] { GetUnknownType () };
@@ -258,8 +283,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DataFlowTypeExtensions.RequiresAll))]
 			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicConstructors), nameof (DataFlowTypeExtensions.RequiresAll))]
-			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll))]
-			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll))]
+			// BUG: illink/nativeaot have an analysis hole here
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
 			static void TestArrayElementAssignment (bool b = true)
 			{
 				var arr1 = new Type[] { GetUnknownType () };

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -35,7 +35,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			PointerDereference.Test ();
 			MultipleOutRefsToField.Test ();
-			SingleRefCapture.Test ();
 			MultipleRefCaptures.Test ();
 		}
 
@@ -191,28 +190,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		[Kept]
-		class SingleRefCapture
-		{
-			[Kept]
-			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Trimmer | Tool.NativeAot)]
-			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
-			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
-			static void TestArrayElementReferenceAssignment ()
-			{
-				var arr1 = new Type[] { GetUnknownType () };
-				ref var local = ref arr1[0];
-				local = GetTypeWithPublicFields ();
-				arr1[0].RequiresAll ();
-			}
-
-			[Kept]
-			public static void Test ()
-			{
-				TestArrayElementReferenceAssignment ();
-			}
-		}
-
-		[Kept]
 		class MultipleRefCaptures
 		{
 			[Kept]
@@ -269,6 +246,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicConstructors), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
 			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
 			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
+			// ILLink/ILCompiler produce different warning code: https://github.com/dotnet/linker/issues/2737
 			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 			static void TestArrayElementReferenceAssignment (bool b = true)
@@ -283,7 +261,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DataFlowTypeExtensions.RequiresAll))]
 			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicConstructors), nameof (DataFlowTypeExtensions.RequiresAll))]
-			// BUG: illink/nativeaot have an analysis hole here
+			// ILLink/ILCompiler analysis hole: https://github.com/dotnet/runtime/issues/90335
 			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
 			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
 			static void TestArrayElementAssignment (bool b = true)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -242,6 +242,34 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			[Kept]
+			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicConstructors), nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll))]
+			static void TestArrayElementReferenceAssignment (bool b = true)
+			{
+				var arr1 = new Type[] { GetUnknownType () };
+				var arr2 = new Type[] { GetTypeWithPublicConstructors () };
+				(b ? ref arr1[0] : ref arr2[0]) = GetTypeWithPublicFields ();
+				arr1[0].RequiresAll ();
+				arr2[0].RequiresAll ();
+			}
+
+			[Kept]
+			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicConstructors), nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll))]
+			static void TestArrayElementAssignment (bool b = true)
+			{
+				var arr1 = new Type[] { GetUnknownType () };
+				var arr2 = new Type[] { GetTypeWithPublicConstructors () };
+				(b ? arr1 : arr2)[0] = GetTypeWithPublicFields ();
+				arr1[0].RequiresAll ();
+				arr2[0].RequiresAll ();
+			}
+
+			[Kept]
 			[ExpectedWarning ("IL2074", nameof (_publicMethodsField), nameof (GetUnknownType))]
 			[ExpectedWarning ("IL2074", nameof (_publicPropertiesField), nameof (GetUnknownType))]
 			static void TestNullCoalescingAssignment (bool b = true)
@@ -287,6 +315,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestFieldAssignment ();
 				TestParameterAssignment ();
 				TestLocalAssignment ();
+				TestArrayElementReferenceAssignment ();
+				TestArrayElementAssignment ();
 				TestNullCoalescingAssignment ();
 				TestNullCoalescingAssignmentComplex ();
 				TestDataFlowOnRightHandOfAssignment ();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -5,10 +5,10 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
-	[SetupCompileArgument ("/langversion:7.3")]
 	[SetupCompileArgument ("/unsafe")]
 	[Kept]
 	[ExpectedNoWarnings]
@@ -35,6 +35,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			PointerDereference.Test ();
 			MultipleOutRefsToField.Test ();
+			MultipleRefCaptures.Test ();
 		}
 
 		[Kept]
@@ -187,5 +188,123 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TwoOutRefs (out _publicMethodsField, out _publicPropertiesField);
 			}
 		}
+
+		[Kept]
+		class MultipleRefCaptures
+		{
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			static Type _publicMethodsField;
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]
+			static Type _publicPropertiesField;
+
+			static Type Prop { get; set; }
+
+			[Kept]
+			[ExpectedWarning ("IL2074", nameof (_publicMethodsField), nameof (GetUnknownType))]
+			[ExpectedWarning ("IL2074", nameof (_publicPropertiesField), nameof (GetUnknownType))]
+			static void TestFieldAssignment (bool b = true)
+			{
+				(b ? ref _publicMethodsField : ref _publicPropertiesField) = GetUnknownType ();
+			}
+
+			[Kept]
+			[ExpectedWarning ("IL2072", nameof (publicMethodsParameter), nameof (GetUnknownType))]
+			[ExpectedWarning ("IL2072", nameof (publicPropertiesParameter), nameof (GetUnknownType))]
+			static void TestParameterAssignment (
+				bool b = true,
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				Type publicMethodsParameter = null,
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]
+				Type publicPropertiesParameter = null)
+			{
+				(b ? ref publicMethodsParameter : ref publicPropertiesParameter) = GetUnknownType ();
+			}
+
+			[Kept]
+			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicConstructors), nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicConstructors), nameof (DataFlowTypeExtensions.RequiresAll))]
+			static void TestLocalAssignment (bool b = true)
+			{
+				var local1 = GetUnknownType ();
+				var local2 = GetTypeWithPublicFields ();
+				(b ? ref local1 : ref local2) = GetTypeWithPublicConstructors ();
+				local1.RequiresAll ();
+				local2.RequiresAll ();
+			}
+
+			[Kept]
+			[ExpectedWarning ("IL2074", nameof (_publicMethodsField), nameof (GetUnknownType))]
+			[ExpectedWarning ("IL2074", nameof (_publicPropertiesField), nameof (GetUnknownType))]
+			static void TestNullCoalescingAssignment (bool b = true)
+			{
+				(b ? ref _publicMethodsField : ref _publicPropertiesField) ??= GetUnknownType ();
+			}
+
+			[Kept]
+			[ExpectedWarning ("IL2074", nameof (_publicMethodsField), nameof (GetUnknownType))]
+			[ExpectedWarning ("IL2074", nameof (_publicMethodsField), nameof (GetTypeWithPublicConstructors))]
+			[ExpectedWarning ("IL2074", nameof (_publicPropertiesField), nameof (GetUnknownType))]
+			[ExpectedWarning ("IL2074", nameof (_publicPropertiesField), nameof (GetTypeWithPublicConstructors))]
+			static void TestNullCoalescingAssignmentComplex (bool b = true)
+			{
+				(b ? ref _publicMethodsField : ref _publicPropertiesField) ??= GetUnknownType () ?? GetTypeWithPublicConstructors ();
+			}
+
+			[Kept]
+			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DynamicallyAccessedMemberTypes.PublicConstructors), nameof (type))]
+			[ExpectedWarning ("IL2074", nameof (_publicMethodsField), nameof (GetUnknownType))]
+			[ExpectedWarning ("IL2074", nameof (_publicPropertiesField), nameof (GetUnknownType))]
+			static void TestDataFlowOnRightHandOfAssignment (
+				bool b = true,
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)] Type type = null)
+			{
+				(b ? ref _publicMethodsField : ref _publicPropertiesField) = (type = GetUnknownType ());
+			}
+
+			[Kept]
+			[ExpectedWarning ("IL2074", nameof (_publicMethodsField), nameof (GetUnknownType))]
+			[ExpectedWarning ("IL2074", nameof (_publicPropertiesField), nameof (GetUnknownType))]
+			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DataFlowTypeExtensions.RequiresAll))]
+			static void TestReturnValue (bool b = true)
+			{
+				var value = (b ? ref _publicMethodsField : ref _publicPropertiesField) = GetUnknownType ();
+				value.RequiresAll ();
+			}
+
+			[Kept]
+			public static void Test ()
+			{
+				TestFieldAssignment ();
+				TestParameterAssignment ();
+				TestLocalAssignment ();
+				TestNullCoalescingAssignment ();
+				TestNullCoalescingAssignmentComplex ();
+				TestDataFlowOnRightHandOfAssignment ();
+				TestReturnValue ();
+			}
+		}
+
+		[Kept]
+		static Type GetUnknownType () => null;
+
+		[Kept]
+		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)]
+		static Type GetTypeWithPublicConstructors () => null;
+
+		[Kept]
+		[return: KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+		static Type GetTypeWithPublicFields () => null;
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompiler.cs
@@ -267,9 +267,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 						emitPdb = true;
 						debugType = DebugInformationFormat.Embedded;
 						break;
-					case "/langversion:7.3":
-						languageVersion = LanguageVersion.CSharp7_3;
-						break;
 					default:
 						var splitIndex = option.IndexOf (":");
 						if (splitIndex != -1 && option[..splitIndex] == "/main") {


### PR DESCRIPTION
Fixes https://github.com/dotnet/linker/issues/3046 by adding analyzer support for assignments to multiple refs, for example:
```csharp
(b ? ref f1 : ref f2) = v;
```

This also includes support for assignments by reference to array elements:
```csharp
(b ? ref a1[0] : ref a2[0]) = v;
```

ILLink and ILCompiler produce a different warning in this case (`stdin.ref` results in the array values being replaced with `UnknownValue`). I attempted to quirk this in the analyzer, but this caused more problems in existing tests because it was difficult to make the quirk specific enough.

Also fixes assignment to multiple arrays on the LHS (this appears to be an analysis hole in ILLink and ILCompiler):
```csharp
(b ? a1 : a2)[0] = v;
```
