### PR TITLE
Improve profiled casts

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5394,6 +5394,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
     // Pessimistically assume the jit cannot expand this as an inline test
     bool                  canExpandInline = false;
     bool                  partialExpand   = false;
+    bool                  reversedMTCheck = false;
     const CorInfoHelpFunc helper          = info.compCompHnd->getCastingHelper(pResolvedToken, isCastClass);
 
     CORINFO_CLASS_HANDLE exactCls = NO_CLASS_HANDLE;
@@ -5478,8 +5479,17 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
                 if ((likelyCls != NO_CLASS_HANDLE) &&
                     (likelyClass.likelihood > (UINT32)JitConfig.JitGuardedDevirtualizationChainLikelihood()))
                 {
-                    if ((info.compCompHnd->compareTypesForCast(likelyCls, pResolvedToken->hClass) ==
-                         TypeCompareState::Must))
+                    TypeCompareState castResult =
+                        info.compCompHnd->compareTypesForCast(likelyCls, pResolvedToken->hClass);
+
+                    // If case of MustNot we still can optimize isinst (only), e.g.:
+                    //
+                    //   bool objIsDisposable = obj is IDisposable;
+                    //
+                    // when the profile tells us that obj is mostly Int32, hence, never implements that interface.
+                    // for castclass it makes little sense as it will always throw a cast exception anyway.
+                    if ((castResult == TypeCompareState::Must) ||
+                        (castResult == TypeCompareState::MustNot && !isCastClass))
                     {
                         bool isAbstract = (info.compCompHnd->getClassAttribs(likelyCls) &
                                            (CORINFO_FLG_INTERFACE | CORINFO_FLG_ABSTRACT)) != 0;
@@ -5489,6 +5499,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
                             JITDUMP("Adding \"is %s (%X)\" check as a fast path for %s using PGO data.\n",
                                     eeGetClassName(likelyCls), likelyCls, isCastClass ? "castclass" : "isinst");
 
+                            reversedMTCheck = castResult == TypeCompareState::MustNot;
                             canExpandInline = true;
                             partialExpand   = true;
                             exactCls        = likelyCls;
@@ -5567,12 +5578,12 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
     //             op1Copy CNS_INT
     //                      null
     //
-    condNull = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewIconNode(0, TYP_REF));
+    condNull = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewNull());
 
     //
     // expand the true and false trees for the condMT
     //
-    GenTree* condFalse = gtClone(op1);
+    GenTree* condFalse = reversedMTCheck ? gtNewNull() : gtClone(op1);
     GenTree* condTrue;
     if (isCastClass)
     {
@@ -5629,7 +5640,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
     //                      /     \.
     //                qmarkMT   op1Copy
     //
-    temp      = new (this, GT_COLON) GenTreeColon(TYP_REF, gtClone(op1), qmarkMT);
+    temp      = new (this, GT_COLON) GenTreeColon(TYP_REF, reversedMTCheck ? gtNewNull() : gtClone(op1), qmarkMT);
     qmarkNull = gtNewQmarkNode(TYP_REF, condNull, temp->AsColon());
     qmarkNull->gtFlags |= GTF_QMARK_CAST_INSTOF;
 


### PR DESCRIPTION
For profiled casts, we currently give up on negative cases (when profiled type is never of the casted interface). This PR fixes that, benchmark:

```cs
object _obj = 42;

[Benchmark]
public bool IsInterface() => _obj is ICollection or IDisposable;
```
```
|      Method |     Mean |    Error |   StdDev |
|------------ |---------:|---------:|---------:|
| IsInterface | 13.80 ns | 1.975 ns | 0.108 ns | Main
| IsInterface |  0.39 ns | 0.029 ns | 0.002 ns | PR

(with DOTNET_JitProfileCasts=1)
```

Basically, we expand it as `obj == null ? null : (obj.GetType() == typeof(int) ? null : helperCall())` (for each isinst)