### PR TITLE
[browser] Use browser cache in WasmApp-style projects by default

### DIFF
--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -152,6 +152,7 @@
     <WasmStripILAfterAOT Condition="'$(WasmStripILAfterAOT)' == ''">false</WasmStripILAfterAOT>
 
     <WasmRuntimeAssetsLocation Condition="'$(WasmRuntimeAssetsLocation)' == ''">_framework</WasmRuntimeAssetsLocation>
+    <BlazorCacheBootResources Condition="'$(BlazorCacheBootResources)' == ''">true</BlazorCacheBootResources>
   </PropertyGroup>
 
   <ItemGroup>
@@ -449,6 +450,7 @@
       WasmIncludeFullIcuData="$(WasmIncludeFullIcuData)"
       WasmIcuDataFileName="$(WasmIcuDataFileName)"
       RuntimeAssetsLocation="$(WasmRuntimeAssetsLocation)"
+      CacheBootResources="$(BlazorCacheBootResources)"
       >
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </WasmAppBuilder>

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -27,6 +27,7 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
     public bool WasmIncludeFullIcuData { get; set; }
     public string? WasmIcuDataFileName { get; set; }
     public string? RuntimeAssetsLocation { get; set; }
+    public bool CacheBootResources { get; set; }
 
     // <summary>
     // Extra json elements to add to _framework/blazor.boot.json
@@ -101,6 +102,9 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
             mainAssemblyName = MainAssemblyName,
             globalizationMode = GetGlobalizationMode().ToString().ToLowerInvariant()
         };
+
+        if (CacheBootResources)
+            bootConfig.cacheBootResources = CacheBootResources;
 
         // Create app
         var runtimeAssetsPath = !string.IsNullOrEmpty(RuntimeAssetsLocation)


### PR DESCRIPTION
- Use `BlazorCacheBootResources=true` by default in WasmApp-style projects
  - This style of projects will be used only by our tests/perf projects
  - Blazor SDK and Wasm SDK has already the same setting