### PR TITLE
Open up `EmbeddedXmlInfo`

### DIFF
--- a/src/tools/illink/src/linker/CompatibilitySuppressions.xml
+++ b/src/tools/illink/src/linker/CompatibilitySuppressions.xml
@@ -1513,6 +1513,12 @@
     <Left>ref/net8.0/illink.dll</Left>
     <Right>lib/net8.0/illink.dll</Right>
   </Suppression>
+    <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Mono.Linker.LinkContext.get_EmbeddedXmlInfo</Target>
+    <Left>ref/net8.0/illink.dll</Left>
+    <Right>lib/net8.0/illink.dll</Right>
+  </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Mono.Linker.LinkContext.get_TrimAction</Target>

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -237,6 +237,7 @@ namespace Mono.Linker.Steps
 		public AnnotationStore Annotations => Context.Annotations;
 		public MarkingHelpers MarkingHelpers => Context.MarkingHelpers;
 		public Tracer Tracer => Context.Tracer;
+		public EmbeddedXmlInfo EmbeddedXmlInfo => Context.EmbeddedXmlInfo;
 
 		public virtual void Process (LinkContext context)
 		{

--- a/src/tools/illink/src/linker/Linker/CustomAttributeSource.cs
+++ b/src/tools/illink/src/linker/Linker/CustomAttributeSource.cs
@@ -45,7 +45,7 @@ namespace Mono.Linker
 				// may ask for attributes (suppressions) and thus we could end up in this very place again
 				// So first add a dummy record and once processed we will replace it with the real data
 				_embeddedXmlInfos.Add (assembly, new AttributeInfo ());
-				xmlInfo = EmbeddedXmlInfo.ProcessAttributes (assembly, _context);
+				xmlInfo = _context.EmbeddedXmlInfo.ProcessAttributes (assembly, _context);
 				_embeddedXmlInfos[assembly] = xmlInfo;
 			}
 

--- a/src/tools/illink/src/linker/Linker/EmbeddedXmlInfo.cs
+++ b/src/tools/illink/src/linker/Linker/EmbeddedXmlInfo.cs
@@ -10,7 +10,7 @@ using Mono.Linker.Steps;
 
 namespace Mono.Linker
 {
-	public static class EmbeddedXmlInfo
+	public class EmbeddedXmlInfo
 	{
 		static EmbeddedResource? GetEmbeddedXml (AssemblyDefinition assembly, Func<Resource, bool> predicate)
 		{
@@ -22,7 +22,7 @@ namespace Mono.Linker
 				.SingleOrDefault () as EmbeddedResource;
 		}
 
-		public static void ProcessDescriptors (AssemblyDefinition assembly, LinkContext context)
+		public void ProcessDescriptors (AssemblyDefinition assembly, LinkContext context)
 		{
 			if (context.Annotations.GetAction (assembly) == AssemblyAction.Skip)
 				return;
@@ -43,7 +43,7 @@ namespace Mono.Linker
 			marker?.Mark ();
 		}
 
-		public static SubstitutionInfo? ProcessSubstitutions (AssemblyDefinition assembly, LinkContext context)
+		public SubstitutionInfo? ProcessSubstitutions (AssemblyDefinition assembly, LinkContext context)
 		{
 			if (context.Annotations.GetAction (assembly) == AssemblyAction.Skip)
 				return null;
@@ -68,7 +68,7 @@ namespace Mono.Linker
 			return substitutionInfo;
 		}
 
-		public static AttributeInfo? ProcessAttributes (AssemblyDefinition assembly, LinkContext context)
+		public AttributeInfo? ProcessAttributes (AssemblyDefinition assembly, LinkContext context)
 		{
 			if (context.Annotations.GetAction (assembly) == AssemblyAction.Skip)
 				return null;
@@ -121,17 +121,17 @@ namespace Mono.Linker
 			}
 		}
 
-		static DescriptorMarker GetExternalResolveStep (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
+		protected virtual DescriptorMarker GetExternalResolveStep (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
 		{
 			return new DescriptorMarker (context, resource.GetResourceStream (), resource, assembly, "resource " + resource.Name + " in " + assembly.FullName);
 		}
 
-		static BodySubstitutionParser GetExternalSubstitutionParser (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
+		protected virtual BodySubstitutionParser GetExternalSubstitutionParser (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
 		{
 			return new BodySubstitutionParser (context, resource.GetResourceStream (), resource, assembly, "resource " + resource.Name + " in " + assembly.FullName);
 		}
 
-		static LinkAttributesParser GetExternalLinkAttributesParser (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
+		protected virtual LinkAttributesParser GetExternalLinkAttributesParser (LinkContext context, EmbeddedResource resource, AssemblyDefinition assembly)
 		{
 			return new LinkAttributesParser (context, resource.GetResourceStream (), resource, assembly, "resource " + resource.Name + " in " + assembly.FullName);
 		}

--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -49,6 +49,7 @@ namespace Mono.Linker
 		public virtual AnnotationStore CreateAnnotationStore (LinkContext context) => new AnnotationStore (context);
 		public virtual MarkingHelpers CreateMarkingHelpers (LinkContext context) => new MarkingHelpers (context);
 		public virtual Tracer CreateTracer (LinkContext context) => new Tracer (context);
+		public virtual EmbeddedXmlInfo CreateEmbeddedXmlInfo () => new ();
 	}
 
 	public static class TargetRuntimeVersion
@@ -174,6 +175,8 @@ namespace Mono.Linker
 
 		public Tracer Tracer { get; private set; }
 
+		public EmbeddedXmlInfo EmbeddedXmlInfo { get; private set; }
+
 		public CodeOptimizationsSettings Optimizations { get; set; }
 
 		public bool AddReflectionAnnotations { get; set; }
@@ -213,6 +216,7 @@ namespace Mono.Linker
 			MarkingHelpers = factory.CreateMarkingHelpers (this);
 			SerializationMarker = new SerializationMarker (this);
 			Tracer = factory.CreateTracer (this);
+			EmbeddedXmlInfo = factory.CreateEmbeddedXmlInfo ();
 			MarkedKnownMembers = new KnownMembers ();
 			PInvokes = new List<PInvokeInfo> ();
 			Suppressions = new UnconditionalSuppressMessageAttributeState (this);

--- a/src/tools/illink/src/linker/Linker/MemberActionStore.cs
+++ b/src/tools/illink/src/linker/Linker/MemberActionStore.cs
@@ -24,7 +24,7 @@ namespace Mono.Linker
 		{
 			var assembly = member.Module.Assembly;
 			if (!_embeddedXmlInfos.TryGetValue (assembly, out xmlInfo)) {
-				xmlInfo = EmbeddedXmlInfo.ProcessSubstitutions (assembly, _context);
+				xmlInfo = _context.EmbeddedXmlInfo.ProcessSubstitutions (assembly, _context);
 				_embeddedXmlInfos.Add (assembly, xmlInfo);
 			}
 


### PR DESCRIPTION
We need to override `GetExternalResolveStep` in order to hook into the xml processing.

We currently don't need to override  `GetExternalSubstitutionParser` and `GetExternalLinkAttributesParser`, but I thought it would be better to have a consistent pattern rather than a 1 off virtual method.