### PR TITLE
[wasm][debugger] Do not run the test with justMyCode enabled in debug mode.

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -39,7 +39,12 @@ namespace DebuggerTests
 #else
             => WasmHost.Firefox;
 #endif
-
+        public static bool ReleaseRuntime
+#if RELEASE_RUNTIME
+            => true;
+#else
+            => false;
+#endif
         public static bool WasmMultiThreaded => EnvironmentVariables.WasmTestsUsingVariant == "multithreaded";
 
         public static bool WasmSingleThreaded => !WasmMultiThreaded;

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
@@ -6,6 +6,7 @@
     <RunAnalyzers>false</RunAnalyzers>
     <DebuggerHost Condition="'$(DebuggerHost)' == '' or ('$(DebuggerHost)' != 'chrome' and '$(DebuggerHost)' != 'firefox')">chrome</DebuggerHost>
     <DefineConstants Condition="'$(DebuggerHost)' == 'chrome'">$(DefineConstants);RUN_IN_CHROME</DefineConstants>
+    <DefineConstants Condition="'$(RuntimeConfiguration)' == 'release'">$(DefineConstants);RELEASE_RUNTIME</DefineConstants>
     <BrowserHost Condition="$([MSBuild]::IsOSPlatform('windows'))">windows</BrowserHost>
     <_ProvisionBrowser Condition="'$(ContinuousIntegrationBuild)' == 'true' or Exists('/.dockerenv')">true</_ProvisionBrowser>
     <InstallChromeForTests Condition="'$(InstallChromeForTests)' == '' and '$(DebuggerHost)' == 'chrome' and '$(_ProvisionBrowser)' == 'true'">true</InstallChromeForTests>

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
@@ -1237,8 +1237,8 @@ namespace DebuggerTests
                 Assert.False(pause_location["callFrames"].Value<JArray>().Any(f => f?["scopeChain"]?[0]?["type"]?.Value<string>()?.Equals("wasm-expression-stack") == true));
             else
                 Assert.True(pause_location["callFrames"].Value<JArray>().Any(f => f?["scopeChain"]?[0]?["type"]?.Value<string>()?.Equals("wasm-expression-stack") == true));
-            if (justMyCode)
-                await StepAndCheck(StepKind.Out, "dotnet://debugger-test.dll/debugger-test.cs", 10, 8, "Math.IntAdd", times: 4);
+            if (justMyCode && ReleaseRuntime)
+                    await StepAndCheck(StepKind.Out, "dotnet://debugger-test.dll/debugger-test.cs", 10, 8, "Math.IntAdd", times: 4);
         }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
@@ -1238,7 +1238,7 @@ namespace DebuggerTests
             else
                 Assert.True(pause_location["callFrames"].Value<JArray>().Any(f => f?["scopeChain"]?[0]?["type"]?.Value<string>()?.Equals("wasm-expression-stack") == true));
             if (justMyCode && ReleaseRuntime)
-                    await StepAndCheck(StepKind.Out, "dotnet://debugger-test.dll/debugger-test.cs", 10, 8, "Math.IntAdd", times: 4);
+                await StepAndCheck(StepKind.Out, "dotnet://debugger-test.dll/debugger-test.cs", 10, 8, "Math.IntAdd", times: 4);
         }
     }
 }


### PR DESCRIPTION
The callstack is different in debug mode, this is expected.
Fixes https://github.com/dotnet/runtime/issues/86387