### PR TITLE
[wasm][debugger] Symbolicate function names on debug callstack

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -322,6 +322,8 @@ namespace Microsoft.WebAssembly.Diagnostics
         public static MonoCommands DetachDebugger(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_detach_debugger()");
 
         public static MonoCommands ReleaseObject(int runtimeId, DotnetObjectId objectId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_release_object('{objectId}')");
+
+        public static MonoCommands SymbolicateFunctionName(int runtimeId, int funcId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_symbolicate('{funcId}')");
     }
 
     internal enum MonoErrorCodes
@@ -473,6 +475,8 @@ namespace Microsoft.WebAssembly.Diagnostics
                 return store;
             }
         }
+
+        public bool DisableSymbolicate { get; internal set; }
 
         public PerScopeCache GetCacheForScope(int scopeId)
         {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -323,7 +323,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public static MonoCommands ReleaseObject(int runtimeId, DotnetObjectId objectId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_release_object('{objectId}')");
 
-        public static MonoCommands SymbolicateFunctionName(int runtimeId, int funcId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_symbolicate('{funcId}')");
+        public static MonoCommands GetSymbols(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_symbols()");
     }
 
     internal enum MonoErrorCodes
@@ -477,6 +477,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
 
         public bool DisableSymbolicate { get; internal set; }
+        public string[] Symbols { get; internal set; }
 
         public PerScopeCache GetCacheForScope(int scopeId)
         {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -323,7 +323,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public static MonoCommands ReleaseObject(int runtimeId, DotnetObjectId objectId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_release_object('{objectId}')");
 
-        public static MonoCommands GetSymbols(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_symbols()");
+        public static MonoCommands GetWasmFunctionIds(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_func_id_to_name_mappings()");
     }
 
     internal enum MonoErrorCodes
@@ -475,9 +475,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 return store;
             }
         }
-
-        public bool DisableSymbolicate { get; internal set; }
-        public string[] Symbols { get; internal set; }
+        public string[] GetWasmFunctionIds { get; internal set; }
 
         public PerScopeCache GetCacheForScope(int scopeId)
         {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -475,7 +475,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 return store;
             }
         }
-        public string[] GetWasmFunctionIds { get; internal set; }
+        public string[] WasmFunctionIds { get; internal set; }
 
         public PerScopeCache GetCacheForScope(int scopeId)
         {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -1126,6 +1126,14 @@ namespace Microsoft.WebAssembly.Diagnostics
                         function_name.StartsWith("_mono_wasm_fire_debugger_agent_message", StringComparison.Ordinal) ||
                         function_name.StartsWith("mono_wasm_fire_debugger_agent_message", StringComparison.Ordinal)))
                 {
+                    if (!context.DisableSymbolicate && function_name.StartsWith("$func", StringComparison.Ordinal) && int.TryParse(function_name.Remove(0, 5), out var funcId))
+                    {
+                        Result funcNameSymbolicated = await SendMonoCommand(sessionId, MonoCommands.SymbolicateFunctionName(RuntimeId, funcId), token);
+                        if (funcNameSymbolicated.IsOk)
+                            frame["functionName"] = funcNameSymbolicated.Value?["result"]?["value"]?.Value<string>();
+                        else
+                            context.DisableSymbolicate = true;
+                    }
                     callFrames.Add(frame);
                 }
             }

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -16,6 +16,7 @@ import { mono_wasm_gc_lock, mono_wasm_gc_unlock } from "./gc-lock";
 import { loadLazyAssembly } from "./lazyLoading";
 import { loadSatelliteAssemblies } from "./satelliteAssemblies";
 import { forceDisposeProxies } from "./gc-handles";
+import { mono_wasm_symbolicate } from "./logging";
 
 export function export_internal(): any {
     return {
@@ -42,6 +43,7 @@ export function export_internal(): any {
         mono_wasm_change_debugger_log_level,
         mono_wasm_debugger_attached,
         mono_wasm_runtime_is_ready: runtimeHelpers.mono_wasm_runtime_is_ready,
+        mono_wasm_symbolicate,
 
         // interop
         get_property,

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -16,7 +16,7 @@ import { mono_wasm_gc_lock, mono_wasm_gc_unlock } from "./gc-lock";
 import { loadLazyAssembly } from "./lazyLoading";
 import { loadSatelliteAssemblies } from "./satelliteAssemblies";
 import { forceDisposeProxies } from "./gc-handles";
-import { mono_wasm_symbolicate } from "./logging";
+import { mono_wasm_get_symbols } from "./logging";
 
 export function export_internal(): any {
     return {
@@ -43,7 +43,7 @@ export function export_internal(): any {
         mono_wasm_change_debugger_log_level,
         mono_wasm_debugger_attached,
         mono_wasm_runtime_is_ready: runtimeHelpers.mono_wasm_runtime_is_ready,
-        mono_wasm_symbolicate,
+        mono_wasm_get_symbols,
 
         // interop
         get_property,

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -16,7 +16,7 @@ import { mono_wasm_gc_lock, mono_wasm_gc_unlock } from "./gc-lock";
 import { loadLazyAssembly } from "./lazyLoading";
 import { loadSatelliteAssemblies } from "./satelliteAssemblies";
 import { forceDisposeProxies } from "./gc-handles";
-import { mono_wasm_get_symbols } from "./logging";
+import { mono_wasm_get_func_id_to_name_mappings } from "./logging";
 
 export function export_internal(): any {
     return {
@@ -43,7 +43,7 @@ export function export_internal(): any {
         mono_wasm_change_debugger_log_level,
         mono_wasm_debugger_attached,
         mono_wasm_runtime_is_ready: runtimeHelpers.mono_wasm_runtime_is_ready,
-        mono_wasm_get_symbols,
+        mono_wasm_get_func_id_to_name_mappings,
 
         // interop
         get_property,

--- a/src/mono/wasm/runtime/logging.ts
+++ b/src/mono/wasm/runtime/logging.ts
@@ -149,3 +149,9 @@ export function parseSymbolMapFile(text: string) {
 
     mono_log_debug(`Loaded ${wasm_func_map.size} symbols`);
 }
+
+
+export function mono_wasm_symbolicate(funcNum: number) {
+    const name = wasm_func_map.get(Number(funcNum));
+    return name;   
+}

--- a/src/mono/wasm/runtime/logging.ts
+++ b/src/mono/wasm/runtime/logging.ts
@@ -151,7 +151,6 @@ export function parseSymbolMapFile(text: string) {
 }
 
 
-export function mono_wasm_symbolicate(funcNum: number) {
-    const name = wasm_func_map.get(Number(funcNum));
-    return name;   
+export function mono_wasm_get_symbols() {
+    return [...wasm_func_map.values()];
 }

--- a/src/mono/wasm/runtime/logging.ts
+++ b/src/mono/wasm/runtime/logging.ts
@@ -150,7 +150,6 @@ export function parseSymbolMapFile(text: string) {
     mono_log_debug(`Loaded ${wasm_func_map.size} symbols`);
 }
 
-
-export function mono_wasm_get_symbols() {
+export function mono_wasm_get_func_id_to_name_mappings() {
     return [...wasm_func_map.values()];
 }


### PR DESCRIPTION
Running the app with Just My Code disabled.
Without the PR a browserwasm app:
![image](https://github.com/dotnet/runtime/assets/4503299/600f4f3b-ed37-4ed6-a028-ed77c0c1b4b3)

With the PR a browserwasm app:
![image](https://github.com/dotnet/runtime/assets/4503299/ae322e59-17c1-402f-b6f1-fcb758daf07d)
