### PR TITLE
Make MemberInfoCache`1<System.__Canon>.AddMethod prejittable

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -11130,8 +11130,11 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                     if (isExact && (handle != NO_CLASS_HANDLE))
                     {
                         JITDUMP("IND(obj) is actually a class handle for %s\n", eeGetClassName(handle));
-                        // Filter out all shared generic instantiations
-                        if ((info.compCompHnd->getClassAttribs(handle) & CORINFO_FLG_SHAREDINST) == 0)
+                        uint32_t attrs = info.compCompHnd->getClassAttribs(handle);
+
+                        // Filter out all shared generic instantiations and non-exact arrays
+                        if (((attrs & CORINFO_FLG_SHAREDINST) == 0) &&
+                            (((attrs & CORINFO_FLG_ARRAY) == 0) || impIsClassExact(handle)))
                         {
                             void* pEmbedClsHnd;
                             void* embedClsHnd = (void*)info.compCompHnd->embedClassHandle(handle, &pEmbedClsHnd);


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/85791

When we run empty app, the following method shows up in JitDisasmSummary:
```
   6: JIT compiled System.RuntimeType+RuntimeTypeCache+MemberInfoCache`1[System.__Canon]:AddMethod(System.RuntimeType,long,int) [Instrumented Tier0, IL size=354, code size=1672]
```
I've debugged why it's not prejitted and, basically, it fails with an exception due to an optimization in jit:
![image](https://github.com/dotnet/runtime/assets/523221/5f601ec2-8dfc-4a42-b2b7-82a5f9e29773)

So when JIT tries to be smart and optimizes `IND(obj)` to just an embedded class handle, it fails here.

It happens on `RuntimeTypeMethod[]` type - I guess the reason is because arrays are not final on R2R?

cc @jkotas @MichalStrehovsky 