### PR TITLE
[JIT] ARM64 - Temporary fix for `ldp`/`stp` optimizations

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -16615,6 +16615,15 @@ emitter::RegisterOrder emitter::IsOptimizableLdrStrWithPair(
     emitAttr  prevSize   = emitLastIns->idOpSize();
     ssize_t   prevImm    = emitGetInsSC(emitLastIns);
 
+    // If we have this format, the 'imm' and/or 'prevImm' are not scaled(encoded),
+    // therefore we cannot proceed.
+    // TODO: In this context, 'imm' and 'prevImm' are assumed to be scaled(encoded).
+    //       They should never be scaled(encoded) until its about to be written to the buffer.
+    if (fmt == IF_LS_2C || lastInsFmt == IF_LS_2C)
+    {
+        return eRO_none;
+    }
+
     // Signed, *raw* immediate value fits in 7 bits, so for LDP/ STP the raw value is from -64 to +63.
     // For LDR/ STR, there are 9 bits, so we need to limit the range explicitly in software.
     if ((imm < -64) || (imm > 63) || (prevImm < -64) || (prevImm > 63))

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85765/Runtime_85765.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85765/Runtime_85765.cs
@@ -52,7 +52,7 @@ public class Runtime_85765
         bytes[0x1A] = 1;
         bytes[0x1B] = 2;
         int sum = Foo(bytes);
-        Assert.Equal(515, sum);
+        Assert.True(sum == 515);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85765/Runtime_85765.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85765/Runtime_85765.cs
@@ -42,4 +42,22 @@ public class Runtime_85765
     {
         return value;
     }
+
+    // ------
+
+    [Fact]
+    public static void Test2()
+    {
+        byte* bytes = stackalloc byte[1024];
+        bytes[0x1A] = 1;
+        bytes[0x1B] = 2;
+        int sum = Foo(bytes);
+        Assert.Equal(515, sum);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Foo(byte* b)
+    {
+        return Unsafe.ReadUnaligned<int>(ref b[0x1A]) + Unsafe.ReadUnaligned<int>(ref b[0x1B]);
+    }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85765/Runtime_85765.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85765/Runtime_85765.cs
@@ -29,6 +29,7 @@ public class Runtime_85765
         Assert.False(Consume(vr2.F2));
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static S1 M4()
     {
         S1 var1 = default(S1);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85765/Runtime_85765.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85765/Runtime_85765.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_85765
+{
+    public struct S0
+    {
+        public S0(bool f1): this()
+        {
+        }
+    }
+
+    public struct S1
+    {
+        public byte F0;
+        public bool F1;
+        public bool F2;
+    }
+
+    [Fact]
+    public static void Test()
+    {
+        S1 vr2 = M4();
+        vr2.F2 |= vr2.F1;
+        Assert.False(Consume(vr2.F2));
+    }
+
+    public static S1 M4()
+    {
+        S1 var1 = default(S1);
+        var vr0 = new S0(false);
+        return var1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Consume(bool value)
+    {
+        return value;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_85765/Runtime_85765.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85765/Runtime_85765.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/85765

With the latest, the code-gen is quite different from what was reported in the issue, and therefore doesn't reproduce. But the issue still exists and is able to be reproduced by a different sample:

```csharp
using System;
using System.Runtime.CompilerServices;

// Expected: 515
// Actual: 0
public unsafe class Program
{
    public static void Main()
    {
        byte* bytes = stackalloc byte[1024];
        bytes[0x1A] = 1;
        bytes[0x1B] = 2;
        int sum = Foo(bytes);
        Console.WriteLine(sum);
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    public static int Foo(byte* b)
    {
        return Unsafe.ReadUnaligned<int>(ref b[0x1A]) + Unsafe.ReadUnaligned<int>(ref b[0x1B]);
    }
}
```