### PR TITLE
[NativeAOT] Made threadstatic helper call sites slightly simpler (static ctor case)

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
@@ -18,7 +18,7 @@ namespace Internal.Runtime
     internal static class ThreadStatics
     {
         [ThreadStatic]
-        private static object t_inlinedThreadStaticBase;
+        internal static object t_inlinedThreadStaticBase;
 
         /// <summary>
         /// This method is called from a ReadyToRun helper to get base address of thread

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
@@ -44,9 +44,18 @@ namespace System.Runtime.CompilerServices
 
         private static unsafe object CheckStaticClassConstructionReturnThreadStaticBase(TypeManagerSlot* pModuleData, int typeTlsIndex, StaticClassConstructionContext* context)
         {
+            if (typeTlsIndex < 0)
+                return CheckStaticClassConstructionReturnThreadStaticBaseInlined(context);
+
             object threadStaticBase = ThreadStatics.GetThreadStaticBaseForType(pModuleData, typeTlsIndex);
             EnsureClassConstructorRun(context);
             return threadStaticBase;
+        }
+
+        private static unsafe object CheckStaticClassConstructionReturnThreadStaticBaseInlined(StaticClassConstructionContext* context)
+        {
+            EnsureClassConstructorRun(context);
+            return ThreadStatics.t_inlinedThreadStaticBase;
         }
 
         public static unsafe void EnsureClassConstructorRun(StaticClassConstructionContext* pContext)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/HelperEntrypoint.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/HelperEntrypoint.cs
@@ -8,6 +8,7 @@ namespace ILCompiler.DependencyAnalysis
         EnsureClassConstructorRunAndReturnGCStaticBase,
         EnsureClassConstructorRunAndReturnNonGCStaticBase,
         EnsureClassConstructorRunAndReturnThreadStaticBase,
+        EnsureClassConstructorRunAndReturnThreadStaticBaseInlined,
         GetThreadStaticBaseForType,
         GetInlinedThreadStaticBaseSlow,
     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -1036,6 +1036,7 @@ namespace ILCompiler.DependencyAnalysis
             new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnGCStaticBase" },
             new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnNonGCStaticBase" },
             new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnThreadStaticBase" },
+            new string[] { "System.Runtime.CompilerServices", "ClassConstructorRunner", "CheckStaticClassConstructionReturnThreadStaticBaseInlined" },
             new string[] { "Internal.Runtime", "ThreadStatics", "GetThreadStaticBaseForType" },
             new string[] { "Internal.Runtime", "ThreadStatics", "GetInlinedThreadStaticBaseSlow" },
         };

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
@@ -80,18 +80,11 @@ namespace ILCompiler.DependencyAnalysis
                             }
                             else
                             {
-                                // First arg: unused address of the TypeManager
-                                // encoder.EmitMOV(encoder.TargetRegister.Arg0, (ushort)0);
+                                encoder.EmitMOV(encoder.TargetRegister.Arg0, factory.TypeNonGCStaticsSymbol(target));
+                                encoder.EmitLDR(encoder.TargetRegister.Arg1, encoder.TargetRegister.Arg0, -NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
+                                encoder.EmitCMP(encoder.TargetRegister.Arg1, 0);
 
-                                // Second arg: ~0 (index of inlined storage)
-                                encoder.EmitMVN(encoder.TargetRegister.Arg1, 0);
-
-                                encoder.EmitMOV(encoder.TargetRegister.Arg2, factory.TypeNonGCStaticsSymbol(target));
-                                encoder.EmitSUB(encoder.TargetRegister.Arg2, NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
-                                encoder.EmitLDR(encoder.TargetRegister.Arg3, encoder.TargetRegister.Arg2);
-                                encoder.EmitCMP(encoder.TargetRegister.Arg3, 0);
-
-                                encoder.EmitJNE(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase));
+                                encoder.EmitJNE(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBaseInlined));
                                 EmitInlineTLSAccess(factory, ref encoder);
                             }
                         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -80,17 +80,11 @@ namespace ILCompiler.DependencyAnalysis
                             }
                             else
                             {
-                                // First arg: unused address of the TypeManager
-                                // encoder.EmitMOV(encoder.TargetRegister.Arg0, 0);
+                                encoder.EmitLEAQ(encoder.TargetRegister.Arg0, factory.TypeNonGCStaticsSymbol(target), -NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
 
-                                // Second arg: -1 (index of inlined storage)
-                                encoder.EmitMOV(encoder.TargetRegister.Arg1, -1);
-
-                                encoder.EmitLEAQ(encoder.TargetRegister.Arg2, factory.TypeNonGCStaticsSymbol(target), -NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
-
-                                AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg2, null, 0, 0, AddrModeSize.Int64);
+                                AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, 0, 0, AddrModeSize.Int64);
                                 encoder.EmitCMP(ref initialized, 0);
-                                encoder.EmitJNE(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase));
+                                encoder.EmitJNE(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBaseInlined));
 
                                 EmitInlineTLSAccess(factory, ref encoder);
                             }


### PR DESCRIPTION
Just noticed that if we have a separate slow helper for the inlined case, we can save a few instructions/registers at the call-sites.