### PR TITLE
Implement IStatefulPinnedMarshalling test marshallers

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
@@ -273,12 +273,31 @@ namespace ComInterfaceGenerator.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/90621")]
+        public void StatefulPinnedMarshalling_EnforcePinning()
+        {
+            var obj = CreateWrapper<StatefulPinnedMarshalling, IStatefulPinnedMarshalling>();
+            var data = new StatefulPinnedType() { I = 4 };
+
+            StatefulPinnedTypeMarshaller.ManagedToUnmanagedIn.DisableNonPinnedPath();
+
+            obj.Method(data);
+            Assert.Equal(4, data.I);
+
+            obj.MethodIn(in data);
+            Assert.Equal(4, data.I);
+
+            StatefulPinnedTypeMarshaller.ManagedToUnmanagedIn.EnableNonPinnedPath();
+        }
+
+        [Fact]
         public void StatefulPinnedMarshalling()
         {
             var obj = CreateWrapper<StatefulPinnedMarshalling, IStatefulPinnedMarshalling>();
             var data = new StatefulPinnedType() { I = 4 };
 
             // In parameters should always use pinning
+            // https://github.com/dotnet/runtime/issues/90621
             //StatefulPinnedTypeMarshaller.ManagedToUnmanagedIn.DisableNonPinnedPath();
 
             obj.Method(data);

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
@@ -296,18 +296,6 @@ namespace ComInterfaceGenerator.Tests
             var obj = CreateWrapper<StatefulPinnedMarshalling, IStatefulPinnedMarshalling>();
             var data = new StatefulPinnedType() { I = 4 };
 
-            // In parameters should always use pinning
-            // https://github.com/dotnet/runtime/issues/90621
-            //StatefulPinnedTypeMarshaller.ManagedToUnmanagedIn.DisableNonPinnedPath();
-
-            obj.Method(data);
-            Assert.Equal(4, data.I);
-
-            obj.MethodIn(in data);
-            Assert.Equal(4, data.I);
-
-            //StatefulPinnedTypeMarshaller.ManagedToUnmanagedIn.EnableNonPinnedPath();
-
             obj.MethodOut(out data);
             Assert.Equal(102, data.I);
 

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
@@ -273,8 +273,7 @@ namespace ComInterfaceGenerator.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/90621")]
-        public void StatefulPinnedMarshalling_EnforcePinning()
+        public void StatefulPinnedMarshalling()
         {
             var obj = CreateWrapper<StatefulPinnedMarshalling, IStatefulPinnedMarshalling>();
             var data = new StatefulPinnedType() { I = 4 };
@@ -288,13 +287,6 @@ namespace ComInterfaceGenerator.Tests
             Assert.Equal(4, data.I);
 
             StatefulPinnedTypeMarshaller.ManagedToUnmanagedIn.EnableNonPinnedPath();
-        }
-
-        [Fact]
-        public void StatefulPinnedMarshalling()
-        {
-            var obj = CreateWrapper<StatefulPinnedMarshalling, IStatefulPinnedMarshalling>();
-            StatefulPinnedType data;
 
             obj.MethodOut(out data);
             Assert.Equal(102, data.I);

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
@@ -294,7 +294,7 @@ namespace ComInterfaceGenerator.Tests
         public void StatefulPinnedMarshalling()
         {
             var obj = CreateWrapper<StatefulPinnedMarshalling, IStatefulPinnedMarshalling>();
-            var data = new StatefulPinnedType() { I = 4 };
+            StatefulPinnedType data;
 
             obj.MethodOut(out data);
             Assert.Equal(102, data.I);

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/RcwAroundCcwTests.cs
@@ -200,17 +200,33 @@ namespace ComInterfaceGenerator.Tests
             var obj = CreateWrapper<StatefulMarshalling, IStatefulMarshalling>();
             var data = new StatefulType() { i = 42 };
 
+            int preCallFreeCount = StatefulTypeMarshaller.FreeCount;
             obj.Method(data);
             Assert.Equal(42, data.i);
+            Assert.Equal(preCallFreeCount + 2, StatefulTypeMarshaller.FreeCount);
+
+            preCallFreeCount = StatefulTypeMarshaller.FreeCount;
             obj.MethodIn(in data);
             Assert.Equal(42, data.i);
+            Assert.Equal(preCallFreeCount + 2, StatefulTypeMarshaller.FreeCount);
+
             var oldData = data;
+            preCallFreeCount = StatefulTypeMarshaller.FreeCount;
             obj.MethodRef(ref data);
+            Assert.Equal(preCallFreeCount + 2, StatefulTypeMarshaller.FreeCount);
             Assert.True(oldData == data); // We want reference equality here
+
+            preCallFreeCount = StatefulTypeMarshaller.FreeCount;
             obj.MethodOut(out data);
+            Assert.Equal(preCallFreeCount + 2, StatefulTypeMarshaller.FreeCount);
             Assert.Equal(1, data.i);
+
+            preCallFreeCount = StatefulTypeMarshaller.FreeCount;
             Assert.Equal(1, obj.Return().i);
+            Assert.Equal(preCallFreeCount + 2, StatefulTypeMarshaller.FreeCount);
+            preCallFreeCount = StatefulTypeMarshaller.FreeCount;
             Assert.Equal(1, obj.ReturnPreserveSig().i);
+            Assert.Equal(preCallFreeCount + 2, StatefulTypeMarshaller.FreeCount);
         }
 
         [Fact]
@@ -219,16 +235,68 @@ namespace ComInterfaceGenerator.Tests
             var obj = CreateWrapper<StatelessCallerAllocatedBufferMarshalling, IStatelessCallerAllocatedBufferMarshalling>();
             var data = new StatelessCallerAllocatedBufferType() { I = 42 };
 
+            // ManagedToUnmanagedIn should use Caller Allocated Buffer and not allocate
+            StatelessCallerAllocatedBufferTypeMarshaller.DisableAllocations();
+
+            var numFreeCalls = StatelessCallerAllocatedBufferTypeMarshaller.FreeCount;
             obj.Method(data);
+            Assert.Equal(1 + numFreeCalls, StatelessCallerAllocatedBufferTypeMarshaller.FreeCount);
             Assert.Equal(42, data.I);
+
+            numFreeCalls = StatelessCallerAllocatedBufferTypeMarshaller.FreeCount;
             obj.MethodIn(in data);
+            Assert.Equal(1 + numFreeCalls, StatelessCallerAllocatedBufferTypeMarshaller.FreeCount);
             Assert.Equal(42, data.I);
+
+            // Other marshal modes will allocate
+            StatelessCallerAllocatedBufferTypeMarshaller.EnableAllocations();
+
+            numFreeCalls = StatelessCallerAllocatedBufferTypeMarshaller.FreeCount;
             obj.MethodRef(ref data);
+            Assert.Equal(2 + numFreeCalls, StatelessCallerAllocatedBufferTypeMarshaller.FreeCount);
+            StatelessCallerAllocatedBufferTypeMarshaller.AssertAllPointersFreed();
             Assert.Equal(200, data.I);
+
+            numFreeCalls = StatelessCallerAllocatedBufferTypeMarshaller.FreeCount;
             obj.MethodOut(out data);
+            Assert.Equal(1 + numFreeCalls, StatelessCallerAllocatedBufferTypeMarshaller.FreeCount);
+            StatelessCallerAllocatedBufferTypeMarshaller.AssertAllPointersFreed();
             Assert.Equal(20, data.I);
+
+            numFreeCalls = StatelessCallerAllocatedBufferTypeMarshaller.FreeCount;
             Assert.Equal(201, obj.Return().I);
+            Assert.Equal(1 + numFreeCalls, StatelessCallerAllocatedBufferTypeMarshaller.FreeCount);
+
+            numFreeCalls = StatelessCallerAllocatedBufferTypeMarshaller.FreeCount;
             Assert.Equal(202, obj.ReturnPreserveSig().I);
+            Assert.Equal(1 + numFreeCalls, StatelessCallerAllocatedBufferTypeMarshaller.FreeCount);
+        }
+
+        [Fact]
+        public void StatefulPinnedMarshalling()
+        {
+            var obj = CreateWrapper<StatefulPinnedMarshalling, IStatefulPinnedMarshalling>();
+            var data = new StatefulPinnedType() { I = 4 };
+
+            // In parameters should always use pinning
+            //StatefulPinnedTypeMarshaller.ManagedToUnmanagedIn.DisableNonPinnedPath();
+
+            obj.Method(data);
+            Assert.Equal(4, data.I);
+
+            obj.MethodIn(in data);
+            Assert.Equal(4, data.I);
+
+            //StatefulPinnedTypeMarshaller.ManagedToUnmanagedIn.EnableNonPinnedPath();
+
+            obj.MethodOut(out data);
+            Assert.Equal(102, data.I);
+
+            obj.MethodRef(ref data);
+            Assert.Equal(103, data.I);
+
+            data = obj.Return();
+            Assert.Equal(104, data.I);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/UnmanagedToManagedCustomMarshallingTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/UnmanagedToManagedCustomMarshallingTests.cs
@@ -2,14 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using SharedTypes;
 using Xunit;
 using static ComInterfaceGenerator.Tests.UnmanagedToManagedCustomMarshallingTests;

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulMarshalling.cs
@@ -50,6 +50,7 @@ namespace SharedTypes.ComInterfaces
     [CustomMarshaller(typeof(StatefulType), MarshalMode.ManagedToUnmanagedRef, typeof(Bidirectional))]
     internal struct StatefulTypeMarshaller
     {
+        public static int FreeCount => Bidirectional.FreeCount + ManagedToUnmanaged.FreeCount + UnmanagedToManaged.FreeCount;
         internal struct Bidirectional
         {
             public static int FreeCount { get; private set; }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulPinnedMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulPinnedMarshalling.cs
@@ -16,46 +16,258 @@ namespace SharedTypes.ComInterfaces
         void MethodOut(out StatefulPinnedType param);
         void MethodRef(ref StatefulPinnedType param);
         StatefulPinnedType Return();
-        [PreserveSig]
-        StatefulPinnedType ReturnPreserveSig();
+    }
+
+    [GeneratedComClass]
+    internal partial class StatefulPinnedMarshalling : IStatefulPinnedMarshalling
+    {
+        public void Method(StatefulPinnedType param) { param.I = 100; }
+        public void MethodIn(in StatefulPinnedType param) { param.I = 101; }
+        public void MethodOut(out StatefulPinnedType param) => param = new StatefulPinnedType() { I = 102 };
+        public void MethodRef(ref StatefulPinnedType param) { param = new StatefulPinnedType() { I = 103 }; }
+        public StatefulPinnedType Return() => new StatefulPinnedType() { I = 104 };
     }
 
     [NativeMarshalling(typeof(StatefulPinnedTypeMarshaller))]
     internal class StatefulPinnedType
     {
+        public int I;
     }
 
-    [CustomMarshaller(typeof(StatefulPinnedType), MarshalMode.Default, typeof(StatefulPinnedTypeMarshaller))]
-    internal struct StatefulPinnedTypeMarshaller
+    internal unsafe struct StatefulPinnedNative
     {
+        public int I;
+    }
 
-        public static int BufferSize => 64;
-        public ref int GetPinnableReference() => throw new System.NotImplementedException();
-        public void FromManaged(StatefulPinnedType managed, Span<byte> buffer)
+    [CustomMarshaller(typeof(StatefulPinnedType), MarshalMode.ManagedToUnmanagedIn, typeof(ManagedToUnmanagedIn))]
+    [CustomMarshaller(typeof(StatefulPinnedType), MarshalMode.UnmanagedToManagedOut, typeof(UnmanagedToManagedOut))]
+    [CustomMarshaller(typeof(StatefulPinnedType), MarshalMode.UnmanagedToManagedIn, typeof(UnmanagedToManagedIn))]
+    [CustomMarshaller(typeof(StatefulPinnedType), MarshalMode.ManagedToUnmanagedOut, typeof(ManagedToUnmanagedOut))]
+    [CustomMarshaller(typeof(StatefulPinnedType), MarshalMode.ManagedToUnmanagedRef, typeof(ManagedToUnmanagedRef))]
+    [CustomMarshaller(typeof(StatefulPinnedType), MarshalMode.UnmanagedToManagedRef, typeof(UnmanagedToManagedRef))]
+    internal unsafe static class StatefulPinnedTypeMarshaller
+    {
+        public ref struct ManagedToUnmanagedIn
         {
-            throw new System.NotImplementedException();
+            static bool s_mustPin;
+            public static void DisableNonPinnedPath() => s_mustPin = true;
+            public static void EnableNonPinnedPath() => s_mustPin = false;
+
+            StatefulPinnedType _managed;
+            bool _hasManaged;
+            Span<byte> buffer;
+            nint _ptr;
+            bool _canFree;
+
+            public void FromManaged(StatefulPinnedType managed)
+            {
+                _hasManaged = true;
+                _managed = managed;
+                buffer = new byte[sizeof(StatefulPinnedNative)];
+            }
+
+            public ref StatefulPinnedNative GetPinnableReference()
+            {
+                if (!_hasManaged)
+                    throw new InvalidOperationException();
+                StatefulPinnedNative native = new() { I = _managed.I };
+                MemoryMarshal.Write(buffer, in native);
+                _canFree = true;
+                return ref MemoryMarshal.AsRef<StatefulPinnedNative>(buffer);
+            }
+
+            public StatefulPinnedNative* ToUnmanaged()
+            {
+                if (s_mustPin)
+                    throw new InvalidOperationException("Expected to pin, but is instead converting with default ToUnmanaged.");
+                if (!_hasManaged)
+                    throw new InvalidOperationException();
+                _ptr = Marshal.AllocHGlobal(sizeof(StatefulPinnedNative));
+                _canFree = true;
+                *(StatefulPinnedNative*)_ptr = new StatefulPinnedNative() { I = _managed.I };
+                return (StatefulPinnedNative*)_ptr;
+            }
+
+            public void Free()
+            {
+                if (!_canFree) throw new InvalidOperationException();
+                if (_ptr != 0)
+                    Marshal.FreeHGlobal(_ptr);
+            }
         }
 
-        public nint ToUnmanaged()
+        public struct ManagedToUnmanagedOut
         {
-            throw new System.NotImplementedException();
+            StatefulPinnedNative* _unmanaged;
+            bool _hasUnmanaged;
+
+            public void FromUnmanaged(StatefulPinnedNative* unmanaged)
+            {
+                _unmanaged = unmanaged;
+                _hasUnmanaged = true;
+            }
+
+            public StatefulPinnedType ToManaged()
+            {
+                if (!_hasUnmanaged)
+                    throw new InvalidOperationException();
+                return new StatefulPinnedType() { I = _unmanaged->I };
+            }
+
+            public void Free()
+            {
+                if (!_hasUnmanaged)
+                    throw new InvalidOperationException();
+                var ptr = (nint)_unmanaged;
+                if (ptr != 0)
+                    Marshal.FreeHGlobal(ptr);
+            }
         }
 
-        public void FromUnmanaged(nint unmanaged)
+        public struct UnmanagedToManagedIn
         {
-            throw new System.NotImplementedException();
+            StatefulPinnedNative* _unmanaged;
+            bool _hasUnmanaged;
+            public void FromUnmanaged(StatefulPinnedNative* unmanaged)
+            {
+                _unmanaged = unmanaged;
+                _hasUnmanaged = true;
+            }
+
+            public StatefulPinnedType ToManaged()
+            {
+                if (!_hasUnmanaged)
+                    throw new InvalidOperationException();
+                return new StatefulPinnedType() { I = _unmanaged->I };
+            }
+
+            public void Free()
+            {
+            }
         }
 
-        public StatefulPinnedType ToManaged()
+        public struct UnmanagedToManagedOut
         {
-            throw new System.NotImplementedException();
+            StatefulPinnedType _managed;
+            bool _hasManaged;
+            nint _ptr;
+
+            public void FromManaged(StatefulPinnedType managed)
+            {
+                _hasManaged = true;
+                _managed = managed;
+            }
+
+            public StatefulPinnedNative* ToUnmanaged()
+            {
+                if (!_hasManaged)
+                    throw new InvalidOperationException();
+                _ptr = Marshal.AllocHGlobal(sizeof(StatefulPinnedNative));
+                *(StatefulPinnedNative*)_ptr = new StatefulPinnedNative() { I = _managed.I };
+                return (StatefulPinnedNative*)_ptr;
+            }
+
+            public void Free()
+            {
+            }
         }
 
-        public void Free()
-        {
-            throw new System.NotImplementedException();
-        }
 
-        public void OnInvoked() { }
+        public struct ManagedToUnmanagedRef
+        {
+            StatefulPinnedNative* _unmanaged;
+            bool _hasUnmanaged;
+            public void FromUnmanaged(StatefulPinnedNative* unmanaged)
+            {
+                _unmanaged = unmanaged;
+                _hasUnmanaged = true;
+            }
+
+            public StatefulPinnedType ToManaged()
+            {
+                if (!_hasUnmanaged)
+                    throw new InvalidOperationException();
+                return new StatefulPinnedType() { I = _unmanaged->I };
+            }
+
+            StatefulPinnedType _managed;
+            bool _hasManaged;
+            nint _ptr;
+            bool _hasAllocated;
+
+            public void FromManaged(StatefulPinnedType managed)
+            {
+                _hasManaged = true;
+                _managed = managed;
+            }
+
+            public StatefulPinnedNative* ToUnmanaged()
+            {
+                if (!_hasManaged)
+                    throw new InvalidOperationException();
+                _ptr = Marshal.AllocHGlobal(sizeof(StatefulPinnedNative));
+                _hasAllocated = true;
+                *(StatefulPinnedNative*)_ptr = new StatefulPinnedNative();
+                return (StatefulPinnedNative*)_ptr;
+            }
+
+            public void Free()
+            {
+                if (_hasUnmanaged)
+                {
+                    Marshal.FreeHGlobal((nint)_unmanaged);
+                }
+                else if (_hasAllocated)
+                {
+                    Marshal.FreeHGlobal(_ptr);
+                }
+            }
+        }
+        public struct UnmanagedToManagedRef
+        {
+            StatefulPinnedNative* _unmanaged;
+            bool _hasUnmanaged;
+            public void FromUnmanaged(StatefulPinnedNative* unmanaged)
+            {
+                _unmanaged = unmanaged;
+                _hasUnmanaged = true;
+            }
+
+            public StatefulPinnedType ToManaged()
+            {
+                if (!_hasUnmanaged)
+                    throw new InvalidOperationException();
+                return new StatefulPinnedType() { I = _unmanaged->I };
+            }
+
+            StatefulPinnedType _managed;
+            bool _hasManaged;
+            nint _ptr;
+            bool _hasAllocated;
+
+            public void FromManaged(StatefulPinnedType managed)
+            {
+                _hasManaged = true;
+                _managed = managed;
+            }
+
+            public StatefulPinnedNative* ToUnmanaged()
+            {
+                if (!_hasManaged)
+                    throw new InvalidOperationException();
+                _ptr = Marshal.AllocHGlobal(sizeof(StatefulPinnedNative));
+                _hasAllocated = true;
+                *(StatefulPinnedNative*)_ptr = new StatefulPinnedNative();
+                return (StatefulPinnedNative*)_ptr;
+            }
+
+            public void Free()
+            {
+                if (_hasAllocated && _hasUnmanaged)
+                {
+                    Marshal.FreeHGlobal((nint)_unmanaged);
+                }
+            }
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulPinnedMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/ComInterfaces/IStatefulPinnedMarshalling.cs
@@ -207,7 +207,7 @@ namespace SharedTypes.ComInterfaces
                     throw new InvalidOperationException();
                 _ptr = Marshal.AllocHGlobal(sizeof(StatefulPinnedNative));
                 _hasAllocated = true;
-                *(StatefulPinnedNative*)_ptr = new StatefulPinnedNative();
+                *(StatefulPinnedNative*)_ptr = new StatefulPinnedNative() { I = _managed.I };
                 return (StatefulPinnedNative*)_ptr;
             }
 
@@ -257,7 +257,7 @@ namespace SharedTypes.ComInterfaces
                     throw new InvalidOperationException();
                 _ptr = Marshal.AllocHGlobal(sizeof(StatefulPinnedNative));
                 _hasAllocated = true;
-                *(StatefulPinnedNative*)_ptr = new StatefulPinnedNative();
+                *(StatefulPinnedNative*)_ptr = new StatefulPinnedNative() { I = _managed.I };
                 return (StatefulPinnedNative*)_ptr;
             }
 


### PR DESCRIPTION
Adds implementation for IStatefulPinnedMarshalling and updates implementation of IStatelessCallerAllocatedBufferMarshalling to use different marshallers for each shape.

Calls to stateful GetPinnableReference are not generated https://github.com/dotnet/runtime/issues/90621