### PR TITLE
Revert "Update perf run yaml with changes for crank on helix (#90368)"

### DIFF
--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -162,11 +162,6 @@ jobs:
       displayName: Performance Setup (Unix)
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
       continueOnError: ${{ parameters.continueOnError }}
-    - script: wget https://bootstrap.pypa.io/pip/3.6/get-pip.py && $(Python) get-pip.py --user
-      displayName: Ensure pip is installed (non-Windows)
-      condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
-    - script: $(Python) -m pip install --user dataclasses
-      displayName: Install dataclasses library used in ci_setup.py
     - script: $(Python) $(PerformanceDirectory)/scripts/ci_setup.py $(SetupArguments) ${{ parameters.additionalSetupParameters }}
       displayName: Run ci setup script
       # Run perf testing in helix

--- a/eng/pipelines/coreclr/templates/run-scenarios-job.yml
+++ b/eng/pipelines/coreclr/templates/run-scenarios-job.yml
@@ -131,11 +131,6 @@ jobs:
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
       continueOnError: ${{ parameters.continueOnError }}
     # run ci-setup
-    - script: wget https://bootstrap.pypa.io/pip/3.6/get-pip.py && $(Python) get-pip.py --user
-      displayName: Ensure pip is installed (non-Windows)
-      condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
-    - script: $(Python) -m pip install --user dataclasses
-      displayName: Install dataclasses library used in ci_setup.py
     - script: $(Python) $(PerformanceDirectory)\scripts\ci_setup.py $(SetupArguments) $(ExtraSetupArguments) --output-file $(WorkItemDirectory)\machine-setup.cmd
       displayName: Run ci setup script (Windows)
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))


### PR DESCRIPTION
This reverts commit bbe40f8cbffe47f685bc50d4cb1a6d4535c68a4d.

This caused perf pipeline runs to break. But https://github.com/dotnet/performance/pull/3251 from @caaavik-msft, along with this revert will fix the issue.

Issue: https://github.com/dotnet/runtime/issues/90420
