### PR TITLE
Revert "[mono] Update runtimeFlavor property for Mono AOT perf jobs"

### DIFF
--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -293,7 +293,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
       buildConfig: release
-      runtimeFlavor: mono
+      runtimeFlavor: aot
       platforms:
       - linux_x64
       jobParameters:

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -158,7 +158,7 @@ extends:
           parameters:
             jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
             buildConfig: release
-            runtimeFlavor: mono
+            runtimeFlavor: aot
             platforms:
             - linux_arm64
             jobParameters:


### PR DESCRIPTION
This PR fixes failing Mono AOT perf jobs. If runtime flavor is set to mono, artifacts can't be found. 

https://dev.azure.com/dnceng/internal/_build/results?buildId=2242319&view=logs&j=3ad9afb5-5506-517e-402a-ab4e139d0d70&t=8949bdb7-a752-5bf3-8dd8-c76bc9ac64db

Reverts dotnet/runtime#90215