### PR TITLE
Adding new method "ConfigurationExtensions.IsPresent(this IConfigurationSection?)"

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/ref/Microsoft.Extensions.Configuration.Abstractions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Extensions.Configuration
         public static bool Exists([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] this Microsoft.Extensions.Configuration.IConfigurationSection? section) { throw null; }
         public static string? GetConnectionString(this Microsoft.Extensions.Configuration.IConfiguration configuration, string name) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationSection GetRequiredSection(this Microsoft.Extensions.Configuration.IConfiguration configuration, string key) { throw null; }
+        public static bool IsPresent([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] this Microsoft.Extensions.Configuration.IConfigurationSection? section) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Property)]
     public sealed partial class ConfigurationKeyNameAttribute : System.Attribute

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationExtensions.cs
@@ -106,5 +106,19 @@ namespace Microsoft.Extensions.Configuration
 
             throw new InvalidOperationException(SR.Format(SR.InvalidSectionName, key));
         }
+
+        /// <summary>
+        /// Determines whether the section has a <see cref="IConfigurationSection.Value"/>.
+        /// </summary>
+        /// <param name="section">The section to enumerate.</param>
+        /// <returns><see langword="true" /> if the section has values; otherwise, <see langword="false" />.</returns>
+        public static bool IsPresent([NotNullWhen(true)] this IConfigurationSection? section)
+        {
+            if (section == null)
+            {
+                return false;
+            }
+            return section.Value != null;
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationTest.cs
@@ -837,6 +837,30 @@ namespace Microsoft.Extensions.Configuration.Test
         }
 
         [Fact]
+        public void IsPresent_Success()
+        {
+            var dict = new Dictionary<string, string>()
+            {
+                {"Mem1", "Value1"},
+                {"Mem1:KeyInMem1", "ValueInMem1"},
+                {"Mem2", ""}
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dict);
+            var config = configurationBuilder.Build();
+
+            var sectionMem1IsPresent1 = config.GetSection("Mem1").IsPresent();
+            var sectionMem1IsPresent2 = config.GetSection("Mem1:KeyInMem1").IsPresent();
+            var sectionMem2IsPresent1 = config.GetSection("Mem2").IsPresent();
+            var sectionMem2IsPresent2 = config.GetSection("Mem2:KeyInMem2").IsPresent();
+
+            Assert.True(sectionMem1IsPresent1);
+            Assert.True(sectionMem1IsPresent2);
+            Assert.True(sectionMem2IsPresent1);
+            Assert.False(sectionMem2IsPresent2);
+        }
+
+        [Fact]
         public void SectionGetRequiredSectionSuccess()
         {
             // Arrange


### PR DESCRIPTION
Adding method `ConfigurationExtensions.IsPresent(this IConfigurationSection?)` for discovering presence of configuration section.
Fix #58104 