### PR TITLE
[workloads] Put quotes around GetFileName call when collecting telemetry

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadTelemetry.targets
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadTelemetry.targets
@@ -38,8 +38,8 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <_WorkloadUsesOther Condition="'$([System.IO.Path]::GetFileName(%(ReferencePath.Identity)).ToLower())' == 'avalonia.dll'">true</_WorkloadUsesOther>
-      <_WorkloadUsesOther Condition="'$([System.IO.Path]::GetFileName(%(ReferencePath.Identity)).ToLower())' == 'uno.dll'">true</_WorkloadUsesOther>
+      <_WorkloadUsesOther Condition="'$([System.IO.Path]::GetFileName(&quot;%(ReferencePath.Identity)&quot;).ToLower())' == 'avalonia.dll'">true</_WorkloadUsesOther>
+      <_WorkloadUsesOther Condition="'$([System.IO.Path]::GetFileName(&quot;%(ReferencePath.Identity)&quot;).ToLower())' == 'uno.dll'">true</_WorkloadUsesOther>
       <_WorkloadUsesMobileSDKOnly Condition="'$(RuntimeIdentifier)' != 'browser-wasm' and '$(UseMaui)' != 'true' and '$(_WorkloadUsesOther)' != 'true'">true</_WorkloadUsesMobileSDKOnly>
     </PropertyGroup>
   </Target>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadTelemetry.targets
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadTelemetry.targets
@@ -38,8 +38,8 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <_WorkloadUsesOther Condition="'$([System.IO.Path]::GetFileName(&quot;%(ReferencePath.Identity)&quot;).ToLower())' == 'avalonia.dll'">true</_WorkloadUsesOther>
-      <_WorkloadUsesOther Condition="'$([System.IO.Path]::GetFileName(&quot;%(ReferencePath.Identity)&quot;).ToLower())' == 'uno.dll'">true</_WorkloadUsesOther>
+      <_WorkloadUsesOther Condition="'$([System.IO.Path]::GetFileName(&quot;%(ReferencePath.Identity)&quot;).ToLowerInvariant())' == 'avalonia.dll'">true</_WorkloadUsesOther>
+      <_WorkloadUsesOther Condition="'$([System.IO.Path]::GetFileName(&quot;%(ReferencePath.Identity)&quot;).ToLowerInvariant())' == 'uno.dll'">true</_WorkloadUsesOther>
       <_WorkloadUsesMobileSDKOnly Condition="'$(RuntimeIdentifier)' != 'browser-wasm' and '$(UseMaui)' != 'true' and '$(_WorkloadUsesOther)' != 'true'">true</_WorkloadUsesMobileSDKOnly>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
There are cases where `%(ReferencePath)` is empty, so prevent exceptions by quoting the value.

Fixes https://github.com/dotnet/runtime/issues/90584