### PR TITLE
Fix NullableAttribute illink test failures

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/NullableOnConstraints.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/NullableOnConstraints.cs
@@ -7,6 +7,7 @@ namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed
 {
 	[SetupCSharpCompilerToUse ("csc")]
 	[SetupLinkerArgument ("--used-attrs-only", "true")]
+	[SetupLinkerTrimMode ("link")]
 	public class NullableOnConstraints
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinqExpressions/CanPreserveNullableCustomOperators.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinqExpressions/CanPreserveNullableCustomOperators.cs
@@ -5,6 +5,7 @@ namespace Mono.Linker.Tests.Cases.LinqExpressions
 {
 	[SetupCompileArgument ("/unsafe")]
 	[SetupLinkerArgument ("--used-attrs-only")]
+	[SetupLinkerTrimMode ("link")]
 	public class CanPreserveNullableCustomOperators
 	{
 		public static void Main ()


### PR DESCRIPTION
When we started building with preview 7 in
5549f72da3b3cea9e74bb81cfbb0f2d27731fc42, NullableAttribute in these testcases started to use the attribute definition from the framework, instead of generating it into the code. This broke the `--used-attrs-only` optimization because `skip` assemblies (the default for the framework in these testcases) are treated as if all types in them are kept, for the purposes of the `--used-attrs-only` optimization. (The optimization removes attribute instances unless the attribute type is preserved for some other reason).

It's not clear what the intended behavior of `--used-attrs-only` is for `skip` assemblies, and the discussion in
https://github.com/dotnet/linker/issues/952 indicates that it's considered experimental, so this fixes the failures by using the `link` action. This represents a more realistic scenario since `skip` is mainly used in testing to avoid linking the framework in every testcase.

An alternative fix is to change
https://github.com/dotnet/runtime/blob/05dfb7eda4b75ac50011b7553b36c73751f482d9/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs#L842-L843
to also set `markOnUse` for `skip` assemblies, but I think such a change would require more discussion of what `skip` is supposed to mean.

Fixes https://github.com/dotnet/runtime/issues/90431