### PR TITLE
Enumerable.ToArray performance improvement using InlineArray

### DIFF
--- a/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/EnumerableHelpers.Linq.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {
@@ -80,9 +80,112 @@ namespace System.Collections.Generic
                 return result;
             }
 
-            LargeArrayBuilder<T> builder = new();
-            builder.AddRange(source);
-            return builder.ToArray();
+            ToArrayHelper<T> helper = new ToArrayHelper<T>(initialCapacity: 4);
+            using (IEnumerator<T> e = source.GetEnumerator())
+            {
+                while (true)
+                {
+                    Span<T> span = helper.CurrentSpan;
+                    for (int i = 0; i < span.Length; i++)
+                    {
+                        if (e.MoveNext())
+                        {
+                            span[i] = e.Current;
+                        }
+                        else
+                        {
+                            return helper.ToArray(i);
+                        }
+                    }
+                    helper.AllocateNextBlock();
+                }
+            }
+        }
+
+        // when smallest block size is 4, reaching Array.MaxLength size is "29".
+        // length, blockSize, totalSize
+        // 1  4          4
+        // 2  8          12
+        // 3  16         28
+        // 4  32         60
+        // 5  64         124
+        // 6  128        252
+        // 7  256        508
+        // 8  512        1020
+        // 9  1024       2044
+        // 10 2048       4092
+        // 11 4096       8188
+        // 12 8192       16380
+        // 13 16384      32764
+        // 14 32768      65532
+        // 15 65536      131068
+        // 16 131072     262140
+        // 17 262144     524284
+        // 18 524288     1048572
+        // 19 1048576    2097148
+        // 20 2097152    4194300
+        // 21 4194304    8388604
+        // 22 8388608    16777212
+        // 23 16777216   33554428
+        // 24 33554432   67108860
+        // 25 67108864   134217724
+        // 26 134217728  268435452
+        // 27 268435456  536870908
+        // 28 536870912  1073741820
+        // 29 1073741771 2147483591 <- reach Array.MaxLength(2147483591)
+        [InlineArray(29)]
+        private struct ArrayBlock<T>
+        {
+#pragma warning disable CA1823 // Avoid unused private fields
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0051 // Remove unused private members
+            private T[] _array;
+#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning restore CA1823 // Avoid unused private fields
+        }
+
+        private struct ToArrayHelper<T>
+        {
+            private int _index;
+            private int _count;
+            private T[] _currentBlock;
+            private ArrayBlock<T> _blocks;
+
+            public ToArrayHelper(int initialCapacity)
+            {
+                _blocks = default(ArrayBlock<T>);
+                _currentBlock = _blocks[0] = new T[initialCapacity];
+            }
+
+            public Span<T> CurrentSpan => _currentBlock;
+
+            public void AllocateNextBlock()
+            {
+                _index++;
+                _count += _currentBlock.Length;
+
+                int nextSize = unchecked(_currentBlock.Length * 2);
+                if (nextSize < 0 || Array.MaxLength < (_count + nextSize))
+                {
+                    nextSize = Array.MaxLength - _count;
+                }
+
+                _currentBlock = _blocks[_index] = new T[nextSize];
+            }
+
+            public T[] ToArray(int lastBlockCount)
+            {
+                T[] array = GC.AllocateUninitializedArray<T>(_count + lastBlockCount);
+                Span<T> dest = array.AsSpan();
+                for (int i = 0; i < _index; i++)
+                {
+                    _blocks[i].CopyTo(dest);
+                    dest = dest.Slice(_blocks[i].Length);
+                }
+                _currentBlock.AsSpan(0, lastBlockCount).CopyTo(dest);
+                return array;
+            }
         }
     }
 }


### PR DESCRIPTION
I've optimized the `Enumerable.ToArray` method for the case when the source is a pure `IEnumerable<T>`.
Typically, when the buffer overflows, an array with double the previous capacity is created, and the copying process repeats.
In this PR, although we still create an array of double the size, instead of copying immediately, we add the array to a list and perform all the copying at the end.
By reducing the number of copy operations, we see a significant performance improvement.

## Benchmark

```
BenchmarkDotNet v0.13.7, Windows 10 (10.0.19045.3324/22H2/2022Update)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 8.0.100-preview.7.23376.3
  [Host]     : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX2
  Job-NGJHUQ : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX2

IterationCount=1  WarmupCount=1  
```

|     Method |     Length |                Mean | Error |      Gen0 |      Gen1 |      Gen2 |    Allocated |
----------- |----------- |--------------------:|------:|----------:|----------:|----------:|-------------:|
|     ToList |         10 |            53.12 ns |    NA |    0.0153 |         - |         - |        256 B |
|    ToArray |         10 |            71.83 ns |    NA |    0.0153 |         - |         - |        256 B |
| PR_ToArray |         10 |            38.40 ns |    NA |    0.0119 |         - |         - |        200 B |
|     ToList |        100 |           220.14 ns |    NA |    0.0730 |         - |         - |       1224 B |
|    ToArray |        100 |           326.60 ns |    NA |    0.0710 |         - |         - |       1192 B |
| PR_ToArray |        100 |           180.50 ns |    NA |    0.0644 |         - |         - |       1080 B |
|     ToList |       1000 |         1,679.32 ns |    NA |    0.5054 |    0.0057 |         - |       8464 B |
|    ToArray |       1000 |         2,081.20 ns |    NA |    0.5074 |         - |         - |       8536 B |
| PR_ToArray |       1000 |         1,384.58 ns |    NA |    0.4978 |         - |         - |       8336 B |
|     ToList |      10000 |        17,214.66 ns |    NA |    7.8430 |    1.2817 |         - |     131440 B |
|    ToArray |      10000 |        21,014.18 ns |    NA |    6.3171 |         - |         - |     106224 B |
| PR_ToArray |      10000 |        13,196.72 ns |    NA |    6.3171 |         - |         - |     105872 B |
|     ToList |     100000 |       338,986.18 ns |    NA |  285.6445 |  285.6445 |  285.6445 |    1049112 B |
|    ToArray |     100000 |       382,722.36 ns |    NA |  249.5117 |  249.5117 |  249.5117 |     925132 B |
| PR_ToArray |     100000 |       358,964.21 ns |    NA |  249.5117 |  249.5117 |  249.5117 |     924780 B |
|     ToList |    1000000 |     4,533,538.28 ns |    NA | 1984.3750 | 1984.3750 | 1984.3750 |    8389748 B |
|    ToArray |    1000000 |     3,067,601.56 ns |    NA |  796.8750 |  796.8750 |  796.8750 |    8195588 B |
| PR_ToArray |    1000000 |     2,418,546.88 ns |    NA |  800.7813 |  800.7813 |  800.7813 |    8195040 B |
| ToList |   10000000 |   197,990,525.00 ns |    NA | 3875.0000 | 3875.0000 | 3875.0000 |  134219664 B |
|    ToArray |   10000000 |   229,693,275.00 ns |    NA | 1875.0000 | 1875.0000 | 1875.0000 |  107110743 B |
| PR_ToArray |   10000000 |    29,184,353.12 ns |    NA | 1968.7500 | 1968.7500 | 1968.7500 |  107110478 B |
| ToList |  100000000 |   583,235,200.00 ns |    NA | 6000.0000 | 6000.0000 | 6000.0000 | 1073744896 B |
|    ToArray |  100000000 |   501,066,800.00 ns |    NA | 3000.0000 | 3000.0000 | 3000.0000 |  936873600 B |
| PR_ToArray |  100000000 |   270,801,200.00 ns |    NA | 2000.0000 | 2000.0000 | 2000.0000 |  936872432 B |
|     ToList | 1000000000 | 4,677,241,700.00 ns |    NA | 9000.0000 | 9000.0000 | 9000.0000 | 8589938744 B |
|    ToArray | 1000000000 | 5,229,577,600.00 ns |    NA | 4000.0000 | 4000.0000 | 4000.0000 | 8294970392 B |
| PR_ToArray | 1000000000 | 3,136,817,900.00 ns |    NA | 4000.0000 | 4000.0000 | 4000.0000 | 8294969760 B |

```csharp
public class ToArrayBenchmark
{
    [Params(10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000)]
    public int Length { get; set; }

    [Benchmark]
    public List<int> ToList()
    {
        return GenerateNumber(Length).ToList();
    }

    [Benchmark]
    public int[] ToArray()
    {
        return GenerateNumber(Length).ToArray();
    }

    [Benchmark]
    public int[] PR_ToArray()
    {
        return EnumerableHelpers.ToArray2(GenerateNumber(Length));
    }

    public static IEnumerable<int> GenerateNumber(int count)
    {
        for (int i = 0; i < count; i++)
        {
            yield return i;
        }
    }
}
```

## Implementation detail

In this scenario, there's a fixed maximum length for the list of arrays that should be allocated.
Starting with 4 and doubling the array size each time, we reach the maximum length after 29 arrays.
Therefore, using `[InlineArray(29)]`, I've reserved a fixed-length space for the `T[]`.

## Option

It's also possible to use `ArrayPool<T>.Shared.Rent` instead of `new T[]`.
In that case, by returning the array when calling ToArray, both copying and returning can be efficiently handled.
I wasn't sure if using ArrayPool was appropriate for this scenario, so in this PR, I've opted for creating new arrays.