### PR TITLE
Fix VersionWithType Crossgen2 check for parameterized types

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -363,8 +363,15 @@ namespace ILCompiler
 
         public sealed override bool VersionsWithType(TypeDesc typeDesc)
         {
-            return typeDesc.GetTypeDefinition() is EcmaType ecmaType &&
-                _versionsWithTypeCache.GetOrAdd(typeDesc, _versionsWithTypeUncached);
+            if (typeDesc.GetTypeDefinition() is EcmaType)
+            {
+                return _versionsWithTypeCache.GetOrAdd(typeDesc, _versionsWithTypeUncached);
+            }
+            if (typeDesc.IsParameterizedType)
+            {
+                return VersionsWithType(((ParameterizedType)typeDesc).ParameterType);
+            }
+            return false;
         }
 
         public bool CrossModuleInlineableModule(ModuleDesc module)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -918,13 +918,7 @@ namespace ILCompiler
 
             static bool ComputeInstantiationTypeVersionsWithCode(Func<TypeDesc, bool> versionsWithTypePredicate, TypeDesc type)
             {
-                if (type == type.Context.CanonType)
-                    return true;
-
-                if (versionsWithTypePredicate(type))
-                    return true;
-
-                return false;
+                return type == type.Context.CanonType || versionsWithTypePredicate(type);
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -363,15 +363,7 @@ namespace ILCompiler
 
         public sealed override bool VersionsWithType(TypeDesc typeDesc)
         {
-            if (typeDesc.GetTypeDefinition() is EcmaType)
-            {
-                return _versionsWithTypeCache.GetOrAdd(typeDesc, _versionsWithTypeUncached);
-            }
-            if (typeDesc.IsParameterizedType)
-            {
-                return VersionsWithType(((ParameterizedType)typeDesc).ParameterType);
-            }
-            return false;
+            return _versionsWithTypeCache.GetOrAdd(typeDesc, _versionsWithTypeUncached);
         }
 
         public bool CrossModuleInlineableModule(ModuleDesc module)
@@ -762,6 +754,16 @@ namespace ILCompiler
 
         private bool ComputeTypeVersionsWithCode(TypeDesc type)
         {
+            if (type.IsParameterizedType)
+            {
+                return VersionsWithType(type.GetParameterType());
+            }
+
+            if (!(type.GetTypeDefinition() is EcmaType))
+            {
+                return false;
+            }
+            
             if (type.IsCanonicalDefinitionType(CanonicalFormKind.Any))
                 return true;
 
@@ -921,12 +923,6 @@ namespace ILCompiler
 
                 if (versionsWithTypePredicate(type))
                     return true;
-
-                if (type.IsArray)
-                    return ComputeInstantiationTypeVersionsWithCode(versionsWithTypePredicate, type.GetParameterType());
-
-                if (type.IsPointer)
-                    return ComputeInstantiationTypeVersionsWithCode(versionsWithTypePredicate, type.GetParameterType());
 
                 return false;
             }


### PR DESCRIPTION
As Egor Bogatov discovered in

https://github.com/dotnet/runtime/pull/90441

Crossgen2 is unable to compile a method taking RuntimeTypeMethod[] parameter because Crossgen2 decides that the array doesn't version with the module being compiled (System.Private.CoreLib in this case). This change modifies the relevant logic so that, for parameterized types, we decide on versioning based on the parameter type.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 