### PR TITLE
Make TimeProvider Delay Continuations Synchronously

### DIFF
--- a/src/libraries/Common/tests/System/TimeProviderTests.cs
+++ b/src/libraries/Common/tests/System/TimeProviderTests.cs
@@ -692,7 +692,7 @@ namespace Tests.System
                 {
                     await taskFactory.Delay(timeProvider, TimeSpan.FromSeconds(10), token);
                 }
-                catch (TaskCanceledException)
+                catch (OperationCanceledException)
                 {
                     // Ignore
                 }

--- a/src/libraries/Common/tests/System/TimeProviderTests.cs
+++ b/src/libraries/Common/tests/System/TimeProviderTests.cs
@@ -656,7 +656,7 @@ namespace Tests.System
             //
 
             ManualTimeProvider manualTimeProvider = new ManualTimeProvider();
-            var callbackCount = 0;
+            int callbackCount = 0;
 
             _ = Continuation(manualTimeProvider, default, () => callbackCount++);
 

--- a/src/libraries/Common/tests/System/TimeProviderTests.cs
+++ b/src/libraries/Common/tests/System/TimeProviderTests.cs
@@ -680,7 +680,7 @@ namespace Tests.System
             Task task = Continuation(manualTimeProvider, cts.Token, () =>  t1Value = tl.Value);
             cts.Cancel();
 
-            // rest the thread local value as the continuation callback could end up running on the this thread pool thread.
+            // reset the thread local value as the continuation callback could end up running on this thread pool thread.
             tl.Value = 0;
             await task;
 

--- a/src/libraries/Common/tests/System/TimeProviderTests.cs
+++ b/src/libraries/Common/tests/System/TimeProviderTests.cs
@@ -649,7 +649,7 @@ namespace Tests.System
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(TaskFactoryData))]
-        public async void TestDelayTaskContinuation(ITestTaskFactory taskFactory)
+        public async Task TestDelayTaskContinuation(ITestTaskFactory taskFactory)
         {
             //
             // Test time expiration and validate continuation is called synchronously.

--- a/src/libraries/Microsoft.Bcl.TimeProvider/src/System/Threading/Tasks/TimeProviderTaskExtensions.cs
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/src/System/Threading/Tasks/TimeProviderTaskExtensions.cs
@@ -15,7 +15,7 @@ namespace System.Threading.Tasks
 #if !NET8_0_OR_GREATER
         private sealed class DelayState : TaskCompletionSource<bool>
         {
-            public DelayState(CancellationToken cancellationToken) : base()
+            public DelayState(CancellationToken cancellationToken)
             {
                 CancellationToken = cancellationToken;
             }

--- a/src/libraries/Microsoft.Bcl.TimeProvider/src/System/Threading/Tasks/TimeProviderTaskExtensions.cs
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/src/System/Threading/Tasks/TimeProviderTaskExtensions.cs
@@ -91,6 +91,7 @@ namespace System.Threading.Tasks
                 DelayState s = (DelayState)delayState!;
 
                 // When cancellation is requested, we need to force the task continuation to run asynchronously
+                // to avoid doing arbitrary amounts of work as part of a call to CancellationTokenSource.Cancel.
                 ThreadPool.UnsafeQueueUserWorkItem(static state =>
                 {
                     DelayState theState = (DelayState)state;

--- a/src/libraries/Microsoft.Bcl.TimeProvider/src/System/Threading/Tasks/TimeProviderTaskExtensions.cs
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/src/System/Threading/Tasks/TimeProviderTaskExtensions.cs
@@ -15,7 +15,7 @@ namespace System.Threading.Tasks
 #if !NET8_0_OR_GREATER
         private sealed class DelayState : TaskCompletionSource<bool>
         {
-            public DelayState(CancellationToken cancellationToken) : base(TaskCreationOptions.RunContinuationsAsynchronously)
+            public DelayState(CancellationToken cancellationToken) : base()
             {
                 CancellationToken = cancellationToken;
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/85326	

The TimeProvider in .NET 8.0 offers Task Delay functionality, and this functionality is also accessible in earlier versions using the System.Bcl.TimeProvider library. When invoked within the .NET 8.0 runtime, it generates a Task like using [DelayPromise](https://github.com/dotnet/runtime/blob/f6d22201603db303d8e7feb4c8c9f27b0dcade6a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L5672C23-L5672C35), configured with a state flags value of 0x07000400. This setting signifies that the Task's continuation will be executed synchronously. Once the Delay duration elapses, the [RunContinuations](https://github.com/dotnet/runtime/blob/f6d22201603db303d8e7feb4c8c9f27b0dcade6a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L3436) function is triggered. Within this process, a check is performed (at [this point](https://github.com/dotnet/runtime/blob/f6d22201603db303d8e7feb4c8c9f27b0dcade6a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L3445)), leading to the synchronous execution of the task continuation due to the absence of the `TaskCreationOptions.RunContinuationsAsynchronously` flag.

In cases where we operate on earlier runtime versions, we explicitly enable the `TaskCreationOptions.RunContinuationsAsynchronously` flag, which modifies the behavior of task continuations compared to .NET 8.0. To ensure consistent behavior with .NET 8.0, the recommended solution is to refrain from setting the `TaskCreationOptions.RunContinuationsAsynchronously` flag when executing on earlier runtime versions.
