### PR TITLE
[release/8.0] Bump to RC2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,7 @@
     <PackageVersionNet7>7.0.8</PackageVersionNet7>
     <PackageVersionNet6>6.0.$([MSBuild]::Add($([System.Version]::Parse('$(PackageVersionNet7)').Build),11))</PackageVersionNet6>
     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <WorkloadVersionSuffix Condition="'$(PreReleaseVersionLabel)' != 'release'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>
     <SdkBandVersionForWorkload_FromRuntimeVersions>$(SdkBandVersion)$(WorkloadVersionSuffix)</SdkBandVersionForWorkload_FromRuntimeVersions>
     <!-- Set assembly version to align with major and minor version,

--- a/eng/native/configureplatform.cmake
+++ b/eng/native/configureplatform.cmake
@@ -2,7 +2,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
 
 # If set, indicates that this is not an officially supported release.
 # Release branches should set this to false.
-set(PRERELEASE 1)
+set(PRERELEASE 0)
 
 #----------------------------------------
 # Detect and set platform variable names


### PR DESCRIPTION
Bump the base release/8.0 branch to target RC2.

Also need to set prerelease to 0 in configureplatform.cmake in RC2 per this comment: https://github.com/dotnet/runtime/pull/72169#discussion_r921232422 