### PR TITLE
Improve profiled casts #2

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1381,18 +1381,26 @@ GenTree* Compiler::impReadyToRunLookupToTree(CORINFO_CONST_LOOKUP* pLookup,
 //
 bool Compiler::impIsCastHelperEligibleForClassProbe(GenTree* tree)
 {
-    if (!opts.jitFlags->IsSet(JitFlags::JIT_FLAG_BBINSTR) || (JitConfig.JitProfileCasts() != 1))
+    if (!opts.IsInstrumented() || (JitConfig.JitProfileCasts() != 1))
     {
         return false;
     }
 
-    if (tree->IsCall() && tree->AsCall()->gtCallType == CT_HELPER)
+    if (tree->IsHelperCall() && impIsCastHelperMayHaveProfileData)
     {
-        const CorInfoHelpFunc helper = eeGetHelperNum(tree->AsCall()->gtCallMethHnd);
-        if ((helper == CORINFO_HELP_ISINSTANCEOFINTERFACE) || (helper == CORINFO_HELP_ISINSTANCEOFCLASS) ||
-            (helper == CORINFO_HELP_CHKCASTCLASS) || (helper == CORINFO_HELP_CHKCASTINTERFACE))
+        switch (eeGetHelperNum(tree->AsCall()->gtCallMethHnd))
         {
-            return true;
+            case CORINFO_HELP_ISINSTANCEOFINTERFACE:
+            case CORINFO_HELP_ISINSTANCEOFARRAY:
+            case CORINFO_HELP_ISINSTANCEOFCLASS:
+            case CORINFO_HELP_ISINSTANCEOFANY:
+            case CORINFO_HELP_CHKCASTINTERFACE:
+            case CORINFO_HELP_CHKCASTARRAY:
+            case CORINFO_HELP_CHKCASTCLASS:
+            case CORINFO_HELP_CHKCASTANY:
+                return true;
+            default:
+                break;
         }
     }
     return false;
@@ -1410,22 +1418,25 @@ bool Compiler::impIsCastHelperEligibleForClassProbe(GenTree* tree)
 //
 bool Compiler::impIsCastHelperMayHaveProfileData(CorInfoHelpFunc helper)
 {
-    if (JitConfig.JitConsumeProfileForCasts() == 0)
+    if ((JitConfig.JitConsumeProfileForCasts() != 1) || !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_BBOPT))
     {
         return false;
     }
 
-    if (!opts.jitFlags->IsSet(JitFlags::JIT_FLAG_BBOPT))
+    switch (helper)
     {
-        return false;
+        case CORINFO_HELP_ISINSTANCEOFINTERFACE:
+        case CORINFO_HELP_ISINSTANCEOFARRAY:
+        case CORINFO_HELP_ISINSTANCEOFCLASS:
+        case CORINFO_HELP_ISINSTANCEOFANY:
+        case CORINFO_HELP_CHKCASTINTERFACE:
+        case CORINFO_HELP_CHKCASTARRAY:
+        case CORINFO_HELP_CHKCASTCLASS:
+        case CORINFO_HELP_CHKCASTANY:
+            return true;
+        default:
+            return false;
     }
-
-    if ((helper == CORINFO_HELP_ISINSTANCEOFINTERFACE) || (helper == CORINFO_HELP_ISINSTANCEOFCLASS) ||
-        (helper == CORINFO_HELP_CHKCASTCLASS) || (helper == CORINFO_HELP_CHKCASTINTERFACE))
-    {
-        return true;
-    }
-    return false;
 }
 
 GenTreeCall* Compiler::impReadyToRunHelperToTree(CORINFO_RESOLVED_TOKEN* pResolvedToken,

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1386,7 +1386,7 @@ bool Compiler::impIsCastHelperEligibleForClassProbe(GenTree* tree)
         return false;
     }
 
-    if (tree->IsHelperCall() && impIsCastHelperMayHaveProfileData)
+    if (tree->IsHelperCall())
     {
         switch (eeGetHelperNum(tree->AsCall()->gtCallMethHnd))
         {

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -73,6 +73,7 @@
       DOTNET_JitRandomlyCollect64BitCounts;
       DOTNET_JitStressModeNames;
       DOTNET_JitGuardedDevirtualizationMaxTypeChecks;
+      DOTNET_JitProfileCasts;
       DOTNET_TieredPGO_InstrumentedTierAlwaysOptimized;
       DOTNET_JitForceControlFlowGuard;
       DOTNET_JitCFGUseDispatcher;
@@ -226,9 +227,9 @@
     <TestEnvironment Include="ilasmroundtrip" RunningIlasmRoundTrip="1" />
     <TestEnvironment Include="clrinterpreter" TieredCompilation="1" />
     <TestEnvironment Include="defaultpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" />
-    <TestEnvironment Include="fullpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0"/>
+    <TestEnvironment Include="fullpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitProfileCasts="1"/>
     <TestEnvironment Include="fullpgo_methodprofiling" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitDelegateProfiling="1" JitVTableProfiling="1" />
-    <TestEnvironment Include="fullpgo_methodprofiling_always_optimized" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitDelegateProfiling="1" JitVTableProfiling="1" TieredPGO_InstrumentedTierAlwaysOptimized="1" JitGuardedDevirtualizationMaxTypeChecks="3" />
+    <TestEnvironment Include="fullpgo_methodprofiling_always_optimized" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitDelegateProfiling="1" JitVTableProfiling="1" TieredPGO_InstrumentedTierAlwaysOptimized="1" JitGuardedDevirtualizationMaxTypeChecks="3" JitProfileCasts="1" />
     <TestEnvironment Include="fullpgo_random_gdv" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitRandomlyCollect64BitCounts="1" />
     <TestEnvironment Include="fullpgo_random_gdv_methodprofiling_only" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitClassProfiling="0" JitDelegateProfiling="1" JitVTableProfiling="1" JitRandomlyCollect64BitCounts="1" />
     <TestEnvironment Include="fullpgo_random_gdv_edge" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitRandomEdgeCounts="1" JitRandomlyCollect64BitCounts="1" />


### PR DESCRIPTION
Small clean up + adds new patterns to recognize, e.g.:
```cs
class Prog
{
    static void Main()
    {
        for (int i = 0; i < 200; i++)
        {
            Test1<int>(new int[10]);
            Test2(new uint[10]);
            Thread.Sleep(16);
        }
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    // NOTE: won't kick in for shared T
    static bool Test1<T>(object o) => o is IEnumerable<T>;

    [MethodImpl(MethodImplOptions.NoInlining)]
    static bool Test2(object o) => o is int[];
}
```
Old codegen:
```asm
; Assembly listing for method Prog:Test1
       sub      rsp, 40
       mov      rdx, rcx
       mov      rcx, 0x7FF955C08F70      ; IEnumerable`1[int]
       call     [CORINFO_HELP_ISINSTANCEOFANY]
       test     rax, rax
       setne    al
       movzx    rax, al
       add      rsp, 40
       ret      
; Total bytes of code 37


; Assembly listing for method Prog:Test2
       sub      rsp, 40
       mov      rdx, rcx
       mov      rcx, 0x7FF955718230      ; int[]
       call     [CORINFO_HELP_ISINSTANCEOFARRAY]
       test     rax, rax
       setne    al
       movzx    rax, al
       add      rsp, 40
       ret      
; Total bytes of code 37
```
New codegen:
```asm
; Assembly listing for method Prog:Test1
       sub      rsp, 40
       mov      rax, rcx
       test     rax, rax
       je       SHORT G_M13683_IG05
       mov      rdx, 0x7FF955728230      ; int[]
       cmp      qword ptr [rax], rdx
       je       SHORT G_M13683_IG05
       mov      rdx, rcx
       mov      rcx, 0x7FF955BBAAD0      ; IEnumerable`1[int]
       call     CORINFO_HELP_ISINSTANCEOFANY
G_M13683_IG05:
       test     rax, rax
       setne    al
       movzx    rax, al
       add      rsp, 40
       ret      
; Total bytes of code 59


; Assembly listing for method Prog:Test2
       sub      rsp, 40
       mov      rax, rcx
       test     rax, rax
       je       SHORT G_M19173_IG05
       mov      rdx, 0x7FF955DC59E0      ; uint[]
       cmp      qword ptr [rax], rdx
       je       SHORT G_M19173_IG05
       mov      rdx, rcx
       mov      rcx, 0x7FF955748230      ; int[]
       call     CORINFO_HELP_ISINSTANCEOFARRAY
G_M19173_IG05:
       test     rax, rax
       setne    al
       movzx    rax, al
       add      rsp, 40
       ret      
; Total bytes of code 59
```
castclass is also improved.