### PR TITLE
JIT: Cleanup redundant local address exposure in RewriteUses

### DIFF
--- a/src/coreclr/jit/objectalloc.h
+++ b/src/coreclr/jit/objectalloc.h
@@ -21,7 +21,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 class ObjectAllocator final : public Phase
 {
-    typedef SmallHashTable<unsigned int, unsigned int, 8U> LocalToLocalMap;
+    typedef SmallHashTable<unsigned int, unsigned int, 8U>       LocalToLocalMap;
     typedef SmallHashTable<unsigned int, unsigned long long, 8U> LocalToLclOffMap;
 
     //===============================================================================

--- a/src/coreclr/jit/objectalloc.h
+++ b/src/coreclr/jit/objectalloc.h
@@ -22,6 +22,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 class ObjectAllocator final : public Phase
 {
     typedef SmallHashTable<unsigned int, unsigned int, 8U> LocalToLocalMap;
+    typedef SmallHashTable<unsigned int, unsigned long long, 8U> LocalToLclOffMap;
 
     //===============================================================================
     // Data members


### PR DESCRIPTION
After escape analysis, we already know whether a local variable is pointing to stack or not.
Remove any redundant local address exposure if there's no assignment to it later, and rewrite uses to make any use to it reference the local address directly.

```csharp
int Test()
{
    var foo = new Foo { X = 3, Y = 4 };
    return foo.X + foo.Y;
}

class Foo
{
    public int X;
    public int Y;
}
```

With `DOTNET_JitObjectStackAllocation=1`:

```nasm
; Assembly listing for method Program:Test():int (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 2 single block inlinees; 0 inlinees without PGO data
; Final local variable assignments
;
;* V00 loc0         [V00    ] (  0,  0   )    long  ->  zero-ref    class-hnd exact <Foo>
;# V01 OutArgs      [V01    ] (  1,  1   )  struct ( 0) [rsp+0x00]  do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
;* V02 tmp1         [V02    ] (  0,  0   )    long  ->  zero-ref    class-hnd exact "NewObj constructor temp" <Foo>
;* V03 tmp2         [V03    ] (  0,  0   )  struct (16) zero-ref    do-not-enreg[SF] "MorphAllocObjNodeIntoStackAlloc temp" <Foo>
;* V04 tmp3         [V04    ] (  0,  0   )    long  ->  zero-ref    single-def "V03.[000..008)"
;* V05 tmp4         [V05    ] (  0,  0   )     int  ->  zero-ref    "V03.[008..012)"
;* V06 tmp5         [V06    ] (  0,  0   )     int  ->  zero-ref    "V03.[012..016)"
;
; Lcl frame size = 0

G_M19777_IG01:  ;; offset=0x0000
                                                ;; size=0 bbWeight=1 PerfScore 0.00
G_M19777_IG02:  ;; offset=0x0000
       mov      eax, 7
                                                ;; size=5 bbWeight=1 PerfScore 0.25
G_M19777_IG03:  ;; offset=0x0005
       ret
                                                ;; size=1 bbWeight=1 PerfScore 1.00

; Total bytes of code 6, prolog size 0, PerfScore 1.85, instruction count 2, allocated bytes for code 6 (MethodHash=06bbb2be) for method Program:Test():int (FullOpts)
; ============================================================
```

Contributes to #4584