### PR TITLE
Add check for tizen in ilc and crossgen2

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -12,6 +12,7 @@
     <PublishDir>$(RuntimeBinDir)ilc-published/</PublishDir>
     <!-- Can't use NativeAOT in source build yet https://github.com/dotnet/runtime/issues/66859 -->
     <NativeAotSupported Condition="'$(DotNetBuildFromSource)' == 'true'">false</NativeAotSupported>
+    <NativeAotSupported Condition="$(OutputRID.StartsWith('tizen')) == 'true'">false</NativeAotSupported>
     <!-- Disable native AOT on FreeBSD when cross building from Linux. -->
     <NativeAotSupported Condition="'$(TargetOS)' == 'freebsd' and '$(CrossBuild)' == 'true'">false</NativeAotSupported>
     <PublishAot Condition="'$(NativeAotSupported)' == 'true'">true</PublishAot>

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
@@ -6,6 +6,7 @@
     <OutputPath>$(RuntimeBinDir)crossgen2</OutputPath>
     <!-- Can't use NativeAOT in source build yet https://github.com/dotnet/runtime/issues/66859 -->
     <NativeAotSupported Condition="'$(DotNetBuildFromSource)' == 'true'">false</NativeAotSupported>
+    <NativeAotSupported Condition="$(OutputRID.StartsWith('tizen')) == 'true'">false</NativeAotSupported>
     <!-- Trimming is not currently working, but set the appropriate feature flags for NativeAOT -->
     <PublishTrimmed Condition="'$(NativeAotSupported)' == 'true'">true</PublishTrimmed>
     <RuntimeIdentifiers Condition="'$(_IsPublishing)' != 'true' and '$(DotNetBuildFromSource)' != 'true'">linux-x64;linux-musl-x64;linux-arm;linux-musl-arm;linux-arm64;linux-musl-arm64;freebsd-x64;freebsd-arm64;osx-x64;osx-arm64;win-x64;win-x86;win-arm64</RuntimeIdentifiers>


### PR DESCRIPTION
Fix tizen x64 build error:
```
ILCompiler -> /home/runtime/artifacts/bin/coreclr/linux.x64.Release/ilc/ilc.dll
Generating native code
/usr/bin/x86_64-linux-gnu-ld.bfd: cannot find crtbeginS.o: No such file or directory
/usr/bin/x86_64-linux-gnu-ld.bfd: cannot find -lgcc: No such file or directory
/usr/bin/x86_64-linux-gnu-ld.bfd: cannot find -lgcc: No such file or directory
clang : error : linker command failed with exit code 1 (use -v to see invocation) [/home/runtime/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj]
/home/runtime/.packages/microsoft.dotnet.ilcompiler/8.0.0-rc.1.23401.3/build/Microsoft.NETCore.Native.targets(360,5): error MSB3073: The command ""/usr/bin/clang-14" --gcc-toolchain=/home/runtime/.tools/rootfs/x64/usr "/home/runtime/artifacts/obj/coreclr/ILCompiler/x64/Release/native/ilc.o" -o "/home/runtime/artifacts/bin/coreclr/linux.x64.Release/ilc/native/ilc" -fuse-ld=bfd /home/runtime/.packages/runtime.linux-x64.microsoft.dotnet.ilcompiler/8.0.0-rc.1.23401.3/sdk/libbootstrapper.o /home/runtime/.packages/runtime.linux-x64.microsoft.dotnet.ilcompiler/8.0.0-rc.1.23401.3/sdk/libRuntime.ServerGC.a /home/runtime/.packages/runtime.linux-x64.microsoft.dotnet.ilcompiler/8.0.0-rc.1.23401.3/sdk/libeventpipe-enabled.a /home/runtime/.packages/runtime.linux-x64.microsoft.dotnet.ilcompiler/8.0.0-rc.1.23401.3/sdk/libstdc++compat.a /home/runtime/.packages/runtime.linux-x64.microsoft.dotnet.ilcompiler/8.0.0-rc.1.23401.3/framework/libSystem.Native.a /home/runtime/.packages/runtime.linux-x64.microsoft.dotnet.ilcompiler/8.0.0-rc.1.23401.3/framework/libSystem.Globalization.Native.a /home/runtime/.packages/runtime.linux-x64.microsoft.dotnet.ilcompiler/8.0.0-rc.1.23401.3/framework/libSystem.IO.Compression.Native.a /home/runtime/.packages/runtime.linux-x64.microsoft.dotnet.ilcompiler/8.0.0-rc.1.23401.3/framework/libSystem.Net.Security.Native.a /home/runtime/.packages/runtime.linux-x64.microsoft.dotnet.ilcompiler/8.0.0-rc.1.23401.3/framework/libSystem.Security.Cryptography.Native.OpenSsl.a --sysroot=/home/runtime/.tools/rootfs/x64 -g -Wl,-rpath,'$ORIGIN' -Wl,--build-id=sha1 -Wl,--as-needed -pthread -ldl -lz -lrt -lm -pie -Wl,-pie -Wl,-z,relro -Wl,-z,now -Wl,--eh-frame-hdr --target=x86_64-linux-gnu -Wl,--discard-all -Wl,--gc-sections" exited with code 1. [/home/runtime/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj]
```

1) Create tizen x64 rootfs 
`sudo ./eng/common/cross/build-rootfs.sh x64 tizen`

2) Build command:
`ROOTFS_DIR=/home/runtime/.tools/rootfs/x64  ./build.sh --portablebuild false --cross --clang --arch x64 --runtimeConfiguration Release --librariesConfiguration Release --subset clr.native+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools+libs.native /p:EnableSourceLink=false /p:UseSharedCompilation=false`

cc @gbalykov @alpencolt @t-mustafin 