### PR TITLE
Fix invalid PGO optimization path on Nuget cache containing spaces.

### DIFF
--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -142,7 +142,7 @@ if /i "%1" == "-ninja"               (shift&goto Arg_Loop)
 if /i "%1" == "-msbuild"             (set __Ninja=0&shift&goto Arg_Loop)
 if /i "%1" == "-pgoinstrument"       (set __PgoInstrument=1&shift&goto Arg_Loop)
 if /i "%1" == "-enforcepgo"          (set __EnforcePgo=1&shift&goto Arg_Loop)
-if /i "%1" == "-pgodatapath"         (set __PgoOptDataPath=%2&set __PgoOptimize=1&shift&shift&goto Arg_Loop)
+if /i "%1" == "-pgodatapath"         (set __PgoOptDataPath=%~2&set __PgoOptimize=1&shift&shift&goto Arg_Loop)
 if /i "%1" == "-component"           (set __RequestedBuildComponents=%__RequestedBuildComponents%-%2&set "__remainingArgs=!__remainingArgs:*%2=!"&shift&shift&goto Arg_Loop)
 if /i "%1" == "-fsanitize"           (set __CMakeArgs=%__CMakeArgs% "-DCLR_CMAKE_ENABLE_SANITIZERS=%2"&shift&shift&goto Arg_Loop)
 


### PR DESCRIPTION
Since CMD does not strip quotes from arguments passed in with quotes by default, if a Nuget package cache path containing a space is passed to `build-runtime.cmd`, it will pass it into an additional CMake argument with an additional set of quotes.

This causes string semantics to be disabled upon reaching the second opening quote, thus separating the cache path into two separate arguments incorrectly, resulting in the PGO data optimization pointing to an invalid path.

This patch fixes this issue by simply removing the redundant quotes when accepting the arguments in `build-runtime.cmd`.