### PR TITLE
[NativeAOT] Natvis visualization for threadstatic variables.

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/NativeAOT.natvis
+++ b/src/coreclr/nativeaot/BuildIntegration/NativeAOT.natvis
@@ -70,6 +70,8 @@
                    GetPerModuleStorage() != nullptr &amp;&amp; GetPerModuleStorage()-&gt;m_Length &gt; ClassIndex &amp;&amp; 
                    GetPerTypeStorage() != nullptr "/>
 
+        <Intrinsic Name="IsInlined" Expression="ClassIndex &lt; 0"/>
+
         <Intrinsic Name="GetPerThreadStorageInlined" Expression="
                    root == nullptr ?
                         nullptr :
@@ -84,11 +86,12 @@
             <Parameter Name="root" Type="InlinedThreadStaticRoot*"/>
         </Intrinsic>
 
-        <Intrinsic Name="IsInlined" Expression="ClassIndex &lt; 0"/>
         <Intrinsic Name="GetUninlined" Expression="IsInit() ? ($T1*)GetPerTypeStorage() : nullptr"/>
-        <Intrinsic Name="GetInlined" Expression="($T1*)GetPerTypeStorageInlined(tls_CurrentThread.m_pInlinedThreadLocalStatics))"/>
+        <Intrinsic Name="GetInlined" Expression="($T1*)GetPerTypeStorageInlined(root)">
+            <Parameter Name="root" Type="InlinedThreadStaticRoot*"/>
+        </Intrinsic>
 
-        <Intrinsic Name="Get" Expression="IsInlined() ? GetInlined() : GetUninlined()"/>
+        <Intrinsic Name="Get" Expression="IsInlined() ? GetInlined(tls_CurrentThread.m_pInlinedThreadLocalStatics) : GetUninlined()"/>
 
         <DisplayString  Condition="Get() == nullptr">Null</DisplayString>
         <DisplayString  Condition="Get() != nullptr">{*Get()}</DisplayString>

--- a/src/coreclr/nativeaot/BuildIntegration/NativeAOT.natvis
+++ b/src/coreclr/nativeaot/BuildIntegration/NativeAOT.natvis
@@ -64,17 +64,25 @@
         <Intrinsic Name="GetPerThreadStorage" Expression="(Array*)tls_CurrentThread.m_pThreadLocalStatics"/>
         <Intrinsic Name="GetPerModuleStorage" Expression="((Array**)((char*)GetPerThreadStorage() + sizeof(Array)))[TypeManagerSlot-&gt;ModuleIndex]"/>
         <Intrinsic Name="GetPerTypeStorage" Expression="((Object**)((char*)GetPerModuleStorage() + sizeof(Array)))[ClassIndex]"/>
-        <Intrinsic Name="Get" Expression="($T1*)GetPerTypeStorage()"/>
 
         <Intrinsic Name="IsInit" Expression="
                    GetPerThreadStorage() != nullptr &amp;&amp; GetPerModuleStorage()-&gt;m_Length &gt; TypeManagerSlot-&gt;ModuleIndex &amp;&amp; 
                    GetPerModuleStorage() != nullptr &amp;&amp; GetPerModuleStorage()-&gt;m_Length &gt; ClassIndex &amp;&amp; 
                    GetPerTypeStorage() != nullptr "/>
 
-        <DisplayString  Condition="!IsInit()">Null</DisplayString>
-        <DisplayString  Condition="IsInit()">{*Get()}</DisplayString>
+        <Intrinsic Name="GetPerThreadStorageInlined" Expression="tls_CurrentThread.m_pInlinedThreadLocalStatics ? tls_CurrentThread.m_pInlinedThreadLocalStatics->m_threadStaticsBase : nullptr"/>
+        <Intrinsic Name="GetPerTypeStorageInlined" Expression="GetPerThreadStorageInlined() ? (Object*)((char*)GetPerThreadStorageInlined() - sizeof(char*) - ClassIndex) : nullptr"/>
+
+        <Intrinsic Name="IsInlined" Expression="ClassIndex &lt; 0"/>
+        <Intrinsic Name="GetUninlined" Expression="IsInit() ? ($T1*)GetPerTypeStorage() : nullptr"/>
+        <Intrinsic Name="GetInlined" Expression="($T1*)GetPerTypeStorageInlined()"/>
+
+        <Intrinsic Name="Get" Expression="IsInlined() ? GetInlined() : GetUninlined()"/>
+
+        <DisplayString  Condition="Get() == nullptr">Null</DisplayString>
+        <DisplayString  Condition="Get() != nullptr">{*Get()}</DisplayString>
         <Expand>
-            <ExpandedItem Condition="IsInit()">Get()</ExpandedItem>
+            <ExpandedItem Condition="Get() != nullptr">Get()</ExpandedItem>
         </Expand>
     </Type>
     <Type Name="Object" Inheritable="false">

--- a/src/coreclr/nativeaot/BuildIntegration/NativeAOT.natvis
+++ b/src/coreclr/nativeaot/BuildIntegration/NativeAOT.natvis
@@ -61,10 +61,15 @@
         </Expand>
     </Type>
     <Type Name="__ThreadStaticHelper&lt;*&gt;">
-        <Intrinsic Name="HasModuleStorage" Expression="TypeManagerSlot-&gt;ModuleIndex &lt; tls_CurrentThread.m_numThreadLocalModuleStatics"/>
-        <Intrinsic Name="GetStorage" Expression="*(__Array&lt;Object&gt;**)tls_CurrentThread.m_pThreadLocalModuleStatics[TypeManagerSlot-&gt;ModuleIndex]"/>
-        <Intrinsic Name="Get" Expression="*($T1**)(&amp;(*GetStorage()).values)[ClassIndex]"/>
-        <Intrinsic Name="IsInit" Expression="HasModuleStorage() &amp;&amp; GetStorage() != nullptr &amp;&amp; ClassIndex &lt; GetStorage()-&gt;count &amp;&amp; Get() != nullptr"/>
+        <Intrinsic Name="GetPerThreadStorage" Expression="(Array*)tls_CurrentThread.m_pThreadLocalStatics"/>
+        <Intrinsic Name="GetPerModuleStorage" Expression="((Array**)((char*)GetPerThreadStorage() + sizeof(Array)))[TypeManagerSlot-&gt;ModuleIndex]"/>
+        <Intrinsic Name="GetPerTypeStorage" Expression="((Object**)((char*)GetPerModuleStorage() + sizeof(Array)))[ClassIndex]"/>
+        <Intrinsic Name="Get" Expression="($T1*)GetPerTypeStorage()"/>
+
+        <Intrinsic Name="IsInit" Expression="
+                   GetPerThreadStorage() != nullptr &amp;&amp; GetPerModuleStorage()-&gt;m_Length &gt; TypeManagerSlot-&gt;ModuleIndex &amp;&amp; 
+                   GetPerModuleStorage() != nullptr &amp;&amp; GetPerModuleStorage()-&gt;m_Length &gt; ClassIndex &amp;&amp; 
+                   GetPerTypeStorage() != nullptr "/>
 
         <DisplayString  Condition="!IsInit()">Null</DisplayString>
         <DisplayString  Condition="IsInit()">{*Get()}</DisplayString>

--- a/src/coreclr/nativeaot/BuildIntegration/NativeAOT.natvis
+++ b/src/coreclr/nativeaot/BuildIntegration/NativeAOT.natvis
@@ -70,12 +70,23 @@
                    GetPerModuleStorage() != nullptr &amp;&amp; GetPerModuleStorage()-&gt;m_Length &gt; ClassIndex &amp;&amp; 
                    GetPerTypeStorage() != nullptr "/>
 
-        <Intrinsic Name="GetPerThreadStorageInlined" Expression="tls_CurrentThread.m_pInlinedThreadLocalStatics ? tls_CurrentThread.m_pInlinedThreadLocalStatics->m_threadStaticsBase : nullptr"/>
-        <Intrinsic Name="GetPerTypeStorageInlined" Expression="GetPerThreadStorageInlined() ? (Object*)((char*)GetPerThreadStorageInlined() - sizeof(char*) - ClassIndex) : nullptr"/>
+        <Intrinsic Name="GetPerThreadStorageInlined" Expression="
+                   root == nullptr ?
+                        nullptr :
+                        root-&gt;m_typeManager == (TypeManager*)TypeManagerSlot-&gt;TypeManager._handleValue ?
+                            root-&gt;m_threadStaticsBase :
+                            nullptr">
+
+            <Parameter Name="root" Type="InlinedThreadStaticRoot*"/>
+        </Intrinsic>
+
+        <Intrinsic Name="GetPerTypeStorageInlined" Expression="GetPerThreadStorageInlined(root) ? (Object*)((char*)GetPerThreadStorageInlined(root) - sizeof(char*) - ClassIndex) : nullptr">
+            <Parameter Name="root" Type="InlinedThreadStaticRoot*"/>
+        </Intrinsic>
 
         <Intrinsic Name="IsInlined" Expression="ClassIndex &lt; 0"/>
         <Intrinsic Name="GetUninlined" Expression="IsInit() ? ($T1*)GetPerTypeStorage() : nullptr"/>
-        <Intrinsic Name="GetInlined" Expression="($T1*)GetPerTypeStorageInlined()"/>
+        <Intrinsic Name="GetInlined" Expression="($T1*)GetPerTypeStorageInlined(tls_CurrentThread.m_pInlinedThreadLocalStatics))"/>
 
         <Intrinsic Name="Get" Expression="IsInlined() ? GetInlined() : GetUninlined()"/>
 

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -1281,17 +1281,19 @@ InlinedThreadStaticRoot* Thread::GetInlinedThreadStaticList()
     return m_pInlinedThreadLocalStatics;
 }
 
-void Thread::RegisterInlinedThreadStaticRoot(InlinedThreadStaticRoot* newRoot)
+void Thread::RegisterInlinedThreadStaticRoot(InlinedThreadStaticRoot* newRoot, TypeManager* typeManager)
 {
     ASSERT(newRoot->m_next == NULL);
     newRoot->m_next = m_pInlinedThreadLocalStatics;
     m_pInlinedThreadLocalStatics = newRoot;
+    // we do not need typeManager for runtime needs, but it may be useful for debugging purposes.
+    newRoot->m_typeManager = typeManager;
 }
 
-COOP_PINVOKE_HELPER(void, RhRegisterInlinedThreadStaticRoot, (Object** root))
+COOP_PINVOKE_HELPER(void, RhRegisterInlinedThreadStaticRoot, (Object** root, TypeManager* typeManager))
 {
     Thread* pCurrentThread = ThreadStore::RawGetCurrentThread();
-    pCurrentThread->RegisterInlinedThreadStaticRoot((InlinedThreadStaticRoot*)root);
+    pCurrentThread->RegisterInlinedThreadStaticRoot((InlinedThreadStaticRoot*)root, typeManager);
 }
 
 // This is function is used to quickly query a value that can uniquely identify a thread

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -77,7 +77,7 @@ struct InlinedThreadStaticRoot
 {
     // The reference to the memory block that stores variables for the current {thread, typeManager} combination
     Object* m_threadStaticsBase;
-    // The next root in the list. All roots in the list belong to the same thread, but to a different typeManagers.
+    // The next root in the list. All roots in the list belong to the same thread, but to different typeManagers.
     InlinedThreadStaticRoot* m_next;
     // m_typeManager is currently unused, but could be useful when debugging
     TypeManager* m_typeManager;

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -79,7 +79,7 @@ struct InlinedThreadStaticRoot
     Object* m_threadStaticsBase;
     // The next root in the list. All roots in the list belong to the same thread, but to different typeManagers.
     InlinedThreadStaticRoot* m_next;
-    // m_typeManager is currently unused, but could be useful when debugging
+    // m_typeManager is used by NativeAOT.natvis when debugging
     TypeManager* m_typeManager;
 };
 

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -12,6 +12,7 @@ class RuntimeInstance;
 class ThreadStore;
 class CLREventStatic;
 class Thread;
+class TypeManager;
 
 #ifdef TARGET_UNIX
 #include "UnixContext.h"
@@ -74,8 +75,12 @@ struct GCFrameRegistration
 
 struct InlinedThreadStaticRoot
 {
+    // The reference to the memory block that stores variables for the current {thread, typeManager} combination
     Object* m_threadStaticsBase;
+    // The next root in the list. All roots in the list belong to the same thread, but to a different typeManagers.
     InlinedThreadStaticRoot* m_next;
+    // m_typeManager is currently unused, but could be useful when debugging
+    TypeManager* m_typeManager;
 };
 
 struct ThreadBuffer
@@ -294,7 +299,7 @@ public:
     Object** GetThreadStaticStorage();
 
     InlinedThreadStaticRoot* GetInlinedThreadStaticList();
-    void RegisterInlinedThreadStaticRoot(InlinedThreadStaticRoot* newRoot);
+    void RegisterInlinedThreadStaticRoot(InlinedThreadStaticRoot* newRoot, TypeManager* typeManager);
 
     NATIVE_CONTEXT* GetInterruptedContext();
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
@@ -40,7 +40,7 @@ namespace Internal.Runtime
             object threadStaticBase = AllocateThreadStaticStorageForType(typeManager, 0);
 
             // register the storage location with the thread for GC reporting.
-            RuntimeImports.RhRegisterInlinedThreadStaticRoot(ref threadStorage);
+            RuntimeImports.RhRegisterInlinedThreadStaticRoot(ref threadStorage, typeManager);
 
             // assign the storage block to the storage variable and return
             threadStorage = threadStaticBase;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -581,7 +581,7 @@ namespace System.Runtime
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhRegisterInlinedThreadStaticRoot")]
-        internal static extern void RhRegisterInlinedThreadStaticRoot(ref object? root);
+        internal static extern void RhRegisterInlinedThreadStaticRoot(ref object? root, TypeManagerHandle module);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhCurrentNativeThreadId")]

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -203,22 +203,20 @@ namespace ILCompiler.DependencyAnalysis
 
             _threadStatics = new NodeCache<MetadataType, ISymbolDefinitionNode>(CreateThreadStaticsNode);
 
-            TypeThreadStaticIndexNode inlinedThreadStatiscIndexNode = null;
             if (_inlinedThreadStatics.IsComputed())
             {
                 _inlinedThreadStatiscNode = new ThreadStaticsNode(_inlinedThreadStatics, this);
-                inlinedThreadStatiscIndexNode = new TypeThreadStaticIndexNode(_inlinedThreadStatiscNode);
             }
 
             _typeThreadStaticIndices = new NodeCache<MetadataType, TypeThreadStaticIndexNode>(type =>
             {
-                if (inlinedThreadStatiscIndexNode != null &&
-                _inlinedThreadStatics.GetOffsets().ContainsKey(type))
+                if (_inlinedThreadStatics.IsComputed() &&
+                    _inlinedThreadStatics.GetOffsets().ContainsKey(type))
                 {
-                    return inlinedThreadStatiscIndexNode;
+                    return new TypeThreadStaticIndexNode(type, _inlinedThreadStatiscNode);
                 }
 
-                return new TypeThreadStaticIndexNode(type);
+                return new TypeThreadStaticIndexNode(type, null);
             });
 
             _GCStaticEETypes = new NodeCache<GCPointerMap, GCStaticEETypeNode>((GCPointerMap gcMap) =>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
@@ -74,11 +74,6 @@ namespace ILCompiler.DependencyAnalysis
                         ISortableSymbolNode index = factory.TypeThreadStaticIndex(target);
                         if (index is TypeThreadStaticIndexNode ti && ti.IsInlined)
                         {
-                            // REVIEW: how to keep a node around?
-                            // we do not need the index node to run our code, but need to keep the node around for natvis.
-                            // emit a junk MOV for now
-                            encoder.EmitMOV(encoder.TargetRegister.Result, index);
-
                             if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
                             {
                                 EmitInlineTLSAccess(factory, ref encoder);
@@ -99,6 +94,11 @@ namespace ILCompiler.DependencyAnalysis
                                 encoder.EmitJNE(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase));
                                 EmitInlineTLSAccess(factory, ref encoder);
                             }
+
+                            // REVIEW: how to keep a node around?
+                            // we do not need the index node to run our code, but need to keep the node around for natvis.
+                            // emit a junk MOV for now  (this code is unreachable)
+                            encoder.EmitMOV(encoder.TargetRegister.Result, index);
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
@@ -72,8 +72,13 @@ namespace ILCompiler.DependencyAnalysis
                     {
                         MetadataType target = (MetadataType)Target;
                         ISortableSymbolNode index = factory.TypeThreadStaticIndex(target);
-                        if (index is TypeThreadStaticIndexNode ti && ti.Type == null)
+                        if (index is TypeThreadStaticIndexNode ti && ti.IsInlined)
                         {
+                            // REVIEW: how to keep a node around?
+                            // we will not use the index node, but need to keep the node around for natvis.
+                            // emit a junk MOV for now
+                            encoder.EmitMOV(encoder.TargetRegister.Result, index);
+
                             if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
                             {
                                 EmitInlineTLSAccess(factory, ref encoder);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
@@ -75,7 +75,7 @@ namespace ILCompiler.DependencyAnalysis
                         if (index is TypeThreadStaticIndexNode ti && ti.IsInlined)
                         {
                             // REVIEW: how to keep a node around?
-                            // we will not use the index node, but need to keep the node around for natvis.
+                            // we do not need the index node to run our code, but need to keep the node around for natvis.
                             // emit a junk MOV for now
                             encoder.EmitMOV(encoder.TargetRegister.Result, index);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
@@ -94,11 +94,6 @@ namespace ILCompiler.DependencyAnalysis
                                 encoder.EmitJNE(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase));
                                 EmitInlineTLSAccess(factory, ref encoder);
                             }
-
-                            // REVIEW: how to keep a node around?
-                            // we do not need the index node to run our code, but need to keep the node around for natvis.
-                            // emit a junk MOV for now  (this code is unreachable)
-                            encoder.EmitMOV(encoder.TargetRegister.Result, index);
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -75,8 +75,8 @@ namespace ILCompiler.DependencyAnalysis
                         if (index is TypeThreadStaticIndexNode ti && ti.IsInlined)
                         {
                             // REVIEW: how to keep a node around?
-                            // we will not use the index node, but need to keep the node around for natvis.
-                            // emit a junk LEA for now
+                            // we do not need the index node to run our code, but need to keep the node around for natvis.
+                            // emit a junk MOV for now
                             encoder.EmitMOV(encoder.TargetRegister.Result, index);
 
                             if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -74,11 +74,6 @@ namespace ILCompiler.DependencyAnalysis
                         ISortableSymbolNode index = factory.TypeThreadStaticIndex(target);
                         if (index is TypeThreadStaticIndexNode ti && ti.IsInlined)
                         {
-                            // REVIEW: how to keep a node around?
-                            // we do not need the index node to run our code, but need to keep the node around for natvis.
-                            // emit a junk MOV for now
-                            encoder.EmitMOV(encoder.TargetRegister.Result, index);
-
                             if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
                             {
                                 EmitInlineTLSAccess(factory, ref encoder);
@@ -99,6 +94,11 @@ namespace ILCompiler.DependencyAnalysis
 
                                 EmitInlineTLSAccess(factory, ref encoder);
                             }
+
+                            // REVIEW: how to keep a node around?
+                            // we do not need the index node to run our code, but need to keep the node around for natvis.
+                            // emit a junk MOV for now  (this code is unreachable)
+                            encoder.EmitMOV(encoder.TargetRegister.Result, index);
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -94,11 +94,6 @@ namespace ILCompiler.DependencyAnalysis
 
                                 EmitInlineTLSAccess(factory, ref encoder);
                             }
-
-                            // REVIEW: how to keep a node around?
-                            // we do not need the index node to run our code, but need to keep the node around for natvis.
-                            // emit a junk MOV for now  (this code is unreachable)
-                            encoder.EmitMOV(encoder.TargetRegister.Result, index);
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -72,8 +72,13 @@ namespace ILCompiler.DependencyAnalysis
                     {
                         MetadataType target = (MetadataType)Target;
                         ISortableSymbolNode index = factory.TypeThreadStaticIndex(target);
-                        if (index is TypeThreadStaticIndexNode ti && ti.Type == null)
+                        if (index is TypeThreadStaticIndexNode ti && ti.IsInlined)
                         {
+                            // REVIEW: how to keep a node around?
+                            // we will not use the index node, but need to keep the node around for natvis.
+                            // emit a junk LEA for now
+                            encoder.EmitMOV(encoder.TargetRegister.Result, index);
+
                             if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
                             {
                                 EmitInlineTLSAccess(factory, ref encoder);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -73,7 +73,6 @@ namespace ILCompiler.DependencyAnalysis
 
             if (_type != null)
             {
-
                 if (factory.PreinitializationManager.HasEagerStaticConstructor(_type))
                 {
                     result.Add(new DependencyListEntry(factory.EagerCctorIndirection(_type.GetStaticConstructor()), "Eager .cctor"));
@@ -89,6 +88,9 @@ namespace ILCompiler.DependencyAnalysis
                     {
                         result.Add(new DependencyListEntry(factory.EagerCctorIndirection(type.GetStaticConstructor()), "Eager .cctor"));
                     }
+
+                    // inlined threadstatics do not need the index for execution, but may need it for debug visualization.
+                    result.Add(new DependencyListEntry(factory.TypeThreadStaticIndex(type), "ThreadStatic index for debug visualization"));
 
                     ModuleUseBasedDependencyAlgorithm.AddDependenciesDueToModuleUse(ref result, factory, type.Module);
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -143,5 +143,7 @@ namespace ILCompiler.DependencyAnalysis
 
             return comparer.Compare(_type, ((ThreadStaticsNode)other)._type);
         }
+
+        internal int GetTypeStorageOffset(MetadataType type) => _inlined.GetOffsets()[type];
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TlsRootNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TlsRootNode.cs
@@ -26,10 +26,15 @@ namespace ILCompiler.DependencyAnalysis
             objData.RequireInitialPointerAlignment();
             objData.AddSymbol(this);
 
-            // root
+            // storage for InlinedThreadStaticRoot instances
+
+            // m_threadStaticsBase
             objData.EmitZeroPointer();
 
-            // next
+            // m_next
+            objData.EmitZeroPointer();
+
+            // m_typeManager
             objData.EmitZeroPointer();
 
             return objData.ToObjectData();

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
@@ -65,7 +65,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (IsInlined)
                 {
                     // Inlined threadstatics are stored as a single data block and thus do not need
-                    // an index in the containing storage (since there is none).
+                    // an index in the containing storage.
                     // We use a negative index to indicate that. Any negative value would work.
                     // For the purpose of natvis we will encode the offset of the type storage within the block.
                     typeTlsIndex = - (_inlinedThreadStatics.GetTypeStorageOffset(_type) + factory.Target.PointerSize);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
@@ -15,19 +15,17 @@ namespace ILCompiler.DependencyAnalysis
         private MetadataType _type;
         private ThreadStaticsNode _inlinedThreadStatics;
 
-        public TypeThreadStaticIndexNode(MetadataType type)
+        public TypeThreadStaticIndexNode(MetadataType type, ThreadStaticsNode inlinedThreadStatics)
         {
             _type = type;
-        }
-
-        public TypeThreadStaticIndexNode(ThreadStaticsNode inlinedThreadStatics)
-        {
             _inlinedThreadStatics = inlinedThreadStatics;
         }
 
+        public bool IsInlined => _inlinedThreadStatics != null;
+
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(_type != null ? nameMangler.NodeMangler.ThreadStaticsIndex(_type) : "_inlinedThreadStaticsIndex");
+            sb.Append(nameMangler.NodeMangler.ThreadStaticsIndex(_type));
         }
 
         public int Offset => 0;
@@ -46,9 +44,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
-            ISymbolDefinitionNode node = _type != null ?
-                        factory.TypeThreadStaticsSymbol(_type) :
-                        _inlinedThreadStatics;
+            ISymbolDefinitionNode node = _inlinedThreadStatics ?? factory.TypeThreadStaticsSymbol(_type);
 
             return new DependencyList
             {
@@ -66,12 +62,7 @@ namespace ILCompiler.DependencyAnalysis
             int typeTlsIndex = 0;
             if (!relocsOnly)
             {
-                if (_type != null)
-                {
-                    ISymbolDefinitionNode node = factory.TypeThreadStaticsSymbol(_type);
-                    typeTlsIndex = ((ThreadStaticsNode)node).IndexFromBeginningOfArray;
-                }
-                else
+                if (IsInlined)
                 {
                     // we use -1 to specify the index of inlined threadstatics,
                     // which are stored separately from uninlined ones.
@@ -80,6 +71,11 @@ namespace ILCompiler.DependencyAnalysis
                     // the type of the storage block for inlined threadstatics, if present,
                     // is serialized as the item #0 among other storage block types.
                     Debug.Assert(_inlinedThreadStatics.IndexFromBeginningOfArray == 0);
+                }
+                else
+                {
+                    ISymbolDefinitionNode node = factory.TypeThreadStaticsSymbol(_type);
+                    typeTlsIndex = ((ThreadStaticsNode)node).IndexFromBeginningOfArray;
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
@@ -64,9 +64,11 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (IsInlined)
                 {
-                    // we use -1 to specify the index of inlined threadstatics,
-                    // which are stored separately from uninlined ones.
-                    typeTlsIndex = -1;
+                    // Inlined threadstatics are stored as a single data block and thus do not need
+                    // an index in the containing storage (since there is none).
+                    // We use a negative index to indicate that. Any negative value would work.
+                    // For the purpose of natvis we will encode the offset of the type storage within the block.
+                    typeTlsIndex = - (_inlinedThreadStatics.GetTypeStorageOffset(_type) + factory.Target.PointerSize);
 
                     // the type of the storage block for inlined threadstatics, if present,
                     // is serialized as the item #0 among other storage block types.


### PR DESCRIPTION
Fixes: #89227

The change implements visualization for threadstatic variables in common cases.


The essence of the change:

=== Uninlined case:
- For reliability reasons the threadstatic storage is all managed in 8.0 (vs. mix of native/managed in 7.0). 
Made corresponding adjustments for indexing of native vs. managed arrays in the natvis.
- Adjusted natvis for renames and removal of redundant `m_numThreadLocalModuleStatics`  

=== Inlined case
- Since `TypeThreadStaticIndexNode` is needed for natvis, start emitting `TypeThreadStaticIndexNode` for inlined types as well.  (we stopped emitting that for inlined threadstatics since the index is not needed at run time)
- Added support in natvis to detect inlined case and interpret `TypeThreadStaticIndexNode` accordingly
(that is mostly to treat the offset not as an _index of the storage block_, but an _offset within the storage block_)

=== overall
- added more comments in a few places
- refactored natvis a bit to make it a bit less painful to read
