### PR TITLE
Make Analyzer crashes a warning

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1,7 +1,7 @@
 is_global = true
 
 # AD0001: Analyzer threw an exception
-dotnet_diagnostic.AD0001.severity = suggestion
+dotnet_diagnostic.AD0001.severity = warning
 
 # BCL0001: Ensure minimum API surface is respected
 dotnet_diagnostic.BCL0001.severity = warning

--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -46,7 +46,8 @@
     <!-- Override InformationalVersion during servicing as it's returned via public api. -->
     <InformationalVersion Condition="'$(PreReleaseVersionLabel)' == 'servicing'">$(ProductVersion)</InformationalVersion>
     <InformationalVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(ProductVersion)</InformationalVersion>
-    <NoWarn>$(NoWarn),0419,0649,CA2249,CA1830</NoWarn>
+    <!-- AD0001 : https://github.com/dotnet/runtime/issues/90356 -->
+    <NoWarn>$(NoWarn),0419,0649,CA2249,CA1830;AD0001</NoWarn>
     <Nullable>enable</Nullable>
 
     <!-- Ignore all previous constants since SPCL is sensitive to what is defined and the Sdk adds some by default -->

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <!-- AD0001 : https://github.com/dotnet/runtime/issues/90356 -->
+    <NoWarn>$(NoWarn);AD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- AD0001 : https://github.com/dotnet/runtime/issues/90357 -->
+    <NoWarn>$(NoWarn);AD0001</NoWarn>
     <IsPackable>true</IsPackable>
     <PackageDescription>Logging abstractions for Microsoft.Extensions.Logging.
 

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -33,7 +33,8 @@
     <!-- Override InformationalVersion during servicing as it's returned via public api. -->
     <InformationalVersion Condition="'$(PreReleaseVersionLabel)' == 'servicing'">$(ProductVersion)</InformationalVersion>
     <InformationalVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(ProductVersion)</InformationalVersion>
-    <NoWarn>$(NoWarn),0419,0649</NoWarn>
+    <!-- AD0001 : https://github.com/dotnet/runtime/issues/90356 -->
+    <NoWarn>$(NoWarn),0419,0649,AD0001</NoWarn>
     <Nullable>enable</Nullable>
 
     <!-- Ignore all previous constants since SPCL is sensitive to what is defined and the Sdk adds some by default -->


### PR DESCRIPTION
Fixes #78412

@stephentoub  - you mentioned: 
> warnings fail the build and there's nothing a developer can do to address them short of disabling the rule (if any are non-deterministic). We can try it once we're clean, though, and see how it goes.

If new warnings are introduced we can add a NoWarn to the project and file an issue.  Agreed that non-deterministic warnings will require undoing this.   Hopefully we can track such a thing against an issue and undo it with fixed.

To get clean I suppressed this warning and filled the following issues:
https://github.com/dotnet/runtime/issues/90356
https://github.com/dotnet/runtime/issues/90357
