### PR TITLE
Fix gcroot SOS command on arm/arm64

### DIFF
--- a/src/coreclr/vm/arm/stubs.cpp
+++ b/src/coreclr/vm/arm/stubs.cpp
@@ -671,6 +671,16 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
         pRD->pCurrentContext->R10 = (DWORD)(pUnwoundState->captureR4_R11[6]);
         pRD->pCurrentContext->R11 = (DWORD)(pUnwoundState->captureR4_R11[7]);
 
+        pRD->pCurrentContextPointers->R4 = &pRD->pCurrentContext->R4;
+        pRD->pCurrentContextPointers->R5 = &pRD->pCurrentContext->R5;
+        pRD->pCurrentContextPointers->R6 = &pRD->pCurrentContext->R6;
+        pRD->pCurrentContextPointers->R7 = &pRD->pCurrentContext->R7;
+        pRD->pCurrentContextPointers->R8 = &pRD->pCurrentContext->R8;
+        pRD->pCurrentContextPointers->R9 = &pRD->pCurrentContext->R9;
+        pRD->pCurrentContextPointers->R10 = &pRD->pCurrentContext->R10;
+        pRD->pCurrentContextPointers->R11 = &pRD->pCurrentContext->R11;
+        pRD->pCurrentContextPointers->Lr = &pRD->pCurrentContext->Lr;
+
         return;
     }
 #endif // DACCESS_COMPILE

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -472,18 +472,18 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
         pRD->pCurrentContext->Fp = (DWORD64)(pUnwoundState->captureX19_X29[10]);
         pRD->pCurrentContext->Lr = NULL; // Unwind again to get Caller's PC
 
-        pRD->pCurrentContextPointers->X19 = pUnwoundState->ptrX19_X29[0];
-        pRD->pCurrentContextPointers->X20 = pUnwoundState->ptrX19_X29[1];
-        pRD->pCurrentContextPointers->X21 = pUnwoundState->ptrX19_X29[2];
-        pRD->pCurrentContextPointers->X22 = pUnwoundState->ptrX19_X29[3];
-        pRD->pCurrentContextPointers->X23 = pUnwoundState->ptrX19_X29[4];
-        pRD->pCurrentContextPointers->X24 = pUnwoundState->ptrX19_X29[5];
-        pRD->pCurrentContextPointers->X25 = pUnwoundState->ptrX19_X29[6];
-        pRD->pCurrentContextPointers->X26 = pUnwoundState->ptrX19_X29[7];
-        pRD->pCurrentContextPointers->X27 = pUnwoundState->ptrX19_X29[8];
-        pRD->pCurrentContextPointers->X28 = pUnwoundState->ptrX19_X29[9];
-        pRD->pCurrentContextPointers->Fp = pUnwoundState->ptrX19_X29[10];
-        pRD->pCurrentContextPointers->Lr = NULL;
+        pRD->pCurrentContextPointers->X19 = &pRD->pCurrentContext->X19;
+        pRD->pCurrentContextPointers->X20 = &pRD->pCurrentContext->X20;
+        pRD->pCurrentContextPointers->X21 = &pRD->pCurrentContext->X21;
+        pRD->pCurrentContextPointers->X22 = &pRD->pCurrentContext->X22;
+        pRD->pCurrentContextPointers->X23 = &pRD->pCurrentContext->X23;
+        pRD->pCurrentContextPointers->X24 = &pRD->pCurrentContext->X24;
+        pRD->pCurrentContextPointers->X25 = &pRD->pCurrentContext->X25;
+        pRD->pCurrentContextPointers->X26 = &pRD->pCurrentContext->X26;
+        pRD->pCurrentContextPointers->X27 = &pRD->pCurrentContext->X27;
+        pRD->pCurrentContextPointers->X28 = &pRD->pCurrentContext->X28;
+        pRD->pCurrentContextPointers->Fp = &pRD->pCurrentContext->Fp;
+        pRD->pCurrentContextPointers->Lr = &pRD->pCurrentContext->Lr;
 
         return;
     }


### PR DESCRIPTION
Faulted in DAC because the HelperMethodFrame's REGDISPLAY CurrentContextPointers were not initialized correctly.

Fixes issue https://github.com/dotnet/diagnostics/issues/3726