### PR TITLE
Fix PortableRuntimeIdentifierGraph.json not found during runtime repo source build

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -260,10 +260,4 @@
           DependsOnTargets="
             ResolveLibrariesRefAssembliesFromLocalBuild;
             ResolveLibrariesRuntimeFilesFromLocalBuild" />
-
-  <PropertyGroup>
-    <!-- Keep in sync with outputs defined in Microsoft.NETCore.Platforms.csproj. -->
-    <BundledRuntimeIdentifierGraphFile>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'Microsoft.NETCore.Platforms', 'runtime.json'))</BundledRuntimeIdentifierGraphFile>
-    <BundledRuntimeIdentifierGraphFile Condition="!Exists('$(BundledRuntimeIdentifierGraphFile)')">$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</BundledRuntimeIdentifierGraphFile>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3592
Will need to go to rc1 as well

Since the full RID graph isn't supposed to be updated any more, stop setting the BundledRuntimeIdentifierGraphFile property, which is currently breaking source-build bootstrapping scenarios.