### PR TITLE
JIT: Remove an overeager assert in forward sub

### DIFF
--- a/src/coreclr/jit/forwardsub.cpp
+++ b/src/coreclr/jit/forwardsub.cpp
@@ -442,6 +442,10 @@ private:
 //    true if statement computation was forwarded.
 //    caller is responsible for removing the now-dead statement.
 //
+// Remarks:
+//    This requires locals to be linked (fgNodeThreading == AllLocals) and
+//    liveness information to be up-to-date (specifically GTF_VAR_DEATH).
+//
 bool Compiler::fgForwardSubStatement(Statement* stmt)
 {
     // Is this tree a def of a single use, unaliased local?
@@ -466,10 +470,6 @@ bool Compiler::fgForwardSubStatement(Statement* stmt)
         JITDUMP(" pinned local\n");
         return false;
     }
-
-    // Cannot forward sub without liveness information.
-    //
-    assert(fgDidEarlyLiveness);
 
     // And local is unalised
     //


### PR DESCRIPTION
Physical promotion invokes `fgForwardSubStatement`, providing its own
liveness information, meaning that early liveness is no longer the only
source of liveness information in this function. This made it possible
to hit an assert when early liveness was disabled via
`DOTNET_JitEnableEarlyLivenessRange`.

Remove the overeager assert and leave it up to the caller to ensure that
there is valid liveness information (`GTF_VAR_DEATH`) when forward sub
is invoked.

Fix https://github.com/dotnet/runtime/issues/90295