### PR TITLE
[mono] Enable Yield_r* tests with full-AOT (llvm)

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2471,10 +2471,6 @@
             <Issue>This test includes an intentionally-invalid UnmanagedCallersOnly method. Invalid UnmanagedCallersOnly methods cause failures at AOT-time.</Issue>
         </ExcludeList>
 
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/HardwareIntrinsics/Arm/ArmBase/Yield_*/**">
-            <Issue>https://github.com/dotnet/runtime/issues/64179</Issue>
-        </ExcludeList>
-
         <ExcludeList Include="$(XunitTestBinBase)/JIT/CheckProjects/CheckProjects/**">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
Enabling `JIT/HardwareIntrinsics/Arm/ArmBase/Yield_r*` tests running on full-AOT (llvm) for Mono. Disabled in https://github.com/dotnet/runtime/issues/64179.

Fixes https://github.com/dotnet/runtime/issues/64179