### PR TITLE
Remove quotes from language versions in source gen diagnostics.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/Strings.resx
@@ -235,6 +235,6 @@
     <value>C# language version not supported by the source generator.</value>
   </data>
   <data name="LoggingUnsupportedLanguageVersionMessageFormat" xml:space="preserve">
-    <value>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</value>
+    <value>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.cs.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.de.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.es.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.fr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.it.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ja.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ko.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pl.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ru.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.tr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionMessageFormat">
-        <source>The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The Logging source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The Logging source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="LoggingUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/Strings.resx
@@ -211,6 +211,6 @@
     <value>C# language version not supported by the source generator.</value>
   </data>
   <data name="OptionsUnsupportedLanguageVersionMessage" xml:space="preserve">
-    <value>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</value>
+    <value>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.cs.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.de.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.es.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.fr.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.it.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ja.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ko.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pl.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.ru.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.tr.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -123,8 +123,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionMessage">
-        <source>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
-        <target state="new">The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</target>
+        <source>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</source>
+        <target state="new">The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionsUnsupportedLanguageVersionTitle">

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Resources/Strings.resx
@@ -214,6 +214,6 @@
     <value>C# language version not supported by the source generator.</value>
   </data>
   <data name="OptionsUnsupportedLanguageVersionMessage" xml:space="preserve">
-    <value>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</value>
+    <value>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Resources/Strings.resx
@@ -214,6 +214,6 @@
     <value>C# language version not supported by the source generator.</value>
   </data>
   <data name="OptionsUnsupportedLanguageVersionMessage" xml:space="preserve">
-    <value>The options validation source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</value>
+    <value>The options validation source generator is not available in C# {0}. Please use language version {1} or greater.</value>
   </data>
 </root>

--- a/src/libraries/System.Text.Json/gen/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/gen/Resources/Strings.resx
@@ -193,7 +193,7 @@
     <value>C# language version not supported by the source generator.</value>
   </data>
   <data name="JsonUnsupportedLanguageVersionMessageFormat" xml:space="preserve">
-    <value>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</value>
+    <value>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</value>
   </data>
   <data name="JsonConstructorInaccessibleTitle" xml:space="preserve">
     <value>Constructor annotated with JsonConstructorAttribute is inaccessible.</value>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.cs.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">Zdrojový generátor System.Text.Json není k dispozici v jazyce C#{0}. Použijte prosím jazykovou verzi {1} nebo vyšší.</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.de.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">Der System.Text.Json-Quellgenerator ist in C# „{0}“ nicht verfügbar. Verwenden Sie die Sprachversion {1} oder höher.</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.es.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">El generador de origen System.Text.Json no está disponible en C# '{0}'. Use la versión de idioma {1} o superior.</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.fr.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">Le générateur de source System.Text.Json n'est pas disponible en C# '{0}'. Veuillez utiliser la version linguistique {1} ou supérieure.</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.it.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">Il generatore di origine System.Text.Json non è disponibile in C# '{0}'. Usare la versione del linguaggio {1} o successiva.</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ja.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">System.Text.Json ソース ジェネレーターは C# '{0}' では使用できません。言語バージョン {1} 以上を使用してください。</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ko.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">System.Text.Json 원본 생성기는 C# '{0}'에서 사용할 수 없습니다. {1} 이상의 언어 버전을 사용하세요.</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pl.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">Generator źródła System.Text.Json nie jest dostępny w języku C# „{0}”. Użyj wersji językowej lub nowszej {1} .</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">O gerador de fonte System.Text.Json não está disponível em C# '{0}'. Use a versão do idioma {1} ou superior.</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ru.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">Генератор исходного кода System.Text.Json не доступен в C# "{0}". Используйте языковую версию {1} или выше.</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.tr.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">System.Text.Json kaynak oluşturucusu C# '{0}' içinde kullanılamıyor. Lütfen dil sürümü {1} veya üstü sürümü kullanın.</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">System.Text.Json 源生成器在 C#“{0}”中不可用。请使用{1}或更高版本的语言版本。</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -113,7 +113,7 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonUnsupportedLanguageVersionMessageFormat">
-        <source>The System.Text.Json source generator is not available in C# '{0}'. Please use language version '{1}' or greater.</source>
+        <source>The System.Text.Json source generator is not available in C# {0}. Please use language version {1} or greater.</source>
         <target state="needs-review-translation">C# '{0}' 中無法使用 System.Text.Json 來源產生器。請使用 {1} 或更新的語言版本。</target>
         <note />
       </trans-unit>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
@@ -531,7 +531,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             var expectedDiagnostics = new DiagnosticData[]
             {
-                new(DiagnosticSeverity.Error, contextLocation, $"The System.Text.Json source generator is not available in C# '{langVersion.ToDisplayString()}'. Please use language version '9.0' or greater.")
+                new(DiagnosticSeverity.Error, contextLocation, $"The System.Text.Json source generator is not available in C# {langVersion.ToDisplayString()}. Please use language version 9.0 or greater.")
             };
 
             CompilationHelper.AssertEqualDiagnosticMessages(expectedDiagnostics, result.Diagnostics);


### PR DESCRIPTION
Following up on https://github.com/dotnet/runtime/pull/90654#discussion_r1296748908 this updates the diagnostic messages so that quotes are never used on language versions.

If it gets merged we should cherry pick the changes in #90709.