### PR TITLE
[libs][mono] Prevent static constructor from referencing `Internal.Runtime.Augments.DynamicDelegateAugments` in build scenarios without linking

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -29,7 +29,7 @@ namespace System.Dynamic.Utils
                 // on runtimes which do not support this private API.
                 if (!CanEmitObjectArrayDelegate)
                 {
-                    return Type.GetType("Internal.Runtime.Augments.DynamicDelegateAugments")!
+                    return Type.GetType("Internal.Runtime.Augments.DynamicDelegateAugments, System.Private.CoreLib")!
                         .GetMethod("CreateObjectArrayDelegate")!
                         .CreateDelegate<Func<Type, Func<object?[], object?>, Delegate>>();
                 }

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -29,7 +29,7 @@ namespace System.Dynamic.Utils
                 // on runtimes which do not support this private API.
                 if (!CanEmitObjectArrayDelegate)
                 {
-                    return Type.GetType("Internal.Runtime.Augments.DynamicDelegateAugments, System.Private.CoreLib")!
+                    return Type.GetType("Internal.Runtime.Augments.DynamicDelegateAugments, System.Private.CoreLib", throwOnError: true)!
                         .GetMethod("CreateObjectArrayDelegate")!
                         .CreateDelegate<Func<Type, Func<object?[], object?>, Delegate>>();
                 }

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -19,23 +19,8 @@ namespace System.Dynamic.Utils
         // with the Reflection.Emit statics below.
         private static class DynamicDelegateLightup
         {
-            public static Func<Type, Func<object?[], object?>, Delegate> CreateObjectArrayDelegate
-            {
-                get
-                {
-                    // CreateObjectArrayDelegateInternal is only supported with NativeAOT which always expects CanEmitObjectArrayDelegate to be false.
-                    // Additionally, this check guards static constructor of trying to resolve 'Internal.Runtime.Augments.DynamicDelegateAugments'
-                    // on runtimes which do not support this private API, which would otherwise cause TypeInitializationException.
-                    if (!CanEmitObjectArrayDelegate)
-                    {
-                        return CreateObjectArrayDelegateInternal();
-                    }
-                    else
-                    {
-                        throw new System.NotImplementedException();
-                    }
-                }
-            }
+            public static Func<Type, Func<object?[], object?>, Delegate> CreateObjectArrayDelegate { get; }
+                = CreateObjectArrayDelegateInternal();
 
             private static Func<Type, Func<object?[], object?>, Delegate> CreateObjectArrayDelegateInternal()
                 => Type.GetType("Internal.Runtime.Augments.DynamicDelegateAugments")!

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -23,9 +23,21 @@ namespace System.Dynamic.Utils
                 = CreateObjectArrayDelegateInternal();
 
             private static Func<Type, Func<object?[], object?>, Delegate> CreateObjectArrayDelegateInternal()
-                => Type.GetType("Internal.Runtime.Augments.DynamicDelegateAugments")!
-                    .GetMethod("CreateObjectArrayDelegate")!
-                    .CreateDelegate<Func<Type, Func<object?[], object?>, Delegate>>();
+            {
+                // This is only supported by NativeAOT which always expects CanEmitObjectArrayDelegate to be false.
+                // This check guards static constructor of trying to resolve 'Internal.Runtime.Augments.DynamicDelegateAugments'
+                // on runtimes which do not support this private API.
+                if (!CanEmitObjectArrayDelegate)
+                {
+                    return Type.GetType("Internal.Runtime.Augments.DynamicDelegateAugments")!
+                        .GetMethod("CreateObjectArrayDelegate")!
+                        .CreateDelegate<Func<Type, Func<object?[], object?>, Delegate>>();
+                }
+                else
+                {
+                    return new Func<Type, Func<object?[], object?>, Delegate>((_x, _y) => throw new NotImplementedException());
+                }
+            }
         }
 
         private static class ForceAllowDynamicCodeLightup


### PR DESCRIPTION
This PR fixes a regression introduced with unifying the `System.Linq.Expressions` library build in https://github.com/dotnet/runtime/pull/88723 when targeting iOS-like platforms without linking (no trimming) with Mono. 

The regression was noticed in libraries tests failures on `tvos-arm64` reported here: https://github.com/dotnet/runtime/issues/90494 which are configured not to perform any trimming during the app build.

The tests are failing due to the fact that `DynamicDelegateLightup` as a type is not trimmed away during library build time (as it previously was before unification), and since the trimming is disabled during app (libraries tests) build time ends up in the final executable. This further cause a problem at runtime because Mono tries to initialise a type which references a type/method which is only implemented by NativeAOT: `Internal.Runtime.Augments.DynamicDelegateAugments` https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/DynamicDelegateAugments.cs

This has been fixed by guarding a reference to the private API that only NativeAOT implements preventing static constructor to throw `TypeInitializationException`

---
Fixes https://github.com/dotnet/runtime/issues/90494