### PR TITLE
Mark Microsoft.NetCore.Platforms as non-shipping

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -13,6 +13,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
 
     <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
     <PackageId>$(MSBuildProjectName)</PackageId>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages.</PackageDescription>


### PR DESCRIPTION
The full RID graph is frozen and won't change anymore. Mark the Microsoft.NETCore.Platforms nuget package as non-shipping as only the sdk repository still requires it.

Contributes to https://github.com/dotnet/runtime/issues/90000