### PR TITLE
Disable JIT/Methodical/inlining/bug505642/test_bug505642/test_bug505642.dll

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -20,6 +20,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/opt/SSA/MemorySsa/**">
             <Issue>https://github.com/dotnet/runtime/issues/86112</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/inlining/bug505642/test_bug505642/*">
+            <Issue>For testing</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All OS/Arch CoreCLR excludes -->


### PR DESCRIPTION
This should allow a clean gcstress_extra run