### PR TITLE
Disable LLVM AOT ARM64 lane

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
@@ -324,7 +324,7 @@ jobs:
     runtimeFlavor: mono
     platforms:
       - linux_x64
-      - linux_arm64
+      # - linux_arm64
     variables:
       - name: timeoutPerTestInMinutes
         value: 60


### PR DESCRIPTION
Closes: https://github.com/dotnet/runtime/issues/86324