### PR TITLE
[wasm] Respect `AppendRuntimeIdentifierToOutputPath`, and `UseArtifactsOutput`

### DIFF
--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -145,12 +145,20 @@
 
       The path might not have been created yet, for example when creating a new project in VS, so don't use an Exists() check
     -->
-    <_AppBundleDirForRunCommand Condition="'$(_AppBundleDirForRunCommand)' == ''">$([System.IO.Path]::Combine($(OutputPath), $(RuntimeIdentifier), 'AppBundle'))</_AppBundleDirForRunCommand>
+
+    <!-- This is the only case where OutputPath needs an additional part -->
+    <_AppBundleDirForRunCommand Condition="'$(_AppBundleDirForRunCommand)' == '' and '$(UseArtifactsOutput)' == '' and '$(AppendRuntimeIdentifierToOutputPath)' != 'false'">$([System.IO.Path]::Combine($(OutputPath), 'wasi-wasm', 'AppBundle'))</_AppBundleDirForRunCommand>
+
+    <!--
+      In case of UseArtifactsOutput==true, the path is like `OutputPath=./bin/wc0/debug_browser-wasm/`. And
+      it remains the same even if `AppendRuntimeIdentifierToOutputPath`==true .
+    -->
+    <_AppBundleDirForRunCommand Condition="'$(_AppBundleDirForRunCommand)' == ''">$([System.IO.Path]::Combine($(OutputPath), 'AppBundle'))</_AppBundleDirForRunCommand>
 
     <!-- Ensure the path is absolute. In case of VS, the cwd might not be the correct one, so explicitly
          use $(MSBuildProjectDirectory). -->
     <_AppBundleDirForRunCommand Condition="'$(_AppBundleDirForRunCommand)' != '' and !$([System.IO.Path]::IsPathRooted($(_AppBundleDirForRunCommand)))">$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(_AppBundleDirForRunCommand)))</_AppBundleDirForRunCommand>
-  </PropertyGroup>
+ </PropertyGroup>
 
   <PropertyGroup Condition="'$(WasmGenerateAppBundle)' == 'true'">
     <RunCommand Condition="'$(DOTNET_HOST_PATH)' != '' and Exists($(DOTNET_HOST_PATH))">$(DOTNET_HOST_PATH)</RunCommand>

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorBuildOptions.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorBuildOptions.cs
@@ -18,5 +18,7 @@ public record BlazorBuildOptions
     bool ExpectFingerprintOnDotnetJs = false,
     RuntimeVariant RuntimeType = RuntimeVariant.SingleThreaded,
     GlobalizationMode GlobalizationMode = GlobalizationMode.Sharded,
-    string PredefinedIcudt = ""
+    string PredefinedIcudt = "",
+    bool AssertAppBundle = true,
+    string? BinFrameworkDir = null
 );

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmProjectProvider.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmProjectProvider.cs
@@ -18,7 +18,7 @@ public class BlazorWasmProjectProvider : WasmSdkBasedProjectProvider
                 Config: options.Config,
                 IsPublish: options.IsPublish,
                 TargetFramework: options.TargetFramework,
-                BinFrameworkDir: FindBinFrameworkDir(options.Config, options.IsPublish, options.TargetFramework),
+                BinFrameworkDir: options.BinFrameworkDir ?? FindBinFrameworkDir(options.Config, options.IsPublish, options.TargetFramework),
                 GlobalizationMode: options.GlobalizationMode,
                 PredefinedIcudt: options.PredefinedIcudt,
                 ExpectFingerprintOnDotnetJs: options.ExpectFingerprintOnDotnetJs,

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
@@ -60,7 +60,7 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
 
         (CommandResult res, string logPath) = BlazorBuildInternal(options.Id, options.Config, publish: false, setWasmDevel: false, expectSuccess: options.ExpectSuccess, extraArgs);
 
-        if (options.ExpectSuccess)
+        if (options.ExpectSuccess && options.AssertAppBundle)
             AssertBundle(res.Output, options with { IsPublish = false });
 
         return (res, logPath);
@@ -73,26 +73,9 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
 
         (CommandResult res, string logPath) = BlazorBuildInternal(options.Id, options.Config, publish: true, setWasmDevel: false, expectSuccess: options.ExpectSuccess, extraArgs);
 
-        if (options.ExpectSuccess)
+        if (options.ExpectSuccess && options.AssertAppBundle)
         {
             AssertBundle(res.Output, options with { IsPublish = true });
-
-            if (options.ExpectedFileType == NativeFilesType.AOT)
-            {
-                // check for this too, so we know the format is correct for the negative
-                // test for jsinterop.webassembly.dll
-                Assert.Contains("Microsoft.JSInterop.dll -> Microsoft.JSInterop.dll.bc", res.Output);
-
-                // make sure this assembly gets skipped
-                Assert.DoesNotContain("Microsoft.JSInterop.WebAssembly.dll -> Microsoft.JSInterop.WebAssembly.dll.bc", res.Output);
-            }
-
-            string objBuildDir = Path.Combine(_projectDir!, "obj", options.Config, options.TargetFramework!, "wasm", "for-build");
-            // Check that we linked only for publish
-            if (options.ExpectRelinkDirWhenPublishing)
-                Assert.True(Directory.Exists(objBuildDir), $"Could not find expected {objBuildDir}, which gets created when relinking during Build. This is likely a test authoring error");
-            else
-                Assert.False(File.Exists(Path.Combine(objBuildDir, "emcc-link.rsp")), $"Found unexpected files in {objBuildDir}, which gets created when relinking during Build");
         }
 
         return (res, logPath);
@@ -135,6 +118,23 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
         }
 
         _provider.AssertBundle(blazorBuildOptions);
+
+        if (blazorBuildOptions.ExpectedFileType == NativeFilesType.AOT)
+        {
+            // check for this too, so we know the format is correct for the negative
+            // test for jsinterop.webassembly.dll
+            Assert.Contains("Microsoft.JSInterop.dll -> Microsoft.JSInterop.dll.bc", buildOutput);
+
+            // make sure this assembly gets skipped
+            Assert.DoesNotContain("Microsoft.JSInterop.WebAssembly.dll -> Microsoft.JSInterop.WebAssembly.dll.bc", buildOutput);
+        }
+
+        string objBuildDir = Path.Combine(_projectDir!, "obj", blazorBuildOptions.Config, blazorBuildOptions.TargetFramework!, "wasm", "for-build");
+        // Check that we linked only for publish
+        if (blazorBuildOptions.ExpectRelinkDirWhenPublishing)
+            Assert.True(Directory.Exists(objBuildDir), $"Could not find expected {objBuildDir}, which gets created when relinking during Build. This is likely a test authoring error");
+        else
+            Assert.False(File.Exists(Path.Combine(objBuildDir, "emcc-link.rsp")), $"Found unexpected files in {objBuildDir}, which gets created when relinking during Build");
     }
 
     protected string CreateProjectWithNativeReference(string id)

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
@@ -119,6 +119,11 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
 
         _provider.AssertBundle(blazorBuildOptions);
 
+        if (!blazorBuildOptions.IsPublish)
+            return;
+
+        // Publish specific checks
+
         if (blazorBuildOptions.ExpectedFileType == NativeFilesType.AOT)
         {
             // check for this too, so we know the format is correct for the negative
@@ -134,7 +139,7 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
         if (blazorBuildOptions.ExpectRelinkDirWhenPublishing)
             Assert.True(Directory.Exists(objBuildDir), $"Could not find expected {objBuildDir}, which gets created when relinking during Build. This is likely a test authoring error");
         else
-            Assert.False(File.Exists(Path.Combine(objBuildDir, "emcc-link.rsp")), $"Found unexpected files in {objBuildDir}, which gets created when relinking during Build");
+            Assert.False(File.Exists(Path.Combine(objBuildDir, "emcc-link.rsp")), $"Found unexpected `emcc-link.rsp` in {objBuildDir}, which gets created when relinking during Build.");
     }
 
     protected string CreateProjectWithNativeReference(string id)

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleMultiThreadedTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleMultiThreadedTests.cs
@@ -21,7 +21,7 @@ public class SimpleMultiThreadedTests : BlazorWasmTestBase
     }
 
     // dotnet-run needed for running with *build* so wwwroot has the index.html etc
-    // [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+    // [Theory]
     // [InlineData("Debug")]
     // [InlineData("Release")]
     // public async Task BlazorBuildRunTest(string config)

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleRunTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleRunTests.cs
@@ -34,7 +34,49 @@ public class SimpleRunTests : BlazorWasmTestBase
         await BlazorRunForBuildWithDotnetRun(new BlazorRunOptions() { Config = config });
     }
 
-    [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+    [Theory]
+    [InlineData("Debug", /*appendRID*/ true, /*useArtifacts*/ false)]
+    [InlineData("Debug", /*appendRID*/ true, /*useArtifacts*/ true)]
+    [InlineData("Debug", /*appendRID*/ false, /*useArtifacts*/ true)]
+    [InlineData("Debug", /*appendRID*/ false, /*useArtifacts*/ false)]
+    public async Task BlazorBuildAndRunForDifferentOutputPaths(string config, bool appendRID, bool useArtifacts)
+    {
+        string id = $"{config}_{GetRandomId()}";
+        string projectFile = CreateWasmTemplateProject(id, "blazorwasm");
+        string projectName = Path.GetFileNameWithoutExtension(projectFile);
+
+        string extraPropertiesForDBP = "";
+        if (appendRID)
+            extraPropertiesForDBP += "<AppendRuntimeIdentifierToOutputPath>true</AppendRuntimeIdentifierToOutputPath>";
+        if (useArtifacts)
+            extraPropertiesForDBP += "<UseArtifactsOutput>true</UseArtifactsOutput><ArtifactsPath>.</ArtifactsPath>";
+
+        string projectDirectory = Path.GetDirectoryName(projectFile)!;
+        if (!string.IsNullOrEmpty(extraPropertiesForDBP))
+            AddItemsPropertiesToProject(Path.Combine(projectDirectory, "Directory.Build.props"),
+                                        extraPropertiesForDBP);
+
+        var buildArgs = new BuildArgs(projectName, config, false, id, null);
+        buildArgs = ExpandBuildArgs(buildArgs);
+
+        BlazorBuildOptions buildOptions = new(id, config, NativeFilesType.FromRuntimePack);
+        if (useArtifacts)
+        {
+            buildOptions = buildOptions with
+            {
+                BinFrameworkDir = Path.Combine(projectDirectory,
+                                               "bin",
+                                               id,
+                                               config.ToLower(),
+                                               "wwwroot",
+                                               "_framework")
+            };
+        }
+        BlazorBuild(buildOptions);
+        await BlazorRunForBuildWithDotnetRun(new BlazorRunOptions() { Config = config });
+    }
+
+    [Theory]
     [InlineData("Debug", false)]
     [InlineData("Debug", true)]
     [InlineData("Release", false)]

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleRunTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleRunTests.cs
@@ -22,7 +22,7 @@ public class SimpleRunTests : BlazorWasmTestBase
         _enablePerTestCleanup = true;
     }
 
-    [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+    [Theory]
     [InlineData("Debug")]
     [InlineData("Release")]
     public async Task BlazorBuildRunTest(string config)

--- a/src/mono/wasm/Wasm.Build.Tests/BuildProjectOptions.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildProjectOptions.cs
@@ -26,5 +26,6 @@ public record BuildProjectOptions
     string              TargetFramework           = BuildTestBase.DefaultTargetFramework,
     string?             MainJS                    = null,
     bool                IsBrowserProject          = true,
-    IDictionary<string, string>? ExtraBuildEnvironmentVariables = null
+    IDictionary<string, string>? ExtraBuildEnvironmentVariables = null,
+    string?             BinFrameworkDir           = null
 );

--- a/src/mono/wasm/Wasm.Build.Tests/NativeLibraryTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NativeLibraryTests.cs
@@ -91,7 +91,7 @@ public class Test
             Assert.Contains("Size: 26462 Height: 599, Width: 499", output);
         }
 
-        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        [Theory]
         [BuildAndRun(aot: false, host: RunHost.Chrome)]
         [BuildAndRun(aot: true, host: RunHost.Chrome)]
         public void ProjectUsingBrowserNativeCrypto(BuildArgs buildArgs, RunHost host, string id)

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -375,7 +375,7 @@ namespace Wasm.Build.Tests
             Assert.Matches("warning\\sWASM0001.*Skipping.*Test::SomeFunction1.*because.*function\\spointer", output);
         }
 
-        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        [Theory]
         [BuildAndRun(host: RunHost.None)]
         public void IcallWithOverloadedParametersAndEnum(BuildArgs buildArgs, string id)
         {

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTests.cs
@@ -179,7 +179,7 @@ namespace Wasm.Build.Tests
                             IsBrowserProject: false));
         }
 
-        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        [Theory]
         [InlineData("Debug", false)]
         [InlineData("Debug", true)]
         [InlineData("Release", false)]
@@ -187,7 +187,7 @@ namespace Wasm.Build.Tests
         public void ConsoleBuildAndRunDefault(string config, bool relinking)
             => ConsoleBuildAndRun(config, relinking, string.Empty, DefaultTargetFramework);
 
-        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        [Theory]
         // [ActiveIssue("https://github.com/dotnet/runtime/issues/79313")]
         // [InlineData("Debug", "-f net7.0", "net7.0")]
         [InlineData("Debug", "-f net8.0", "net8.0")]
@@ -253,7 +253,7 @@ namespace Wasm.Build.Tests
             return data;
         }
 
-        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        [Theory]
         [MemberData(nameof(TestDataForAppBundleDir))]
         public async Task RunWithDifferentAppBundleLocations(bool forConsole, bool runOutsideProjectDirectory, string extraProperties)
             => await (forConsole
@@ -354,7 +354,7 @@ namespace Wasm.Build.Tests
             return data;
         }
 
-        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        [Theory]
         [MemberData(nameof(TestDataForConsolePublishAndRun))]
         public void ConsolePublishAndRun(string config, bool aot, bool relinking)
         {
@@ -406,7 +406,7 @@ namespace Wasm.Build.Tests
             Assert.Contains("args[2] = z", res.Output);
         }
 
-        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        [Theory]
         [InlineData("", BuildTestBase.DefaultTargetFramework, DefaultRuntimeAssetsRelativePath)]
         [InlineData("", BuildTestBase.DefaultTargetFramework, "./")]
         // [ActiveIssue("https://github.com/dotnet/runtime/issues/79313")]

--- a/src/mono/wasm/Wasm.Build.Tests/TestMainJsProjectProvider.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/TestMainJsProjectProvider.cs
@@ -82,7 +82,8 @@ public class TestMainJsProjectProvider : ProjectProviderBase
 
     public void AssertBundle(BuildArgs buildArgs, BuildProjectOptions buildProjectOptions)
     {
-        string binFrameworkDir = FindBinFrameworkDir(buildArgs.Config,
+        string binFrameworkDir = buildProjectOptions.BinFrameworkDir
+                                    ?? FindBinFrameworkDir(buildArgs.Config,
                                                      buildProjectOptions.Publish,
                                                      buildProjectOptions.TargetFramework);
         NativeFilesType expectedFileType = buildArgs.AOT

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -175,7 +175,15 @@
 
       The path might not have been created yet, for example when creating a new project in VS, so don't use an Exists() check
     -->
-    <_AppBundleDirForRunCommand Condition="'$(_AppBundleDirForRunCommand)' == ''">$([System.IO.Path]::Combine($(OutputPath), 'browser-wasm', 'AppBundle'))</_AppBundleDirForRunCommand>
+
+    <!-- This is the only case where OutputPath needs an additional part -->
+    <_AppBundleDirForRunCommand Condition="'$(_AppBundleDirForRunCommand)' == '' and '$(UseArtifactsOutput)' == '' and '$(AppendRuntimeIdentifierToOutputPath)' != 'false'">$([System.IO.Path]::Combine($(OutputPath), 'browser-wasm', 'AppBundle'))</_AppBundleDirForRunCommand>
+
+    <!--
+      In case of UseArtifactsOutput==true, the path is like `OutputPath=./bin/wc0/debug_browser-wasm/`. And
+      it remains the same even if `AppendRuntimeIdentifierToOutputPath`==true .
+    -->
+    <_AppBundleDirForRunCommand Condition="'$(_AppBundleDirForRunCommand)' == ''">$([System.IO.Path]::Combine($(OutputPath), 'AppBundle'))</_AppBundleDirForRunCommand>
 
     <!-- Ensure the path is absolute. In case of VS, the cwd might not be the correct one, so explicitly
          use $(MSBuildProjectDirectory). -->


### PR DESCRIPTION
Also, remove all instances of `ConditionalTheory IsUsingWorkloads`
because we run tests in two modes:

1. with workloads - all the tests *without* `no-workload` category are
   run (thus the default)
2. no workloads - all the tests *with* `no-workload` category are run
   (thus need explicitly attributes)

Fixes https://github.com/dotnet/runtime/issues/89744 .
