### PR TITLE
[LoongArch64] fix the compiling errors after #90318.

### DIFF
--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -1257,7 +1257,7 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
             }
 
 #if defined(TARGET_LOONGARCH64)
-            if (varTypeIsFloating(spillType) && emitter::isGeneralRegister(tree->GetRegNum()))
+            if (varTypeIsFloating(unspillType) && emitter::isGeneralRegister(tree->GetRegNum()))
             {
                 unspillType = unspillType == TYP_FLOAT ? TYP_INT : TYP_LONG;
             }


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

Fix the compiling errors after #90318.