### PR TITLE
Ensure GetPESectionBlock uses its cache

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
@@ -385,6 +385,12 @@ namespace System.Reflection.PortableExecutable
                 Interlocked.CompareExchange(ref _lazyPESectionBlocks, new AbstractMemoryBlock[PEHeaders.SectionHeaders.Length], null);
             }
 
+            AbstractMemoryBlock? existingBlock = Volatile.Read(ref _lazyPESectionBlocks[index]);
+            if (existingBlock != null)
+            {
+                return existingBlock;
+            }
+
             AbstractMemoryBlock newBlock;
             if (IsLoadedImage)
             {


### PR DESCRIPTION
Fixes #53080

PEReader had a cache for section blocks but never used it.  It would always read the new block before checking the cache.

I wrote a rudimentary benchmark for this:
```C#
using PEReader pe = new PEReader(File.OpenRead(typeof(object).Assembly.Location));

var sw = Stopwatch.StartNew();
for (int i = 0; i < 10000; i++)
{
    var section = pe.GetSectionData(".text");
}
sw.Stop();
Console.WriteLine(sw.Elapsed);
```


Before change:
00:00:00.0102182

After change:
00:00:00.0090209

10x reduction seems worth it.