### PR TITLE
Extract general syntax generation code to SyntaxFactoryExtensions and use where possible

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportCodeGenerator.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Interop.JavaScript
 
             if (!(statements.GuaranteedUnmarshal.IsEmpty && statements.CleanupCalleeAllocated.IsEmpty))
             {
-                setupStatements.Add(MarshallerHelpers.Declare(PredefinedType(Token(SyntaxKind.BoolKeyword)), InvokeSucceededIdentifier, initializeToDefault: true));
+                setupStatements.Add(SyntaxFactoryExtensions.Declare(PredefinedType(Token(SyntaxKind.BoolKeyword)), InvokeSucceededIdentifier, initializeToDefault: true));
             }
 
             setupStatements.AddRange(declarations.Initializations);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportCodeGenerator.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Interop.JavaScript
 
             if (!(statements.GuaranteedUnmarshal.IsEmpty && statements.CleanupCalleeAllocated.IsEmpty))
             {
-                setupStatements.Add(MarshallerHelpers.Declare(PredefinedType(Token(SyntaxKind.BoolKeyword)), InvokeSucceededIdentifier, initializeToDefault: true));
+                setupStatements.Add(SyntaxFactoryExtensions.Declare(PredefinedType(Token(SyntaxKind.BoolKeyword)), InvokeSucceededIdentifier, initializeToDefault: true));
             }
 
             setupStatements.AddRange(declarations.Initializations);

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.Interop.SyntaxFactoryExtensions;
 
 namespace Microsoft.Interop
 {
@@ -467,11 +468,9 @@ namespace Microsoft.Interop
                             .Select(context => context.Stub.Node)));
         }
 
-        private static readonly TypeSyntax VoidStarStarSyntax = PointerType(PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword))));
-
         private const string CreateManagedVirtualFunctionTableMethodName = "CreateManagedVirtualFunctionTable";
 
-        private static readonly MethodDeclarationSyntax CreateManagedVirtualFunctionTableMethodTemplate = MethodDeclaration(VoidStarStarSyntax, CreateManagedVirtualFunctionTableMethodName)
+        private static readonly MethodDeclarationSyntax CreateManagedVirtualFunctionTableMethodTemplate = MethodDeclaration(TypeSyntaxes.VoidStarStar, CreateManagedVirtualFunctionTableMethodName)
             .AddModifiers(Token(SyntaxKind.InternalKeyword), Token(SyntaxKind.StaticKeyword));
 
         private static InterfaceDeclarationSyntax GenerateImplementationVTable(ComInterfaceAndMethodsContext interfaceMethods, CancellationToken _)
@@ -486,25 +485,19 @@ namespace Microsoft.Interop
 
             // void** vtable = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(<interfaceType>, sizeof(void*) * <max(vtableIndex) + 1>);
             var vtableDeclarationStatement =
-                LocalDeclarationStatement(
-                    VariableDeclaration(
-                        VoidStarStarSyntax,
-                        SingletonSeparatedList(
-                            VariableDeclarator(vtableLocalName)
-                            .WithInitializer(
-                                EqualsValueClause(
-                                    CastExpression(VoidStarStarSyntax,
-                                        InvocationExpression(
-                                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                                TypeSyntaxes.System_Runtime_CompilerServices_RuntimeHelpers,
-                                                IdentifierName("AllocateTypeAssociatedMemory")))
-                                        .AddArgumentListArguments(
-                                            Argument(TypeOfExpression(interfaceType.Syntax)),
-                                            Argument(
-                                                BinaryExpression(
-                                                    SyntaxKind.MultiplyExpression,
-                                                    SizeOfExpression(PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword)))),
-                                                    LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(3 + interfaceMethods.Methods.Length)))))))))));
+                Declare(
+                    TypeSyntaxes.VoidStarStar,
+                    vtableLocalName,
+                    CastExpression(TypeSyntaxes.VoidStarStar,
+                        MethodInvocation(
+                            TypeSyntaxes.System_Runtime_CompilerServices_RuntimeHelpers,
+                            IdentifierName("AllocateTypeAssociatedMemory"),
+                            Argument(TypeOfExpression(interfaceType.Syntax)),
+                            Argument(
+                                BinaryExpression(
+                                    SyntaxKind.MultiplyExpression,
+                                    SizeOfExpression(TypeSyntaxes.VoidStar),
+                                    IntLiteral(3 + interfaceMethods.Methods.Length))))));
 
             BlockSyntax fillBaseInterfaceSlots;
 
@@ -522,105 +515,53 @@ namespace Microsoft.Interop
                                 VariableDeclarator("v2")
                             )),
                         // ComWrappers.GetIUnknownImpl(out v0, out v1, out v2);
-                        ExpressionStatement(
-                            InvocationExpression(
-                                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                    TypeSyntaxes.System_Runtime_InteropServices_ComWrappers,
-                                    IdentifierName("GetIUnknownImpl")))
-                            .AddArgumentListArguments(
-                                Argument(IdentifierName("v0"))
-                                        .WithRefKindKeyword(Token(SyntaxKind.OutKeyword)),
-                                Argument(IdentifierName("v1"))
-                                    .WithRefKindKeyword(Token(SyntaxKind.OutKeyword)),
-                                Argument(IdentifierName("v2"))
-                                    .WithRefKindKeyword(Token(SyntaxKind.OutKeyword)))),
+                        MethodInvocationStatement(
+                            TypeSyntaxes.System_Runtime_InteropServices_ComWrappers,
+                            IdentifierName("GetIUnknownImpl"),
+                            OutArgument(IdentifierName("v0")),
+                            OutArgument(IdentifierName("v1")),
+                            OutArgument(IdentifierName("v2"))),
                         // m_vtable[0] = (void*)v0;
-                        ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                                ElementAccessExpression(
-                                    IdentifierName(vtableLocalName),
-                                    BracketedArgumentList(
-                                        SingletonSeparatedList(
-                                            Argument(
-                                                LiteralExpression(
-                                                    SyntaxKind.NumericLiteralExpression,
-                                                    Literal(0)))))),
-                                CastExpression(
-                                    PointerType(
-                                        PredefinedType(Token(SyntaxKind.VoidKeyword))),
-                                    IdentifierName("v0")))),
+                        AssignmentStatement(
+                            IndexExpression(
+                                IdentifierName(vtableLocalName),
+                                Argument(IntLiteral(0))),
+                            CastExpression(TypeSyntaxes.VoidStar, IdentifierName("v0"))),
                         // m_vtable[1] = (void*)v1;
-                        ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                                ElementAccessExpression(
-                                    IdentifierName(vtableLocalName),
-                                    BracketedArgumentList(
-                                        SingletonSeparatedList(
-                                            Argument(
-                                                LiteralExpression(
-                                                    SyntaxKind.NumericLiteralExpression,
-                                                    Literal(1)))))),
-                                CastExpression(
-                                    PointerType(
-                                        PredefinedType(Token(SyntaxKind.VoidKeyword))),
-                                    IdentifierName("v1")))),
+                        AssignmentStatement(
+                            IndexExpression(
+                                IdentifierName(vtableLocalName),
+                                Argument(IntLiteral(1))),
+                            CastExpression(TypeSyntaxes.VoidStar, IdentifierName("v1"))),
                         // m_vtable[2] = (void*)v2;
-                        ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                                ElementAccessExpression(
-                                    IdentifierName(vtableLocalName),
-                                    BracketedArgumentList(
-                                        SingletonSeparatedList(
-                                            Argument(
-                                                LiteralExpression(
-                                                    SyntaxKind.NumericLiteralExpression,
-                                                    Literal(2)))))),
-                                CastExpression(
-                                    PointerType(
-                                        PredefinedType(Token(SyntaxKind.VoidKeyword))),
-                                    IdentifierName("v2")))));
+                        AssignmentStatement(
+                            IndexExpression(
+                                IdentifierName(vtableLocalName),
+                                Argument(IntLiteral(2))),
+                            CastExpression(TypeSyntaxes.VoidStar, IdentifierName("v2"))));
             }
             else
             {
                 // NativeMemory.Copy(StrategyBasedComWrappers.DefaultIUnknownInteraceDetailsStrategy.GetIUnknownDerivedDetails(typeof(<baseInterfaceType>).TypeHandle).ManagedVirtualMethodTable, vtable, (nuint)(sizeof(void*) * <startingOffset>));
-                fillBaseInterfaceSlots = Block()
-                    .AddStatements(
-                        ExpressionStatement(
-                            InvocationExpression(
-                                MemberAccessExpression(
-                                    SyntaxKind.SimpleMemberAccessExpression,
-                                    TypeSyntaxes.System_Runtime_InteropServices_NativeMemory,
-                                    IdentifierName("Copy")))
-                            .WithArgumentList(
-                                ArgumentList(
-                                    SeparatedList(
-                                        new[]
-                                        {
-                                            Argument(
-                                                MemberAccessExpression(
-                                                    SyntaxKind.SimpleMemberAccessExpression,
-                                                    InvocationExpression(
-                                                        MemberAccessExpression(
-                                                            SyntaxKind.SimpleMemberAccessExpression,
-                                                            MemberAccessExpression(
-                                                                SyntaxKind.SimpleMemberAccessExpression,
-                                                                TypeSyntaxes.StrategyBasedComWrappers,
-                                                                IdentifierName("DefaultIUnknownInterfaceDetailsStrategy")),
-                                                            IdentifierName("GetIUnknownDerivedDetails")))
-                                                    .WithArgumentList(
-                                                        ArgumentList(
-                                                            SingletonSeparatedList(
-                                                                Argument(
-                                                                    MemberAccessExpression(
-                                                                        SyntaxKind.SimpleMemberAccessExpression,
-                                                                        TypeOfExpression(
-                                                                            ParseTypeName(interfaceMethods.Interface.Base.Info.Type.FullTypeName)), //baseInterfaceTypeInfo.BaseInterface.FullTypeName)),
-                                                                        IdentifierName("TypeHandle")))))),
-                                                    IdentifierName("ManagedVirtualMethodTable"))),
-                                            Argument(IdentifierName(vtableLocalName)),
-                                            Argument(CastExpression(IdentifierName("nuint"),
-                                                ParenthesizedExpression(
-                                                    BinaryExpression(SyntaxKind.MultiplyExpression,
-                                                        SizeOfExpression(PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword)))),
-                                                        LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(interfaceMethods.ShadowingMethods.Count() + 3))))))
-                                        })))));
+                fillBaseInterfaceSlots = Block(
+                        MethodInvocationStatement(
+                            TypeSyntaxes.System_Runtime_InteropServices_NativeMemory,
+                            IdentifierName("Copy"),
+                            Argument(
+                                MethodInvocation(
+                                    TypeSyntaxes.StrategyBasedComWrappers
+                                        .Dot(IdentifierName("DefaultIUnknownInterfaceDetailsStrategy")),
+                                    IdentifierName("GetIUnknownDerivedDetails"),
+                                    Argument( //baseInterfaceTypeInfo.BaseInterface.FullTypeName)),
+                                        TypeOfExpression(ParseTypeName(interfaceMethods.Interface.Base.Info.Type.FullTypeName))
+                                            .Dot(IdentifierName("TypeHandle"))))
+                                    .Dot(IdentifierName("ManagedVirtualMethodTable"))),
+                            Argument(IdentifierName(vtableLocalName)),
+                            Argument(CastExpression(IdentifierName("nuint"),
+                                ParenthesizedExpression(
+                                    BinaryExpression(SyntaxKind.MultiplyExpression,
+                                        SizeOfExpression(PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword)))),
+                                        LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(interfaceMethods.ShadowingMethods.Count() + 3))))))));
             }
 
             var vtableSlotAssignments = VirtualMethodPointerStubGenerator.GenerateVirtualMethodTableSlotAssignments(
@@ -666,10 +607,10 @@ namespace Microsoft.Interop
                 const string vtableFieldName = "_vtable";
                 return interfaceInformationType.AddMembers(
                         // private static void** _vtable;
-                        FieldDeclaration(VariableDeclaration(VoidStarStarSyntax, SingletonSeparatedList(VariableDeclarator(vtableFieldName))))
+                        FieldDeclaration(VariableDeclaration(TypeSyntaxes.VoidStarStar, SingletonSeparatedList(VariableDeclarator(vtableFieldName))))
                             .AddModifiers(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.StaticKeyword)),
                         // public static void* VirtualMethodTableManagedImplementation => _vtable != null ? _vtable : (_vtable = InterfaceImplementation.CreateManagedVirtualMethodTable());
-                        PropertyDeclaration(VoidStarStarSyntax, "ManagedVirtualMethodTable")
+                        PropertyDeclaration(TypeSyntaxes.VoidStarStar, "ManagedVirtualMethodTable")
                             .AddModifiers(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword))
                             .WithExpressionBody(
                                 ArrowExpressionClause(
@@ -681,15 +622,14 @@ namespace Microsoft.Interop
                                         ParenthesizedExpression(
                                             AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
                                                 IdentifierName(vtableFieldName),
-                                                InvocationExpression(
-                                                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                                        IdentifierName("InterfaceImplementation"),
-                                                        IdentifierName(CreateManagedVirtualFunctionTableMethodName))))))))
+                                                MethodInvocation(
+                                                    IdentifierName("InterfaceImplementation"),
+                                                    IdentifierName(CreateManagedVirtualFunctionTableMethodName)))))))
                             .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)));
             }
 
             return interfaceInformationType.AddMembers(
-                PropertyDeclaration(VoidStarStarSyntax, "ManagedVirtualMethodTable")
+                PropertyDeclaration(TypeSyntaxes.VoidStarStar, "ManagedVirtualMethodTable")
                     .AddModifiers(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword))
                     .WithExpressionBody(ArrowExpressionClause(LiteralExpression(SyntaxKind.NullLiteralExpression)))
                     .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)));

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComMethodContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComMethodContext.cs
@@ -125,9 +125,7 @@ namespace Microsoft.Interop
         private MethodDeclarationSyntax GenerateShadow()
         {
             // DeclarationCopiedFromBaseDeclaration(<Arguments>)
-            // {
-            //    return ((<baseInterfaceType>)this).<MethodName>(<Arguments>);
-            // }
+            //    => ((<baseInterfaceType>)this).<MethodName>(<Arguments>);
             var forwarder = new Forwarder();
             return MethodDeclaration(GenerationContext.SignatureContext.StubReturnType, MethodInfo.MethodName)
                 .WithModifiers(TokenList(Token(SyntaxKind.NewKeyword)))

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ManagedHResultExceptionMarshallerFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ManagedHResultExceptionMarshallerFactory.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.Interop.SyntaxFactoryExtensions;
 
 namespace Microsoft.Interop
 {
@@ -59,13 +60,10 @@ namespace Microsoft.Interop
                 (string managedIdentifier, _) = context.GetIdentifiers(info);
 
                 // Marshal.ThrowExceptionForHR(<managed>);
-                yield return ExpressionStatement(
-                    InvocationExpression(
-                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            TypeSyntaxes.System_Runtime_InteropServices_Marshal,
-                            IdentifierName("ThrowExceptionForHR")),
-                        ArgumentList(
-                            SingletonSeparatedList(Argument(IdentifierName(managedIdentifier))))));
+                yield return MethodInvocationStatement(
+                                TypeSyntaxes.System_Runtime_InteropServices_Marshal,
+                                IdentifierName("ThrowExceptionForHR"),
+                                Argument(IdentifierName(managedIdentifier)));
             }
 
             public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info) => SignatureBehavior.NativeType;

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ObjectUnwrapperMarshallerFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ObjectUnwrapperMarshallerFactory.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.Interop.SyntaxFactoryExtensions;
 
 namespace Microsoft.Interop
 {
@@ -38,24 +38,18 @@ namespace Microsoft.Interop
                 (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);
 
                 // <managed> = (<managedType>)UnmanagedObjectUnwrapper.GetObjectFormUnmanagedWrapper<TUnmanagedUnwrapper>(<native>);
-                yield return ExpressionStatement(
-                    AssignmentExpression(
-                        SyntaxKind.SimpleAssignmentExpression,
+                yield return AssignmentStatement(
                         IdentifierName(managedIdentifier),
                         CastExpression(
                             info.ManagedType.Syntax,
-                            InvocationExpression(
-                                MemberAccessExpression(
-                                    SyntaxKind.SimpleMemberAccessExpression,
+                            MethodInvocation(
                                     TypeSyntaxes.UnmanagedObjectUnwrapper,
                                     GenericName(Identifier("GetObjectForUnmanagedWrapper"))
                                         .WithTypeArgumentList(
                                             TypeArgumentList(
                                                 SingletonSeparatedList(
-                                                    unwrapperType)))),
-                                ArgumentList(
-                                    SingletonSeparatedList(
-                                        Argument(IdentifierName(nativeIdentifier))))))));
+                                                    unwrapperType))),
+                                    Argument(IdentifierName(nativeIdentifier)))));
             }
 
             public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info) => SignatureBehavior.NativeType;

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/StructAsHResultMarshallerFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/StructAsHResultMarshallerFactory.cs
@@ -4,10 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.Interop.SyntaxFactoryExtensions;
 
 namespace Microsoft.Interop
 {
@@ -47,42 +46,36 @@ namespace Microsoft.Interop
                         if (MarshallerHelpers.GetMarshalDirection(info, context) is MarshalDirection.ManagedToUnmanaged or MarshalDirection.Bidirectional)
                         {
                             // unmanaged = Unsafe.BitCast<managedType, int>(managed);
-                            yield return ExpressionStatement(
-                            AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                            IdentifierName(unmanaged),
-                            InvocationExpression(
-                                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            yield return AssignmentStatement(
+                                IdentifierName(unmanaged),
+                                MethodInvocation(
                                     ParseTypeName(TypeNames.System_Runtime_CompilerServices_Unsafe),
                                     GenericName(Identifier("BitCast"),
                                         TypeArgumentList(
-                                            SeparatedList(
-                                                new[]
+                                            SeparatedList(new[]
                                                 {
-                                                info.ManagedType.Syntax,
-                                                AsNativeType(info).Syntax
-                                                })))),
-                                ArgumentList(SingletonSeparatedList(Argument(IdentifierName(managed)))))));
+                                                    info.ManagedType.Syntax,
+                                                    AsNativeType(info).Syntax
+                                                }))),
+                                    Argument(IdentifierName(managed))));
                         }
                         break;
                     case StubCodeContext.Stage.Unmarshal:
                         if (MarshallerHelpers.GetMarshalDirection(info, context) is MarshalDirection.UnmanagedToManaged or MarshalDirection.Bidirectional)
                         {
                             // managed = Unsafe.BitCast<int, managedType>(unmanaged);
-                            yield return ExpressionStatement(
-                            AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                            yield return AssignmentStatement(
                             IdentifierName(managed),
-                            InvocationExpression(
-                                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                    ParseTypeName(TypeNames.System_Runtime_CompilerServices_Unsafe),
-                                    GenericName(Identifier("BitCast"),
-                                        TypeArgumentList(
-                                            SeparatedList(
-                                                new[]
-                                                {
+                            MethodInvocation(
+                                ParseTypeName(TypeNames.System_Runtime_CompilerServices_Unsafe),
+                                GenericName(Identifier("BitCast"),
+                                    TypeArgumentList(
+                                        SeparatedList(new[]
+                                            {
                                                 AsNativeType(info).Syntax,
                                                 info.ManagedType.Syntax
-                                                })))),
-                                ArgumentList(SingletonSeparatedList(Argument(IdentifierName(unmanaged)))))));
+                                            }))),
+                                Argument(IdentifierName(unmanaged))));
                         }
                         break;
                     default:

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubCodeGenerator.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.Interop.SyntaxFactoryExtensions;
 
 namespace Microsoft.Interop
 {
@@ -116,7 +117,7 @@ namespace Microsoft.Interop
             if (_setLastError)
             {
                 // Declare variable for last error
-                setupStatements.Add(MarshallerHelpers.Declare(
+                setupStatements.Add(Declare(
                     PredefinedType(Token(SyntaxKind.IntKeyword)),
                     LastErrorIdentifier,
                     initializeToDefault: false));
@@ -124,7 +125,7 @@ namespace Microsoft.Interop
 
             if (!(statements.GuaranteedUnmarshal.IsEmpty && statements.CleanupCalleeAllocated.IsEmpty))
             {
-                setupStatements.Add(MarshallerHelpers.Declare(PredefinedType(Token(SyntaxKind.BoolKeyword)), InvokeSucceededIdentifier, initializeToDefault: true));
+                setupStatements.Add(Declare(PredefinedType(Token(SyntaxKind.BoolKeyword)), InvokeSucceededIdentifier, initializeToDefault: true));
             }
 
             setupStatements.AddRange(declarations.Initializations);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.Interop.SyntaxFactoryExtensions;
 
 namespace Microsoft.Interop
 {
@@ -40,9 +41,7 @@ namespace Microsoft.Interop
                     if (elementMarshalDirection is MarshalDirection.ManagedToUnmanaged or MarshalDirection.Bidirectional)
                     {
                         // <nativeIdentifier> = <managedIdentifier> != null ? Marshal.GetFunctionPointerForDelegate(<managedIdentifier>) : default;
-                        yield return ExpressionStatement(
-                            AssignmentExpression(
-                                SyntaxKind.SimpleAssignmentExpression,
+                        yield return AssignmentStatement(
                                 IdentifierName(nativeIdentifier),
                                 ConditionalExpression(
                                     BinaryExpression(
@@ -50,39 +49,33 @@ namespace Microsoft.Interop
                                         IdentifierName(managedIdentifier),
                                         LiteralExpression(SyntaxKind.NullLiteralExpression)
                                     ),
-                                    InvocationExpression(
-                                        MemberAccessExpression(
-                                            SyntaxKind.SimpleMemberAccessExpression,
+                                    MethodInvocation(
                                             TypeSyntaxes.System_Runtime_InteropServices_Marshal,
-                                            IdentifierName("GetFunctionPointerForDelegate")),
-                                        ArgumentList(SingletonSeparatedList(Argument(IdentifierName(managedIdentifier))))),
-                                    LiteralExpression(SyntaxKind.DefaultLiteralExpression))));
+                                            IdentifierName("GetFunctionPointerForDelegate"),
+                                        Argument(IdentifierName(managedIdentifier))),
+                                    LiteralExpression(SyntaxKind.DefaultLiteralExpression)));
                     }
                     break;
                 case StubCodeContext.Stage.Unmarshal:
                     if (elementMarshalDirection is MarshalDirection.UnmanagedToManaged or MarshalDirection.Bidirectional)
                     {
                         // <managedIdentifier> = <nativeIdentifier> != default : Marshal.GetDelegateForFunctionPointer<<managedType>>(<nativeIdentifier>) : null;
-                        yield return ExpressionStatement(
-                            AssignmentExpression(
-                                SyntaxKind.SimpleAssignmentExpression,
+                        yield return AssignmentStatement(
                                 IdentifierName(managedIdentifier),
                                 ConditionalExpression(
                                     BinaryExpression(
                                         SyntaxKind.NotEqualsExpression,
                                         IdentifierName(nativeIdentifier),
                                         LiteralExpression(SyntaxKind.DefaultLiteralExpression)),
-                                    InvocationExpression(
-                                        MemberAccessExpression(
-                                            SyntaxKind.SimpleMemberAccessExpression,
+                                    MethodInvocation(
                                             TypeSyntaxes.System_Runtime_InteropServices_Marshal,
                                             GenericName(Identifier("GetDelegateForFunctionPointer"))
                                             .WithTypeArgumentList(
                                                 TypeArgumentList(
                                                     SingletonSeparatedList(
-                                                        info.ManagedType.Syntax)))),
-                                        ArgumentList(SingletonSeparatedList(Argument(IdentifierName(nativeIdentifier))))),
-                                    LiteralExpression(SyntaxKind.NullLiteralExpression))));
+                                                        info.ManagedType.Syntax))),
+                                        Argument(IdentifierName(nativeIdentifier))),
+                                    LiteralExpression(SyntaxKind.NullLiteralExpression)));
                     }
                     break;
                 case StubCodeContext.Stage.NotifyForSuccessfulInvoke:

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.Interop.SyntaxFactoryExtensions;
 
 namespace Microsoft.Interop
 {
@@ -28,25 +29,29 @@ namespace Microsoft.Interop
             CollectionSource = collectionSource;
         }
 
-        public StatementSyntax GenerateClearManagedSource(TypePositionInfo info, StubCodeContext context)
+        /// <summary>
+        /// <code>
+        /// &lt; GetUnmanagedValuesDestination &gt;.Clear();
+        /// </code>
+        /// </summary>
+        public StatementSyntax GenerateClearUnmanagedValuesDestination(TypePositionInfo info, StubCodeContext context)
         {
             // <GetUnmanagedValuesDestination>.Clear();
-            return ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
+            return MethodInvocationStatement(
                         CollectionSource.GetUnmanagedValuesDestination(info, context),
-                        IdentifierName("Clear"))));
+                        IdentifierName("Clear"));
         }
+        /// <summary>
+        /// <code>
+        /// &lt; GetManagedValuesDestination &gt;.Clear();
+        /// </code>
+        /// </summary>
         public StatementSyntax GenerateClearManagedValuesDestination(TypePositionInfo info, StubCodeContext context)
         {
-            // <GetUnmanagedValuesSource>.Clear();
-            return ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
+            // <GetManagedValuedDestination>.Clear();
+            return MethodInvocationStatement(
                         CollectionSource.GetManagedValuesDestination(info, context),
-                        IdentifierName("Clear"))));
+                        IdentifierName("Clear"));
         }
 
         public abstract StatementSyntax GenerateSetupStatement(TypePositionInfo info, StubCodeContext context);
@@ -110,38 +115,24 @@ namespace Microsoft.Interop
         {
             // MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(<GetUnmanagedValuesSource>), <GetUnmanagedValuesSource>.Length)
             ExpressionSyntax destination = CastToManagedIfNecessary(
-                InvocationExpression(
-                    MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
-                        IdentifierName("CreateSpan")),
-                    ArgumentList(
-                        SeparatedList(new[]
-                        {
-                            Argument(
-                                InvocationExpression(
-                                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                        TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
-                                        IdentifierName("GetReference")),
-                                    ArgumentList(SingletonSeparatedList(
-                                        Argument(CollectionSource.GetUnmanagedValuesSource(info, context))))))
-                                .WithRefKindKeyword(
-                                    Token(SyntaxKind.RefKeyword)),
-                            Argument(
-                                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                    CollectionSource.GetUnmanagedValuesSource(info, context),
-                                    IdentifierName("Length")))
-                        }))));
+                MethodInvocation(
+                    TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
+                    IdentifierName("CreateSpan"),
+                    RefArgument(
+                        MethodInvocation(
+                            TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
+                            IdentifierName("GetReference"),
+                            Argument(CollectionSource.GetUnmanagedValuesSource(info, context)))),
+                    Argument(
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            CollectionSource.GetUnmanagedValuesSource(info, context),
+                            IdentifierName("Length")))));
 
             // <GetManagedValuesDestination>.CopyTo(<source>);
-            return ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        CollectionSource.GetManagedValuesDestination(info, context),
-                        IdentifierName("CopyTo")))
-                .AddArgumentListArguments(
-                    Argument(destination)));
+            return MethodInvocationStatement(
+                    CollectionSource.GetManagedValuesDestination(info, context),
+                    IdentifierName("CopyTo"),
+                    Argument(destination));
         }
 
         public override StatementSyntax GenerateMarshalStatement(TypePositionInfo info, StubCodeContext context)
@@ -149,14 +140,10 @@ namespace Microsoft.Interop
             ExpressionSyntax destination = CastToManagedIfNecessary(CollectionSource.GetUnmanagedValuesDestination(info, context));
 
             // <GetManagedValuesSource>.CopyTo(<destination>);
-            return ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        CollectionSource.GetManagedValuesSource(info, context),
-                        IdentifierName("CopyTo")))
-                .AddArgumentListArguments(
-                    Argument(destination)));
+            return MethodInvocationStatement(
+                    CollectionSource.GetManagedValuesSource(info, context),
+                    IdentifierName("CopyTo"),
+                    Argument(destination));
         }
 
         public override StatementSyntax GenerateManagedToUnmanagedByValueOutUnmarshalStatement(TypePositionInfo info, StubCodeContext context)
@@ -164,28 +151,18 @@ namespace Microsoft.Interop
             ExpressionSyntax source = CastToManagedIfNecessary(CollectionSource.GetUnmanagedValuesDestination(info, context));
 
             // MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(<GetManagedValuesSource>), <GetManagedValuesSource>.Length)
-            ExpressionSyntax destination = InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
+            ExpressionSyntax destination = MethodInvocation(
                     TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
-                    IdentifierName("CreateSpan")),
-                ArgumentList(
-                    SeparatedList(new[]
-                    {
-                        Argument(
-                            InvocationExpression(
-                                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                    TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
-                                    IdentifierName("GetReference")),
-                                ArgumentList(SingletonSeparatedList(
-                                    Argument(CollectionSource.GetManagedValuesSource(info, context))))))
-                            .WithRefKindKeyword(
-                                Token(SyntaxKind.RefKeyword)),
+                    IdentifierName("CreateSpan"),
+                        RefArgument(
+                            MethodInvocation(
+                                TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
+                                IdentifierName("GetReference"),
+                                Argument(CollectionSource.GetManagedValuesSource(info, context)))),
                         Argument(
                             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                                 CollectionSource.GetManagedValuesSource(info, context),
-                                IdentifierName("Length")))
-                    })));
+                                IdentifierName("Length"))));
 
             // <source>.CopyTo(<destination>);
             return ExpressionStatement(
@@ -203,14 +180,10 @@ namespace Microsoft.Interop
             ExpressionSyntax source = CastToManagedIfNecessary(CollectionSource.GetUnmanagedValuesSource(info, context));
 
             // <source>.CopyTo(<GetManagedValuesDestination>);
-            return ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        source,
-                        IdentifierName("CopyTo")))
-                .AddArgumentListArguments(
-                    Argument(CollectionSource.GetManagedValuesDestination(info, context))));
+            return MethodInvocationStatement(
+                    source,
+                    IdentifierName("CopyTo"),
+                    Argument(CollectionSource.GetManagedValuesDestination(info, context)));
         }
 
         private ExpressionSyntax CastToManagedIfNecessary(ExpressionSyntax expression)
@@ -220,20 +193,16 @@ namespace Microsoft.Interop
                 return expression;
 
             // MemoryMarshal.Cast<<unmanagedElementType>, <elementType>>(<expression>)
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
+            return MethodInvocation(
                     TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
                     GenericName(
                         Identifier("Cast"),
-                        TypeArgumentList(SeparatedList(
-                            new[]
+                        TypeArgumentList(SeparatedList(new[]
                             {
                                 _unmanagedElementType,
                                 _managedElementType
-                            })))),
-                ArgumentList(SingletonSeparatedList(
-                    Argument(expression))));
+                            }))),
+                    Argument(expression));
         }
 
         public override StatementSyntax GenerateElementCleanupStatement(TypePositionInfo info, StubCodeContext context) => EmptyStatement();
@@ -272,34 +241,22 @@ namespace Microsoft.Interop
             // << marshal contents >>
             var statements = new List<StatementSyntax>()
             {
-                LocalDeclarationStatement(VariableDeclaration(
-                    GenericName(
-                        Identifier(TypeNames.System_ReadOnlySpan),
-                        TypeArgumentList(SingletonSeparatedList(_elementInfo.ManagedType.Syntax))),
-                    SingletonSeparatedList(
-                        VariableDeclarator(Identifier(managedSpanIdentifier))
-                        .WithInitializer(EqualsValueClause(
-                            CollectionSource.GetManagedValuesSource(info, context)))))),
-                LocalDeclarationStatement(VariableDeclaration(
-                    GenericName(
-                        Identifier(TypeNames.System_Span),
-                        TypeArgumentList(SingletonSeparatedList(_unmanagedElementType))),
-                    SingletonSeparatedList(
-                        VariableDeclarator(
-                            Identifier(nativeSpanIdentifier))
-                        .WithInitializer(EqualsValueClause(
-                            CollectionSource.GetUnmanagedValuesDestination(info, context))))))
+                Declare(
+                    ReadOnlySpanOf(_elementInfo.ManagedType.Syntax),
+                    managedSpanIdentifier,
+                    CollectionSource.GetManagedValuesSource(info, context)),
+                Declare(
+                    SpanOf(_unmanagedElementType),
+                    nativeSpanIdentifier,
+                    CollectionSource.GetUnmanagedValuesDestination(info, context))
             };
             // If it is a multidimensional array, we will just clear each allocated span.
             if (ShouldCleanUpAllElements(info, context))
             {
                 // <nativeSpanIdentifier>.Clear()
-                statements.Add(ExpressionStatement(
-                    InvocationExpression(
-                        MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
+                statements.Add(MethodInvocationStatement(
                             IdentifierName(nativeSpanIdentifier),
-                            IdentifierName("Clear")))));
+                            IdentifierName("Clear")));
             }
             statements.Add(GenerateContentsMarshallingStatement(
                     info,
@@ -321,24 +278,14 @@ namespace Microsoft.Interop
             // Span<T> <managedSpan> = <GetManagedValuesDestination>
             // << unmarshal contents >>
             return Block(
-                LocalDeclarationStatement(VariableDeclaration(
-                    GenericName(
-                        Identifier(TypeNames.System_ReadOnlySpan),
-                        TypeArgumentList(SingletonSeparatedList(_unmanagedElementType))),
-                    SingletonSeparatedList(
-                        VariableDeclarator(
-                            Identifier(nativeSpanIdentifier))
-                        .WithInitializer(EqualsValueClause(
-                            CollectionSource.GetUnmanagedValuesSource(info, context)))))),
-                LocalDeclarationStatement(VariableDeclaration(
-                    GenericName(
-                        Identifier(TypeNames.System_Span),
-                        TypeArgumentList(SingletonSeparatedList(_elementInfo.ManagedType.Syntax))),
-                    SingletonSeparatedList(
-                        VariableDeclarator(
-                            Identifier(managedSpanIdentifier))
-                        .WithInitializer(EqualsValueClause(
-                            CollectionSource.GetManagedValuesDestination(info, context)))))),
+                Declare(
+                    ReadOnlySpanOf(_unmanagedElementType),
+                    nativeSpanIdentifier,
+                    CollectionSource.GetUnmanagedValuesSource(info, context)),
+                Declare(
+                    SpanOf(_elementInfo.ManagedType.Syntax),
+                    managedSpanIdentifier,
+                    CollectionSource.GetManagedValuesDestination(info, context)),
                 GenerateContentsMarshallingStatement(
                     info,
                     context,
@@ -359,55 +306,27 @@ namespace Microsoft.Interop
             var setNumElements = CollectionSource.GetNumElementsAssignmentFromManagedValuesSource(info, context);
 
             // Span<TElement> <managedSpan> = MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in <GetManagedValuesSource>.GetPinnableReference(), <numElements>));
-            LocalDeclarationStatementSyntax managedValuesDeclaration = LocalDeclarationStatement(VariableDeclaration(
-                GenericName(
-                    Identifier(TypeNames.System_Span),
-                    TypeArgumentList(
-                        SingletonSeparatedList(_elementInfo.ManagedType.Syntax))
-                ),
-                SingletonSeparatedList(VariableDeclarator(managedSpanIdentifier).WithInitializer(EqualsValueClause(
-                    InvocationExpression(
-                        MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
-                            IdentifierName("CreateSpan")))
-                    .WithArgumentList(
-                        ArgumentList(
-                            SeparatedList(
-                                new[]
-                                {
-                                    Argument(
-                                        InvocationExpression(
-                                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                                TypeSyntaxes.System_Runtime_CompilerServices_Unsafe,
-                                                IdentifierName("AsRef")),
-                                            ArgumentList(SingletonSeparatedList(
-                                                Argument(
-                                                    InvocationExpression(
-                                                        MemberAccessExpression(
-                                                            SyntaxKind.SimpleMemberAccessExpression,
-                                                            CollectionSource.GetManagedValuesSource(info, context),
-                                                            IdentifierName("GetPinnableReference")),
-                                                            ArgumentList()))
-                                                .WithRefKindKeyword(
-                                                    Token(SyntaxKind.InKeyword))))))
-                                    .WithRefKindKeyword(
-                                        Token(SyntaxKind.RefKeyword)),
-                                    Argument(
-                                        IdentifierName(numElementsIdentifier))
-                                }))))))));
+            LocalDeclarationStatementSyntax managedValuesDeclaration = Declare(SpanOf(_elementInfo.ManagedType.Syntax),
+            managedSpanIdentifier,
+            MethodInvocation(
+                TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
+                IdentifierName("CreateSpan"),
+                RefArgument(
+                    MethodInvocation(
+                        TypeSyntaxes.System_Runtime_CompilerServices_Unsafe,
+                        IdentifierName("AsRef"),
+                        InArgument(
+                            MethodInvocation(
+                                CollectionSource.GetManagedValuesSource(info, context),
+                                IdentifierName("GetPinnableReference"))))),
+                Argument(IdentifierName(numElementsIdentifier))));
 
             // Span<TUnmanagedElement> <nativeSpan> = <GetUnmanagedValuesDestination>
             string nativeSpanIdentifier = MarshallerHelpers.GetNativeSpanIdentifier(info, context);
-            LocalDeclarationStatementSyntax unmanagedValuesDeclaration = LocalDeclarationStatement(VariableDeclaration(
-                GenericName(
-                    Identifier(TypeNames.System_Span),
-                    TypeArgumentList(SingletonSeparatedList(_unmanagedElementType))),
-                SingletonSeparatedList(
-                    VariableDeclarator(
-                        Identifier(nativeSpanIdentifier))
-                    .WithInitializer(EqualsValueClause(
-                        CollectionSource.GetUnmanagedValuesDestination(info, context))))));
+            LocalDeclarationStatementSyntax unmanagedValuesDeclaration = Declare(
+                SpanOf(_unmanagedElementType),
+                nativeSpanIdentifier,
+                CollectionSource.GetUnmanagedValuesDestination(info, context));
 
             return Block(
                 setNumElements,
@@ -447,26 +366,20 @@ namespace Microsoft.Interop
             {
                 if (UsesLastIndexMarshalled(info, context))
                 {
-                    return ExpressionStatement(
-                        AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                    return AssignmentStatement(
                             IdentifierName("_"),
-                            IdentifierName(MarshallerHelpers.GetLastIndexMarshalledIdentifier(info, context))));
+                            IdentifierName(MarshallerHelpers.GetLastIndexMarshalledIdentifier(info, context)));
                 }
                 return EmptyStatement();
             }
 
             return Block(
-                LocalDeclarationStatement(VariableDeclaration(
-                GenericName(
-                    Identifier(TypeNames.System_ReadOnlySpan),
-                    TypeArgumentList(SingletonSeparatedList(_unmanagedElementType))),
-                SingletonSeparatedList(
-                    VariableDeclarator(
-                        Identifier(nativeSpanIdentifier))
-                    .WithInitializer(EqualsValueClause(
-                            MarshallerHelpers.GetMarshalDirection(info, context) == MarshalDirection.ManagedToUnmanaged
-                                ? CollectionSource.GetUnmanagedValuesDestination(info, context)
-                                : CollectionSource.GetUnmanagedValuesSource(info, context)))))),
+                Declare(
+                    ReadOnlySpanOf(_unmanagedElementType),
+                    nativeSpanIdentifier,
+                    MarshallerHelpers.GetMarshalDirection(info, context) == MarshalDirection.ManagedToUnmanaged
+                        ? CollectionSource.GetUnmanagedValuesDestination(info, context)
+                        : CollectionSource.GetUnmanagedValuesSource(info, context)),
                 contentsCleanupStatements);
         }
 
@@ -482,44 +395,22 @@ namespace Microsoft.Interop
 
             var setNumElements = CollectionSource.GetNumElementsAssignmentFromManagedValuesDestination(info, context);
 
-            // Span<TUnmanagedElement> <nativeSpan> = MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in <GetUnmanagedValuesSource>.GetPinnableReference(), <numElements>));
-            LocalDeclarationStatementSyntax unmanagedValuesSource = LocalDeclarationStatement(VariableDeclaration(
-                GenericName(
-                    Identifier(TypeNames.System_Span),
-                    TypeArgumentList(
-                        SingletonSeparatedList(_unmanagedElementType))
-                ),
-                SingletonSeparatedList(VariableDeclarator(nativeSpanIdentifier).WithInitializer(EqualsValueClause(
-                    InvocationExpression(
-                        MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
-                            IdentifierName("CreateSpan")))
-                    .WithArgumentList(
-                        ArgumentList(
-                            SeparatedList(
-                                new[]
-                                {
-                                    Argument(
-                                        InvocationExpression(
-                                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                                TypeSyntaxes.System_Runtime_CompilerServices_Unsafe,
-                                                IdentifierName("AsRef")),
-                                            ArgumentList(SingletonSeparatedList(
-                                                Argument(
-                                                    InvocationExpression(
-                                                        MemberAccessExpression(
-                                                            SyntaxKind.SimpleMemberAccessExpression,
-                                                            CollectionSource.GetUnmanagedValuesSource(info, context),
-                                                            IdentifierName("GetPinnableReference")),
-                                                            ArgumentList()))
-                                                .WithRefKindKeyword(
-                                                    Token(SyntaxKind.InKeyword))))))
-                                    .WithRefKindKeyword(
-                                        Token(SyntaxKind.RefKeyword)),
-                                    Argument(
-                                        IdentifierName(numElementsIdentifier))
-                                }))))))));
+            // Span<TUnmanagedElement> <nativeSpan> = MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in <GetUnmanagedValuesSource>.GetPinnableReference()), <numElements>);
+            LocalDeclarationStatementSyntax unmanagedValuesSource = Declare(
+                SpanOf(_unmanagedElementType),
+                nativeSpanIdentifier,
+                MethodInvocation(
+                    TypeSyntaxes.System_Runtime_InteropServices_MemoryMarshal,
+                    IdentifierName("CreateSpan"),
+                    RefArgument(
+                        MethodInvocation(
+                            TypeSyntaxes.System_Runtime_CompilerServices_Unsafe,
+                            IdentifierName("AsRef"),
+                            InArgument(
+                                MethodInvocation(
+                                    CollectionSource.GetUnmanagedValuesSource(info, context),
+                                    IdentifierName("GetPinnableReference"))))),
+                    Argument(IdentifierName(numElementsIdentifier))));
 
             // Span<TElement> <managedSpan> = <GetManagedValuesDestination>
             LocalDeclarationStatementSyntax managedValuesDestination = LocalDeclarationStatement(VariableDeclaration(
@@ -614,7 +505,7 @@ namespace Microsoft.Interop
                 }
 
                 // Iterate through the elements of the native collection to marshal them
-                var forLoop = MarshallerHelpers.GetForLoop(lengthExpression, elementSetupSubContext.IndexerIdentifier)
+                var forLoop = ForLoop(elementSetupSubContext.IndexerIdentifier, lengthExpression)
                     .WithStatement(marshallingStatement);
                 // If we're tracking LastIndexMarshalled, increment that each iteration as well.
                 if (UsesLastIndexMarshalled(info, context) && stagesToGeneratePerElement.Contains(StubCodeContext.Stage.Marshal))

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -7,76 +7,13 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.Interop.SyntaxFactoryExtensions;
 
 namespace Microsoft.Interop
 {
     public static class MarshallerHelpers
     {
         public static readonly TypeSyntax SystemIntPtrType = TypeSyntaxes.System_IntPtr;
-
-        public static ForStatementSyntax GetForLoop(ExpressionSyntax lengthExpression, string indexerIdentifier)
-        {
-            // for(int <indexerIdentifier> = 0; <indexerIdentifier> < <lengthIdentifier>; ++<indexerIdentifier>)
-            //      ;
-            return ForStatement(EmptyStatement())
-            .WithDeclaration(
-                VariableDeclaration(
-                    PredefinedType(
-                        Token(SyntaxKind.IntKeyword)))
-                .WithVariables(
-                    SingletonSeparatedList(
-                        VariableDeclarator(
-                            Identifier(indexerIdentifier))
-                        .WithInitializer(
-                            EqualsValueClause(
-                                LiteralExpression(
-                                    SyntaxKind.NumericLiteralExpression,
-                                    Literal(0)))))))
-            .WithCondition(
-                BinaryExpression(
-                    SyntaxKind.LessThanExpression,
-                    IdentifierName(indexerIdentifier),
-                    lengthExpression))
-            .WithIncrementors(
-                SingletonSeparatedList<ExpressionSyntax>(
-                    PrefixUnaryExpression(
-                        SyntaxKind.PreIncrementExpression,
-                        IdentifierName(indexerIdentifier))));
-        }
-
-        /// <summary>
-        /// <code><paramref name="typeSyntax"/> <paramref name="identifier"/> = default;</code>
-        /// or
-        /// <code><paramref name="typeSyntax"/> <paramref name="identifier"/>;</code>
-        /// </summary>
-        public static LocalDeclarationStatementSyntax Declare(TypeSyntax typeSyntax, string identifier, bool initializeToDefault)
-        {
-            return Declare(typeSyntax, identifier, initializeToDefault ? LiteralExpression(SyntaxKind.DefaultLiteralExpression) : null);
-        }
-
-        /// <summary>
-        /// <code><paramref name="typeSyntax"/> <paramref name="identifier"/> = <paramref name="identifier"/>;</code>
-        /// or
-        /// <code><paramref name="typeSyntax"/> <paramref name="identifier"/>;</code>
-        /// </summary>
-        public static LocalDeclarationStatementSyntax Declare(TypeSyntax typeSyntax, string identifier, ExpressionSyntax? initializer)
-        {
-            VariableDeclaratorSyntax decl = VariableDeclarator(identifier);
-            if (initializer is not null)
-            {
-                decl = decl.WithInitializer(
-                    EqualsValueClause(
-                        initializer));
-            }
-
-            // <type> <identifier>;
-            // or
-            // <type> <identifier> = <initializer>;
-            return LocalDeclarationStatement(
-                VariableDeclaration(
-                    typeSyntax,
-                    SingletonSeparatedList(decl)));
-        }
 
         public static RefKind GetRefKindForByValueContentsKind(this ByValueContentsMarshalKind byValue)
         {
@@ -102,39 +39,27 @@ namespace Microsoft.Interop
         }
 
 
-        // Marshal.SetLastSystemError(<errorCode>);
+        /// <summary>
+        /// <c>Marshal.SetLastSystemError(<paramref name="errorCode"/>);</c>
+        /// </summary>
         public static StatementSyntax CreateClearLastSystemErrorStatement(int errorCode) =>
-            ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        TypeSyntaxes.System_Runtime_InteropServices_Marshal,
-                        IdentifierName("SetLastSystemError")),
-                    ArgumentList(SingletonSeparatedList(
-                        Argument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(errorCode)))))));
+            MethodInvocationStatement(
+                TypeSyntaxes.System_Runtime_InteropServices_Marshal,
+                IdentifierName("SetLastSystemError"),
+                Argument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(errorCode))));
 
-        // <lastError> = Marshal.GetLastSystemError();
+        /// <summary>
+        /// <code><paramref name="lastErrorIdentifier"/> = Marshal.GetLastSystemError();</code>
+        /// </summary>
         public static StatementSyntax CreateGetLastSystemErrorStatement(string lastErrorIdentifier) =>
-            ExpressionStatement(
-                AssignmentExpression(
-                    SyntaxKind.SimpleAssignmentExpression,
-                    IdentifierName(lastErrorIdentifier),
-                    InvocationExpression(
-                        MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        TypeSyntaxes.System_Runtime_InteropServices_Marshal,
-                        IdentifierName("GetLastSystemError")))));
+            AssignmentStatement(IdentifierName(lastErrorIdentifier), MethodInvocation(TypeSyntaxes.System_Runtime_InteropServices_Marshal, IdentifierName("GetLastSystemError")));
 
-        // Marshal.SetLastPInvokeError(<lastError>);
+        //
+        /// <summary>
+        /// <code>Marshal.SetLastPInvokeError(<paramref name="lastErrorIdentifier"/>);</code>
+        /// </summary>
         public static StatementSyntax CreateSetLastPInvokeErrorStatement(string lastErrorIdentifier) =>
-            ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        TypeSyntaxes.System_Runtime_InteropServices_Marshal,
-                        IdentifierName("SetLastPInvokeError")),
-                    ArgumentList(SingletonSeparatedList(
-                        Argument(IdentifierName(lastErrorIdentifier))))));
+            MethodInvocationStatement(TypeSyntaxes.System_Runtime_InteropServices_Marshal, IdentifierName("SetLastPInvokeError"), Argument(IdentifierName(lastErrorIdentifier)));
 
         public static string GetMarshallerIdentifier(TypePositionInfo info, StubCodeContext context)
         {
@@ -315,6 +240,7 @@ namespace Microsoft.Interop
             }
         }
 
+        // private static readonly InvocationExpressionSyntax SkipInitInvocation =
         public static StatementSyntax SkipInitOrDefaultInit(TypePositionInfo info, StubCodeContext context)
         {
             (TargetFramework fmk, _) = context.GetTargetFramework();
@@ -325,25 +251,16 @@ namespace Microsoft.Interop
                 // Use the Unsafe.SkipInit<T> API when available and
                 // managed type is usable as a generic parameter.
                 return ExpressionStatement(
-                    InvocationExpression(
-                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            TypeSyntaxes.System_Runtime_CompilerServices_Unsafe,
-                            IdentifierName("SkipInit")))
-                    .WithArgumentList(
-                        ArgumentList(SingletonSeparatedList(
-                            Argument(IdentifierName(info.InstanceIdentifier))
-                            .WithRefOrOutKeyword(Token(SyntaxKind.OutKeyword))))));
+                    MethodInvocation(TypeSyntaxes.System_Runtime_CompilerServices_Unsafe, IdentifierName("SkipInit"),
+                                Argument(IdentifierName(info.InstanceIdentifier))
+                                .WithRefOrOutKeyword(Token(SyntaxKind.OutKeyword))));
             }
             else
             {
                 // Assign out params to default
-                return ExpressionStatement(
-                    AssignmentExpression(
-                        SyntaxKind.SimpleAssignmentExpression,
-                        IdentifierName(info.InstanceIdentifier),
-                        LiteralExpression(
-                            SyntaxKind.DefaultLiteralExpression,
-                            Token(SyntaxKind.DefaultKeyword))));
+                return AssignmentStatement(
+                    IdentifierName(info.InstanceIdentifier),
+                    LiteralExpression(SyntaxKind.DefaultLiteralExpression, Token(SyntaxKind.DefaultKeyword)));
             }
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.Interop.SyntaxFactoryExtensions;
 
 namespace Microsoft.Interop
 {
@@ -39,12 +40,9 @@ namespace Microsoft.Interop
                 yield break;
 
             // <marshaller>.Free();
-            yield return ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+            yield return MethodInvocationStatement(
                         IdentifierName(context.GetAdditionalIdentifier(info, MarshallerIdentifier)),
-                        IdentifierName(ShapeMemberNames.Free)),
-                    ArgumentList()));
+                        IdentifierName(ShapeMemberNames.Free));
         }
 
         public IEnumerable<StatementSyntax> GenerateCleanupCalleeAllocatedResourcesStatements(TypePositionInfo info, StubCodeContext context)
@@ -56,12 +54,9 @@ namespace Microsoft.Interop
                 yield break;
 
             // <marshaller>.Free();
-            yield return ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+            yield return MethodInvocationStatement(
                         IdentifierName(context.GetAdditionalIdentifier(info, MarshallerIdentifier)),
-                        IdentifierName(ShapeMemberNames.Free)),
-                    ArgumentList()));
+                        IdentifierName(ShapeMemberNames.Free));
         }
 
         public IEnumerable<StatementSyntax> GenerateGuaranteedUnmarshalStatements(TypePositionInfo info, StubCodeContext context)
@@ -72,15 +67,11 @@ namespace Microsoft.Interop
             (string managedIdentifier, _) = context.GetIdentifiers(info);
 
             // <managedIdentifier> = <marshaller>.ToManagedFinally();
-            yield return ExpressionStatement(
-                AssignmentExpression(
-                    SyntaxKind.SimpleAssignmentExpression,
-                    IdentifierName(managedIdentifier),
-                    InvocationExpression(
-                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            IdentifierName(context.GetAdditionalIdentifier(info, MarshallerIdentifier)),
-                            IdentifierName(ShapeMemberNames.Value.Stateful.ToManagedFinally)),
-                        ArgumentList())));
+            yield return AssignmentStatement(
+                            IdentifierName(managedIdentifier),
+                            MethodInvocation(
+                                IdentifierName(context.GetAdditionalIdentifier(info, MarshallerIdentifier)),
+                                IdentifierName(ShapeMemberNames.Value.Stateful.ToManagedFinally)));
         }
 
         public IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context)
@@ -91,13 +82,10 @@ namespace Microsoft.Interop
             (string managedIdentifier, _) = context.GetIdentifiers(info);
 
             // <marshaller>.FromManaged(<managedIdentifier>);
-            yield return ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+            yield return MethodInvocationStatement(
                         IdentifierName(context.GetAdditionalIdentifier(info, MarshallerIdentifier)),
-                        IdentifierName(ShapeMemberNames.Value.Stateful.FromManaged)),
-                    ArgumentList(SingletonSeparatedList(
-                        Argument(IdentifierName(managedIdentifier))))));
+                        IdentifierName(ShapeMemberNames.Value.Stateful.FromManaged),
+                        Argument(IdentifierName(managedIdentifier)));
         }
 
         public IEnumerable<StatementSyntax> GeneratePinnedMarshalStatements(TypePositionInfo info, StubCodeContext context)
@@ -108,15 +96,11 @@ namespace Microsoft.Interop
             (_, string nativeIdentifier) = context.GetIdentifiers(info);
 
             // <nativeIdentifier> = <marshaller>.ToUnmanaged();
-            yield return ExpressionStatement(
-                AssignmentExpression(
-                    SyntaxKind.SimpleAssignmentExpression,
-                    IdentifierName(nativeIdentifier),
-                    InvocationExpression(
-                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            IdentifierName(context.GetAdditionalIdentifier(info, MarshallerIdentifier)),
-                            IdentifierName(ShapeMemberNames.Value.Stateful.ToUnmanaged)),
-                        ArgumentList())));
+            yield return AssignmentStatement(
+                            IdentifierName(nativeIdentifier),
+                            MethodInvocation(
+                                IdentifierName(context.GetAdditionalIdentifier(info, MarshallerIdentifier)),
+                                IdentifierName(ShapeMemberNames.Value.Stateful.ToUnmanaged)));
         }
 
         public IEnumerable<StatementSyntax> GenerateUnmarshalStatements(TypePositionInfo info, StubCodeContext context)
@@ -127,15 +111,11 @@ namespace Microsoft.Interop
             (string managedIdentifier, _) = context.GetIdentifiers(info);
 
             // <managedIdentifier> = <marshaller>.ToManaged();
-            yield return ExpressionStatement(
-                AssignmentExpression(
-                    SyntaxKind.SimpleAssignmentExpression,
-                    IdentifierName(managedIdentifier),
-                    InvocationExpression(
-                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            IdentifierName(context.GetAdditionalIdentifier(info, MarshallerIdentifier)),
-                            IdentifierName(ShapeMemberNames.Value.Stateful.ToManaged)),
-                        ArgumentList())));
+            yield return AssignmentStatement(
+                            IdentifierName(managedIdentifier),
+                            MethodInvocation(
+                                IdentifierName(context.GetAdditionalIdentifier(info, MarshallerIdentifier)),
+                                IdentifierName(ShapeMemberNames.Value.Stateful.ToManaged)));
         }
 
         public IEnumerable<StatementSyntax> GenerateUnmarshalCaptureStatements(TypePositionInfo info, StubCodeContext context)
@@ -146,19 +126,16 @@ namespace Microsoft.Interop
             (_, string nativeIdentifier) = context.GetIdentifiers(info);
 
             // <marshaller>.FromUnmanaged(<nativeIdentifier>);
-            yield return ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+            yield return MethodInvocationStatement(
                         IdentifierName(context.GetAdditionalIdentifier(info, MarshallerIdentifier)),
-                        IdentifierName(ShapeMemberNames.Value.Stateful.FromUnmanaged)),
-                    ArgumentList(SingletonSeparatedList(
-                        Argument(IdentifierName(nativeIdentifier))))));
+                        IdentifierName(ShapeMemberNames.Value.Stateful.FromUnmanaged),
+                        Argument(IdentifierName(nativeIdentifier)));
         }
 
         public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context)
         {
             // <marshaller> = new();
-            LocalDeclarationStatementSyntax declaration = MarshallerHelpers.Declare(
+            LocalDeclarationStatementSyntax declaration = Declare(
                 _marshallerType.Syntax,
                 context.GetAdditionalIdentifier(info, MarshallerIdentifier),
                 ImplicitObjectCreationExpression(ArgumentList(), initializer: null));
@@ -183,9 +160,10 @@ namespace Microsoft.Interop
                 yield break;
 
             string unusedIdentifier = context.GetAdditionalIdentifier(info, "unused");
+            // fixed(void* <unused> = <marshaller>) ;
             yield return FixedStatement(
                 VariableDeclaration(
-                    PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword))),
+                    TypeSyntaxes.VoidStar,
                     SingletonSeparatedList(
                         VariableDeclarator(unusedIdentifier)
                             .WithInitializer(EqualsValueClause(IdentifierName(context.GetAdditionalIdentifier(info, MarshallerIdentifier)))))),
@@ -198,12 +176,9 @@ namespace Microsoft.Interop
                 yield break;
 
             // <marshaller>.OnInvoked();
-            yield return ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+            yield return MethodInvocationStatement(
                         IdentifierName(context.GetAdditionalIdentifier(info, MarshallerIdentifier)),
-                        IdentifierName(ShapeMemberNames.Value.Stateful.OnInvoked)),
-                    ArgumentList()));
+                        IdentifierName(ShapeMemberNames.Value.Stateful.OnInvoked));
         }
 
         public static string GetMarshallerIdentifier(TypePositionInfo info, StubCodeContext context)
@@ -257,23 +232,17 @@ namespace Microsoft.Interop
                 (string managedIdentifier, _) = context.GetIdentifiers(info);
 
                 // <marshaller>.FromManaged(<managedIdentifier>, stackalloc <bufferElementType>[<marshallerType>.BufferSize]);
-                yield return ExpressionStatement(
-                    InvocationExpression(
-                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            IdentifierName(context.GetAdditionalIdentifier(info, StatefulValueMarshalling.MarshallerIdentifier)),
-                            IdentifierName(ShapeMemberNames.Value.Stateful.FromManaged)),
-                        ArgumentList(SeparatedList(
-                            new[]
-                            {
+                yield return MethodInvocationStatement(
+                                IdentifierName(context.GetAdditionalIdentifier(info, StatefulValueMarshalling.MarshallerIdentifier)),
+                                IdentifierName(ShapeMemberNames.Value.Stateful.FromManaged),
                                 Argument(IdentifierName(managedIdentifier)),
                                 Argument(StackAllocArrayCreationExpression(
-                                        ArrayType(
-                                            _bufferElementType,
-                                            SingletonList(ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(
-                                                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                                    _marshallerType,
-                                                    IdentifierName(ShapeMemberNames.BufferSize))))))))
-                            }))));
+                                    ArrayType(
+                                        _bufferElementType,
+                                        SingletonList(ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(
+                                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                                                _marshallerType,
+                                                IdentifierName(ShapeMemberNames.BufferSize)))))))));
             }
         }
 
@@ -318,12 +287,9 @@ namespace Microsoft.Interop
             string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
 
             // <marshaller>.GetUnmanagedValuesDestination()
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
+            return MethodInvocation(
                     IdentifierName(marshaller),
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetUnmanagedValuesDestination)),
-                ArgumentList());
+                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetUnmanagedValuesDestination));
         }
 
         public InvocationExpressionSyntax GetManagedValuesSource(TypePositionInfo info, StubCodeContext context)
@@ -331,12 +297,9 @@ namespace Microsoft.Interop
             string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
 
             // <marshaller>.GetManagedValuesSource()
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
+            return MethodInvocation(
                     IdentifierName(marshaller),
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetManagedValuesSource)),
-                ArgumentList());
+                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetManagedValuesSource));
         }
 
         public InvocationExpressionSyntax GetUnmanagedValuesSource(TypePositionInfo info, StubCodeContext context)
@@ -345,13 +308,10 @@ namespace Microsoft.Interop
             string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
 
             // <marshaller>.GetUnmanagedValuesSource(<numElements>)
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
+            return MethodInvocation(
                     IdentifierName(marshaller),
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetUnmanagedValuesSource)),
-                ArgumentList(SingletonSeparatedList(
-                    Argument(IdentifierName(numElementsIdentifier)))));
+                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetUnmanagedValuesSource),
+                    Argument(IdentifierName(numElementsIdentifier)));
         }
 
         public InvocationExpressionSyntax GetManagedValuesDestination(TypePositionInfo info, StubCodeContext context)
@@ -360,13 +320,10 @@ namespace Microsoft.Interop
             string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
 
             // <marshaller>.GetManagedValuesDestination(<numElements>)
-            return InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
+            return MethodInvocation(
                     IdentifierName(marshaller),
-                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetManagedValuesDestination)),
-                ArgumentList(SingletonSeparatedList(
-                    Argument(IdentifierName(numElementsIdentifier)))));
+                    IdentifierName(ShapeMemberNames.LinearCollection.Stateful.GetManagedValuesDestination),
+                    Argument(IdentifierName(numElementsIdentifier)));
         }
     }
 
@@ -438,7 +395,7 @@ namespace Microsoft.Interop
             {
                 // If the parameter is marshalled by-value [Out], then we don't marshal the contents of the collection.
                 // We do clear the span, so that if the invoke target doesn't fill it, we aren't left with undefined content.
-                yield return _elementsMarshalling.GenerateClearManagedSource(info, context);
+                yield return _elementsMarshalling.GenerateClearUnmanagedValuesDestination(info, context);
                 yield break;
             }
             if (context.Direction == MarshalDirection.UnmanagedToManaged && !info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out))
@@ -466,11 +423,11 @@ namespace Microsoft.Interop
             }
 
             string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
-            yield return LocalDeclarationStatement(
-                VariableDeclaration(
+            // int <numElements>;
+            yield return Declare(
                     PredefinedType(Token(SyntaxKind.IntKeyword)),
-                    SingletonSeparatedList(
-                        VariableDeclarator(numElementsIdentifier))));
+                    numElementsIdentifier,
+                    initializeToDefault: false);
 
             var elementsSetup = _elementsMarshalling.GenerateSetupStatement(info, context);
             if (elementsSetup is not EmptyStatementSyntax)
@@ -512,10 +469,7 @@ namespace Microsoft.Interop
             string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
 
             // <numElements> = <numElementsExpression>;
-            yield return ExpressionStatement(
-                AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                    IdentifierName(numElementsIdentifier),
-                    _numElementsExpression));
+            yield return AssignmentStatement(IdentifierName(numElementsIdentifier), _numElementsExpression);
 
             yield return _elementsMarshalling.GenerateUnmarshalStatement(info, context);
 
@@ -556,12 +510,9 @@ namespace Microsoft.Interop
 
             string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
             // <marshaller>.Free();
-            yield return ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+            yield return MethodInvocationStatement(
                         IdentifierName(marshaller),
-                        IdentifierName(ShapeMemberNames.Free)),
-                    ArgumentList()));
+                        IdentifierName(ShapeMemberNames.Free));
         }
 
         public IEnumerable<StatementSyntax> GenerateCleanupCalleeAllocatedResourcesStatements(TypePositionInfo info, StubCodeContext context)
@@ -576,12 +527,9 @@ namespace Microsoft.Interop
 
             string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
             // <marshaller>.Free();
-            yield return ExpressionStatement(
-                InvocationExpression(
-                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+            yield return MethodInvocationStatement(
                         IdentifierName(marshaller),
-                        IdentifierName(ShapeMemberNames.Free)),
-                    ArgumentList()));
+                        IdentifierName(ShapeMemberNames.Free));
         }
         public IEnumerable<StatementSyntax> GenerateGuaranteedUnmarshalStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateGuaranteedUnmarshalStatements(info, context);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
@@ -673,7 +673,7 @@ namespace Microsoft.Interop
             {
                 // If the parameter is marshalled by-value [Out], then we don't marshal the contents of the collection.
                 // We do clear the span, so that if the invoke target doesn't fill it, we aren't left with undefined content.
-                yield return _elementsMarshalling.GenerateClearManagedSource(info, context);
+                yield return _elementsMarshalling.GenerateClearUnmanagedValuesDestination(info, context);
                 yield break;
             }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -42,6 +43,14 @@ namespace Microsoft.Interop
 
     public static class TypeSyntaxes
     {
+        public static TypeSyntax Void { get; } = PredefinedType(Token(SyntaxKind.VoidKeyword));
+
+        public static TypeSyntax VoidStar { get; } = PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword)));
+
+        public static TypeSyntax VoidStarStar { get; } = PointerType(PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword))));
+
+        public static TypeSyntax Nint { get; } = ParseTypeName(TypeNames.Nint);
+
         private static TypeSyntax? _StringMarshalling;
         public static TypeSyntax StringMarshalling => _StringMarshalling ??= ParseTypeName(TypeNames.GlobalAlias + TypeNames.StringMarshalling);
 
@@ -134,6 +143,7 @@ namespace Microsoft.Interop
             };
         }
     }
+
     public static class TypeNames
     {
         public const string GlobalAlias = "global::";
@@ -300,5 +310,6 @@ namespace Microsoft.Interop
         public const string CallConvThiscallName = "System.Runtime.CompilerServices.CallConvThiscall";
         public const string CallConvSuppressGCTransitionName = "System.Runtime.CompilerServices.CallConvSuppressGCTransition";
         public const string CallConvMemberFunctionName = "System.Runtime.CompilerServices.CallConvMemberFunction";
+        public const string Nint = "nint";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Utils/SyntaxFactoryExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Utils/SyntaxFactoryExtensions.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Interop
+{
+    public static class SyntaxFactoryExtensions
+    {
+        /// <summary>
+        /// <code><paramref name="typeSyntax"/> <paramref name="identifier"/> = default;</code>
+        /// or
+        /// <code><paramref name="typeSyntax"/> <paramref name="identifier"/>;</code>
+        /// </summary>
+        public static LocalDeclarationStatementSyntax Declare(TypeSyntax typeSyntax, string identifier, bool initializeToDefault)
+        {
+            return Declare(typeSyntax, identifier, initializeToDefault ? LiteralExpression(SyntaxKind.DefaultLiteralExpression) : null);
+        }
+
+        /// <summary>
+        /// <code><paramref name="typeSyntax"/> <paramref name="identifier"/> = <paramref name="identifier"/>;</code>
+        /// or
+        /// <code><paramref name="typeSyntax"/> <paramref name="identifier"/>;</code>
+        /// </summary>
+        public static LocalDeclarationStatementSyntax Declare(TypeSyntax typeSyntax, string identifier, ExpressionSyntax? initializer)
+        {
+            VariableDeclaratorSyntax decl = VariableDeclarator(identifier);
+            if (initializer is not null)
+            {
+                decl = decl.WithInitializer(
+                    EqualsValueClause(
+                        initializer));
+            }
+
+            // <type> <identifier>;
+            // or
+            // <type> <identifier> = <initializer>;
+            return LocalDeclarationStatement(
+                VariableDeclaration(
+                    typeSyntax,
+                    SingletonSeparatedList(decl)));
+        }
+
+        public static InvocationExpressionSyntax MethodInvocation(ExpressionSyntax objectOrClass, SimpleNameSyntax methodName)
+            => InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        objectOrClass,
+                        methodName),
+                    ArgumentList(SeparatedList<ArgumentSyntax>()));
+
+        public static InvocationExpressionSyntax MethodInvocation(ExpressionSyntax objectOrClass, SimpleNameSyntax methodName, params ArgumentSyntax[] arguments)
+            => InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        objectOrClass,
+                        methodName),
+                    ArgumentList(SeparatedList(arguments)));
+
+        /// <summary>
+        /// <code>
+        /// <paramref name="objectOrClass"/>.<paramref name="methodName"/>(<paramref name="arguments"/>);
+        /// </code>
+        /// </summary>
+        public static ExpressionStatementSyntax MethodInvocationStatement(ExpressionSyntax objectOrClass, SimpleNameSyntax methodName, params ArgumentSyntax[] arguments)
+            => ExpressionStatement(MethodInvocation(objectOrClass, methodName, arguments));
+
+        public static ArgumentSyntax RefArgument(ExpressionSyntax expression)
+            => Argument(null, Token(SyntaxKind.RefKeyword), expression);
+
+        public static ArgumentSyntax InArgument(ExpressionSyntax expression)
+            => Argument(null, Token(SyntaxKind.InKeyword), expression);
+
+        public static ArgumentSyntax OutArgument(ExpressionSyntax expression)
+            => Argument(null, Token(SyntaxKind.OutKeyword), expression);
+
+        private static readonly SyntaxToken _span = Identifier(TypeNames.System_Span);
+        public static GenericNameSyntax SpanOf(TypeSyntax type) => GenericName(_span, TypeArgumentList(SingletonSeparatedList(type)));
+
+        private static readonly SyntaxToken _readonlySpan = Identifier(TypeNames.System_ReadOnlySpan);
+        public static GenericNameSyntax ReadOnlySpanOf(TypeSyntax type) => GenericName(_readonlySpan, TypeArgumentList(SingletonSeparatedList(type)));
+
+        public static MemberAccessExpressionSyntax Dot(this ExpressionSyntax expression, SimpleNameSyntax member) =>
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        expression,
+                        member);
+
+        public static ElementAccessExpressionSyntax IndexExpression(ExpressionSyntax indexed, ArgumentSyntax argument)
+            => ElementAccessExpression(
+                indexed,
+                BracketedArgumentList(SingletonSeparatedList(argument)));
+
+        public static LiteralExpressionSyntax IntLiteral(int number) => LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(number));
+
+        /// <summary>
+        /// <code>
+        /// <paramref name="left"/> = <paramref name="right"/>;
+        /// </code>
+        /// </summary>
+        public static ExpressionStatementSyntax AssignmentStatement(ExpressionSyntax left, ExpressionSyntax right)
+            => ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, left, right));
+
+        /// <summary>
+        /// Returns a for loop with no body:
+        /// <code>
+        /// for(int <paramref name="indexerIdentifier"/>; <paramref name="indexerIdentifier"/> &lt; <paramref name="lengthExpression"/>; ++<paramref name="indexerIdentifier"/>)
+        /// ;
+        /// </code>
+        /// </summary>
+        public static ForStatementSyntax ForLoop(string indexerIdentifier, ExpressionSyntax lengthExpression)
+        {
+            // for(int <indexerIdentifier> = 0; <indexerIdentifier> < <lengthIdentifier>; ++<indexerIdentifier>)
+            //      ;
+            return ForStatement(EmptyStatement())
+            .WithDeclaration(
+                VariableDeclaration(
+                    PredefinedType(
+                        Token(SyntaxKind.IntKeyword)))
+                .WithVariables(
+                    SingletonSeparatedList(
+                        VariableDeclarator(
+                            Identifier(indexerIdentifier))
+                        .WithInitializer(
+                            EqualsValueClause(
+                                LiteralExpression(
+                                    SyntaxKind.NumericLiteralExpression,
+                                    Literal(0)))))))
+            .WithCondition(
+                BinaryExpression(
+                    SyntaxKind.LessThanExpression,
+                    IdentifierName(indexerIdentifier),
+                    lengthExpression))
+            .WithIncrementors(
+                SingletonSeparatedList<ExpressionSyntax>(
+                    PrefixUnaryExpression(
+                        SyntaxKind.PreIncrementExpression,
+                        IdentifierName(indexerIdentifier))));
+        }
+
+
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Microsoft.Interop.SyntaxFactoryExtensions;
 
 namespace Microsoft.Interop
 {
@@ -58,7 +59,7 @@ namespace Microsoft.Interop
                 // Declare variable for return value
                 if (marshaller.TypeInfo.IsManagedReturnPosition || marshaller.TypeInfo.IsNativeReturnPosition)
                 {
-                    statementsToUpdate.Add(MarshallerHelpers.Declare(
+                    statementsToUpdate.Add(Declare(
                         marshaller.TypeInfo.ManagedType.Syntax,
                         managed,
                         initializeToDefault));
@@ -67,7 +68,7 @@ namespace Microsoft.Interop
                 // Declare variable with native type for parameter or return value
                 if (marshaller.Generator.UsesNativeIdentifier(marshaller.TypeInfo, context))
                 {
-                    statementsToUpdate.Add(MarshallerHelpers.Declare(
+                    statementsToUpdate.Add(Declare(
                         marshaller.Generator.AsNativeType(marshaller.TypeInfo).Syntax,
                         native,
                         initializeToDefault));
@@ -118,14 +119,14 @@ namespace Microsoft.Interop
                     bool nativeReturnUsesNativeIdentifier = marshaller.Generator.UsesNativeIdentifier(marshaller.TypeInfo, context);
 
                     // Always initialize the return value.
-                    statementsToUpdate.Add(MarshallerHelpers.Declare(
+                    statementsToUpdate.Add(Declare(
                         marshaller.TypeInfo.ManagedType.Syntax,
                         managed,
                         initializeToDefault || !nativeReturnUsesNativeIdentifier));
 
                     if (nativeReturnUsesNativeIdentifier)
                     {
-                        statementsToUpdate.Add(MarshallerHelpers.Declare(
+                        statementsToUpdate.Add(Declare(
                             marshaller.Generator.AsNativeType(marshaller.TypeInfo).Syntax,
                             native,
                             initializeToDefault: true));
@@ -145,7 +146,7 @@ namespace Microsoft.Interop
                         TypeSyntax localType = marshaller.Generator.AsNativeType(marshaller.TypeInfo).Syntax;
                         if (boundaryBehavior != ValueBoundaryBehavior.AddressOfNativeIdentifier)
                         {
-                            statementsToUpdate.Add(MarshallerHelpers.Declare(
+                            statementsToUpdate.Add(Declare(
                                 localType,
                                 native,
                                 false));
@@ -156,7 +157,7 @@ namespace Microsoft.Interop
                             // we'll just declare the native identifier as a ref to its type.
                             // The rest of the code we generate will work as expected, and we don't need
                             // to manually propogate back the updated values after the call.
-                            statementsToUpdate.Add(MarshallerHelpers.Declare(
+                            statementsToUpdate.Add(Declare(
                                 RefType(localType),
                                 native,
                                 marshaller.Generator.GenerateNativeByRefInitialization(marshaller.TypeInfo, context)));
@@ -165,7 +166,7 @@ namespace Microsoft.Interop
 
                     if (boundaryBehavior != ValueBoundaryBehavior.ManagedIdentifier)
                     {
-                        statementsToUpdate.Add(MarshallerHelpers.Declare(
+                        statementsToUpdate.Add(Declare(
                             marshaller.TypeInfo.ManagedType.Syntax,
                             managed,
                             initializeToDefault));

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/SharedTypes.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/SharedTypes.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Ancillary.Interop\Ancillary.Interop.csproj" />
+    <ProjectReference Include="..\..\..\gen\ComInterfaceGenerator\ComInterfaceGenerator.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
To improve readability and make it easier to add generation in the future, I thought it would be helpful to extract some common patterns (like method invocations, assignments, etc) into methods and use them where possible. There were also a few methods in MarshallerHelpers that are not strictly related to marshalling that I moved to this type.

I confirmed there's no difference in generated code for any of our test types.