### PR TITLE
Reenable an assert on OSX

### DIFF
--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -78,15 +78,11 @@ PEImageLayout* PEImageLayout::LoadConverted(PEImage* pOwner, bool disableMapping
     if (pFlat == NULL || !pFlat->CheckILOnlyFormat())
         EEFileLoadException::Throw(pOwner->GetPathForErrorMessages(), COR_E_BADIMAGEFORMAT);
 
-// TODO: enable on OSX eventually
-//       right now we have binaries that will trigger this in a singlefile bundle.
-#ifdef TARGET_LINUX
     // we should not see R2R files here on Unix.
     // ConvertedImageLayout may be able to handle them, but the fact that we were unable to
     // load directly implies that MAPMapPEFile could not consume what crossgen produced.
     // that is suspicious, one or another might have a bug.
     _ASSERTE(!pOwner->IsFile() || !pFlat->HasReadyToRunHeader() || disableMapping);
-#endif
 
     // ignore R2R if the image is not a file.
     if ((pFlat->HasReadyToRunHeader() && pOwner->IsFile()) ||

--- a/src/native/corehost/bundle/info.cpp
+++ b/src/native/corehost/bundle/info.cpp
@@ -29,8 +29,7 @@ info_t::info_t(const pal::char_t* bundle_path,
     // There is no known use-case for it yet, and the facility is TBD.
 
     m_deps_json = config_t(get_deps_from_app_binary(m_base_path, app_path));
-    const pal::string_t name = get_filename_without_ext(app_path);
-    m_runtimeconfig_json = config_t(get_runtime_config_path(m_base_path, name));
+    m_runtimeconfig_json = config_t(get_runtime_config_path(m_base_path, get_filename_without_ext(app_path)));
 }
 
 StatusCode info_t::process_bundle(const pal::char_t* bundle_path, const pal::char_t* app_path, int64_t header_offset)

--- a/src/native/corehost/bundle/info.cpp
+++ b/src/native/corehost/bundle/info.cpp
@@ -29,7 +29,8 @@ info_t::info_t(const pal::char_t* bundle_path,
     // There is no known use-case for it yet, and the facility is TBD.
 
     m_deps_json = config_t(get_deps_from_app_binary(m_base_path, app_path));
-    m_runtimeconfig_json = config_t(get_runtime_config_path(m_base_path, get_filename_without_ext(app_path)));
+    const pal::string_t name = get_filename_without_ext(app_path);
+    m_runtimeconfig_json = config_t(get_runtime_config_path(m_base_path, name));
 }
 
 StatusCode info_t::process_bundle(const pal::char_t* bundle_path, const pal::char_t* app_path, int64_t header_offset)

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -409,8 +409,8 @@ pal::string_t get_deps_from_app_binary(const pal::string_t& app_base, const pal:
 pal::string_t get_runtime_config_path(const pal::string_t& path, const pal::string_t& name)
 {
     auto json_path = path;
-    auto json_name = name + _X(".runtimeconfig.json");
-    append_path(&json_path, json_name.c_str());
+    append_path(&json_path, name.c_str());
+    json_path.append(_X(".runtimeconfig.json"));
     return json_path;
 }
 

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -417,8 +417,8 @@ pal::string_t get_runtime_config_path(const pal::string_t& path, const pal::stri
 pal::string_t get_runtime_config_dev_path(const pal::string_t& path, const pal::string_t& name)
 {
     auto dev_json_path = path;
-    auto dev_json_name = name + _X(".runtimeconfig.dev.json");
-    append_path(&dev_json_path, dev_json_name.c_str());
+    append_path(&dev_json_path, name.c_str());
+    dev_json_path.append(_X(".runtimeconfig.dev.json"));
     return dev_json_path;
 }
 


### PR DESCRIPTION
Fixes: #68873

When singlefile was fixed on OSX last time (#68845), we left a Unix-specific assert disabled on OSX, since we could still possibly see old binaries with unusable R2R info, which would be triggering the assert.

It was a year and half ago. It should be safe to re-enable the assert.