### PR TITLE
Update 6.0 staging branch with Ubuntu 22.04 queue for Perf runs

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -464,7 +464,7 @@ jobs:
         projectFile: crossgen_perf.proj
         runKind: crossgen_scenarios
         runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perftiger'
+        logicalmachine: 'perftiger_crossgen'
 
   # run mono wasm blazor perf job
   - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -44,9 +44,10 @@ $Queue = ""
 
 if ($Internal) {
     switch ($LogicalMachine) {
-        "perftiger" { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf"  }
-        "perfowl" { $Queue = "Windows.10.Amd64.20H2.Owl.Perf"  }
-        "perfsurf" { $Queue = "Windows.10.Arm64.Perf.Surf"  }
+        "perftiger" { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
+        "perftiger_crossgen" { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
+        "perfowl" { $Queue = "Windows.10.Amd64.20H2.Owl.Perf" }
+        "perfsurf" { $Queue = "Windows.10.Arm64.Perf.Surf" }
         "perfpixel4a" { $Queue = "Windows.10.Amd64.Pixel.Perf" }
         Default { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
     }

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -211,7 +211,7 @@ if [[ "$internal" == true ]]; then
         elif [[ "$logical_machine" == "perftiger_crossgen" ]]; then
             queue=Ubuntu.1804.Amd64.Tiger.Perf
         else
-            queue=Ubuntu.1804.Amd64.Tiger.Perf
+            queue=Ubuntu.2204.Amd64.Tiger.Perf
         fi
     fi
 

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -208,6 +208,8 @@ if [[ "$internal" == true ]]; then
     else
         if [[ "$logical_machine" = "perfowl" ]]; then
             queue=Ubuntu.1804.Amd64.Owl.Perf
+        elif [[ "$logical_machine" == "perftiger_crossgen" ]]; then
+            queue=Ubuntu.1804.Amd64.Tiger.Perf
         else
             queue=Ubuntu.1804.Amd64.Tiger.Perf
         fi


### PR DESCRIPTION
This updates the servicing branches to use the new Ubuntu 22.04 queues.

## Customer Impact

None, as this does not change product code.

## Regression?

No.

## Testing

Currently running on main branches successfully 

## Risk

Low. This is not a product change, and as such I expect the risk to be zero.