### PR TITLE
[mono] Disable InlineArrayValid and InlineArrayInvalid tests on Android

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3640,6 +3640,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/GenericContext/**">
             <Issue>https://github.com/dotnet/runtime/issues/67359</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/InlineArray/**">
+            <Issue>https://github.com/dotnet/runtime/issues/90398</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetOS)' == 'android' And '$(TargetArchitecture)' == 'arm64'">


### PR DESCRIPTION
Disabling failing InlineArrayValid and InlineArrayInvalid runtime tests on Android CI lines. 

Tracked in https://github.com/dotnet/runtime/issues/90398.