### PR TITLE
[wasm] Pin sdk version to 8.0.100-rc.1.23415.5 for workload testing

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -204,7 +204,7 @@
     <GrpcDotnetClientVersion>2.45.0</GrpcDotnetClientVersion>
     <GrpcToolsVersion>2.45.0</GrpcToolsVersion>
     <!-- Uncomment to set a fixed version, else the latest is used -->
-    <!--<SdkVersionForWorkloadTesting>8.0.100-preview.6.23314.19</SdkVersionForWorkloadTesting>-->
+    <SdkVersionForWorkloadTesting>8.0.100-rc.1.23415.5</SdkVersionForWorkloadTesting>
     <CompilerPlatformTestingVersion>1.1.2-beta1.23323.1</CompilerPlatformTestingVersion>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20221010.1</MicrosoftPrivateIntellisenseVersion>


### PR DESCRIPTION
.. because `dotnet-install --channel 8.0` is returning 9.0-alpha sdks right now.

Fixes https://github.com/dotnet/runtime/issues/90742
Fixes https://github.com/dotnet/runtime/issues/90743