### PR TITLE
[release/8.0] Do not set fetch depth on source-build

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -147,7 +147,10 @@ jobs:
     steps:
     - checkout: self
       clean: true
-      fetchDepth: $(checkoutFetchDepth)
+      # If running in source build mode, a git stash will be used for the inner clone. Avoid setting a fetch depth,
+      # as a stash of a shallow cloned repo is not currently supported.
+      ${{ if ne(parameters.isSourceBuild, true) }}:
+        fetchDepth: $(checkoutFetchDepth)
 
     - ${{ if and(eq(parameters.isOfficialBuild, true), notin(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator')) }}:
       - template: /eng/pipelines/common/restore-internal-tools.yml


### PR DESCRIPTION
The nuget feed setup that happens in an official build will alter the local working copy, causing source build to attempt a stash. Stashes of changes in shallow cloned repos aren't currently supported by arcade.