### PR TITLE
Clean up AggressiveOpt tier in vm

### DIFF
--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -3035,6 +3035,9 @@ bool MethodDesc::DetermineAndSetIsEligibleForTieredCompilation()
         // Functional requirement - These methods have no IL that could be optimized
         !IsWrapperStub() &&
 
+        // Functions with AggressiveOptimization attribute bypass tiering
+        !RequestedAggressiveOptimization() &&
+
         // Policy - Generating optimized code is not disabled
         !IsJitOptimizationDisabledForSpecificMethod())
     {

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -3035,11 +3035,8 @@ bool MethodDesc::DetermineAndSetIsEligibleForTieredCompilation()
         // Functional requirement - These methods have no IL that could be optimized
         !IsWrapperStub() &&
 
-        // Functions with AggressiveOptimization attribute bypass tiering
-        !RequestedAggressiveOptimization() &&
-
-        // Policy - Generating optimized code is not disabled
-        !IsJitOptimizationDisabledForSpecificMethod())
+        // Functions with NoOptimization or AggressiveOptimization don't participate in tiering
+        !IsJitOptimizationLevelRequested())
     {
         m_wFlags3AndTokenRemainder |= enum_flag3_IsEligibleForTieredCompilation;
         _ASSERTE(IsVersionable());
@@ -3063,6 +3060,17 @@ bool MethodDesc::IsJitOptimizationDisabled()
 bool MethodDesc::IsJitOptimizationDisabledForSpecificMethod()
 {
     return (!IsNoMetadata() && IsMiNoOptimization(GetImplAttrs()));
+}
+
+bool MethodDesc::IsJitOptimizationLevelRequested()
+{
+    if (IsNoMetadata())
+    {
+        return false;
+    }
+
+    const DWORD attrs = GetImplAttrs();
+    return IsMiNoOptimization(attrs) || IsMiAggressiveOptimization(attrs);
 }
 
 bool MethodDesc::IsJitOptimizationDisabledForAllMethodsInChunk()

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1124,6 +1124,7 @@ public:
     bool IsJitOptimizationDisabled();
     bool IsJitOptimizationDisabledForAllMethodsInChunk();
     bool IsJitOptimizationDisabledForSpecificMethod();
+    bool IsJitOptimizationLevelRequested();
 
 private:
     // This function is not intended to be called in most places, and is named as such to discourage calling it accidentally


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/90490

Currently, MethodDesc with `[AggressiveOptimization]` attribute still returns `true` for `IsEligibleForTieredCompilation()`. This PR makes it `false` + clean up.

So now methods with that attribute are reported as FullOpts instead of Tier1.

PS: I recommend disabling "show whitespaces" on the review page.