### PR TITLE
Rework SnakeCase/KebabCase naming policies to closer match Json.NET's

### DIFF
--- a/src/libraries/System.Text.Json/Common/JsonSeparatorNamingPolicy.cs
+++ b/src/libraries/System.Text.Json/Common/JsonSeparatorNamingPolicy.cs
@@ -47,9 +47,13 @@ namespace System.Text.Json
 
             for (int i = 0; i < chars.Length; i++)
             {
-                char current = chars[i];
+                // NB this implementation ignores surrogate pairs
+                // cf. https://github.com/dotnet/runtime/issues/90352
 
-                switch (char.GetUnicodeCategory(current))
+                char current = chars[i];
+                UnicodeCategory category = char.GetUnicodeCategory(current);
+
+                switch (category)
                 {
                     case UnicodeCategory.UppercaseLetter:
 
@@ -100,7 +104,7 @@ namespace System.Text.Json
                             WriteChar(separator, ref destination);
                         }
 
-                        if (!lowercase)
+                        if (!lowercase && category is UnicodeCategory.LowercaseLetter)
                         {
                             current = char.ToUpperInvariant(current);
                         }

--- a/src/libraries/System.Text.Json/Common/JsonSeparatorNamingPolicy.cs
+++ b/src/libraries/System.Text.Json/Common/JsonSeparatorNamingPolicy.cs
@@ -86,7 +86,9 @@ namespace System.Text.Json
                         }
 
                         if (lowercase)
+                        {
                             current = char.ToLowerInvariant(current);
+                        }
 
                         WriteChar(current, ref destination);
                         state = SeparatorState.UppercaseLetter;
@@ -102,7 +104,9 @@ namespace System.Text.Json
                         }
 
                         if (!lowercase)
+                        {
                             current = char.ToUpperInvariant(current);
+                        }
 
                         WriteChar(current, ref destination);
                         state = SeparatorState.LowercaseLetterOrDigit;

--- a/src/libraries/System.Text.Json/Common/JsonSeparatorNamingPolicy.cs
+++ b/src/libraries/System.Text.Json/Common/JsonSeparatorNamingPolicy.cs
@@ -11,14 +11,14 @@ namespace System.Text.Json
     internal abstract class JsonSeparatorNamingPolicy : JsonNamingPolicy
     {
         private readonly bool _lowercase;
-        private readonly Rune _separator;
+        private readonly char _separator;
 
         internal JsonSeparatorNamingPolicy(bool lowercase, char separator)
         {
             Debug.Assert(char.IsPunctuation(separator));
 
             _lowercase = lowercase;
-            _separator = new Rune(separator);
+            _separator = separator;
         }
 
         public sealed override string ConvertName(string name)
@@ -31,7 +31,7 @@ namespace System.Text.Json
             return ConvertNameCore(_separator, _lowercase, name);
         }
 
-        private static string ConvertNameCore(Rune separator, bool lowercase, string name)
+        private static string ConvertNameCore(char separator, bool lowercase, string name)
         {
             Debug.Assert(name != null);
 
@@ -44,15 +44,15 @@ namespace System.Text.Json
                 ? stackalloc char[JsonConstants.StackallocCharThreshold]
                 : (rentedBuffer = ArrayPool<char>.Shared.Rent(initialBufferLength));
 
+            ReadOnlySpan<char> chars = name.AsSpan();
             SeparatorState state = SeparatorState.NotStarted;
             int charsWritten = 0;
 
-            for (int i = 0; i < name.Length;)
+            for (int i = 0; i < chars.Length; i++)
             {
-                Rune current = Rune.GetRuneAt(name, i);
-                int charLength = current.Utf16SequenceLength;
+                char current = chars[i];
 
-                switch (Rune.GetUnicodeCategory(current))
+                switch (char.GetUnicodeCategory(current))
                 {
                     case UnicodeCategory.UppercaseLetter:
 
@@ -65,7 +65,7 @@ namespace System.Text.Json
                             case SeparatorState.SpaceSeparator:
                                 // An uppercase letter following a sequence of lowercase letters or spaces
                                 // denotes the start of a new grouping: emit a separator character.
-                                Write(separator, ref destination);
+                                WriteChar(separator, ref destination);
                                 break;
 
                             case SeparatorState.UppercaseLetter:
@@ -74,15 +74,10 @@ namespace System.Text.Json
                                 // final letter, assuming it is followed by lowercase letters.
                                 // For example, the value 'XMLReader' should render as 'xml_reader',
                                 // however 'SHA512Hash' should render as 'sha512-hash'.
-                                if (i + charLength < name.Length)
+                                if (i + 1 < chars.Length && char.IsLower(chars[i + 1]))
                                 {
-                                    Rune next = Rune.GetRuneAt(name, i + charLength);
-                                    if (Rune.GetUnicodeCategory(next) is UnicodeCategory.LowercaseLetter)
-                                    {
-                                        Write(separator, ref destination);
-                                    }
+                                    WriteChar(separator, ref destination);
                                 }
-
                                 break;
 
                             default:
@@ -91,11 +86,9 @@ namespace System.Text.Json
                         }
 
                         if (lowercase)
-                        {
-                            current = Rune.ToLowerInvariant(current);
-                        }
+                            current = char.ToLowerInvariant(current);
 
-                        Write(current, ref destination);
+                        WriteChar(current, ref destination);
                         state = SeparatorState.UppercaseLetter;
                         break;
 
@@ -105,15 +98,13 @@ namespace System.Text.Json
                         if (state is SeparatorState.SpaceSeparator)
                         {
                             // Normalize preceding spaces to one separator.
-                            Write(separator, ref destination);
+                            WriteChar(separator, ref destination);
                         }
 
                         if (!lowercase)
-                        {
-                            current = Rune.ToUpperInvariant(current);
-                        }
+                            current = char.ToUpperInvariant(current);
 
-                        Write(current, ref destination);
+                        WriteChar(current, ref destination);
                         state = SeparatorState.LowercaseLetterOrDigit;
                         break;
 
@@ -131,12 +122,10 @@ namespace System.Text.Json
                         // are written as-is to the output and reset the separator state.
                         // E.g. 'ABC???def' maps to 'abc???def' in snake_case.
 
-                        Write(current, ref destination);
+                        WriteChar(current, ref destination);
                         state = SeparatorState.NotStarted;
                         break;
                 }
-
-                i += charLength;
             }
 
             name = destination.Slice(0, charsWritten).ToString();
@@ -150,16 +139,14 @@ namespace System.Text.Json
             return name;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            void Write(Rune rune, ref Span<char> destination)
+            void WriteChar(char value, ref Span<char> destination)
             {
-                if (charsWritten + 2 > destination.Length)
+                if (charsWritten == destination.Length)
                 {
                     ExpandBuffer(ref destination);
                 }
 
-                int written = rune.EncodeToUtf16(destination.Slice(charsWritten));
-                Debug.Assert(written == rune.Utf16SequenceLength);
-                charsWritten += written;
+                destination[charsWritten++] = value;
             }
 
             void ExpandBuffer(ref Span<char> destination)
@@ -179,118 +166,6 @@ namespace System.Text.Json
             }
         }
 
-#if !NETCOREAPP
-        // Provides a basic Rune polyfill that handles surrogate pairs
-        // TODO remove once https://github.com/dotnet/runtime/issues/52947 is complete.
-        private readonly struct Rune
-        {
-            private readonly char _first;
-            private readonly char? _lowSurrogate;
-            private readonly UnicodeCategory _category;
-
-            public int Utf16SequenceLength => _lowSurrogate.HasValue ? 2 : 1;
-
-            public static UnicodeCategory GetUnicodeCategory(Rune rune)
-                => rune._category;
-
-            public Rune(char ch) : this(ch, char.GetUnicodeCategory(ch))
-            {
-            }
-
-            private Rune(char ch, UnicodeCategory category)
-            {
-                Debug.Assert(!char.IsSurrogate(ch));
-                _first = ch;
-                _category = category;
-            }
-
-            private Rune(char highSurrogate, char lowSurrogate, UnicodeCategory category)
-            {
-                Debug.Assert(char.IsSurrogatePair(highSurrogate, lowSurrogate));
-                _first = highSurrogate;
-                _lowSurrogate = lowSurrogate;
-                _category = category;
-            }
-
-            public static Rune ToLowerInvariant(Rune value)
-            {
-                UnicodeCategory category = value._category;
-                if (category is UnicodeCategory.UppercaseLetter)
-                {
-                    category = UnicodeCategory.LowercaseLetter;
-                }
-
-                if (value._lowSurrogate is not char lowSurrogate)
-                {
-                    return new Rune(char.ToLowerInvariant(value._first), category);
-                }
-
-                ReadOnlySpan<char> source = stackalloc char[] { value._first, lowSurrogate };
-                Span<char> destination = stackalloc char[2];
-
-                source.ToLowerInvariant(destination);
-                return new Rune(destination[0], destination[1], category);
-            }
-
-            public static Rune ToUpperInvariant(Rune value)
-            {
-                UnicodeCategory category = value._category;
-                if (category is UnicodeCategory.LowercaseLetter)
-                {
-                    category = UnicodeCategory.UppercaseLetter;
-                }
-
-                if (value._lowSurrogate is not char lowSurrogate)
-                {
-                    return new Rune(char.ToUpperInvariant(value._first), category);
-                }
-
-                ReadOnlySpan<char> source = stackalloc char[] { value._first, lowSurrogate };
-                Span<char> destination = stackalloc char[2];
-
-                source.ToUpperInvariant(destination);
-                return new Rune(destination[0], destination[1], category);
-            }
-
-            public int EncodeToUtf16(Span<char> destination)
-            {
-                Debug.Assert(Utf16SequenceLength <= destination.Length);
-                destination[0] = _first;
-
-                if (_lowSurrogate is not char lowSurrogate)
-                {
-                    return 1;
-                }
-
-                destination[1] = lowSurrogate;
-                return 2;
-            }
-
-            public static Rune GetRuneAt(string input, int index)
-            {
-                char first = input[index];
-                UnicodeCategory category = char.GetUnicodeCategory(first);
-                if (category is UnicodeCategory.Surrogate)
-                {
-                    char lowSurrogate = default;
-                    if (index + 1 == input.Length ||
-                        !char.IsSurrogatePair(first, lowSurrogate = input[index + 1]))
-                    {
-                        // CharUnicodeInfo.GetUnicodeCategory does
-                        // not throw so we throw here instead.
-                        ThrowArgumentException();
-
-                        static void ThrowArgumentException() => throw new ArgumentException(nameof(input));
-                    }
-
-                    category = CharUnicodeInfo.GetUnicodeCategory(input, index);
-                    return new Rune(first, lowSurrogate, category);
-                }
-
-                return new Rune(first, category);
-            }
-        }
-#endif
         private enum SeparatorState
         {
             NotStarted,

--- a/src/libraries/System.Text.Json/Common/JsonSeparatorNamingPolicy.cs
+++ b/src/libraries/System.Text.Json/Common/JsonSeparatorNamingPolicy.cs
@@ -47,7 +47,7 @@ namespace System.Text.Json
 
             for (int i = 0; i < chars.Length; i++)
             {
-                // NB this implementation ignores surrogate pairs
+                // NB this implementation does not handle surrogate pair letters
                 // cf. https://github.com/dotnet/runtime/issues/90352
 
                 char current = chars[i];
@@ -123,7 +123,7 @@ namespace System.Text.Json
                         break;
 
                     default:
-                        // Non-alphanumeric characters (including the separator character itself)
+                        // Non-alphanumeric characters (including the separator character and surrogates)
                         // are written as-is to the output and reset the separator state.
                         // E.g. 'ABC???def' maps to 'abc???def' in snake_case.
 

--- a/src/libraries/System.Text.Json/Common/JsonSeparatorNamingPolicy.cs
+++ b/src/libraries/System.Text.Json/Common/JsonSeparatorNamingPolicy.cs
@@ -15,7 +15,7 @@ namespace System.Text.Json
 
         internal JsonSeparatorNamingPolicy(bool lowercase, char separator)
         {
-            Debug.Assert(!char.IsLetter(separator) && !char.IsWhiteSpace(separator));
+            Debug.Assert(char.IsPunctuation(separator));
 
             _lowercase = lowercase;
             _separator = separator;
@@ -37,8 +37,9 @@ namespace System.Text.Json
 
             char[]? rentedBuffer = null;
 
-            // Rented buffer 20% longer that the input.
-            int initialBufferLength = (12 * name.Length) / 10;
+            // While we can't predict the expansion factor of the resultant string,
+            // start with a buffer that is at least 20% larger than the input.
+            int initialBufferLength = (int)(1.2 * name.Length);
             Span<char> destination = initialBufferLength <= JsonConstants.StackallocCharThreshold
                 ? stackalloc char[JsonConstants.StackallocCharThreshold]
                 : (rentedBuffer = ArrayPool<char>.Shared.Rent(initialBufferLength));

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
@@ -23,6 +23,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("😀葛🀄", "😀葛🀄")] // Surrogate pairs
         [InlineData("άλφαΒήταΓάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
         [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
+        [InlineData("\ude00\ud83d", "\ude00\ud83d")] // Unpaired surrogates
         [InlineData("person", "Person")]
         [InlineData("iPhone", "iPhone")]
         [InlineData("iPhone", "IPhone")]
@@ -115,6 +116,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("άλφα_βήτα_γάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
         [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
         [InlineData("𐐀abc_def𐐨abc😀def𐐀", "𐐀AbcDef𐐨Abc😀Def𐐀")]
+        [InlineData("\ude00\ud83d", "\ude00\ud83d")] // Unpaired surrogates
         [InlineData("a%", "a%")]
         [InlineData("_?#-", "_?#-")]
         [InlineData("?!?", "? ! ?")]
@@ -185,6 +187,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ΆΛΦΑ_ΒΉΤΑ_ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
         [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
         [InlineData("𐐀ABC_DEF𐐨ABC😀DEF𐐀", "𐐀AbcDef𐐨Abc😀Def𐐀")]
+        [InlineData("\ude00\ud83d", "\ude00\ud83d")] // Unpaired surrogates
         [InlineData("A%", "a%")]
         [InlineData("_?#-", "_?#-")]
         [InlineData("?!?", "? ! ?")]
@@ -255,6 +258,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("άλφα-βήτα-γάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
         [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
         [InlineData("𐐀abc-def𐐨abc😀def𐐀", "𐐀AbcDef𐐨Abc😀Def𐐀")]
+        [InlineData("\ude00\ud83d", "\ude00\ud83d")] // Unpaired surrogates
         [InlineData("a%", "a%")]
         [InlineData("-?#_", "-?#_")]
         [InlineData("?!?", "? ! ?")]
@@ -325,6 +329,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ΆΛΦΑ-ΒΉΤΑ-ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
         [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
         [InlineData("𐐀ABC-DEF𐐨ABC😀DEF𐐀", "𐐀AbcDef𐐨Abc😀Def𐐀")]
+        [InlineData("\ude00\ud83d", "\ude00\ud83d")] // Unpaired surrogates
         [InlineData("A%", "a%")]
         [InlineData("-?#_", "-?#_")]
         [InlineData("?!?", "? ! ?")]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
@@ -12,6 +12,7 @@ namespace System.Text.Json.Serialization.Tests
     public static class NamingPolicyUnitTests
     {
         private readonly static CamelCaseNamingStrategy s_newtonsoftCamelCaseNamingStrategy = new();
+
         [Theory]
         // These test cases were copied from Json.NET.
         [InlineData("urlValue", "URLValue")]
@@ -19,6 +20,9 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("id", "ID")]
         [InlineData("i", "I")]
         [InlineData("", "")]
+        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("άλφαΒήταΓάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
+        [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
         [InlineData("person", "Person")]
         [InlineData("iPhone", "iPhone")]
         [InlineData("iPhone", "IPhone")]
@@ -65,7 +69,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("i18n", "i18n")]
         [InlineData("i18n_policy", "I18nPolicy")]
         [InlineData("7samurai", "7samurai")]
-        [InlineData("άλφα_βήτα_γάμμα", "ΆλφαΒήταΓάμμα")]
         [InlineData("camel_case", "camelCase")]
         [InlineData("camel_case", "CamelCase")]
         [InlineData("snake_case", "snake_case")]
@@ -95,6 +98,10 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("abc_7ef", "  abc 7ef  ")]
         [InlineData("ab7_def", "  ab7 def  ")]
         [InlineData("_abc", "_abc")]
+        [InlineData("", "")]
+        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("άλφα_βήτα_γάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
+        [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
         [InlineData("a%", "a%")]
         [InlineData("_?#-", "_?#-")]
         [InlineData("?!?", "? ! ?")]
@@ -128,7 +135,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("I18N", "i18n")]
         [InlineData("I18N_POLICY", "I18nPolicy")]
         [InlineData("7SAMURAI", "7samurai")]
-        [InlineData("ΆΛΦΑ_ΒΉΤΑ_ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")]
         [InlineData("CAMEL_CASE", "camelCase")]
         [InlineData("CAMEL_CASE", "CamelCase")]
         [InlineData("SNAKE_CASE", "snake_case")]
@@ -158,6 +164,10 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ABC_7EF", "  abc 7ef  ")]
         [InlineData("AB7_DEF", "  ab7 def  ")]
         [InlineData("_ABC", "_abc")]
+        [InlineData("", "")]
+        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("ΆΛΦΑ_ΒΉΤΑ_ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
+        [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
         [InlineData("A%", "a%")]
         [InlineData("_?#-", "_?#-")]
         [InlineData("?!?", "? ! ?")]
@@ -191,7 +201,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("i18n", "i18n")]
         [InlineData("i18n-policy", "I18nPolicy")]
         [InlineData("7samurai", "7samurai")]
-        [InlineData("άλφα-βήτα-γάμμα", "ΆλφαΒήταΓάμμα")]
         [InlineData("camel-case", "camelCase")]
         [InlineData("camel-case", "CamelCase")]
         [InlineData("snake_case", "snake_case")]
@@ -222,6 +231,10 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("abc-7ef", "  abc 7ef  ")]
         [InlineData("ab7-def", "  ab7 def  ")]
         [InlineData("-abc", "-abc")]
+        [InlineData("", "")]
+        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("άλφα-βήτα-γάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
+        [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
         [InlineData("a%", "a%")]
         [InlineData("-?#_", "-?#_")]
         [InlineData("?!?", "? ! ?")]
@@ -255,7 +268,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("I18N", "i18n")]
         [InlineData("I18N-POLICY", "I18nPolicy")]
         [InlineData("7SAMURAI", "7samurai")]
-        [InlineData("ΆΛΦΑ-ΒΉΤΑ-ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")]
         [InlineData("CAMEL-CASE", "camelCase")]
         [InlineData("CAMEL-CASE", "CamelCase")]
         [InlineData("SNAKE_CASE", "snake_case")]
@@ -286,6 +298,10 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ABC-7EF", "  abc 7ef  ")]
         [InlineData("AB7-DEF", "  ab7 def  ")]
         [InlineData("-ABC", "-abc")]
+        [InlineData("", "")]
+        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("ΆΛΦΑ-ΒΉΤΑ-ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
+        [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
         [InlineData("A%", "a%")]
         [InlineData("-?#_", "-?#_")]
         [InlineData("?!?", "? ! ?")]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
@@ -20,7 +20,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("id", "ID")]
         [InlineData("i", "I")]
         [InlineData("", "")]
-        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("😀葛🀄", "😀葛🀄")] // Surrogate pairs
         [InlineData("άλφαΒήταΓάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
         [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
         [InlineData("person", "Person")]
@@ -111,9 +111,10 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ab7_def", "  ab7 def  ")]
         [InlineData("_abc", "_abc")]
         [InlineData("", "")]
-        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("😀葛🀄", "😀葛🀄")] // Surrogate pairs
         [InlineData("άλφα_βήτα_γάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
         [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
+        [InlineData("𐐀abc_def𐐨abc😀def𐐀", "𐐀AbcDef𐐨Abc😀Def𐐀")]
         [InlineData("a%", "a%")]
         [InlineData("_?#-", "_?#-")]
         [InlineData("?!?", "? ! ?")]
@@ -180,9 +181,10 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("AB7_DEF", "  ab7 def  ")]
         [InlineData("_ABC", "_abc")]
         [InlineData("", "")]
-        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("😀葛🀄", "😀葛🀄")] // Surrogate pairs
         [InlineData("ΆΛΦΑ_ΒΉΤΑ_ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
         [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
+        [InlineData("𐐀ABC_DEF𐐨ABC😀DEF𐐀", "𐐀AbcDef𐐨Abc😀Def𐐀")]
         [InlineData("A%", "a%")]
         [InlineData("_?#-", "_?#-")]
         [InlineData("?!?", "? ! ?")]
@@ -249,9 +251,10 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ab7-def", "  ab7 def  ")]
         [InlineData("-abc", "-abc")]
         [InlineData("", "")]
-        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("😀葛🀄", "😀葛🀄")] // Surrogate pairs
         [InlineData("άλφα-βήτα-γάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
         [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
+        [InlineData("𐐀abc-def𐐨abc😀def𐐀", "𐐀AbcDef𐐨Abc😀Def𐐀")]
         [InlineData("a%", "a%")]
         [InlineData("-?#_", "-?#_")]
         [InlineData("?!?", "? ! ?")]
@@ -318,9 +321,10 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("AB7-DEF", "  ab7 def  ")]
         [InlineData("-ABC", "-abc")]
         [InlineData("", "")]
-        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("😀葛🀄", "😀葛🀄")] // Surrogate pairs
         [InlineData("ΆΛΦΑ-ΒΉΤΑ-ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
         [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
+        [InlineData("𐐀ABC-DEF𐐨ABC😀DEF𐐀", "𐐀AbcDef𐐨Abc😀Def𐐀")]
         [InlineData("A%", "a%")]
         [InlineData("-?#_", "-?#_")]
         [InlineData("?!?", "? ! ?")]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
@@ -1,235 +1,310 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json.Serialization;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
 {
     public static class NamingPolicyUnitTests
     {
-        [Fact]
-        public static void ToCamelCaseTest()
+        private readonly static CamelCaseNamingStrategy s_newtonsoftCamelCaseNamingStrategy = new();
+        private readonly static SnakeCaseNamingStrategy s_newtonsoftSnakeCaseNamingStrategy = new();
+        private readonly static KebabCaseNamingStrategy s_newtonsoftKebabCaseNamingStrategy = new();
+
+        [Theory]
+        // These test cases were copied from Json.NET.
+        [InlineData("urlValue", "URLValue")]
+        [InlineData("url", "URL")]
+        [InlineData("id", "ID")]
+        [InlineData("i", "I")]
+        [InlineData("", "")]
+        [InlineData("person", "Person")]
+        [InlineData("iPhone", "iPhone")]
+        [InlineData("iPhone", "IPhone")]
+        [InlineData("i Phone", "I Phone")]
+        [InlineData("i  Phone", "I  Phone")]
+        [InlineData(" IPhone", " IPhone")]
+        [InlineData(" IPhone ", " IPhone ")]
+        [InlineData("isCIA", "IsCIA")]
+        [InlineData("vmQ", "VmQ")]
+        [InlineData("xml2Json", "Xml2Json")]
+        [InlineData("snAkEcAsE", "SnAkEcAsE")]
+        [InlineData("snA__kEcAsE", "SnA__kEcAsE")]
+        [InlineData("snA__ kEcAsE", "SnA__ kEcAsE")]
+        [InlineData("already_snake_case_ ", "already_snake_case_ ")]
+        [InlineData("isJSONProperty", "IsJSONProperty")]
+        [InlineData("shoutinG_CASE", "SHOUTING_CASE")]
+        [InlineData("9999-12-31T23:59:59.9999999Z", "9999-12-31T23:59:59.9999999Z")]
+        [InlineData("hi!! This is text. Time to test.", "Hi!! This is text. Time to test.")]
+        [InlineData("building", "BUILDING")]
+        [InlineData("building Property", "BUILDING Property")]
+        [InlineData("building Property", "Building Property")]
+        [InlineData("building PROPERTY", "BUILDING PROPERTY")]
+        public static void ToCamelCaseTest(string expectedResult, string name)
         {
-            // These test cases were copied from Json.NET.
-            Assert.Equal("urlValue", Convert("URLValue"));
-            Assert.Equal("url", Convert("URL"));
-            Assert.Equal("id", Convert("ID"));
-            Assert.Equal("i", Convert("I"));
-            Assert.Equal("", Convert(""));
-            Assert.Null(Convert(null));
-            Assert.Equal("person", Convert("Person"));
-            Assert.Equal("iPhone", Convert("iPhone"));
-            Assert.Equal("iPhone", Convert("IPhone"));
-            Assert.Equal("i Phone", Convert("I Phone"));
-            Assert.Equal("i  Phone", Convert("I  Phone"));
-            Assert.Equal(" IPhone", Convert(" IPhone"));
-            Assert.Equal(" IPhone ", Convert(" IPhone "));
-            Assert.Equal("isCIA", Convert("IsCIA"));
-            Assert.Equal("vmQ", Convert("VmQ"));
-            Assert.Equal("xml2Json", Convert("Xml2Json"));
-            Assert.Equal("snAkEcAsE", Convert("SnAkEcAsE"));
-            Assert.Equal("snA__kEcAsE", Convert("SnA__kEcAsE"));
-            Assert.Equal("snA__ kEcAsE", Convert("SnA__ kEcAsE"));
-            Assert.Equal("already_snake_case_ ", Convert("already_snake_case_ "));
-            Assert.Equal("isJSONProperty", Convert("IsJSONProperty"));
-            Assert.Equal("shoutinG_CASE", Convert("SHOUTING_CASE"));
-            Assert.Equal("9999-12-31T23:59:59.9999999Z", Convert("9999-12-31T23:59:59.9999999Z"));
-            Assert.Equal("hi!! This is text. Time to test.", Convert("Hi!! This is text. Time to test."));
-            Assert.Equal("building", Convert("BUILDING"));
-            Assert.Equal("building Property", Convert("BUILDING Property"));
-            Assert.Equal("building Property", Convert("Building Property"));
-            Assert.Equal("building PROPERTY", Convert("BUILDING PROPERTY"));
-            
-            static string Convert(string name)
-            {
-                JsonNamingPolicy policy = JsonNamingPolicy.CamelCase;
-                string value = policy.ConvertName(name);
-                return value;
-            }
+            JsonNamingPolicy policy = JsonNamingPolicy.CamelCase;
+            string newtonsoftResult = s_newtonsoftCamelCaseNamingStrategy.GetPropertyName(name, false);
+
+            string value = policy.ConvertName(name);
+
+            Assert.Equal(expectedResult, value);
+            Assert.Equal(newtonsoftResult, value);
         }
 
         [Fact]
-        public static void ToSnakeLowerCase()
+        public static void CamelCaseNullNameReturnsNull()
         {
-            Assert.Equal("xml_http_request", Convert("XMLHttpRequest"));
-            Assert.Equal("camel_case", Convert("camelCase"));
-            Assert.Equal("camel_case", Convert("CamelCase"));
-            Assert.Equal("snake_case", Convert("snake_case"));
-            Assert.Equal("snake_case", Convert("SNAKE_CASE"));
-            Assert.Equal("kebab_case", Convert("kebab-case"));
-            Assert.Equal("kebab_case", Convert("KEBAB-CASE"));
-            Assert.Equal("double_space", Convert("double  space"));
-            Assert.Equal("double_underscore", Convert("double__underscore"));
-            Assert.Equal("abc", Convert("abc"));
-            Assert.Equal("ab_c", Convert("abC"));
-            Assert.Equal("a_bc", Convert("aBc"));
-            Assert.Equal("a_bc", Convert("aBC"));
-            Assert.Equal("a_bc", Convert("ABc"));
-            Assert.Equal("abc", Convert("ABC"));
-            Assert.Equal("abc123def456", Convert("abc123def456"));
-            Assert.Equal("abc123_def456", Convert("abc123Def456"));
-            Assert.Equal("abc123_def456", Convert("abc123DEF456"));
-            Assert.Equal("abc123def456", Convert("ABC123DEF456"));
-            Assert.Equal("abc123def456", Convert("ABC123def456"));
-            Assert.Equal("abc123def456", Convert("Abc123def456"));
-            Assert.Equal("abc", Convert("  abc"));
-            Assert.Equal("abc", Convert("abc  "));
-            Assert.Equal("abc", Convert("  abc  "));
-            Assert.Equal("abc_def", Convert("  abc def  "));
-            Assert.Equal(
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                Convert("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-            Assert.Equal(
-                "a_haaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                Convert("aHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-            Assert.Equal(
-                "a_towel_it_says_is_about_the_most_massively_useful_thing_an_interstellar_hitchhiker_can_have_partly_it_has_great_practical_value_you_can_wrap_it_around_you_for_warmth_as_you_bound_across_the_cold_moons_of_jaglan_beta_you_can_lie_on_it_on_the_brilliant_marble_sanded_beaches_of_santraginus_v_inhaling_the_heady_sea_vapors_you_can_sleep_under_it_beneath_the_stars_which_shine_so_redly_on_the_desert_world_of_kakrafoon_use_it_to_sail_a_miniraft_down_the_slow_heavy_river_moth_wet_it_for_use_in_hand_to_hand_combat_wrap_it_round_your_head_to_ward_off_noxious_fumes_or_avoid_the_gaze_of_the_ravenous_bugblatter_beast_of_traal_a_mind_bogglingly_stupid_animal_it_assumes_that_if_you_cant_see_it_it_cant_see_you_daft_as_a_brush_but_very_very_ravenous_you_can_wave_your_towel_in_emergencies_as_a_distress_signal_and_of_course_dry_yourself_of_with_it_if_it_still_seems_to_be_clean_enough",
-                Convert("ATowelItSaysIsAboutTheMostMassivelyUsefulThingAnInterstellarHitchhikerCanHave_PartlyItHasGreatPracticalValue_YouCanWrapItAroundYouForWarmthAsYouBoundAcrossTheColdMoonsOfJaglanBeta_YouCanLieOnItOnTheBrilliantMarbleSandedBeachesOfSantraginusVInhalingTheHeadySeaVapors_YouCanSleepUnderItBeneathTheStarsWhichShineSoRedlyOnTheDesertWorldOfKakrafoon_UseItToSailAMiniraftDownTheSlowHeavyRiverMoth_WetItForUseInHandToHandCombat_WrapItRoundYourHeadToWardOffNoxiousFumesOrAvoidTheGazeOfTheRavenousBugblatterBeastOfTraalAMindBogglinglyStupidAnimal_ItAssumesThatIfYouCantSeeItItCantSeeYouDaftAsABrushButVeryVeryRavenous_YouCanWaveYourTowelInEmergenciesAsADistressSignalAndOfCourseDryYourselfOfWithItIfItStillSeemsToBeCleanEnough"));
-            
-            static string Convert(string name)
-            {
-                JsonNamingPolicy policy = JsonNamingPolicy.SnakeCaseLower;
-                string value = policy.ConvertName(name);
-                return value;
-            }
+            JsonNamingPolicy policy = JsonNamingPolicy.CamelCase;
+            Assert.Null(policy.ConvertName(null));
         }
 
-        [Fact]
-        public static void ToSnakeUpperCase()
+        [Theory]
+        [InlineData("xml_http_request", "XMLHttpRequest")]
+        [InlineData("camel_case", "camelCase")]
+        [InlineData("camel_case", "CamelCase")]
+        [InlineData("snake_case", "snake_case")]
+        [InlineData("snake_case", "SNAKE_CASE")]
+        [InlineData("kebab-case", "kebab-case")]
+        [InlineData("keba_b-_case", "KEBAB-CASE")]
+        [InlineData("double_space", "double  space")]
+        [InlineData("double__underscore", "double__underscore")]
+        [InlineData("abc", "abc")]
+        [InlineData("ab_c", "abC")]
+        [InlineData("a_bc", "aBc")]
+        [InlineData("a_bc", "aBC")]
+        [InlineData("a_bc", "ABc")]
+        [InlineData("abc", "ABC")]
+        [InlineData("abc123def456", "abc123def456")]
+        [InlineData("abc123_def456", "abc123Def456")]
+        [InlineData("abc123_de_f456", "abc123DEF456")]
+        [InlineData("ab_c123_de_f456", "ABC123DEF456")]
+        [InlineData("ab_c123def456", "ABC123def456")]
+        [InlineData("abc123def456", "Abc123def456")]
+        [InlineData("abc", "  abc")]
+        [InlineData("abc", "abc  ")]
+        [InlineData("abc", "  abc  ")]
+        [InlineData("abc_def", "  abc def  ")]
+        [InlineData("_abc", "_abc")]
+        [InlineData("a%", "a%")]
+        [InlineData("_?#-", "_?#-")]
+        [InlineData("$type", "$type")]
+        [InlineData("abc%def", "abc%def")]
+        [InlineData("__abc__def__", "__abc__def__")]
+        [InlineData("_abc_abc_abc", "_abcAbc_abc")]
+        [InlineData(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+        [InlineData(
+            "a_haaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "aHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+        [InlineData(
+            "a_towel_it_says_is_about_the_most_massively_useful_thing_an_interstellar_hitchhiker_can_have_partly_it_has_great_practical_value_you_can_wrap_it_around_you_for_warmth_as_you_bound_across_the_cold_moons_of_jaglan_beta_you_can_lie_on_it_on_the_brilliant_marble_sanded_beaches_of_santraginus_v_inhaling_the_heady_sea_vapors_you_can_sleep_under_it_beneath_the_stars_which_shine_so_redly_on_the_desert_world_of_kakrafoon_use_it_to_sail_a_miniraft_down_the_slow_heavy_river_moth_wet_it_for_use_in_hand_to_hand_combat_wrap_it_round_your_head_to_ward_off_noxious_fumes_or_avoid_the_gaze_of_the_ravenous_bugblatter_beast_of_traal_a_mind_bogglingly_stupid_animal_it_assumes_that_if_you_cant_see_it_it_cant_see_you_daft_as_a_brush_but_very_very_ravenous_you_can_wave_your_towel_in_emergencies_as_a_distress_signal_and_of_course_dry_yourself_of_with_it_if_it_still_seems_to_be_clean_enough",
+            "ATowelItSaysIsAboutTheMostMassivelyUsefulThingAnInterstellarHitchhikerCanHave_PartlyItHasGreatPracticalValue_YouCanWrapItAroundYouForWarmthAsYouBoundAcrossTheColdMoonsOfJaglanBeta_YouCanLieOnItOnTheBrilliantMarbleSandedBeachesOfSantraginusVInhalingTheHeadySeaVapors_YouCanSleepUnderItBeneathTheStarsWhichShineSoRedlyOnTheDesertWorldOfKakrafoon_UseItToSailAMiniraftDownTheSlowHeavyRiverMoth_WetItForUseInHandToHandCombat_WrapItRoundYourHeadToWardOffNoxiousFumesOrAvoidTheGazeOfTheRavenousBugblatterBeastOfTraalAMindBogglinglyStupidAnimal_ItAssumesThatIfYouCantSeeItItCantSeeYouDaftAsABrushButVeryVeryRavenous_YouCanWaveYourTowelInEmergenciesAsADistressSignalAndOfCourseDryYourselfOfWithItIfItStillSeemsToBeCleanEnough")]
+        public static void ToSnakeLowerCase(string expectedResult, string name)
         {
-            Assert.Equal("XML_HTTP_REQUEST", Convert("XMLHttpRequest"));
-            Assert.Equal("CAMEL_CASE", Convert("camelCase"));
-            Assert.Equal("CAMEL_CASE", Convert("CamelCase"));
-            Assert.Equal("SNAKE_CASE", Convert("snake_case"));
-            Assert.Equal("SNAKE_CASE", Convert("SNAKE_CASE"));
-            Assert.Equal("KEBAB_CASE", Convert("kebab-case"));
-            Assert.Equal("KEBAB_CASE", Convert("KEBAB-CASE"));
-            Assert.Equal("DOUBLE_SPACE", Convert("double  space"));
-            Assert.Equal("DOUBLE_UNDERSCORE", Convert("double__underscore"));
-            Assert.Equal("ABC", Convert("abc"));
-            Assert.Equal("AB_C", Convert("abC"));
-            Assert.Equal("A_BC", Convert("aBc"));
-            Assert.Equal("A_BC", Convert("aBC"));
-            Assert.Equal("A_BC", Convert("ABc"));
-            Assert.Equal("ABC", Convert("ABC"));
-            Assert.Equal("ABC123DEF456", Convert("abc123def456"));
-            Assert.Equal("ABC123_DEF456", Convert("abc123Def456"));
-            Assert.Equal("ABC123_DEF456", Convert("abc123DEF456"));
-            Assert.Equal("ABC123DEF456", Convert("ABC123DEF456"));
-            Assert.Equal("ABC123DEF456", Convert("ABC123def456"));
-            Assert.Equal("ABC123DEF456", Convert("Abc123def456"));
-            Assert.Equal("ABC", Convert("  ABC"));
-            Assert.Equal("ABC", Convert("ABC  "));
-            Assert.Equal("ABC", Convert("  ABC  "));
-            Assert.Equal("ABC_DEF", Convert("  ABC def  "));
-            Assert.Equal(
-                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                Convert("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-            Assert.Equal(
-                "A_HAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                Convert("aHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-            Assert.Equal(
-                "A_TOWEL_IT_SAYS_IS_ABOUT_THE_MOST_MASSIVELY_USEFUL_THING_AN_INTERSTELLAR_HITCHHIKER_CAN_HAVE_PARTLY_IT_HAS_GREAT_PRACTICAL_VALUE_YOU_CAN_WRAP_IT_AROUND_YOU_FOR_WARMTH_AS_YOU_BOUND_ACROSS_THE_COLD_MOONS_OF_JAGLAN_BETA_YOU_CAN_LIE_ON_IT_ON_THE_BRILLIANT_MARBLE_SANDED_BEACHES_OF_SANTRAGINUS_V_INHALING_THE_HEADY_SEA_VAPORS_YOU_CAN_SLEEP_UNDER_IT_BENEATH_THE_STARS_WHICH_SHINE_SO_REDLY_ON_THE_DESERT_WORLD_OF_KAKRAFOON_USE_IT_TO_SAIL_A_MINIRAFT_DOWN_THE_SLOW_HEAVY_RIVER_MOTH_WET_IT_FOR_USE_IN_HAND_TO_HAND_COMBAT_WRAP_IT_ROUND_YOUR_HEAD_TO_WARD_OFF_NOXIOUS_FUMES_OR_AVOID_THE_GAZE_OF_THE_RAVENOUS_BUGBLATTER_BEAST_OF_TRAAL_A_MIND_BOGGLINGLY_STUPID_ANIMAL_IT_ASSUMES_THAT_IF_YOU_CANT_SEE_IT_IT_CANT_SEE_YOU_DAFT_AS_A_BRUSH_BUT_VERY_VERY_RAVENOUS_YOU_CAN_WAVE_YOUR_TOWEL_IN_EMERGENCIES_AS_A_DISTRESS_SIGNAL_AND_OF_COURSE_DRY_YOURSELF_OF_WITH_IT_IF_IT_STILL_SEEMS_TO_BE_CLEAN_ENOUGH",
-                Convert("ATowelItSaysIsAboutTheMostMassivelyUsefulThingAnInterstellarHitchhikerCanHave_PartlyItHasGreatPracticalValue_YouCanWrapItAroundYouForWarmthAsYouBoundAcrossTheColdMoonsOfJaglanBeta_YouCanLieOnItOnTheBrilliantMarbleSandedBeachesOfSantraginusVInhalingTheHeadySeaVapors_YouCanSleepUnderItBeneathTheStarsWhichShineSoRedlyOnTheDesertWorldOfKakrafoon_UseItToSailAMiniraftDownTheSlowHeavyRiverMoth_WetItForUseInHandToHandCombat_WrapItRoundYourHeadToWardOffNoxiousFumesOrAvoidTheGazeOfTheRavenousBugblatterBeastOfTraalAMindBogglinglyStupidAnimal_ItAssumesThatIfYouCantSeeItItCantSeeYouDaftAsABrushButVeryVeryRavenous_YouCanWaveYourTowelInEmergenciesAsADistressSignalAndOfCourseDryYourselfOfWithItIfItStillSeemsToBeCleanEnough"));
-            
-            static string Convert(string name)
-            {
-                JsonNamingPolicy policy = JsonNamingPolicy.SnakeCaseUpper;
-                string value = policy.ConvertName(name);
-                return value;
-            }
+            JsonNamingPolicy policy = JsonNamingPolicy.SnakeCaseLower;
+            string newtonsoftResult = s_newtonsoftSnakeCaseNamingStrategy.GetPropertyName(name, hasSpecifiedName: false);
+
+            string result = policy.ConvertName(name);
+            Assert.Equal(expectedResult, result);
+            Assert.Equal(newtonsoftResult, result);
         }
 
-        [Fact]
-        public static void ToKebabLowerCase()
+        [Theory]
+        [InlineData("XML_HTTP_REQUEST", "XMLHttpRequest")]
+        [InlineData("CAMEL_CASE", "camelCase")]
+        [InlineData("CAMEL_CASE", "CamelCase")]
+        [InlineData("SNAKE_CASE", "snake_case")]
+        [InlineData("SNAKE_CASE", "SNAKE_CASE")]
+        [InlineData("KEBAB-CASE", "kebab-case")]
+        [InlineData("KEBA_B-_CASE", "KEBAB-CASE")]
+        [InlineData("DOUBLE_SPACE", "double  space")]
+        [InlineData("DOUBLE__UNDERSCORE", "double__underscore")]
+        [InlineData("ABC", "abc")]
+        [InlineData("AB_C", "abC")]
+        [InlineData("A_BC", "aBc")]
+        [InlineData("A_BC", "aBC")]
+        [InlineData("A_BC", "ABc")]
+        [InlineData("ABC", "ABC")]
+        [InlineData("ABC123DEF456", "abc123def456")]
+        [InlineData("ABC123_DEF456", "abc123Def456")]
+        [InlineData("ABC123_DE_F456", "abc123DEF456")]
+        [InlineData("AB_C123_DE_F456", "ABC123DEF456")]
+        [InlineData("AB_C123DEF456", "ABC123def456")]
+        [InlineData("ABC123DEF456", "Abc123def456")]
+        [InlineData("ABC", "  ABC")]
+        [InlineData("AB_C", "ABC  ")]
+        [InlineData("AB_C", "  ABC  ")]
+        [InlineData("AB_C_DEF", "  ABC def  ")]
+        [InlineData("_ABC", "_abc")]
+        [InlineData("A%", "a%")]
+        [InlineData("_?#-", "_?#-")]
+        [InlineData("$TYPE", "$type")]
+        [InlineData("ABC%DEF", "abc%def")]
+        [InlineData("__ABC__DEF__", "__abc__def__")]
+        [InlineData("_ABC_ABC_ABC", "_abcAbc_abc")]
+        [InlineData(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+        [InlineData(
+            "A_HAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "aHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+        [InlineData(
+            "A_TOWEL_IT_SAYS_IS_ABOUT_THE_MOST_MASSIVELY_USEFUL_THING_AN_INTERSTELLAR_HITCHHIKER_CAN_HAVE_PARTLY_IT_HAS_GREAT_PRACTICAL_VALUE_YOU_CAN_WRAP_IT_AROUND_YOU_FOR_WARMTH_AS_YOU_BOUND_ACROSS_THE_COLD_MOONS_OF_JAGLAN_BETA_YOU_CAN_LIE_ON_IT_ON_THE_BRILLIANT_MARBLE_SANDED_BEACHES_OF_SANTRAGINUS_V_INHALING_THE_HEADY_SEA_VAPORS_YOU_CAN_SLEEP_UNDER_IT_BENEATH_THE_STARS_WHICH_SHINE_SO_REDLY_ON_THE_DESERT_WORLD_OF_KAKRAFOON_USE_IT_TO_SAIL_A_MINIRAFT_DOWN_THE_SLOW_HEAVY_RIVER_MOTH_WET_IT_FOR_USE_IN_HAND_TO_HAND_COMBAT_WRAP_IT_ROUND_YOUR_HEAD_TO_WARD_OFF_NOXIOUS_FUMES_OR_AVOID_THE_GAZE_OF_THE_RAVENOUS_BUGBLATTER_BEAST_OF_TRAAL_A_MIND_BOGGLINGLY_STUPID_ANIMAL_IT_ASSUMES_THAT_IF_YOU_CANT_SEE_IT_IT_CANT_SEE_YOU_DAFT_AS_A_BRUSH_BUT_VERY_VERY_RAVENOUS_YOU_CAN_WAVE_YOUR_TOWEL_IN_EMERGENCIES_AS_A_DISTRESS_SIGNAL_AND_OF_COURSE_DRY_YOURSELF_OF_WITH_IT_IF_IT_STILL_SEEMS_TO_BE_CLEAN_ENOUGH",
+            "ATowelItSaysIsAboutTheMostMassivelyUsefulThingAnInterstellarHitchhikerCanHave_PartlyItHasGreatPracticalValue_YouCanWrapItAroundYouForWarmthAsYouBoundAcrossTheColdMoonsOfJaglanBeta_YouCanLieOnItOnTheBrilliantMarbleSandedBeachesOfSantraginusVInhalingTheHeadySeaVapors_YouCanSleepUnderItBeneathTheStarsWhichShineSoRedlyOnTheDesertWorldOfKakrafoon_UseItToSailAMiniraftDownTheSlowHeavyRiverMoth_WetItForUseInHandToHandCombat_WrapItRoundYourHeadToWardOffNoxiousFumesOrAvoidTheGazeOfTheRavenousBugblatterBeastOfTraalAMindBogglinglyStupidAnimal_ItAssumesThatIfYouCantSeeItItCantSeeYouDaftAsABrushButVeryVeryRavenous_YouCanWaveYourTowelInEmergenciesAsADistressSignalAndOfCourseDryYourselfOfWithItIfItStillSeemsToBeCleanEnough")]
+        public static void ToSnakeUpperCase(string expectedResult, string name)
         {
-            Assert.Equal("xml-http-request", Convert("XMLHttpRequest"));
-            Assert.Equal("camel-case", Convert("camelCase"));
-            Assert.Equal("camel-case", Convert("CamelCase"));
-            Assert.Equal("snake-case", Convert("snake_case"));
-            Assert.Equal("snake-case", Convert("SNAKE_CASE"));
-            Assert.Equal("kebab-case", Convert("kebab-case"));
-            Assert.Equal("kebab-case", Convert("KEBAB-CASE"));
-            Assert.Equal("double-space", Convert("double  space"));
-            Assert.Equal("double-underscore", Convert("double__underscore"));
-            Assert.Equal("abc", Convert("abc"));
-            Assert.Equal("ab-c", Convert("abC"));
-            Assert.Equal("a-bc", Convert("aBc"));
-            Assert.Equal("a-bc", Convert("aBC"));
-            Assert.Equal("a-bc", Convert("ABc"));
-            Assert.Equal("abc", Convert("ABC"));
-            Assert.Equal("abc123def456", Convert("abc123def456"));
-            Assert.Equal("abc123-def456", Convert("abc123Def456"));
-            Assert.Equal("abc123-def456", Convert("abc123DEF456"));
-            Assert.Equal("abc123def456", Convert("ABC123DEF456"));
-            Assert.Equal("abc123def456", Convert("ABC123def456"));
-            Assert.Equal("abc123def456", Convert("Abc123def456"));
-            Assert.Equal("abc", Convert("  abc"));
-            Assert.Equal("abc", Convert("abc  "));
-            Assert.Equal("abc", Convert("  abc  "));
-            Assert.Equal("abc-def", Convert("  abc def  "));
-            Assert.Equal(
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                Convert("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-            Assert.Equal(
-                "a-haaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                Convert("aHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-            Assert.Equal(
-                "a-towel-it-says-is-about-the-most-massively-useful-thing-an-interstellar-hitchhiker-can-have-partly-it-has-great-practical-value-you-can-wrap-it-around-you-for-warmth-as-you-bound-across-the-cold-moons-of-jaglan-beta-you-can-lie-on-it-on-the-brilliant-marble-sanded-beaches-of-santraginus-v-inhaling-the-heady-sea-vapors-you-can-sleep-under-it-beneath-the-stars-which-shine-so-redly-on-the-desert-world-of-kakrafoon-use-it-to-sail-a-miniraft-down-the-slow-heavy-river-moth-wet-it-for-use-in-hand-to-hand-combat-wrap-it-round-your-head-to-ward-off-noxious-fumes-or-avoid-the-gaze-of-the-ravenous-bugblatter-beast-of-traal-a-mind-bogglingly-stupid-animal-it-assumes-that-if-you-cant-see-it-it-cant-see-you-daft-as-a-brush-but-very-very-ravenous-you-can-wave-your-towel-in-emergencies-as-a-distress-signal-and-of-course-dry-yourself-of-with-it-if-it-still-seems-to-be-clean-enough",
-                Convert("ATowelItSaysIsAboutTheMostMassivelyUsefulThingAnInterstellarHitchhikerCanHave_PartlyItHasGreatPracticalValue_YouCanWrapItAroundYouForWarmthAsYouBoundAcrossTheColdMoonsOfJaglanBeta_YouCanLieOnItOnTheBrilliantMarbleSandedBeachesOfSantraginusVInhalingTheHeadySeaVapors_YouCanSleepUnderItBeneathTheStarsWhichShineSoRedlyOnTheDesertWorldOfKakrafoon_UseItToSailAMiniraftDownTheSlowHeavyRiverMoth_WetItForUseInHandToHandCombat_WrapItRoundYourHeadToWardOffNoxiousFumesOrAvoidTheGazeOfTheRavenousBugblatterBeastOfTraalAMindBogglinglyStupidAnimal_ItAssumesThatIfYouCantSeeItItCantSeeYouDaftAsABrushButVeryVeryRavenous_YouCanWaveYourTowelInEmergenciesAsADistressSignalAndOfCourseDryYourselfOfWithItIfItStillSeemsToBeCleanEnough"));
-            
-            static string Convert(string name)
-            {
-                JsonNamingPolicy policy = JsonNamingPolicy.KebabCaseLower;
-                string value = policy.ConvertName(name);
-                return value;
-            }
+            JsonNamingPolicy policy = JsonNamingPolicy.SnakeCaseUpper;
+
+            string value = policy.ConvertName(name);
+
+            Assert.Equal(expectedResult, value);
         }
 
-        [Fact]
-        public static void ToKebabUpperCase()
+        [Theory]
+        [InlineData("xml-http-request", "XMLHttpRequest")]
+        [InlineData("camel-case", "camelCase")]
+        [InlineData("camel-case", "CamelCase")]
+        [InlineData("snake_case", "snake_case")]
+        [InlineData("snak-e_-case", "SNAKE_CASE")]
+        [InlineData("kebab-case", "kebab-case")]
+        [InlineData("kebab-case", "KEBAB-CASE")]
+        [InlineData("double-space", "double  space")]
+        [InlineData("double__underscore", "double__underscore")]
+        [InlineData("double--dash", "double--dash")]
+        [InlineData("abc", "abc")]
+        [InlineData("ab-c", "abC")]
+        [InlineData("a-bc", "aBc")]
+        [InlineData("a-bc", "aBC")]
+        [InlineData("a-bc", "ABc")]
+        [InlineData("abc", "ABC")]
+        [InlineData("abc123def456", "abc123def456")]
+        [InlineData("abc123-def456", "abc123Def456")]
+        [InlineData("abc123-de-f456", "abc123DEF456")]
+        [InlineData("ab-c123-de-f456", "ABC123DEF456")]
+        [InlineData("ab-c123def456", "ABC123def456")]
+        [InlineData("abc123def456", "Abc123def456")]
+        [InlineData("abc", "  abc")]
+        [InlineData("abc", "abc  ")]
+        [InlineData("abc", "  abc  ")]
+        [InlineData("abc-def", "  abc def  ")]
+        [InlineData("-abc", "-abc")]
+        [InlineData("a%", "a%")]
+        [InlineData("-?#_", "-?#_")]
+        [InlineData("$type", "$type")]
+        [InlineData("abc%def", "abc%def")]
+        [InlineData("--abc--def--", "--abc--def--")]
+        [InlineData("-abc-abc-abc", "-abcAbc-abc")]
+        [InlineData(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+        [InlineData(
+            "a-haaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "aHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+        [InlineData(
+            "a-towel-it-says-is-about-the-most-massively-useful-thing-an-interstellar-hitchhiker-can-have_-partly-it-has-great-practical-value_-you-can-wrap-it-around-you-for-warmth-as-you-bound-across-the-cold-moons-of-jaglan-beta_-you-can-lie-on-it-on-the-brilliant-marble-sanded-beaches-of-santraginus-v-inhaling-the-heady-sea-vapors_-you-can-sleep-under-it-beneath-the-stars-which-shine-so-redly-on-the-desert-world-of-kakrafoon_-use-it-to-sail-a-miniraft-down-the-slow-heavy-river-moth_-wet-it-for-use-in-hand-to-hand-combat_-wrap-it-round-your-head-to-ward-off-noxious-fumes-or-avoid-the-gaze-of-the-ravenous-bugblatter-beast-of-traal-a-mind-bogglingly-stupid-animal_-it-assumes-that-if-you-cant-see-it-it-cant-see-you-daft-as-a-brush-but-very-very-ravenous_-you-can-wave-your-towel-in-emergencies-as-a-distress-signal-and-of-course-dry-yourself-of-with-it-if-it-still-seems-to-be-clean-enough",
+            "ATowelItSaysIsAboutTheMostMassivelyUsefulThingAnInterstellarHitchhikerCanHave_PartlyItHasGreatPracticalValue_YouCanWrapItAroundYouForWarmthAsYouBoundAcrossTheColdMoonsOfJaglanBeta_YouCanLieOnItOnTheBrilliantMarbleSandedBeachesOfSantraginusVInhalingTheHeadySeaVapors_YouCanSleepUnderItBeneathTheStarsWhichShineSoRedlyOnTheDesertWorldOfKakrafoon_UseItToSailAMiniraftDownTheSlowHeavyRiverMoth_WetItForUseInHandToHandCombat_WrapItRoundYourHeadToWardOffNoxiousFumesOrAvoidTheGazeOfTheRavenousBugblatterBeastOfTraalAMindBogglinglyStupidAnimal_ItAssumesThatIfYouCantSeeItItCantSeeYouDaftAsABrushButVeryVeryRavenous_YouCanWaveYourTowelInEmergenciesAsADistressSignalAndOfCourseDryYourselfOfWithItIfItStillSeemsToBeCleanEnough")]            
+        public static void ToKebabLowerCase(string expectedResult, string name)
         {
-            Assert.Equal("XML-HTTP-REQUEST", Convert("XMLHttpRequest"));
-            Assert.Equal("CAMEL-CASE", Convert("camelCase"));
-            Assert.Equal("CAMEL-CASE", Convert("CamelCase"));
-            Assert.Equal("SNAKE-CASE", Convert("snake_case"));
-            Assert.Equal("SNAKE-CASE", Convert("SNAKE_CASE"));
-            Assert.Equal("KEBAB-CASE", Convert("kebab-case"));
-            Assert.Equal("KEBAB-CASE", Convert("KEBAB-CASE"));
-            Assert.Equal("DOUBLE-SPACE", Convert("double  space"));
-            Assert.Equal("DOUBLE-UNDERSCORE", Convert("double__underscore"));
-            Assert.Equal("ABC", Convert("abc"));
-            Assert.Equal("AB-C", Convert("abC"));
-            Assert.Equal("A-BC", Convert("aBc"));
-            Assert.Equal("A-BC", Convert("aBC"));
-            Assert.Equal("A-BC", Convert("ABc"));
-            Assert.Equal("ABC", Convert("ABC"));
-            Assert.Equal("ABC123DEF456", Convert("abc123def456"));
-            Assert.Equal("ABC123-DEF456", Convert("abc123Def456"));
-            Assert.Equal("ABC123-DEF456", Convert("abc123DEF456"));
-            Assert.Equal("ABC123DEF456", Convert("ABC123DEF456"));
-            Assert.Equal("ABC123DEF456", Convert("ABC123def456"));
-            Assert.Equal("ABC123DEF456", Convert("Abc123def456"));
-            Assert.Equal("ABC", Convert("  ABC"));
-            Assert.Equal("ABC", Convert("ABC  "));
-            Assert.Equal("ABC", Convert("  ABC  "));
-            Assert.Equal("ABC-DEF", Convert("  ABC def  "));
-            Assert.Equal(
-                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                Convert("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-            Assert.Equal(
-                "A-HAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                Convert("aHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-            Assert.Equal(
-                "A-TOWEL-IT-SAYS-IS-ABOUT-THE-MOST-MASSIVELY-USEFUL-THING-AN-INTERSTELLAR-HITCHHIKER-CAN-HAVE-PARTLY-IT-HAS-GREAT-PRACTICAL-VALUE-YOU-CAN-WRAP-IT-AROUND-YOU-FOR-WARMTH-AS-YOU-BOUND-ACROSS-THE-COLD-MOONS-OF-JAGLAN-BETA-YOU-CAN-LIE-ON-IT-ON-THE-BRILLIANT-MARBLE-SANDED-BEACHES-OF-SANTRAGINUS-V-INHALING-THE-HEADY-SEA-VAPORS-YOU-CAN-SLEEP-UNDER-IT-BENEATH-THE-STARS-WHICH-SHINE-SO-REDLY-ON-THE-DESERT-WORLD-OF-KAKRAFOON-USE-IT-TO-SAIL-A-MINIRAFT-DOWN-THE-SLOW-HEAVY-RIVER-MOTH-WET-IT-FOR-USE-IN-HAND-TO-HAND-COMBAT-WRAP-IT-ROUND-YOUR-HEAD-TO-WARD-OFF-NOXIOUS-FUMES-OR-AVOID-THE-GAZE-OF-THE-RAVENOUS-BUGBLATTER-BEAST-OF-TRAAL-A-MIND-BOGGLINGLY-STUPID-ANIMAL-IT-ASSUMES-THAT-IF-YOU-CANT-SEE-IT-IT-CANT-SEE-YOU-DAFT-AS-A-BRUSH-BUT-VERY-VERY-RAVENOUS-YOU-CAN-WAVE-YOUR-TOWEL-IN-EMERGENCIES-AS-A-DISTRESS-SIGNAL-AND-OF-COURSE-DRY-YOURSELF-OF-WITH-IT-IF-IT-STILL-SEEMS-TO-BE-CLEAN-ENOUGH",
-                Convert("ATowelItSaysIsAboutTheMostMassivelyUsefulThingAnInterstellarHitchhikerCanHave_PartlyItHasGreatPracticalValue_YouCanWrapItAroundYouForWarmthAsYouBoundAcrossTheColdMoonsOfJaglanBeta_YouCanLieOnItOnTheBrilliantMarbleSandedBeachesOfSantraginusVInhalingTheHeadySeaVapors_YouCanSleepUnderItBeneathTheStarsWhichShineSoRedlyOnTheDesertWorldOfKakrafoon_UseItToSailAMiniraftDownTheSlowHeavyRiverMoth_WetItForUseInHandToHandCombat_WrapItRoundYourHeadToWardOffNoxiousFumesOrAvoidTheGazeOfTheRavenousBugblatterBeastOfTraalAMindBogglinglyStupidAnimal_ItAssumesThatIfYouCantSeeItItCantSeeYouDaftAsABrushButVeryVeryRavenous_YouCanWaveYourTowelInEmergenciesAsADistressSignalAndOfCourseDryYourselfOfWithItIfItStillSeemsToBeCleanEnough"));
-            
-            static string Convert(string name)
-            {
-                JsonNamingPolicy policy = JsonNamingPolicy.KebabCaseUpper;
-                string value = policy.ConvertName(name);
-                return value;
-            }
+            JsonNamingPolicy policy = JsonNamingPolicy.KebabCaseLower;
+            string newtonsoftResult = s_newtonsoftKebabCaseNamingStrategy.GetPropertyName(name, false);
+
+            string value = policy.ConvertName(name);
+
+            Assert.Equal(expectedResult, value);
+            Assert.Equal(newtonsoftResult, value);
         }
+
+        [Theory]
+        [InlineData("XML-HTTP-REQUEST", "XMLHttpRequest")]
+        [InlineData("CAMEL-CASE", "camelCase")]
+        [InlineData("CAMEL-CASE", "CamelCase")]
+        [InlineData("SNAKE_CASE", "snake_case")]
+        [InlineData("SNAK-E_-CASE", "SNAKE_CASE")]
+        [InlineData("KEBAB-CASE", "kebab-case")]
+        [InlineData("KEBAB-CASE", "KEBAB-CASE")]
+        [InlineData("DOUBLE-SPACE", "double  space")]
+        [InlineData("DOUBLE__UNDERSCORE", "double__underscore")]
+        [InlineData("DOUBLE--DASH", "double--dash")]
+        [InlineData("ABC", "abc")]
+        [InlineData("AB-C", "abC")]
+        [InlineData("A-BC", "aBc")]
+        [InlineData("A-BC", "aBC")]
+        [InlineData("A-BC", "ABc")]
+        [InlineData("ABC", "ABC")]
+        [InlineData("ABC123DEF456", "abc123def456")]
+        [InlineData("ABC123-DEF456", "abc123Def456")]
+        [InlineData("ABC123-DE-F456", "abc123DEF456")]
+        [InlineData("AB-C123-DE-F456", "ABC123DEF456")]
+        [InlineData("AB-C123DEF456", "ABC123def456")]
+        [InlineData("ABC123DEF456", "Abc123def456")]
+        [InlineData("ABC", "  ABC")]
+        [InlineData("AB-C", "ABC  ")]
+        [InlineData("AB-C", "  ABC  ")]
+        [InlineData("AB-C-DEF", "  ABC def  ")]
+        [InlineData("-ABC", "-abc")]
+        [InlineData("A%", "a%")]
+        [InlineData("-?#_", "-?#_")]
+        [InlineData("$TYPE", "$type")]
+        [InlineData("ABC%DEF", "abc%def")]
+        [InlineData("--ABC--DEF--", "--abc--def--")]
+        [InlineData("-ABC-ABC-ABC", "-abcAbc-abc")]
+        [InlineData(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+        [InlineData(
+            "A-HAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "aHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+        [InlineData(
+            "A-TOWEL-IT-SAYS-IS-ABOUT-THE-MOST-MASSIVELY-USEFUL-THING-AN-INTERSTELLAR-HITCHHIKER-CAN-HAVE_-PARTLY-IT-HAS-GREAT-PRACTICAL-VALUE_-YOU-CAN-WRAP-IT-AROUND-YOU-FOR-WARMTH-AS-YOU-BOUND-ACROSS-THE-COLD-MOONS-OF-JAGLAN-BETA_-YOU-CAN-LIE-ON-IT-ON-THE-BRILLIANT-MARBLE-SANDED-BEACHES-OF-SANTRAGINUS-V-INHALING-THE-HEADY-SEA-VAPORS_-YOU-CAN-SLEEP-UNDER-IT-BENEATH-THE-STARS-WHICH-SHINE-SO-REDLY-ON-THE-DESERT-WORLD-OF-KAKRAFOON_-USE-IT-TO-SAIL-A-MINIRAFT-DOWN-THE-SLOW-HEAVY-RIVER-MOTH_-WET-IT-FOR-USE-IN-HAND-TO-HAND-COMBAT_-WRAP-IT-ROUND-YOUR-HEAD-TO-WARD-OFF-NOXIOUS-FUMES-OR-AVOID-THE-GAZE-OF-THE-RAVENOUS-BUGBLATTER-BEAST-OF-TRAAL-A-MIND-BOGGLINGLY-STUPID-ANIMAL_-IT-ASSUMES-THAT-IF-YOU-CANT-SEE-IT-IT-CANT-SEE-YOU-DAFT-AS-A-BRUSH-BUT-VERY-VERY-RAVENOUS_-YOU-CAN-WAVE-YOUR-TOWEL-IN-EMERGENCIES-AS-A-DISTRESS-SIGNAL-AND-OF-COURSE-DRY-YOURSELF-OF-WITH-IT-IF-IT-STILL-SEEMS-TO-BE-CLEAN-ENOUGH",
+            "ATowelItSaysIsAboutTheMostMassivelyUsefulThingAnInterstellarHitchhikerCanHave_PartlyItHasGreatPracticalValue_YouCanWrapItAroundYouForWarmthAsYouBoundAcrossTheColdMoonsOfJaglanBeta_YouCanLieOnItOnTheBrilliantMarbleSandedBeachesOfSantraginusVInhalingTheHeadySeaVapors_YouCanSleepUnderItBeneathTheStarsWhichShineSoRedlyOnTheDesertWorldOfKakrafoon_UseItToSailAMiniraftDownTheSlowHeavyRiverMoth_WetItForUseInHandToHandCombat_WrapItRoundYourHeadToWardOffNoxiousFumesOrAvoidTheGazeOfTheRavenousBugblatterBeastOfTraalAMindBogglinglyStupidAnimal_ItAssumesThatIfYouCantSeeItItCantSeeYouDaftAsABrushButVeryVeryRavenous_YouCanWaveYourTowelInEmergenciesAsADistressSignalAndOfCourseDryYourselfOfWithItIfItStillSeemsToBeCleanEnough")]
+        public static void ToKebabUpperCase(string expectedResult, string name)
+        {
+            JsonNamingPolicy policy = JsonNamingPolicy.KebabCaseUpper;
+
+            string value = policy.ConvertName(name);
+
+            Assert.Equal(expectedResult, value);
+        }
+
+        [Theory, OuterLoop]
+        [MemberData(nameof(GetValidMemberNames))]
+        public static void CamelCaseNamingPolicyMatchesNewtonsoftNamingStrategy(string name)
+        {
+            string newtonsoftResult = s_newtonsoftCamelCaseNamingStrategy.GetPropertyName(name, hasSpecifiedName: false);
+            string stjResult = JsonNamingPolicy.CamelCase.ConvertName(name);
+            Assert.Equal(newtonsoftResult, stjResult);
+        }
+
+        [Theory, OuterLoop]
+        [MemberData(nameof(GetValidMemberNames))]
+        public static void SnakeCaseNamingPolicyMatchesNewtonsoftNamingStrategy(string name)
+        {
+            string newtonsoftResult = s_newtonsoftSnakeCaseNamingStrategy.GetPropertyName(name, hasSpecifiedName: false);
+            string stjResult = JsonNamingPolicy.SnakeCaseLower.ConvertName(name);
+            Assert.Equal(newtonsoftResult, stjResult);
+        }
+
+        [Theory, OuterLoop]
+        [MemberData(nameof(GetValidMemberNames))]
+        public static void KebabCaseNamingPolicyMatchesNewtonsoftNamingStrategy(string name)
+        {
+            string newtonsoftResult = s_newtonsoftKebabCaseNamingStrategy.GetPropertyName(name, hasSpecifiedName: false);
+            string stjResult = JsonNamingPolicy.KebabCaseLower.ConvertName(name);
+            Assert.Equal(newtonsoftResult, stjResult);
+        }
+
+        public static IEnumerable<object[]> GetValidMemberNames()
+            => typeof(PropertyNameTestsDynamic).Assembly.GetTypes()
+                .SelectMany(t => t.GetMembers(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                .Where(m => m.MemberType is MemberTypes.Property or MemberTypes.Field)
+                .Select(m => m.Name)
+                .Distinct()
+                .Select(name => new object[] { name })
+                .ToArray();
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
@@ -12,9 +12,6 @@ namespace System.Text.Json.Serialization.Tests
     public static class NamingPolicyUnitTests
     {
         private readonly static CamelCaseNamingStrategy s_newtonsoftCamelCaseNamingStrategy = new();
-        private readonly static SnakeCaseNamingStrategy s_newtonsoftSnakeCaseNamingStrategy = new();
-        private readonly static KebabCaseNamingStrategy s_newtonsoftKebabCaseNamingStrategy = new();
-
         [Theory]
         // These test cases were copied from Json.NET.
         [InlineData("urlValue", "URLValue")]
@@ -64,12 +61,16 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [InlineData("xml_http_request", "XMLHttpRequest")]
+        [InlineData("sha512_hash_algorithm", "SHA512HashAlgorithm")]
+        [InlineData("i18n", "i18n")]
+        [InlineData("i18n_policy", "I18nPolicy")]
+        [InlineData("7samurai", "7samurai")]
         [InlineData("camel_case", "camelCase")]
         [InlineData("camel_case", "CamelCase")]
         [InlineData("snake_case", "snake_case")]
         [InlineData("snake_case", "SNAKE_CASE")]
         [InlineData("kebab-case", "kebab-case")]
-        [InlineData("keba_b-_case", "KEBAB-CASE")]
+        [InlineData("kebab-case", "KEBAB-CASE")]
         [InlineData("double_space", "double  space")]
         [InlineData("double__underscore", "double__underscore")]
         [InlineData("abc", "abc")]
@@ -80,21 +81,28 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("abc", "ABC")]
         [InlineData("abc123def456", "abc123def456")]
         [InlineData("abc123_def456", "abc123Def456")]
-        [InlineData("abc123_de_f456", "abc123DEF456")]
-        [InlineData("ab_c123_de_f456", "ABC123DEF456")]
-        [InlineData("ab_c123def456", "ABC123def456")]
+        [InlineData("abc123_def456", "abc123DEF456")]
+        [InlineData("abc123_def456", "ABC123DEF456")]
+        [InlineData("abc123def456", "ABC123def456")]
         [InlineData("abc123def456", "Abc123def456")]
         [InlineData("abc", "  abc")]
         [InlineData("abc", "abc  ")]
         [InlineData("abc", "  abc  ")]
+        [InlineData("abc", "  Abc  ")]
+        [InlineData("7ab7", "  7ab7  ")]
         [InlineData("abc_def", "  abc def  ")]
+        [InlineData("abc_7ef", "  abc 7ef  ")]
+        [InlineData("ab7_def", "  ab7 def  ")]
         [InlineData("_abc", "_abc")]
         [InlineData("a%", "a%")]
         [InlineData("_?#-", "_?#-")]
+        [InlineData("?!?", "? ! ?")]
         [InlineData("$type", "$type")]
         [InlineData("abc%def", "abc%def")]
         [InlineData("__abc__def__", "__abc__def__")]
         [InlineData("_abc_abc_abc", "_abcAbc_abc")]
+        [InlineData("abc???def", "ABC???def")]
+        [InlineData("ab_cd-_-de_f", "ABCd  - _ -   DE f")]
         [InlineData(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
@@ -107,21 +115,24 @@ namespace System.Text.Json.Serialization.Tests
         public static void ToSnakeLowerCase(string expectedResult, string name)
         {
             JsonNamingPolicy policy = JsonNamingPolicy.SnakeCaseLower;
-            string newtonsoftResult = s_newtonsoftSnakeCaseNamingStrategy.GetPropertyName(name, hasSpecifiedName: false);
 
             string result = policy.ConvertName(name);
+
             Assert.Equal(expectedResult, result);
-            Assert.Equal(newtonsoftResult, result);
         }
 
         [Theory]
         [InlineData("XML_HTTP_REQUEST", "XMLHttpRequest")]
+        [InlineData("SHA512_HASH_ALGORITHM", "SHA512HashAlgorithm")]
+        [InlineData("I18N", "i18n")]
+        [InlineData("I18N_POLICY", "I18nPolicy")]
+        [InlineData("7SAMURAI", "7samurai")]
         [InlineData("CAMEL_CASE", "camelCase")]
         [InlineData("CAMEL_CASE", "CamelCase")]
         [InlineData("SNAKE_CASE", "snake_case")]
         [InlineData("SNAKE_CASE", "SNAKE_CASE")]
         [InlineData("KEBAB-CASE", "kebab-case")]
-        [InlineData("KEBA_B-_CASE", "KEBAB-CASE")]
+        [InlineData("KEBAB-CASE", "KEBAB-CASE")]
         [InlineData("DOUBLE_SPACE", "double  space")]
         [InlineData("DOUBLE__UNDERSCORE", "double__underscore")]
         [InlineData("ABC", "abc")]
@@ -132,21 +143,28 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ABC", "ABC")]
         [InlineData("ABC123DEF456", "abc123def456")]
         [InlineData("ABC123_DEF456", "abc123Def456")]
-        [InlineData("ABC123_DE_F456", "abc123DEF456")]
-        [InlineData("AB_C123_DE_F456", "ABC123DEF456")]
-        [InlineData("AB_C123DEF456", "ABC123def456")]
+        [InlineData("ABC123_DEF456", "abc123DEF456")]
+        [InlineData("ABC123_DEF456", "ABC123DEF456")]
+        [InlineData("ABC123DEF456", "ABC123def456")]
         [InlineData("ABC123DEF456", "Abc123def456")]
         [InlineData("ABC", "  ABC")]
-        [InlineData("AB_C", "ABC  ")]
-        [InlineData("AB_C", "  ABC  ")]
-        [InlineData("AB_C_DEF", "  ABC def  ")]
+        [InlineData("ABC", "ABC  ")]
+        [InlineData("ABC", "  ABC  ")]
+        [InlineData("ABC", "  Abc  ")]
+        [InlineData("7AB7", "  7ab7  ")]
+        [InlineData("ABC_DEF", "  ABC def  ")]
+        [InlineData("ABC_7EF", "  abc 7ef  ")]
+        [InlineData("AB7_DEF", "  ab7 def  ")]
         [InlineData("_ABC", "_abc")]
         [InlineData("A%", "a%")]
         [InlineData("_?#-", "_?#-")]
+        [InlineData("?!?", "? ! ?")]
         [InlineData("$TYPE", "$type")]
         [InlineData("ABC%DEF", "abc%def")]
         [InlineData("__ABC__DEF__", "__abc__def__")]
         [InlineData("_ABC_ABC_ABC", "_abcAbc_abc")]
+        [InlineData("ABC???DEF", "ABC???def")]
+        [InlineData("AB_CD-_-DE_F", "ABCd  - _ -   DE f")]
         [InlineData(
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
@@ -167,10 +185,14 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [InlineData("xml-http-request", "XMLHttpRequest")]
+        [InlineData("sha512-hash-algorithm", "SHA512HashAlgorithm")]
+        [InlineData("i18n", "i18n")]
+        [InlineData("i18n-policy", "I18nPolicy")]
+        [InlineData("7samurai", "7samurai")]
         [InlineData("camel-case", "camelCase")]
         [InlineData("camel-case", "CamelCase")]
         [InlineData("snake_case", "snake_case")]
-        [InlineData("snak-e_-case", "SNAKE_CASE")]
+        [InlineData("snake_case", "SNAKE_CASE")]
         [InlineData("kebab-case", "kebab-case")]
         [InlineData("kebab-case", "KEBAB-CASE")]
         [InlineData("double-space", "double  space")]
@@ -184,21 +206,28 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("abc", "ABC")]
         [InlineData("abc123def456", "abc123def456")]
         [InlineData("abc123-def456", "abc123Def456")]
-        [InlineData("abc123-de-f456", "abc123DEF456")]
-        [InlineData("ab-c123-de-f456", "ABC123DEF456")]
-        [InlineData("ab-c123def456", "ABC123def456")]
+        [InlineData("abc123-def456", "abc123DEF456")]
+        [InlineData("abc123-def456", "ABC123DEF456")]
+        [InlineData("abc123def456", "ABC123def456")]
         [InlineData("abc123def456", "Abc123def456")]
         [InlineData("abc", "  abc")]
         [InlineData("abc", "abc  ")]
         [InlineData("abc", "  abc  ")]
+        [InlineData("abc", "  Abc  ")]
+        [InlineData("7ab7", "  7ab7  ")]
         [InlineData("abc-def", "  abc def  ")]
+        [InlineData("abc-7ef", "  abc 7ef  ")]
+        [InlineData("ab7-def", "  ab7 def  ")]
         [InlineData("-abc", "-abc")]
         [InlineData("a%", "a%")]
         [InlineData("-?#_", "-?#_")]
+        [InlineData("?!?", "? ! ?")]
         [InlineData("$type", "$type")]
         [InlineData("abc%def", "abc%def")]
         [InlineData("--abc--def--", "--abc--def--")]
         [InlineData("-abc-abc-abc", "-abcAbc-abc")]
+        [InlineData("abc???def", "ABC???def")]
+        [InlineData("ab-cd-_-de-f", "ABCd  - _ -   DE f")]
         [InlineData(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
@@ -206,25 +235,27 @@ namespace System.Text.Json.Serialization.Tests
             "a-haaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "aHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
         [InlineData(
-            "a-towel-it-says-is-about-the-most-massively-useful-thing-an-interstellar-hitchhiker-can-have_-partly-it-has-great-practical-value_-you-can-wrap-it-around-you-for-warmth-as-you-bound-across-the-cold-moons-of-jaglan-beta_-you-can-lie-on-it-on-the-brilliant-marble-sanded-beaches-of-santraginus-v-inhaling-the-heady-sea-vapors_-you-can-sleep-under-it-beneath-the-stars-which-shine-so-redly-on-the-desert-world-of-kakrafoon_-use-it-to-sail-a-miniraft-down-the-slow-heavy-river-moth_-wet-it-for-use-in-hand-to-hand-combat_-wrap-it-round-your-head-to-ward-off-noxious-fumes-or-avoid-the-gaze-of-the-ravenous-bugblatter-beast-of-traal-a-mind-bogglingly-stupid-animal_-it-assumes-that-if-you-cant-see-it-it-cant-see-you-daft-as-a-brush-but-very-very-ravenous_-you-can-wave-your-towel-in-emergencies-as-a-distress-signal-and-of-course-dry-yourself-of-with-it-if-it-still-seems-to-be-clean-enough",
+            "a-towel-it-says-is-about-the-most-massively-useful-thing-an-interstellar-hitchhiker-can-have_partly-it-has-great-practical-value_you-can-wrap-it-around-you-for-warmth-as-you-bound-across-the-cold-moons-of-jaglan-beta_you-can-lie-on-it-on-the-brilliant-marble-sanded-beaches-of-santraginus-v-inhaling-the-heady-sea-vapors_you-can-sleep-under-it-beneath-the-stars-which-shine-so-redly-on-the-desert-world-of-kakrafoon_use-it-to-sail-a-miniraft-down-the-slow-heavy-river-moth_wet-it-for-use-in-hand-to-hand-combat_wrap-it-round-your-head-to-ward-off-noxious-fumes-or-avoid-the-gaze-of-the-ravenous-bugblatter-beast-of-traal-a-mind-bogglingly-stupid-animal_it-assumes-that-if-you-cant-see-it-it-cant-see-you-daft-as-a-brush-but-very-very-ravenous_you-can-wave-your-towel-in-emergencies-as-a-distress-signal-and-of-course-dry-yourself-of-with-it-if-it-still-seems-to-be-clean-enough",
             "ATowelItSaysIsAboutTheMostMassivelyUsefulThingAnInterstellarHitchhikerCanHave_PartlyItHasGreatPracticalValue_YouCanWrapItAroundYouForWarmthAsYouBoundAcrossTheColdMoonsOfJaglanBeta_YouCanLieOnItOnTheBrilliantMarbleSandedBeachesOfSantraginusVInhalingTheHeadySeaVapors_YouCanSleepUnderItBeneathTheStarsWhichShineSoRedlyOnTheDesertWorldOfKakrafoon_UseItToSailAMiniraftDownTheSlowHeavyRiverMoth_WetItForUseInHandToHandCombat_WrapItRoundYourHeadToWardOffNoxiousFumesOrAvoidTheGazeOfTheRavenousBugblatterBeastOfTraalAMindBogglinglyStupidAnimal_ItAssumesThatIfYouCantSeeItItCantSeeYouDaftAsABrushButVeryVeryRavenous_YouCanWaveYourTowelInEmergenciesAsADistressSignalAndOfCourseDryYourselfOfWithItIfItStillSeemsToBeCleanEnough")]            
         public static void ToKebabLowerCase(string expectedResult, string name)
         {
             JsonNamingPolicy policy = JsonNamingPolicy.KebabCaseLower;
-            string newtonsoftResult = s_newtonsoftKebabCaseNamingStrategy.GetPropertyName(name, false);
 
             string value = policy.ConvertName(name);
 
             Assert.Equal(expectedResult, value);
-            Assert.Equal(newtonsoftResult, value);
         }
 
         [Theory]
         [InlineData("XML-HTTP-REQUEST", "XMLHttpRequest")]
+        [InlineData("SHA512-HASH-ALGORITHM", "SHA512HashAlgorithm")]
+        [InlineData("I18N", "i18n")]
+        [InlineData("I18N-POLICY", "I18nPolicy")]
+        [InlineData("7SAMURAI", "7samurai")]
         [InlineData("CAMEL-CASE", "camelCase")]
         [InlineData("CAMEL-CASE", "CamelCase")]
         [InlineData("SNAKE_CASE", "snake_case")]
-        [InlineData("SNAK-E_-CASE", "SNAKE_CASE")]
+        [InlineData("SNAKE_CASE", "SNAKE_CASE")]
         [InlineData("KEBAB-CASE", "kebab-case")]
         [InlineData("KEBAB-CASE", "KEBAB-CASE")]
         [InlineData("DOUBLE-SPACE", "double  space")]
@@ -238,21 +269,28 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ABC", "ABC")]
         [InlineData("ABC123DEF456", "abc123def456")]
         [InlineData("ABC123-DEF456", "abc123Def456")]
-        [InlineData("ABC123-DE-F456", "abc123DEF456")]
-        [InlineData("AB-C123-DE-F456", "ABC123DEF456")]
-        [InlineData("AB-C123DEF456", "ABC123def456")]
+        [InlineData("ABC123-DEF456", "abc123DEF456")]
+        [InlineData("ABC123-DEF456", "ABC123DEF456")]
+        [InlineData("ABC123DEF456", "ABC123def456")]
         [InlineData("ABC123DEF456", "Abc123def456")]
         [InlineData("ABC", "  ABC")]
-        [InlineData("AB-C", "ABC  ")]
-        [InlineData("AB-C", "  ABC  ")]
-        [InlineData("AB-C-DEF", "  ABC def  ")]
+        [InlineData("ABC", "ABC  ")]
+        [InlineData("ABC", "  ABC  ")]
+        [InlineData("ABC", "  Abc  ")]
+        [InlineData("7AB7", "  7ab7  ")]
+        [InlineData("ABC-DEF", "  ABC def  ")]
+        [InlineData("ABC-7EF", "  abc 7ef  ")]
+        [InlineData("AB7-DEF", "  ab7 def  ")]
         [InlineData("-ABC", "-abc")]
         [InlineData("A%", "a%")]
         [InlineData("-?#_", "-?#_")]
+        [InlineData("?!?", "? ! ?")]
         [InlineData("$TYPE", "$type")]
         [InlineData("ABC%DEF", "abc%def")]
         [InlineData("--ABC--DEF--", "--abc--def--")]
         [InlineData("-ABC-ABC-ABC", "-abcAbc-abc")]
+        [InlineData("ABC???DEF", "ABC???def")]
+        [InlineData("AB-CD-_-DE-F", "ABCd  - _ -   DE f")]
         [InlineData(
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
@@ -260,7 +298,7 @@ namespace System.Text.Json.Serialization.Tests
             "A-HAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
             "aHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
         [InlineData(
-            "A-TOWEL-IT-SAYS-IS-ABOUT-THE-MOST-MASSIVELY-USEFUL-THING-AN-INTERSTELLAR-HITCHHIKER-CAN-HAVE_-PARTLY-IT-HAS-GREAT-PRACTICAL-VALUE_-YOU-CAN-WRAP-IT-AROUND-YOU-FOR-WARMTH-AS-YOU-BOUND-ACROSS-THE-COLD-MOONS-OF-JAGLAN-BETA_-YOU-CAN-LIE-ON-IT-ON-THE-BRILLIANT-MARBLE-SANDED-BEACHES-OF-SANTRAGINUS-V-INHALING-THE-HEADY-SEA-VAPORS_-YOU-CAN-SLEEP-UNDER-IT-BENEATH-THE-STARS-WHICH-SHINE-SO-REDLY-ON-THE-DESERT-WORLD-OF-KAKRAFOON_-USE-IT-TO-SAIL-A-MINIRAFT-DOWN-THE-SLOW-HEAVY-RIVER-MOTH_-WET-IT-FOR-USE-IN-HAND-TO-HAND-COMBAT_-WRAP-IT-ROUND-YOUR-HEAD-TO-WARD-OFF-NOXIOUS-FUMES-OR-AVOID-THE-GAZE-OF-THE-RAVENOUS-BUGBLATTER-BEAST-OF-TRAAL-A-MIND-BOGGLINGLY-STUPID-ANIMAL_-IT-ASSUMES-THAT-IF-YOU-CANT-SEE-IT-IT-CANT-SEE-YOU-DAFT-AS-A-BRUSH-BUT-VERY-VERY-RAVENOUS_-YOU-CAN-WAVE-YOUR-TOWEL-IN-EMERGENCIES-AS-A-DISTRESS-SIGNAL-AND-OF-COURSE-DRY-YOURSELF-OF-WITH-IT-IF-IT-STILL-SEEMS-TO-BE-CLEAN-ENOUGH",
+            "A-TOWEL-IT-SAYS-IS-ABOUT-THE-MOST-MASSIVELY-USEFUL-THING-AN-INTERSTELLAR-HITCHHIKER-CAN-HAVE_PARTLY-IT-HAS-GREAT-PRACTICAL-VALUE_YOU-CAN-WRAP-IT-AROUND-YOU-FOR-WARMTH-AS-YOU-BOUND-ACROSS-THE-COLD-MOONS-OF-JAGLAN-BETA_YOU-CAN-LIE-ON-IT-ON-THE-BRILLIANT-MARBLE-SANDED-BEACHES-OF-SANTRAGINUS-V-INHALING-THE-HEADY-SEA-VAPORS_YOU-CAN-SLEEP-UNDER-IT-BENEATH-THE-STARS-WHICH-SHINE-SO-REDLY-ON-THE-DESERT-WORLD-OF-KAKRAFOON_USE-IT-TO-SAIL-A-MINIRAFT-DOWN-THE-SLOW-HEAVY-RIVER-MOTH_WET-IT-FOR-USE-IN-HAND-TO-HAND-COMBAT_WRAP-IT-ROUND-YOUR-HEAD-TO-WARD-OFF-NOXIOUS-FUMES-OR-AVOID-THE-GAZE-OF-THE-RAVENOUS-BUGBLATTER-BEAST-OF-TRAAL-A-MIND-BOGGLINGLY-STUPID-ANIMAL_IT-ASSUMES-THAT-IF-YOU-CANT-SEE-IT-IT-CANT-SEE-YOU-DAFT-AS-A-BRUSH-BUT-VERY-VERY-RAVENOUS_YOU-CAN-WAVE-YOUR-TOWEL-IN-EMERGENCIES-AS-A-DISTRESS-SIGNAL-AND-OF-COURSE-DRY-YOURSELF-OF-WITH-IT-IF-IT-STILL-SEEMS-TO-BE-CLEAN-ENOUGH",
             "ATowelItSaysIsAboutTheMostMassivelyUsefulThingAnInterstellarHitchhikerCanHave_PartlyItHasGreatPracticalValue_YouCanWrapItAroundYouForWarmthAsYouBoundAcrossTheColdMoonsOfJaglanBeta_YouCanLieOnItOnTheBrilliantMarbleSandedBeachesOfSantraginusVInhalingTheHeadySeaVapors_YouCanSleepUnderItBeneathTheStarsWhichShineSoRedlyOnTheDesertWorldOfKakrafoon_UseItToSailAMiniraftDownTheSlowHeavyRiverMoth_WetItForUseInHandToHandCombat_WrapItRoundYourHeadToWardOffNoxiousFumesOrAvoidTheGazeOfTheRavenousBugblatterBeastOfTraalAMindBogglinglyStupidAnimal_ItAssumesThatIfYouCantSeeItItCantSeeYouDaftAsABrushButVeryVeryRavenous_YouCanWaveYourTowelInEmergenciesAsADistressSignalAndOfCourseDryYourselfOfWithItIfItStillSeemsToBeCleanEnough")]
         public static void ToKebabUpperCase(string expectedResult, string name)
         {
@@ -277,24 +315,6 @@ namespace System.Text.Json.Serialization.Tests
         {
             string newtonsoftResult = s_newtonsoftCamelCaseNamingStrategy.GetPropertyName(name, hasSpecifiedName: false);
             string stjResult = JsonNamingPolicy.CamelCase.ConvertName(name);
-            Assert.Equal(newtonsoftResult, stjResult);
-        }
-
-        [Theory, OuterLoop]
-        [MemberData(nameof(GetValidMemberNames))]
-        public static void SnakeCaseNamingPolicyMatchesNewtonsoftNamingStrategy(string name)
-        {
-            string newtonsoftResult = s_newtonsoftSnakeCaseNamingStrategy.GetPropertyName(name, hasSpecifiedName: false);
-            string stjResult = JsonNamingPolicy.SnakeCaseLower.ConvertName(name);
-            Assert.Equal(newtonsoftResult, stjResult);
-        }
-
-        [Theory, OuterLoop]
-        [MemberData(nameof(GetValidMemberNames))]
-        public static void KebabCaseNamingPolicyMatchesNewtonsoftNamingStrategy(string name)
-        {
-            string newtonsoftResult = s_newtonsoftKebabCaseNamingStrategy.GetPropertyName(name, hasSpecifiedName: false);
-            string stjResult = JsonNamingPolicy.KebabCaseLower.ConvertName(name);
             Assert.Equal(newtonsoftResult, stjResult);
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
@@ -63,6 +63,15 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Null(policy.ConvertName(null));
         }
 
+        [Theory, OuterLoop]
+        [MemberData(nameof(GetValidMemberNames))]
+        public static void CamelCaseNamingPolicyMatchesNewtonsoftNamingStrategy(string name)
+        {
+            string newtonsoftResult = s_newtonsoftCamelCaseNamingStrategy.GetPropertyName(name, hasSpecifiedName: false);
+            string stjResult = JsonNamingPolicy.CamelCase.ConvertName(name);
+            Assert.Equal(newtonsoftResult, stjResult);
+        }
+
         [Theory]
         [InlineData("xml_http_request", "XMLHttpRequest")]
         [InlineData("sha512_hash_algorithm", "SHA512HashAlgorithm")]
@@ -77,6 +86,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("kebab-case", "KEBAB-CASE")]
         [InlineData("double_space", "double  space")]
         [InlineData("double__underscore", "double__underscore")]
+        [InlineData("double--dash", "double--dash")]
         [InlineData("abc", "abc")]
         [InlineData("ab_c", "abC")]
         [InlineData("a_bc", "aBc")]
@@ -95,6 +105,8 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("abc", "  Abc  ")]
         [InlineData("7ab7", "  7ab7  ")]
         [InlineData("abc_def", "  abc def  ")]
+        [InlineData("abc_def", "  abc  def  ")]
+        [InlineData("abc_def", "  abc   def  ")]
         [InlineData("abc_7ef", "  abc 7ef  ")]
         [InlineData("ab7_def", "  ab7 def  ")]
         [InlineData("_abc", "_abc")]
@@ -143,6 +155,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("KEBAB-CASE", "KEBAB-CASE")]
         [InlineData("DOUBLE_SPACE", "double  space")]
         [InlineData("DOUBLE__UNDERSCORE", "double__underscore")]
+        [InlineData("DOUBLE--DASH", "double--dash")]
         [InlineData("ABC", "abc")]
         [InlineData("AB_C", "abC")]
         [InlineData("A_BC", "aBc")]
@@ -161,6 +174,8 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ABC", "  Abc  ")]
         [InlineData("7AB7", "  7ab7  ")]
         [InlineData("ABC_DEF", "  ABC def  ")]
+        [InlineData("ABC_DEF", "  abc  def  ")]
+        [InlineData("ABC_DEF", "  abc   def  ")]
         [InlineData("ABC_7EF", "  abc 7ef  ")]
         [InlineData("AB7_DEF", "  ab7 def  ")]
         [InlineData("_ABC", "_abc")]
@@ -228,6 +243,8 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("abc", "  Abc  ")]
         [InlineData("7ab7", "  7ab7  ")]
         [InlineData("abc-def", "  abc def  ")]
+        [InlineData("abc-def", "  abc  def  ")]
+        [InlineData("abc-def", "  abc   def  ")]
         [InlineData("abc-7ef", "  abc 7ef  ")]
         [InlineData("ab7-def", "  ab7 def  ")]
         [InlineData("-abc", "-abc")]
@@ -295,6 +312,8 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ABC", "  Abc  ")]
         [InlineData("7AB7", "  7ab7  ")]
         [InlineData("ABC-DEF", "  ABC def  ")]
+        [InlineData("ABC-DEF", "  abc  def  ")]
+        [InlineData("ABC-DEF", "  abc   def  ")]
         [InlineData("ABC-7EF", "  abc 7ef  ")]
         [InlineData("AB7-DEF", "  ab7 def  ")]
         [InlineData("-ABC", "-abc")]
@@ -327,15 +346,6 @@ namespace System.Text.Json.Serialization.Tests
             string value = policy.ConvertName(name);
 
             Assert.Equal(expectedResult, value);
-        }
-
-        [Theory, OuterLoop]
-        [MemberData(nameof(GetValidMemberNames))]
-        public static void CamelCaseNamingPolicyMatchesNewtonsoftNamingStrategy(string name)
-        {
-            string newtonsoftResult = s_newtonsoftCamelCaseNamingStrategy.GetPropertyName(name, hasSpecifiedName: false);
-            string stjResult = JsonNamingPolicy.CamelCase.ConvertName(name);
-            Assert.Equal(newtonsoftResult, stjResult);
         }
 
         public static IEnumerable<object[]> GetValidMemberNames()

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -65,6 +65,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("i18n", "i18n")]
         [InlineData("i18n_policy", "I18nPolicy")]
         [InlineData("7samurai", "7samurai")]
+        [InlineData("άλφα_βήτα_γάμμα", "ΆλφαΒήταΓάμμα")]
         [InlineData("camel_case", "camelCase")]
         [InlineData("camel_case", "CamelCase")]
         [InlineData("snake_case", "snake_case")]
@@ -127,6 +128,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("I18N", "i18n")]
         [InlineData("I18N_POLICY", "I18nPolicy")]
         [InlineData("7SAMURAI", "7samurai")]
+        [InlineData("ΆΛΦΑ_ΒΉΤΑ_ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")]
         [InlineData("CAMEL_CASE", "camelCase")]
         [InlineData("CAMEL_CASE", "CamelCase")]
         [InlineData("SNAKE_CASE", "snake_case")]
@@ -189,6 +191,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("i18n", "i18n")]
         [InlineData("i18n-policy", "I18nPolicy")]
         [InlineData("7samurai", "7samurai")]
+        [InlineData("άλφα-βήτα-γάμμα", "ΆλφαΒήταΓάμμα")]
         [InlineData("camel-case", "camelCase")]
         [InlineData("camel-case", "CamelCase")]
         [InlineData("snake_case", "snake_case")]
@@ -252,6 +255,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("I18N", "i18n")]
         [InlineData("I18N-POLICY", "I18nPolicy")]
         [InlineData("7SAMURAI", "7samurai")]
+        [InlineData("ΆΛΦΑ-ΒΉΤΑ-ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")]
         [InlineData("CAMEL-CASE", "camelCase")]
         [InlineData("CAMEL-CASE", "CamelCase")]
         [InlineData("SNAKE_CASE", "snake_case")]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
@@ -12,7 +12,6 @@ namespace System.Text.Json.Serialization.Tests
     public static class NamingPolicyUnitTests
     {
         private readonly static CamelCaseNamingStrategy s_newtonsoftCamelCaseNamingStrategy = new();
-
         [Theory]
         // These test cases were copied from Json.NET.
         [InlineData("urlValue", "URLValue")]
@@ -66,6 +65,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("i18n", "i18n")]
         [InlineData("i18n_policy", "I18nPolicy")]
         [InlineData("7samurai", "7samurai")]
+        [InlineData("άλφα_βήτα_γάμμα", "ΆλφαΒήταΓάμμα")]
         [InlineData("camel_case", "camelCase")]
         [InlineData("camel_case", "CamelCase")]
         [InlineData("snake_case", "snake_case")]
@@ -95,10 +95,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("abc_7ef", "  abc 7ef  ")]
         [InlineData("ab7_def", "  ab7 def  ")]
         [InlineData("_abc", "_abc")]
-        [InlineData("", "")]
-        [InlineData("😀", "😀")] // Surrogate pairs
-        [InlineData("άλφα_βήτα_γάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
-        [InlineData("𐐨𐐨𐐨_𐐨𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters
         [InlineData("a%", "a%")]
         [InlineData("_?#-", "_?#-")]
         [InlineData("?!?", "? ! ?")]
@@ -132,6 +128,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("I18N", "i18n")]
         [InlineData("I18N_POLICY", "I18nPolicy")]
         [InlineData("7SAMURAI", "7samurai")]
+        [InlineData("ΆΛΦΑ_ΒΉΤΑ_ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")]
         [InlineData("CAMEL_CASE", "camelCase")]
         [InlineData("CAMEL_CASE", "CamelCase")]
         [InlineData("SNAKE_CASE", "snake_case")]
@@ -161,10 +158,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ABC_7EF", "  abc 7ef  ")]
         [InlineData("AB7_DEF", "  ab7 def  ")]
         [InlineData("_ABC", "_abc")]
-        [InlineData("", "")]
-        [InlineData("😀", "😀")] // Surrogate pairs
-        [InlineData("ΆΛΦΑ_ΒΉΤΑ_ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
-        [InlineData("𐐀𐐀𐐀_𐐀𐐀𐐀", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters
         [InlineData("A%", "a%")]
         [InlineData("_?#-", "_?#-")]
         [InlineData("?!?", "? ! ?")]
@@ -198,6 +191,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("i18n", "i18n")]
         [InlineData("i18n-policy", "I18nPolicy")]
         [InlineData("7samurai", "7samurai")]
+        [InlineData("άλφα-βήτα-γάμμα", "ΆλφαΒήταΓάμμα")]
         [InlineData("camel-case", "camelCase")]
         [InlineData("camel-case", "CamelCase")]
         [InlineData("snake_case", "snake_case")]
@@ -228,10 +222,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("abc-7ef", "  abc 7ef  ")]
         [InlineData("ab7-def", "  ab7 def  ")]
         [InlineData("-abc", "-abc")]
-        [InlineData("", "")]
-        [InlineData("😀", "😀")] // Surrogate pairs
-        [InlineData("άλφα-βήτα-γάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
-        [InlineData("𐐨𐐨𐐨-𐐨𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters
         [InlineData("a%", "a%")]
         [InlineData("-?#_", "-?#_")]
         [InlineData("?!?", "? ! ?")]
@@ -265,6 +255,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("I18N", "i18n")]
         [InlineData("I18N-POLICY", "I18nPolicy")]
         [InlineData("7SAMURAI", "7samurai")]
+        [InlineData("ΆΛΦΑ-ΒΉΤΑ-ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")]
         [InlineData("CAMEL-CASE", "camelCase")]
         [InlineData("CAMEL-CASE", "CamelCase")]
         [InlineData("SNAKE_CASE", "snake_case")]
@@ -295,10 +286,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ABC-7EF", "  abc 7ef  ")]
         [InlineData("AB7-DEF", "  ab7 def  ")]
         [InlineData("-ABC", "-abc")]
-        [InlineData("", "")]
-        [InlineData("😀", "😀")] // Surrogate pairs
-        [InlineData("ΆΛΦΑ-ΒΉΤΑ-ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
-        [InlineData("𐐀𐐀𐐀-𐐀𐐀𐐀", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters
         [InlineData("A%", "a%")]
         [InlineData("-?#_", "-?#_")]
         [InlineData("?!?", "? ! ?")]
@@ -324,22 +311,6 @@ namespace System.Text.Json.Serialization.Tests
             string value = policy.ConvertName(name);
 
             Assert.Equal(expectedResult, value);
-        }
-
-        [Fact]
-        public static void SnakeCasePolicy_MissingSurrogatePair_ThrowsArgumentException()
-        {
-            string value = "xyz\ud83d";
-            Assert.Throws<ArgumentException>(() => JsonNamingPolicy.SnakeCaseLower.ConvertName(value));
-            Assert.Throws<ArgumentException>(() => JsonNamingPolicy.SnakeCaseUpper.ConvertName(value));
-        }
-
-        [Fact]
-        public static void KebabCasePolicy_MissingSurrogatePair_ThrowsArgumentException()
-        {
-            string value = "xyz\ud83d";
-            Assert.Throws<ArgumentException>(() => JsonNamingPolicy.KebabCaseLower.ConvertName(value));
-            Assert.Throws<ArgumentException>(() => JsonNamingPolicy.KebabCaseUpper.ConvertName(value));
         }
 
         [Theory, OuterLoop]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
@@ -12,6 +12,7 @@ namespace System.Text.Json.Serialization.Tests
     public static class NamingPolicyUnitTests
     {
         private readonly static CamelCaseNamingStrategy s_newtonsoftCamelCaseNamingStrategy = new();
+
         [Theory]
         // These test cases were copied from Json.NET.
         [InlineData("urlValue", "URLValue")]
@@ -65,7 +66,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("i18n", "i18n")]
         [InlineData("i18n_policy", "I18nPolicy")]
         [InlineData("7samurai", "7samurai")]
-        [InlineData("άλφα_βήτα_γάμμα", "ΆλφαΒήταΓάμμα")]
         [InlineData("camel_case", "camelCase")]
         [InlineData("camel_case", "CamelCase")]
         [InlineData("snake_case", "snake_case")]
@@ -95,6 +95,10 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("abc_7ef", "  abc 7ef  ")]
         [InlineData("ab7_def", "  ab7 def  ")]
         [InlineData("_abc", "_abc")]
+        [InlineData("", "")]
+        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("άλφα_βήτα_γάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
+        [InlineData("𐐨𐐨𐐨_𐐨𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters
         [InlineData("a%", "a%")]
         [InlineData("_?#-", "_?#-")]
         [InlineData("?!?", "? ! ?")]
@@ -128,7 +132,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("I18N", "i18n")]
         [InlineData("I18N_POLICY", "I18nPolicy")]
         [InlineData("7SAMURAI", "7samurai")]
-        [InlineData("ΆΛΦΑ_ΒΉΤΑ_ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")]
         [InlineData("CAMEL_CASE", "camelCase")]
         [InlineData("CAMEL_CASE", "CamelCase")]
         [InlineData("SNAKE_CASE", "snake_case")]
@@ -158,6 +161,10 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ABC_7EF", "  abc 7ef  ")]
         [InlineData("AB7_DEF", "  ab7 def  ")]
         [InlineData("_ABC", "_abc")]
+        [InlineData("", "")]
+        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("ΆΛΦΑ_ΒΉΤΑ_ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
+        [InlineData("𐐀𐐀𐐀_𐐀𐐀𐐀", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters
         [InlineData("A%", "a%")]
         [InlineData("_?#-", "_?#-")]
         [InlineData("?!?", "? ! ?")]
@@ -191,7 +198,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("i18n", "i18n")]
         [InlineData("i18n-policy", "I18nPolicy")]
         [InlineData("7samurai", "7samurai")]
-        [InlineData("άλφα-βήτα-γάμμα", "ΆλφαΒήταΓάμμα")]
         [InlineData("camel-case", "camelCase")]
         [InlineData("camel-case", "CamelCase")]
         [InlineData("snake_case", "snake_case")]
@@ -222,6 +228,10 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("abc-7ef", "  abc 7ef  ")]
         [InlineData("ab7-def", "  ab7 def  ")]
         [InlineData("-abc", "-abc")]
+        [InlineData("", "")]
+        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("άλφα-βήτα-γάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
+        [InlineData("𐐨𐐨𐐨-𐐨𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters
         [InlineData("a%", "a%")]
         [InlineData("-?#_", "-?#_")]
         [InlineData("?!?", "? ! ?")]
@@ -255,7 +265,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("I18N", "i18n")]
         [InlineData("I18N-POLICY", "I18nPolicy")]
         [InlineData("7SAMURAI", "7samurai")]
-        [InlineData("ΆΛΦΑ-ΒΉΤΑ-ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")]
         [InlineData("CAMEL-CASE", "camelCase")]
         [InlineData("CAMEL-CASE", "CamelCase")]
         [InlineData("SNAKE_CASE", "snake_case")]
@@ -286,6 +295,10 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("ABC-7EF", "  abc 7ef  ")]
         [InlineData("AB7-DEF", "  ab7 def  ")]
         [InlineData("-ABC", "-abc")]
+        [InlineData("", "")]
+        [InlineData("😀", "😀")] // Surrogate pairs
+        [InlineData("ΆΛΦΑ-ΒΉΤΑ-ΓΆΜΜΑ", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
+        [InlineData("𐐀𐐀𐐀-𐐀𐐀𐐀", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters
         [InlineData("A%", "a%")]
         [InlineData("-?#_", "-?#_")]
         [InlineData("?!?", "? ! ?")]
@@ -311,6 +324,22 @@ namespace System.Text.Json.Serialization.Tests
             string value = policy.ConvertName(name);
 
             Assert.Equal(expectedResult, value);
+        }
+
+        [Fact]
+        public static void SnakeCasePolicy_MissingSurrogatePair_ThrowsArgumentException()
+        {
+            string value = "xyz\ud83d";
+            Assert.Throws<ArgumentException>(() => JsonNamingPolicy.SnakeCaseLower.ConvertName(value));
+            Assert.Throws<ArgumentException>(() => JsonNamingPolicy.SnakeCaseUpper.ConvertName(value));
+        }
+
+        [Fact]
+        public static void KebabCasePolicy_MissingSurrogatePair_ThrowsArgumentException()
+        {
+            string value = "xyz\ud83d";
+            Assert.Throws<ArgumentException>(() => JsonNamingPolicy.KebabCaseLower.ConvertName(value));
+            Assert.Throws<ArgumentException>(() => JsonNamingPolicy.KebabCaseUpper.ConvertName(value));
         }
 
         [Theory, OuterLoop]


### PR DESCRIPTION
This PR:

1. Updates the JsonSeparatorNamingPolicy so that non-alphanumeric characters are not being truncated, minimizing the probability of naming collisions.
2. Extends unit test coverage for the component.

After a lot of discussion we concluded that:

1. The policies should keep the fixes for https://github.com/JamesNK/Newtonsoft.Json/issues/1956, resulting in some deviation from Json.NET semantics. We need to document these where appropriate.
2. We will not be adding support for surrogate pairs. Surrogate pairs are handled gracefully by the current implementation, however uppercase surrogate pairs are not recognized as such. This matches the implementation of `JsonNamingPolicy.CamelCase`. We should consider adding surrogate pair support in the future, although that would require addressing https://github.com/dotnet/runtime/issues/52947.

Fix https://github.com/dotnet/runtime/issues/77309.