### PR TITLE
Prefix type names with global and use static TypeSyntax and NameSyntax instead of Parse(Type)Name

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/AddMarshalAsToElementFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/AddMarshalAsToElementFixer.cs
@@ -53,10 +53,10 @@ namespace Microsoft.Interop.Analyzers
                                     SyntaxGenerator gen = editor.Generator;
 
                                     SyntaxNode marshalAsAttribute = gen.Attribute(
-                                                TypeNames.System_Runtime_InteropServices_MarshalAsAttribute,
+                                                TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_MarshalAsAttribute,
                                                 gen.AttributeArgument(
                                                     gen.MemberAccessExpression(
-                                                        gen.DottedName(TypeNames.System_Runtime_InteropServices_UnmanagedType),
+                                                        gen.DottedName(TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_UnmanagedType),
                                                         gen.IdentifierName(unmanagedTypeName.Trim()))));
 
                                     if (node.IsKind(SyntaxKind.MethodDeclaration))

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/AddMarshalAsToElementFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/AddMarshalAsToElementFixer.cs
@@ -1,12 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -53,10 +49,10 @@ namespace Microsoft.Interop.Analyzers
                                     SyntaxGenerator gen = editor.Generator;
 
                                     SyntaxNode marshalAsAttribute = gen.Attribute(
-                                                TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_MarshalAsAttribute,
+                                                TypeNames.System_Runtime_InteropServices_MarshalAsAttribute,
                                                 gen.AttributeArgument(
                                                     gen.MemberAccessExpression(
-                                                        gen.DottedName(TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_UnmanagedType),
+                                                        gen.DottedName(TypeNames.System_Runtime_InteropServices_UnmanagedType),
                                                         gen.IdentifierName(unmanagedTypeName.Trim()))));
 
                                     if (node.IsKind(SyntaxKind.MethodDeclaration))

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceAnalyzer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Interop.Analyzers
                     context.Compilation,
                     targetFramework.TargetFramework,
                     targetFramework.Version,
-                    context.Compilation.SourceModule.GetAttributes().Any(attr => attr.AttributeClass.ToDisplayString() == TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute_Metadata));
+                    context.Compilation.SourceModule.GetAttributes().Any(attr => attr.AttributeClass.ToDisplayString() == TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute));
 
                 context.RegisterSymbolAction(context =>
                 {

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceFixer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Interop.Analyzers
                     generatedComInterfaceAttribute,
                     new[]
                     {
-                       gen.AttributeArgument("StringMarshalling", gen.MemberAccessExpression(gen.DottedName(TypeNames.StringMarshalling), gen.IdentifierName(nameof(StringMarshalling.Custom)))),
+                       gen.AttributeArgument("StringMarshalling", gen.MemberAccessExpression(gen.DottedName(TypeNames.GlobalAlias + TypeNames.StringMarshalling), gen.IdentifierName(nameof(StringMarshalling.Custom)))),
                        gen.AttributeArgument("StringMarshallingCustomType", gen.TypeOfExpression(gen.TypeExpression(comp.GetTypeByMetadataName(TypeNames.BStrStringMarshaller))))
                     });
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceFixer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Interop.Analyzers
                     generatedComInterfaceAttribute,
                     new[]
                     {
-                       gen.AttributeArgument("StringMarshalling", gen.MemberAccessExpression(gen.DottedName(TypeNames.GlobalAlias + TypeNames.StringMarshalling), gen.IdentifierName(nameof(StringMarshalling.Custom)))),
+                       gen.AttributeArgument("StringMarshalling", gen.MemberAccessExpression(gen.DottedName(TypeNames.StringMarshalling), gen.IdentifierName(nameof(StringMarshalling.Custom)))),
                        gen.AttributeArgument("StringMarshallingCustomType", gen.TypeOfExpression(gen.TypeExpression(comp.GetTypeByMetadataName(TypeNames.BStrStringMarshaller))))
                     });
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComClassGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComClassGenerator.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Interop
 
         private static readonly AttributeSyntax s_comExposedClassAttributeTemplate =
             Attribute(
-                GenericName(TypeNames.ComExposedClassAttribute)
+                GenericName(TypeNames.GlobalAlias + TypeNames.ComExposedClassAttribute)
                     .AddTypeArgumentListArguments(
                         IdentifierName(ClassInfoTypeName)));
         private static MemberDeclarationSyntax GenerateClassInfoAttributeOnUserType(ContainingSyntaxContext containingSyntaxContext, ContainingSyntax classSyntax) =>

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComClassGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComClassGenerator.cs
@@ -124,12 +124,11 @@ namespace Microsoft.Interop
                     Token(SyntaxKind.FileKeyword),
                     Token(SyntaxKind.SealedKeyword),
                     Token(SyntaxKind.UnsafeKeyword))
-                .AddBaseListTypes(SimpleBaseType(ParseTypeName(TypeNames.IComExposedClass)))
+                .AddBaseListTypes(SimpleBaseType(TypeSyntaxes.IComExposedClass))
                 .AddMembers(
                     FieldDeclaration(
                         VariableDeclaration(
-                            PointerType(
-                                ParseTypeName(TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry)),
+                            PointerType(TypeSyntaxes.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry),
                             SingletonSeparatedList(VariableDeclarator(vtablesField))))
                     .AddModifiers(
                         Token(SyntaxKind.PrivateKeyword),
@@ -140,31 +139,29 @@ namespace Microsoft.Interop
                 // ComInterfaceEntry* vtables = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(<ClassInfoTypeName>), sizeof(ComInterfaceEntry) * <numInterfaces>);
                 LocalDeclarationStatement(
                     VariableDeclaration(
-                            PointerType(
-                                ParseTypeName(TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry)),
+                            PointerType(TypeSyntaxes.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry),
                             SingletonSeparatedList(
                                 VariableDeclarator(vtablesLocal)
                                     .WithInitializer(EqualsValueClause(
                                         CastExpression(
-                                            PointerType(
-                                                ParseTypeName(TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry)),
+                                            PointerType(TypeSyntaxes.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry),
                                         InvocationExpression(
                                             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                                ParseTypeName(TypeNames.System_Runtime_CompilerServices_RuntimeHelpers),
+                                                TypeSyntaxes.System_Runtime_CompilerServices_RuntimeHelpers,
                                                 IdentifierName("AllocateTypeAssociatedMemory")))
                                         .AddArgumentListArguments(
                                             Argument(TypeOfExpression(IdentifierName(ClassInfoTypeName))),
                                             Argument(
                                                 BinaryExpression(
                                                     SyntaxKind.MultiplyExpression,
-                                                    SizeOfExpression(ParseTypeName(TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry)),
+                                                    SizeOfExpression(TypeSyntaxes.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry),
                                                     LiteralExpression(
                                                         SyntaxKind.NumericLiteralExpression,
                                                         Literal(implementedInterfaces.Length))))))))))),
                 // IIUnknownDerivedDetails details;
                 LocalDeclarationStatement(
                     VariableDeclaration(
-                        ParseTypeName(TypeNames.IIUnknownDerivedDetails),
+                        TypeSyntaxes.IIUnknownDerivedDetails,
                         SingletonSeparatedList(
                             VariableDeclarator(detailsTempLocal))))
             };
@@ -180,7 +177,7 @@ namespace Microsoft.Interop
                             InvocationExpression(
                                 MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                        ParseTypeName(TypeNames.StrategyBasedComWrappers),
+                                        TypeSyntaxes.StrategyBasedComWrappers,
                                         IdentifierName("DefaultIUnknownInterfaceDetailsStrategy")),
                                     IdentifierName("GetIUnknownDerivedDetails")),
                                 ArgumentList(
@@ -253,7 +250,7 @@ namespace Microsoft.Interop
                 // { body }
                 MethodDeclaration(
                     PointerType(
-                        ParseTypeName(TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry)),
+                        TypeSyntaxes.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry),
                     "GetComInterfaceEntries")
                     .AddParameterListParameters(
                         Parameter(Identifier(countIdentifier))

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Interop
 
             context.RegisterSourceOutput(filesToGenerate, (context, data) =>
             {
-                context.AddSource(data.TypeName.Replace("global::", ""), data.Source);
+                context.AddSource(data.TypeName.Replace(TypeNames.GlobalAlias, ""), data.Source);
             });
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -452,7 +452,7 @@ namespace Microsoft.Interop
                         .Select(ctx => ctx.Stub.Node)
                         .Concat(shadowImplementations)
                         .Concat(inheritedStubs)))
-                .AddAttributeLists(AttributeList(SingletonSeparatedList(Attribute(ParseName(TypeNames.System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute)))));
+                .AddAttributeLists(AttributeList(SingletonSeparatedList(Attribute(NameSyntaxes.System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute))));
         }
 
         private static InterfaceDeclarationSyntax GenerateImplementationVTableMethods(ComInterfaceAndMethodsContext comInterfaceAndMethods, CancellationToken _)
@@ -496,7 +496,7 @@ namespace Microsoft.Interop
                                     CastExpression(VoidStarStarSyntax,
                                         InvocationExpression(
                                             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                                ParseTypeName(TypeNames.System_Runtime_CompilerServices_RuntimeHelpers),
+                                                TypeSyntaxes.System_Runtime_CompilerServices_RuntimeHelpers,
                                                 IdentifierName("AllocateTypeAssociatedMemory")))
                                         .AddArgumentListArguments(
                                             Argument(TypeOfExpression(interfaceType.Syntax)),
@@ -525,7 +525,7 @@ namespace Microsoft.Interop
                         ExpressionStatement(
                             InvocationExpression(
                                 MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                    ParseTypeName(TypeNames.System_Runtime_InteropServices_ComWrappers),
+                                    TypeSyntaxes.System_Runtime_InteropServices_ComWrappers,
                                     IdentifierName("GetIUnknownImpl")))
                             .AddArgumentListArguments(
                                 Argument(IdentifierName("v0"))
@@ -586,7 +586,7 @@ namespace Microsoft.Interop
                             InvocationExpression(
                                 MemberAccessExpression(
                                     SyntaxKind.SimpleMemberAccessExpression,
-                                    ParseTypeName(TypeNames.System_Runtime_InteropServices_NativeMemory),
+                                    TypeSyntaxes.System_Runtime_InteropServices_NativeMemory,
                                     IdentifierName("Copy")))
                             .WithArgumentList(
                                 ArgumentList(
@@ -601,7 +601,7 @@ namespace Microsoft.Interop
                                                             SyntaxKind.SimpleMemberAccessExpression,
                                                             MemberAccessExpression(
                                                                 SyntaxKind.SimpleMemberAccessExpression,
-                                                                ParseTypeName(TypeNames.StrategyBasedComWrappers),
+                                                                TypeSyntaxes.StrategyBasedComWrappers,
                                                                 IdentifierName("DefaultIUnknownInterfaceDetailsStrategy")),
                                                             IdentifierName("GetIUnknownDerivedDetails")))
                                                     .WithArgumentList(
@@ -643,14 +643,14 @@ namespace Microsoft.Interop
         private static readonly ClassDeclarationSyntax InterfaceInformationTypeTemplate =
             ClassDeclaration("InterfaceInformation")
             .AddModifiers(Token(SyntaxKind.FileKeyword), Token(SyntaxKind.UnsafeKeyword))
-            .AddBaseListTypes(SimpleBaseType(ParseTypeName(TypeNames.IIUnknownInterfaceType)));
+            .AddBaseListTypes(SimpleBaseType(TypeSyntaxes.IIUnknownInterfaceType));
 
         private static ClassDeclarationSyntax GenerateInterfaceInformation(ComInterfaceInfo context, CancellationToken _)
         {
             ClassDeclarationSyntax interfaceInformationType = InterfaceInformationTypeTemplate
                 .AddMembers(
                     // public static System.Guid Iid { get; } = new(<embeddedDataBlob>);
-                    PropertyDeclaration(ParseTypeName(TypeNames.System_Guid), "Iid")
+                    PropertyDeclaration(TypeSyntaxes.System_Guid, "Iid")
                         .AddModifiers(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword))
                         .AddAccessorListAccessors(
                             AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithSemicolonToken(Token(SyntaxKind.SemicolonToken)))

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Interop
 
         private static readonly AttributeSyntax s_iUnknownDerivedAttributeTemplate =
             Attribute(
-                GenericName(TypeNames.IUnknownDerivedAttribute)
+                GenericName(TypeNames.GlobalAlias + TypeNames.IUnknownDerivedAttribute)
                     .AddTypeArgumentListArguments(
                         IdentifierName("InterfaceInformation"),
                         IdentifierName("InterfaceImplementation")));

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceInfo.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Interop
                         stringMarshallingDiagnostic = DiagnosticInfo.Create(
                             GeneratorDiagnostics.StringMarshallingCustomTypeNotAccessibleByGeneratedCode,
                             syntax.Identifier.GetLocation(),
-                            attrInfo.StringMarshallingCustomType.FullTypeName.Replace("global::", ""),
+                            attrInfo.StringMarshallingCustomType.FullTypeName.Replace(TypeNames.GlobalAlias, ""),
                             details);
                         return false;
                     }

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComMethodContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComMethodContext.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Interop
                 .WithExpressionBody(ArrowExpressionClause(
                     ThrowExpression(
                         ObjectCreationExpression(
-                            ParseTypeName(TypeNames.UnreachableException))
+                            TypeSyntaxes.UnreachableException)
                             .WithArgumentList(ArgumentList()))));
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ManagedToNativeVTableMethodGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ManagedToNativeVTableMethodGenerator.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Interop
                                 SyntaxKind.SimpleMemberAccessExpression,
                                 ParenthesizedExpression(
                                     CastExpression(
-                                        ParseTypeName(TypeNames.IUnmanagedVirtualMethodTableProvider),
+                                        TypeSyntaxes.IUnmanagedVirtualMethodTableProvider,
                                         ThisExpression())),
                                 IdentifierName("GetVirtualMethodTableInfoForKey") ))
                         .WithArgumentList(
@@ -189,7 +189,7 @@ namespace Microsoft.Interop
                 ExpressionStatement(
                     InvocationExpression(
                         MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            ParseTypeName(TypeNames.System_GC),
+                            TypeSyntaxes.System_GC,
                             IdentifierName("KeepAlive")),
                         ArgumentList(SingletonSeparatedList(Argument(ThisExpression()))))));
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ComInterfaceDispatchMarshallerFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ComInterfaceDispatchMarshallerFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Interop
         {
             public ManagedTypeInfo AsNativeType(TypePositionInfo info) =>
                 new PointerTypeInfo(
-                    $"global::{TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch}*",
+                    $"{TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch}*",
                     $"{TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch}*",
                     IsFunctionPointer: false);
             public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ComInterfaceDispatchMarshallerFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ComInterfaceDispatchMarshallerFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Interop
         {
             public ManagedTypeInfo AsNativeType(TypePositionInfo info) =>
                 new PointerTypeInfo(
-                    $"{TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch}*",
+                    $"global::{TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch}*",
                     $"{TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch}*",
                     IsFunctionPointer: false);
             public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)
@@ -47,7 +47,7 @@ namespace Microsoft.Interop
                         IdentifierName(managed),
                         InvocationExpression(
                             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                ParseName(TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch),
+                                TypeSyntaxes.System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch,
                                 GenericName(
                                     Identifier("GetInstance"),
                                     TypeArgumentList(SingletonSeparatedList(info.ManagedType.Syntax)))),

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ManagedHResultExceptionMarshallerFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ManagedHResultExceptionMarshallerFactory.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Interop
                 yield return ExpressionStatement(
                     InvocationExpression(
                         MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            ParseName(TypeNames.System_Runtime_InteropServices_Marshal),
+                            TypeSyntaxes.System_Runtime_InteropServices_Marshal,
                             IdentifierName("ThrowExceptionForHR")),
                         ArgumentList(
                             SingletonSeparatedList(Argument(IdentifierName(managedIdentifier))))));

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ObjectUnwrapperMarshallerFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ObjectUnwrapperMarshallerFactory.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Interop
                             InvocationExpression(
                                 MemberAccessExpression(
                                     SyntaxKind.SimpleMemberAccessExpression,
-                                    ParseTypeName(TypeNames.UnmanagedObjectUnwrapper),
+                                    TypeSyntaxes.UnmanagedObjectUnwrapper,
                                     GenericName(Identifier("GetObjectForUnmanagedWrapper"))
                                         .WithTypeArgumentList(
                                             TypeArgumentList(

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Interop
             {
                 elements.Add(
                     new TypePositionInfo(
-                        new ReferenceTypeInfo($"global::{TypeNames.System_Exception}", TypeNames.System_Exception),
+                        new ReferenceTypeInfo(TypeNames.GlobalAlias + TypeNames.System_Exception, TypeNames.System_Exception),
                         methodStub.ExceptionMarshallingInfo)
                     {
                         InstanceIdentifier = "__exception",

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Interop
             (ParameterListSyntax unmanagedParameterList, TypeSyntax returnType, _) = stubGenerator.GenerateAbiMethodSignatureData();
 
             AttributeSyntax unmanagedCallersOnlyAttribute = Attribute(
-                ParseName(TypeNames.UnmanagedCallersOnlyAttribute));
+                NameSyntaxes.UnmanagedCallersOnlyAttribute);
 
             if (methodStub.CallingConvention.Array.Length != 0)
             {
@@ -94,7 +94,7 @@ namespace Microsoft.Interop
                         ImplicitArrayCreationExpression(
                             InitializerExpression(SyntaxKind.CollectionInitializerExpression,
                                 SeparatedList<ExpressionSyntax>(
-                                    methodStub.CallingConvention.Array.Select(callConv => TypeOfExpression(ParseName($"System.Runtime.CompilerServices.CallConv{callConv.Name.ValueText}")))))))
+                                    methodStub.CallingConvention.Array.Select(callConv => TypeOfExpression(ParseName($"global::System.Runtime.CompilerServices.CallConv{callConv.Name.ValueText}")))))))
                     .WithNameEquals(NameEquals(IdentifierName("CallConvs"))));
             }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Interop
                         ImplicitArrayCreationExpression(
                             InitializerExpression(SyntaxKind.CollectionInitializerExpression,
                                 SeparatedList<ExpressionSyntax>(
-                                    methodStub.CallingConvention.Array.Select(callConv => TypeOfExpression(ParseName($"global::System.Runtime.CompilerServices.CallConv{callConv.Name.ValueText}")))))))
+                                    methodStub.CallingConvention.Array.Select(callConv => TypeOfExpression(TypeSyntaxes.CallConv(callConv.Name.ValueText)))))))
                     .WithNameEquals(NameEquals(IdentifierName("CallConvs"))));
             }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VtableIndexStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VtableIndexStubGenerator.cs
@@ -413,9 +413,6 @@ namespace Microsoft.Interop
 
             // Verify there is an [UnmanagedObjectUnwrapperAttribute<TMapper>]
             if (!method.ContainingType.GetAttributes().Any(att => att.AttributeClass.IsOfType(TypeNames.UnmanagedObjectUnwrapperAttribute)))
-            //!method.ContainingType.GetAttributes().Any(att =>
-            //att.AttributeClass.MetadataName == TypeNames.UnmanagedObjectUnwrapperAttribute.Substring(TypeNames.UnmanagedObjectUnwrapperAttribute.LastIndexOf('.') + 1)
-            //&& att.AttributeClass.OriginalDefinition.ToDisplayString().Substring(0, att.AttributeClass.OriginalDefinition.ToDisplayString().LastIndexOf(att.AttributeClass.ToDisplayString())) == TypeNames.UnmanagedObjectUnwrapperAttribute.Substring(0, TypeNames.UnmanagedObjectUnwrapperAttribute.LastIndexOf('.'))))
             {
                 return Diagnostic.Create(GeneratorDiagnostics.InvalidAttributedMethodContainingTypeMissingUnmanagedObjectUnwrapperAttribute, methodSyntax.Identifier.GetLocation(), method.Name);
             }
@@ -429,7 +426,7 @@ namespace Microsoft.Interop
                 InterfaceDeclaration("Native")
                 .WithModifiers(TokenList(Token(SyntaxKind.InternalKeyword), Token(SyntaxKind.PartialKeyword)))
                 .WithBaseList(BaseList(SingletonSeparatedList((BaseTypeSyntax)SimpleBaseType(IdentifierName(context.ContainingSyntax[0].Identifier)))))
-                .AddAttributeLists(AttributeList(SingletonSeparatedList(Attribute(ParseName(TypeNames.System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute))))));
+                .AddAttributeLists(AttributeList(SingletonSeparatedList(Attribute(NameSyntaxes.System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute)))));
         }
 
         private static MemberDeclarationSyntax GeneratePopulateVTableMethod(IGrouping<ContainingSyntaxContext, IncrementalMethodStubGenerationContext> vtableMethods)

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/AddDisableRuntimeMarshallingAttributeFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/AddDisableRuntimeMarshallingAttributeFixer.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Interop.Analyzers
                 syntaxRoot,
                 editor.Generator.AddAttributes(
                     syntaxRoot,
-                    editor.Generator.Attribute(editor.Generator.DottedName(TypeNames.System_Runtime_CompilerServices_DisableRuntimeMarshallingAttribute))));
+                    editor.Generator.Attribute(editor.Generator.DottedName(TypeNames.GlobalAlias + TypeNames.System_Runtime_CompilerServices_DisableRuntimeMarshallingAttribute))));
 
             return editor.GetChangedDocument().Project.Solution;
 

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/AddDisableRuntimeMarshallingAttributeFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/AddDisableRuntimeMarshallingAttributeFixer.cs
@@ -1,12 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -65,7 +63,7 @@ namespace Microsoft.Interop.Analyzers
                 syntaxRoot,
                 editor.Generator.AddAttributes(
                     syntaxRoot,
-                    editor.Generator.Attribute(editor.Generator.DottedName(TypeNames.GlobalAlias + TypeNames.System_Runtime_CompilerServices_DisableRuntimeMarshallingAttribute))));
+                    editor.Generator.Attribute(editor.Generator.DottedName(TypeNames.System_Runtime_CompilerServices_DisableRuntimeMarshallingAttribute))));
 
             return editor.GetChangedDocument().Project.Solution;
 

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Interop.Analyzers
                         context.Compilation,
                         targetFramework.TargetFramework,
                         targetFramework.Version,
-                        context.Compilation.SourceModule.GetAttributes().Any(attr => attr.AttributeClass.ToDisplayString() == TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute_Metadata));
+                        context.Compilation.SourceModule.GetAttributes().Any(attr => attr.AttributeClass.ToDisplayString() == TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute));
 
                     context.RegisterSymbolAction(symbolContext => AnalyzeSymbol(symbolContext, libraryImportAttrType, env), SymbolKind.Method);
                 });

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Interop.Analyzers
             char? entryPointSuffix,
             CancellationToken cancellationToken)
         {
-            INamedTypeSymbol? dllImportAttrType = editor.SemanticModel.Compilation.GetBestTypeByMetadataName(typeof(DllImportAttribute).FullName);
+            INamedTypeSymbol? dllImportAttrType = editor.SemanticModel.Compilation.GetBestTypeByMetadataName(TypeNames.DllImportAttribute);
             if (dllImportAttrType == null)
                 return methodSyntax;
 

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
@@ -602,7 +602,7 @@ namespace Microsoft.Interop.Analyzers
                 return false;
             }
 
-            unmanagedCallConvAttribute = generator.Attribute(TypeNames.GlobalAlias + TypeNames.UnmanagedCallConvAttribute,
+            unmanagedCallConvAttribute = generator.Attribute(TypeNames.UnmanagedCallConvAttribute,
                 generator.AttributeArgument("CallConvs",
                     generator.ArrayCreationExpression(
                         generator.TypeExpression(editor.SemanticModel.Compilation.GetBestTypeByMetadataName(TypeNames.System_Type)),

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
@@ -602,7 +602,7 @@ namespace Microsoft.Interop.Analyzers
                 return false;
             }
 
-            unmanagedCallConvAttribute = generator.Attribute(TypeNames.UnmanagedCallConvAttribute,
+            unmanagedCallConvAttribute = generator.Attribute(TypeNames.GlobalAlias + TypeNames.UnmanagedCallConvAttribute,
                 generator.AttributeArgument("CallConvs",
                     generator.ArrayCreationExpression(
                         generator.TypeExpression(editor.SemanticModel.Compilation.GetBestTypeByMetadataName(TypeNames.System_Type)),

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -425,25 +425,25 @@ namespace Microsoft.Interop
                         SingletonSeparatedList(
                                 Attribute(
                                     NameSyntaxes.DllImportAttribute,
-                                AttributeArgumentList(
-                                    SeparatedList(
-                                        new[]
-                                        {
-                                            AttributeArgument(LiteralExpression(
-                                                    SyntaxKind.StringLiteralExpression,
-                                                    Literal(libraryImportData.ModuleName))),
-                                            AttributeArgument(
-                                                NameEquals(nameof(DllImportAttribute.EntryPoint)),
-                                                null,
-                                                LiteralExpression(
-                                                    SyntaxKind.StringLiteralExpression,
-                                                    Literal(libraryImportData.EntryPoint ?? stubMethodName))),
-                                            AttributeArgument(
-                                                NameEquals(nameof(DllImportAttribute.ExactSpelling)),
-                                                null,
-                                                LiteralExpression(SyntaxKind.TrueLiteralExpression))
-                                        }
-                                        )))))))
+                                    AttributeArgumentList(
+                                        SeparatedList(
+                                            new[]
+                                            {
+                                                AttributeArgument(LiteralExpression(
+                                                        SyntaxKind.StringLiteralExpression,
+                                                        Literal(libraryImportData.ModuleName))),
+                                                AttributeArgument(
+                                                    NameEquals(nameof(DllImportAttribute.EntryPoint)),
+                                                    null,
+                                                    LiteralExpression(
+                                                        SyntaxKind.StringLiteralExpression,
+                                                        Literal(libraryImportData.EntryPoint ?? stubMethodName))),
+                                                AttributeArgument(
+                                                    NameEquals(nameof(DllImportAttribute.ExactSpelling)),
+                                                    null,
+                                                    LiteralExpression(SyntaxKind.TrueLiteralExpression))
+                                            }
+                                            )))))))
                 .WithParameterList(parameterList);
             if (returnTypeAttributes is not null)
             {

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -113,11 +113,11 @@ namespace Microsoft.Interop
 
             if (suppressGCTransitionAttribute is not null)
             {
-                attributes.Add(Attribute(ParseName(TypeNames.SuppressGCTransitionAttribute)));
+                attributes.Add(Attribute(NameSyntaxes.SuppressGCTransitionAttribute));
             }
             if (unmanagedCallConvAttribute is not null)
             {
-                AttributeSyntax unmanagedCallConvSyntax = Attribute(ParseName(TypeNames.UnmanagedCallConvAttribute));
+                AttributeSyntax unmanagedCallConvSyntax = Attribute(NameSyntaxes.UnmanagedCallConvAttribute);
                 foreach (KeyValuePair<string, TypedConstant> arg in unmanagedCallConvAttribute.NamedArguments)
                 {
                     if (arg.Key == CallConvsField)
@@ -129,7 +129,7 @@ namespace Microsoft.Interop
                                 TypeOfExpression(((ITypeSymbol)callConv.Value!).AsTypeSyntax()));
                         }
 
-                        ArrayTypeSyntax arrayOfSystemType = ArrayType(ParseTypeName(TypeNames.System_Type), SingletonList(ArrayRankSpecifier()));
+                        ArrayTypeSyntax arrayOfSystemType = ArrayType(TypeSyntaxes.System_Type, SingletonList(ArrayRankSpecifier()));
 
                         unmanagedCallConvSyntax = unmanagedCallConvSyntax.AddArgumentListArguments(
                             AttributeArgument(
@@ -143,9 +143,9 @@ namespace Microsoft.Interop
             if (defaultDllImportSearchPathsAttribute is not null)
             {
                 attributes.Add(
-                    Attribute(ParseName(TypeNames.DefaultDllImportSearchPathsAttribute)).AddArgumentListArguments(
+                    Attribute(NameSyntaxes.DefaultDllImportSearchPathsAttribute).AddArgumentListArguments(
                         AttributeArgument(
-                            CastExpression(ParseTypeName(TypeNames.DllImportSearchPath),
+                            CastExpression(TypeSyntaxes.DllImportSearchPath,
                                 LiteralExpression(SyntaxKind.NumericLiteralExpression,
                                     Literal((int)defaultDllImportSearchPathsAttribute.ConstructorArguments[0].Value!))))));
             }
@@ -424,7 +424,7 @@ namespace Microsoft.Interop
                     SingletonList(AttributeList(
                         SingletonSeparatedList(
                                 Attribute(
-                                ParseName(typeof(DllImportAttribute).FullName),
+                                    NameSyntaxes.DllImportAttribute,
                                 AttributeArgumentList(
                                     SeparatedList(
                                         new[]
@@ -486,7 +486,7 @@ namespace Microsoft.Interop
 
             // Create new attribute
             return Attribute(
-                ParseName(typeof(DllImportAttribute).FullName),
+                NameSyntaxes.DllImportAttribute,
                 AttributeArgumentList(SeparatedList(newAttributeArgs)));
 
             static ExpressionSyntax CreateBoolExpressionSyntax(bool trueOrFalse)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Interop
                     managedExceptionMarshaller.TypeInfo, context with { CurrentStage = StubCodeContext.Stage.PinnedMarshal }));
             return ImmutableArray.Create(
                 CatchClause(
-                    CatchDeclaration(ParseTypeName(TypeNames.System_Exception), Identifier(managed)),
+                    CatchDeclaration(TypeSyntaxes.System_Exception, Identifier(managed)),
                     filter: null,
                     Block(List(catchClauseBuilder))));
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/IncrementalGeneratorInitializationContextExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/IncrementalGeneratorInitializationContextExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Interop
 
             var isModuleSkipLocalsInit = context.SyntaxProvider
                 .ForAttributeWithMetadataName(
-                    TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute_Metadata,
+                    TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute,
                     (node, ct) => node is ICompilationUnitSyntax,
                     // If SkipLocalsInit is applied at the top level, it is either applied to the module
                     // or is invalid syntax. As a result, we just need to know if there's any top-level

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshalAsAttributeParser.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshalAsAttributeParser.cs
@@ -162,10 +162,10 @@ namespace Microsoft.Interop
         {
             string? marshallerName = unmanagedType switch
             {
-                UnmanagedType.BStr => TypeNames.BStrStringMarshaller,
-                UnmanagedType.LPStr => TypeNames.AnsiStringMarshaller,
-                UnmanagedType.LPTStr or UnmanagedType.LPWStr => TypeNames.Utf16StringMarshaller,
-                MarshalAsInfo.UnmanagedType_LPUTF8Str => TypeNames.Utf8StringMarshaller,
+                UnmanagedType.BStr => TypeNames.GlobalAlias + TypeNames.BStrStringMarshaller,
+                UnmanagedType.LPStr => TypeNames.GlobalAlias + TypeNames.AnsiStringMarshaller,
+                UnmanagedType.LPTStr or UnmanagedType.LPWStr => TypeNames.GlobalAlias + TypeNames.Utf16StringMarshaller,
+                MarshalAsInfo.UnmanagedType_LPUTF8Str => TypeNames.GlobalAlias + TypeNames.Utf8StringMarshaller,
                 _ => null
             };
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshalAsAttributeParser.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshalAsAttributeParser.cs
@@ -162,10 +162,10 @@ namespace Microsoft.Interop
         {
             string? marshallerName = unmanagedType switch
             {
-                UnmanagedType.BStr => TypeNames.GlobalAlias + TypeNames.BStrStringMarshaller,
-                UnmanagedType.LPStr => TypeNames.GlobalAlias + TypeNames.AnsiStringMarshaller,
-                UnmanagedType.LPTStr or UnmanagedType.LPWStr => TypeNames.GlobalAlias + TypeNames.Utf16StringMarshaller,
-                MarshalAsInfo.UnmanagedType_LPUTF8Str => TypeNames.GlobalAlias + TypeNames.Utf8StringMarshaller,
+                UnmanagedType.BStr => TypeNames.BStrStringMarshaller,
+                UnmanagedType.LPStr => TypeNames.AnsiStringMarshaller,
+                UnmanagedType.LPTStr or UnmanagedType.LPWStr => TypeNames.Utf16StringMarshaller,
+                MarshalAsInfo.UnmanagedType_LPUTF8Str => TypeNames.Utf8StringMarshaller,
                 _ => null
             };
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Interop
                                     InvocationExpression(
                                         MemberAccessExpression(
                                             SyntaxKind.SimpleMemberAccessExpression,
-                                            ParseName(TypeNames.System_Runtime_InteropServices_Marshal),
+                                            TypeSyntaxes.System_Runtime_InteropServices_Marshal,
                                             IdentifierName("GetFunctionPointerForDelegate")),
                                         ArgumentList(SingletonSeparatedList(Argument(IdentifierName(managedIdentifier))))),
                                     LiteralExpression(SyntaxKind.DefaultLiteralExpression))));
@@ -75,7 +75,7 @@ namespace Microsoft.Interop
                                     InvocationExpression(
                                         MemberAccessExpression(
                                             SyntaxKind.SimpleMemberAccessExpression,
-                                            ParseName(TypeNames.System_Runtime_InteropServices_Marshal),
+                                            TypeSyntaxes.System_Runtime_InteropServices_Marshal,
                                             GenericName(Identifier("GetDelegateForFunctionPointer"))
                                             .WithTypeArgumentList(
                                                 TypeArgumentList(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Interop
                                     Argument(
                                         InvocationExpression(
                                             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                                NameSyntaxes.System_Runtime_CompilerServices_Unsafe,
+                                                TypeSyntaxes.System_Runtime_CompilerServices_Unsafe,
                                                 IdentifierName("AsRef")),
                                             ArgumentList(SingletonSeparatedList(
                                                 Argument(
@@ -503,7 +503,7 @@ namespace Microsoft.Interop
                                     Argument(
                                         InvocationExpression(
                                             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                                NameSyntaxes.System_Runtime_CompilerServices_Unsafe,
+                                                TypeSyntaxes.System_Runtime_CompilerServices_Unsafe,
                                                 IdentifierName("AsRef")),
                                             ArgumentList(SingletonSeparatedList(
                                                 Argument(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Interop
                 InvocationExpression(
                     MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
-                        ParseName(TypeNames.System_Runtime_InteropServices_MemoryMarshal),
+                        TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
                         IdentifierName("CreateSpan")),
                     ArgumentList(
                         SeparatedList(new[]
@@ -121,7 +121,7 @@ namespace Microsoft.Interop
                             Argument(
                                 InvocationExpression(
                                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                        ParseName(TypeNames.System_Runtime_InteropServices_MemoryMarshal),
+                                        TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
                                         IdentifierName("GetReference")),
                                     ArgumentList(SingletonSeparatedList(
                                         Argument(CollectionSource.GetUnmanagedValuesSource(info, context))))))
@@ -167,7 +167,7 @@ namespace Microsoft.Interop
             ExpressionSyntax destination = InvocationExpression(
                 MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    ParseName(TypeNames.System_Runtime_InteropServices_MemoryMarshal),
+                    TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
                     IdentifierName("CreateSpan")),
                 ArgumentList(
                     SeparatedList(new[]
@@ -175,7 +175,7 @@ namespace Microsoft.Interop
                         Argument(
                             InvocationExpression(
                                 MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                    ParseName(TypeNames.System_Runtime_InteropServices_MemoryMarshal),
+                                    TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
                                     IdentifierName("GetReference")),
                                 ArgumentList(SingletonSeparatedList(
                                     Argument(CollectionSource.GetManagedValuesSource(info, context))))))
@@ -223,7 +223,7 @@ namespace Microsoft.Interop
             return InvocationExpression(
                 MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    ParseTypeName(TypeNames.System_Runtime_InteropServices_MemoryMarshal),
+                    TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
                     GenericName(
                         Identifier("Cast"),
                         TypeArgumentList(SeparatedList(
@@ -369,7 +369,7 @@ namespace Microsoft.Interop
                     InvocationExpression(
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
-                            ParseName(TypeNames.System_Runtime_InteropServices_MemoryMarshal),
+                            TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
                             IdentifierName("CreateSpan")))
                     .WithArgumentList(
                         ArgumentList(
@@ -379,7 +379,7 @@ namespace Microsoft.Interop
                                     Argument(
                                         InvocationExpression(
                                             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                                ParseName(TypeNames.System_Runtime_CompilerServices_Unsafe),
+                                                NameSyntaxes.System_Runtime_CompilerServices_Unsafe,
                                                 IdentifierName("AsRef")),
                                             ArgumentList(SingletonSeparatedList(
                                                 Argument(
@@ -493,7 +493,7 @@ namespace Microsoft.Interop
                     InvocationExpression(
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
-                            ParseName(TypeNames.System_Runtime_InteropServices_MemoryMarshal),
+                            TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
                             IdentifierName("CreateSpan")))
                     .WithArgumentList(
                         ArgumentList(
@@ -503,7 +503,7 @@ namespace Microsoft.Interop
                                     Argument(
                                         InvocationExpression(
                                             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                                ParseName(TypeNames.System_Runtime_CompilerServices_Unsafe),
+                                                NameSyntaxes.System_Runtime_CompilerServices_Unsafe,
                                                 IdentifierName("AsRef")),
                                             ArgumentList(SingletonSeparatedList(
                                                 Argument(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Interop
 {
     public static class MarshallerHelpers
     {
-        public static readonly TypeSyntax SystemIntPtrType = ParseTypeName(TypeNames.System_IntPtr);
+        public static readonly TypeSyntax SystemIntPtrType = TypeSyntaxes.System_IntPtr;
 
         public static ForStatementSyntax GetForLoop(ExpressionSyntax lengthExpression, string indexerIdentifier)
         {
@@ -96,7 +96,7 @@ namespace Microsoft.Interop
             if (spanElementTypeSyntax is PointerTypeSyntax)
             {
                 // Pointers cannot be passed to generics, so use IntPtr for this case.
-                spanElementTypeSyntax = SystemIntPtrType;
+                spanElementTypeSyntax = TypeSyntaxes.System_IntPtr;
             }
             return spanElementTypeSyntax;
         }
@@ -108,7 +108,7 @@ namespace Microsoft.Interop
                 InvocationExpression(
                     MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
-                        ParseName(TypeNames.System_Runtime_InteropServices_Marshal),
+                        TypeSyntaxes.System_Runtime_InteropServices_Marshal,
                         IdentifierName("SetLastSystemError")),
                     ArgumentList(SingletonSeparatedList(
                         Argument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(errorCode)))))));
@@ -122,7 +122,7 @@ namespace Microsoft.Interop
                     InvocationExpression(
                         MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
-                        ParseName(TypeNames.System_Runtime_InteropServices_Marshal),
+                        TypeSyntaxes.System_Runtime_InteropServices_Marshal,
                         IdentifierName("GetLastSystemError")))));
 
         // Marshal.SetLastPInvokeError(<lastError>);
@@ -131,7 +131,7 @@ namespace Microsoft.Interop
                 InvocationExpression(
                     MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
-                        ParseName(TypeNames.System_Runtime_InteropServices_Marshal),
+                        TypeSyntaxes.System_Runtime_InteropServices_Marshal,
                         IdentifierName("SetLastPInvokeError")),
                     ArgumentList(SingletonSeparatedList(
                         Argument(IdentifierName(lastErrorIdentifier))))));
@@ -327,7 +327,7 @@ namespace Microsoft.Interop
                 return ExpressionStatement(
                     InvocationExpression(
                         MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            ParseName(TypeNames.System_Runtime_CompilerServices_Unsafe),
+                            NameSyntaxes.System_Runtime_CompilerServices_Unsafe,
                             IdentifierName("SkipInit")))
                     .WithArgumentList(
                         ArgumentList(SingletonSeparatedList(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Interop
                 return ExpressionStatement(
                     InvocationExpression(
                         MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            NameSyntaxes.System_Runtime_CompilerServices_Unsafe,
+                            TypeSyntaxes.System_Runtime_CompilerServices_Unsafe,
                             IdentifierName("SkipInit")))
                     .WithArgumentList(
                         ArgumentList(SingletonSeparatedList(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorExtensions.cs
@@ -137,9 +137,9 @@ namespace Microsoft.Interop
             // so explicitly do not resurface a [MarshalAs(UnmanagdType.CustomMarshaler)] attribute.
             if (info.MarshallingAttributeInfo is MarshalAsInfo { UnmanagedType: not UnmanagedType.CustomMarshaler } marshalAs)
             {
-                marshalAsAttribute = Attribute(ParseName(TypeNames.System_Runtime_InteropServices_MarshalAsAttribute))
+                marshalAsAttribute = Attribute(NameSyntaxes.System_Runtime_InteropServices_MarshalAsAttribute)
                         .WithArgumentList(AttributeArgumentList(SingletonSeparatedList(AttributeArgument(
-                        CastExpression(ParseTypeName(TypeNames.System_Runtime_InteropServices_UnmanagedType),
+                        CastExpression(TypeSyntaxes.System_Runtime_InteropServices_UnmanagedType,
                         LiteralExpression(SyntaxKind.NumericLiteralExpression,
                             Literal((int)marshalAs.UnmanagedType)))))));
                 return true;
@@ -184,7 +184,7 @@ namespace Microsoft.Interop
                 List<AttributeArgumentSyntax> marshalAsArguments = new List<AttributeArgumentSyntax>
                 {
                     AttributeArgument(
-                        CastExpression(ParseTypeName(TypeNames.System_Runtime_InteropServices_UnmanagedType),
+                        CastExpression(TypeSyntaxes.System_Runtime_InteropServices_UnmanagedType,
                         LiteralExpression(SyntaxKind.NumericLiteralExpression,
                             Literal((int)UnmanagedType.LPArray))))
                 };
@@ -213,12 +213,12 @@ namespace Microsoft.Interop
                 {
                     marshalAsArguments.Add(
                         AttributeArgument(NameEquals("ArraySubType"), null,
-                            CastExpression(ParseTypeName(TypeNames.System_Runtime_InteropServices_UnmanagedType),
+                            CastExpression(TypeSyntaxes.System_Runtime_InteropServices_UnmanagedType,
                             LiteralExpression(SyntaxKind.NumericLiteralExpression,
                                 Literal((int)elementMarshalAs.UnmanagedType))))
                         );
                 }
-                marshalAsAttribute = Attribute(ParseName(TypeNames.System_Runtime_InteropServices_MarshalAsAttribute))
+                marshalAsAttribute = Attribute(NameSyntaxes.System_Runtime_InteropServices_MarshalAsAttribute)
                         .WithArgumentList(AttributeArgumentList(SeparatedList(marshalAsArguments)));
                 return true;
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/PointerNativeTypeAssignmentRewriter.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/PointerNativeTypeAssignmentRewriter.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Interop
             {
                 return node.WithInitializer(
                     EqualsValueClause(
-                        CastExpression(MarshallerHelpers.SystemIntPtrType, node.Initializer.Value)));
+                        CastExpression(TypeSyntaxes.System_IntPtr, node.Initializer.Value)));
             }
             if (node.Initializer.Value.ToString() == _nativeIdentifier)
             {
@@ -52,7 +52,7 @@ namespace Microsoft.Interop
             if (node.Left.ToString() == _nativeIdentifier)
             {
                 return node.WithRight(
-                    CastExpression(MarshallerHelpers.SystemIntPtrType, node.Right));
+                    CastExpression(TypeSyntaxes.System_IntPtr, node.Right));
             }
             if (node.Right.ToString() == _nativeIdentifier)
             {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/SafeHandleMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/SafeHandleMarshaller.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Interop
                             InvocationExpression(
                                 MemberAccessExpression(
                                     SyntaxKind.SimpleMemberAccessExpression,
-                                    ParseTypeName(TypeNames.System_Activator),
+                                    TypeSyntaxes.System_Activator,
                                     IdentifierName("CreateInstance")))
                             .WithArgumentList(
                                 ArgumentList(
@@ -168,7 +168,7 @@ namespace Microsoft.Interop
                     StatementSyntax unmarshalStatement = ExpressionStatement(
                         InvocationExpression(
                             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                ParseTypeName(TypeNames.System_Runtime_InteropServices_Marshal),
+                                TypeSyntaxes.System_Runtime_InteropServices_Marshal,
                                 IdentifierName("InitHandle")),
                             ArgumentList(SeparatedList(
                                 new[]

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
@@ -1,14 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.Interop
 {
@@ -155,12 +150,12 @@ namespace Microsoft.Interop
         {
             return unmanagedReturnType switch
             {
-                SpecialTypeInfo(_, _, SpecialType.System_Void) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.ExceptionAsVoidMarshaller}", unmanagedReturnType),
-                SpecialTypeInfo(_, _, SpecialType.System_Int32) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.ExceptionAsHResultMarshaller}<int>", unmanagedReturnType),
-                SpecialTypeInfo(_, _, SpecialType.System_UInt32) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.ExceptionAsHResultMarshaller}<uint>", unmanagedReturnType),
-                SpecialTypeInfo(_, _, SpecialType.System_Single) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.ExceptionAsNaNMarshaller}<float>", unmanagedReturnType),
-                SpecialTypeInfo(_, _, SpecialType.System_Double) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.ExceptionAsNaNMarshaller}<double>", unmanagedReturnType),
-                _ => CreateWellKnownComExceptionMarshallingData($"{TypeNames.ExceptionAsDefaultMarshaller}<{MarshallerHelpers.GetCompatibleGenericTypeParameterSyntax(SyntaxFactory.ParseTypeName(unmanagedReturnType.FullTypeName))}>", unmanagedReturnType),
+                SpecialTypeInfo(_, _, SpecialType.System_Void) => CreateWellKnownComExceptionMarshallingData(TypeNames.GlobalAlias + TypeNames.ExceptionAsVoidMarshaller, unmanagedReturnType),
+                SpecialTypeInfo(_, _, SpecialType.System_Int32) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.GlobalAlias + TypeNames.ExceptionAsHResultMarshaller}<int>", unmanagedReturnType),
+                SpecialTypeInfo(_, _, SpecialType.System_UInt32) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.GlobalAlias + TypeNames.ExceptionAsHResultMarshaller}<uint>", unmanagedReturnType),
+                SpecialTypeInfo(_, _, SpecialType.System_Single) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.GlobalAlias + TypeNames.ExceptionAsNaNMarshaller}<float>", unmanagedReturnType),
+                SpecialTypeInfo(_, _, SpecialType.System_Double) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.GlobalAlias + TypeNames.ExceptionAsNaNMarshaller}<double>", unmanagedReturnType),
+                _ => CreateWellKnownComExceptionMarshallingData($"{TypeNames.GlobalAlias + TypeNames.ExceptionAsDefaultMarshaller}<{MarshallerHelpers.GetCompatibleGenericTypeParameterSyntax(SyntaxFactory.ParseTypeName(unmanagedReturnType.FullTypeName))}>", unmanagedReturnType),
             };
 
             static NativeMarshallingAttributeInfo CreateWellKnownComExceptionMarshallingData(string marshallerName, ManagedTypeInfo unmanagedType)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
@@ -150,17 +150,17 @@ namespace Microsoft.Interop
         {
             return unmanagedReturnType switch
             {
-                SpecialTypeInfo(_, _, SpecialType.System_Void) => CreateWellKnownComExceptionMarshallingData(TypeNames.GlobalAlias + TypeNames.ExceptionAsVoidMarshaller, unmanagedReturnType),
-                SpecialTypeInfo(_, _, SpecialType.System_Int32) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.GlobalAlias + TypeNames.ExceptionAsHResultMarshaller}<int>", unmanagedReturnType),
-                SpecialTypeInfo(_, _, SpecialType.System_UInt32) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.GlobalAlias + TypeNames.ExceptionAsHResultMarshaller}<uint>", unmanagedReturnType),
-                SpecialTypeInfo(_, _, SpecialType.System_Single) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.GlobalAlias + TypeNames.ExceptionAsNaNMarshaller}<float>", unmanagedReturnType),
-                SpecialTypeInfo(_, _, SpecialType.System_Double) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.GlobalAlias + TypeNames.ExceptionAsNaNMarshaller}<double>", unmanagedReturnType),
-                _ => CreateWellKnownComExceptionMarshallingData($"{TypeNames.GlobalAlias + TypeNames.ExceptionAsDefaultMarshaller}<{MarshallerHelpers.GetCompatibleGenericTypeParameterSyntax(SyntaxFactory.ParseTypeName(unmanagedReturnType.FullTypeName))}>", unmanagedReturnType),
+                SpecialTypeInfo(_, _, SpecialType.System_Void) => CreateWellKnownComExceptionMarshallingData(TypeNames.ExceptionAsVoidMarshaller, unmanagedReturnType),
+                SpecialTypeInfo(_, _, SpecialType.System_Int32) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.ExceptionAsHResultMarshaller}<int>", unmanagedReturnType),
+                SpecialTypeInfo(_, _, SpecialType.System_UInt32) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.ExceptionAsHResultMarshaller}<uint>", unmanagedReturnType),
+                SpecialTypeInfo(_, _, SpecialType.System_Single) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.ExceptionAsNaNMarshaller}<float>", unmanagedReturnType),
+                SpecialTypeInfo(_, _, SpecialType.System_Double) => CreateWellKnownComExceptionMarshallingData($"{TypeNames.ExceptionAsNaNMarshaller}<double>", unmanagedReturnType),
+                _ => CreateWellKnownComExceptionMarshallingData($"{TypeNames.ExceptionAsDefaultMarshaller}<{MarshallerHelpers.GetCompatibleGenericTypeParameterSyntax(SyntaxFactory.ParseTypeName(unmanagedReturnType.FullTypeName))}>", unmanagedReturnType),
             };
 
             static NativeMarshallingAttributeInfo CreateWellKnownComExceptionMarshallingData(string marshallerName, ManagedTypeInfo unmanagedType)
             {
-                ManagedTypeInfo marshallerTypeInfo = new ReferenceTypeInfo(marshallerName, marshallerName);
+                ManagedTypeInfo marshallerTypeInfo = new ReferenceTypeInfo(TypeNames.GlobalAlias + marshallerName, marshallerName);
                 return new NativeMarshallingAttributeInfo(marshallerTypeInfo,
                     new CustomTypeMarshallers(ImmutableDictionary<MarshalMode, CustomTypeMarshallerData>.Empty.Add(
                         MarshalMode.UnmanagedToManagedOut,

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Interop
                     AttributeList(
                         SingletonSeparatedList(
                             Attribute(
-                                ParseName(TypeNames.System_CodeDom_Compiler_GeneratedCodeAttribute_WithGlobal),
+                                NameSyntaxes.System_CodeDom_Compiler_GeneratedCodeAttribute,
                                 AttributeArgumentList(
                                     SeparatedList(
                                         new[]
@@ -104,7 +104,7 @@ namespace Microsoft.Interop
                             // Adding the skip locals init indiscriminately since the source generator is
                             // targeted at non-blittable method signatures which typically will contain locals
                             // in the generated code.
-                            Attribute(ParseName(TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute_WithGlobal)))));
+                            Attribute(NameSyntaxes.System_Runtime_CompilerServices_SkipLocalsInitAttribute))));
             }
 
             return new SignatureContext()
@@ -187,7 +187,7 @@ namespace Microsoft.Interop
             return false;
 
             static bool IsSkipLocalsInitAttribute(AttributeData a)
-                => a.AttributeClass?.ToDisplayString() == TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute_Metadata;
+                => a.AttributeClass?.ToDisplayString() == TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute;
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StringMarshallingInfoProvider.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StringMarshallingInfoProvider.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Interop
                 // No marshalling info was computed, but a character encoding was provided.
                 return _defaultMarshallingInfo.CharEncoding switch
                 {
-                    CharEncoding.Utf16 => CreateStringMarshallingInfo(_compilation, type, TypeNames.Utf16StringMarshaller),
-                    CharEncoding.Utf8 => CreateStringMarshallingInfo(_compilation, type, TypeNames.Utf8StringMarshaller),
+                    CharEncoding.Utf16 => CreateStringMarshallingInfo(_compilation, type, TypeNames.GlobalAlias + TypeNames.Utf16StringMarshaller),
+                    CharEncoding.Utf8 => CreateStringMarshallingInfo(_compilation, type, TypeNames.GlobalAlias + TypeNames.Utf8StringMarshaller),
                     _ => throw new InvalidOperationException()
                 };
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StringMarshallingInfoProvider.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StringMarshallingInfoProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Interop
@@ -61,8 +59,8 @@ namespace Microsoft.Interop
                 // No marshalling info was computed, but a character encoding was provided.
                 return _defaultMarshallingInfo.CharEncoding switch
                 {
-                    CharEncoding.Utf16 => CreateStringMarshallingInfo(_compilation, type, TypeNames.GlobalAlias + TypeNames.Utf16StringMarshaller),
-                    CharEncoding.Utf8 => CreateStringMarshallingInfo(_compilation, type, TypeNames.GlobalAlias + TypeNames.Utf8StringMarshaller),
+                    CharEncoding.Utf16 => CreateStringMarshallingInfo(_compilation, type, TypeNames.Utf16StringMarshaller),
+                    CharEncoding.Utf8 => CreateStringMarshallingInfo(_compilation, type, TypeNames.Utf8StringMarshaller),
                     _ => throw new InvalidOperationException()
                 };
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
@@ -1,8 +1,118 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
 namespace Microsoft.Interop
 {
+    public static class NameSyntaxes
+    {
+        private static NameSyntax? _DllImportAttribute;
+        public static NameSyntax DllImportAttribute => _DllImportAttribute ??= ParseName("global::" + TypeNames.DllImportAttribute);
+
+        private static NameSyntax? _LibraryImportAttribute;
+        public static NameSyntax LibraryImportAttribute => _LibraryImportAttribute ??= ParseName("global::" + TypeNames.LibraryImportAttribute);
+
+        private static NameSyntax? _System_Runtime_CompilerServices_Unsafe;
+        public static NameSyntax System_Runtime_CompilerServices_Unsafe => _System_Runtime_CompilerServices_Unsafe ??= ParseName("global::" + TypeNames.System_Runtime_CompilerServices_Unsafe);
+
+        private static NameSyntax? _System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute;
+        public static NameSyntax System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute => _System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute ??= ParseName("global::" + TypeNames.System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute);
+
+        private static NameSyntax? _System_Runtime_InteropServices_MarshalAsAttribute;
+        public static NameSyntax System_Runtime_InteropServices_MarshalAsAttribute => _System_Runtime_InteropServices_MarshalAsAttribute ??= ParseName("global::" + TypeNames.System_Runtime_InteropServices_MarshalAsAttribute);
+
+        private static NameSyntax? _DefaultDllImportSearchPathsAttribute;
+        public static NameSyntax DefaultDllImportSearchPathsAttribute => _DefaultDllImportSearchPathsAttribute ??= ParseName("global::" + TypeNames.DefaultDllImportSearchPathsAttribute);
+
+        private static NameSyntax? _SuppressGCTransitionAttribute;
+        public static NameSyntax SuppressGCTransitionAttribute => _SuppressGCTransitionAttribute ??= ParseName("global::" + TypeNames.SuppressGCTransitionAttribute);
+
+        private static NameSyntax? _UnmanagedCallConvAttribute;
+        public static NameSyntax UnmanagedCallConvAttribute => _UnmanagedCallConvAttribute ??= ParseName("global::" + TypeNames.UnmanagedCallConvAttribute);
+
+        private static NameSyntax? _System_Runtime_CompilerServices_SkipLocalsInitAttribute;
+        public static NameSyntax System_Runtime_CompilerServices_SkipLocalsInitAttribute => _System_Runtime_CompilerServices_SkipLocalsInitAttribute ??= ParseName("global::" + TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute);
+
+        private static NameSyntax? _System_CodeDom_Compiler_GeneratedCodeAttribute;
+        public static NameSyntax System_CodeDom_Compiler_GeneratedCodeAttribute => _System_CodeDom_Compiler_GeneratedCodeAttribute ??= ParseName("global::" + TypeNames.System_CodeDom_Compiler_GeneratedCodeAttribute);
+
+        private static NameSyntax? _UnmanagedCallersOnlyAttribute;
+        public static NameSyntax UnmanagedCallersOnlyAttribute => _UnmanagedCallersOnlyAttribute ??= ParseName("global::" + TypeNames.UnmanagedCallersOnlyAttribute);
+    }
+
+    public static class TypeSyntaxes
+    {
+        private static TypeSyntax? _StringMarshalling;
+        public static TypeSyntax StringMarshalling => _StringMarshalling ??= ParseTypeName("global::" + TypeNames.StringMarshalling);
+
+        private static TypeSyntax? _System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry;
+        public static TypeSyntax System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry => _System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry);
+
+        private static TypeSyntax? _System_Runtime_InteropServices_NativeMemory;
+        public static TypeSyntax System_Runtime_InteropServices_NativeMemory => _System_Runtime_InteropServices_NativeMemory ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_NativeMemory);
+
+        private static TypeSyntax? _StrategyBasedComWrappers;
+        public static TypeSyntax StrategyBasedComWrappers => _StrategyBasedComWrappers ??= ParseTypeName("global::" + TypeNames.StrategyBasedComWrappers);
+
+        private static TypeSyntax? _IUnmanagedVirtualMethodTableProvider;
+        public static TypeSyntax IUnmanagedVirtualMethodTableProvider => _IUnmanagedVirtualMethodTableProvider ??= ParseTypeName("global::" + TypeNames.IUnmanagedVirtualMethodTableProvider);
+
+        private static TypeSyntax? _IIUnknownInterfaceType;
+        public static TypeSyntax IIUnknownInterfaceType => _IIUnknownInterfaceType ??= ParseTypeName("global::" + TypeNames.IIUnknownInterfaceType);
+
+        private static TypeSyntax? _IIUnknownDerivedDetails;
+        public static TypeSyntax IIUnknownDerivedDetails => _IIUnknownDerivedDetails ??= ParseTypeName("global::" + TypeNames.IIUnknownDerivedDetails);
+
+        private static TypeSyntax? _UnmanagedObjectUnwrapper;
+        public static TypeSyntax UnmanagedObjectUnwrapper => _UnmanagedObjectUnwrapper ??= ParseTypeName("global::" + TypeNames.UnmanagedObjectUnwrapper);
+
+        private static TypeSyntax? _IComExposedClass;
+        public static TypeSyntax IComExposedClass => _IComExposedClass ??= ParseTypeName("global::" + TypeNames.IComExposedClass);
+
+        private static TypeSyntax? _UnreachableException;
+        public static TypeSyntax UnreachableException => _UnreachableException ??= ParseTypeName("global::" + TypeNames.UnreachableException);
+
+        private static TypeSyntax? _System_Runtime_CompilerServices_RuntimeHelpers;
+        public static TypeSyntax System_Runtime_CompilerServices_RuntimeHelpers => _System_Runtime_CompilerServices_RuntimeHelpers ??= ParseTypeName("global::" + TypeNames.System_Runtime_CompilerServices_RuntimeHelpers);
+
+        private static TypeSyntax? _System_Runtime_InteropServices_ComWrappers;
+        public static TypeSyntax System_Runtime_InteropServices_ComWrappers => _System_Runtime_InteropServices_ComWrappers ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_ComWrappers);
+
+        private static TypeSyntax? _System_IntPtr;
+        public static TypeSyntax System_IntPtr => _System_IntPtr ??= ParseTypeName("global::" + TypeNames.System_IntPtr);
+
+        private static TypeSyntax? _System_Guid;
+        public static TypeSyntax System_Guid => _System_Guid ??= ParseTypeName("global::" + TypeNames.System_Guid);
+
+        private static TypeSyntax? _DllImportSearchPath;
+        public static TypeSyntax DllImportSearchPath => _DllImportSearchPath ??= ParseTypeName("global::" + TypeNames.DllImportSearchPath);
+
+        private static TypeSyntax? _System_Type;
+        public static TypeSyntax System_Type => _System_Type ??= ParseTypeName("global::" + TypeNames.System_Type);
+
+        private static TypeSyntax? _System_Activator;
+        public static TypeSyntax System_Activator => _System_Activator ??= ParseTypeName("global::" + TypeNames.System_Activator);
+
+        private static TypeSyntax? _System_Runtime_InteropServices_Marshal;
+        public static TypeSyntax System_Runtime_InteropServices_Marshal => _System_Runtime_InteropServices_Marshal ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_Marshal);
+
+        private static TypeSyntax? _System_Runtime_InteropServices_UnmanagedType;
+        public static TypeSyntax System_Runtime_InteropServices_UnmanagedType => _System_Runtime_InteropServices_UnmanagedType ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_UnmanagedType);
+
+        private static TypeSyntax? _System_Runtime_InteropServices_MemoryMarshal;
+        public static TypeSyntax System_Runtime_InteropServices_MemoryMarshal => _System_Runtime_InteropServices_MemoryMarshal ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_MemoryMarshal);
+
+        private static TypeSyntax? _System_Exception;
+        public static TypeSyntax System_Exception => _System_Exception ??= ParseTypeName("global::" + TypeNames.System_Exception);
+
+        private static TypeSyntax? _System_GC;
+        public static TypeSyntax System_GC => _System_GC ??= ParseTypeName("global::" + TypeNames.System_GC);
+
+        private static TypeSyntax? _System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch;
+        public static TypeSyntax System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch => _System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch);
+    }
     public static class TypeNames
     {
         public const string DllImportAttribute = "System.Runtime.InteropServices.DllImportAttribute";
@@ -94,9 +204,7 @@ namespace Microsoft.Interop
 
         public const string System_Runtime_InteropServices_InAttribute = "System.Runtime.InteropServices.InAttribute";
 
-        public const string System_Runtime_CompilerServices_SkipLocalsInitAttribute_WithGlobal = "global::System.Runtime.CompilerServices.SkipLocalsInitAttribute";
-
-        public const string System_Runtime_CompilerServices_SkipLocalsInitAttribute_Metadata = "System.Runtime.CompilerServices.SkipLocalsInitAttribute";
+        public const string System_Runtime_CompilerServices_SkipLocalsInitAttribute = "System.Runtime.CompilerServices.SkipLocalsInitAttribute";
 
         public const string System_Runtime_CompilerServices_Unsafe = "System.Runtime.CompilerServices.Unsafe";
 
@@ -106,7 +214,7 @@ namespace Microsoft.Interop
 
         public const string DllImportSearchPath = "System.Runtime.InteropServices.DllImportSearchPath";
 
-        public const string System_CodeDom_Compiler_GeneratedCodeAttribute_WithGlobal = "global::System.CodeDom.Compiler.GeneratedCodeAttribute";
+        public const string System_CodeDom_Compiler_GeneratedCodeAttribute = "System.CodeDom.Compiler.GeneratedCodeAttribute";
 
         public const string System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute = "System.Runtime.InteropServices.DynamicInterfaceCastableImplementationAttribute";
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -115,7 +114,7 @@ namespace Microsoft.Interop
         private static TypeSyntax? _System_Runtime_CompilerServices_Unsafe;
         public static TypeSyntax System_Runtime_CompilerServices_Unsafe => _System_Runtime_CompilerServices_Unsafe ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Runtime_CompilerServices_Unsafe);
 
-        private static TypeSyntax? _CallConvCDecl;
+        private static TypeSyntax? _CallConvCdecl;
         private static TypeSyntax? _CallConvFastcall;
         private static TypeSyntax? _CallConvMemberFunction;
         private static TypeSyntax? _CallConvStdcall;
@@ -125,7 +124,7 @@ namespace Microsoft.Interop
         {
             return callConv switch
             {
-                "CDecl" => _CallConvCDecl ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvCDeclName),
+                "Cdecl" => _CallConvCdecl ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvCdeclName),
                 "Fastcall" => _CallConvFastcall ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvFastcallName),
                 "MemberFunction" => _CallConvMemberFunction ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvMemberFunctionName),
                 "Stdcall" => _CallConvStdcall ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvStdcallName),
@@ -295,7 +294,7 @@ namespace Microsoft.Interop
 
         public const string System_Runtime_InteropServices_NFloat = "System.Runtime.InteropServices.NFloat";
 
-        public const string CallConvCDeclName = "System.Runtime.CompilerServices.CallConvCDecl";
+        public const string CallConvCdeclName = "System.Runtime.CompilerServices.CallConvCdecl";
         public const string CallConvFastcallName = "System.Runtime.CompilerServices.CallConvFastcall";
         public const string CallConvStdcallName = "System.Runtime.CompilerServices.CallConvStdcall";
         public const string CallConvThiscallName = "System.Runtime.CompilerServices.CallConvThiscall";

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
@@ -117,7 +117,9 @@ namespace Microsoft.Interop
 
         private static TypeSyntax? _CallConvCDecl;
         private static TypeSyntax? _CallConvFastcall;
+        private static TypeSyntax? _CallConvMemberFunction;
         private static TypeSyntax? _CallConvStdcall;
+        private static TypeSyntax? _CallConvSuppressGCTransition;
         private static TypeSyntax? _CallConvThiscall;
         public static TypeSyntax CallConv(string callConv)
         {
@@ -125,9 +127,11 @@ namespace Microsoft.Interop
             {
                 "CDecl" => _CallConvCDecl ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvCDeclName),
                 "Fastcall" => _CallConvFastcall ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvFastcallName),
+                "MemberFunction" => _CallConvMemberFunction ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvMemberFunctionName),
                 "Stdcall" => _CallConvStdcall ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvStdcallName),
+                "SuppressGCTransition" => _CallConvSuppressGCTransition ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvSuppressGCTransitionName),
                 "Thiscall" => _CallConvThiscall ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvThiscallName),
-                _ => throw new ArgumentException("Unexpected CallConv")
+                _ => throw new ArgumentException($"Unexpected CallConv: {callConv}")
             };
         }
     }
@@ -295,5 +299,7 @@ namespace Microsoft.Interop
         public const string CallConvFastcallName = "System.Runtime.CompilerServices.CallConvFastcall";
         public const string CallConvStdcallName = "System.Runtime.CompilerServices.CallConvStdcall";
         public const string CallConvThiscallName = "System.Runtime.CompilerServices.CallConvThiscall";
+        public const string CallConvSuppressGCTransitionName = "System.Runtime.CompilerServices.CallConvSuppressGCTransition";
+        public const string CallConvMemberFunctionName = "System.Runtime.CompilerServices.CallConvMemberFunction";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -9,112 +11,130 @@ namespace Microsoft.Interop
     public static class NameSyntaxes
     {
         private static NameSyntax? _DllImportAttribute;
-        public static NameSyntax DllImportAttribute => _DllImportAttribute ??= ParseName("global::" + TypeNames.DllImportAttribute);
+        public static NameSyntax DllImportAttribute => _DllImportAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.DllImportAttribute);
 
         private static NameSyntax? _LibraryImportAttribute;
-        public static NameSyntax LibraryImportAttribute => _LibraryImportAttribute ??= ParseName("global::" + TypeNames.LibraryImportAttribute);
-
-        private static NameSyntax? _System_Runtime_CompilerServices_Unsafe;
-        public static NameSyntax System_Runtime_CompilerServices_Unsafe => _System_Runtime_CompilerServices_Unsafe ??= ParseName("global::" + TypeNames.System_Runtime_CompilerServices_Unsafe);
+        public static NameSyntax LibraryImportAttribute => _LibraryImportAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.LibraryImportAttribute);
 
         private static NameSyntax? _System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute;
-        public static NameSyntax System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute => _System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute ??= ParseName("global::" + TypeNames.System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute);
+        public static NameSyntax System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute => _System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_DynamicInterfaceCastableImplementationAttribute);
 
         private static NameSyntax? _System_Runtime_InteropServices_MarshalAsAttribute;
-        public static NameSyntax System_Runtime_InteropServices_MarshalAsAttribute => _System_Runtime_InteropServices_MarshalAsAttribute ??= ParseName("global::" + TypeNames.System_Runtime_InteropServices_MarshalAsAttribute);
+        public static NameSyntax System_Runtime_InteropServices_MarshalAsAttribute => _System_Runtime_InteropServices_MarshalAsAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_MarshalAsAttribute);
 
         private static NameSyntax? _DefaultDllImportSearchPathsAttribute;
-        public static NameSyntax DefaultDllImportSearchPathsAttribute => _DefaultDllImportSearchPathsAttribute ??= ParseName("global::" + TypeNames.DefaultDllImportSearchPathsAttribute);
+        public static NameSyntax DefaultDllImportSearchPathsAttribute => _DefaultDllImportSearchPathsAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.DefaultDllImportSearchPathsAttribute);
 
         private static NameSyntax? _SuppressGCTransitionAttribute;
-        public static NameSyntax SuppressGCTransitionAttribute => _SuppressGCTransitionAttribute ??= ParseName("global::" + TypeNames.SuppressGCTransitionAttribute);
+        public static NameSyntax SuppressGCTransitionAttribute => _SuppressGCTransitionAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.SuppressGCTransitionAttribute);
 
         private static NameSyntax? _UnmanagedCallConvAttribute;
-        public static NameSyntax UnmanagedCallConvAttribute => _UnmanagedCallConvAttribute ??= ParseName("global::" + TypeNames.UnmanagedCallConvAttribute);
+        public static NameSyntax UnmanagedCallConvAttribute => _UnmanagedCallConvAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.UnmanagedCallConvAttribute);
 
         private static NameSyntax? _System_Runtime_CompilerServices_SkipLocalsInitAttribute;
-        public static NameSyntax System_Runtime_CompilerServices_SkipLocalsInitAttribute => _System_Runtime_CompilerServices_SkipLocalsInitAttribute ??= ParseName("global::" + TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute);
+        public static NameSyntax System_Runtime_CompilerServices_SkipLocalsInitAttribute => _System_Runtime_CompilerServices_SkipLocalsInitAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute);
 
         private static NameSyntax? _System_CodeDom_Compiler_GeneratedCodeAttribute;
-        public static NameSyntax System_CodeDom_Compiler_GeneratedCodeAttribute => _System_CodeDom_Compiler_GeneratedCodeAttribute ??= ParseName("global::" + TypeNames.System_CodeDom_Compiler_GeneratedCodeAttribute);
+        public static NameSyntax System_CodeDom_Compiler_GeneratedCodeAttribute => _System_CodeDom_Compiler_GeneratedCodeAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.System_CodeDom_Compiler_GeneratedCodeAttribute);
 
         private static NameSyntax? _UnmanagedCallersOnlyAttribute;
-        public static NameSyntax UnmanagedCallersOnlyAttribute => _UnmanagedCallersOnlyAttribute ??= ParseName("global::" + TypeNames.UnmanagedCallersOnlyAttribute);
+        public static NameSyntax UnmanagedCallersOnlyAttribute => _UnmanagedCallersOnlyAttribute ??= ParseName(TypeNames.GlobalAlias + TypeNames.UnmanagedCallersOnlyAttribute);
     }
 
     public static class TypeSyntaxes
     {
         private static TypeSyntax? _StringMarshalling;
-        public static TypeSyntax StringMarshalling => _StringMarshalling ??= ParseTypeName("global::" + TypeNames.StringMarshalling);
+        public static TypeSyntax StringMarshalling => _StringMarshalling ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.StringMarshalling);
 
         private static TypeSyntax? _System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry;
-        public static TypeSyntax System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry => _System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry);
+        public static TypeSyntax System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry => _System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceEntry);
 
         private static TypeSyntax? _System_Runtime_InteropServices_NativeMemory;
-        public static TypeSyntax System_Runtime_InteropServices_NativeMemory => _System_Runtime_InteropServices_NativeMemory ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_NativeMemory);
+        public static TypeSyntax System_Runtime_InteropServices_NativeMemory => _System_Runtime_InteropServices_NativeMemory ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_NativeMemory);
 
         private static TypeSyntax? _StrategyBasedComWrappers;
-        public static TypeSyntax StrategyBasedComWrappers => _StrategyBasedComWrappers ??= ParseTypeName("global::" + TypeNames.StrategyBasedComWrappers);
+        public static TypeSyntax StrategyBasedComWrappers => _StrategyBasedComWrappers ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.StrategyBasedComWrappers);
 
         private static TypeSyntax? _IUnmanagedVirtualMethodTableProvider;
-        public static TypeSyntax IUnmanagedVirtualMethodTableProvider => _IUnmanagedVirtualMethodTableProvider ??= ParseTypeName("global::" + TypeNames.IUnmanagedVirtualMethodTableProvider);
+        public static TypeSyntax IUnmanagedVirtualMethodTableProvider => _IUnmanagedVirtualMethodTableProvider ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.IUnmanagedVirtualMethodTableProvider);
 
         private static TypeSyntax? _IIUnknownInterfaceType;
-        public static TypeSyntax IIUnknownInterfaceType => _IIUnknownInterfaceType ??= ParseTypeName("global::" + TypeNames.IIUnknownInterfaceType);
+        public static TypeSyntax IIUnknownInterfaceType => _IIUnknownInterfaceType ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.IIUnknownInterfaceType);
 
         private static TypeSyntax? _IIUnknownDerivedDetails;
-        public static TypeSyntax IIUnknownDerivedDetails => _IIUnknownDerivedDetails ??= ParseTypeName("global::" + TypeNames.IIUnknownDerivedDetails);
+        public static TypeSyntax IIUnknownDerivedDetails => _IIUnknownDerivedDetails ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.IIUnknownDerivedDetails);
 
         private static TypeSyntax? _UnmanagedObjectUnwrapper;
-        public static TypeSyntax UnmanagedObjectUnwrapper => _UnmanagedObjectUnwrapper ??= ParseTypeName("global::" + TypeNames.UnmanagedObjectUnwrapper);
+        public static TypeSyntax UnmanagedObjectUnwrapper => _UnmanagedObjectUnwrapper ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.UnmanagedObjectUnwrapper);
 
         private static TypeSyntax? _IComExposedClass;
-        public static TypeSyntax IComExposedClass => _IComExposedClass ??= ParseTypeName("global::" + TypeNames.IComExposedClass);
+        public static TypeSyntax IComExposedClass => _IComExposedClass ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.IComExposedClass);
 
         private static TypeSyntax? _UnreachableException;
-        public static TypeSyntax UnreachableException => _UnreachableException ??= ParseTypeName("global::" + TypeNames.UnreachableException);
+        public static TypeSyntax UnreachableException => _UnreachableException ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.UnreachableException);
 
         private static TypeSyntax? _System_Runtime_CompilerServices_RuntimeHelpers;
-        public static TypeSyntax System_Runtime_CompilerServices_RuntimeHelpers => _System_Runtime_CompilerServices_RuntimeHelpers ??= ParseTypeName("global::" + TypeNames.System_Runtime_CompilerServices_RuntimeHelpers);
+        public static TypeSyntax System_Runtime_CompilerServices_RuntimeHelpers => _System_Runtime_CompilerServices_RuntimeHelpers ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Runtime_CompilerServices_RuntimeHelpers);
 
         private static TypeSyntax? _System_Runtime_InteropServices_ComWrappers;
-        public static TypeSyntax System_Runtime_InteropServices_ComWrappers => _System_Runtime_InteropServices_ComWrappers ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_ComWrappers);
+        public static TypeSyntax System_Runtime_InteropServices_ComWrappers => _System_Runtime_InteropServices_ComWrappers ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_ComWrappers);
 
         private static TypeSyntax? _System_IntPtr;
-        public static TypeSyntax System_IntPtr => _System_IntPtr ??= ParseTypeName("global::" + TypeNames.System_IntPtr);
+        public static TypeSyntax System_IntPtr => _System_IntPtr ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_IntPtr);
 
         private static TypeSyntax? _System_Guid;
-        public static TypeSyntax System_Guid => _System_Guid ??= ParseTypeName("global::" + TypeNames.System_Guid);
+        public static TypeSyntax System_Guid => _System_Guid ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Guid);
 
         private static TypeSyntax? _DllImportSearchPath;
-        public static TypeSyntax DllImportSearchPath => _DllImportSearchPath ??= ParseTypeName("global::" + TypeNames.DllImportSearchPath);
+        public static TypeSyntax DllImportSearchPath => _DllImportSearchPath ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.DllImportSearchPath);
 
         private static TypeSyntax? _System_Type;
-        public static TypeSyntax System_Type => _System_Type ??= ParseTypeName("global::" + TypeNames.System_Type);
+        public static TypeSyntax System_Type => _System_Type ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Type);
 
         private static TypeSyntax? _System_Activator;
-        public static TypeSyntax System_Activator => _System_Activator ??= ParseTypeName("global::" + TypeNames.System_Activator);
+        public static TypeSyntax System_Activator => _System_Activator ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Activator);
 
         private static TypeSyntax? _System_Runtime_InteropServices_Marshal;
-        public static TypeSyntax System_Runtime_InteropServices_Marshal => _System_Runtime_InteropServices_Marshal ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_Marshal);
+        public static TypeSyntax System_Runtime_InteropServices_Marshal => _System_Runtime_InteropServices_Marshal ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_Marshal);
 
         private static TypeSyntax? _System_Runtime_InteropServices_UnmanagedType;
-        public static TypeSyntax System_Runtime_InteropServices_UnmanagedType => _System_Runtime_InteropServices_UnmanagedType ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_UnmanagedType);
+        public static TypeSyntax System_Runtime_InteropServices_UnmanagedType => _System_Runtime_InteropServices_UnmanagedType ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_UnmanagedType);
 
         private static TypeSyntax? _System_Runtime_InteropServices_MemoryMarshal;
-        public static TypeSyntax System_Runtime_InteropServices_MemoryMarshal => _System_Runtime_InteropServices_MemoryMarshal ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_MemoryMarshal);
+        public static TypeSyntax System_Runtime_InteropServices_MemoryMarshal => _System_Runtime_InteropServices_MemoryMarshal ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_MemoryMarshal);
 
         private static TypeSyntax? _System_Exception;
-        public static TypeSyntax System_Exception => _System_Exception ??= ParseTypeName("global::" + TypeNames.System_Exception);
+        public static TypeSyntax System_Exception => _System_Exception ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Exception);
 
         private static TypeSyntax? _System_GC;
-        public static TypeSyntax System_GC => _System_GC ??= ParseTypeName("global::" + TypeNames.System_GC);
+        public static TypeSyntax System_GC => _System_GC ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_GC);
 
         private static TypeSyntax? _System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch;
-        public static TypeSyntax System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch => _System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch ??= ParseTypeName("global::" + TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch);
+        public static TypeSyntax System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch => _System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Runtime_InteropServices_ComWrappers_ComInterfaceDispatch);
+
+        private static TypeSyntax? _System_Runtime_CompilerServices_Unsafe;
+        public static TypeSyntax System_Runtime_CompilerServices_Unsafe => _System_Runtime_CompilerServices_Unsafe ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.System_Runtime_CompilerServices_Unsafe);
+
+        private static TypeSyntax? _CallConvCDecl;
+        private static TypeSyntax? _CallConvFastcall;
+        private static TypeSyntax? _CallConvStdcall;
+        private static TypeSyntax? _CallConvThiscall;
+        public static TypeSyntax CallConv(string callConv)
+        {
+            return callConv switch
+            {
+                "CDecl" => _CallConvCDecl ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvCDeclName),
+                "Fastcall" => _CallConvFastcall ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvFastcallName),
+                "Stdcall" => _CallConvStdcall ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvStdcallName),
+                "Thiscall" => _CallConvThiscall ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.CallConvThiscallName),
+                _ => throw new ArgumentException("Unexpected CallConv")
+            };
+        }
     }
     public static class TypeNames
     {
+        public const string GlobalAlias = "global::";
+
         public const string DllImportAttribute = "System.Runtime.InteropServices.DllImportAttribute";
         public const string LibraryImportAttribute = "System.Runtime.InteropServices.LibraryImportAttribute";
         public const string LibraryImportAttribute_ShortName = "LibraryImportAttribute";
@@ -156,9 +176,9 @@ namespace Microsoft.Interop
         public const string IUnmanagedInterfaceType_Metadata = "System.Runtime.InteropServices.Marshalling.IUnmanagedInterfaceType";
 
         public const string System_Span_Metadata = "System.Span`1";
-        public const string System_Span = "System.Span";
+        public const string System_Span = GlobalAlias + "System.Span";
         public const string System_ReadOnlySpan_Metadata = "System.ReadOnlySpan`1";
-        public const string System_ReadOnlySpan = "System.ReadOnlySpan";
+        public const string System_ReadOnlySpan = GlobalAlias + "System.ReadOnlySpan";
 
         public const string System_IntPtr = "System.IntPtr";
 
@@ -270,5 +290,10 @@ namespace Microsoft.Interop
         public const string System_Runtime_InteropServices_CULong = "System.Runtime.InteropServices.CULong";
 
         public const string System_Runtime_InteropServices_NFloat = "System.Runtime.InteropServices.NFloat";
+
+        public const string CallConvCDeclName = "System.Runtime.CompilerServices.CallConvCDecl";
+        public const string CallConvFastcallName = "System.Runtime.CompilerServices.CallConvFastcall";
+        public const string CallConvStdcallName = "System.Runtime.CompilerServices.CallConvStdcall";
+        public const string CallConvThiscallName = "System.Runtime.CompilerServices.CallConvThiscall";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/ComInterfaceGenerator.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/ComInterfaceGenerator.Tests.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EnabledGenerators Include="ComInterfaceGenerator" />
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs" Link="Common\DisableRuntimeMarshalling.cs" />
     <Compile Include="..\TestAssets\SharedTypes\ComInterfaces\**\*.cs" Link="ComInterfaces\%(RecursiveDir)\%(FileName).cs" />
   </ItemGroup>

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/CustomMarshallingTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/CustomMarshallingTests.cs
@@ -16,6 +16,8 @@ namespace LibraryImportGenerator.IntegrationTests
     {
         internal partial class Stateless
         {
+            public static string System = "Make sure generated code prefixes type references with global::";
+
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "stringcontainer_deepduplicate")]
             public static partial void DeepDuplicateStrings(StringContainer strings, out StringContainer pStringsOut);
 

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AddDisableRuntimeMarshallingAttributeFixerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AddDisableRuntimeMarshallingAttributeFixerTests.cs
@@ -4,12 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.Interop;
 using Xunit;
-using System.IO;
-
 using VerifyCS = Microsoft.Interop.UnitTests.Verifiers.CSharpCodeFixVerifier<
     Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer,
     Microsoft.Interop.Analyzers.AddDisableRuntimeMarshallingAttributeFixer>;

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
@@ -4,6 +4,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.Interop;
 using Microsoft.Interop.UnitTests;
 using System.Collections.Generic;
 using System.Linq;
@@ -286,7 +287,7 @@ namespace LibraryImportGenerator.UnitTests
                         }
 
                         AttributeSyntax syntax = (AttributeSyntax)attr.ApplicationSyntaxReference!.GetSyntax();
-                        return syntax.Name.ToString().StartsWith("global::");
+                        return syntax.Name.ToString().StartsWith(TypeNames.GlobalAlias);
                     }
                 }
                 else

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/ISystem.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/ISystem.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SharedTypes.ComInterfaces
+{
+    [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf8)]
+    [Guid(IID)]
+    internal partial interface ISystem
+    {
+        // Make sure method names System and Microsoft don't interfere with framework type / method references
+        void Microsoft(int p);
+        void System(int p);
+        public const string IID = "3BFFE3FD-D11E-4195-8250-0C73321977A0";
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/SharedTypes.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/SharedTypes.csproj
@@ -3,13 +3,10 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CompilerGeneratedFilesOutputPath Condition="'$(InteropCompilerGeneratedFilesOutputPath)' == ''">$(OutputPath)\Generated</CompilerGeneratedFilesOutputPath>
-    <CompilerGeneratedFilesOutputPath Condition="'$(InteropCompilerGeneratedFilesOutputPath)' != ''">$(InteropCompilerGeneratedFilesOutputPath)\ComInterfaceGenerator.Tests</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs" Link="Common\DisableRuntimeMarshalling.cs" />
-    <EnabledGenerators Include="ComInterfaceGenerator" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/SharedTypes.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/SharedTypes.csproj
@@ -3,10 +3,13 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CompilerGeneratedFilesOutputPath Condition="'$(InteropCompilerGeneratedFilesOutputPath)' == ''">$(OutputPath)\Generated</CompilerGeneratedFilesOutputPath>
+    <CompilerGeneratedFilesOutputPath Condition="'$(InteropCompilerGeneratedFilesOutputPath)' != ''">$(InteropCompilerGeneratedFilesOutputPath)\ComInterfaceGenerator.Tests</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs" Link="Common\DisableRuntimeMarshalling.cs" />
+    <EnabledGenerators Include="ComInterfaceGenerator" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/90299

There were a few places where we would use the type names without the global:: prefix that causes issues when there is another "System" symbol in the context. To avoid this, we can use a static TypeSyntax and NameSyntax for well-known types instead of calling ParseTypeName or ParseName and remembering to prefix "global::". Though of course now we need to remember to use these instead of ParseTypeName...