### PR TITLE
Check opportunistic ISAs in crossgen for CompExactlyDependsOn

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -604,7 +604,9 @@ namespace Internal.JitInterface
                         // This instruction set isn't supported on the current platform at all.
                         continue;
                     }
-                    if (instructionSetSupport.IsInstructionSetSupported(instructionSet) || instructionSetSupport.IsInstructionSetExplicitlyUnsupported(instructionSet))
+                    if (instructionSetSupport.IsInstructionSetSupported(instructionSet) ||
+                        instructionSetSupport.IsInstructionSetOptimisticallySupported(instructionSet) ||
+                        instructionSetSupport.IsInstructionSetExplicitlyUnsupported(instructionSet))
                     {
                         doBypass = false;
                     }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -592,8 +592,7 @@ namespace Internal.JitInterface
 
             if (compExactlyDependsOnList != null && compExactlyDependsOnList.Count > 0)
             {
-                // Default to true, and set to false if at least one of the types is actually supported in the current environment, and none of the
-                // intrinsic types are in an opportunistic state.
+                // Default to true, and set to false if at least one of the types is actually (or opportunistically) supported in the current environment.
                 bool doBypass = true;
 
                 foreach (var intrinsicType in compExactlyDependsOnList)


### PR DESCRIPTION
@stephentoub noticed that the following method shows up as non-prejitted in an empty app:
```cs
[MethodImpl(MethodImplOptions.AggressiveInlining)]
[CompExactlyDependsOn(typeof(Ssse3))]
[CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
private static (Vector128<byte>, Vector128<byte>, Vector128<byte>) FormatGuidVector128Utf8(Guid value, bool useDashes)
{
```
Crossgen uses SSE2 as a baseline (+ SSE4.2 as opportunistic) we should still compile this method since it can be reached with opportunistic ISAs.

With this fix I no longer see this method non-prejitted (along with a few others)