### PR TITLE
Use non-generic `Memmove` for pointers in `String`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -135,8 +135,8 @@ namespace System
 
             Buffer.Memmove(
                 elementCount: (uint)result.Length, // derefing Length now allows JIT to prove 'result' not null below
-                destination: ref result._firstChar,
-                source: ref *ptr);
+                destination: ref Unsafe.As<char, byte>(ref result._firstChar),
+                source: ref Unsafe.AsRef<byte>(ptr));
 
             return result;
         }
@@ -168,9 +168,9 @@ namespace System
             string result = FastAllocateString(length);
 
             Buffer.Memmove(
-               elementCount: (uint)result.Length, // derefing Length now allows JIT to prove 'result' not null below
-               destination: ref result._firstChar,
-               source: ref *pStart);
+                elementCount: (uint)result.Length, // derefing Length now allows JIT to prove 'result' not null below
+                destination: ref Unsafe.As<char, byte>(ref result._firstChar),
+                source: ref Unsafe.AsRef<byte>(pStart));
 
             return result;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -136,7 +136,7 @@ namespace System
             Buffer.Memmove(
                 len: (uint)result.Length * sizeof(char), // derefing Length now allows JIT to prove 'result' not null below
                 dest: ref Unsafe.As<char, byte>(ref result._firstChar),
-                src: ref Unsafe.AsRef<byte>(ptr));
+                src: ref *(byte*)ptr);
 
             return result;
         }
@@ -170,7 +170,7 @@ namespace System
             Buffer.Memmove(
                 len: (uint)result.Length * sizeof(char), // derefing Length now allows JIT to prove 'result' not null below
                 dest: ref Unsafe.As<char, byte>(ref result._firstChar),
-                src: ref Unsafe.AsRef<byte>(pStart));
+                src: ref *(byte*)pStart);
 
             return result;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -134,7 +134,7 @@ namespace System
             string result = FastAllocateString(count);
 
             Buffer.Memmove(
-                elementCount: (uint)result.Length, // derefing Length now allows JIT to prove 'result' not null below
+                elementCount: (uint)result.Length * sizeof(char), // derefing Length now allows JIT to prove 'result' not null below
                 destination: ref Unsafe.As<char, byte>(ref result._firstChar),
                 source: ref Unsafe.AsRef<byte>(ptr));
 
@@ -168,7 +168,7 @@ namespace System
             string result = FastAllocateString(length);
 
             Buffer.Memmove(
-                elementCount: (uint)result.Length, // derefing Length now allows JIT to prove 'result' not null below
+                elementCount: (uint)result.Length * sizeof(char), // derefing Length now allows JIT to prove 'result' not null below
                 destination: ref Unsafe.As<char, byte>(ref result._firstChar),
                 source: ref Unsafe.AsRef<byte>(pStart));
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -134,9 +134,9 @@ namespace System
             string result = FastAllocateString(count);
 
             Buffer.Memmove(
-                elementCount: (uint)result.Length * sizeof(char), // derefing Length now allows JIT to prove 'result' not null below
-                destination: ref Unsafe.As<char, byte>(ref result._firstChar),
-                source: ref Unsafe.AsRef<byte>(ptr));
+                len: (uint)result.Length * sizeof(char), // derefing Length now allows JIT to prove 'result' not null below
+                dest: ref Unsafe.As<char, byte>(ref result._firstChar),
+                src: ref Unsafe.AsRef<byte>(ptr));
 
             return result;
         }
@@ -168,9 +168,9 @@ namespace System
             string result = FastAllocateString(length);
 
             Buffer.Memmove(
-                elementCount: (uint)result.Length * sizeof(char), // derefing Length now allows JIT to prove 'result' not null below
-                destination: ref Unsafe.As<char, byte>(ref result._firstChar),
-                source: ref Unsafe.AsRef<byte>(pStart));
+                len: (uint)result.Length * sizeof(char), // derefing Length now allows JIT to prove 'result' not null below
+                dest: ref Unsafe.As<char, byte>(ref result._firstChar),
+                src: ref Unsafe.AsRef<byte>(pStart));
 
             return result;
         }


### PR DESCRIPTION
Existing string public APIs call `System.Buffer.Memmove<T>(ref T, ref T, nuint)` with an unmanaged pointer of unknown providence. This is technically undefined behavior as the pointer may not be properly aligned for the referenced type.

Diffs show a very minor improvement in codegen, `add edx, edx` instead of `add rdx, rdx`, see MihuBot/runtime-utils/issues/162.