### PR TITLE
JIT: Disallow mismatched GC-ness for physical promotions

### DIFF
--- a/src/coreclr/jit/layout.cpp
+++ b/src/coreclr/jit/layout.cpp
@@ -421,12 +421,41 @@ void ClassLayout::InitializeGCPtrs(Compiler* compiler)
 //
 // Return value:
 //    true if at least one GC ByRef, false otherwise.
+//
 bool ClassLayout::HasGCByRef() const
 {
     unsigned slots = GetSlotCount();
     for (unsigned i = 0; i < slots; i++)
     {
         if (IsGCByRef(i))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+//------------------------------------------------------------------------
+// IntersectsGCPtr: check if the specified interval intersects with a GC
+// pointer.
+//
+// Parameters:
+//   offset - The start offset of the interval
+//   size   - The size of the interval
+//
+// Return value:
+//   True if it does.
+//
+bool ClassLayout::IntersectsGCPtr(unsigned offset, unsigned size) const
+{
+    unsigned startSlot = offset / TARGET_POINTER_SIZE;
+    unsigned endSlot   = (offset + size - 1) / TARGET_POINTER_SIZE;
+    assert((startSlot < GetSlotCount()) && (endSlot < GetSlotCount()));
+
+    for (unsigned i = startSlot; i <= endSlot; i++)
+    {
+        if (IsGCPtr(i))
         {
             return true;
         }

--- a/src/coreclr/jit/layout.cpp
+++ b/src/coreclr/jit/layout.cpp
@@ -449,6 +449,11 @@ bool ClassLayout::HasGCByRef() const
 //
 bool ClassLayout::IntersectsGCPtr(unsigned offset, unsigned size) const
 {
+    if (!HasGCPtr())
+    {
+        return false;
+    }
+
     unsigned startSlot = offset / TARGET_POINTER_SIZE;
     unsigned endSlot   = (offset + size - 1) / TARGET_POINTER_SIZE;
     assert((startSlot < GetSlotCount()) && (endSlot < GetSlotCount()));

--- a/src/coreclr/jit/layout.h
+++ b/src/coreclr/jit/layout.h
@@ -216,6 +216,8 @@ public:
         }
     }
 
+    bool IntersectsGCPtr(unsigned offset, unsigned size) const;
+
     static bool AreCompatible(const ClassLayout* layout1, const ClassLayout* layout2);
 
 private:


### PR DESCRIPTION
Physical promotion was working under the assumption that reinterpreting GC pointers is undefined behavior, and would happily promote GC pointers as integers if it saw such accesses. However, physical promotion is function wide while the UB accesses can be happening in a restricted (dynamically unreachable) scope. This exact situation happens in [MemoryExtensions.Contains](https://github.com/dotnet/runtime/blob/2ed506c010b41c41c01997c81df977831f0fa217/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs#L343-L349). The issue was uncovered under jit stress where we did not fold away the guard early enough, meaning that promotion then saw a `TYP_LONG` access of a `struct { object, int }` and proceeded to promote it as such.

Fix #90602

No diffs are expected.