### PR TITLE
[browser] Allow JS modules to be injected as pre-loaded assets

### DIFF
--- a/src/mono/sample/wasm/browser-minimal-config/main.js
+++ b/src/mono/sample/wasm/browser-minimal-config/main.js
@@ -43,7 +43,7 @@ const assets = [
     {
         name: "Wasm.Browser.Config.Sample.wasm",
         // demo buffer promise
-        buffer: await fetchBinary("./_framework/Wasm.Browser.Config.Sample.wasm"),
+        buffer: fetchBinary("./_framework/Wasm.Browser.Config.Sample.wasm"),
         behavior: "assembly"
     },
     {

--- a/src/mono/sample/wasm/browser-minimal-config/main.js
+++ b/src/mono/sample/wasm/browser-minimal-config/main.js
@@ -1,24 +1,35 @@
 import { dotnet } from "./_framework/dotnet.js";
+import * as runtime from "./_framework/dotnet.runtime.js";
 
-async function fetchBinary(uri) {
-    return new Uint8Array(await (await fetch(uri)).arrayBuffer());
+async function fetchBinary(url) {
+    return (await fetch(url, { cache: "no-cache" })).arrayBuffer();
+}
+
+function fetchWasm(url) {
+    return {
+        response: fetch(url, { cache: "no-cache" }),
+        url,
+        name: url.substring(url.lastIndexOf("/") + 1)
+    };
 }
 
 const assets = [
     {
         name: "dotnet.native.js",
+        // demo dynamic import
+        moduleExports: import("./_framework/dotnet.native.js"),
         behavior: "js-module-native"
     },
     {
-        name: "dotnet.js",
-        behavior: "js-module-dotnet"
-    },
-    {
         name: "dotnet.runtime.js",
+        // demo static import
+        moduleExports: runtime,
         behavior: "js-module-runtime"
     },
     {
         name: "dotnet.native.wasm",
+        // demo pending download promise
+        pendingDownload: fetchWasm("./_framework/dotnet.native.wasm"),
         behavior: "dotnetwasm"
     },
     {
@@ -31,6 +42,7 @@ const assets = [
     },
     {
         name: "Wasm.Browser.Config.Sample.wasm",
+        // demo buffer promise
         buffer: await fetchBinary("./_framework/Wasm.Browser.Config.Sample.wasm"),
         behavior: "assembly"
     },

--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -266,7 +266,12 @@ interface AssetEntry {
      * If provided, runtime doesn't have to fetch the data.
      * Runtime would set the buffer to null after instantiation to free the memory.
      */
-    buffer?: ArrayBuffer;
+    buffer?: ArrayBuffer | Promise<ArrayBuffer>;
+    /**
+     * If provided, runtime doesn't have to import it's JavaScript modules.
+     * This will not work for multi-threaded runtime.
+     */
+    moduleExports?: any | Promise<any>;
     /**
      * It's metadata + fetch-like Promise<Response>
      * If provided, the runtime doesn't have to initiate the download. It would just await the response.

--- a/src/mono/wasm/runtime/loader/assets.ts
+++ b/src/mono/wasm/runtime/loader/assets.ts
@@ -201,10 +201,11 @@ export async function mono_download_assets(): Promise<void> {
                 const asset = await downloadPromise;
                 if (asset.buffer) {
                     if (!skipInstantiateByAssetTypes[asset.behavior]) {
-                        mono_assert(asset.buffer && typeof asset.buffer === "object", "asset buffer must be array or buffer like");
+                        mono_assert(asset.buffer && typeof asset.buffer === "object", "asset buffer must be array or buffer like or promise of it");
                         mono_assert(typeof asset.resolvedUrl === "string", "resolvedUrl must be string");
                         const url = asset.resolvedUrl!;
-                        const data = new Uint8Array(asset.buffer!);
+                        const buffer = await asset.buffer;
+                        const data = new Uint8Array(buffer);
                         cleanupAsset(asset);
 
                         // wait till after onRuntimeInitialized and after memory snapshot is loaded or skipped
@@ -487,7 +488,7 @@ async function start_asset_download_sources(asset: AssetEntryInternal): Promise<
         return asset.pendingDownloadInternal.response;
     }
     if (asset.buffer) {
-        const buffer = asset.buffer;
+        const buffer = await asset.buffer;
         if (!asset.resolvedUrl) {
             asset.resolvedUrl = "undefined://" + asset.name;
         }
@@ -707,6 +708,7 @@ export function cleanupAsset(asset: AssetEntryInternal) {
     asset.pendingDownloadInternal = null as any; // GC
     asset.pendingDownload = null as any; // GC
     asset.buffer = null as any; // GC
+    asset.moduleExports = null as any; // GC
 }
 
 function fileName(name: string) {

--- a/src/mono/wasm/runtime/loader/assets.ts
+++ b/src/mono/wasm/runtime/loader/assets.ts
@@ -201,7 +201,7 @@ export async function mono_download_assets(): Promise<void> {
                 const asset = await downloadPromise;
                 if (asset.buffer) {
                     if (!skipInstantiateByAssetTypes[asset.behavior]) {
-                        mono_assert(asset.buffer && typeof asset.buffer === "object", "asset buffer must be array or buffer like or promise of it");
+                        mono_assert(asset.buffer && typeof asset.buffer === "object", "asset buffer must be array-like or buffer-like or promise of these");
                         mono_assert(typeof asset.resolvedUrl === "string", "resolvedUrl must be string");
                         const url = asset.resolvedUrl!;
                         const buffer = await asset.buffer;

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -493,6 +493,7 @@ async function instantiate_wasm_module(
         assetToLoad.pendingDownloadInternal = null as any; // GC
         assetToLoad.pendingDownload = null as any; // GC
         assetToLoad.buffer = null as any; // GC
+        assetToLoad.moduleExports = null as any; // GC
 
         mono_log_debug("instantiate_wasm_module done");
 

--- a/src/mono/wasm/runtime/types/index.ts
+++ b/src/mono/wasm/runtime/types/index.ts
@@ -205,7 +205,14 @@ export interface AssetEntry {
      * If provided, runtime doesn't have to fetch the data. 
      * Runtime would set the buffer to null after instantiation to free the memory.
      */
-    buffer?: ArrayBuffer
+    buffer?: ArrayBuffer | Promise<ArrayBuffer>,
+
+    /**
+     * If provided, runtime doesn't have to import it's JavaScript modules.
+     * This will not work for multi-threaded runtime.
+     */
+    moduleExports?: any | Promise<any>,
+
     /**
      * It's metadata + fetch-like Promise<Response>
      * If provided, the runtime doesn't have to initiate the download. It would just await the response.


### PR DESCRIPTION
- new `asset.moduleExports` field which could be pre-populated with ES6 exports of runtime modules
- demo in `browser-minimal-config\main.js`
- allow promise in `asset.buffer`

To address user feedback 
Fixes https://github.com/dotnet/runtime/issues/89510