### PR TITLE
Add DiagnosticDescriptorHelper to set HelpURI for generator / analyzer diagnostics

### DIFF
--- a/src/libraries/Common/src/Roslyn/DiagnosticDescriptorHelper.cs
+++ b/src/libraries/Common/src/Roslyn/DiagnosticDescriptorHelper.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.CodeAnalysis.DotnetRuntime.Extensions
+{
+    internal static partial class DiagnosticDescriptorHelper
+    {
+        public static DiagnosticDescriptor Create(
+            string id,
+            LocalizableString title,
+            LocalizableString messageFormat,
+            string category,
+            DiagnosticSeverity defaultSeverity,
+            bool isEnabledByDefault,
+            LocalizableString? description = null,
+            params string[] customTags)
+        {
+            string helpLink = $"https://learn.microsoft.com/dotnet/fundamentals/syslib-diagnostics/{id.ToLowerInvariant()}.md";
+
+            return new DiagnosticDescriptor(id, title, messageFormat, category, defaultSeverity, isEnabledByDefault, description, helpLink, customTags);
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/Diagnostics.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/Diagnostics.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
 
 namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 {
@@ -21,7 +22,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 public static DiagnosticDescriptor MultiDimArraysNotSupported { get; } = CreateTypeNotSupportedDescriptor(nameof(SR.MultiDimArraysNotSupported));
                 public static DiagnosticDescriptor NullableUnderlyingTypeNotSupported { get; } = CreateTypeNotSupportedDescriptor(nameof(SR.NullableUnderlyingTypeNotSupported));
 
-                public static DiagnosticDescriptor PropertyNotSupported { get; } = new DiagnosticDescriptor(
+                public static DiagnosticDescriptor PropertyNotSupported { get; } = DiagnosticDescriptorHelper.Create(
                     id: "SYSLIB1101",
                     title: new LocalizableResourceString(nameof(SR.PropertyNotSupportedTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
                     messageFormat: new LocalizableResourceString(nameof(SR.PropertyNotSupportedMessageFormat), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
@@ -29,7 +30,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     defaultSeverity: DiagnosticSeverity.Warning,
                     isEnabledByDefault: true);
 
-                public static DiagnosticDescriptor LanguageVersionNotSupported { get; } = new DiagnosticDescriptor(
+                public static DiagnosticDescriptor LanguageVersionNotSupported { get; } = DiagnosticDescriptorHelper.Create(
                     id: "SYSLIB1102",
                     title: new LocalizableResourceString(nameof(SR.LanguageVersionIsNotSupportedTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
                     messageFormat: new LocalizableResourceString(nameof(SR.Language_VersionIsNotSupportedMessageFormat), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
@@ -37,7 +38,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     defaultSeverity: DiagnosticSeverity.Error,
                     isEnabledByDefault: true);
 
-                public static DiagnosticDescriptor ValueTypesInvalidForBind { get; } = new DiagnosticDescriptor(
+                public static DiagnosticDescriptor ValueTypesInvalidForBind { get; } = DiagnosticDescriptorHelper.Create(
                     id: "SYSLIB1103",
                     title: new LocalizableResourceString(nameof(SR.ValueTypesInvalidForBindTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
                     messageFormat: new LocalizableResourceString(nameof(SR.ValueTypesInvalidForBindMessageFormat), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
@@ -45,7 +46,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     defaultSeverity: DiagnosticSeverity.Warning,
                     isEnabledByDefault: true);
 
-                public static DiagnosticDescriptor CouldNotDetermineTypeInfo { get; } = new DiagnosticDescriptor(
+                public static DiagnosticDescriptor CouldNotDetermineTypeInfo { get; } = DiagnosticDescriptorHelper.Create(
                     id: "SYSLIB1104",
                     title: new LocalizableResourceString(nameof(SR.CouldNotDetermineTypeInfoTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
                     messageFormat: new LocalizableResourceString(nameof(SR.CouldNotDetermineTypeInfoMessageFormat), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
@@ -54,7 +55,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     isEnabledByDefault: true);
 
                 private static DiagnosticDescriptor CreateTypeNotSupportedDescriptor(string nameofLocalizableMessageFormat) =>
-                    new DiagnosticDescriptor(
+                    DiagnosticDescriptorHelper.Create(
                     id: "SYSLIB1100",
                     title: new LocalizableResourceString(nameof(SR.TypeNotSupportedTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),
                     messageFormat: new LocalizableResourceString(nameofLocalizableMessageFormat, SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Configuration.Binder.SourceGeneration.SR)),

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj
@@ -20,6 +20,7 @@
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\RequiredMemberAttribute.cs" Link="Common\System\Runtime\CompilerServices\RequiredMemberAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Collections\Generic\ValueListBuilder.cs" Link="Production\ValueListBuilder.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Collections\Generic\ValueListBuilder.Pop.cs" Link="Production\ValueListBuilder.Pop.cs" />
+    <Compile Include="$(CommonPath)\Roslyn\DiagnosticDescriptorHelper.cs" Link="Common\Roslyn\DiagnosticDescriptorHelper.cs" />
     <Compile Include="$(CommonPath)\Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
     <Compile Include="$(CommonPath)\SourceGenerators\SourceWriter.cs" Link="Common\SourceGenerators\SourceWriter.cs" />
     <Compile Include="ConfigurationBindingGenerator.cs" />

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/DiagnosticDescriptors.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/DiagnosticDescriptors.cs
@@ -3,12 +3,13 @@
 
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
 
 namespace Microsoft.Extensions.Logging.Generators
 {
     public static class DiagnosticDescriptors
     {
-        public static DiagnosticDescriptor InvalidLoggingMethodName { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor InvalidLoggingMethodName { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1001",
             title: new LocalizableResourceString(nameof(SR.InvalidLoggingMethodNameMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.InvalidLoggingMethodNameMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -16,7 +17,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor ShouldntMentionLogLevelInMessage { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor ShouldntMentionLogLevelInMessage { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1002",
             title: new LocalizableResourceString(nameof(SR.ShouldntMentionLogLevelInMessageTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.ShouldntMentionInTemplateMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -24,7 +25,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor InvalidLoggingMethodParameterName { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor InvalidLoggingMethodParameterName { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1003",
             title: new LocalizableResourceString(nameof(SR.InvalidLoggingMethodParameterNameMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.InvalidLoggingMethodParameterNameMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -32,7 +33,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor MissingRequiredType { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor MissingRequiredType { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1005",
             title: new LocalizableResourceString(nameof(SR.MissingRequiredTypeTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.MissingRequiredTypeMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -40,7 +41,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor ShouldntReuseEventIds { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor ShouldntReuseEventIds { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1006",
             title: new LocalizableResourceString(nameof(SR.ShouldntReuseEventIdsTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.ShouldntReuseEventIdsMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -48,7 +49,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Info,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor LoggingMethodMustReturnVoid { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor LoggingMethodMustReturnVoid { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1007",
             title: new LocalizableResourceString(nameof(SR.LoggingMethodMustReturnVoidMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.LoggingMethodMustReturnVoidMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -56,7 +57,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor MissingLoggerArgument { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor MissingLoggerArgument { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1008",
             title: new LocalizableResourceString(nameof(SR.MissingLoggerArgumentTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.MissingLoggerArgumentMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -64,7 +65,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor LoggingMethodShouldBeStatic { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor LoggingMethodShouldBeStatic { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1009",
             title: new LocalizableResourceString(nameof(SR.LoggingMethodShouldBeStaticMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.LoggingMethodShouldBeStaticMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -72,7 +73,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor LoggingMethodMustBePartial { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor LoggingMethodMustBePartial { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1010",
             title: new LocalizableResourceString(nameof(SR.LoggingMethodMustBePartialMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.LoggingMethodMustBePartialMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -80,7 +81,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor LoggingMethodIsGeneric { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor LoggingMethodIsGeneric { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1011",
             title: new LocalizableResourceString(nameof(SR.LoggingMethodIsGenericMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.LoggingMethodIsGenericMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -88,7 +89,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor RedundantQualifierInMessage { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor RedundantQualifierInMessage { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1012",
             title: new LocalizableResourceString(nameof(SR.RedundantQualifierInMessageTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.RedundantQualifierInMessageMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -96,7 +97,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor ShouldntMentionExceptionInMessage { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor ShouldntMentionExceptionInMessage { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1013",
             title: new LocalizableResourceString(nameof(SR.ShouldntMentionExceptionInMessageTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.ShouldntMentionInTemplateMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -104,7 +105,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor TemplateHasNoCorrespondingArgument { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor TemplateHasNoCorrespondingArgument { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1014",
             title: new LocalizableResourceString(nameof(SR.TemplateHasNoCorrespondingArgumentTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.TemplateHasNoCorrespondingArgumentMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -112,7 +113,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor ArgumentHasNoCorrespondingTemplate { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor ArgumentHasNoCorrespondingTemplate { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1015",
             title: new LocalizableResourceString(nameof(SR.ArgumentHasNoCorrespondingTemplateTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.ArgumentHasNoCorrespondingTemplateMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -120,7 +121,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor LoggingMethodHasBody { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor LoggingMethodHasBody { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1016",
             title: new LocalizableResourceString(nameof(SR.LoggingMethodHasBodyMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.LoggingMethodHasBodyMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -128,7 +129,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor MissingLogLevel { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor MissingLogLevel { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1017",
             title: new LocalizableResourceString(nameof(SR.MissingLogLevelMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.MissingLogLevelMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -136,7 +137,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor ShouldntMentionLoggerInMessage { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor ShouldntMentionLoggerInMessage { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1018",
             title: new LocalizableResourceString(nameof(SR.ShouldntMentionLoggerInMessageTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.ShouldntMentionInTemplateMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -144,7 +145,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor MissingLoggerField { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor MissingLoggerField { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1019",
             title: new LocalizableResourceString(nameof(SR.MissingLoggerFieldTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.MissingLoggerFieldMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -152,7 +153,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor MultipleLoggerFields { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor MultipleLoggerFields { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1020",
             title: new LocalizableResourceString(nameof(SR.MultipleLoggerFieldsTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.MultipleLoggerFieldsMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -160,7 +161,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor InconsistentTemplateCasing { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor InconsistentTemplateCasing { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1021",
             title: new LocalizableResourceString(nameof(SR.InconsistentTemplateCasingMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.InconsistentTemplateCasingMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -168,7 +169,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor MalformedFormatStrings { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor MalformedFormatStrings { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1022",
             title: new LocalizableResourceString(nameof(SR.MalformedFormatStringsTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.MalformedFormatStringsMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -176,7 +177,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor GeneratingForMax6Arguments { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor GeneratingForMax6Arguments { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1023",
             title: new LocalizableResourceString(nameof(SR.GeneratingForMax6ArgumentsMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.GeneratingForMax6ArgumentsMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -184,7 +185,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor InvalidLoggingMethodParameterOut { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor InvalidLoggingMethodParameterOut { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1024",
             title: new LocalizableResourceString(nameof(SR.InvalidLoggingMethodParameterOutTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.InvalidLoggingMethodParameterOutMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
@@ -192,7 +193,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor ShouldntReuseEventNames { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor ShouldntReuseEventNames { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1025",
             title: new LocalizableResourceString(nameof(SR.ShouldntReuseEventNamesTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.ShouldntReuseEventNamesMessage), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Microsoft.Extensions.Logging.Generators.targets
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Microsoft.Extensions.Logging.Generators.targets
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(CommonPath)\Roslyn\DiagnosticDescriptorHelper.cs" Link="Common\Roslyn\DiagnosticDescriptorHelper.cs" />
     <Compile Include="$(CommonPath)\Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
   </ItemGroup>
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/GeneratorDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/GeneratorDiagnostics.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -30,7 +31,7 @@ namespace Microsoft.Interop
         private const string Category = "JSImportGenerator";
 
         public static readonly DiagnosticDescriptor ConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitle)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessage)),
@@ -40,7 +41,7 @@ namespace Microsoft.Interop
                 description: GetResourceString(nameof(SR.ConfigurationNotSupportedDescription)));
 
         public static readonly DiagnosticDescriptor ConfigurationValueNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitle)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageValue)),
@@ -50,7 +51,7 @@ namespace Microsoft.Interop
                 description: GetResourceString(nameof(SR.ConfigurationNotSupportedDescription)));
 
         public static readonly DiagnosticDescriptor MarshallingAttributeConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitle)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageMarshallingInfo)),
@@ -60,7 +61,7 @@ namespace Microsoft.Interop
                 description: GetResourceString(nameof(SR.ConfigurationNotSupportedDescription)));
 
         public static readonly DiagnosticDescriptor ReturnTypeNotSupportedWithDetails =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(SR.TypeNotSupportedTitle)),
                 GetResourceString(nameof(SR.TypeNotSupportedMessageReturnWithDetails)),
@@ -70,7 +71,7 @@ namespace Microsoft.Interop
                 description: GetResourceString(nameof(SR.TypeNotSupportedDescription)));
 
         public static readonly DiagnosticDescriptor ParameterTypeNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(SR.TypeNotSupportedTitle)),
                 GetResourceString(nameof(SR.TypeNotSupportedMessageParameter)),
@@ -80,7 +81,7 @@ namespace Microsoft.Interop
                 description: GetResourceString(nameof(SR.TypeNotSupportedDescription)));
 
         public static readonly DiagnosticDescriptor ReturnTypeNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(SR.TypeNotSupportedTitle)),
                 GetResourceString(nameof(SR.TypeNotSupportedMessageReturn)),
@@ -90,7 +91,7 @@ namespace Microsoft.Interop
                 description: GetResourceString(nameof(SR.TypeNotSupportedDescription)));
 
         public static readonly DiagnosticDescriptor ParameterTypeNotSupportedWithDetails =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(SR.TypeNotSupportedTitle)),
                 GetResourceString(nameof(SR.TypeNotSupportedMessageParameterWithDetails)),
@@ -100,7 +101,7 @@ namespace Microsoft.Interop
                 description: GetResourceString(nameof(SR.TypeNotSupportedDescription)));
 
         public static readonly DiagnosticDescriptor ParameterConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitle)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageParameter)),
@@ -110,7 +111,7 @@ namespace Microsoft.Interop
                 description: GetResourceString(nameof(SR.ConfigurationNotSupportedDescription)));
 
         public static readonly DiagnosticDescriptor ReturnConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitle)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageReturn)),
@@ -120,7 +121,7 @@ namespace Microsoft.Interop
                 description: GetResourceString(nameof(SR.ConfigurationNotSupportedDescription)));
 
         public static readonly DiagnosticDescriptor InvalidImportAttributedMethodSignature =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidJSImportAttributeUsage,
             GetResourceString(nameof(SR.InvalidJSImportAttributeUsageTitle)),
             GetResourceString(nameof(SR.InvalidJSImportAttributedMethodSignatureMessage)),
@@ -130,7 +131,7 @@ namespace Microsoft.Interop
             description: GetResourceString(nameof(SR.InvalidJSImportAttributedMethodDescription)));
 
         public static readonly DiagnosticDescriptor InvalidExportAttributedMethodSignature =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidJSExportAttributeUsage,
             GetResourceString(nameof(SR.InvalidJSExportAttributeUsageTitle)),
             GetResourceString(nameof(SR.InvalidJSExportAttributedMethodSignatureMessage)),
@@ -140,7 +141,7 @@ namespace Microsoft.Interop
             description: GetResourceString(nameof(SR.InvalidJSExportAttributedMethodDescription)));
 
         public static readonly DiagnosticDescriptor InvalidImportAttributedMethodContainingTypeMissingModifiers =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidJSImportAttributeUsage,
             GetResourceString(nameof(SR.InvalidJSImportAttributeUsageTitle)),
             GetResourceString(nameof(SR.InvalidAttributedMethodContainingTypeMissingModifiersMessage)),
@@ -150,7 +151,7 @@ namespace Microsoft.Interop
             description: GetResourceString(nameof(SR.InvalidJSImportAttributedMethodDescription)));
 
         public static readonly DiagnosticDescriptor InvalidExportAttributedMethodContainingTypeMissingModifiers =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidJSExportAttributeUsage,
             GetResourceString(nameof(SR.InvalidJSExportAttributeUsageTitle)),
             GetResourceString(nameof(SR.InvalidAttributedMethodContainingTypeMissingModifiersMessage)),
@@ -160,7 +161,7 @@ namespace Microsoft.Interop
             description: GetResourceString(nameof(SR.InvalidJSExportAttributedMethodDescription)));
 
         public static readonly DiagnosticDescriptor JSImportRequiresAllowUnsafeBlocks =
-                   new DiagnosticDescriptor(
+                   DiagnosticDescriptorHelper.Create(
                        Ids.JSImportRequiresAllowUnsafeBlocks,
                        GetResourceString(nameof(SR.JSImportRequiresAllowUnsafeBlocksTitle)),
                        GetResourceString(nameof(SR.JSImportRequiresAllowUnsafeBlocksMessage)),
@@ -170,7 +171,7 @@ namespace Microsoft.Interop
                        description: GetResourceString(nameof(SR.JSImportRequiresAllowUnsafeBlocksDescription)));
 
         public static readonly DiagnosticDescriptor JSExportRequiresAllowUnsafeBlocks =
-                   new DiagnosticDescriptor(
+                   DiagnosticDescriptorHelper.Create(
                        Ids.JSExportRequiresAllowUnsafeBlocks,
                        GetResourceString(nameof(SR.JSExportRequiresAllowUnsafeBlocksTitle)),
                        GetResourceString(nameof(SR.JSExportRequiresAllowUnsafeBlocksMessage)),

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <Folder Include="Resources\xlf\" />
+    <Compile Include="$(CommonPath)Roslyn\DiagnosticDescriptorHelper.cs" Link="Common\Roslyn\DiagnosticDescriptorHelper.cs" />
     <Compile Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\src\System\Runtime\InteropServices\JavaScript\MarshalerType.cs" Link="System\Runtime\InteropServices\JavaScript\MarshalerType.cs" />
   </ItemGroup>
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/AnalyzerDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/AnalyzerDiagnostics.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
+
 namespace Microsoft.Interop.Analyzers
 {
     public static class AnalyzerDiagnostics
@@ -30,7 +32,7 @@ namespace Microsoft.Interop.Analyzers
         }
 
         public static readonly DiagnosticDescriptor ConvertToGeneratedComInterface =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConvertToGeneratedComInterface,
                 GetResourceString(nameof(SR.ConvertToGeneratedComInterfaceTitle)),
                 GetResourceString(nameof(SR.ConvertToGeneratedComInterfaceMessage)),
@@ -40,7 +42,7 @@ namespace Microsoft.Interop.Analyzers
                 description: GetResourceString(nameof(SR.ConvertToGeneratedComInterfaceDescription)));
 
         public static readonly DiagnosticDescriptor AddGeneratedComClassAttribute =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.AddGeneratedComClassAttribute,
                 GetResourceString(nameof(SR.AddGeneratedComClassAttributeTitle)),
                 GetResourceString(nameof(SR.AddGeneratedComClassAttributeMessage)),
@@ -50,7 +52,7 @@ namespace Microsoft.Interop.Analyzers
                 description: GetResourceString(nameof(SR.AddGeneratedComClassAttributeDescription)));
 
         public static readonly DiagnosticDescriptor ComHostingDoesNotSupportGeneratedComInterface =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ComHostingDoesNotSupportGeneratedComInterface,
                 GetResourceString(nameof(SR.ComHostingDoesNotSupportGeneratedComInterfaceTitle)),
                 GetResourceString(nameof(SR.ComHostingDoesNotSupportGeneratedComInterfaceMessage)),
@@ -60,7 +62,7 @@ namespace Microsoft.Interop.Analyzers
                 description: GetResourceString(nameof(SR.ComHostingDoesNotSupportGeneratedComInterfaceDescription)));
 
         public static readonly DiagnosticDescriptor RuntimeComApisDoNotSupportSourceGeneratedCom =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.RuntimeComAndGeneratedComDoNotMix,
                 GetResourceString(nameof(SR.RuntimeComApisDoNotSupportSourceGeneratedComTitle)),
                 GetResourceString(nameof(SR.RuntimeComApisDoNotSupportSourceGeneratedComMessage)),
@@ -70,7 +72,7 @@ namespace Microsoft.Interop.Analyzers
                 description: GetResourceString(nameof(SR.RuntimeComApisDoNotSupportSourceGeneratedComDescription)));
 
         public static readonly DiagnosticDescriptor CastsBetweenRuntimeComAndSourceGeneratedComNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.RuntimeComAndGeneratedComDoNotMix,
                 GetResourceString(nameof(SR.CastsBetweenRuntimeComAndSourceGeneratedComNotSupportedTitle)),
                 GetResourceString(nameof(SR.CastsBetweenRuntimeComAndSourceGeneratedComNotSupportedMessage)),

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.csproj
@@ -23,6 +23,7 @@
     <Compile Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\src\System\Runtime\InteropServices\Marshalling\ComInterfaceOptions.cs" Link="Production\ComInterfaceOptions.cs" />
     <Compile Include="..\Common\DefaultMarshallingInfoParser.cs" Link="Common\DefaultMarshallingInfoParser.cs" />
     <Compile Include="..\..\tests\Common\ExceptionMarshalling.cs" Link="Common\ExceptionMarshalling.cs" />
+    <Compile Include="$(CommonPath)\Roslyn\DiagnosticDescriptorHelper.cs" Link="Common\Roslyn\DiagnosticDescriptorHelper.cs" />
     <Compile Include="$(CommonPath)\Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
     <Compile Include="..\Common\OperationExtensions.cs" Link="Common\OperationExtensions.cs" />
     <Compile Include="..\Common\ConvertToSourceGeneratedInteropFixer.cs" Link="Common\ConvertToSourceGeneratedInteropFixer.cs" />

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/GeneratorDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/GeneratorDiagnostics.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
 
 namespace Microsoft.Interop
 {
@@ -32,7 +33,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.RequiresAllowUnsafeBlocksMessageCom"/>
         public static readonly DiagnosticDescriptor RequiresAllowUnsafeBlocks =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.RequiresAllowUnsafeBlocks,
                 GetResourceString(nameof(SR.RequiresAllowUnsafeBlocksTitleCom)),
                 GetResourceString(nameof(SR.RequiresAllowUnsafeBlocksMessageCom)),
@@ -43,7 +44,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidAttributedMethodSignatureMessageCom"/>
         public static readonly DiagnosticDescriptor InvalidAttributedMethodSignature =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidLibraryImportAttributeUsage,
             GetResourceString(nameof(SR.InvalidVirtualMethodIndexAttributeUsage)),
             GetResourceString(nameof(SR.InvalidAttributedMethodSignatureMessageCom)),
@@ -54,7 +55,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidAttributedMethodContainingTypeMissingModifiersMessageCom"/>
         public static readonly DiagnosticDescriptor InvalidAttributedMethodContainingTypeMissingModifiers =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidLibraryImportAttributeUsage,
             GetResourceString(nameof(SR.InvalidVirtualMethodIndexAttributeUsage)),
             GetResourceString(nameof(SR.InvalidAttributedMethodContainingTypeMissingModifiersMessageCom)),
@@ -65,7 +66,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidGeneratedComInterfaceUsageMissingPartialModifier"/>
         public static readonly DiagnosticDescriptor InvalidAttributedInterfaceMissingPartialModifiers =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidGeneratedComInterfaceAttributeUsage,
             GetResourceString(nameof(SR.InvalidGeneratedComInterfaceAttributeUsageTitle)),
             GetResourceString(nameof(SR.InvalidGeneratedComInterfaceUsageMissingPartialModifier)),
@@ -76,7 +77,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidAttributedMethodContainingTypeMissingUnmanagedObjectUnwrapperAttributeMessage"/>
         public static readonly DiagnosticDescriptor InvalidAttributedMethodContainingTypeMissingUnmanagedObjectUnwrapperAttribute =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidLibraryImportAttributeUsage,
             GetResourceString(nameof(SR.InvalidVirtualMethodIndexAttributeUsage)),
             GetResourceString(nameof(SR.InvalidAttributedMethodContainingTypeMissingUnmanagedObjectUnwrapperAttributeMessage)),
@@ -87,7 +88,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidStringMarshallingConfigurationOnInterfaceMessage"/>
         public static readonly DiagnosticDescriptor InvalidStringMarshallingMismatchBetweenBaseAndDerived =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidGeneratedComInterfaceAttributeUsage,
             GetResourceString(nameof(SR.InvalidGeneratedComInterfaceAttributeUsageTitle)),
             GetResourceString(nameof(SR.InvalidStringMarshallingConfigurationOnInterfaceMessage)),
@@ -98,7 +99,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidOptionsOnInterfaceMessage"/>
         public static readonly DiagnosticDescriptor InvalidOptionsOnInterface =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidGeneratedComInterfaceAttributeUsage,
             GetResourceString(nameof(SR.InvalidGeneratedComInterfaceAttributeUsageTitle)),
             GetResourceString(nameof(SR.InvalidOptionsOnInterfaceMessage)),
@@ -109,7 +110,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidStringMarshallingConfigurationOnMethodMessage"/>
         public static readonly DiagnosticDescriptor InvalidStringMarshallingConfigurationOnMethod =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidLibraryImportAttributeUsage,
             GetResourceString(nameof(SR.InvalidVirtualMethodIndexAttributeUsage)),
             GetResourceString(nameof(SR.InvalidStringMarshallingConfigurationOnMethodMessage)),
@@ -120,7 +121,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidStringMarshallingConfigurationOnInterfaceMessage"/>
         public static readonly DiagnosticDescriptor InvalidStringMarshallingConfigurationOnInterface =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidGeneratedComInterfaceAttributeUsage,
             GetResourceString(nameof(SR.InvalidGeneratedComInterfaceAttributeUsageTitle)),
             GetResourceString(nameof(SR.InvalidStringMarshallingConfigurationOnInterfaceMessage)),
@@ -131,7 +132,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.StringMarshallingCustomTypeNotAccessibleByGeneratedCode"/>
         public static readonly DiagnosticDescriptor StringMarshallingCustomTypeNotAccessibleByGeneratedCode =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidGeneratedComInterfaceAttributeUsage,
             GetResourceString(nameof(SR.InvalidGeneratedComInterfaceAttributeUsageTitle)),
             GetResourceString(nameof(SR.StringMarshallingCustomTypeNotAccessibleByGeneratedCode)),
@@ -141,7 +142,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidExceptionMarshallingConfigurationMessage"/>
         public static readonly DiagnosticDescriptor InvalidExceptionMarshallingConfiguration =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidLibraryImportAttributeUsage,
             GetResourceString(nameof(SR.InvalidVirtualMethodIndexAttributeUsage)),
             GetResourceString(nameof(SR.InvalidExceptionMarshallingConfigurationMessage)),
@@ -152,7 +153,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.TypeNotSupportedMessageParameterCom"/>
         public static readonly DiagnosticDescriptor ParameterTypeNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(SR.TypeNotSupportedTitleCom)),
                 GetResourceString(nameof(SR.TypeNotSupportedMessageParameterCom)),
@@ -163,7 +164,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.TypeNotSupportedMessageReturnCom"/>
         public static readonly DiagnosticDescriptor ReturnTypeNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(SR.TypeNotSupportedTitleCom)),
                 GetResourceString(nameof(SR.TypeNotSupportedMessageReturnCom)),
@@ -174,7 +175,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.TypeNotSupportedMessageParameterWithDetails"/>
         public static readonly DiagnosticDescriptor ParameterTypeNotSupportedWithDetails =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(SR.TypeNotSupportedTitleCom)),
                 GetResourceString(nameof(SR.TypeNotSupportedMessageParameterWithDetails)),
@@ -185,7 +186,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.TypeNotSupportedMessageReturnWithDetails"/>
         public static readonly DiagnosticDescriptor ReturnTypeNotSupportedWithDetails =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(SR.TypeNotSupportedTitleCom)),
                 GetResourceString(nameof(SR.TypeNotSupportedMessageReturnWithDetails)),
@@ -196,7 +197,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.ConfigurationNotSupportedMessageParameterCom"/>
         public static readonly DiagnosticDescriptor ParameterConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleCom)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageParameterCom)),
@@ -207,7 +208,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.ConfigurationNotSupportedMessageReturnCom"/>
         public static readonly DiagnosticDescriptor ReturnConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleCom)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageReturnCom)),
@@ -218,7 +219,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.MarshalAsConfigurationNotSupportedMessageParameterCom"/>
         public static readonly DiagnosticDescriptor MarshalAsParameterConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 GeneratorDiagnostics.Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleCom)),
                 GetResourceString(nameof(SR.MarshalAsConfigurationNotSupportedMessageParameterCom)),
@@ -229,7 +230,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.MarshalAsConfigurationNotSupportedMessageReturnCom"/>
         public static readonly DiagnosticDescriptor MarshalAsReturnConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 GeneratorDiagnostics.Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleCom)),
                 GetResourceString(nameof(SR.MarshalAsConfigurationNotSupportedMessageReturnCom)),
@@ -240,7 +241,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.ConfigurationNotSupportedMessageCom"/>
         public static readonly DiagnosticDescriptor ConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleCom)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageCom)),
@@ -251,7 +252,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.ConfigurationNotSupportedMessageValueCom"/>
         public static readonly DiagnosticDescriptor ConfigurationValueNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleCom)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageValueCom)),
@@ -262,7 +263,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.ConfigurationNotSupportedMessageMarshallingInfoCom"/>
         public static readonly DiagnosticDescriptor MarshallingAttributeConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleCom)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageMarshallingInfoCom)),
@@ -273,7 +274,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.MethodNotDeclaredInAttributedInterfaceMessage"/>
         public static readonly DiagnosticDescriptor MethodNotDeclaredInAttributedInterface =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.MemberWillNotBeSourceGenerated,
                 GetResourceString(nameof(SR.MethodNotDeclaredInAttributedInterfaceTitle)),
                 GetResourceString(nameof(SR.MethodNotDeclaredInAttributedInterfaceMessage)),
@@ -284,7 +285,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InstancePropertyDeclaredInInterfaceMessage"/>
         public static readonly DiagnosticDescriptor InstancePropertyDeclaredInInterface =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.MemberWillNotBeSourceGenerated,
                 GetResourceString(nameof(SR.InstancePropertyDeclaredInInterfaceTitle)),
                 GetResourceString(nameof(SR.InstancePropertyDeclaredInInterfaceMessage)),
@@ -295,7 +296,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InstanceEventDeclaredInInterfaceMessage"/>
         public static readonly DiagnosticDescriptor InstanceEventDeclaredInInterface =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.MemberWillNotBeSourceGenerated,
                 GetResourceString(nameof(SR.InstanceEventDeclaredInInterfaceTitle)),
                 GetResourceString(nameof(SR.InstanceEventDeclaredInInterfaceMessage)),
@@ -306,7 +307,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidGeneratedComInterfaceAttributeUsageInterfaceNotAccessible"/>
         public static readonly DiagnosticDescriptor InvalidAttributedInterfaceNotAccessible =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidGeneratedComInterfaceAttributeUsage,
                 GetResourceString(nameof(SR.InvalidGeneratedComInterfaceAttributeUsageTitle)),
                 GetResourceString(nameof(SR.InvalidGeneratedComInterfaceAttributeUsageInterfaceNotAccessible)),
@@ -317,7 +318,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidGeneratedComInterfaceAttributeUsageMissingGuidAttribute"/>
         public static readonly DiagnosticDescriptor InvalidAttributedInterfaceMissingGuidAttribute =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidGeneratedComInterfaceAttributeUsage,
                 GetResourceString(nameof(SR.InvalidGeneratedComInterfaceAttributeUsageTitle)),
                 GetResourceString(nameof(SR.InvalidGeneratedComInterfaceAttributeUsageMissingGuidAttribute)),
@@ -328,7 +329,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidGeneratedComInterfaceAttributeUsageInterfaceIsGeneric"/>
         public static readonly DiagnosticDescriptor InvalidAttributedInterfaceGenericNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidGeneratedComInterfaceAttributeUsage,
                 GetResourceString(nameof(SR.InvalidGeneratedComInterfaceAttributeUsageTitle)),
                 GetResourceString(nameof(SR.InvalidGeneratedComInterfaceAttributeUsageInterfaceIsGeneric)),
@@ -339,7 +340,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.MultipleComInterfaceBaseTypesMessage"/>
         public static readonly DiagnosticDescriptor MultipleComInterfaceBaseTypes =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidGeneratedComInterfaceAttributeUsage,
                 GetResourceString(nameof(SR.MultipleComInterfaceBaseTypesTitle)),
                 GetResourceString(nameof(SR.MultipleComInterfaceBaseTypesMessage)),
@@ -350,7 +351,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.AnalysisFailedMethodMessage"/>
         public static readonly DiagnosticDescriptor CannotAnalyzeMethodPattern =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.AnalysisFailed,
                 GetResourceString(nameof(SR.AnalysisFailedTitle)),
                 GetResourceString(nameof(SR.AnalysisFailedMethodMessage)),
@@ -361,7 +362,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.AnalysisFailedInterfaceMessage"/>
         public static readonly DiagnosticDescriptor CannotAnalyzeInterfacePattern =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.AnalysisFailed,
                 GetResourceString(nameof(SR.AnalysisFailedTitle)),
                 GetResourceString(nameof(SR.AnalysisFailedInterfaceMessage)),
@@ -372,7 +373,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.BaseInterfaceCannotBeGeneratedMessage"/>
         public static readonly DiagnosticDescriptor BaseInterfaceIsNotGenerated =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.BaseInterfaceFailedGeneration,
                 GetResourceString(nameof(SR.BaseInterfaceCannotBeGeneratedTitle)),
                 GetResourceString(nameof(SR.BaseInterfaceCannotBeGeneratedMessage)),
@@ -383,7 +384,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidGeneratedComClassAttributeUsageMissingPartialModifier"/>
         public static readonly DiagnosticDescriptor InvalidAttributedClassMissingPartialModifier =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidGeneratedComClassAttributeUsage,
                 GetResourceString(nameof(SR.InvalidGeneratedComClassAttributeUsageTitle)),
                 GetResourceString(nameof(SR.InvalidGeneratedComClassAttributeUsageMissingPartialModifier)),
@@ -394,7 +395,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InterfaceTypeNotSupportedMessage"/>
         public static readonly DiagnosticDescriptor InterfaceTypeNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidGeneratedComInterfaceAttributeUsage,
                 GetResourceString(nameof(SR.InterfaceTypeNotSupportedTitle)),
                 GetResourceString(nameof(SR.InterfaceTypeNotSupportedMessage)),
@@ -405,7 +406,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.ClassDoesNotImplementAnyGeneratedComInterfacesMessage"/>
         public static readonly DiagnosticDescriptor ClassDoesNotImplementAnyGeneratedComInterface =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidGeneratedComClassAttributeUsage,
                 GetResourceString(nameof(SR.InvalidGeneratedComClassAttributeUsageTitle)),
                 GetResourceString(nameof(SR.ClassDoesNotImplementAnyGeneratedComInterfacesMessage)),
@@ -416,7 +417,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.UnnecessaryParameterMarshallingInfoMessage"/>
         public static readonly DiagnosticDescriptor UnnecessaryParameterMarshallingInfo =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.UnnecessaryMarshallingInfo,
                 GetResourceString(nameof(SR.UnnecessaryMarshallingInfoTitle)),
                 GetResourceString(nameof(SR.UnnecessaryParameterMarshallingInfoMessage)),
@@ -431,7 +432,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.UnnecessaryReturnMarshallingInfoMessage"/>
         public static readonly DiagnosticDescriptor UnnecessaryReturnMarshallingInfo =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.UnnecessaryMarshallingInfo,
                 GetResourceString(nameof(SR.UnnecessaryMarshallingInfoTitle)),
                 GetResourceString(nameof(SR.UnnecessaryReturnMarshallingInfoMessage)),
@@ -446,7 +447,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.SizeOfCollectionMustBeKnownAtMarshalTimeMessageOutParam"/>
         public static readonly DiagnosticDescriptor SizeOfInCollectionMustBeDefinedAtCallOutParam =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidGeneratedComInterfaceAttributeUsage,
                 GetResourceString(nameof(SR.SizeOfCollectionMustBeKnownAtMarshalTimeTitle)),
                 GetResourceString(nameof(SR.SizeOfCollectionMustBeKnownAtMarshalTimeMessageOutParam)),
@@ -456,7 +457,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.SizeOfCollectionMustBeKnownAtMarshalTimeMessageReturnValue"/>
         public static readonly DiagnosticDescriptor SizeOfInCollectionMustBeDefinedAtCallReturnValue =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidGeneratedComInterfaceAttributeUsage,
                 GetResourceString(nameof(SR.SizeOfCollectionMustBeKnownAtMarshalTimeTitle)),
                 GetResourceString(nameof(SR.SizeOfCollectionMustBeKnownAtMarshalTimeMessageReturnValue)),
@@ -466,7 +467,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.ComMethodReturningIntWillBeOutParameterMessage"/>
         public static readonly DiagnosticDescriptor ComMethodManagedReturnWillBeOutVariable =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.NotRecommendedGeneratedComInterfaceUsage,
                 GetResourceString(nameof(SR.ComMethodReturningIntWillBeOutParameterTitle)),
                 GetResourceString(nameof(SR.ComMethodReturningIntWillBeOutParameterMessage)),

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Interop.Analyzers
         private const string Category = "Interoperability";
 
         public static readonly DiagnosticDescriptor ConvertToLibraryImport =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConvertToLibraryImport,
                 GetResourceString(nameof(SR.ConvertToLibraryImportTitle)),
                 GetResourceString(nameof(SR.ConvertToLibraryImportMessage)),

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomMarshallerAttributeAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/CustomMarshallerAttributeAnalyzer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.MarshallerTypeMustSpecifyManagedTypeMessage" />
         public static readonly DiagnosticDescriptor MarshallerTypeMustSpecifyManagedTypeRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidCustomMarshallerAttributeUsage,
                 GetResourceString(nameof(SR.InvalidCustomMarshallerAttributeUsageTitle)),
                 GetResourceString(nameof(SR.MarshallerTypeMustSpecifyManagedTypeMessage)),
@@ -52,7 +52,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.MarshallerTypeMustBeStaticClassOrStructMessage" />
         public static readonly DiagnosticDescriptor MarshallerTypeMustBeStaticClassOrStructRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidMarshallerType,
                 GetResourceString(nameof(SR.InvalidMarshallerTypeTitle)),
                 GetResourceString(nameof(SR.MarshallerTypeMustBeStaticClassOrStructMessage)),
@@ -63,7 +63,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.ElementMarshallerCannotBeStatefulMessage" />
         public static readonly DiagnosticDescriptor ElementMarshallerCannotBeStatefulRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidMarshallerType,
                 GetResourceString(nameof(SR.InvalidMarshallerTypeTitle)),
                 GetResourceString(nameof(SR.ElementMarshallerCannotBeStatefulMessage)),
@@ -74,7 +74,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.TypeMustBeUnmanagedMessage" />
         public static readonly DiagnosticDescriptor UnmanagedTypeMustBeUnmanagedRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidNativeType,
                 GetResourceString(nameof(SR.InvalidMarshallerTypeTitle)),
                 GetResourceString(nameof(SR.TypeMustBeUnmanagedMessage)),
@@ -85,7 +85,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.GetPinnableReferenceReturnTypeBlittableMessage" />
         public static readonly DiagnosticDescriptor GetPinnableReferenceReturnTypeBlittableRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidSignaturesInMarshallerShape,
                 GetResourceString(nameof(SR.InvalidSignaturesInMarshallerShapeTitle)),
                 GetResourceString(nameof(SR.GetPinnableReferenceReturnTypeBlittableMessage)),
@@ -96,7 +96,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.TypeMustHaveExplicitCastFromVoidPointerMessage" />
         public static readonly DiagnosticDescriptor TypeMustHaveExplicitCastFromVoidPointerRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidNativeType,
                 GetResourceString(nameof(SR.InvalidMarshallerTypeTitle)),
                 GetResourceString(nameof(SR.TypeMustHaveExplicitCastFromVoidPointerMessage)),
@@ -107,7 +107,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.StatelessValueInRequiresConvertToUnmanagedMessage" />
         public static readonly DiagnosticDescriptor StatelessValueInRequiresConvertToUnmanagedRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.StatelessValueInRequiresConvertToUnmanagedMessage)),
@@ -118,7 +118,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.StatelessLinearCollectionRequiresTwoParameterAllocateContainerForUnmanagedElementsMessage" />
         public static readonly DiagnosticDescriptor StatelessLinearCollectionRequiresTwoParameterAllocateContainerForUnmanagedElementsRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.StatelessLinearCollectionRequiresTwoParameterAllocateContainerForUnmanagedElementsMessage)),
@@ -129,7 +129,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.OutRequiresToManagedMessage" />
         public static readonly DiagnosticDescriptor OutRequiresToManagedRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.OutRequiresToManagedMessage)),
@@ -140,7 +140,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.StatelessRequiresConvertToManagedMessage" />
         public static readonly DiagnosticDescriptor StatelessRequiresConvertToManagedRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.StatelessRequiresConvertToManagedMessage)),
@@ -151,7 +151,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.LinearCollectionInRequiresCollectionMethodsMessage" />
         public static readonly DiagnosticDescriptor LinearCollectionInRequiresCollectionMethodsRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.LinearCollectionInRequiresCollectionMethodsMessage)),
@@ -162,7 +162,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.StatelessLinearCollectionInRequiresCollectionMethodsMessage" />
         public static readonly DiagnosticDescriptor StatelessLinearCollectionInRequiresCollectionMethodsRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.StatelessLinearCollectionInRequiresCollectionMethodsMessage)),
@@ -173,7 +173,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.LinearCollectionOutRequiresCollectionMethodsMessage" />
         public static readonly DiagnosticDescriptor LinearCollectionOutRequiresCollectionMethodsRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.LinearCollectionOutRequiresCollectionMethodsMessage)),
@@ -184,7 +184,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.StatelessLinearCollectionOutRequiresCollectionMethodsMessage" />
         public static readonly DiagnosticDescriptor StatelessLinearCollectionOutRequiresCollectionMethodsRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.StatelessLinearCollectionOutRequiresCollectionMethodsMessage)),
@@ -195,7 +195,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.StatelessLinearCollectionRequiresTwoParameterAllocateContainerForManagedElementsMessage" />
         public static readonly DiagnosticDescriptor StatelessLinearCollectionRequiresTwoParameterAllocateContainerForManagedElementsRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.StatelessLinearCollectionRequiresTwoParameterAllocateContainerForManagedElementsMessage)),
@@ -206,7 +206,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.CallerAllocFromManagedMustHaveBufferSizeMessage" />
         public static readonly DiagnosticDescriptor CallerAllocFromManagedMustHaveBufferSizeRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.CallerAllocFromManagedMustHaveBufferSizeMessage)),
@@ -217,7 +217,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.StatelessLinearCollectionCallerAllocFromManagedMustHaveBufferSizeMessage" />
         public static readonly DiagnosticDescriptor StatelessLinearCollectionCallerAllocFromManagedMustHaveBufferSizeRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.StatelessLinearCollectionCallerAllocFromManagedMustHaveBufferSizeMessage)),
@@ -228,7 +228,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.StatefulMarshallerRequiresFromManagedMessage" />
         public static readonly DiagnosticDescriptor StatefulMarshallerRequiresFromManagedRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.StatefulMarshallerRequiresFromManagedMessage)),
@@ -239,7 +239,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.StatefulMarshallerRequiresToUnmanagedMessage" />
         public static readonly DiagnosticDescriptor StatefulMarshallerRequiresToUnmanagedRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.StatefulMarshallerRequiresToUnmanagedMessage)),
@@ -250,7 +250,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.StatefulMarshallerRequiresToManagedMessage" />
         public static readonly DiagnosticDescriptor StatefulMarshallerRequiresToManagedRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.StatefulMarshallerRequiresToManagedMessage)),
@@ -261,7 +261,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.StatefulMarshallerRequiresFromUnmanagedMessage" />
         public static readonly DiagnosticDescriptor StatefulMarshallerRequiresFromUnmanagedRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.StatefulMarshallerRequiresFromUnmanagedMessage)),
@@ -272,7 +272,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.StatefulMarshallerRequiresFreeMessage" />
         public static readonly DiagnosticDescriptor StatefulMarshallerRequiresFreeRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.StatefulMarshallerRequiresFreeMessage)),
@@ -283,7 +283,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.FromUnmanagedOverloadsNotSupportedMessage" />
         public static readonly DiagnosticDescriptor FromUnmanagedOverloadsNotSupportedRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CustomMarshallerTypeMustHaveRequiredShape,
                 GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                 GetResourceString(nameof(SR.FromUnmanagedOverloadsNotSupportedMessage)),
@@ -294,7 +294,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.MarshallerTypeMustBeClosedOrMatchArityMessage" />
         public static readonly DiagnosticDescriptor MarshallerTypeMustBeClosedOrMatchArityRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidCustomMarshallerAttributeUsage,
                 GetResourceString(nameof(SR.InvalidMarshallerTypeTitle)),
                 GetResourceString(nameof(SR.MarshallerTypeMustBeClosedOrMatchArityMessage)),
@@ -305,7 +305,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.MarshallerTypeMustBeNonNullMessage" />
         public static readonly DiagnosticDescriptor MarshallerTypeMustBeNonNullRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidCustomMarshallerAttributeUsage,
                 GetResourceString(nameof(SR.InvalidMarshallerTypeTitle)),
                 GetResourceString(nameof(SR.MarshallerTypeMustBeNonNullMessage)),
@@ -316,7 +316,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.FirstParameterMustMatchReturnTypeMessage" />
         public static readonly DiagnosticDescriptor FirstParameterMustMatchReturnTypeRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidSignaturesInMarshallerShape,
                 GetResourceString(nameof(SR.InvalidSignaturesInMarshallerShapeTitle)),
                 GetResourceString(nameof(SR.FirstParameterMustMatchReturnTypeMessage)),
@@ -327,7 +327,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.ReturnTypesMustMatchMessage" />
         public static readonly DiagnosticDescriptor ReturnTypesMustMatchRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidSignaturesInMarshallerShape,
                 GetResourceString(nameof(SR.InvalidSignaturesInMarshallerShapeTitle)),
                 GetResourceString(nameof(SR.ReturnTypesMustMatchMessage)),
@@ -338,7 +338,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.FirstParametersMustMatchMessage" />
         public static readonly DiagnosticDescriptor FirstParametersMustMatchRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidSignaturesInMarshallerShape,
                 GetResourceString(nameof(SR.InvalidSignaturesInMarshallerShapeTitle)),
                 GetResourceString(nameof(SR.FirstParametersMustMatchMessage)),
@@ -349,7 +349,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.ElementTypesOfReturnTypesMustMatchMessage" />
         public static readonly DiagnosticDescriptor ElementTypesOfReturnTypesMustMatchRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidSignaturesInMarshallerShape,
                 GetResourceString(nameof(SR.InvalidSignaturesInMarshallerShapeTitle)),
                 GetResourceString(nameof(SR.ElementTypesOfReturnTypesMustMatchMessage)),
@@ -360,7 +360,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.ReturnTypeMustBeExpectedTypeMessage" />
         public static readonly DiagnosticDescriptor ReturnTypeMustBeExpectedTypeRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidSignaturesInMarshallerShape,
                 GetResourceString(nameof(SR.InvalidSignaturesInMarshallerShapeTitle)),
                 GetResourceString(nameof(SR.ReturnTypeMustBeExpectedTypeMessage)),
@@ -371,7 +371,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.ManagedTypeMustBeClosedOrMatchArityMessage" />
         public static readonly DiagnosticDescriptor ManagedTypeMustBeClosedOrMatchArityRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidCustomMarshallerAttributeUsage,
                 GetResourceString(nameof(SR.InvalidManagedTypeTitle)),
                 GetResourceString(nameof(SR.ManagedTypeMustBeClosedOrMatchArityMessage)),
@@ -382,7 +382,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.ManagedTypeMustBeNonNullMessage" />
         public static readonly DiagnosticDescriptor ManagedTypeMustBeNonNullRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidCustomMarshallerAttributeUsage,
                 GetResourceString(nameof(SR.InvalidManagedTypeTitle)),
                 GetResourceString(nameof(SR.ManagedTypeMustBeNonNullMessage)),
@@ -393,7 +393,7 @@ namespace Microsoft.Interop.Analyzers
 
         /// <inheritdoc cref="SR.MarshalModeMustBeValidEnumValue" />
         public static readonly DiagnosticDescriptor MarshalModeMustBeValidValue =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidCustomMarshallerAttributeUsage,
                 GetResourceString(nameof(SR.InvalidMarshalModeTitle)),
                 GetResourceString(nameof(SR.MarshalModeMustBeValidEnumValue)),
@@ -411,7 +411,7 @@ namespace Microsoft.Interop.Analyzers
         {
             /// <inheritdoc cref="CustomMarshallerAttributeAnalyzer.StatelessValueInRequiresConvertToUnmanagedRule" />
             private static readonly DiagnosticDescriptor StatelessValueInRequiresConvertToUnmanagedRule =
-                new DiagnosticDescriptor(
+                DiagnosticDescriptorHelper.Create(
                     Ids.CustomMarshallerTypeMustHaveRequiredShape,
                     GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                     GetResourceString(nameof(SR.StatelessValueInRequiresConvertToUnmanagedMessage)),
@@ -422,7 +422,7 @@ namespace Microsoft.Interop.Analyzers
 
             /// <inheritdoc cref="CustomMarshallerAttributeAnalyzer.StatelessLinearCollectionRequiresTwoParameterAllocateContainerForUnmanagedElementsRule" />
             private static readonly DiagnosticDescriptor StatelessLinearCollectionRequiresTwoParameterAllocateContainerForUnmanagedElementsRule =
-                new DiagnosticDescriptor(
+                DiagnosticDescriptorHelper.Create(
                     Ids.CustomMarshallerTypeMustHaveRequiredShape,
                     GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                     GetResourceString(nameof(SR.StatelessLinearCollectionRequiresTwoParameterAllocateContainerForUnmanagedElementsMessage)),
@@ -433,7 +433,7 @@ namespace Microsoft.Interop.Analyzers
 
             /// <inheritdoc cref="CustomMarshallerAttributeAnalyzer.StatelessRequiresConvertToManagedRule" />
             private static readonly DiagnosticDescriptor StatelessRequiresConvertToManagedRule =
-                new DiagnosticDescriptor(
+                DiagnosticDescriptorHelper.Create(
                     Ids.CustomMarshallerTypeMustHaveRequiredShape,
                     GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                     GetResourceString(nameof(SR.StatelessRequiresConvertToManagedMessage)),
@@ -444,7 +444,7 @@ namespace Microsoft.Interop.Analyzers
 
             /// <inheritdoc cref="CustomMarshallerAttributeAnalyzer.StatelessLinearCollectionInRequiresCollectionMethodsRule" />
             private static readonly DiagnosticDescriptor StatelessLinearCollectionInRequiresCollectionMethodsRule =
-                new DiagnosticDescriptor(
+                DiagnosticDescriptorHelper.Create(
                     Ids.CustomMarshallerTypeMustHaveRequiredShape,
                     GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                     GetResourceString(nameof(SR.StatelessLinearCollectionInRequiresCollectionMethodsMessage)),
@@ -455,7 +455,7 @@ namespace Microsoft.Interop.Analyzers
 
             /// <inheritdoc cref="CustomMarshallerAttributeAnalyzer.StatelessLinearCollectionOutRequiresCollectionMethodsMessage" />
             private static readonly DiagnosticDescriptor StatelessLinearCollectionOutRequiresCollectionMethodsRule =
-                new DiagnosticDescriptor(
+                DiagnosticDescriptorHelper.Create(
                     Ids.CustomMarshallerTypeMustHaveRequiredShape,
                     GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                     GetResourceString(nameof(SR.StatelessLinearCollectionOutRequiresCollectionMethodsMessage)),
@@ -466,7 +466,7 @@ namespace Microsoft.Interop.Analyzers
 
             /// <inheritdoc cref="CustomMarshallerAttributeAnalyzer.StatelessLinearCollectionRequiresTwoParameterAllocateContainerForManagedElementsMessage" />
             private static readonly DiagnosticDescriptor StatelessLinearCollectionRequiresTwoParameterAllocateContainerForManagedElementsRule =
-                new DiagnosticDescriptor(
+                DiagnosticDescriptorHelper.Create(
                     Ids.CustomMarshallerTypeMustHaveRequiredShape,
                     GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                     GetResourceString(nameof(SR.StatelessLinearCollectionRequiresTwoParameterAllocateContainerForManagedElementsMessage)),
@@ -477,7 +477,7 @@ namespace Microsoft.Interop.Analyzers
 
             /// <inheritdoc cref="CustomMarshallerAttributeAnalyzer.StatefulMarshallerRequiresFromManagedRule" />
             private static readonly DiagnosticDescriptor StatefulMarshallerRequiresFromManagedRule =
-                new DiagnosticDescriptor(
+                DiagnosticDescriptorHelper.Create(
                     Ids.CustomMarshallerTypeMustHaveRequiredShape,
                     GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                     GetResourceString(nameof(SR.StatefulMarshallerRequiresFromManagedMessage)),
@@ -488,7 +488,7 @@ namespace Microsoft.Interop.Analyzers
 
             /// <inheritdoc cref="CustomMarshallerAttributeAnalyzer.StatefulMarshallerRequiresToUnmanagedRule" />
             private static readonly DiagnosticDescriptor StatefulMarshallerRequiresToUnmanagedRule =
-                new DiagnosticDescriptor(
+                DiagnosticDescriptorHelper.Create(
                     Ids.CustomMarshallerTypeMustHaveRequiredShape,
                     GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                     GetResourceString(nameof(SR.StatefulMarshallerRequiresToUnmanagedMessage)),
@@ -499,7 +499,7 @@ namespace Microsoft.Interop.Analyzers
 
             /// <inheritdoc cref="CustomMarshallerAttributeAnalyzer.StatefulMarshallerRequiresToManagedRule" />
             private static readonly DiagnosticDescriptor StatefulMarshallerRequiresToManagedRule =
-                new DiagnosticDescriptor(
+                DiagnosticDescriptorHelper.Create(
                     Ids.CustomMarshallerTypeMustHaveRequiredShape,
                     GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                     GetResourceString(nameof(SR.StatefulMarshallerRequiresToManagedMessage)),
@@ -510,7 +510,7 @@ namespace Microsoft.Interop.Analyzers
 
             /// <inheritdoc cref="CustomMarshallerAttributeAnalyzer.StatefulMarshallerRequiresFromUnmanagedRule" />
             private static readonly DiagnosticDescriptor StatefulMarshallerRequiresFromUnmanagedRule =
-                new DiagnosticDescriptor(
+                DiagnosticDescriptorHelper.Create(
                     Ids.CustomMarshallerTypeMustHaveRequiredShape,
                     GetResourceString(nameof(SR.CustomMarshallerTypeMustHaveRequiredShapeTitle)),
                     GetResourceString(nameof(SR.StatefulMarshallerRequiresFromUnmanagedMessage)),

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/NativeMarshallingAttributeAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/NativeMarshallingAttributeAnalyzer.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
 using static Microsoft.Interop.Analyzers.AnalyzerDiagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -21,7 +22,7 @@ namespace Microsoft.Interop.Analyzers
         private const string Category = "Usage";
 
         public static readonly DiagnosticDescriptor MarshallerEntryPointTypeMustHaveCustomMarshallerAttributeWithMatchingManagedTypeRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidNativeMarshallingAttributeUsage,
                 GetResourceString(nameof(SR.InvalidNativeMarshallingAttributeUsageTitle)),
                 GetResourceString(nameof(SR.EntryPointTypeMustHaveCustomMarshallerAttributeWithMatchingManagedTypeMessage)),
@@ -31,7 +32,7 @@ namespace Microsoft.Interop.Analyzers
                 description: GetResourceString(nameof(SR.EntryPointTypeMustHaveCustomMarshallerAttributeWithMatchingManagedTypeDescription)));
 
         public static readonly DiagnosticDescriptor MarshallerEntryPointTypeMustBeNonNullRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidNativeMarshallingAttributeUsage,
                 GetResourceString(nameof(SR.InvalidNativeMarshallingAttributeUsageTitle)),
                 GetResourceString(nameof(SR.EntryPointTypeMustBeNonNullMessage)),
@@ -41,7 +42,7 @@ namespace Microsoft.Interop.Analyzers
                 description: GetResourceString(nameof(SR.EntryPointTypeMustBeNonNullDescription)));
 
         public static readonly DiagnosticDescriptor GenericEntryPointMarshallerTypeMustBeClosedOrMatchArityRule =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidNativeMarshallingAttributeUsage,
                 GetResourceString(nameof(SR.InvalidNativeMarshallingAttributeUsageTitle)),
                 GetResourceString(nameof(SR.GenericEntryPointMarshallerTypeMustBeClosedOrMatchArityMessage)),

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/GeneratorDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/GeneratorDiagnostics.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
 
 namespace Microsoft.Interop
 {
@@ -29,7 +30,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidAttributedMethodSignatureMessageLibraryImport"/>
         public static readonly DiagnosticDescriptor InvalidAttributedMethodSignature =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidLibraryImportAttributeUsage,
             GetResourceString(nameof(SR.InvalidLibraryImportAttributeUsageTitle)),
             GetResourceString(nameof(SR.InvalidAttributedMethodSignatureMessageLibraryImport)),
@@ -40,7 +41,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidAttributedMethodContainingTypeMissingModifiersMessageLibraryImport"/>
         public static readonly DiagnosticDescriptor InvalidAttributedMethodContainingTypeMissingModifiers =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidLibraryImportAttributeUsage,
             GetResourceString(nameof(SR.InvalidLibraryImportAttributeUsageTitle)),
             GetResourceString(nameof(SR.InvalidAttributedMethodContainingTypeMissingModifiersMessageLibraryImport)),
@@ -51,7 +52,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.InvalidStringMarshallingConfigurationMessageLibraryImport"/>
         public static readonly DiagnosticDescriptor InvalidStringMarshallingConfiguration =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
             Ids.InvalidLibraryImportAttributeUsage,
             GetResourceString(nameof(SR.InvalidLibraryImportAttributeUsageTitle)),
             GetResourceString(nameof(SR.InvalidStringMarshallingConfigurationMessageLibraryImport)),
@@ -62,7 +63,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.TypeNotSupportedMessageParameterLibraryImport"/>
         public static readonly DiagnosticDescriptor ParameterTypeNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(SR.TypeNotSupportedTitle)),
                 GetResourceString(nameof(SR.TypeNotSupportedMessageParameterLibraryImport)),
@@ -73,7 +74,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.TypeNotSupportedMessageReturnLibraryImport"/>
         public static readonly DiagnosticDescriptor ReturnTypeNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(SR.TypeNotSupportedTitle)),
                 GetResourceString(nameof(SR.TypeNotSupportedMessageReturnLibraryImport)),
@@ -84,7 +85,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.TypeNotSupportedMessageParameterWithDetails"/>
         public static readonly DiagnosticDescriptor ParameterTypeNotSupportedWithDetails =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(SR.TypeNotSupportedTitle)),
                 GetResourceString(nameof(SR.TypeNotSupportedMessageParameterWithDetails)),
@@ -95,7 +96,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.TypeNotSupportedMessageReturnWithDetails"/>
         public static readonly DiagnosticDescriptor ReturnTypeNotSupportedWithDetails =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(SR.TypeNotSupportedTitle)),
                 GetResourceString(nameof(SR.TypeNotSupportedMessageReturnWithDetails)),
@@ -106,7 +107,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.ConfigurationNotSupportedMessageParameterLibraryImport"/>
         public static readonly DiagnosticDescriptor ParameterConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleLibraryImport)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageParameterLibraryImport)),
@@ -117,7 +118,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.ConfigurationNotSupportedMessageReturnLibraryImport"/>
         public static readonly DiagnosticDescriptor ReturnConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleLibraryImport)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageReturnLibraryImport)),
@@ -128,7 +129,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.MarshalAsConfigurationNotSupportedMessageParameterLibraryImport"/>
         public static readonly DiagnosticDescriptor MarshalAsParameterConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 GeneratorDiagnostics.Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleLibraryImport)),
                 GetResourceString(nameof(SR.MarshalAsConfigurationNotSupportedMessageParameterLibraryImport)),
@@ -139,7 +140,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.MarshalAsConfigurationNotSupportedMessageReturnLibraryImport"/>
         public static readonly DiagnosticDescriptor MarshalAsReturnConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 GeneratorDiagnostics.Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleLibraryImport)),
                 GetResourceString(nameof(SR.MarshalAsConfigurationNotSupportedMessageReturnLibraryImport)),
@@ -150,7 +151,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.ConfigurationNotSupportedMessageLibraryImport"/>
         public static readonly DiagnosticDescriptor ConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleLibraryImport)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageLibraryImport)),
@@ -161,7 +162,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.ConfigurationNotSupportedMessageValueLibraryImport"/>
         public static readonly DiagnosticDescriptor ConfigurationValueNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleLibraryImport)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageValueLibraryImport)),
@@ -172,7 +173,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.ConfigurationNotSupportedMessageMarshallingInfoLibraryImport"/>
         public static readonly DiagnosticDescriptor MarshallingAttributeConfigurationNotSupported =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(SR.ConfigurationNotSupportedTitleLibraryImport)),
                 GetResourceString(nameof(SR.ConfigurationNotSupportedMessageMarshallingInfoLibraryImport)),
@@ -183,7 +184,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.CannotForwardToDllImportMessage"/>
         public static readonly DiagnosticDescriptor CannotForwardToDllImport =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.CannotForwardToDllImport,
                 GetResourceString(nameof(SR.CannotForwardToDllImportTitle)),
                 GetResourceString(nameof(SR.CannotForwardToDllImportMessage)),
@@ -194,7 +195,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.RequiresAllowUnsafeBlocksMessageLibraryImport"/>
         public static readonly DiagnosticDescriptor RequiresAllowUnsafeBlocks =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.RequiresAllowUnsafeBlocks,
                 GetResourceString(nameof(SR.RequiresAllowUnsafeBlocksTitleLibraryImport)),
                 GetResourceString(nameof(SR.RequiresAllowUnsafeBlocksMessageLibraryImport)),
@@ -205,7 +206,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.UnnecessaryParameterMarshallingInfoMessage"/>
         public static readonly DiagnosticDescriptor UnnecessaryParameterMarshallingInfo =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.UnnecessaryMarshallingInfo,
                 GetResourceString(nameof(SR.UnnecessaryMarshallingInfoTitle)),
                 GetResourceString(nameof(SR.UnnecessaryParameterMarshallingInfoMessage)),
@@ -220,7 +221,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.UnnecessaryMarshallingInfoDescription"/>
         public static readonly DiagnosticDescriptor UnnecessaryReturnMarshallingInfo =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.UnnecessaryMarshallingInfo,
                 GetResourceString(nameof(SR.UnnecessaryMarshallingInfoTitle)),
                 GetResourceString(nameof(SR.UnnecessaryReturnMarshallingInfoMessage)),
@@ -235,7 +236,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.SizeOfCollectionMustBeKnownAtMarshalTimeMessageOutParam"/>
         public static readonly DiagnosticDescriptor SizeOfInCollectionMustBeDefinedAtCallOutParam =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidLibraryImportAttributeUsage,
                 GetResourceString(nameof(SR.SizeOfCollectionMustBeKnownAtMarshalTimeTitle)),
                 GetResourceString(nameof(SR.SizeOfCollectionMustBeKnownAtMarshalTimeMessageOutParam)),
@@ -245,7 +246,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.SizeOfCollectionMustBeKnownAtMarshalTimeMessageReturnValue"/>
         public static readonly DiagnosticDescriptor SizeOfInCollectionMustBeDefinedAtCallReturnValue =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.InvalidLibraryImportAttributeUsage,
                 GetResourceString(nameof(SR.SizeOfCollectionMustBeKnownAtMarshalTimeTitle)),
                 GetResourceString(nameof(SR.SizeOfCollectionMustBeKnownAtMarshalTimeMessageReturnValue)),

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(CommonPath)Roslyn\DiagnosticDescriptorHelper.cs" Link="Common\Roslyn\DiagnosticDescriptorHelper.cs" />
     <Compile Include="$(CommonPath)Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
     <Compile Include="..\Common\DefaultMarshallingInfoParser.cs" Link="Common\DefaultMarshallingInfoParser.cs" />
     <Compile Include="..\Common\OperationExtensions.cs" Link="Common\OperationExtensions.cs" />

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.DiagnosticDescriptors.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.DiagnosticDescriptors.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
 
 namespace System.Text.Json.SourceGeneration
 {
@@ -11,7 +12,7 @@ namespace System.Text.Json.SourceGeneration
         {
             // Must be kept in sync with https://github.com/dotnet/runtime/blob/main/docs/project/list-of-diagnostics.md
 
-            public static DiagnosticDescriptor TypeNotSupported { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor TypeNotSupported { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1030",
                 title: new LocalizableResourceString(nameof(SR.TypeNotSupportedTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.TypeNotSupportedMessageFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -19,7 +20,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor DuplicateTypeName { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor DuplicateTypeName { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1031",
                 title: new LocalizableResourceString(nameof(SR.DuplicateTypeNameTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.DuplicateTypeNameMessageFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -27,7 +28,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor ContextClassesMustBePartial { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor ContextClassesMustBePartial { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1032",
                 title: new LocalizableResourceString(nameof(SR.ContextClassesMustBePartialTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.ContextClassesMustBePartialMessageFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -35,7 +36,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor MultipleJsonConstructorAttribute { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor MultipleJsonConstructorAttribute { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1033",
                 title: new LocalizableResourceString(nameof(SR.MultipleJsonConstructorAttributeTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.MultipleJsonConstructorAttributeFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -43,7 +44,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Error,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor JsonStringEnumConverterNotSupportedInAot { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor JsonStringEnumConverterNotSupportedInAot { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1034",
                 title: new LocalizableResourceString(nameof(SR.JsonStringEnumConverterNotSupportedTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.JsonStringEnumConverterNotSupportedMessageFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -51,7 +52,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor MultipleJsonExtensionDataAttribute { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor MultipleJsonExtensionDataAttribute { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1035",
                 title: new LocalizableResourceString(nameof(SR.MultipleJsonExtensionDataAttributeTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.MultipleJsonExtensionDataAttributeFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -59,7 +60,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Error,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor DataExtensionPropertyInvalid { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor DataExtensionPropertyInvalid { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1036",
                 title: new LocalizableResourceString(nameof(SR.DataExtensionPropertyInvalidTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.DataExtensionPropertyInvalidFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -67,7 +68,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Error,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor InaccessibleJsonIncludePropertiesNotSupported { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor InaccessibleJsonIncludePropertiesNotSupported { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1038",
                 title: new LocalizableResourceString(nameof(SR.InaccessibleJsonIncludePropertiesNotSupportedTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.InaccessibleJsonIncludePropertiesNotSupportedFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -75,7 +76,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor PolymorphismNotSupported { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor PolymorphismNotSupported { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1039",
                 title: new LocalizableResourceString(nameof(SR.FastPathPolymorphismNotSupportedTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.FastPathPolymorphismNotSupportedMessageFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -83,7 +84,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor JsonConverterAttributeInvalidType { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor JsonConverterAttributeInvalidType { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1220",
                 title: new LocalizableResourceString(nameof(SR.JsonConverterAttributeInvalidTypeTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.JsonConverterAttributeInvalidTypeMessageFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -91,7 +92,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor JsonUnsupportedLanguageVersion { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor JsonUnsupportedLanguageVersion { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1221",
                 title: new LocalizableResourceString(nameof(SR.JsonUnsupportedLanguageVersionTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.JsonUnsupportedLanguageVersionMessageFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -99,7 +100,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Error,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor JsonConstructorInaccessible { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor JsonConstructorInaccessible { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1222",
                 title: new LocalizableResourceString(nameof(SR.JsonConstructorInaccessibleTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.JsonConstructorInaccessibleMessageFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -107,7 +108,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor DerivedJsonConverterAttributesNotSupported { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor DerivedJsonConverterAttributesNotSupported { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1223",
                 title: new LocalizableResourceString(nameof(SR.DerivedJsonConverterAttributesNotSupportedTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.DerivedJsonConverterAttributesNotSupportedMessageFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
@@ -115,7 +116,7 @@ namespace System.Text.Json.SourceGeneration
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
 
-            public static DiagnosticDescriptor JsonSerializableAttributeOnNonContextType { get; } = new DiagnosticDescriptor(
+            public static DiagnosticDescriptor JsonSerializableAttributeOnNonContextType { get; } = DiagnosticDescriptorHelper.Create(
                 id: "SYSLIB1224",
                 title: new LocalizableResourceString(nameof(SR.JsonSerializableAttributeOnNonContextTypeTitle), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),
                 messageFormat: new LocalizableResourceString(nameof(SR.JsonSerializableAttributeOnNonContextTypeMessageFormat), SR.ResourceManager, typeof(FxResources.System.Text.Json.SourceGeneration.SR)),

--- a/src/libraries/System.Text.Json/gen/System.Text.Json.SourceGeneration.targets
+++ b/src/libraries/System.Text.Json/gen/System.Text.Json.SourceGeneration.targets
@@ -28,6 +28,7 @@
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\CompilerFeatureRequiredAttribute.cs" Link="Common\System\Runtime\CompilerServices\CompilerFeatureRequiredAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\RequiredMemberAttribute.cs" Link="Common\System\Runtime\CompilerServices\RequiredMemberAttribute.cs" />
+    <Compile Include="$(CommonPath)\Roslyn\DiagnosticDescriptorHelper.cs" Link="Common\Roslyn\DiagnosticDescriptorHelper.cs" />
     <Compile Include="$(CommonPath)\Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
     <Compile Include="$(CommonPath)\SourceGenerators\SourceWriter.cs" Link="Common\SourceGenerators\SourceWriter.cs" />
     <Compile Include="..\Common\JsonCamelCaseNamingPolicy.cs" Link="Common\System\Text\Json\JsonCamelCaseNamingPolicy.cs" />

--- a/src/libraries/System.Text.RegularExpressions/gen/DiagnosticDescriptors.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/DiagnosticDescriptors.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
 
 namespace System.Text.RegularExpressions.Generator
 {
@@ -10,7 +11,7 @@ namespace System.Text.RegularExpressions.Generator
     {
         private const string Category = "Performance";
 
-        public static DiagnosticDescriptor InvalidGeneratedRegexAttribute { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor InvalidGeneratedRegexAttribute { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1040",
             title: new LocalizableResourceString(nameof(SR.InvalidGeneratedRegexAttributeTitle), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.InvalidGeneratedRegexAttributeMessage), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
@@ -19,7 +20,7 @@ namespace System.Text.RegularExpressions.Generator
             isEnabledByDefault: true,
             customTags: WellKnownDiagnosticTags.NotConfigurable);
 
-        public static DiagnosticDescriptor MultipleGeneratedRegexAttributes { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor MultipleGeneratedRegexAttributes { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1041",
             title: new LocalizableResourceString(nameof(SR.InvalidGeneratedRegexAttributeTitle), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.MultipleGeneratedRegexAttributesMessage), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
@@ -28,7 +29,7 @@ namespace System.Text.RegularExpressions.Generator
             isEnabledByDefault: true,
             customTags: WellKnownDiagnosticTags.NotConfigurable);
 
-        public static DiagnosticDescriptor InvalidRegexArguments { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor InvalidRegexArguments { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1042",
             title: new LocalizableResourceString(nameof(SR.InvalidGeneratedRegexAttributeTitle), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.InvalidRegexArgumentsMessage), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
@@ -37,7 +38,7 @@ namespace System.Text.RegularExpressions.Generator
             isEnabledByDefault: true,
             customTags: WellKnownDiagnosticTags.NotConfigurable);
 
-        public static DiagnosticDescriptor RegexMethodMustHaveValidSignature { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor RegexMethodMustHaveValidSignature { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1043",
             title: new LocalizableResourceString(nameof(SR.InvalidGeneratedRegexAttributeTitle), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.RegexMethodMustHaveValidSignatureMessage), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
@@ -46,7 +47,7 @@ namespace System.Text.RegularExpressions.Generator
             isEnabledByDefault: true,
             customTags: WellKnownDiagnosticTags.NotConfigurable);
 
-        public static DiagnosticDescriptor LimitedSourceGeneration { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor LimitedSourceGeneration { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1044",
             title: new LocalizableResourceString(nameof(SR.LimitedSourceGenerationTitle), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.LimitedSourceGenerationMessage), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
@@ -54,7 +55,7 @@ namespace System.Text.RegularExpressions.Generator
             DiagnosticSeverity.Info,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor UseRegexSourceGeneration { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor UseRegexSourceGeneration { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1045",
             title: new LocalizableResourceString(nameof(SR.UseRegexSourceGeneratorTitle), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.UseRegexSourceGeneratorMessage), SR.ResourceManager, typeof(FxResources.System.Text.RegularExpressions.Generator.SR)),

--- a/src/libraries/System.Text.RegularExpressions/gen/System.Text.RegularExpressions.Generator.csproj
+++ b/src/libraries/System.Text.RegularExpressions/gen/System.Text.RegularExpressions.Generator.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <!-- Common generator support -->
+    <Compile Include="$(CommonPath)Roslyn\DiagnosticDescriptorHelper.cs" Link="Common\Roslyn\DiagnosticDescriptorHelper.cs" />
     <Compile Include="$(CommonPath)Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
 

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DiagnosticDescriptors.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DiagnosticDescriptors.cs
@@ -16,7 +16,8 @@ namespace ILLink.RoslynAnalyzer
 				diagnosticString.GetMessageFormat (),
 				diagnosticId.GetDiagnosticCategory (),
 				DiagnosticSeverity.Warning,
-				true);
+				true,
+				diagnosticId.GetHelpUri());
 		}
 
 		public static DiagnosticDescriptor GetDiagnosticDescriptor (DiagnosticId diagnosticId, DiagnosticString diagnosticString)
@@ -25,7 +26,8 @@ namespace ILLink.RoslynAnalyzer
 				diagnosticString.GetMessage (),
 				diagnosticId.GetDiagnosticCategory (),
 				DiagnosticSeverity.Warning,
-				true);
+				true,
+				diagnosticId.GetHelpUri());
 
 		public static DiagnosticDescriptor GetDiagnosticDescriptor (DiagnosticId diagnosticId,
 			LocalizableResourceString? lrsTitle = null,
@@ -35,6 +37,8 @@ namespace ILLink.RoslynAnalyzer
 			bool isEnabledByDefault = true,
 			string? helpLinkUri = null)
 		{
+			helpLinkUri ??= diagnosticId.GetHelpUri();
+
 			if (lrsTitle == null || lrsMessage == null) {
 				var diagnosticString = new DiagnosticString (diagnosticId);
 				return new DiagnosticDescriptor (diagnosticId.AsString (),

--- a/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
@@ -235,5 +235,8 @@ namespace ILLink.Shared
 				>= 3050 and <= 6000 => DiagnosticCategory.AOT,
 				_ => throw new ArgumentException ($"The provided diagnostic id '{diagnosticId}' does not fall into the range of supported warning codes 2001 to 6000 (inclusive).")
 			};
+
+		public static string GetHelpUri(this DiagnosticId diagnosticId) =>
+			$"https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il{(int) diagnosticId}";
 	}
 }

--- a/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
@@ -236,7 +236,12 @@ namespace ILLink.Shared
 				_ => throw new ArgumentException ($"The provided diagnostic id '{diagnosticId}' does not fall into the range of supported warning codes 2001 to 6000 (inclusive).")
 			};
 
-		public static string GetHelpUri(this DiagnosticId diagnosticId) =>
-			$"https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il{(int) diagnosticId}";
+		public static string? GetHelpUri(this DiagnosticId diagnosticId) =>
+			diagnosticId.GetDiagnosticCategory() switch {
+				DiagnosticCategory.Trimming => $"https://learn.microsoft.com/dotnet/core/deploying/trimming/trim-warnings/il{(int) diagnosticId}",
+				DiagnosticCategory.SingleFile => $"https://learn.microsoft.com/dotnet/core/deploying/single-file/warnings/il{(int) diagnosticId}",
+				DiagnosticCategory.AOT =>$"https://learn.microsoft.com/dotnet/core/deploying/native-aot/warnings/il{(int) diagnosticId}",
+				_ => null
+			};
 	}
 }


### PR DESCRIPTION
Fixes #85181 

Create a helper method that formats and sets the helpLink for DiagnosticDescriptors

See https://github.com/search?q=repo%3Adotnet%2Fruntime+%28%22new+DiagnosticDescriptor%28%22+OR+%22new+DiagnosticDescriptor+%28%22%29&type=code

Absent are those from https://github.com/dotnet/runtime/blob/79b970739df6ff8d75ff7f4f262a8b2785c20940/src/tools/illink/src/ILLink.RoslynAnalyzer/DiagnosticDescriptors.cs#L14

I wasn't sure if those are published at the same URL.  Maybe those are all here: https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2001 ?  If so - perhaps we can just modify that existing helper class.   Thoughts @mateoatr @vitek-karas?