### PR TITLE
[RISC-V] Fix tmpReg in emitInsTernary

### DIFF
--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -4287,8 +4287,8 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
                 }
                 else
                 {
-                    tempReg1 = REG_RA; // src1->GetSingleTempReg();
-                    tempReg2 = REG_T5; // TODO-RISCV64-Bug?: Assign proper temp register
+                    tempReg1 = REG_RA;
+                    tempReg2 = dst->GetSingleTempReg();
                     assert(tempReg1 != tempReg2);
                     assert(tempReg1 != saveOperReg1);
                     assert(tempReg2 != saveOperReg2);


### PR DESCRIPTION
Fixes assert in System.Linq.Parallel.Tests.

Part of #84834
cc @alpencolt @gbalykov @ashaurtaev @clamp03 @tomeksowi