### PR TITLE
[iOS] Fix iOS nativeaot runtime test build

### DIFF
--- a/src/mono/msbuild/android/build/AndroidBuild.props
+++ b/src/mono/msbuild/android/build/AndroidBuild.props
@@ -8,7 +8,7 @@
     <_HostOS Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx</_HostOS>
     <_HostOS Condition="'$(_HostOS)' == ''">linux</_HostOS>
 
-    <_IsLibraryMode Condition="'$(NativeLib)' != ''">true</_IsLibraryMode>
+    <_IsLibraryMode Condition="'$(UseNativeAOTRuntime)' != 'true' and '$(NativeLib)' != ''">true</_IsLibraryMode>
 
     <AndroidBuildAfterThisTarget Condition="'$(AndroidBuildAfterThisTarget)' == ''">Publish</AndroidBuildAfterThisTarget>
     <AndroidBuildDependsOn>

--- a/src/mono/msbuild/apple/build/AppleBuild.props
+++ b/src/mono/msbuild/apple/build/AppleBuild.props
@@ -19,7 +19,7 @@
     <!-- Tracking issue: https://github.com/dotnet/runtime/issues/87740 -->
     <!-- <ShouldILStrip Condition="'$(RunAOTCompilation)' == 'true' and '$(MonoForceInterpreter)' != 'true'">true</ShouldILStrip> -->
 
-    <_IsLibraryMode Condition="'$(NativeLib)' != ''">true</_IsLibraryMode>
+    <_IsLibraryMode Condition="'$(UseNativeAOTRuntime)' != 'true' and '$(NativeLib)' != ''">true</_IsLibraryMode>
 
     <AppleBuildAfterThisTarget Condition="'$(AppleBuildAfterThisTarget)' == ''">Publish</AppleBuildAfterThisTarget>
     <AppleBuildDependsOn>

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -414,7 +414,6 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <NativeDependencies>$(IntermediateOutputPath)\..\$(TestRelativePath)\$(TestName)\native\$(TestName).o</NativeDependencies>
       <DevTeamProvisioning>-</DevTeamProvisioning>
       <AppleGenerateAppBundle>true</AppleGenerateAppBundle>
       <GenerateXcodeProject>true</GenerateXcodeProject>
@@ -422,6 +421,10 @@
       <RunAOTCompilation>false</RunAOTCompilation>
       <MonoForceInterpreter>false</MonoForceInterpreter>
     </PropertyGroup>
+
+    <ItemGroup>
+      <NativeDependencies Include="$(IntermediateOutputPath)\..\$(TestRelativePath)\$(TestName)\native\$(TestName).o" />
+    </ItemGroup>
 
     <ItemGroup>
       <_LinkerFlagsToDrop Include="@(NativeFramework->'-framework %(Identity)')" />


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/89869, the call to the AppleAppBuilderTask passed an item for `NativeDependencies` as opposed to a property. The change wasn't reflected in the runtime test build.proj, so the built test app wasn't being sent in.

Fixes https://github.com/dotnet/runtime/issues/90312

Fixes https://github.com/dotnet/runtime/issues/90218