### PR TITLE
[DependencyInjection] Avoid useless reflection call in ActivatorUtilities

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
@@ -508,13 +508,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static bool TryGetServiceKey(ParameterInfo parameterInfo, out object? key)
         {
-            foreach (var attribute in parameterInfo.GetCustomAttributes(true))
+            foreach (var attribute in parameterInfo.GetCustomAttributes<FromKeyedServicesAttribute>(false))
             {
-                if (attribute is FromKeyedServicesAttribute keyed)
-                {
-                    key = keyed.Key;
-                    return true;
-                }
+                key = attribute.Key;
+                return true;
             }
             key = null;
             return false;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
@@ -508,15 +508,12 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static bool TryGetServiceKey(ParameterInfo parameterInfo, out object? key)
         {
-            if (parameterInfo.CustomAttributes != null)
+            foreach (var attribute in parameterInfo.GetCustomAttributes(true))
             {
-                foreach (var attribute in parameterInfo.GetCustomAttributes(true))
+                if (attribute is FromKeyedServicesAttribute keyed)
                 {
-                    if (attribute is FromKeyedServicesAttribute keyed)
-                    {
-                        key = keyed.Key;
-                        return true;
-                    }
+                    key = keyed.Key;
+                    return true;
                 }
             }
             key = null;


### PR DESCRIPTION
Follow up on #89964

`parameterInfo.CustomAttributes` is never `null`, removing this check speed up the code.