### PR TITLE
[wasm] Fix builds for blazor app + InvariantGlobalization=true

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
@@ -45,7 +45,7 @@
         '$(WasmEnableSIMD)' == 'false' or
         '$(WasmEnableExceptionHandling)' == 'false' or
         '$(InvariantTimezone)' == 'true' or
-        '$(InvariantGlobalization)' == 'true' or
+        ('$(_UsingBlazorOrWasmSdk)' != 'true' and '$(InvariantGlobalization)' == 'true') or
         '$(WasmNativeStrip)' == 'false'">true</_WasmPropertiesDifferFromRuntimePackThusNativeBuildNeeded>
 
     <!-- $(WasmBuildNative)==true is needed to enable workloads, when using native references, without AOT -->

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/WorkloadRequiredTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/WorkloadRequiredTests.cs
@@ -24,7 +24,7 @@ public class WorkloadRequiredTests : BlazorWasmTestBase
         ("WasmEnableSIMD", false),
         ("WasmEnableExceptionHandling", false),
         ("InvariantTimezone", true),
-        ("InvariantGlobalization", true),
+        //("InvariantGlobalization", true), - not applicable for blazor
         ("WasmNativeStrip", false)
     };
 
@@ -59,6 +59,14 @@ public class WorkloadRequiredTests : BlazorWasmTestBase
     [MemberData(nameof(SettingDifferentFromValuesInRuntimePack), parameters: false)]
     public void WorkloadRequiredForPublish(string config, string extraProperties, bool workloadNeeded)
         => CheckWorkloadRequired(config, extraProperties, workloadNeeded, publish: true);
+
+    [Theory, TestCategory("no-workload")]
+    [InlineData("Debug", "<InvariantGlobalization>true</InvariantGlobalization>", /*workloadNeeded*/ false, /*publish*/ false)]
+    [InlineData("Debug", "<InvariantGlobalization>false</InvariantGlobalization>", /*workloadNeeded*/ false, /*publish*/ false)]
+    [InlineData("Release", "<InvariantGlobalization>true</InvariantGlobalization>", /*workloadNeeded*/ false, /*publish*/ true)]
+    [InlineData("Release", "<InvariantGlobalization>false</InvariantGlobalization>", /*workloadNeeded*/ false, /*publish*/ true)]
+    public void WorkloadNotRequiredForInvariantGlobalization(string config, string extraProperties, bool workloadNeeded, bool publish)
+        => CheckWorkloadRequired(config, extraProperties, workloadNeeded, publish: publish);
 
     private void CheckWorkloadRequired(string config, string extraProperties, bool workloadNeeded, bool publish)
     {


### PR DESCRIPTION
The following commit caused workload to be required for a blazor app
when `InvariantGlobalization==true`, but this is not required.

```
commit 26ae09784c16dfa6707cd73eca2aeb00a28741d0
Author: Ankit Jain <radical@gmail.com>
Date:   Thu Aug 10 23:39:10 2023 -0400

    [wasm] Fix up conditions to trigger relink, and require `wasm-tools` workload (#89754)
```

And this broke some sdk tests in https://github.com/dotnet/sdk/pull/34522 .
```
Microsoft.NET.Sdk.BlazorWebAssembly.Tests.WasmPublishIntegrationTest.Publish_WithInvariantGlobalizationEnabled_DoesNotCopyGlobalizationData [FAIL]
    Expected command to pass but it did not.
    File Name: /datadisks/disk1/work/A6630924/p/d/dotnet
    Arguments: msbuild /t:Publish /datadisks/disk1/work/A6630924/w/AB7D09B1/e/testExecutionDirectory/Publish_WithI---129F25F8_2/blazorwasm-minimal.csproj /restore
    Exit Code: 1
    StdOut:
    MSBuild version 17.6.1+8ffc3fe3d for .NET
      Determining projects to restore...
    /datadisks/disk1/work/A6630924/p/d/sdk/8.0.100-ci/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.ImportWorkloads.targets(38,5): error NETSDK1147: To build this project, the following workloads must be installed: wasm-tools [/datadisks/disk1/work/A6630924/w/AB7D09B1/e/testExecutionDirectory/Publish_WithI---129F25F8_2/blazorwasm-minimal.csproj]
    /datadisks/disk1/work/A6630924/p/d/sdk/8.0.100-ci/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.ImportWorkloads.targets(38,5): error NETSDK1147: To install these workloads, run the following command: dotnet workload restore [/datadisks/disk1/work/A6630924/w/AB7D09B1/e/testExecutionDirectory/Publish_WithI---129F25F8_2/blazorwasm-minimal.csproj]
    StdErr:
    
    
      Stack Trace:
         at FluentAssertions.Execution.XUnit2TestFramework.Throw(String message)
         at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
         at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
         at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
      /_/src/Tests/Microsoft.NET.TestFramework/Assertions/CommandResultAssertions.cs(29,0): at Microsoft.NET.TestFramework.Assertions.CommandResultAssertions.Pass()
      /_/src/Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/WasmPublishIntegrationTest.cs(1321,0): at Microsoft.NET.Sdk.BlazorWebAssembly.Tests.WasmPublishIntegrationTest.Publish_WithInvariantGlobalizationEnabled_DoesNotCopyGlobalizationData()
         at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
         at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```