### PR TITLE
Improve error message in the new `JsonNode.GetElementIndex()` and `GetPropertyName()` methods.

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -576,6 +576,9 @@
   <data name="NodeWrongType" xml:space="preserve">
     <value>The node must be of type '{0}'.</value>
   </data>
+  <data name="NodeParentWrongType" xml:space="preserve">
+    <value>The node must have a parent node of type '{0}'.</value>
+  </data>
   <data name="NodeDuplicateKey" xml:space="preserve">
     <value>An item with the same key has already been added. Key: {0}</value>
   </data>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.cs
@@ -261,14 +261,14 @@ namespace System.Text.Json.Nodes
         /// </exception>
         public string GetPropertyName()
         {
-            JsonObject? jsonObject = _parent as JsonObject;
+            JsonObject? parentObject = _parent as JsonObject;
 
-            if (jsonObject is null)
+            if (parentObject is null)
             {
-                ThrowHelper.ThrowInvalidOperationException_NodeWrongType(nameof(JsonObject));
+                ThrowHelper.ThrowInvalidOperationException_NodeParentWrongType(nameof(JsonObject));
             }
 
-            return jsonObject.GetPropertyName(this);
+            return parentObject.GetPropertyName(this);
         }
 
         /// <summary>
@@ -279,14 +279,14 @@ namespace System.Text.Json.Nodes
         /// </exception>
         public int GetElementIndex()
         {
-            JsonArray? jsonArray = _parent as JsonArray;
+            JsonArray? parentArray = _parent as JsonArray;
 
-            if (jsonArray is null)
+            if (parentArray is null)
             {
-                ThrowHelper.ThrowInvalidOperationException_NodeWrongType(nameof(JsonArray));
+                ThrowHelper.ThrowInvalidOperationException_NodeParentWrongType(nameof(JsonArray));
             }
 
-            return jsonArray.GetElementIndex(this);
+            return parentArray.GetElementIndex(this);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Node.cs
@@ -50,6 +50,12 @@ namespace System.Text.Json
             throw new InvalidOperationException(SR.Format(SR.NodeWrongType, typeName));
         }
 
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_NodeParentWrongType(string typeName)
+        {
+            throw new InvalidOperationException(SR.Format(SR.NodeParentWrongType, typeName));
+        }
+
         public static NotSupportedException GetNotSupportedException_CollectionIsReadOnly()
         {
             return new NotSupportedException(SR.CollectionIsReadOnly);


### PR DESCRIPTION
Fix #90474