### PR TITLE
Limit language version on Logger and Options source gens

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -142,10 +142,10 @@ The diagnostic id values reserved for .NET Libraries analyzer warnings are `SYSL
 |  __`SYSLIB1023`__ | Generating more than 6 arguments is not supported |
 |  __`SYSLIB1024`__ | Argument is using the unsupported out parameter modifier |
 |  __`SYSLIB1025`__ | Multiple logging methods cannot use the same event name within a class |
-|  __`SYSLIB1026`__ | _`SYSLIB1026`-`SYSLIB1029` reserved for logging._ |
-|  __`SYSLIB1027`__ | _`SYSLIB1026`-`SYSLIB1029` reserved for logging._ |
-|  __`SYSLIB1028`__ | _`SYSLIB1026`-`SYSLIB1029` reserved for logging._ |
-|  __`SYSLIB1029`__ | _`SYSLIB1026`-`SYSLIB1029` reserved for logging._ |
+|  __`SYSLIB1026`__ | C# language version not supported by the logging source generator. |
+|  __`SYSLIB1027`__ | _`SYSLIB1001`-`SYSLIB1029` reserved for logging._ |
+|  __`SYSLIB1028`__ | _`SYSLIB1001`-`SYSLIB1029` reserved for logging._ |
+|  __`SYSLIB1029`__ | _`SYSLIB1001`-`SYSLIB1029` reserved for logging._ |
 |  __`SYSLIB1030`__ | JsonSourceGenerator did not generate serialization metadata for type |
 |  __`SYSLIB1031`__ | JsonSourceGenerator encountered a duplicate JsonTypeInfo property name |
 |  __`SYSLIB1032`__ | JsonSourceGenerator encountered a context class that is not partial |
@@ -250,7 +250,7 @@ The diagnostic id values reserved for .NET Libraries analyzer warnings are `SYSL
 |  __`SYSLIB1213`__ | Options validation generator: Member potentially missing enumerable validation. |
 |  __`SYSLIB1214`__ | Options validation generator: Can't validate constants, static fields or properties. |
 |  __`SYSLIB1215`__ | Options validation generator: Validation attribute on the member is inaccessible from the validator type. |
-|  __`SYSLIB1216`__ | *_`SYSLIB1201`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
+|  __`SYSLIB1216`__ | C# language version not supported by the options validation source generator. |
 |  __`SYSLIB1217`__ | *_`SYSLIB1201`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
 |  __`SYSLIB1218`__ | *_`SYSLIB1201`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |
 |  __`SYSLIB1219`__ | *_`SYSLIB1201`-`SYSLIB1219` reserved for Microsoft.Extensions.Options.SourceGeneration.* |

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/DiagnosticDescriptors.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/DiagnosticDescriptors.cs
@@ -200,5 +200,13 @@ namespace Microsoft.Extensions.Logging.Generators
             category: "LoggingGenerator",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
+
+        public static DiagnosticDescriptor LoggingUnsupportedLanguageVersion { get; } = new DiagnosticDescriptor(
+            id: "SYSLIB1026",
+            title: new LocalizableResourceString(nameof(SR.LoggingUnsupportedLanguageVersionTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
+            messageFormat: new LocalizableResourceString(nameof(SR.LoggingUnsupportedLanguageVersionMessageFormat), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
+            category: "LoggingGenerator",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -591,6 +591,13 @@ namespace Microsoft.Extensions.Logging.Generators
                     }
                 }
 
+                if (results.Count > 0 && ((CSharpCompilation)_compilation).LanguageVersion < LanguageVersion.CSharp8)
+                {
+                    // we only support C# 8.0 and above
+                    Diag(DiagnosticDescriptors.LoggingUnsupportedLanguageVersion, null, ((CSharpCompilation)_compilation).LanguageVersion.ToDisplayString(), LanguageVersion.CSharp8.ToDisplayString());
+                    return Array.Empty<LoggerClass>();
+                }
+
                 return results;
             }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -591,10 +591,10 @@ namespace Microsoft.Extensions.Logging.Generators
                     }
                 }
 
-                if (results.Count > 0 && (_compilation is CSharpCompilation { LanguageVersion : < LanguageVersion.CSharp8 }))
+                if (results.Count > 0 && _compilation is CSharpCompilation { LanguageVersion : LanguageVersion version and < LanguageVersion.CSharp8 })
                 {
                     // we only support C# 8.0 and above
-                    Diag(DiagnosticDescriptors.LoggingUnsupportedLanguageVersion, null, ((CSharpCompilation)_compilation).LanguageVersion.ToDisplayString(), LanguageVersion.CSharp8.ToDisplayString());
+                    Diag(DiagnosticDescriptors.LoggingUnsupportedLanguageVersion, null, version.ToDisplayString(), LanguageVersion.CSharp8.ToDisplayString());
                     return Array.Empty<LoggerClass>();
                 }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -591,7 +591,7 @@ namespace Microsoft.Extensions.Logging.Generators
                     }
                 }
 
-                if (results.Count > 0 && ((CSharpCompilation)_compilation).LanguageVersion < LanguageVersion.CSharp8)
+                if (results.Count > 0 && (_compilation is CSharpCompilation { LanguageVersion : < LanguageVersion.CSharp8 }))
                 {
                     // we only support C# 8.0 and above
                     Diag(DiagnosticDescriptors.LoggingUnsupportedLanguageVersion, null, ((CSharpCompilation)_compilation).LanguageVersion.ToDisplayString(), LanguageVersion.CSharp8.ToDisplayString());

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/Strings.resx
@@ -231,4 +231,10 @@
   <data name="MalformedFormatStringsTitle" xml:space="preserve">
     <value>Logging method contains malformed format strings</value>
   </data>
+  <data name="LoggingUnsupportedLanguageVersionTitle" xml:space="preserve">
+    <value>C# language version not supported by the source generator.</value>
+  </data>
+  <data name="LoggingUnsupportedLanguageVersionMessageFormat" xml:space="preserve">
+    <value>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/Strings.resx
@@ -235,6 +235,6 @@
     <value>C# language version not supported by the source generator.</value>
   </data>
   <data name="LoggingUnsupportedLanguageVersionMessageFormat" xml:space="preserve">
-    <value>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</value>
+    <value>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.cs.xlf
@@ -67,6 +67,16 @@
         <target state="translated">Metody protokolování musí být statické.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">Metoda protokolování {0} obsahuje řetězce s poškozeným formátem.</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.cs.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.de.xlf
@@ -67,6 +67,16 @@
         <target state="translated">Protokollierungsmethoden müssen statisch sein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">Die Protokollierungsmethode „{0}“ enthält nicht wohlgeformte Formatzeichenfolgen.</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.de.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.es.xlf
@@ -67,6 +67,16 @@
         <target state="translated">Los métodos de registro deben ser estáticos</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">El método de registro “{0}” contiene cadenas con formato incorrecto</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.es.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.fr.xlf
@@ -67,6 +67,16 @@
         <target state="translated">Les méthodes de journalisation doivent être statiques</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">La méthode de journalisation « {0} »contient des chaînes de format incorrectes</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.fr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.it.xlf
@@ -67,6 +67,16 @@
         <target state="translated">I metodi di registrazione devono essere statici</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">Il metodo di registrazione '{0}' contiene stringhe in formato non valido</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.it.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ja.xlf
@@ -67,6 +67,16 @@
         <target state="translated">ログ メソッドは静的である必要があります</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">ログ メソッド '{0}' に、形式の正しくない文字列が含まれています</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ja.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ko.xlf
@@ -67,6 +67,16 @@
         <target state="translated">로깅 메서드는 정적이어야 함</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">로깅 메서드 '{0}'에 잘못된 형식의 문자열이 포함되어 있습니다.</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ko.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pl.xlf
@@ -67,6 +67,16 @@
         <target state="translated">Metody rejestrowania muszą być statyczne</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">Metoda rejestrowania „{0}” zawiera źle sformułowane ciągi formatu</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pl.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -67,6 +67,16 @@
         <target state="translated">Os métodos de registro em log devem ser estáticos</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">O método de registro '{0}' contém strings de formato malformado</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ru.xlf
@@ -67,6 +67,16 @@
         <target state="translated">Методы ведения журнала должны быть статическими</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">Метод ведения журнала событий "{0}" содержит строки неправильного формата</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ru.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.tr.xlf
@@ -67,6 +67,16 @@
         <target state="translated">Günlüğe kaydetme yöntemleri statik olmalıdır</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">'{0}' günlüğe kaydetme yöntemi hatalı biçimlendirilmiş biçim dizeleri içeriyor</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.tr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -67,6 +67,16 @@
         <target state="translated">日志记录方法必须为静态方法</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">日志记录方法“{0}”包含格式错误的字符串</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -67,6 +67,16 @@
         <target state="translated">記錄方法必須是靜態</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LoggingUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MalformedFormatStringsMessage">
         <source>Logging method '{0}' contains malformed format strings</source>
         <target state="translated">記錄方法 '{0}' 包含格式錯誤的格式字串</target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/DiagDescriptors.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/DiagDescriptors.cs
@@ -105,5 +105,12 @@ namespace Microsoft.Extensions.Options.Generators
             messageFormat: SR.InaccessibleValidationAttributeMessage,
             category: Category,
             defaultSeverity: DiagnosticSeverity.Info);
+
+        public static DiagnosticDescriptor OptionsUnsupportedLanguageVersion { get; } = Make(
+            id: "SYSLIB1216",
+            title: SR.OptionsUnsupportedLanguageVersionTitle,
+            messageFormat: SR.OptionsUnsupportedLanguageVersionMessage,
+            category: Category,
+            defaultSeverity: DiagnosticSeverity.Error);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
@@ -143,6 +143,13 @@ namespace Microsoft.Extensions.Options.Generators
             results.AddRange(_synthesizedValidators.Values);
             _synthesizedValidators.Clear();
 
+            if (results.Count > 0 && ((CSharpCompilation)_compilation).LanguageVersion < LanguageVersion.CSharp8)
+            {
+                // we only support C# 8.0 and above
+                Diag(DiagDescriptors.OptionsUnsupportedLanguageVersion, null, ((CSharpCompilation)_compilation).LanguageVersion.ToDisplayString(), LanguageVersion.CSharp8.ToDisplayString());
+                return new List<ValidatorType>();
+            }
+
             return results;
         }
 

--- a/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
@@ -143,10 +143,10 @@ namespace Microsoft.Extensions.Options.Generators
             results.AddRange(_synthesizedValidators.Values);
             _synthesizedValidators.Clear();
 
-            if (results.Count > 0 && (_compilation is CSharpCompilation { LanguageVersion : < LanguageVersion.CSharp8 }))
+            if (results.Count > 0 && _compilation is CSharpCompilation { LanguageVersion : LanguageVersion version and < LanguageVersion.CSharp8 })
             {
                 // we only support C# 8.0 and above
-                Diag(DiagDescriptors.OptionsUnsupportedLanguageVersion, null, ((CSharpCompilation)_compilation).LanguageVersion.ToDisplayString(), LanguageVersion.CSharp8.ToDisplayString());
+                Diag(DiagDescriptors.OptionsUnsupportedLanguageVersion, null, version.ToDisplayString(), LanguageVersion.CSharp8.ToDisplayString());
                 return new List<ValidatorType>();
             }
 

--- a/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Extensions.Options.Generators
             results.AddRange(_synthesizedValidators.Values);
             _synthesizedValidators.Clear();
 
-            if (results.Count > 0 && ((CSharpCompilation)_compilation).LanguageVersion < LanguageVersion.CSharp8)
+            if (results.Count > 0 && (_compilation is CSharpCompilation { LanguageVersion : < LanguageVersion.CSharp8 }))
             {
                 // we only support C# 8.0 and above
                 Diag(DiagDescriptors.OptionsUnsupportedLanguageVersion, null, ((CSharpCompilation)_compilation).LanguageVersion.ToDisplayString(), LanguageVersion.CSharp8.ToDisplayString());

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/Strings.resx
@@ -207,4 +207,10 @@
   <data name="InaccessibleValidationAttributeTitle" xml:space="preserve">
     <value>Validation attribute on the member is inaccessible from the validator type..</value>
   </data>
+  <data name="OptionsUnsupportedLanguageVersionTitle" xml:space="preserve">
+    <value>C# language version not supported by the source generator.</value>
+  </data>
+  <data name="OptionsUnsupportedLanguageVersionMessage" xml:space="preserve">
+    <value>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/Strings.resx
@@ -211,6 +211,6 @@
     <value>C# language version not supported by the source generator.</value>
   </data>
   <data name="OptionsUnsupportedLanguageVersionMessage" xml:space="preserve">
-    <value>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</value>
+    <value>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.cs.xlf
@@ -122,6 +122,16 @@
         <target state="translated">Pro atributy ValidateObjectMembersAttribute nebo ValidateEnumeratedItemsAttribute byl specifikovaný typ validátoru s hodnotou null.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">Typ {0} obsahuje validační anotace, ale člen {1} neurčuje [ValidateEnumeratedItems], což může být přehlédnutí.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.cs.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">Typ {0} již implementuje metodu Validate.</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">Typ už obsahuje implementaci metody Validate.</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">[OptionsValidator] nelze použít pro statickou třídu {0}.</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">OptionsValidatorAttribute nelze použít pro statickou třídu.</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">U polí nebo vlastností s otevřeným obecným typem {0} nelze použít [ValidateObjectMembers] nebo [ValidateEnumeratedItems].</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">U polí nebo vlastností s otevřenými obecnými typy nelze použít ValidateObjectMembersAttribute nebo ValidateEnumeratedItemsAttribute.</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">Atributy ověřování nelze použít u konstantního ani statického člena {0}.</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">Nelze ověřit konstanty, statická pole ani vlastnosti.</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">Existuje cyklický odkaz obsahující typ {0}, který brání jeho použití pro statické ověření.</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">Nepodporované cyklické odkazy v typech modelů.</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">Typ {0} neimplementuje požadované rozhraní IValidateOptions&lt;{1}&gt; .</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">Typ anotovaný třídou OptionsValidatorAttribute neimplementuje nezbytné rozhraní.</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">Ověřovací atribut „{0}“ u člena „{1}“ není přístupný z typu validátoru „{2}“.</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">Ověřovací atribut u člena není přístupný z typu validátoru.</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">Ověřovací atributy nelze použít u privátního pole nebo vlastnosti {0}.</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">Nelze ověřit privátní pole nebo vlastnosti.</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">Typ {0} nemá žádná pole ani vlastnosti k ověření, na které odkazuje člen {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">Typ člena nemá žádná pole ani vlastnosti k ověření.</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">Typ {0} nemá žádná pole ani vlastnosti k ověření, na které odkazuje typ {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">Typ nemá žádná pole ani vlastnosti k ověření.</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">[ValidateEnumeratedItems] nelze použít u členů typu {0}, protože neimplementuje rozhraní IEnumerable&lt;T&gt;.</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">Typ členu není výčtový.</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">Typ validátoru s hodnotou null zadaný v atributech [ValidateObjectMembers] nebo [ValidateEnumeratedItems].</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">Pro atributy ValidateObjectMembersAttribute nebo ValidateEnumeratedItemsAttribute byl specifikovaný typ validátoru s hodnotou null.</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">Typ {0} obsahuje validační anotace, ale člen {1} neurčuje [ValidateEnumeratedItems], což může být přehlédnutí.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">U člena potenciálně chybí ověření výčtu.</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">Typ {0} obsahuje validační anotace, ale člen {1} neurčuje [ValidateObjectMembers], což může být přehlédnutí.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">U člena potenciálně chybí přenositelné ověření.</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">Typ validátoru {0} nemá konstruktor bez parametrů.</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">Validátory používané pro přenositelné nebo výčtové ověřování musí mít konstruktor bez parametrů.</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.de.xlf
@@ -122,6 +122,16 @@
         <target state="translated">Für die Attribute "ValidateObjectMembersAttribute" oder "ValidateEnumeratedItemsAttribute" wurde ein NULL-Validierungssteuerelementtyp angegeben.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">Der Typ "{0}" weist Validierungsanmerkungen auf, der Member "{1}" gibt jedoch keine [ValidateEnumeratedItems] an, die eine Vorhersage darstellen könnten.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.de.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">Der Typ "{0}" implementiert bereits die Validate-Methode.</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">Ein Typ enthält bereits eine Implementierung der Validate-Methode.</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">[OptionsValidator] kann nicht auf die statische Klasse "{0}" angewendet werden.</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">"OptionsValidatorAttribute" kann nicht auf eine statische Klasse angewendet werden.</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">"ValidateObjectMembers" oder "ValidateEnumeratedItems" kann nicht für Felder oder Eigenschaften mit offenem generischen Typ {0} verwendet werden.</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">"ValidateObjectMembersAttribute" oder "ValidateEnumeratedItemsAttribute" kann nicht für Felder oder Eigenschaften mit offenen generischen Typen verwendet werden.</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">Validierungsattribute können nicht auf konstanten oder statischen Member {0} angewendet werden.</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">Konstanten, statische Felder oder Eigenschaften können nicht überprüft werden.</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">Es gibt einen Zirkelverweis, der den Typ "{0}" verhindert, dass er für die statische Validierung verwendet wird.</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">Nicht unterstützte Zirkelverweise in Modelltypen.</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">Der Typ "{0}" implementiert nicht die erforderliche IValidateOptions&lt;{1}&gt;-Schnittstelle.</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">Ein mit "OptionsValidatorAttribute" versehener Typ implementiert nicht die erforderliche Schnittstelle.</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">Auf das Validierungsattribut "{0}" für den Member "{1}" kann vom Validierungssteuerelementtyp "{2}" nicht zugegriffen werden.</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">Auf das Validierungsattribut für den Member kann vom Validierungssteuerelementtyp nicht zugegriffen werden.</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">Validierungsattribute können nicht auf private Felder oder Eigenschaften {0} angewendet werden.</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">Private Felder oder Eigenschaften können nicht überprüft werden.</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">Der Typ "{0}" weist keine zu überprüfenden Felder oder Eigenschaften auf, auf die von Member "{1}" verwiesen wird.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">Ein Membertyp weist keine zu überprüfenden Felder oder Eigenschaften auf.</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">Der Typ "{0}" weist keine zu überprüfenden Felder oder Eigenschaften auf, auf die vom Typ "{1}" verwiesen wird.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">Ein Typ weist keine zu überprüfenden Felder oder Eigenschaften auf.</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">[ValidateEnumeratedItems] kann nicht für Member vom Typ "{0}" verwendet werden, da es IEnumerable&lt;T&gt; nicht implementiert.</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">Der Membertyp ist nicht aufzählbar.</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">Der in den Attributen [ValidateObjectMembers] oder [ValidateEnumeratedItems] angegebene NULL-Validierungssteuerelementtyp.</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">Für die Attribute "ValidateObjectMembersAttribute" oder "ValidateEnumeratedItemsAttribute" wurde ein NULL-Validierungssteuerelementtyp angegeben.</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">Der Typ "{0}" weist Validierungsanmerkungen auf, der Member "{1}" gibt jedoch keine [ValidateEnumeratedItems] an, die eine Vorhersage darstellen könnten.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">Dem Mitglied fehlt möglicherweise eine aufzählbare Validierung.</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">Der Typ "{0}" weist Validierungsanmerkungen auf, aber Member "{1}" gibt [ValidateObjectMembers] nicht an, was ein Versehen sein könnte.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">Dem Member fehlt möglicherweise die transitive Validierung.</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">Der Validierungssteuerelementtyp "{0}" hat keinen parameterlosen Konstruktor.</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">Validierungssteuerelemente, die für die transitive oder enumerierbare Validierung verwendet werden, müssen über einen Konstruktor ohne Parameter verfügen.</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.es.xlf
@@ -122,6 +122,16 @@
         <target state="translated">Se especificó un tipo de validador nulo para los atributos “ValidateObjectMembersAttribute” o “ValidateEnumeratedItemsAttribute”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">El tipo {0} tiene anotaciones de validación, pero el miembro {1} no especifica [ValidateEnumeratedItems], lo que podría ser un error.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.es.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">El tipo {0} ya implementa el método Validate.</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">Un tipo ya incluye una implementación del método “Validate”.</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">No se puede aplicar [OptionsValidator] a la clase estática {0}.</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">“OptionsValidatorAttribute” no se puede aplicar a una clase estática.</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">No se puede usar [ValidateObjectMembers] ni [ValidateEnumeratedItems] en campos o propiedades con tipos genéricos abiertos {0}.</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">No se puede usar “ValidateObjectMembersAttribute” o “ValidateEnumeratedItemsAttribute” en campos o propiedades con tipos genéricos abiertos.</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">No se pueden aplicar atributos de validación a un miembro {0}constante o estático.</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">No se pueden validar constantes, campos estáticos ni propiedades.</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">Hay una referencia de tipo circular que implica al tipo {0} que impide que se use para la validación estática.</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">Referencias circulares no admitidas en los tipos de modelo.</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">El tipo {0} no implementa la interfaz IValidateOptions&lt;{1}&gt; necesaria.</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">Un tipo anotado con “OptionsValidatorAttribute” no implementa la interfaz necesaria.</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">No se puede obtener acceso al atributo de validación '{0}' en el miembro '{1}' desde el tipo de validador '{2}'.</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">No se puede obtener acceso al atributo de validación en el miembro desde el tipo de validador.</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">No se pueden aplicar atributos de validación a la propiedad o campo privado {0}.</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">No se pueden validar los campos o propiedades privadas.</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">El tipo {0} no tiene campos ni propiedades para validar, al que hace referencia el tipo {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">Un tipo de miembro no tiene campos ni propiedades para validar.</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">El tipo {0} no tiene campos ni propiedades para validar, al que hace referencia el tipo {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">Un tipo no tiene campos ni propiedades para validar.</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">[ValidateEnumeratedItems] no se puede usar en miembros de tipo {0} porque no implementa IEnumerable&lt;T&gt;.</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">El tipo de miembro no es enumerable.</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">Se especificó un tipo de validador nulo en los atributos [ValidateObjectMembers] o [ValidateEnumeratedItems].</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">Se especificó un tipo de validador nulo para los atributos “ValidateObjectMembersAttribute” o “ValidateEnumeratedItemsAttribute”.</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">El tipo {0} tiene anotaciones de validación, pero el miembro {1} no especifica [ValidateEnumeratedItems], lo que podría ser un error.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">Posiblemente falta la validación enumerable en el miembro.</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">El tipo {0} tiene anotaciones de validación, pero el miembro {1} no especifica [ValidateObjectMembers], lo que podría ser un error.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">Posiblemente falta la validación transitiva en el miembro.</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">El tipo de validador {0} no tiene un constructor sin parámetros.</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">Los validadores usados para la validación transitiva o enumerable deben tener un constructor sin parámetros.</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.fr.xlf
@@ -122,6 +122,16 @@
         <target state="translated">Type de validateur Null spécifié pour les attributs 'ValidateObjectMembersAttribute' ou 'ValidateEnumeratedItemsAttribute'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">Le type {0} a des annotations de validation, mais le membre {1} ne spécifie pas [ValidateEnumeratedItems] qui peut être une supervision.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.fr.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">Le type {0} implémente déjà la méthode Validate.</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">Un type inclut déjà une implémentation de la méthode 'Validate'.</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">[OptionsValidator] ne peut pas être appliqué à la classe statique {0}.</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">'OptionsValidatorAttribute' ne peut pas être appliqué à une classe statique.</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">Impossible d’utiliser [ValidateObjectMembers] ou [ValidateEnumeratedItems] sur des champs ou des propriétés avec un type générique ouvert {0}.</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">Impossible d’utiliser 'ValidateObjectMembersAttribute' ou 'ValidateEnumeratedItemsAttribute' sur des champs ou des propriétés avec des types génériques ouverts.</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">Impossible d’appliquer les attributs de validation au membre constant ou statique {0}.</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">Impossible de valider les constantes, les champs statiques ou les propriétés.</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">Une référence de type circulaire implique un type {0} l’empêche d’être utilisé pour la validation statique.</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">Références circulaires non prises en charge dans les types de modèle.</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">Le type {0} n’implémente pas l’interface&lt;{1}&gt; IValidateOptions requise.</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">Un type annoté avec 'OptionsValidatorAttribute' n’implémente pas l’interface nécessaire.</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">L’attribut de validation '{0}' sur le membre '{1}' n’est pas accessible à partir du type de validateur '{2}'.</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">L’attribut de validation sur le membre n’est pas accessible à partir du type de validateur.</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">Impossible d’appliquer les attributs de validation au champ privé ou à la propriété {0}.</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">Impossible de valider les champs ou propriétés privés.</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">Le type {0} n’a aucun champ ou propriété à valider, référencé à partir du membre {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">Un type de membre n’a aucun champ ou propriété à valider.</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">Le type {0} n’a pas de champs ou de propriétés à valider, référencé par type {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">Un type n’a pas de champs ou de propriétés à valider.</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">[ValidateEnumeratedItems] ne peut pas être utilisé sur des membres de type {0}, car il n’implémente pas IEnumerable&lt;T&gt;.</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">Le type de membre n’est pas énumérable.</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">Type de validateur Null spécifié dans les attributs [ValidateObjectMembers] ou [ValidateEnumeratedItems].</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">Type de validateur Null spécifié pour les attributs 'ValidateObjectMembersAttribute' ou 'ValidateEnumeratedItemsAttribute'.</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">Le type {0} a des annotations de validation, mais le membre {1} ne spécifie pas [ValidateEnumeratedItems] qui peut être une supervision.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">Le membre n’a peut-être pas de validation énumérable.</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">Le type {0} a des annotations de validation, mais le membre {1} ne spécifie pas [ValidateObjectMembers] qui pourrait être une méthode de récupération.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">Le membre n’a peut-être pas de validation transitive.</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">Le type de validateur {0} n’a pas de constructeur sans paramètre.</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">Les validateurs utilisés pour la validation transitive ou énumérable doivent avoir un constructeur sans paramètres.</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.it.xlf
@@ -122,6 +122,16 @@
         <target state="translated">Tipo di validator Null specificato per gli attributi 'ValidateObjectMembersAttribute' o 'ValidateEnumeratedItemsAttribute'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">Il tipo {0} include annotazioni di convalida, ma il membro {1} non specifica [ValidateEnumeratedItems] che potrebbe essere una supervisione.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.it.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">Il tipo {0} implementa già il metodo Validate.</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">Un tipo include già un'implementazione del metodo 'Validate'.</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">impossibile applicare [OptionsValidator] alla classe statica {0}.</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">'OptionsValidatorAttribute' non può essere applicato a una classe statica.</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">Non è possibile usare [ValidateObjectMembers] o [ValidateEnumeratedItems] in campi o proprietà con tipo generico aperto {0}.</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">Non è possibile usare 'ValidateObjectMembersAttribute' o 'ValidateEnumeratedItemsAttribute' nei campi o nelle proprietà con tipi generici aperti.</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">Non è possibile applicare attributi di convalida a un membro costante o statico {0}.</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">Non è possibile convalidare costanti, campi statici o proprietà.</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">Esiste un riferimento di tipo circolare che interessa il tipo {0} e ne impedisce l'utilizzo per la convalida statica.</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">Riferimenti circolari non supportati nei tipi di modello.</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">Il tipo {0} non implementa l'interfaccia IValidateOptions&lt;{1}&gt; richiesta.</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">Un tipo annotato con 'OptionsValidatorAttribute' non implementa l'interfaccia necessaria.</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">L'attributo di convalida '{0}' nel membro '{1}' non è accessibile dal tipo di validator '{2}'.</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">L'attributo di convalida nel membro non è accessibile dal tipo di validator.</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">Non è possibile applicare gli attributi di convalida al campo privato o alla proprietà {0}.</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">Non è possibile convalidare proprietà o campi privati.</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">Il tipo {0} non contiene campi o proprietà da convalidare, riferiti dal membro {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">Un tipo di membro non contiene campi o proprietà da convalidare.</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">Il tipo {0} non contiene campi o proprietà da convalidare, riferiti per tipo {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">Un tipo non contiene campi o proprietà da convalidare.</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">[ValidateEnumeratedItems] non può essere usato nei membri di tipo {0} perché non implementa IEnumerable&lt;T&gt;.</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">Il tipo di membro non è enumerabile.</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">Tipo di validator Null specificato negli attributi [ValidateObjectMembers] o [ValidateEnumeratedItems].</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">Tipo di validator Null specificato per gli attributi 'ValidateObjectMembersAttribute' o 'ValidateEnumeratedItemsAttribute'.</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">Il tipo {0} include annotazioni di convalida, ma il membro {1} non specifica [ValidateEnumeratedItems] che potrebbe essere una supervisione.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">Convalida enumerabile potenzialmente mancante nel membro.</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">Il tipo {0} include annotazioni di convalida, ma il membro {1} non specifica [ValidateObjectMembers] che potrebbe essere una supervisione.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">Il membro potrebbe non avere una convalida transitiva.</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">Il tipo di convalida {0} non dispone di un costruttore senza parametri.</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">I convalidatori usati per la convalida transitiva o enumerabile devono avere un costruttore senza parametri.</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ja.xlf
@@ -122,6 +122,16 @@
         <target state="translated">'ValidateObjectMembersAttribute' 属性または 'ValidateEnumeratedItemsAttribute' 属性に対して NULL のバリデーター型が指定されています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">型 {0} には検証の注釈がありますが、メンバー {1} では [ValidateEnumeratedItem] が指定されていません。これは誤りである可能性があります。</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ja.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">型 {0} に Validate メソッドが既に実装されています。</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">型には 'Validate' メソッドの実装が既に含まれています。</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">静的クラス {0} には [OptionsValidator] を適用できません。</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">'OptionsValidatorAttribute' は静的クラスに適用できません。</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">[ValidateObjectMembers] または [ValidateEnumeratedItems] は、オープンジェネリック型 {0} を持つフィールドまたはプロパティでは使用できません。</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">'ValidateObjectMembersAttribute' または 'ValidateEnumeratedItemsAttribute' は、オープンジェネリック型を持つフィールドまたはプロパティでは使用できません。</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">定数または静的メンバー {0} に検証属性を適用できません。</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">定数、静的フィールド、またはプロパティを検証できません。</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">型{0}を含む循環型参照があるため、静的検証に使用できません。</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">モデル型でサポートされていない循環参照です。</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">必要な IValidateOptions&lt;{1}&gt; インターフェイスが型 {0} に実装されていません。</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">'OptionsValidatorAttribute' の注釈が付けられた型が、必要とされるインターフェイスを実装していません。</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">メンバー '{0}' の検証属性 '{1}' は、検証コントロールの種類 '{2}'からアクセスできません。</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">メンバーの検証属性は、検証コントロールの種類からアクセスできません...</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">プライベート フィールドまたはプロパティ {0} には検証属性を適用できません。</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">プライベート フィールドまたはプロパティを検証できません。</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">型 {0} にメンバー {1} から参照されている検証対象のフィールドまたはプロパティがありません。</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">メンバー型に検証対象のフィールドまたはプロパティがありません。</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">型 {0} に型 {1} で参照されている検証対象のフィールドまたはプロパティがありません。</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">型に検証対象のフィールドまたはプロパティがありません。</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">[ValidateEnumeratedItems] は IEnumerable&lt;T&gt; を実装していないため、型 {0} のメンバーでは使用できません。</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">メンバー型は列挙型ではありません。</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">[ValidateObjectMembers] 属性または [ValidateEnumeratedItems] 属性で null のバリデーター型が指定されています。</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">'ValidateObjectMembersAttribute' 属性または 'ValidateEnumeratedItemsAttribute' 属性に対して NULL のバリデーター型が指定されています。</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">型 {0} には検証の注釈がありますが、メンバー {1} では [ValidateEnumeratedItem] が指定されていません。これは誤りである可能性があります。</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">列挙型の検証がメンバーに存在しない可能性があります。</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">型 {0} には検証の注釈がありますが、メンバー {1} では [ValidateObjectMembers] が指定されていません。これは誤りである可能性があります。</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">メンバーに推移性の検証がない可能性があります。</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">バリデーター型 {0} にパラメーターなしのコンストラクターがありません。</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">推移性または列挙型の検証に使用されるバリデーターには、パラメーターのないコンストラクターが必要です。</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ko.xlf
@@ -122,6 +122,16 @@
         <target state="translated">'ValidateObjectMembersAttribute' 또는 'ValidateEnumeratedItemsAttribute' 특성에 Null 유효성 검사기 형식이 지정되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">형식 {0}은(는) 유효성 검사 주석이 있지만 멤버 {1}은(는) 참조할 수 있는 [ValidateEnumeratedItems]을(를) 지정하지 않습니다.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ko.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">형식 {0}은(는) Validate 메서드를 이미 구현하고 있습니다.</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">형식에 'Validate' 메서드 구현이 이미 포함되어 있습니다.</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">[OptionsValidator]은(는) 정적 클래스 {0}에 적용할 수 없습니다.</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">'OptionsValidatorAttribute'는 정적 클래스에 적용할 수 없습니다.</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">열린 제네릭 형식 {0}의 필드 또는 속성에는 [ValidateObjectMembers] 또는 [ValidateEnumeratedItems]을(를) 사용할 수 없습니다.</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">열린 제네릭 형식의 필드 또는 속성에는 'ValidateObjectMembersAttribute' 또는 'ValidateEnumeratedItemsAttribute'를 사용할 수 없습니다.</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">상수 또는 정적 멤버 {0}에 유효성 검사 특성을 적용할 수 없습니다.</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">상수, 정적 필드 또는 속성을 확인할 수 없습니다.</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">정적 유효성 검사에 사용할 수 없으므로 형식 {0} 관련된 순환 형식 참조가 있습니다.</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">모델 형식에 지원되지 않는 순환 참조가 있습니다.</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">형식 {0}은(는) 필요한 IValidateOptions&lt;{1}&gt; 인터페이스를 구현하지 않습니다.</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">'OptionsValidatorAttribute'로 주석이 추가된 형식은 필요한 인터페이스를 구현하지 않습니다.</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">유효성 검사기 유형 '{2}'에서 '{1}' 멤버의 '{0}' 유효성 검사 특성에 액세스할 수 없습니다.</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">유효성 검사기 유형에서 멤버의 유효성 검사 특성에 액세스할 수 없습니다.</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">프라이빗 필드 또는 속성 {0}에 유효성 검사 특성을 적용할 수 없습니다.</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">프라이빗 필드 또는 속성의 유효성을 검사할 수 없습니다.</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">형식 {0}은(는) 유효성을 검사할 필드 또는 속성이 없으므로 멤버 {1}을(를) 참조합니다.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">멤버 형식에 유효성을 검사할 필드 또는 속성이 없습니다.</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">형식 {0}은(는) 유효성을 검사할 필드 또는 속성이 없으므로 형식 {1}을(를) 참조합니다.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">형식에 유효성을 검사할 필드 또는 속성이 없습니다.</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">[ValidateEnumeratedItems]은(는) IEnumerable&lt;T&gt;을(를) 구현하지 않으므로 형식 {0}의 멤버에 사용할 수 없습니다.</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">멤버 형식을 열거할 수 없습니다.</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">[ValidateObjectMembers] 또는 [ValidateEnumeratedItems] 특성에 Null 유효성 검사기 형식이 지정되었습니다.</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">'ValidateObjectMembersAttribute' 또는 'ValidateEnumeratedItemsAttribute' 특성에 Null 유효성 검사기 형식이 지정되었습니다.</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">형식 {0}은(는) 유효성 검사 주석이 있지만 멤버 {1}은(는) 참조할 수 있는 [ValidateEnumeratedItems]을(를) 지정하지 않습니다.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">멤버에 열거 가능한 유효성 검사가 누락되었을 수 있습니다.</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">형식 {0}은(는) 유효성 검사 주석이 있지만 멤버 {1}은(는) 참조할 수 있는 [ValidateObjectMembers]을(를) 지정하지 않습니다.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">멤버에 전이적 유효성 검사가 누락되었을 수 있습니다.</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">유효성 검사기 형식 {0}은(는) 매개 변수가 없는 생성자가 없습니다.</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">전이적 또는 열거형 유효성 검사에 사용되는 유효성 검사기에는 매개 변수가 없는 생성자가 있어야 합니다.</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pl.xlf
@@ -122,6 +122,16 @@
         <target state="translated">Określono typ modułu sprawdzania poprawności o wartości null dla atrybutu „ValidateObjectMembersAttribute” lub „ValidateEnumeratedItemsAttribute”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">Typ {0} ma adnotacje walidacji, ale element członkowski {1} nie określa atrybutu [ValidateEnumeratedItems], co może być przeoczeniem.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pl.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">Typ {0} już implementuje metodę Validate.</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">Typ zawiera już implementację metody „Validate”.</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">Nie można zastosować elementu [OptionsValidator] do klasy statycznej {0}.</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">Nie można zastosować elementu „OptionsValidatorAttribute” do klasy statycznej.</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">Nie można użyć atrybutu [ValidateObjectMembers] lub [ValidateEnumeratedItems] w polach lub właściwościach z otwartymi typami ogólnymi {0}.</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">Nie można użyć atrybutu „ValidateObjectMembersAttribute” lub „ValidateEnumeratedItemsAttribute” w polach lub właściwościach z otwartymi typami ogólnymi.</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">Nie można zastosować atrybutów walidacji do stałych lub statycznych elementów członkowskich {0}.</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">Nie można zweryfikować stałych, pól statycznych lub właściwości.</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">Istnieje cykliczne odwołanie do typu dotyczące typu {0} uniemożliwiające użycie go do weryfikacji statycznej.</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">Nieobsługiwane odwołania cykliczne w typach modeli.</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">Typ {0} nie implementuje wymaganego interfejsu IValidateOptions&lt;{1}&gt;.</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">Typ z adnotacją „OptionsValidatorAttribute” nie implementuje wymaganego interfejsu.</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">Atrybut walidacji „{0}” elementu członkowskiego „{1}” jest niedostępny z typu modułu sprawdzania poprawności „{2}”.</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">Atrybut walidacji elementu członkowskiego jest niedostępny z typu modułu sprawdzania poprawności.</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">Nie można zastosować atrybutów weryfikacji do pola prywatnego lub właściwości {0}.</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">Nie można zweryfikować prywatnych pól lub właściwości.</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">Typ {0} nie ma pól ani właściwości do zweryfikowania, do których odwołuje się element członkowski {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">Typ elementu członkowskiego nie ma pól ani właściwości do zweryfikowania.</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">Typ {0} nie ma pól ani właściwości do zweryfikowania, do których odwołuje się typ {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">Typ nie ma pól ani właściwości do zweryfikowania.</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">Atrybutu [ValidateEnumeratedItems] nie można używać w przypadku elementów członkowskich typu {0}, ponieważ nie implementuje interfejsu IEnumerable&lt;T&gt;.</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">Nie można wyliczyć typu elementu członkowskiego.</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">W atrybutach [ValidateObjectMembers] lub [ValidateEnumeratedItems] określono typ modułu sprawdzania poprawności o wartości null.</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">Określono typ modułu sprawdzania poprawności o wartości null dla atrybutu „ValidateObjectMembersAttribute” lub „ValidateEnumeratedItemsAttribute”.</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">Typ {0} ma adnotacje walidacji, ale element członkowski {1} nie określa atrybutu [ValidateEnumeratedItems], co może być przeoczeniem.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">W elemencie członkowskim może brakować walidacji możliwej do wyliczenia.</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">Typ {0} ma adnotacje walidacji, ale element członkowski {1} nie określa atrybutu [ValidateObjectMembers], co może być przeoczeniem.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">W przypadku elementu członkowskiego może potencjalnie brakować weryfikacji przechodniej.</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">Typ modułu sprawdzania poprawności {0} nie ma konstruktora bez parametrów.</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">Moduły sprawdzania poprawności używane do weryfikacji przechodniej lub weryfikacji możliwej do wyliczenia muszą mieć konstruktora bez żadnych parametrów.</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -122,6 +122,16 @@
         <target state="translated">Tipo de validador nulo especificado para os atributos "ValidateObjectMembersAttribute" ou "ValidateEnumeratedItemsAttribute".</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">O tipo {0} tem anotações de validação, mas o membro {1} não especifica [ValidateEnumeratedItems], o que pode ser uma desatenção.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">O tipo {0} já implementa o método Validar.</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">Um tipo já inclui uma implementação do método "Validar".</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">[OptionsValidator] não pode ser aplicado à classe estática {0}.</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">"OptionsValidatorAttribute" não pode ser aplicado a uma classe estática.</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">Não é possível usar [ValidateObjectMembers] ou [ValidateEnumeratedItems] em campos ou propriedades com o tipo genérico aberto {0}.</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">Não é possível usar "ValidateObjectMembersAttribute" ou "ValidateEnumeratedItemsAttribute" em campos ou propriedades com tipos genéricos abertos.</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">Não é possível aplicar atributos de validação a um membro constante ou estático {0}.</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">Não é possível validar constantes, campos estáticos ou propriedades.</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">Há uma referência de tipo circular que envolve o tipo {0} que a impede de ser usada para validação estática.</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">Referências circulares sem suporte em tipos de modelo.</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">O tipo {0} não implementa a interface IValidateOptions&lt;{1}&gt; necessária.</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">Um tipo anotado com "OptionsValidatorAttribute" não implementa a interface necessária.</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">O atributo de validação '{0}' no membro '{1}' está inacessível do tipo de validador '{2}'.</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">O atributo de validação no membro está inacessível do tipo de validador.</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">Não é possível aplicar atributos de validação a um campo privado ou propriedade {0}.</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">Não é possível validar propriedades ou campos privados.</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">O tipo {0} não tem campos ou propriedades para validar, referenciados do membro {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">Um tipo de membro não tem campos ou propriedades a serem validados.</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">O tipo {0} não tem campos ou propriedades para validar, referenciados por tipo {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">Um tipo não tem campos ou propriedades a serem validados.</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">[ValidateEnumeratedItems] não pode ser usado em membros do tipo {0}, pois ele não implementa IEnumerable&lt;T&gt;.</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">O tipo de membro não é enumerável.</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">Tipo de validador nulo especificado nos atributos [ValidateObjectMembers] ou [ValidateEnumeratedItems].</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">Tipo de validador nulo especificado para os atributos "ValidateObjectMembersAttribute" ou "ValidateEnumeratedItemsAttribute".</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">O tipo {0} tem anotações de validação, mas o membro {1} não especifica [ValidateEnumeratedItems], o que pode ser uma desatenção.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">Membro potencialmente ausente na validação enumerável.</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">O tipo {0} tem anotações de validação, mas o membro {1} não especifica [ValidateObjectMembers], o que pode ser uma desatenção.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">Membro potencialmente ausente na validação transitiva.</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">O tipo de validador {0} não tem um construtor sem parâmetros.</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">Os validadores usados para validação transitiva ou enumerável devem ter um construtor sem parâmetros.</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ru.xlf
@@ -122,6 +122,16 @@
         <target state="translated">Для атрибутов ValidateObjectMembersAttribute или ValidateEnumeratedItemsAttribute указан тип проверяющего элемента управления NULL.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">Тип {0} содержит примечания проверки, но элемент {1} не указывает [ValidateEnumeratedItems], который может быть задан.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ru.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">Тип {0} уже реализует метод Validate.</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">Тип уже содержит реализацию метода Validate.</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">[OptionsValidator] невозможно применить к статическому классу {0}.</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">Параметр OptionsValidatorAttribute не может быть применен к статическому классу.</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">Нельзя использовать [ValidateObjectMembers] или [ValidateEnumeratedItems] для полей или свойств с открытыми универсальными типами {0}.</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">Нельзя использовать "ValidateObjectMembersAttribute" или "ValidateEnumeratedItemsAttribute" для полей или свойств с открытыми универсальными типами.</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">Не удалось применить атрибуты проверки к константе или статическому элементу {0}.</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">Не удалось проверить константы, статические поля или свойства.</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">Существует циклическая ссылка на тип, включающая тип {0}, предотвращающий его использование для статической проверки.</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">Неподдерживаемые циклические ссылки в типах моделей.</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">Тип {0} не реализует требуемый интерфейс IValidateOptions&lt;{1}&gt;.</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">Тип с аннотацией OptionsValidatorAttribute не реализует необходимый интерфейс.</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">Атрибут проверки "{0}" элемента "{1}" недоступен из типа средства проверки "{2}".</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">Атрибут проверки элемента недоступен из типа средства проверки.</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">Не удается применить атрибуты проверки к закрытому полю или свойству {0}.</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">Не удается проверить частные поля или свойства.</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">Тип {0} не содержит полей или свойств для проверки, на которые ссылается из элемента {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">Тип элемента не имеет полей или свойств для проверки.</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">Тип {0} не содержит полей или свойств для проверки, на которые ссылается тип {1}.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">Тип не имеет полей или свойств для проверки.</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">[ValidateEnumeratedItems] не может использоваться для элементов типа {0}, так как он не реализует IEnumerable&lt;T&gt;.</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">Тип элемента не является перечисляемым.</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">Тип проверяющего элемента управления, указанный в [ValidateObjectMembers] или [ValidateEnumeratedItems] атрибутах, имеет значение NULL.</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">Для атрибутов ValidateObjectMembersAttribute или ValidateEnumeratedItemsAttribute указан тип проверяющего элемента управления NULL.</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">Тип {0} содержит примечания проверки, но элемент {1} не указывает [ValidateEnumeratedItems], который может быть задан.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">Элемент потенциально пропускает перечисляемую проверку.</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">Тип {0} содержит примечания проверки, но элемент {1} не указывает [ValidateObjectMembers], который может быть задан.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">Возможно, в элементе отсутствует транзитивная проверка.</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">Тип проверяющего элемента управления {0} не имеет конструктора без параметров.</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">У проверяющих элементов управления, используемых для транзитивной или перечисляемой проверки, должен быть конструктор без параметров.</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.tr.xlf
@@ -122,6 +122,16 @@
         <target state="translated">'ValidateObjectMembersAttribute' veya 'ValidateEnumeratedItemsAttribute' öznitelikleri için null doğrulayıcı türü belirtildi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">{0} türünde doğrulama ek açıklamaları var, ancak {1} üyesi gözden kaçmış olabilecek [ValidateEnumeratedItems] belirtmiyor.</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.tr.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">{0} türü Doğrulama yöntemini zaten uyguluyor.</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">Bir tür zaten 'Validate' yönteminin bir uygulamasını içeriyor.</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">[OptionsValidator], {0} statik sınıfına uygulanamıyor.</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">'OptionsValidatorAttribute' statik sınıfa uygulanamaz.</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">{0} açık genel türündeki alanlarda veya özelliklerde [ValidateObjectMembers] veya [ValidateEnumeratedItems] kullanılamaz.</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">Açık genel türleri olan alanlarda veya özelliklerde 'ValidateObjectMembersAttribute' veya 'ValidateEnumeratedItemsAttribute' kullanılamaz.</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">Doğrulama öznitelikleri sabit veya statik üye {0} için geçerli değildir.</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">Sabitler, statik alanlar veya özellikler doğrulanamıyor.</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">Statik doğrulama için kullanılmasını engelleyen {0} türü içeren döngüsel bir tür başvurusu var.</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">Model türlerde döngüsel başvurular desteklenmiyor.</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">{0} türü gerekli IValidateOptions&lt;{1}&gt; arabirimini uygulamıyor.</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">'OptionsValidatorAttribute' ile açıklama eklenmiş bir tür gerekli arabirimi uygulamıyor.</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">'{1}' adlı üye üzerindeki '{0}' doğrulama özniteliğine '{2}' doğrulayıcı türünden erişilemiyor.</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">Üye üzerindeki doğrulama özniteliğine doğrulayıcı türünden erişilemiyor.</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">Doğrulama öznitelikleri, {0} özel alanına veya özelliğine uygulanamıyor.</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">Özel alanlar veya özellikler doğrulanamıyor.</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">{0} türünde doğrulanacak alan veya özellik yok, {1} üyesinden başvurulur.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">Üye türünde doğrulanacak alan veya özellik yok.</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">{0} türünde doğrulanacak alan veya özellik yok, {1} türü tarafından başvurulur.</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">Türde doğrulanacak alan veya özellik yok.</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">[ValidateEnumeratedItems], IEnumerable&lt;T&gt; uygulamadığından {0} türündeki üyeler üzerinde kullanılamıyor.</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">Üye türü numaralandırılabilir değil.</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">[ValidateObjectMembers] veya [ValidateEnumeratedItems] özniteliklerinde null doğrulayıcı türü belirtildi.</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">'ValidateObjectMembersAttribute' veya 'ValidateEnumeratedItemsAttribute' öznitelikleri için null doğrulayıcı türü belirtildi.</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">{0} türünde doğrulama ek açıklamaları var, ancak {1} üyesi gözden kaçmış olabilecek [ValidateEnumeratedItems] belirtmiyor.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">Üyede numaralandırılabilir doğrulama eksik olabilir.</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">{0} türünde doğrulama ek açıklamaları var, ancak {1} üyesi gözden kaçmış olabilecek [ValidateObjectMembers] belirtmiyor.</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">Üyede geçişli doğrulama eksik olabilir.</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">{0} doğrulayıcı türü parametresiz bir oluşturucuya sahip değil.</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">Geçişli veya numaralandırılabilir doğrulama için kullanılan doğrulayıcıların parametresi olmayan bir oluşturucusu olmalıdır.</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -122,6 +122,16 @@
         <target state="translated">为“ValidateObjectMembersAttribute”或“ValidateEnumeratedItemsAttribute”属性指定的验证程序类型为 Null。</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">类型 {0} 具有验证注释，但成员 {1} 未指定 [ValidateEnumeratedItems]，这可能是一种监督。</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">类型 {0} 已实现 Validate 方法。</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">类型已包含“Validate”方法的实现。</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">[OptionsValidator] 无法应用于静态类 {0}。</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">“OptionsValidatorAttribute”不能应用于静态类。</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">不能对具有开放泛型类型 {0} 的字段或属性使用 [ValidateObjectMembers] 或 [ValidateEnumeratedItems]。</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">不能对具有开放泛型类型的字段或属性使用 "ValidateObjectMembersAttribute" 或 "ValidateEnumeratedItemsAttribute"。</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">无法将验证属性应用于常量或静态成员 {0}。</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">无法验证常量、静态字段或属性。</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">存在一个循环类型引用，其中涉及的类型 {0} 阻止将其用于静态验证。</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">模型类型中不支持的循环引用。</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">类型 {0} 未实现所需的 IValidateOptions&lt;{1}&gt; 接口。</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">用 "OptionsValidatorAttribute" 批注的类型未实现必要的接口。</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">无法从验证程序类型“{2}”访问成员“{1}”上的验证属性“{0}”。</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">无法从验证程序类型访问成员上的验证属性。</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">无法将验证属性应用于专用字段或属性 {0}。</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">无法验证专用字段或属性。</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">类型 {0} 没有要验证的字段或属性，从成员 {1} 中引用。</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">成员类型没有要验证的字段或属性。</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">类型 {0} 没有要验证的字段或属性，由类型 {1} 引用。</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">类型没有要验证的字段或属性。</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">无法对类型 {0} 的成员使用 [ValidateEnumeratedItems]，因为它未实现 IEnumerable&lt;T&gt;。</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">成员类型不可枚举。</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">[ValidateObjectMembers] 或 [ValidateEnumeratedItems] 属性中指定的 Null 验证程序类型。</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">为“ValidateObjectMembersAttribute”或“ValidateEnumeratedItemsAttribute”属性指定的验证程序类型为 Null。</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">类型 {0} 具有验证注释，但成员 {1} 未指定 [ValidateEnumeratedItems]，这可能是一种监督。</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">成员可能缺少可枚举验证。</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">类型 {0} 具有验证注释，但成员 {1} 未指定 [ValidateObjectMembers]，这可能是一种监督。</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">成员可能缺少可传递验证。</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">验证程序类型 {0} 没有无参数构造函数。</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">用于可传递验证或可枚举验证的验证程序必须具有没有参数的构造函数。</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -122,6 +122,16 @@
         <target state="translated">為 'ValidateObjectMembersAttribute' 或 'ValidateEnumeratedItemsAttribute' 屬性指定的 Null 驗證程式類型。</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
+        <source>C# language version not supported by the source generator.</source>
+        <target state="new">C# language version not supported by the source generator.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
         <target state="translated">成員 {0} 具備驗證註釋，但成員 {1} 未指定 [ValidateObjectMembers] (可能為監督)。</target>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -4,127 +4,127 @@
     <body>
       <trans-unit id="AlreadyImplementsValidateMethodMessage">
         <source>Type {0} already implements the Validate method.</source>
-        <target state="translated">類型 {0} 已實作 [驗證] 方法。</target>
+        <target state="new">Type {0} already implements the Validate method.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyImplementsValidateMethodTitle">
         <source>A type already includes an implementation of the 'Validate' method.</source>
-        <target state="translated">類型已經包含 [驗證] 方法的實作。</target>
+        <target state="new">A type already includes an implementation of the 'Validate' method.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassMessage">
         <source>[OptionsValidator] cannot be applied to static class {0}.</source>
-        <target state="translated">[OptionsValidator] 無法套用至靜態類別 {0}。</target>
+        <target state="new">[OptionsValidator] cannot be applied to static class {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantBeStaticClassTitle">
         <source>'OptionsValidatorAttribute' can't be applied to a static class.</source>
-        <target state="translated">無法將 'OptionsValidatorAttribute' 套用至靜態類別。</target>
+        <target state="new">'OptionsValidatorAttribute' can't be applied to a static class.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesMessage">
         <source>Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</source>
-        <target state="translated">無法在有開放式泛型型別 {0} 的欄位或屬性上使用 [ValidateObjectMembers] 或 [ValidateEnumeratedItems]。</target>
+        <target state="new">Can't use [ValidateObjectMembers] or [ValidateEnumeratedItems] on fields or properties with open generic type {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantUseWithGenericTypesTitle">
         <source>Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</source>
-        <target state="translated">無法在有開放式泛型型別的欄位或屬性上使用 'ValidateObjectMembersAttribute' 或 'ValidateEnumeratedItemsAttribute'。</target>
+        <target state="new">Can't use 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' on fields or properties with open generic types.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberMessage">
         <source>Can't apply validation attributes to constant or static member {0}.</source>
-        <target state="translated">無法將驗證屬性套用至常數或靜態成員 {0}。</target>
+        <target state="new">Can't apply validation attributes to constant or static member {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CantValidateStaticOrConstMemberTitle">
         <source>Can't validate constants, static fields or properties.</source>
-        <target state="translated">無法驗證常數、靜態欄位或屬性。</target>
+        <target state="new">Can't validate constants, static fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesMessage">
         <source>There is a circular type reference involving type {0} preventing it from being used for static validation.</source>
-        <target state="translated">有涉及類型 {0} 的循環類型參考讓它無法用於靜態驗證。</target>
+        <target state="new">There is a circular type reference involving type {0} preventing it from being used for static validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="CircularTypeReferencesTitle">
         <source>Unsupported circular references in model types.</source>
-        <target state="translated">模型類型中不支援的循環參考。</target>
+        <target state="new">Unsupported circular references in model types.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsMessage">
         <source>Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</source>
-        <target state="translated">類型 {0} 未實作必要的 IValidateOptions&lt;{1}&gt; 介面。</target>
+        <target state="new">Type {0} does not implement the required IValidateOptions&lt;{1}&gt; interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesntImplementIValidateOptionsTitle">
         <source>A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</source>
-        <target state="translated">以 'OptionsValidatorAttribute' 附註的類型未實作必要的介面。</target>
+        <target state="new">A type annotated with 'OptionsValidatorAttribute' doesn't implement the necessary interface.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeMessage">
         <source>Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</source>
-        <target state="translated">無法從驗證程式類型 '{2}' 存取成員 '{1}' 上的驗證屬性 '{0}'。</target>
+        <target state="new">Validation attribute '{0}' on the member '{1}' is inaccessible from the validator type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InaccessibleValidationAttributeTitle">
         <source>Validation attribute on the member is inaccessible from the validator type..</source>
-        <target state="translated">無法從驗證程式類型存取成員上的驗證屬性。</target>
+        <target state="new">Validation attribute on the member is inaccessible from the validator type..</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleMessage">
         <source>Can't apply validation attributes to private field or property {0}.</source>
-        <target state="translated">無法將驗證屬性套用至私用欄位或屬性 {0}。</target>
+        <target state="new">Can't apply validation attributes to private field or property {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberIsInaccessibleTitle">
         <source>Can't validate private fields or properties.</source>
-        <target state="translated">無法驗證私人欄位或屬性。</target>
+        <target state="new">Can't validate private fields or properties.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberMessage">
         <source>Type {0} has no fields or properties to validate, referenced from member {1}.</source>
-        <target state="translated">參照會員 {1}，類型 {0} 沒有欄位或屬性可供驗證。</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced from member {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMemberTitle">
         <source>A member type has no fields or properties to validate.</source>
-        <target state="translated">成員類型沒有欄位或屬性可供驗證。</target>
+        <target state="new">A member type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorMessage">
         <source>Type {0} has no fields or properties to validate, referenced by type {1}.</source>
-        <target state="translated">參照類型 {1}，類型 {0} 沒有欄位或屬性可供驗證。</target>
+        <target state="new">Type {0} has no fields or properties to validate, referenced by type {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoEligibleMembersFromValidatorTitle">
         <source>A type has no fields or properties to validate.</source>
-        <target state="translated">類型沒有欄位或屬性可供驗證。</target>
+        <target state="new">A type has no fields or properties to validate.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeMessage">
         <source>[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</source>
-        <target state="translated">[ValidateEnumeratedItems] 無法用於類型 {0} 的成員，因為其未實作 IEnumerable&lt;T&gt;。</target>
+        <target state="new">[ValidateEnumeratedItems] cannot be used on members of type {0} as it doesn't implement IEnumerable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotEnumerableTypeTitle">
         <source>Member type is not enumerable.</source>
-        <target state="translated">成員類型無法列舉。</target>
+        <target state="new">Member type is not enumerable.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeMessage">
         <source>Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</source>
-        <target state="translated">[ValidateObjectMembers] 或 [ValidateEnumeratedItems] 屬性中指定的 Null 驗證程式類型。</target>
+        <target state="new">Null validator type specified in [ValidateObjectMembers] or [ValidateEnumeratedItems] attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="NullValidatorTypeTitle">
         <source>Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</source>
-        <target state="translated">為 'ValidateObjectMembersAttribute' 或 'ValidateEnumeratedItemsAttribute' 屬性指定的 Null 驗證程式類型。</target>
+        <target state="new">Null validator type specified for the 'ValidateObjectMembersAttribute' or 'ValidateEnumeratedItemsAttribute' attributes.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</target>
+        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">
@@ -134,32 +134,32 @@
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</source>
-        <target state="translated">成員 {0} 具備驗證註釋，但成員 {1} 未指定 [ValidateObjectMembers] (可能為監督)。</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateEnumeratedItems] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingEnumerableValidationTitle">
         <source>Member potentially missing enumerable validation.</source>
-        <target state="translated">成員可能遺漏可列舉的驗證。</target>
+        <target state="new">Member potentially missing enumerable validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationMessage">
         <source>Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</source>
-        <target state="translated">類型 {0} 具備驗證註釋，但成員 {1} 未指定 [ValidateObjectMembers] (可能為監督)。</target>
+        <target state="new">Type {0} has validation annotations, but member {1} doesn't specify [ValidateObjectMembers] which could be an oversight.</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentiallyMissingTransitiveValidationTitle">
         <source>Member potentially missing transitive validation.</source>
-        <target state="translated">成員可能遺漏轉移的驗證。</target>
+        <target state="new">Member potentially missing transitive validation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorMessage">
         <source>Validator type {0} doesn't have a parameterless constructor.</source>
-        <target state="translated">驗證程式類型 {0} 沒有無參數建構函式。</target>
+        <target state="new">Validator type {0} doesn't have a parameterless constructor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidatorsNeedSimpleConstructorTitle">
         <source>Validators used for transitive or enumerable validation must have a constructor with no parameters.</source>
-        <target state="translated">用於轉移或可列舉驗證的驗證程式必須具備沒有參數的建構函式。</target>
+        <target state="new">Validators used for transitive or enumerable validation must have a constructor with no parameters.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
@@ -1582,6 +1582,63 @@ namespace __OptionValidationStaticInstances
         Assert.Equal(DiagDescriptors.NotEnumerableType.Id, diagnostics[0].Id);
     }
 
+    [Fact]
+    public async Task LanguageVersionTest()
+    {
+        string source = """
+            using System;
+            using System.ComponentModel.DataAnnotations;
+            using Microsoft.Extensions.Options;
+
+            public class FirstModel
+            {
+                [Required]
+                public string? P1 { get; set; }
+            }
+
+            [OptionsValidator]
+            public partial class FirstModelValidator : IValidateOptions<FirstModel>
+            {
+            }
+        """;
+
+        Assembly [] refAssemblies = new []
+        {
+            Assembly.GetAssembly(typeof(RequiredAttribute)),
+            Assembly.GetAssembly(typeof(OptionsValidatorAttribute)),
+            Assembly.GetAssembly(typeof(IValidateOptions<object>)),
+        };
+
+        // Run the generator with C# 7.0 and verify that it fails.
+        var (diagnostics, generatedSources) = await RoslynTestUtils.RunGenerator(
+                new Generator(), refAssemblies.ToArray(), new[] { source }, includeBaseReferences: true, LanguageVersion.CSharp7).ConfigureAwait(false);
+
+        Assert.NotEmpty(diagnostics);
+        Assert.Equal("SYSLIB1216", diagnostics[0].Id);
+        Assert.Empty(generatedSources);
+
+        // Run the generator with C# 8.0 and verify that it succeeds.
+        (diagnostics, generatedSources) = await RoslynTestUtils.RunGenerator(
+            new Generator(), refAssemblies.ToArray(), new[] { source }, includeBaseReferences: true, LanguageVersion.CSharp8).ConfigureAwait(false);
+
+        Assert.Empty(diagnostics);
+        Assert.Single(generatedSources);
+
+        // Compile the generated code with C# 7.0 and verify that it fails.
+        CSharpParseOptions parseOptions = new CSharpParseOptions(LanguageVersion.CSharp7);
+        SyntaxTree syntaxTree = SyntaxFactory.ParseSyntaxTree(generatedSources[0].SourceText.ToString(), parseOptions);
+        var diags = syntaxTree.GetDiagnostics().ToArray();
+        Assert.Equal(1, diags.Length);
+        // error CS8107: Feature 'nullable reference types' is not available in C# 7.0. Please use language version 8.0 or greater.
+        Assert.Equal("CS8107", diags[0].Id);
+
+        // Compile the generated code with C# 8.0 and verify that it succeeds.
+        parseOptions = new CSharpParseOptions(LanguageVersion.CSharp8);
+        syntaxTree = SyntaxFactory.ParseSyntaxTree(generatedSources[0].SourceText.ToString(), parseOptions);
+        diags = syntaxTree.GetDiagnostics().ToArray();
+        Assert.Equal(0, diags.Length);
+    }
+
     private static CSharpCompilation CreateCompilationForOptionsSource(string assemblyName, string source, string? refAssemblyPath = null)
     {
         // Ensure the generated source compiles

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
@@ -1582,7 +1582,7 @@ namespace __OptionValidationStaticInstances
         Assert.Equal(DiagDescriptors.NotEnumerableType.Id, diagnostics[0].Id);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
     public async Task LanguageVersionTest()
     {
         string source = """

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Resources/Strings.resx
@@ -210,4 +210,10 @@
   <data name="InaccessibleValidationAttributeTitle" xml:space="preserve">
     <value>Validation attribute on the member is inaccessible from the validator type..</value>
   </data>
+  <data name="OptionsUnsupportedLanguageVersionTitle" xml:space="preserve">
+    <value>C# language version not supported by the source generator.</value>
+  </data>
+  <data name="OptionsUnsupportedLanguageVersionMessage" xml:space="preserve">
+    <value>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Resources/Strings.resx
@@ -214,6 +214,6 @@
     <value>C# language version not supported by the source generator.</value>
   </data>
   <data name="OptionsUnsupportedLanguageVersionMessage" xml:space="preserve">
-    <value>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</value>
+    <value>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Resources/Strings.resx
@@ -210,4 +210,10 @@
   <data name="InaccessibleValidationAttributeTitle" xml:space="preserve">
     <value>Validation attribute on the member is inaccessible from the validator type..</value>
   </data>
+  <data name="OptionsUnsupportedLanguageVersionTitle" xml:space="preserve">
+    <value>C# language version not supported by the source generator.</value>
+  </data>
+  <data name="OptionsUnsupportedLanguageVersionMessage" xml:space="preserve">
+    <value>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Resources/Strings.resx
@@ -214,6 +214,6 @@
     <value>C# language version not supported by the source generator.</value>
   </data>
   <data name="OptionsUnsupportedLanguageVersionMessage" xml:space="preserve">
-    <value>The options validation source generator is not available in C# '{0}'. Please use language version {1} or greater.</value>
+    <value>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</value>
   </data>
 </root>

--- a/src/libraries/System.Text.Json/gen/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/gen/Resources/Strings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -193,7 +193,7 @@
     <value>C# language version not supported by the source generator.</value>
   </data>
   <data name="JsonUnsupportedLanguageVersionMessageFormat" xml:space="preserve">
-    <value>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</value>
+    <value>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</value>
   </data>
   <data name="JsonConstructorInaccessibleTitle" xml:space="preserve">
     <value>Constructor annotated with JsonConstructorAttribute is inaccessible.</value>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.cs.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">Zdrojový generátor System.Text.Json není k dispozici v jazyce C#{0}. Použijte prosím jazykovou verzi {1} nebo vyšší.</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">Zdrojový generátor System.Text.Json není k dispozici v jazyce C#{0}. Použijte prosím jazykovou verzi {1} nebo vyšší.</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.de.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">Der System.Text.Json-Quellgenerator ist in C# „{0}“ nicht verfügbar. Verwenden Sie die Sprachversion {1} oder höher.</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">Der System.Text.Json-Quellgenerator ist in C# „{0}“ nicht verfügbar. Verwenden Sie die Sprachversion {1} oder höher.</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.es.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">El generador de origen System.Text.Json no está disponible en C# '{0}'. Use la versión de idioma {1} o superior.</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">El generador de origen System.Text.Json no está disponible en C# '{0}'. Use la versión de idioma {1} o superior.</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.fr.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">Le générateur de source System.Text.Json n'est pas disponible en C# '{0}'. Veuillez utiliser la version linguistique {1} ou supérieure.</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">Le générateur de source System.Text.Json n'est pas disponible en C# '{0}'. Veuillez utiliser la version linguistique {1} ou supérieure.</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.it.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">Il generatore di origine System.Text.Json non è disponibile in C# '{0}'. Usare la versione del linguaggio {1} o successiva.</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">Il generatore di origine System.Text.Json non è disponibile in C# '{0}'. Usare la versione del linguaggio {1} o successiva.</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ja.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">System.Text.Json ソース ジェネレーターは C# '{0}' では使用できません。言語バージョン {1} 以上を使用してください。</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">System.Text.Json ソース ジェネレーターは C# '{0}' では使用できません。言語バージョン {1} 以上を使用してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ko.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">System.Text.Json 원본 생성기는 C# '{0}'에서 사용할 수 없습니다. {1} 이상의 언어 버전을 사용하세요.</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">System.Text.Json 원본 생성기는 C# '{0}'에서 사용할 수 없습니다. {1} 이상의 언어 버전을 사용하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pl.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">Generator źródła System.Text.Json nie jest dostępny w języku C# „{0}”. Użyj wersji językowej lub nowszej {1} .</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">Generator źródła System.Text.Json nie jest dostępny w języku C# „{0}”. Użyj wersji językowej lub nowszej {1} .</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">O gerador de fonte System.Text.Json não está disponível em C# '{0}'. Use a versão do idioma {1} ou superior.</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">O gerador de fonte System.Text.Json não está disponível em C# '{0}'. Use a versão do idioma {1} ou superior.</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ru.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">Генератор исходного кода System.Text.Json не доступен в C# "{0}". Используйте языковую версию {1} или выше.</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">Генератор исходного кода System.Text.Json не доступен в C# "{0}". Используйте языковую версию {1} или выше.</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.tr.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">System.Text.Json kaynak oluşturucusu C# '{0}' içinde kullanılamıyor. Lütfen dil sürümü {1} veya üstü sürümü kullanın.</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">System.Text.Json kaynak oluşturucusu C# '{0}' içinde kullanılamıyor. Lütfen dil sürümü {1} veya üstü sürümü kullanın.</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">System.Text.Json 源生成器在 C#“{0}”中不可用。请使用{1}或更高版本的语言版本。</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">System.Text.Json 源生成器在 C#“{0}”中不可用。请使用{1}或更高版本的语言版本。</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -113,8 +113,8 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version {1} or greater.</source>
-        <target state="translated">C# '{0}' 中無法使用 System.Text.Json 來源產生器。請使用 {1} 或更新的語言版本。</target>
+        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <target state="needs-review-translation">C# '{0}' 中無法使用 System.Text.Json 來源產生器。請使用 {1} 或更新的語言版本。</target>
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionTitle">

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
@@ -416,7 +416,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 using System.Text.Json.Serialization;
 
                 namespace HelloWorld
-                { 
+                {
                     public class MyClass
                     {
                         public MyClass(int value)
@@ -457,7 +457,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 using System.Text.Json.Serialization;
 
                 namespace HelloWorld
-                { 
+                {
                     public class MyClass<T>
                     {
                         public MyClass(
@@ -504,7 +504,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 using System.Text.Json.Serialization;
 
                 namespace HelloWorld
-                { 
+                {
                     public class MyClass
                     {
                         public MyClass(int value)
@@ -531,7 +531,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             var expectedDiagnostics = new DiagnosticData[]
             {
-                new(DiagnosticSeverity.Error, contextLocation, $"The System.Text.Json source generator is not available in C# '{langVersion.ToDisplayString()}'. Please use language version 9.0 or greater.")
+                new(DiagnosticSeverity.Error, contextLocation, $"The System.Text.Json source generator is not available in C# '{langVersion.ToDisplayString()}'. Please use language version '9.0' or greater.")
             };
 
             CompilationHelper.AssertEqualDiagnosticMessages(expectedDiagnostics, result.Diagnostics);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/83393

These source generators generate code using nullable feature which not supported before C# 8. The change here is require at least C# 8 for source generation. 

Candidate to port to rc1