### PR TITLE
[DependencyInjection] Use '==' instead of 'Equals()` to test service type equality

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceIdentifier.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceIdentifier.cs
@@ -32,11 +32,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             if (ServiceKey == null && other.ServiceKey == null)
             {
-                return ServiceType.Equals(other.ServiceType);
+                return ServiceType == other.ServiceType;
             }
             else if (ServiceKey != null && other.ServiceKey != null)
             {
-                return ServiceType.Equals(other.ServiceType) && ServiceKey.Equals(other.ServiceKey);
+                return ServiceType == other.ServiceType && ServiceKey.Equals(other.ServiceKey);
             }
             return false;
         }


### PR DESCRIPTION
Related issue: https://github.com/dotnet/aspnetcore/issues/49485

It seems that scrutor uses a custom implementation of `Type`: https://github.com/khellang/Scrutor/blob/master/src/Scrutor/DecoratedType.cs#L15

Unfortunately, this type override the `Equals()` method, making it non "symetrical" with `Type`:
```csharp
Type t = typeof(object);
var decoratedType = new DecoratedType(t);
var result1 = t.Equals(decoratedType); // returns true
var result2 = decoratedType.Equals(t); // returns false
```

Using `==` to test if two types are the same seems to fix the issue.

