### PR TITLE
Add boolean field to indicate whether or not the Windows thread pool is being used

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
@@ -10,11 +10,10 @@ namespace System.Threading
 {
     public static partial class ThreadPool
     {
-        internal static bool UseWindowsThreadPool { get; } =
+        private static readonly bool s_useWindowsThreadPool = // name relied on by sos
             AppContextConfigHelper.GetBooleanConfig("System.Threading.ThreadPool.UseWindowsThreadPool", "DOTNET_ThreadPool_UseWindowsThreadPool");
-
-        // Exposes whether or not the Windows thread pool is used for diagnostics purposes
-        private static readonly bool s_useWindowsThreadPoolForDebugger = UseWindowsThreadPool;
+        
+        internal static bool UseWindowsThreadPool => s_useWindowsThreadPool;
 
 #if NATIVEAOT
         private const bool IsWorkerTrackingEnabledInConfig = false;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
@@ -12,7 +12,7 @@ namespace System.Threading
     {
         private static readonly bool s_useWindowsThreadPool = // name relied on by sos
             AppContextConfigHelper.GetBooleanConfig("System.Threading.ThreadPool.UseWindowsThreadPool", "DOTNET_ThreadPool_UseWindowsThreadPool");
-        
+
         internal static bool UseWindowsThreadPool => s_useWindowsThreadPool;
 
 #if NATIVEAOT

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
@@ -13,6 +13,9 @@ namespace System.Threading
         internal static bool UseWindowsThreadPool { get; } =
             AppContextConfigHelper.GetBooleanConfig("System.Threading.ThreadPool.UseWindowsThreadPool", "DOTNET_ThreadPool_UseWindowsThreadPool");
 
+        // Exposes whether or not the Windows thread pool is used for diagnostics purposes
+        private static readonly bool s_useWindowsThreadPoolForDebugger = UseWindowsThreadPool;
+
 #if NATIVEAOT
         private const bool IsWorkerTrackingEnabledInConfig = false;
 #else

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
@@ -10,7 +10,8 @@ namespace System.Threading
 {
     public static partial class ThreadPool
     {
-        private static readonly bool s_useWindowsThreadPool = // name relied on by sos
+        // name relied on by sos
+        private static readonly bool s_useWindowsThreadPool =
             AppContextConfigHelper.GetBooleanConfig("System.Threading.ThreadPool.UseWindowsThreadPool", "DOTNET_ThreadPool_UseWindowsThreadPool");
 
         internal static bool UseWindowsThreadPool => s_useWindowsThreadPool;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
@@ -10,11 +10,12 @@ namespace System.Threading
 {
     public static partial class ThreadPool
     {
-        // name relied on by sos
-        private static readonly bool s_useWindowsThreadPool =
+        internal static bool UseWindowsThreadPool { get; } =
             AppContextConfigHelper.GetBooleanConfig("System.Threading.ThreadPool.UseWindowsThreadPool", "DOTNET_ThreadPool_UseWindowsThreadPool");
 
-        internal static bool UseWindowsThreadPool => s_useWindowsThreadPool;
+        // The field should reflect what the property returns because the property can be stubbed by trimming,
+        // such that sos reflects the actual state of what thread pool is being used and not just the config value.
+        private static readonly bool s_useWindowsThreadPool = UseWindowsThreadPool; // Name relied on by sos
 
 #if NATIVEAOT
         private const bool IsWorkerTrackingEnabledInConfig = false;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
@@ -13,9 +13,11 @@ namespace System.Threading
         internal static bool UseWindowsThreadPool { get; } =
             AppContextConfigHelper.GetBooleanConfig("System.Threading.ThreadPool.UseWindowsThreadPool", "DOTNET_ThreadPool_UseWindowsThreadPool");
 
+#pragma warning disable CA1823
         // The field should reflect what the property returns because the property can be stubbed by trimming,
         // such that sos reflects the actual state of what thread pool is being used and not just the config value.
         private static readonly bool s_useWindowsThreadPool = UseWindowsThreadPool; // Name relied on by sos
+#pragma warning restore CA1823
 
 #if NATIVEAOT
         private const bool IsWorkerTrackingEnabledInConfig = false;


### PR DESCRIPTION
This field is being added for diagnostics purposes. It will be used by `ThreadPool` SOS command.