### PR TITLE
[mono][debugger] Add support for MONO_DEBUG_VAR_ADDRESS_MODE_VTADDR in set_var

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -6043,6 +6043,7 @@ set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domai
 		mono_gc_memmove_atomic (addr, val, size);
 		break;
 	case MONO_DEBUG_VAR_ADDRESS_MODE_REGOFFSET_INDIR:
+	case MONO_DEBUG_VAR_ADDRESS_MODE_VTADDR:
 		/* Same as regoffset, but with an indirection */
 		addr = (guint8 *)mono_arch_context_get_int_reg (ctx, reg);
 		addr += (gint32)var->offset;


### PR DESCRIPTION
Add support for MONO_DEBUG_VAR_ADDRESS_MODE_VTADDR in set_var for debugger-agent

Rider's debugger will in some cases send the MONO_DEBUG_VAR_ADDRESS_MODE_VTADDR flag for set_var, which is currently not supported. This PR implements it, running the same code as MONO_DEBUG_VAR_ADDRESS_MODE_REGOFFSET_INDIR.
