### PR TITLE
[wasm] Pin chrome version for testing to 115.0.579.x

### DIFF
--- a/eng/testing/ProvisioningVersions.props
+++ b/eng/testing/ProvisioningVersions.props
@@ -44,20 +44,20 @@
   <PropertyGroup>
     <!-- To use a specific version, set ChromeFindLatestAvailableVersion=false,
          and set the version, and revisions in the propertygroup below -->
-    <!--<ChromeFindLatestAvailableVersion>false</ChromeFindLatestAvailableVersion>-->
+    <ChromeFindLatestAvailableVersion>false</ChromeFindLatestAvailableVersion>
 
     <ChromeFindLatestAvailableVersion Condition="'$(ChromeFindLatestAvailableVersion)' == ''">true</ChromeFindLatestAvailableVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Use specific version of chrome" Condition="'$(ChromeFindLatestAvailableVersion)' != 'true' and $([MSBuild]::IsOSPlatform('linux'))">
-    <ChromeVersion>113.0.5672.63</ChromeVersion>
-    <ChromeRevision>1121455</ChromeRevision>
-    <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1121461</_ChromeBaseSnapshotUrl>
+    <ChromeVersion>115.0.5790.170</ChromeVersion>
+    <ChromeRevision>1148114</ChromeRevision>
+    <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1148123</_ChromeBaseSnapshotUrl>
   </PropertyGroup>
   <PropertyGroup Label="Use specific version of chrome" Condition="'$(ChromeFindLatestAvailableVersion)' != 'true' and $([MSBuild]::IsOSPlatform('windows'))">
-    <ChromeVersion>113.0.5672.64</ChromeVersion>
-    <ChromeRevision>1121455</ChromeRevision>
-    <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1121477</_ChromeBaseSnapshotUrl>
+    <ChromeVersion>115.0.5790.171</ChromeVersion>
+    <ChromeRevision>1148114</ChromeRevision>
+    <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1148119</_ChromeBaseSnapshotUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BrowserHost)' != 'windows'">


### PR DESCRIPTION
Hybrid globalization tests are breaking with 116.0.5845.0
