### PR TITLE
Fix condition for setting if symbol is a file in native AOT publish targets

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -104,7 +104,7 @@
       <_symbolSourcePath>$(NativeOutputPath)$(TargetName)$(_symbolExt)</_symbolSourcePath>
       <_symbolTargetPath>$(PublishDir)\$(TargetName)$(_symbolExt)</_symbolTargetPath>
       <!-- If the symbol is a dsym bundle, it's a folder not a file. -->
-      <_symbolIsFile Condition="'$(_symbolExt)' == '.dsym'">false</_symbolIsFile>
+      <_symbolIsFile Condition="'$(NativeSymbolExt)' == '.dsym'">false</_symbolIsFile>
       <_symbolIsFile Condition="'$(_symbolIsFile)' == ''">true</_symbolIsFile>
     </PropertyGroup>
 


### PR DESCRIPTION
Hit in https://github.com/dotnet/sdk/pull/34522.

`Microsoft.NETCore.Native.Publish.targets(117,5): error MSB3025: The source file "bin/Debug/net8.0/osx-x64/native/AotSharedLibraryPublish.dylib.dsym" is actually a directory.  The "Copy" task does not support copying directories. [/private/tmp/helix/working/ACA70954/w/929C0880/e/testExecutionDirectory/NativeAotShar---BB97B19D_2/AotSharedLibraryPublish/AotSharedLibraryPublish.csproj]`