### PR TITLE
Return false from ComWrappers.Try... methods

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -1542,7 +1542,7 @@ namespace System.ComponentModel
                 {
                     type = ComObjectType;
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                else if (OperatingSystem.IsWindows()
                     && ComWrappers.TryGetComInstance(instance, out nint unknown))
                 {
                     // ComObjectType uses the Windows Forms provided ComNativeDescriptor. It currently has hard Win32

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.PlatformNotSupported.cs
@@ -11,12 +11,14 @@ namespace System.Runtime.InteropServices
     {
         public static unsafe bool TryGetComInstance(object obj, out IntPtr unknown)
         {
-            throw new PlatformNotSupportedException();
+            unknown = default;
+            return false;
         }
 
         public static unsafe bool TryGetObject(IntPtr unknown, [NotNullWhen(true)] out object? obj)
         {
-            throw new PlatformNotSupportedException();
+            obj = default;
+            return false;
         }
 
         public partial struct ComInterfaceDispatch


### PR DESCRIPTION
Return false from ComWrappers.TryGetComInstance/TryGetObject instead of throwing PNSE. It saves callers from needing to protect against PNSE.

Fix #90311