### PR TITLE
[mono][tasks] Generate uncompressed mibc files

### DIFF
--- a/src/tasks/MonoTargetsTasks/NetTraceToMibcConverterTask/NetTraceToMibcConverter.cs
+++ b/src/tasks/MonoTargetsTasks/NetTraceToMibcConverterTask/NetTraceToMibcConverter.cs
@@ -109,7 +109,7 @@ public class NetTraceToMibcConverter : ToolTask
             string? fullPath = refAsmItem.GetMetadata("FullPath");
             mibcConverterArgsStr.Append($" --reference \"{fullPath}\" ");
         }
-
+        mibcConverterArgsStr.Append($" --compressed false");
         mibcConverterArgsStr.Append($" --output \"{MibcFilePath}\"");
 
         return mibcConverterArgsStr.ToString();


### PR DESCRIPTION
The [dotnet-pgo](https://github.com/dotnet/runtime/blob/main/src/coreclr/tools/dotnet-pgo/README.md) tool began emitting a compressed form beginning from https://github.com/dotnet/runtime/pull/76467. The dotnet-pgo based profiled AOT story for mono needs to [open and read the uncompressed form](https://github.com/dotnet/runtime/blob/15e89256b7f35b839725cefc9a8180b917573cdc/src/mono/mono/metadata/image.c#L1148-L1153), so default the NetTraceToMibc task to generate uncompressed `.mibc` files for consumption in the MonoAOTCompiler.