### PR TITLE
[wasm] Cache the output of `mono-aot-cross --print-icall-table`

### DIFF
--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -319,7 +319,7 @@
     <Error Condition="'$(_MonoAotCrossCompilerPath)' == '' or !Exists('$(_MonoAotCrossCompilerPath)')"
            Text="Could not find AOT cross compiler at %24(_MonoAotCrossCompilerPath)=$(_MonoAotCrossCompilerPath)" />
 
-    <Exec Command='"$(_MonoAotCrossCompilerPath)" --print-icall-table > "$(_WasmRuntimeICallTablePath)"' />
+    <Exec Command='"$(_MonoAotCrossCompilerPath)" --print-icall-table > "$(_WasmRuntimeICallTablePath)"' Condition="!Exists($(_WasmRuntimeICallTablePath))" />
     <ItemGroup>
       <FileWrites Include="$(_WasmRuntimeICallTablePath)" />
     </ItemGroup>


### PR DESCRIPTION
Currently, this is invoked to get the runtime icall table for native builds, even if it is not needed by ManagedtoNativeGenerator (for example when outputs are up-to-date). This will change only with the cross compiler, so it can be cached.

Suggested by @vargaz .

Fixes https://github.com/dotnet/runtime/issues/90366 .
