### PR TITLE
Use crossplat vectors in GetPointerToFirstInvalidChar

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -3221,5 +3221,21 @@ namespace System.Runtime.Intrinsics
             }
             return AdvSimd.SubtractSaturate(left, right);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        [CompExactlyDependsOn(typeof(Sse2))]
+        internal static Vector128<ushort> AddSaturate(Vector128<ushort> left, Vector128<ushort> right)
+        {
+            if (Sse2.IsSupported)
+            {
+                return Sse2.AddSaturate(left, right);
+            }
+            else if (!AdvSimd.Arm64.IsSupported)
+            {
+                ThrowHelper.ThrowNotSupportedException();
+            }
+            return AdvSimd.AddSaturate(left, right);
+        }
     }
 }


### PR DESCRIPTION
This whole path is currently not used on ARM64 (it uses `Vector<>` instead).

Sse4.1 requirement was lifted to Sse2