### PR TITLE
Run trimming tests for global.json changes

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -135,6 +135,7 @@ jobs:
     - subset: tools_illink
       include:
       - src/tools/illink/*
+      - global.json
 
     - subset: installer
       include:


### PR DESCRIPTION
This should ensure that failures like https://github.com/dotnet/runtime/issues/90431 are caught in the SDK update PR next time.