### PR TITLE
Add -skipcrossarchnative and -verbose options

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -524,6 +524,11 @@ while [[ $# > 0 ]]; do
       shift 2
       ;;
 
+      -verbose)
+      arguments="$arguments /p:CoreclrVerbose=true"
+      shift 2
+      ;;
+
       *)
       extraargs="$extraargs $1"
       shift 1

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -526,7 +526,7 @@ while [[ $# > 0 ]]; do
 
       -verbose)
       arguments="$arguments /p:CoreclrVerbose=true"
-      shift 2
+      shift 1
       ;;
 
       *)

--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -20,7 +20,6 @@ export PYTHON
 
 usage_list+=("-pgodatapath: path to profile guided optimization data.")
 usage_list+=("-pgoinstrument: generate instrumented code for profile guided optimization enabled binaries.")
-usage_list+=("-skipcrossarchnative: Skip building cross-architecture native binaries.")
 usage_list+=("-staticanalyzer: use scan_build static analyzer.")
 usage_list+=("-component: Build individual components instead of the full project. Available options are 'hosts', 'jit', 'runtime', 'paltests', 'alljits', 'iltools', 'nativeaot', and 'spmi'. Can be specified multiple times.")
 usage_list+=("-subdir: Append a directory with the provided name to the obj and bin paths.")

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -33,6 +33,7 @@
       <_CoreClrBuildArg Condition="'$(PortableBuild)' != 'true'" Include="-portablebuild=false" />
       <_CoreClrBuildArg Condition="'$(KeepNativeSymbols)' != 'false'" Include="-keepnativesymbols" />
       <_CoreClrBuildArg Include="-os $(_BuildNativeTargetOS)" />
+      <_CoreClrBuildArg Condition="'$(CoreclrVerbose)' == 'true'" Include="-verbose" />
 
       <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and
                                    ('$(TargetArchitecture)' == 'x86' or '$(TargetArchitecture)' == 'x64') and


### PR DESCRIPTION
Build.sh lacks -skipcrossarchnative and -verbose for coreclr building so let's add these 2 options to be forwarded to coreclr build system.