### PR TITLE
[mono][debugger] Do not use `select(2)` on debugger-agent

### DIFF
--- a/src/mono/mono/utils/mono-poll.c
+++ b/src/mono/mono/utils/mono-poll.c
@@ -31,7 +31,7 @@ mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout)
 
 #else
 
-#if defined(HAVE_POLL) && !defined(__APPLE__)
+#if defined(HAVE_POLL)
 
 int
 mono_poll_can_add (mono_pollfd *ufds, unsigned int nfds, int fd)


### PR DESCRIPTION
Avoid using the select routine in the Mono debugger agent to handle file descriptors larger than FD_SETSIZE
Because of this PR: https://github.com/dotnet/runtime/pull/82429

Fixes #82493