### PR TITLE
Switch fx_ver_t::as_str from stringstream to append/to_string

### DIFF
--- a/src/native/corehost/fxr/fx_ver.cpp
+++ b/src/native/corehost/fxr/fx_ver.cpp
@@ -70,31 +70,18 @@ bool fx_ver_t::operator >=(const fx_ver_t& b) const
 
 pal::string_t fx_ver_t::as_str() const
 {
-    pal::stringstream_t stream;
-    stream << m_major << _X(".") << m_minor << _X(".") << m_patch;
+    pal::string_t version = pal::to_string(m_major);
+    version += _X('.');
+    version += pal::to_string(m_minor);
+    version += _X('.');
+    version += pal::to_string(m_patch);
     if (!m_pre.empty())
-    {
-        stream << m_pre;
-    }
+        version += m_pre;
+
     if (!m_build.empty())
-    {
-        stream << m_build;
-    }
-    return stream.str();
-}
+        version += m_build;
 
-pal::string_t fx_ver_t::prerelease_glob() const
-{
-    pal::stringstream_t stream;
-    stream << m_major << _X(".") << m_minor << _X(".") << m_patch << _X("-*");
-    return stream.str();
-}
-
-pal::string_t fx_ver_t::patch_glob() const
-{
-    pal::stringstream_t stream;
-    stream << m_major << _X(".") << m_minor << _X(".*");
-    return stream.str();
+    return version;
 }
 
 static pal::string_t getId(const pal::string_t &ids, size_t idStart)

--- a/src/native/corehost/fxr/fx_ver.h
+++ b/src/native/corehost/fxr/fx_ver.h
@@ -26,8 +26,6 @@ struct fx_ver_t
     bool is_empty() const { return m_major == -1; }
 
     pal::string_t as_str() const;
-    pal::string_t prerelease_glob() const;
-    pal::string_t patch_glob() const;
 
     bool operator ==(const fx_ver_t& b) const;
     bool operator !=(const fx_ver_t& b) const;

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -16,7 +16,6 @@
 #include <fcntl.h>
 #include <fnmatch.h>
 #include <ctime>
-#include <locale>
 #include <pwd.h>
 #include "config.h"
 #include <minipal/getexepath.h>

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -7,7 +7,6 @@
 #include "longfile.h"
 
 #include <cassert>
-#include <locale>
 #include <ShlObj.h>
 #include <ctime>
 

--- a/src/native/corehost/hostpolicy/version.cpp
+++ b/src/native/corehost/hostpolicy/version.cpp
@@ -51,29 +51,31 @@ bool version_t::operator >=(const version_t& b) const
 
 pal::string_t version_t::as_str() const
 {
-    pal::stringstream_t stream;
-
+    pal::string_t version;
     if (m_major >= 0)
     {
-        stream << m_major;
+        version += pal::to_string(m_major);
 
         if (m_minor >= 0)
         {
-            stream << _X(".") << m_minor;
+            version += _X('.');
+            version += pal::to_string(m_minor);
 
             if (m_build >= 0)
             {
-                stream << _X(".") << m_build;
+                version += _X('.');
+                version += pal::to_string(m_build);
 
                 if (m_revision >= 0)
                 {
-                    stream << _X(".") << m_revision;
+                    version += _X('.');
+                    version += pal::to_string(m_revision);
                 }
             }
         }
     }
 
-    return stream.str();
+    return version;
 }
 
 /*static*/ int version_t::compare(const version_t&a, const version_t& b)


### PR DESCRIPTION
Stop using `std::stringstream` to convert `fx_ver_t` to a string. It pulls in `std::locale` (and other things) in all the host binaries when we really just need a simple conversion of the numbers to a string. In some binaries, it was also the only usage of stringstream. In theory, this should also be faster, although this is not a particularly perf-sensitive function (most usage is for when tracing is enabled).

On my local Windows x64 build, the sizes on disk were:
| | before (kB) | after (kB) | diff (kB) |
| --- | ---: | ---: | ---: |
| apphost | 153 | 136 | -17 |
| comhost | 189 |  174 | -15 |
| dotnet | 172 | 129 | -43 |
| ijwhost | 141 | 101 | -40 |
| nethost | 131 | 88 | - 43 |