### PR TITLE
[release/7.0-staging] Eliminate cancellation deadlock in RateLimiter implementations (#90285)

### DIFF
--- a/src/libraries/System.Threading.RateLimiting/src/System.Threading.RateLimiting.csproj
+++ b/src/libraries/System.Threading.RateLimiting/src/System.Threading.RateLimiting.csproj
@@ -1,7 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
     <!-- Enable package baseline validation this when we release the 7.0.0 version. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <PackageDescription>APIs to help manage rate limiting.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
@@ -156,8 +156,17 @@ namespace System.Threading.RateLimiting
                             Debug.Assert(_queueCount >= 0);
                             if (!oldestRequest.TrySetResult(FailedLease))
                             {
-                                // Updating queue count is handled by the cancellation code
-                                _queueCount += oldestRequest.Count;
+                                if (!oldestRequest.QueueCountModified)
+                                {
+                                    // We already updated the queue count, the Cancel code is about to run or running and waiting on our lock,
+                                    // tell Cancel not to do anything
+                                    oldestRequest.QueueCountModified = true;
+                                }
+                                else
+                                {
+                                    // Updating queue count was handled by the cancellation code, don't double count
+                                    _queueCount += oldestRequest.Count;
+                                }
                             }
                             else
                             {
@@ -277,10 +286,19 @@ namespace System.Threading.RateLimiting
                         // Check if request was canceled
                         if (!nextPendingRequest.TrySetResult(lease))
                         {
-                            // Queued item was canceled so add count back
+                            // Queued item was canceled so add count back, permits weren't acquired
                             _permitCount += nextPendingRequest.Count;
-                            // Updating queue count is handled by the cancellation code
-                            _queueCount += nextPendingRequest.Count;
+                            if (!nextPendingRequest.QueueCountModified)
+                            {
+                                // We already updated the queue count, the Cancel code is about to run or running and waiting on our lock,
+                                // tell Cancel not to do anything
+                                nextPendingRequest.QueueCountModified = true;
+                            }
+                            else
+                            {
+                                // Updating queue count was handled by the cancellation code, don't double count
+                                _queueCount += nextPendingRequest.Count;
+                            }
                         }
                         else
                         {
@@ -397,6 +415,9 @@ namespace System.Threading.RateLimiting
             private readonly CancellationToken _cancellationToken;
             private CancellationTokenRegistration _cancellationTokenRegistration;
 
+            // Update under the limiter lock and only if the queue count was updated by the calling code
+            public bool QueueCountModified { get; set; }
+
             // this field is used only by the disposal mechanics and never shared between threads
             private RequestRegistration? _next;
 
@@ -427,7 +448,14 @@ namespace System.Threading.RateLimiting
                     var limiter = (ConcurrencyLimiter)registration.Task.AsyncState!;
                     lock (limiter.Lock)
                     {
-                        limiter._queueCount -= registration.Count;
+                        // Queuing and replenishing code might modify the _queueCount, since there is no guarantee of when the cancellation
+                        // code runs and we only want to update the _queueCount once, we set a bool (under a lock) so either method
+                        // can update the count and not double count.
+                        if (!registration.QueueCountModified)
+                        {
+                            limiter._queueCount -= registration.Count;
+                            registration.QueueCountModified = true;
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
@@ -132,6 +132,8 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
+            using var disposer = default(RequestRegistration.Disposer);
+
             // Perf: Check SemaphoreSlim implementation instead of locking
             lock (Lock)
             {
@@ -152,7 +154,7 @@ namespace System.Threading.RateLimiting
                             RequestRegistration oldestRequest = _queue.DequeueHead();
                             _queueCount -= oldestRequest.Count;
                             Debug.Assert(_queueCount >= 0);
-                            if (!oldestRequest.Tcs.TrySetResult(FailedLease))
+                            if (!oldestRequest.TrySetResult(FailedLease))
                             {
                                 // Updating queue count is handled by the cancellation code
                                 _queueCount += oldestRequest.Count;
@@ -161,6 +163,7 @@ namespace System.Threading.RateLimiting
                             {
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
+                            disposer.Add(oldestRequest);
                         }
                         while (_options.QueueLimit - _queueCount < permitCount);
                     }
@@ -172,22 +175,12 @@ namespace System.Threading.RateLimiting
                     }
                 }
 
-                CancelQueueState tcs = new CancelQueueState(permitCount, this, cancellationToken);
-                CancellationTokenRegistration ctr = default;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    ctr = cancellationToken.Register(static obj =>
-                    {
-                        ((CancelQueueState)obj!).TrySetCanceled();
-                    }, tcs);
-                }
-
-                RequestRegistration request = new RequestRegistration(permitCount, tcs, ctr);
+                var request = new RequestRegistration(permitCount, this, cancellationToken);
                 _queue.EnqueueTail(request);
                 _queueCount += permitCount;
                 Debug.Assert(_queueCount <= _options.QueueLimit);
 
-                return new ValueTask<RateLimitLease>(request.Tcs.Task);
+                return new ValueTask<RateLimitLease>(request.Task);
             }
         }
 
@@ -223,8 +216,15 @@ namespace System.Threading.RateLimiting
             return false;
         }
 
+#if DEBUG
+        // for unit testing
+        internal event Action? ReleasePreHook;
+        internal event Action? ReleasePostHook;
+#endif
+
         private void Release(int releaseCount)
         {
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (_disposed)
@@ -235,12 +235,32 @@ namespace System.Threading.RateLimiting
                 _permitCount += releaseCount;
                 Debug.Assert(_permitCount <= _options.PermitLimit);
 
+#if DEBUG
+                ReleasePreHook?.Invoke();
+#endif
+
                 while (_queue.Count > 0)
                 {
                     RequestRegistration nextPendingRequest =
                         _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.PeekHead()
                         : _queue.PeekTail();
+
+                    // Request was handled already, either via cancellation or being kicked from the queue due to a newer request being queued.
+                    // We just need to remove the item and let the next queued item be considered for completion.
+                    if (nextPendingRequest.Task.IsCompleted)
+                    {
+                        nextPendingRequest =
+                            _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
+                            ? _queue.DequeueHead()
+                            : _queue.DequeueTail();
+                        disposer.Add(nextPendingRequest);
+                        continue;
+                    }
+
+#if DEBUG
+                    ReleasePostHook?.Invoke();
+#endif
 
                     if (_permitCount >= nextPendingRequest.Count)
                     {
@@ -255,7 +275,7 @@ namespace System.Threading.RateLimiting
 
                         ConcurrencyLease lease = nextPendingRequest.Count == 0 ? SuccessfulLease : new ConcurrencyLease(true, this, nextPendingRequest.Count);
                         // Check if request was canceled
-                        if (!nextPendingRequest.Tcs.TrySetResult(lease))
+                        if (!nextPendingRequest.TrySetResult(lease))
                         {
                             // Queued item was canceled so add count back
                             _permitCount += nextPendingRequest.Count;
@@ -266,7 +286,7 @@ namespace System.Threading.RateLimiting
                         {
                             Interlocked.Increment(ref _successfulLeasesCount);
                         }
-                        nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        disposer.Add(nextPendingRequest);
                         Debug.Assert(_queueCount >= 0);
                     }
                     else
@@ -278,7 +298,6 @@ namespace System.Threading.RateLimiting
                 if (_permitCount == _options.PermitLimit)
                 {
                     Debug.Assert(_idleSince is null);
-                    Debug.Assert(_queueCount == 0);
                     _idleSince = Stopwatch.GetTimestamp();
                 }
             }
@@ -291,6 +310,7 @@ namespace System.Threading.RateLimiting
                 return;
             }
 
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (_disposed)
@@ -303,8 +323,8 @@ namespace System.Threading.RateLimiting
                     RequestRegistration next = _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
-                    next.CancellationTokenRegistration.Dispose();
-                    next.Tcs.TrySetResult(FailedLease);
+                    disposer.Add(next);
+                    next.TrySetResult(FailedLease);
                 }
             }
         }
@@ -372,49 +392,68 @@ namespace System.Threading.RateLimiting
             }
         }
 
-        private readonly struct RequestRegistration
+        private sealed class RequestRegistration : TaskCompletionSource<RateLimitLease>
         {
-            public RequestRegistration(int requestedCount, TaskCompletionSource<RateLimitLease> tcs,
-                CancellationTokenRegistration cancellationTokenRegistration)
+            private readonly CancellationToken _cancellationToken;
+            private CancellationTokenRegistration _cancellationTokenRegistration;
+
+            // this field is used only by the disposal mechanics and never shared between threads
+            private RequestRegistration? _next;
+
+            public RequestRegistration(int permitCount, ConcurrencyLimiter limiter, CancellationToken cancellationToken)
+                : base(limiter, TaskCreationOptions.RunContinuationsAsynchronously)
             {
-                Count = requestedCount;
-                // Perf: Use AsyncOperation<TResult> instead
-                Tcs = tcs;
-                CancellationTokenRegistration = cancellationTokenRegistration;
+                Count = permitCount;
+                _cancellationToken = cancellationToken;
+
+                // RequestRegistration objects are created while the limiter lock is held
+                // if cancellationToken fires before or while the lock is held, UnsafeRegister
+                // is going to invoke the callback synchronously, but this does not create
+                // a deadlock because lock are reentrant
+                if (cancellationToken.CanBeCanceled)
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this);
+#else
+                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this);
+#endif
             }
 
             public int Count { get; }
 
-            public TaskCompletionSource<RateLimitLease> Tcs { get; }
-
-            public CancellationTokenRegistration CancellationTokenRegistration { get; }
-        }
-
-        private sealed class CancelQueueState : TaskCompletionSource<RateLimitLease>
-        {
-            private readonly int _permitCount;
-            private readonly ConcurrencyLimiter _limiter;
-            private readonly CancellationToken _cancellationToken;
-
-            public CancelQueueState(int permitCount, ConcurrencyLimiter limiter, CancellationToken cancellationToken)
-                : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            private static void Cancel(object? state)
             {
-                _permitCount = permitCount;
-                _limiter = limiter;
-                _cancellationToken = cancellationToken;
+                if (state is RequestRegistration registration && registration.TrySetCanceled(registration._cancellationToken))
+                {
+                    var limiter = (ConcurrencyLimiter)registration.Task.AsyncState!;
+                    lock (limiter.Lock)
+                    {
+                        limiter._queueCount -= registration.Count;
+                    }
+                }
             }
 
-            public new bool TrySetCanceled()
+            /// <summary>
+            /// Collects registrations to dispose outside the limiter lock to avoid deadlock.
+            /// </summary>
+            public struct Disposer : IDisposable
             {
-                if (TrySetCanceled(_cancellationToken))
+                private RequestRegistration? _next;
+
+                public void Add(RequestRegistration request)
                 {
-                    lock (_limiter.Lock)
-                    {
-                        _limiter._queueCount -= _permitCount;
-                    }
-                    return true;
+                    request._next = _next;
+                    _next = request;
                 }
-                return false;
+
+                public void Dispose()
+                {
+                    for (var current = _next; current is not null; current = current._next)
+                    {
+                        current._cancellationTokenRegistration.Dispose();
+                    }
+
+                    _next = null;
+                }
             }
         }
     }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -151,6 +151,7 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (TryLeaseUnsynchronized(permitCount, out RateLimitLease? lease))
@@ -170,7 +171,7 @@ namespace System.Threading.RateLimiting
                             RequestRegistration oldestRequest = _queue.DequeueHead();
                             _queueCount -= oldestRequest.Count;
                             Debug.Assert(_queueCount >= 0);
-                            if (!oldestRequest.Tcs.TrySetResult(FailedLease))
+                            if (!oldestRequest.TrySetResult(FailedLease))
                             {
                                 _queueCount += oldestRequest.Count;
                             }
@@ -178,6 +179,7 @@ namespace System.Threading.RateLimiting
                             {
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
+                            disposer.Add(oldestRequest);
                         }
                         while (_options.QueueLimit - _queueCount < permitCount);
                     }
@@ -189,22 +191,12 @@ namespace System.Threading.RateLimiting
                     }
                 }
 
-                CancelQueueState tcs = new CancelQueueState(permitCount, this, cancellationToken);
-                CancellationTokenRegistration ctr = default;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    ctr = cancellationToken.Register(static obj =>
-                    {
-                        ((CancelQueueState)obj!).TrySetCanceled();
-                    }, tcs);
-                }
-
-                RequestRegistration registration = new RequestRegistration(permitCount, tcs, ctr);
+                var registration = new RequestRegistration(permitCount, this, cancellationToken);
                 _queue.EnqueueTail(registration);
                 _queueCount += permitCount;
                 Debug.Assert(_queueCount <= _options.QueueLimit);
 
-                return new ValueTask<RateLimitLease>(registration.Tcs.Task);
+                return new ValueTask<RateLimitLease>(registration.Task);
             }
         }
 
@@ -279,6 +271,8 @@ namespace System.Threading.RateLimiting
         // Used in tests that test behavior with specific time intervals
         private void ReplenishInternal(long nowTicks)
         {
+            using var disposer = default(RequestRegistration.Disposer);
+
             // Method is re-entrant (from Timer), lock to avoid multiple simultaneous replenishes
             lock (Lock)
             {
@@ -312,7 +306,17 @@ namespace System.Threading.RateLimiting
                           ? _queue.PeekHead()
                           : _queue.PeekTail();
 
-                    if (_permitCount >= nextPendingRequest.Count)
+                    // Request was handled already, either via cancellation or being kicked from the queue due to a newer request being queued.
+                    // We just need to remove the item and let the next queued item be considered for completion.
+                    if (nextPendingRequest.Task.IsCompleted)
+                    {
+                        nextPendingRequest =
+                            _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
+                            ? _queue.DequeueHead()
+                            : _queue.DequeueTail();
+                        disposer.Add(nextPendingRequest);
+                    }
+                    else if (_permitCount >= nextPendingRequest.Count)
                     {
                         // Request can be fulfilled
                         nextPendingRequest =
@@ -324,7 +328,7 @@ namespace System.Threading.RateLimiting
                         _permitCount -= nextPendingRequest.Count;
                         Debug.Assert(_permitCount >= 0);
 
-                        if (!nextPendingRequest.Tcs.TrySetResult(SuccessfulLease))
+                        if (!nextPendingRequest.TrySetResult(SuccessfulLease))
                         {
                             // Queued item was canceled so add count back
                             _permitCount += nextPendingRequest.Count;
@@ -335,7 +339,7 @@ namespace System.Threading.RateLimiting
                         {
                             Interlocked.Increment(ref _successfulLeasesCount);
                         }
-                        nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        disposer.Add(nextPendingRequest);
                         Debug.Assert(_queueCount >= 0);
                     }
                     else
@@ -348,7 +352,6 @@ namespace System.Threading.RateLimiting
                 if (_permitCount == _options.PermitLimit)
                 {
                     Debug.Assert(_idleSince is null);
-                    Debug.Assert(_queueCount == 0);
                     _idleSince = Stopwatch.GetTimestamp();
                 }
             }
@@ -361,6 +364,7 @@ namespace System.Threading.RateLimiting
                 return;
             }
 
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (_disposed)
@@ -374,8 +378,8 @@ namespace System.Threading.RateLimiting
                     RequestRegistration next = _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
-                    next.CancellationTokenRegistration.Dispose();
-                    next.Tcs.TrySetResult(FailedLease);
+                    disposer.Add(next);
+                    next.TrySetResult(FailedLease);
                 }
             }
         }
@@ -424,48 +428,68 @@ namespace System.Threading.RateLimiting
             }
         }
 
-        private readonly struct RequestRegistration
+        private sealed class RequestRegistration : TaskCompletionSource<RateLimitLease>
         {
-            public RequestRegistration(int permitCount, TaskCompletionSource<RateLimitLease> tcs, CancellationTokenRegistration cancellationTokenRegistration)
+            private readonly CancellationToken _cancellationToken;
+            private CancellationTokenRegistration _cancellationTokenRegistration;
+
+            // this field is used only by the disposal mechanics and never shared between threads
+            private RequestRegistration? _next;
+
+            public RequestRegistration(int permitCount, FixedWindowRateLimiter limiter, CancellationToken cancellationToken)
+                : base(limiter, TaskCreationOptions.RunContinuationsAsynchronously)
             {
                 Count = permitCount;
-                // Use VoidAsyncOperationWithData<T> instead
-                Tcs = tcs;
-                CancellationTokenRegistration = cancellationTokenRegistration;
+                _cancellationToken = cancellationToken;
+
+                // RequestRegistration objects are created while the limiter lock is held
+                // if cancellationToken fires before or while the lock is held, UnsafeRegister
+                // is going to invoke the callback synchronously, but this does not create
+                // a deadlock because lock are reentrant
+                if (cancellationToken.CanBeCanceled)
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this);
+#else
+                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this);
+#endif
             }
 
             public int Count { get; }
 
-            public TaskCompletionSource<RateLimitLease> Tcs { get; }
-
-            public CancellationTokenRegistration CancellationTokenRegistration { get; }
-        }
-
-        private sealed class CancelQueueState : TaskCompletionSource<RateLimitLease>
-        {
-            private readonly int _permitCount;
-            private readonly FixedWindowRateLimiter _limiter;
-            private readonly CancellationToken _cancellationToken;
-
-            public CancelQueueState(int permitCount, FixedWindowRateLimiter limiter, CancellationToken cancellationToken)
-                : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            private static void Cancel(object? state)
             {
-                _permitCount = permitCount;
-                _limiter = limiter;
-                _cancellationToken = cancellationToken;
+                if (state is RequestRegistration registration && registration.TrySetCanceled(registration._cancellationToken))
+                {
+                    var limiter = (FixedWindowRateLimiter)registration.Task.AsyncState!;
+                    lock (limiter.Lock)
+                    {
+                        limiter._queueCount -= registration.Count;
+                    }
+                }
             }
 
-            public new bool TrySetCanceled()
+            /// <summary>
+            /// Collects registrations to dispose outside the limiter lock to avoid deadlock.
+            /// </summary>
+            public struct Disposer : IDisposable
             {
-                if (TrySetCanceled(_cancellationToken))
+                private RequestRegistration? _next;
+
+                public void Add(RequestRegistration request)
                 {
-                    lock (_limiter.Lock)
-                    {
-                        _limiter._queueCount -= _permitCount;
-                    }
-                    return true;
+                    request._next = _next;
+                    _next = request;
                 }
-                return false;
+
+                public void Dispose()
+                {
+                    for (var current = _next; current is not null; current = current._next)
+                    {
+                        current._cancellationTokenRegistration.Dispose();
+                    }
+
+                    _next = null;
+                }
             }
         }
     }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -173,7 +173,17 @@ namespace System.Threading.RateLimiting
                             Debug.Assert(_queueCount >= 0);
                             if (!oldestRequest.TrySetResult(FailedLease))
                             {
-                                _queueCount += oldestRequest.Count;
+                                if (!oldestRequest.QueueCountModified)
+                                {
+                                    // We already updated the queue count, the Cancel code is about to run or running and waiting on our lock,
+                                    // tell Cancel not to do anything
+                                    oldestRequest.QueueCountModified = true;
+                                }
+                                else
+                                {
+                                    // Updating queue count was handled by the cancellation code, don't double count
+                                    _queueCount += oldestRequest.Count;
+                                }
                             }
                             else
                             {
@@ -330,10 +340,19 @@ namespace System.Threading.RateLimiting
 
                         if (!nextPendingRequest.TrySetResult(SuccessfulLease))
                         {
-                            // Queued item was canceled so add count back
+                            // Queued item was canceled so add count back, permits weren't acquired
                             _permitCount += nextPendingRequest.Count;
-                            // Updating queue count is handled by the cancellation code
-                            _queueCount += nextPendingRequest.Count;
+                            if (!nextPendingRequest.QueueCountModified)
+                            {
+                                // We already updated the queue count, the Cancel code is about to run or running and waiting on our lock,
+                                // tell Cancel not to do anything
+                                nextPendingRequest.QueueCountModified = true;
+                            }
+                            else
+                            {
+                                // Updating queue count was handled by the cancellation code, don't double count
+                                _queueCount += nextPendingRequest.Count;
+                            }
                         }
                         else
                         {
@@ -433,6 +452,9 @@ namespace System.Threading.RateLimiting
             private readonly CancellationToken _cancellationToken;
             private CancellationTokenRegistration _cancellationTokenRegistration;
 
+            // Update under the limiter lock and only if the queue count was updated by the calling code
+            public bool QueueCountModified { get; set; }
+
             // this field is used only by the disposal mechanics and never shared between threads
             private RequestRegistration? _next;
 
@@ -463,7 +485,14 @@ namespace System.Threading.RateLimiting
                     var limiter = (FixedWindowRateLimiter)registration.Task.AsyncState!;
                     lock (limiter.Lock)
                     {
-                        limiter._queueCount -= registration.Count;
+                        // Queuing and replenishing code might modify the _queueCount, since there is no guarantee of when the cancellation
+                        // code runs and we only want to update the _queueCount once, we set a bool (under a lock) so either method
+                        // can update the count and not double count.
+                        if (!registration.QueueCountModified)
+                        {
+                            limiter._queueCount -= registration.Count;
+                            registration.QueueCountModified = true;
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -159,6 +159,7 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (TryLeaseUnsynchronized(permitCount, out RateLimitLease? lease))
@@ -178,7 +179,7 @@ namespace System.Threading.RateLimiting
                             RequestRegistration oldestRequest = _queue.DequeueHead();
                             _queueCount -= oldestRequest.Count;
                             Debug.Assert(_queueCount >= 0);
-                            if (!oldestRequest.Tcs.TrySetResult(FailedLease))
+                            if (!oldestRequest.TrySetResult(FailedLease))
                             {
                                 _queueCount += oldestRequest.Count;
                             }
@@ -186,6 +187,7 @@ namespace System.Threading.RateLimiting
                             {
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
+                            disposer.Add(oldestRequest);
                         }
                         while (_options.QueueLimit - _queueCount < permitCount);
                     }
@@ -197,22 +199,12 @@ namespace System.Threading.RateLimiting
                     }
                 }
 
-                CancelQueueState tcs = new CancelQueueState(permitCount, this, cancellationToken);
-                CancellationTokenRegistration ctr = default;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    ctr = cancellationToken.Register(static obj =>
-                    {
-                        ((CancelQueueState)obj!).TrySetCanceled();
-                    }, tcs);
-                }
-
-                RequestRegistration registration = new RequestRegistration(permitCount, tcs, ctr);
+                var registration = new RequestRegistration(permitCount, this, cancellationToken);
                 _queue.EnqueueTail(registration);
                 _queueCount += permitCount;
                 Debug.Assert(_queueCount <= _options.QueueLimit);
 
-                return new ValueTask<RateLimitLease>(registration.Tcs.Task);
+                return new ValueTask<RateLimitLease>(registration.Task);
             }
         }
 
@@ -281,6 +273,8 @@ namespace System.Threading.RateLimiting
         // Used in tests that test behavior with specific time intervals
         private void ReplenishInternal(long nowTicks)
         {
+            using var disposer = default(RequestRegistration.Disposer);
+
             // Method is re-entrant (from Timer), lock to avoid multiple simultaneous replenishes
             lock (Lock)
             {
@@ -318,8 +312,18 @@ namespace System.Threading.RateLimiting
                           ? _queue.PeekHead()
                           : _queue.PeekTail();
 
+                    // Request was handled already, either via cancellation or being kicked from the queue due to a newer request being queued.
+                    // We just need to remove the item and let the next queued item be considered for completion.
+                    if (nextPendingRequest.Task.IsCompleted)
+                    {
+                        nextPendingRequest =
+                            _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
+                            ? _queue.DequeueHead()
+                            : _queue.DequeueTail();
+                        disposer.Add(nextPendingRequest);
+                    }
                     // If we have enough permits after replenishing to serve the queued requests
-                    if (_permitCount >= nextPendingRequest.Count)
+                    else if (_permitCount >= nextPendingRequest.Count)
                     {
                         // Request can be fulfilled
                         nextPendingRequest =
@@ -332,7 +336,7 @@ namespace System.Threading.RateLimiting
                         _requestsPerSegment[_currentSegmentIndex] += nextPendingRequest.Count;
                         Debug.Assert(_permitCount >= 0);
 
-                        if (!nextPendingRequest.Tcs.TrySetResult(SuccessfulLease))
+                        if (!nextPendingRequest.TrySetResult(SuccessfulLease))
                         {
                             // Queued item was canceled so add count back
                             _permitCount += nextPendingRequest.Count;
@@ -344,7 +348,7 @@ namespace System.Threading.RateLimiting
                         {
                             Interlocked.Increment(ref _successfulLeasesCount);
                         }
-                        nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        disposer.Add(nextPendingRequest);
                         Debug.Assert(_queueCount >= 0);
                     }
                     else
@@ -357,7 +361,6 @@ namespace System.Threading.RateLimiting
                 if (_permitCount == _options.PermitLimit)
                 {
                     Debug.Assert(_idleSince is null);
-                    Debug.Assert(_queueCount == 0);
                     _idleSince = Stopwatch.GetTimestamp();
                 }
             }
@@ -370,6 +373,7 @@ namespace System.Threading.RateLimiting
                 return;
             }
 
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (_disposed)
@@ -383,8 +387,8 @@ namespace System.Threading.RateLimiting
                     RequestRegistration next = _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
-                    next.CancellationTokenRegistration.Dispose();
-                    next.Tcs.TrySetResult(FailedLease);
+                    disposer.Add(next);
+                    next.TrySetResult(FailedLease);
                 }
             }
         }
@@ -433,48 +437,68 @@ namespace System.Threading.RateLimiting
             }
         }
 
-        private readonly struct RequestRegistration
+        private sealed class RequestRegistration : TaskCompletionSource<RateLimitLease>
         {
-            public RequestRegistration(int permitCount, TaskCompletionSource<RateLimitLease> tcs, CancellationTokenRegistration cancellationTokenRegistration)
+            private readonly CancellationToken _cancellationToken;
+            private CancellationTokenRegistration _cancellationTokenRegistration;
+
+            // this field is used only by the disposal mechanics and never shared between threads
+            private RequestRegistration? _next;
+
+            public RequestRegistration(int permitCount, SlidingWindowRateLimiter limiter, CancellationToken cancellationToken)
+                : base(limiter, TaskCreationOptions.RunContinuationsAsynchronously)
             {
                 Count = permitCount;
-                // Use VoidAsyncOperationWithData<T> instead
-                Tcs = tcs;
-                CancellationTokenRegistration = cancellationTokenRegistration;
+                _cancellationToken = cancellationToken;
+
+                // RequestRegistration objects are created while the limiter lock is held
+                // if cancellationToken fires before or while the lock is held, UnsafeRegister
+                // is going to invoke the callback synchronously, but this does not create
+                // a deadlock because lock are reentrant
+                if (cancellationToken.CanBeCanceled)
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this);
+#else
+                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this);
+#endif
             }
 
             public int Count { get; }
 
-            public TaskCompletionSource<RateLimitLease> Tcs { get; }
-
-            public CancellationTokenRegistration CancellationTokenRegistration { get; }
-        }
-
-        private sealed class CancelQueueState : TaskCompletionSource<RateLimitLease>
-        {
-            private readonly int _permitCount;
-            private readonly SlidingWindowRateLimiter _limiter;
-            private readonly CancellationToken _cancellationToken;
-
-            public CancelQueueState(int permitCount, SlidingWindowRateLimiter limiter, CancellationToken cancellationToken)
-                : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            private static void Cancel(object? state)
             {
-                _permitCount = permitCount;
-                _limiter = limiter;
-                _cancellationToken = cancellationToken;
+                if (state is RequestRegistration registration && registration.TrySetCanceled(registration._cancellationToken))
+                {
+                    var limiter = (SlidingWindowRateLimiter)registration.Task.AsyncState!;
+                    lock (limiter.Lock)
+                    {
+                        limiter._queueCount -= registration.Count;
+                    }
+                }
             }
 
-            public new bool TrySetCanceled()
+            /// <summary>
+            /// Collects registrations to dispose outside the limiter lock to avoid deadlock.
+            /// </summary>
+            public struct Disposer : IDisposable
             {
-                if (TrySetCanceled(_cancellationToken))
+                private RequestRegistration? _next;
+
+                public void Add(RequestRegistration request)
                 {
-                    lock (_limiter.Lock)
-                    {
-                        _limiter._queueCount -= _permitCount;
-                    }
-                    return true;
+                    request._next = _next;
+                    _next = request;
                 }
-                return false;
+
+                public void Dispose()
+                {
+                    for (var current = _next; current is not null; current = current._next)
+                    {
+                        current._cancellationTokenRegistration.Dispose();
+                    }
+
+                    _next = null;
+                }
             }
         }
     }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -181,7 +181,17 @@ namespace System.Threading.RateLimiting
                             Debug.Assert(_queueCount >= 0);
                             if (!oldestRequest.TrySetResult(FailedLease))
                             {
-                                _queueCount += oldestRequest.Count;
+                                if (!oldestRequest.QueueCountModified)
+                                {
+                                    // We already updated the queue count, the Cancel code is about to run or running and waiting on our lock,
+                                    // tell Cancel not to do anything
+                                    oldestRequest.QueueCountModified = true;
+                                }
+                                else
+                                {
+                                    // Updating queue count was handled by the cancellation code, don't double count
+                                    _queueCount += oldestRequest.Count;
+                                }
                             }
                             else
                             {
@@ -338,11 +348,20 @@ namespace System.Threading.RateLimiting
 
                         if (!nextPendingRequest.TrySetResult(SuccessfulLease))
                         {
-                            // Queued item was canceled so add count back
+                            // Queued item was canceled so add count back, permits weren't acquired
                             _permitCount += nextPendingRequest.Count;
                             _requestsPerSegment[_currentSegmentIndex] -= nextPendingRequest.Count;
-                            // Updating queue count is handled by the cancellation code
-                            _queueCount += nextPendingRequest.Count;
+                            if (!nextPendingRequest.QueueCountModified)
+                            {
+                                // We already updated the queue count, the Cancel code is about to run or running and waiting on our lock,
+                                // tell Cancel not to do anything
+                                nextPendingRequest.QueueCountModified = true;
+                            }
+                            else
+                            {
+                                // Updating queue count was handled by the cancellation code, don't double count
+                                _queueCount += nextPendingRequest.Count;
+                            }
                         }
                         else
                         {
@@ -442,6 +461,9 @@ namespace System.Threading.RateLimiting
             private readonly CancellationToken _cancellationToken;
             private CancellationTokenRegistration _cancellationTokenRegistration;
 
+            // Update under the limiter lock and only if the queue count was updated by the calling code
+            public bool QueueCountModified { get; set; }
+
             // this field is used only by the disposal mechanics and never shared between threads
             private RequestRegistration? _next;
 
@@ -472,7 +494,14 @@ namespace System.Threading.RateLimiting
                     var limiter = (SlidingWindowRateLimiter)registration.Task.AsyncState!;
                     lock (limiter.Lock)
                     {
-                        limiter._queueCount -= registration.Count;
+                        // Queuing and replenishing code might modify the _queueCount, since there is no guarantee of when the cancellation
+                        // code runs and we only want to update the _queueCount once, we set a bool (under a lock) so either method
+                        // can update the count and not double count.
+                        if (!registration.QueueCountModified)
+                        {
+                            limiter._queueCount -= registration.Count;
+                            registration.QueueCountModified = true;
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -152,6 +152,7 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(SuccessfulLease);
             }
 
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (TryLeaseUnsynchronized(tokenCount, out RateLimitLease? lease))
@@ -171,7 +172,7 @@ namespace System.Threading.RateLimiting
                             RequestRegistration oldestRequest = _queue.DequeueHead();
                             _queueCount -= oldestRequest.Count;
                             Debug.Assert(_queueCount >= 0);
-                            if (!oldestRequest.Tcs.TrySetResult(FailedLease))
+                            if (!oldestRequest.TrySetResult(FailedLease))
                             {
                                 // Updating queue count is handled by the cancellation code
                                 _queueCount += oldestRequest.Count;
@@ -180,6 +181,7 @@ namespace System.Threading.RateLimiting
                             {
                                 Interlocked.Increment(ref _failedLeasesCount);
                             }
+                            disposer.Add(oldestRequest);
                         }
                         while (_options.QueueLimit - _queueCount < tokenCount);
                     }
@@ -191,22 +193,12 @@ namespace System.Threading.RateLimiting
                     }
                 }
 
-                CancelQueueState tcs = new CancelQueueState(tokenCount, this, cancellationToken);
-                CancellationTokenRegistration ctr = default;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    ctr = cancellationToken.Register(static obj =>
-                    {
-                        ((CancelQueueState)obj!).TrySetCanceled();
-                    }, tcs);
-                }
-
-                RequestRegistration registration = new RequestRegistration(tokenCount, tcs, ctr);
+                var registration = new RequestRegistration(tokenCount, this, cancellationToken);
                 _queue.EnqueueTail(registration);
                 _queueCount += tokenCount;
                 Debug.Assert(_queueCount <= _options.QueueLimit);
 
-                return new ValueTask<RateLimitLease>(registration.Tcs.Task);
+                return new ValueTask<RateLimitLease>(registration.Task);
             }
         }
 
@@ -283,6 +275,8 @@ namespace System.Threading.RateLimiting
         // Used in tests to avoid dealing with real time
         private void ReplenishInternal(long nowTicks)
         {
+            using var disposer = default(RequestRegistration.Disposer);
+
             // method is re-entrant (from Timer), lock to avoid multiple simultaneous replenishes
             lock (Lock)
             {
@@ -323,7 +317,17 @@ namespace System.Threading.RateLimiting
                           ? queue.PeekHead()
                           : queue.PeekTail();
 
-                    if (_tokenCount >= nextPendingRequest.Count)
+                    // Request was handled already, either via cancellation or being kicked from the queue due to a newer request being queued.
+                    // We just need to remove the item and let the next queued item be considered for completion.
+                    if (nextPendingRequest.Task.IsCompleted)
+                    {
+                        nextPendingRequest =
+                            _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
+                            ? queue.DequeueHead()
+                            : queue.DequeueTail();
+                        disposer.Add(nextPendingRequest);
+                    }
+                    else if (_tokenCount >= nextPendingRequest.Count)
                     {
                         // Request can be fulfilled
                         nextPendingRequest =
@@ -335,7 +339,7 @@ namespace System.Threading.RateLimiting
                         _tokenCount -= nextPendingRequest.Count;
                         Debug.Assert(_tokenCount >= 0);
 
-                        if (!nextPendingRequest.Tcs.TrySetResult(SuccessfulLease))
+                        if (!nextPendingRequest.TrySetResult(SuccessfulLease))
                         {
                             // Queued item was canceled so add count back
                             _tokenCount += nextPendingRequest.Count;
@@ -346,7 +350,7 @@ namespace System.Threading.RateLimiting
                         {
                             Interlocked.Increment(ref _successfulLeasesCount);
                         }
-                        nextPendingRequest.CancellationTokenRegistration.Dispose();
+                        disposer.Add(nextPendingRequest);
                         Debug.Assert(_queueCount >= 0);
                     }
                     else
@@ -359,7 +363,6 @@ namespace System.Threading.RateLimiting
                 if (_tokenCount == _options.TokenLimit)
                 {
                     Debug.Assert(_idleSince is null);
-                    Debug.Assert(_queueCount == 0);
                     _idleSince = Stopwatch.GetTimestamp();
                 }
             }
@@ -372,6 +375,7 @@ namespace System.Threading.RateLimiting
                 return;
             }
 
+            using var disposer = default(RequestRegistration.Disposer);
             lock (Lock)
             {
                 if (_disposed)
@@ -385,8 +389,8 @@ namespace System.Threading.RateLimiting
                     RequestRegistration next = _options.QueueProcessingOrder == QueueProcessingOrder.OldestFirst
                         ? _queue.DequeueHead()
                         : _queue.DequeueTail();
-                    next.CancellationTokenRegistration.Dispose();
-                    next.Tcs.TrySetResult(FailedLease);
+                    disposer.Add(next);
+                    next.TrySetResult(FailedLease);
                 }
             }
         }
@@ -435,48 +439,68 @@ namespace System.Threading.RateLimiting
             }
         }
 
-        private readonly struct RequestRegistration
+        private sealed class RequestRegistration : TaskCompletionSource<RateLimitLease>
         {
-            public RequestRegistration(int tokenCount, TaskCompletionSource<RateLimitLease> tcs, CancellationTokenRegistration cancellationTokenRegistration)
+            private readonly CancellationToken _cancellationToken;
+            private CancellationTokenRegistration _cancellationTokenRegistration;
+
+            // this field is used only by the disposal mechanics and never shared between threads
+            private RequestRegistration? _next;
+
+            public RequestRegistration(int permitCount, TokenBucketRateLimiter limiter, CancellationToken cancellationToken)
+                : base(limiter, TaskCreationOptions.RunContinuationsAsynchronously)
             {
-                Count = tokenCount;
-                // Use VoidAsyncOperationWithData<T> instead
-                Tcs = tcs;
-                CancellationTokenRegistration = cancellationTokenRegistration;
+                Count = permitCount;
+                _cancellationToken = cancellationToken;
+
+                // RequestRegistration objects are created while the limiter lock is held
+                // if cancellationToken fires before or while the lock is held, UnsafeRegister
+                // is going to invoke the callback synchronously, but this does not create
+                // a deadlock because lock are reentrant
+                if (cancellationToken.CanBeCanceled)
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+                    _cancellationTokenRegistration = cancellationToken.UnsafeRegister(Cancel, this);
+#else
+                    _cancellationTokenRegistration = cancellationToken.Register(Cancel, this);
+#endif
             }
 
             public int Count { get; }
 
-            public TaskCompletionSource<RateLimitLease> Tcs { get; }
-
-            public CancellationTokenRegistration CancellationTokenRegistration { get; }
-        }
-
-        private sealed class CancelQueueState : TaskCompletionSource<RateLimitLease>
-        {
-            private readonly int _tokenCount;
-            private readonly TokenBucketRateLimiter _limiter;
-            private readonly CancellationToken _cancellationToken;
-
-            public CancelQueueState(int tokenCount, TokenBucketRateLimiter limiter, CancellationToken cancellationToken)
-                : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            private static void Cancel(object? state)
             {
-                _tokenCount = tokenCount;
-                _limiter = limiter;
-                _cancellationToken = cancellationToken;
+                if (state is RequestRegistration registration && registration.TrySetCanceled(registration._cancellationToken))
+                {
+                    var limiter = (TokenBucketRateLimiter)registration.Task.AsyncState!;
+                    lock (limiter.Lock)
+                    {
+                        limiter._queueCount -= registration.Count;
+                    }
+                }
             }
 
-            public new bool TrySetCanceled()
+            /// <summary>
+            /// Collects registrations to dispose outside the limiter lock to avoid deadlock.
+            /// </summary>
+            public struct Disposer : IDisposable
             {
-                if (TrySetCanceled(_cancellationToken))
+                private RequestRegistration? _next;
+
+                public void Add(RequestRegistration request)
                 {
-                    lock (_limiter.Lock)
-                    {
-                        _limiter._queueCount -= _tokenCount;
-                    }
-                    return true;
+                    request._next = _next;
+                    _next = request;
                 }
-                return false;
+
+                public void Dispose()
+                {
+                    for (var current = _next; current is not null; current = current._next)
+                    {
+                        current._cancellationTokenRegistration.Dispose();
+                    }
+
+                    _next = null;
+                }
             }
         }
     }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -174,8 +174,17 @@ namespace System.Threading.RateLimiting
                             Debug.Assert(_queueCount >= 0);
                             if (!oldestRequest.TrySetResult(FailedLease))
                             {
-                                // Updating queue count is handled by the cancellation code
-                                _queueCount += oldestRequest.Count;
+                                if (!oldestRequest.QueueCountModified)
+                                {
+                                    // We already updated the queue count, the Cancel code is about to run or running and waiting on our lock,
+                                    // tell Cancel not to do anything
+                                    oldestRequest.QueueCountModified = true;
+                                }
+                                else
+                                {
+                                    // Updating queue count was handled by the cancellation code, don't double count
+                                    _queueCount += oldestRequest.Count;
+                                }
                             }
                             else
                             {
@@ -341,10 +350,19 @@ namespace System.Threading.RateLimiting
 
                         if (!nextPendingRequest.TrySetResult(SuccessfulLease))
                         {
-                            // Queued item was canceled so add count back
+                            // Queued item was canceled so add count back, permits weren't acquired
                             _tokenCount += nextPendingRequest.Count;
-                            // Updating queue count is handled by the cancellation code
-                            _queueCount += nextPendingRequest.Count;
+                            if (!nextPendingRequest.QueueCountModified)
+                            {
+                                // We already updated the queue count, the Cancel code is about to run or running and waiting on our lock,
+                                // tell Cancel not to do anything
+                                nextPendingRequest.QueueCountModified = true;
+                            }
+                            else
+                            {
+                                // Updating queue count was handled by the cancellation code, don't double count
+                                _queueCount += nextPendingRequest.Count;
+                            }
                         }
                         else
                         {
@@ -444,6 +462,9 @@ namespace System.Threading.RateLimiting
             private readonly CancellationToken _cancellationToken;
             private CancellationTokenRegistration _cancellationTokenRegistration;
 
+            // Update under the limiter lock and only if the queue count was updated by the calling code
+            public bool QueueCountModified { get; set; }
+
             // this field is used only by the disposal mechanics and never shared between threads
             private RequestRegistration? _next;
 
@@ -474,7 +495,14 @@ namespace System.Threading.RateLimiting
                     var limiter = (TokenBucketRateLimiter)registration.Task.AsyncState!;
                     lock (limiter.Lock)
                     {
-                        limiter._queueCount -= registration.Count;
+                        // Queuing and replenishing code might modify the _queueCount, since there is no guarantee of when the cancellation
+                        // code runs and we only want to update the _queueCount once, we set a bool (under a lock) so either method
+                        // can update the count and not double count.
+                        if (!registration.QueueCountModified)
+                        {
+                            limiter._queueCount -= registration.Count;
+                            registration.QueueCountModified = true;
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -122,6 +123,51 @@ namespace System.Threading.RateLimiting.Test
             lease = await wait1;
             Assert.True(lease.IsAcquired);
         }
+
+#if DEBUG
+        [Fact]
+        public Task DoesNotDeadlockCleaningUpCanceledRequestedLease_Pre() =>
+            DoesNotDeadlockCleaningUpCanceledRequestedLease((limiter, hook) => SetReleasePreHook(limiter, hook));
+
+        [Fact]
+        public Task DoesNotDeadlockCleaningUpCanceledRequestedLease_Post() =>
+            DoesNotDeadlockCleaningUpCanceledRequestedLease((limiter, hook) => SetReleasePostHook(limiter, hook));
+
+        private void SetReleasePreHook(ConcurrencyLimiter limiter, Action hook)
+        {
+            typeof(ConcurrencyLimiter).GetEvent("ReleasePreHook", BindingFlags.NonPublic | BindingFlags.Instance).AddMethod.Invoke(limiter, new object[] { hook });
+        }
+
+        private void SetReleasePostHook(ConcurrencyLimiter limiter, Action hook)
+        {
+            typeof(ConcurrencyLimiter).GetEvent("ReleasePostHook", BindingFlags.NonPublic | BindingFlags.Instance).AddMethod.Invoke(limiter, new object[] { hook });
+        }
+
+        private async Task DoesNotDeadlockCleaningUpCanceledRequestedLease(Action<ConcurrencyLimiter, Action> attachHook)
+        {
+            using var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+            {
+                PermitLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 1
+            });
+            var lease = limiter.AttemptAcquire(1);
+            Assert.True(lease.IsAcquired);
+
+            var cts = new CancellationTokenSource();
+            _ = limiter.AcquireAsync(1, cts.Token);
+            attachHook(limiter, () =>
+            {
+                Task.Run(cts.Cancel);
+                Thread.Sleep(1);
+            });
+
+            var task1 = Task.Delay(1000);
+            var task2 = Task.Run(lease.Dispose);
+            Assert.Same(task2, await Task.WhenAny(task1, task2));
+            await task2;
+        }
+#endif
 
         [Fact]
         public override async Task FailsWhenQueuingMoreThanLimit_OldestFirst()


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/90285 to release/7.0-staging

## Customer Impact

Rate limiting operations could deadlock in specific scenarios.

## Testing

Manual testing and automated test with internal hooks added

## Risk

Low. Issue was clear once pointed out.