### PR TITLE
Improve codegen in impStringEqualsOrStartsWith

### DIFF
--- a/src/coreclr/jit/importervectorization.cpp
+++ b/src/coreclr/jit/importervectorization.cpp
@@ -616,11 +616,19 @@ GenTree* Compiler::impStringEqualsOrStartsWith(bool startsWith, CORINFO_SIG_INFO
         op2 = impStackTop(0).val;
     }
 
-    if (!(op1->OperIs(GT_CNS_STR) ^ op2->OperIs(GT_CNS_STR)))
+    if (!op1->OperIs(GT_CNS_STR) && !op2->OperIs(GT_CNS_STR))
     {
-        // either op1 or op2 has to be CNS_STR, but not both - that case is optimized
-        // just fine as is.
         return nullptr;
+    }
+
+    if (op1->OperIs(GT_CNS_STR) && op2->OperIs(GT_CNS_STR) && GenTree::Compare(op1, op2))
+    {
+        // Both are literals and represent the same string - return true
+        for (int i = 0; i < argsCount; i++)
+        {
+            impPopStack();
+        }
+        return gtNewTrue();
     }
 
     GenTree*       varStr;

--- a/src/coreclr/jit/importervectorization.cpp
+++ b/src/coreclr/jit/importervectorization.cpp
@@ -621,16 +621,6 @@ GenTree* Compiler::impStringEqualsOrStartsWith(bool startsWith, CORINFO_SIG_INFO
         return nullptr;
     }
 
-    if (op1->OperIs(GT_CNS_STR) && op2->OperIs(GT_CNS_STR) && GenTree::Compare(op1, op2))
-    {
-        // Both are literals and represent the same string - return true
-        for (int i = 0; i < argsCount; i++)
-        {
-            impPopStack();
-        }
-        return gtNewTrue();
-    }
-
     GenTree*       varStr;
     GenTreeStrCon* cnsStr;
     if (op2->OperIs(GT_CNS_STR))


### PR DESCRIPTION
A quick improvement for `impStringEqualsOrStartsWith` suboptimal codegen noticed by @MichalPetryka 
```cs
public static int A() => B("b");

[MethodImpl(MethodImplOptions.AggressiveInlining)]
public static int B(string s)
{
    switch (s)
    {
        case "a":
            return 1;
        case "b":
            return 2;
        case "c":
            return 3;
        default:
            return 0;
    }
}
```
Old codegen for `A`:
```asm
; Method Tests:A():int (FullOpts)
       mov      rax, 0x1BC003094DC
       movzx    rax, word  ptr [rax]
       mov      rcx, 0x1BC003094F4
       cmp      ax, word  ptr [rcx]
       sete     al
       movzx    rax, al
       test     eax, eax
       je       SHORT G_M44172_IG04
       mov      eax, 1
       jmp      SHORT G_M44172_IG05
G_M44172_IG04:  ;; offset=0x002B
       mov      eax, 2
       ret      
; Total bytes of code: 49
```
New codegen for `A`:
```asm
; Method Tests:A():int (FullOpts)
       mov      eax, 2
       ret      
; Total bytes of code: 6
```