### PR TITLE
[ios] Add optimized property to the Native AOT sample app

### DIFF
--- a/src/mono/sample/iOS-NativeAOT/Program.csproj
+++ b/src/mono/sample/iOS-NativeAOT/Program.csproj
@@ -9,6 +9,7 @@
     <RuntimeIdentifier>$(TargetOS)-$(TargetArchitecture)</RuntimeIdentifier>
     <AppName>HelloiOS</AppName>
     <GenerateXcodeProject>true</GenerateXcodeProject>
+    <Optimized Condition="'$(Configuration)' == 'Release'">true</Optimized>
     <UseNativeAOTRuntime Condition="'$(UseNativeAOTRuntime)' == ''">true</UseNativeAOTRuntime>
     <RunAOTCompilation>false</RunAOTCompilation>
     <NativeLib>static</NativeLib>


### PR DESCRIPTION
This PR adds optimized property to the sample app for AppleAppBuilder.

Fixes failing perf job https://dev.azure.com/dnceng/internal/_build/results?buildId=2243250&view=logs&j=3ed67216-8d06-57e4-e860-09ab51946aa1&t=ae27ed72-ed5a-5253-cbac-402a1b387446