### PR TITLE
Move event pipe utf8/utf16 string conversion functions to shared event pipe code

### DIFF
--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.cpp
@@ -180,7 +180,7 @@ ds_rt_aot_transport_get_default_name (
     const ep_char8_t *suffix)
 {
     STATIC_CONTRACT_NOTHROW;
-    
+
 #ifdef TARGET_UNIX
 
     EP_ASSERT (name != NULL);
@@ -202,7 +202,7 @@ ds_rt_aot_transport_get_default_name (
     // also try to use 0 as the value.
     if (!aot_ipc_get_process_id_disambiguation_key (id, &disambiguation_key))
         EP_ASSERT (disambiguation_key == 0);
-    
+
     // Get a temp file location
     format_result = ep_rt_temp_path_get (format_buffer, name_len);
     if (format_result == 0) {
@@ -238,8 +238,8 @@ uint32_t
 ds_rt_aot_set_environment_variable (const ep_char16_t *name, const ep_char16_t *value)
 {
 #ifdef TARGET_UNIX
-    ep_char8_t *nameNarrow = ep_rt_utf16le_to_utf8_string (name, ep_rt_utf16_string_len (name));
-    ep_char8_t *valueNarrow = ep_rt_utf16le_to_utf8_string (value, ep_rt_utf16_string_len (value));
+    ep_char8_t *nameNarrow = ep_rt_utf16le_to_utf8_string (name);
+    ep_char8_t *valueNarrow = ep_rt_utf16le_to_utf8_string (value);
     int32_t ret_value = setenv(nameNarrow, valueNarrow, 1);
     free(nameNarrow);
     free(valueNarrow);

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ds-rt-aot.h
@@ -157,7 +157,7 @@ uint32_t
 ds_rt_config_value_get_default_port_suspend (void)
 {
     STATIC_CONTRACT_NOTHROW;
-    
+
     uint64_t value;
     if (RhConfig::Environment::TryGetIntegerValue("DefaultDiagnosticPortSuspend", &value))
     {
@@ -192,7 +192,7 @@ ds_rt_generate_core_dump (
     }
     const ep_char16_t *dumpName = ds_generate_core_dump_command_payload_get_dump_name (payload);
     int32_t dumpType = static_cast<int32_t>(ds_generate_core_dump_command_payload_get_dump_type (payload));
-    ep_char8_t *dumpNameUtf8 = ep_rt_utf16le_to_utf8_string (dumpName, ep_rt_utf16_string_len (dumpName));
+    ep_char8_t *dumpNameUtf8 = ep_rt_utf16le_to_utf8_string (dumpName);
     extern bool PalGenerateCoreDump(const char* dumpName, int dumpType, uint32_t flags, char* errorMessageBuffer, int cbErrorMessageBuffer);
     if (PalGenerateCoreDump(dumpNameUtf8, dumpType, flags, errorMessageBuffer, cbErrorMessageBuffer))
     {

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.cpp
@@ -94,7 +94,7 @@ ep_rt_aot_entrypoint_assembly_name_get_utf8 (void)
             if (extension != NULL) {
                 len = extension - process_name_const;
             }
-            entrypoint_assembly_name_local = ep_rt_utf16_to_utf8_string(reinterpret_cast<const ep_char16_t *>(process_name_const), len);
+            entrypoint_assembly_name_local = ep_rt_utf16_to_utf8_string_n(reinterpret_cast<const ep_char16_t *>(process_name_const), len);
 #else
             const ep_char8_t* process_name_const = strrchr(wszModuleFileName, DIRECTORY_SEPARATOR_CHAR);
             if (process_name_const != NULL) {
@@ -132,7 +132,7 @@ ep_rt_aot_diagnostics_command_line_get (void)
     // TODO: revisit commandline for AOT
 #ifdef TARGET_WINDOWS
     const ep_char16_t* command_line = reinterpret_cast<const ep_char16_t *>(::GetCommandLineW());
-    return ep_rt_utf16_to_utf8_string(command_line, -1);
+    return ep_rt_utf16_to_utf8_string(command_line);
 #elif TARGET_LINUX
     FILE *cmdline_file = ::fopen("/proc/self/cmdline", "r");
     if (cmdline_file == nullptr)
@@ -438,7 +438,7 @@ ep_rt_aot_file_open_write (const ep_char8_t *path)
         return INVALID_HANDLE_VALUE;
 
 #ifdef TARGET_WINDOWS
-    ep_char16_t *path_utf16 = ep_rt_utf8_to_utf16le_string (path, -1);
+    ep_char16_t *path_utf16 = ep_rt_utf8_to_utf16le_string (path);
     if (!path_utf16)
         return INVALID_HANDLE_VALUE;
 
@@ -768,7 +768,7 @@ void ep_rt_aot_os_environment_get_utf16 (dn_vector_ptr_t *env_array)
 #else
     ep_char8_t **next = NULL;
     for (next = environ; *next != NULL; ++next)
-        dn_vector_ptr_push_back (env_array, ep_rt_utf8_to_utf16le_string (*next, -1));
+        dn_vector_ptr_push_back (env_array, ep_rt_utf8_to_utf16le_string (*next));
 #endif
 }
 

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
@@ -18,6 +18,7 @@
 #include <eventpipe/ep-types.h>
 #include <eventpipe/ep-provider.h>
 #include <eventpipe/ep-session-provider.h>
+#include <eventpipe/ep-string.h>
 
 #include "rhassert.h"
 #include <RhConfig.h>
@@ -1314,49 +1315,6 @@ ep_rt_utf8_string_replace (
     return false;
 }
 
-
-static
-ep_char16_t *
-ep_rt_utf8_to_utf16le_string (
-    const ep_char8_t *str,
-    size_t len)
-{
-    STATIC_CONTRACT_NOTHROW;
-
-    if (!str)
-        return NULL;
-
-    if (len == (size_t) -1) {
-        len = strlen(str);
-    }
-
-    if (len == 0) {
-        // Return an empty string if the length is 0
-        CHAR16_T * lpDestEmptyStr = reinterpret_cast<CHAR16_T *>(malloc(1 * sizeof(CHAR16_T)));
-        if(lpDestEmptyStr==NULL) {
-            return NULL;
-        }
-        *lpDestEmptyStr = '\0';
-        return reinterpret_cast<ep_char16_t*>(lpDestEmptyStr);
-    }
-
-    int32_t flags = MINIPAL_MB_NO_REPLACE_INVALID_CHARS | MINIPAL_TREAT_AS_LITTLE_ENDIAN;
-
-    size_t ret = minipal_get_length_utf8_to_utf16 (str, len, flags);
-
-    if (ret <= 0)
-        return NULL;
-
-    CHAR16_T * lpDestStr = reinterpret_cast<CHAR16_T *>(malloc((ret + 1) * sizeof(CHAR16_T)));
-    if(lpDestStr==NULL) {
-        return NULL;
-    }
-    ret = minipal_convert_utf8_to_utf16 (str, len, lpDestStr, ret, flags);
-    lpDestStr[ret] = '\0';
-
-    return reinterpret_cast<ep_char16_t*>(lpDestStr);
-}
-
 static
 inline
 ep_char16_t *
@@ -1372,6 +1330,13 @@ ep_rt_utf16_string_dup (const ep_char16_t *str)
     if (str_dup)
         memcpy (str_dup, str, str_size);
     return str_dup;
+}
+
+static
+ep_char8_t *
+ep_rt_utf8_string_alloc (size_t len)
+{
+    return reinterpret_cast<ep_char8_t *>(malloc(len));
 }
 
 static
@@ -1397,52 +1362,10 @@ ep_rt_utf16_string_len (const ep_char16_t *str)
 }
 
 static
-ep_char8_t *
-ep_rt_utf16_to_utf8_string (
-    const ep_char16_t *str,
-    size_t len)
+ep_char16_t *
+ep_rt_utf16_string_alloc (size_t len)
 {
-    STATIC_CONTRACT_NOTHROW;
-    if (!str)
-        return NULL;
-
-    if (len == (size_t) -1) {
-        len = ep_rt_utf16_string_len (str);
-    }
-
-    if (len == 0) {
-        // Return an empty string if the length is 0
-        char * lpDestEmptyStr = reinterpret_cast<char *>(malloc(1 * sizeof(char)));
-        if(lpDestEmptyStr==NULL) {
-            return NULL;
-        }
-        *lpDestEmptyStr = '\0';
-        return reinterpret_cast<ep_char8_t*>(lpDestEmptyStr);
-    }
-
-    size_t ret = minipal_get_length_utf16_to_utf8 (reinterpret_cast<const CHAR16_T *>(str), len, 0);
-
-    if (ret <= 0)
-        return NULL;
-
-    char* lpDestStr = reinterpret_cast<char *>(malloc((ret + 1) * sizeof(char)));
-    if(lpDestStr==NULL) {
-        return NULL;
-    }
-    ret = minipal_convert_utf16_to_utf8 (reinterpret_cast<const CHAR16_T*>(str), len, lpDestStr, ret, 0);
-    lpDestStr[ret] = '\0';
-
-    return reinterpret_cast<ep_char8_t*>(lpDestStr);
-}
-
-static
-inline
-ep_char8_t *
-ep_rt_utf16le_to_utf8_string (
-    const ep_char16_t *str,
-    size_t len)
-{
-    return ep_rt_utf16_to_utf8_string (str, len);
+    return reinterpret_cast<ep_char16_t *>(malloc(len * sizeof(ep_char16_t)));
 }
 
 static

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
@@ -1211,24 +1211,6 @@ ep_rt_utf8_string_compare_ignore_case (
 
 static
 inline
-bool
-ep_rt_utf8_string_is_null_or_empty (const ep_char8_t *str)
-{
-    STATIC_CONTRACT_NOTHROW;
-
-    if (str == NULL)
-        return true;
-
-    while (*str) {
-        if (!isspace (*str))
-            return false;
-        str++;
-    }
-    return true;
-}
-
-static
-inline
 ep_char8_t *
 ep_rt_utf8_string_dup (const ep_char8_t *str)
 {

--- a/src/coreclr/nativeaot/Runtime/eventpipeadapter.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipeadapter.h
@@ -24,7 +24,7 @@ class EventPipeAdapter final
 public:
     static inline EventPipeProvider * CreateProvider(const WCHAR* providerName, EventPipeCallback callback, void* pCallbackContext = nullptr)
     {
-        ep_char8_t *providerNameUTF8 = ep_rt_utf16_to_utf8_string(reinterpret_cast<const ep_char16_t *>(providerName), -1);
+        ep_char8_t *providerNameUTF8 = ep_rt_utf16_to_utf8_string(reinterpret_cast<const ep_char16_t *>(providerName));
         EventPipeProvider * provider = ep_create_provider (providerNameUTF8, callback, pCallbackContext);
         ep_rt_utf8_string_free (providerNameUTF8);
         return provider;

--- a/src/coreclr/nativeaot/Runtime/eventpipeinternal.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventpipeinternal.cpp
@@ -59,16 +59,16 @@ EXTERN_C NATIVEAOT_API uint64_t __cdecl RhEventPipeInternal_Enable(
         for (uint32_t i = 0; i < numProviders; ++i) {
             ep_provider_config_init (
                 &configProviders[i],
-                ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(nativeProviders[i].pProviderName), -1),
+                ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(nativeProviders[i].pProviderName)),
                 nativeProviders[i].keywords,
                 static_cast<EventPipeEventLevel>(nativeProviders[i].loggingLevel),
-                ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(nativeProviders[i].pFilterData), -1));
+                ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(nativeProviders[i].pFilterData)));
         }
     }
 
     ep_char8_t *outputPathUTF8 = NULL;
     if (outputFile)
-        outputPathUTF8 = ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(outputFile), -1);
+        outputPathUTF8 = ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(outputFile));
     EventPipeSessionID result = ep_enable (
         outputPathUTF8,
         circularBufferSizeInMB,
@@ -133,7 +133,7 @@ EXTERN_C NATIVEAOT_API intptr_t __cdecl RhEventPipeInternal_GetProvider(const WC
     EventPipeProvider * provider = NULL;
     if (providerName)
     {
-        ep_char8_t *providerNameUTF8 = ep_rt_utf16_to_utf8_string(reinterpret_cast<const ep_char16_t *>(providerName), -1);
+        ep_char8_t *providerNameUTF8 = ep_rt_utf16_to_utf8_string(reinterpret_cast<const ep_char16_t *>(providerName));
         provider = ep_get_provider (providerNameUTF8);
         ep_rt_utf8_string_free(providerNameUTF8);
     }

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -166,7 +166,7 @@ ds_rt_config_value_get_ports (void)
 	STATIC_CONTRACT_NOTHROW;
 
 	CLRConfigStringHolder value(CLRConfig::GetConfigValue (CLRConfig::EXTERNAL_DOTNET_DiagnosticPorts));
-	return ep_rt_utf16_to_utf8_string (reinterpret_cast<ep_char16_t *>(value.GetValue ()), -1);
+	return ep_rt_utf16_to_utf8_string (reinterpret_cast<ep_char16_t *>(value.GetValue ()));
 }
 
 static

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -508,7 +508,7 @@ ep_rt_config_value_get_config (void)
 {
 	STATIC_CONTRACT_NOTHROW;
 	CLRConfigStringHolder value(CLRConfig::GetConfigValue (CLRConfig::INTERNAL_EventPipeConfig));
-	return ep_rt_utf16_to_utf8_string (reinterpret_cast<ep_char16_t *>(value.GetValue ()), -1);
+	return ep_rt_utf16_to_utf8_string (reinterpret_cast<ep_char16_t *>(value.GetValue ()));
 }
 
 static
@@ -518,7 +518,7 @@ ep_rt_config_value_get_output_path (void)
 {
 	STATIC_CONTRACT_NOTHROW;
 	CLRConfigStringHolder value(CLRConfig::GetConfigValue (CLRConfig::INTERNAL_EventPipeOutputPath));
-	return ep_rt_utf16_to_utf8_string (reinterpret_cast<ep_char16_t *>(value.GetValue ()), -1);
+	return ep_rt_utf16_to_utf8_string (reinterpret_cast<ep_char16_t *>(value.GetValue ()));
 }
 
 static
@@ -1048,7 +1048,7 @@ ep_rt_file_open_write (const ep_char8_t *path)
 {
 	STATIC_CONTRACT_NOTHROW;
 
-	ep_char16_t *path_utf16 = ep_rt_utf8_to_utf16le_string (path, -1);
+	ep_char16_t *path_utf16 = ep_rt_utf8_to_utf16le_string (path);
 	ep_return_null_if_nok (path_utf16 != NULL);
 
 	CFileStream *file_stream = new (nothrow) CFileStream ();
@@ -1506,7 +1506,7 @@ ep_rt_diagnostics_command_line_get (void)
 	extern ep_char8_t *volatile _ep_rt_coreclr_diagnostics_cmd_line;
 
 	ep_char8_t *old_cmd_line = _ep_rt_coreclr_diagnostics_cmd_line;
-	ep_char8_t *new_cmd_line = ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(GetCommandLineForDiagnostics ()), -1);
+	ep_char8_t *new_cmd_line = ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(GetCommandLineForDiagnostics ()));
 	if (old_cmd_line && ep_rt_utf8_string_compare (old_cmd_line, new_cmd_line) == 0) {
 		// same as old, so free the new one
 		ep_rt_utf8_string_free (new_cmd_line);

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1335,24 +1335,6 @@ ep_rt_utf8_string_compare_ignore_case (
 
 static
 inline
-bool
-ep_rt_utf8_string_is_null_or_empty (const ep_char8_t *str)
-{
-	STATIC_CONTRACT_NOTHROW;
-
-	if (str == NULL)
-		return true;
-
-	while (*str) {
-		if (!isspace (*str))
-			return false;
-		str++;
-	}
-	return true;
-}
-
-static
-inline
 ep_char8_t *
 ep_rt_utf8_string_dup (const ep_char8_t *str)
 {

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -12,6 +12,7 @@
 #include <eventpipe/ep-types.h>
 #include <eventpipe/ep-provider.h>
 #include <eventpipe/ep-session-provider.h>
+#include <eventpipe/ep-string.h>
 #include "fstream.h"
 #include "typestring.h"
 #include "clrversion.h"
@@ -1431,38 +1432,6 @@ ep_rt_utf8_string_replace (
 }
 
 static
-ep_char16_t *
-ep_rt_utf8_to_utf16le_string (
-	const ep_char8_t *str,
-	size_t len)
-{
-	STATIC_CONTRACT_NOTHROW;
-
-	if (!str)
-		return NULL;
-
-	COUNT_T len_utf16 = WszMultiByteToWideChar (CP_UTF8, 0, str, static_cast<int>(len), 0, 0);
-	if (len_utf16 == 0)
-		return NULL;
-
-	if (static_cast<int>(len) != -1)
-		len_utf16 += 1;
-
-	ep_char16_t *str_utf16 = reinterpret_cast<ep_char16_t *>(malloc (len_utf16 * sizeof (ep_char16_t)));
-	if (!str_utf16)
-		return NULL;
-
-	len_utf16 = WszMultiByteToWideChar (CP_UTF8, 0, str, static_cast<int>(len), reinterpret_cast<LPWSTR>(str_utf16), len_utf16);
-	if (len_utf16 == 0) {
-		free (str_utf16);
-		return NULL;
-	}
-
-	str_utf16 [len_utf16 - 1] = 0;
-	return str_utf16;
-}
-
-static
 inline
 ep_char16_t *
 ep_rt_utf16_string_dup (const ep_char16_t *str)
@@ -1477,6 +1446,13 @@ ep_rt_utf16_string_dup (const ep_char16_t *str)
 	if (str_dup)
 		memcpy (str_dup, str, str_size);
 	return str_dup;
+}
+
+static
+ep_char8_t *
+ep_rt_utf8_string_alloc (size_t len)
+{
+	return reinterpret_cast<ep_char8_t *>(malloc(len));
 }
 
 static
@@ -1502,45 +1478,10 @@ ep_rt_utf16_string_len (const ep_char16_t *str)
 }
 
 static
-ep_char8_t *
-ep_rt_utf16_to_utf8_string (
-	const ep_char16_t *str,
-	size_t len)
+ep_char16_t *
+ep_rt_utf16_string_alloc (size_t len)
 {
-	STATIC_CONTRACT_NOTHROW;
-
-	if (!str)
-		return NULL;
-
-	COUNT_T size_utf8 = WszWideCharToMultiByte (CP_UTF8, 0, reinterpret_cast<LPCWSTR>(str), static_cast<int>(len), NULL, 0, NULL, NULL);
-	if (size_utf8 == 0)
-		return NULL;
-
-	if (static_cast<int>(len) != -1)
-		size_utf8 += 1;
-
-	ep_char8_t *str_utf8 = reinterpret_cast<ep_char8_t *>(malloc (size_utf8));
-	if (!str_utf8)
-		return NULL;
-
-	size_utf8 = WszWideCharToMultiByte (CP_UTF8, 0, reinterpret_cast<LPCWSTR>(str), static_cast<int>(len), reinterpret_cast<LPSTR>(str_utf8), size_utf8, NULL, NULL);
-	if (size_utf8 == 0) {
-		free (str_utf8);
-		return NULL;
-	}
-
-	str_utf8 [size_utf8 - 1] = 0;
-	return str_utf8;
-}
-
-static
-inline
-ep_char8_t *
-ep_rt_utf16le_to_utf8_string (
-	const ep_char16_t *str,
-	size_t len)
-{
-	return ep_rt_utf16_to_utf8_string (str, len);
+	return reinterpret_cast<ep_char16_t *>(malloc(len * sizeof(ep_char16_t)));
 }
 
 static

--- a/src/coreclr/vm/eventpipeadapter.h
+++ b/src/coreclr/vm/eventpipeadapter.h
@@ -42,10 +42,10 @@ public:
 			for (uint32_t i = 0; i < providerConfigsLen; ++i) {
 				ep_provider_config_init (
 					&m_providerConfigs[i],
-					ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(providerConfigs[i].providerName), -1),
+					ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(providerConfigs[i].providerName)),
 					providerConfigs[i].keywords,
 					static_cast<EventPipeEventLevel>(providerConfigs[i].loggingLevel),
-					ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(providerConfigs[i].filterData), -1));
+					ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(providerConfigs[i].filterData)));
 			}
 		}
 	}
@@ -213,7 +213,7 @@ public:
 
 		ep_char8_t *outputPathUTF8 = NULL;
 		if (outputPath)
-			outputPathUTF8 = ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(outputPath), -1);
+			outputPathUTF8 = ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(outputPath));
 		EventPipeSessionID result = ep_enable (
 			outputPathUTF8,
 			circularBufferSizeInMB,
@@ -328,7 +328,7 @@ public:
 		}
 		CONTRACTL_END;
 
-		ep_char8_t *providerNameUTF8 = ep_rt_utf16_to_utf8_string(reinterpret_cast<const ep_char16_t *>(providerName.GetUnicode ()), -1);
+		ep_char8_t *providerNameUTF8 = ep_rt_utf16_to_utf8_string(reinterpret_cast<const ep_char16_t *>(providerName.GetUnicode ()));
 		EventPipeProvider * provider = ep_create_provider (providerNameUTF8, callback, callbackContext);
 		ep_rt_utf8_string_free (providerNameUTF8);
 		return provider;
@@ -360,7 +360,7 @@ public:
 		if (!providerName)
 			return NULL;
 
-		ep_char8_t *providerNameUTF8 = ep_rt_utf16_to_utf8_string(reinterpret_cast<const ep_char16_t *>(providerName), -1);
+		ep_char8_t *providerNameUTF8 = ep_rt_utf16_to_utf8_string(reinterpret_cast<const ep_char16_t *>(providerName));
 		EventPipeProvider * provider = ep_get_provider (providerNameUTF8);
 		ep_rt_utf8_string_free(providerNameUTF8);
 		return provider;

--- a/src/mono/mono/eventpipe/ds-rt-mono.h
+++ b/src/mono/mono/eventpipe/ds-rt-mono.h
@@ -214,8 +214,8 @@ static
 uint32_t
 ds_rt_set_environment_variable (const ep_char16_t *name, const ep_char16_t *value)
 {
-	gchar *nameNarrow = ep_rt_utf16le_to_utf8_string (name, -1);
-	gchar *valueNarrow = ep_rt_utf16le_to_utf8_string (value, -1);
+	gchar *nameNarrow = ep_rt_utf16le_to_utf8_string (name);
+	gchar *valueNarrow = ep_rt_utf16le_to_utf8_string (value);
 
 	gboolean success = g_setenv(nameNarrow, valueNarrow, true);
 

--- a/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
@@ -2372,7 +2372,7 @@ write_event_exception_thrown (MonoObject *obj)
 			if (exception->inner_ex)
 				flags |= EXCEPTION_THROWN_FLAGS_HAS_INNER;
 			if (exception->message)
-				exception_message = ep_rt_utf16_to_utf8_string (mono_string_chars_internal (exception->message), mono_string_length_internal (exception->message));
+				exception_message = ep_rt_utf16_to_utf8_string_n (mono_string_chars_internal (exception->message), mono_string_length_internal (exception->message));
 			hresult = exception->hresult;
 		}
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -105,7 +105,7 @@ ep_rt_mono_file_open_write (const ep_char8_t *path)
 	if (!path)
 		return INVALID_HANDLE_VALUE;
 
-	ep_char16_t *path_utf16 = ep_rt_utf8_to_utf16le_string (path, -1);
+	ep_char16_t *path_utf16 = ep_rt_utf8_to_utf16le_string (path);
 
 	if (!path_utf16)
 		return INVALID_HANDLE_VALUE;
@@ -600,7 +600,7 @@ ep_rt_mono_os_environment_get_utf16 (dn_vector_ptr_t *os_env)
 #else
 	gchar **next = NULL;
 	for (next = environ; *next != NULL; ++next)
-		dn_vector_ptr_push_back (os_env, ep_rt_utf8_to_utf16le_string (*next, -1));
+		dn_vector_ptr_push_back (os_env, ep_rt_utf8_to_utf16le_string (*next));
 #endif
 }
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -10,6 +10,7 @@
 #include <eventpipe/ep-types.h>
 #include <eventpipe/ep-provider.h>
 #include <eventpipe/ep-session-provider.h>
+#include <eventpipe/ep-string.h>
 
 #include <glib.h>
 #include <mono/utils/checked-build.h>
@@ -1384,16 +1385,6 @@ ep_rt_utf8_string_replace (
 static
 inline
 ep_char16_t *
-ep_rt_utf8_to_utf16le_string (
-	const ep_char8_t *str,
-	size_t len)
-{
-	return (ep_char16_t *)(g_utf8_to_utf16le ((const gchar *)str, (glong)len, NULL, NULL, NULL));
-}
-
-static
-inline
-ep_char16_t *
 ep_rt_utf16_string_dup (const ep_char16_t *str)
 {
 	size_t str_size = (ep_rt_utf16_string_len (str) + 1) * sizeof (ep_char16_t);
@@ -1401,6 +1392,13 @@ ep_rt_utf16_string_dup (const ep_char16_t *str)
 	if (str_dup)
 		memcpy (str_dup, str, str_size);
 	return str_dup;
+}
+
+static
+ep_char8_t *
+ep_rt_utf8_string_alloc (size_t len)
+{
+	return g_new(ep_char8_t, len);
 }
 
 static
@@ -1420,23 +1418,10 @@ ep_rt_utf16_string_len (const ep_char16_t *str)
 }
 
 static
-inline
-ep_char8_t *
-ep_rt_utf16_to_utf8_string (
-	const ep_char16_t *str,
-	size_t len)
+ep_char16_t *
+ep_rt_utf16_string_alloc (size_t len)
 {
-	return g_utf16_to_utf8 ((const gunichar2 *)str, (glong)len, NULL, NULL, NULL);
-}
-
-static
-inline
-ep_char8_t *
-ep_rt_utf16le_to_utf8_string (
-	const ep_char16_t *str,
-	size_t len)
-{
-	return g_utf16le_to_utf8 ((const gunichar2 *)str, (glong)len, NULL, NULL, NULL);
+	return g_new(ep_char16_t, len);
 }
 
 static

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1295,22 +1295,6 @@ ep_rt_utf8_string_compare_ignore_case (
 
 static
 inline
-bool
-ep_rt_utf8_string_is_null_or_empty (const ep_char8_t *str)
-{
-	if (str == NULL)
-		return true;
-
-	while (*str) {
-		if (!isspace(*str))
-			return false;
-		str++;
-	}
-	return true;
-}
-
-static
-inline
 ep_char8_t *
 ep_rt_utf8_string_dup (const ep_char8_t *str)
 {

--- a/src/native/eventpipe/ds-dump-protocol.c
+++ b/src/native/eventpipe/ds-dump-protocol.c
@@ -106,7 +106,7 @@ dump_protocol_generate_core_dump_response_init(
 
 	payload->error = error;
 	// If this conversion failures it will set error_message to NULL which will send an empty message
-	payload->error_message = ep_rt_utf8_to_utf16le_string (errorText, -1);
+	payload->error_message = ep_rt_utf8_to_utf16le_string (errorText);
 }
 
 static

--- a/src/native/eventpipe/ds-eventpipe-protocol.c
+++ b/src/native/eventpipe/ds-eventpipe-protocol.c
@@ -187,7 +187,7 @@ eventpipe_collect_tracing_command_try_parse_config (
 		uint32_t provider_name_byte_array_len = 0;
 		ep_raise_error_if_nok (ds_ipc_message_try_parse_string_utf16_t_byte_array_alloc (buffer, buffer_len, &provider_name_byte_array, &provider_name_byte_array_len));
 
-		provider_name_utf8 = ep_rt_utf16le_to_utf8_string ((const ep_char16_t *)provider_name_byte_array, -1);
+		provider_name_utf8 = ep_rt_utf16le_to_utf8_string ((const ep_char16_t *)provider_name_byte_array);
 		ep_raise_error_if_nok (provider_name_utf8 != NULL);
 
 		ep_raise_error_if_nok (!ep_rt_utf8_string_is_null_or_empty (provider_name_utf8));
@@ -200,7 +200,7 @@ eventpipe_collect_tracing_command_try_parse_config (
 
 		// This parameter is optional.
 		if (filter_data_byte_array) {
-			filter_data_utf8 = ep_rt_utf16le_to_utf8_string ((const ep_char16_t *)filter_data_byte_array, -1);
+			filter_data_utf8 = ep_rt_utf16le_to_utf8_string ((const ep_char16_t *)filter_data_byte_array);
 			ep_raise_error_if_nok (filter_data_utf8 != NULL);
 
 			ep_rt_byte_array_free (filter_data_byte_array);

--- a/src/native/eventpipe/ds-process-protocol.c
+++ b/src/native/eventpipe/ds-process-protocol.c
@@ -667,13 +667,13 @@ process_protocol_helper_get_process_info (
 	DiagnosticsProcessInfoPayload payload;
 	DiagnosticsProcessInfoPayload *process_info_payload = NULL;
 
-	command_line = ep_rt_utf8_to_utf16le_string (ep_rt_diagnostics_command_line_get (), -1);
+	command_line = ep_rt_utf8_to_utf16le_string (ep_rt_diagnostics_command_line_get ());
 	ep_raise_error_if_nok (command_line != NULL);
 
-	os_info = ep_rt_utf8_to_utf16le_string (ep_event_source_get_os_info (), -1);
+	os_info = ep_rt_utf8_to_utf16le_string (ep_event_source_get_os_info ());
 	ep_raise_error_if_nok (os_info != NULL);
 
-	arch_info = ep_rt_utf8_to_utf16le_string (ep_event_source_get_arch_info (), -1);
+	arch_info = ep_rt_utf8_to_utf16le_string (ep_event_source_get_arch_info ());
 	ep_raise_error_if_nok (arch_info != NULL);
 
 	process_info_payload = ds_process_info_payload_init (
@@ -729,19 +729,19 @@ process_protocol_helper_get_process_info_2 (
 	DiagnosticsProcessInfo2Payload payload;
 	DiagnosticsProcessInfo2Payload *process_info_2_payload = NULL;
 
-	command_line = ep_rt_utf8_to_utf16le_string (ep_rt_diagnostics_command_line_get (), -1);
+	command_line = ep_rt_utf8_to_utf16le_string (ep_rt_diagnostics_command_line_get ());
 	ep_raise_error_if_nok (command_line != NULL);
 
-	os_info = ep_rt_utf8_to_utf16le_string (ep_event_source_get_os_info (), -1);
+	os_info = ep_rt_utf8_to_utf16le_string (ep_event_source_get_os_info ());
 	ep_raise_error_if_nok (os_info != NULL);
 
-	arch_info = ep_rt_utf8_to_utf16le_string (ep_event_source_get_arch_info (), -1);
+	arch_info = ep_rt_utf8_to_utf16le_string (ep_event_source_get_arch_info ());
 	ep_raise_error_if_nok (arch_info != NULL);
 
-	managed_entrypoint_assembly_name = ep_rt_utf8_to_utf16le_string (ep_rt_entrypoint_assembly_name_get_utf8 (), -1);
+	managed_entrypoint_assembly_name = ep_rt_utf8_to_utf16le_string (ep_rt_entrypoint_assembly_name_get_utf8 ());
 	ep_raise_error_if_nok (managed_entrypoint_assembly_name != NULL);
 
-	clr_product_version = ep_rt_utf8_to_utf16le_string (ep_rt_runtime_version_get_utf8 (), -1);
+	clr_product_version = ep_rt_utf8_to_utf16le_string (ep_rt_runtime_version_get_utf8 ());
 	ep_raise_error_if_nok (clr_product_version != NULL);
 
 	process_info_2_payload = ds_process_info_2_payload_init (
@@ -802,22 +802,22 @@ process_protocol_helper_get_process_info_3 (
 	DiagnosticsProcessInfo3Payload payload;
 	DiagnosticsProcessInfo3Payload *process_info_3_payload = NULL;
 
-	command_line = ep_rt_utf8_to_utf16le_string (ep_rt_diagnostics_command_line_get (), -1);
+	command_line = ep_rt_utf8_to_utf16le_string (ep_rt_diagnostics_command_line_get ());
 	ep_raise_error_if_nok (command_line != NULL);
 
-	os_info = ep_rt_utf8_to_utf16le_string (ep_event_source_get_os_info (), -1);
+	os_info = ep_rt_utf8_to_utf16le_string (ep_event_source_get_os_info ());
 	ep_raise_error_if_nok (os_info != NULL);
 
-	arch_info = ep_rt_utf8_to_utf16le_string (ep_event_source_get_arch_info (), -1);
+	arch_info = ep_rt_utf8_to_utf16le_string (ep_event_source_get_arch_info ());
 	ep_raise_error_if_nok (arch_info != NULL);
 
-	managed_entrypoint_assembly_name = ep_rt_utf8_to_utf16le_string (ep_rt_entrypoint_assembly_name_get_utf8 (), -1);
+	managed_entrypoint_assembly_name = ep_rt_utf8_to_utf16le_string (ep_rt_entrypoint_assembly_name_get_utf8 ());
 	ep_raise_error_if_nok (managed_entrypoint_assembly_name != NULL);
 
-	clr_product_version = ep_rt_utf8_to_utf16le_string (ep_rt_runtime_version_get_utf8 (), -1);
+	clr_product_version = ep_rt_utf8_to_utf16le_string (ep_rt_runtime_version_get_utf8 ());
 	ep_raise_error_if_nok (clr_product_version != NULL);
 
-	portable_rid = ep_rt_utf8_to_utf16le_string (ds_rt_get_portable_rid (), -1);
+	portable_rid = ep_rt_utf8_to_utf16le_string (ds_rt_get_portable_rid ());
 	ep_raise_error_if_nok (portable_rid != NULL);
 
 	process_info_3_payload = ds_process_info_3_payload_init (

--- a/src/native/eventpipe/ep-event-source.c
+++ b/src/native/eventpipe/ep-event-source.c
@@ -110,19 +110,19 @@ ep_event_source_init (EventPipeEventSource *event_source)
 	uint32_t params_len;
 	params_len = (uint32_t)ARRAY_SIZE (params);
 
-	command_line_arg_utf16 = ep_rt_utf8_to_utf16le_string ("CommandLine", -1);
+	command_line_arg_utf16 = ep_rt_utf8_to_utf16le_string ("CommandLine");
 	ep_raise_error_if_nok (command_line_arg_utf16 != NULL);
 	ep_parameter_desc_init (&params[0], EP_PARAMETER_TYPE_STRING, command_line_arg_utf16);
 
-	os_info_arg_utf16 = ep_rt_utf8_to_utf16le_string ("OSInformation", -1);
+	os_info_arg_utf16 = ep_rt_utf8_to_utf16le_string ("OSInformation");
 	ep_raise_error_if_nok (os_info_arg_utf16 != NULL);
 	ep_parameter_desc_init (&params[1], EP_PARAMETER_TYPE_STRING, os_info_arg_utf16);
 
-	arch_info_arg_utf16 = ep_rt_utf8_to_utf16le_string ("ArchInformation", -1);
+	arch_info_arg_utf16 = ep_rt_utf8_to_utf16le_string ("ArchInformation");
 	ep_raise_error_if_nok (arch_info_arg_utf16 != NULL);
 	ep_parameter_desc_init (&params[2], EP_PARAMETER_TYPE_STRING, arch_info_arg_utf16);
 
-	event_name_utf16 = ep_rt_utf8_to_utf16le_string ("ProcessInfo", -1);
+	event_name_utf16 = ep_rt_utf8_to_utf16le_string ("ProcessInfo");
 	ep_raise_error_if_nok (event_name_utf16 != NULL);
 
 	size_t metadata_len;
@@ -217,9 +217,9 @@ ep_event_source_send_process_info (
 	ep_char16_t *os_info_utf16 = NULL;
 	ep_char16_t *arch_info_utf16 = NULL;
 
-	command_line_utf16 = ep_rt_utf8_to_utf16le_string (command_line, -1);
-	os_info_utf16 = ep_rt_utf8_to_utf16le_string (ep_event_source_get_os_info (), -1);
-	arch_info_utf16 = ep_rt_utf8_to_utf16le_string (ep_event_source_get_arch_info (), -1);
+	command_line_utf16 = ep_rt_utf8_to_utf16le_string (command_line);
+	os_info_utf16 = ep_rt_utf8_to_utf16le_string (ep_event_source_get_os_info ());
+	arch_info_utf16 = ep_rt_utf8_to_utf16le_string (ep_event_source_get_arch_info ());
 
 	EventData data [3] = { { 0 } };
 	if (command_line_utf16)

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -187,7 +187,7 @@ ep_provider_alloc (
 	instance->provider_name = ep_rt_utf8_string_dup (provider_name);
 	ep_raise_error_if_nok (instance->provider_name != NULL);
 
-	instance->provider_name_utf16 = ep_rt_utf8_to_utf16le_string (provider_name, -1);
+	instance->provider_name_utf16 = ep_rt_utf8_to_utf16le_string (provider_name);
 	ep_raise_error_if_nok (instance->provider_name_utf16 != NULL);
 
 	instance->event_list = dn_list_alloc ();

--- a/src/native/eventpipe/ep-rt.h
+++ b/src/native/eventpipe/ep-rt.h
@@ -518,13 +518,11 @@ ep_rt_utf8_string_replace (
 
 static
 ep_char16_t *
-ep_rt_utf8_to_utf16le_string (
-	const ep_char8_t *str,
-	size_t len);
+ep_rt_utf16_string_dup (const ep_char16_t *str);
 
 static
-ep_char16_t *
-ep_rt_utf16_string_dup (const ep_char16_t *str);
+ep_char8_t *
+ep_rt_utf8_string_alloc (size_t len);
 
 static
 void
@@ -535,16 +533,8 @@ size_t
 ep_rt_utf16_string_len (const ep_char16_t *str);
 
 static
-ep_char8_t *
-ep_rt_utf16_to_utf8_string (
-	const ep_char16_t *str,
-	size_t len);
-
-static
-ep_char8_t *
-ep_rt_utf16le_to_utf8_string (
-	const ep_char16_t *str,
-	size_t len);
+ep_char16_t *
+ep_rt_utf16_string_alloc (size_t len);
 
 static
 void

--- a/src/native/eventpipe/ep-rt.h
+++ b/src/native/eventpipe/ep-rt.h
@@ -485,10 +485,6 @@ ep_rt_utf8_string_compare_ignore_case (
 	const ep_char8_t *str2);
 
 static
-bool
-ep_rt_utf8_string_is_null_or_empty (const ep_char8_t *str);
-
-static
 ep_char8_t *
 ep_rt_utf8_string_dup (const ep_char8_t *str);
 

--- a/src/native/eventpipe/ep-sources.c
+++ b/src/native/eventpipe/ep-sources.c
@@ -25,6 +25,7 @@
 #include "ep-session-provider.c"
 #include "ep-stack-contents.c"
 #include "ep-stream.c"
+#include "ep-string.c"
 #include "ep-thread.c"
 #endif
 

--- a/src/native/eventpipe/ep-string.c
+++ b/src/native/eventpipe/ep-string.c
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "ep-rt-config.h"
+
+#ifdef ENABLE_PERFTRACING
+#if !defined(EP_INCLUDE_SOURCE_FILES) || defined(EP_FORCE_INCLUDE_SOURCE_FILES)
+
+#include "ep-rt.h"
+#include <minipal/utf8.h>
+
+ep_char16_t *
+ep_rt_utf8_to_utf16le_string (
+	const ep_char8_t *str,
+	size_t len)
+{
+	if (!str)
+		return NULL;
+
+	if (len == (size_t) -1)
+		len = strlen(str);
+
+	if (len == 0) {
+		// Return an empty string if the length is 0
+		ep_char16_t * empty_str = ep_rt_utf16_string_alloc(1);
+		if(empty_str == NULL)
+			return NULL;
+
+		*empty_str = '\0';
+		return empty_str;
+	}
+
+	int32_t flags = MINIPAL_MB_NO_REPLACE_INVALID_CHARS | MINIPAL_TREAT_AS_LITTLE_ENDIAN;
+	size_t ret = minipal_get_length_utf8_to_utf16 (str, len, flags);
+	if (ret <= 0)
+		return NULL;
+
+	ep_char16_t * converted_str = ep_rt_utf16_string_alloc(ret + 1);
+	if (converted_str == NULL)
+		return NULL;
+
+	ret = minipal_convert_utf8_to_utf16 (str, len, (CHAR16_T *)converted_str, ret, flags);
+	converted_str[ret] = '\0';
+	return converted_str;
+}
+
+static
+ep_char8_t *
+ep_utf16_to_utf8_string_impl (
+	const ep_char16_t *str,
+	size_t len,
+	bool treat_as_le)
+{
+	if (!str)
+		return NULL;
+
+	if (len == (size_t) -1)
+		len = ep_rt_utf16_string_len (str);
+
+	if (len == 0) {
+		// Return an empty string if the length is 0
+		ep_char8_t * empty_str = ep_rt_utf8_string_alloc(1);
+		if (empty_str == NULL)
+			return NULL;
+
+		*empty_str = '\0';
+		return empty_str;
+	}
+
+	int32_t flags = treat_as_le ? MINIPAL_TREAT_AS_LITTLE_ENDIAN : 0;
+	size_t ret = minipal_get_length_utf16_to_utf8 ((const CHAR16_T *)str, len, flags);
+	if (ret <= 0)
+		return NULL;
+
+	ep_char8_t * converted_str = ep_rt_utf8_string_alloc(ret + 1);
+	if (converted_str == NULL)
+		return NULL;
+
+	ret = minipal_convert_utf16_to_utf8 ((const CHAR16_T *)str, len, converted_str, ret, flags);
+	converted_str[ret] = '\0';
+	return converted_str;
+}
+
+ep_char8_t *
+ep_rt_utf16_to_utf8_string (
+	const ep_char16_t *str,
+	size_t len)
+{
+	return ep_utf16_to_utf8_string_impl(str, len, /*treat_as_le*/ false);
+}
+
+ep_char8_t *
+ep_rt_utf16le_to_utf8_string (
+	const ep_char16_t *str,
+	size_t len)
+{
+	return ep_utf16_to_utf8_string_impl(str, len, /*treat_as_le*/ true);
+}
+
+#endif /* !defined(EP_INCLUDE_SOURCE_FILES) || defined(EP_FORCE_INCLUDE_SOURCE_FILES) */
+#endif /* ENABLE_PERFTRACING */
+
+#if !defined(ENABLE_PERFTRACING) || (defined(EP_INCLUDE_SOURCE_FILES) && !defined(EP_FORCE_INCLUDE_SOURCE_FILES))
+extern const char quiet_linker_empty_file_warning_eventpipe_string;
+const char quiet_linker_empty_file_warning_eventpipe_string = 0;
+#endif

--- a/src/native/eventpipe/ep-string.c
+++ b/src/native/eventpipe/ep-string.c
@@ -9,17 +9,12 @@
 #include "ep-rt.h"
 #include <minipal/utf8.h>
 
+static
 ep_char16_t *
-ep_rt_utf8_to_utf16le_string (
+ep_utf8_to_utf16le_string_impl (
 	const ep_char8_t *str,
 	size_t len)
 {
-	if (!str)
-		return NULL;
-
-	if (len == (size_t) -1)
-		len = strlen(str);
-
 	if (len == 0) {
 		// Return an empty string if the length is 0
 		ep_char16_t * empty_str = ep_rt_utf16_string_alloc(1);
@@ -44,6 +39,27 @@ ep_rt_utf8_to_utf16le_string (
 	return converted_str;
 }
 
+ep_char16_t *
+ep_rt_utf8_to_utf16le_string (
+	const ep_char8_t *str)
+{
+	if (!str)
+		return NULL;
+
+	return ep_utf8_to_utf16le_string_impl (str, strlen(str));
+}
+
+ep_char16_t *
+ep_rt_utf8_to_utf16le_string_n (
+	const ep_char8_t *str,
+	size_t len)
+{
+	if (!str)
+		return NULL;
+
+	return ep_utf8_to_utf16le_string_impl (str, len);
+}
+
 static
 ep_char8_t *
 ep_utf16_to_utf8_string_impl (
@@ -51,12 +67,6 @@ ep_utf16_to_utf8_string_impl (
 	size_t len,
 	bool treat_as_le)
 {
-	if (!str)
-		return NULL;
-
-	if (len == (size_t) -1)
-		len = ep_rt_utf16_string_len (str);
-
 	if (len == 0) {
 		// Return an empty string if the length is 0
 		ep_char8_t * empty_str = ep_rt_utf8_string_alloc(1);
@@ -83,17 +93,43 @@ ep_utf16_to_utf8_string_impl (
 
 ep_char8_t *
 ep_rt_utf16_to_utf8_string (
+	const ep_char16_t *str)
+{
+	if (!str)
+		return NULL;
+
+	return ep_utf16_to_utf8_string_impl(str, ep_rt_utf16_string_len (str), /*treat_as_le*/ false);
+}
+
+ep_char8_t *
+ep_rt_utf16_to_utf8_string_n (
 	const ep_char16_t *str,
 	size_t len)
 {
+	if (!str)
+		return NULL;
+
 	return ep_utf16_to_utf8_string_impl(str, len, /*treat_as_le*/ false);
 }
 
 ep_char8_t *
 ep_rt_utf16le_to_utf8_string (
+	const ep_char16_t *str)
+{
+	if (!str)
+		return NULL;
+
+	return ep_utf16_to_utf8_string_impl(str, ep_rt_utf16_string_len (str), /*treat_as_le*/ true);
+}
+
+ep_char8_t *
+ep_rt_utf16le_to_utf8_string_n (
 	const ep_char16_t *str,
 	size_t len)
 {
+	if (!str)
+		return NULL;
+
 	return ep_utf16_to_utf8_string_impl(str, len, /*treat_as_le*/ true);
 }
 

--- a/src/native/eventpipe/ep-string.h
+++ b/src/native/eventpipe/ep-string.h
@@ -27,18 +27,36 @@ ep_rt_utf8_string_is_null_or_empty (const ep_char8_t *str)
 	return true;
 }
 
+// Convert a null-terminated string from UTF-8 to UTF-16LE
 ep_char16_t *
 ep_rt_utf8_to_utf16le_string (
+	const ep_char8_t *str);
+
+// Convert the specified number of characters of a string from UTF-8 to UTF-16LE
+ep_char16_t *
+ep_rt_utf8_to_utf16le_string_n (
 	const ep_char8_t *str,
 	size_t len);
 
+// Convert a null-terminated string from UTF-16 to UTF-8
 ep_char8_t *
 ep_rt_utf16_to_utf8_string (
+	const ep_char16_t *str);
+
+// Convert the specified number of characters of a string from UTF-16 to UTF-8
+ep_char8_t *
+ep_rt_utf16_to_utf8_string_n (
 	const ep_char16_t *str,
 	size_t len);
 
+// Convert a null-terminated string from UTF-16LE to UTF-8
 ep_char8_t *
 ep_rt_utf16le_to_utf8_string (
+	const ep_char16_t *str);
+
+// Convert the specified number of characters of a string from UTF-16LE to UTF-8
+ep_char8_t *
+ep_rt_utf16le_to_utf8_string_n (
 	const ep_char16_t *str,
 	size_t len);
 

--- a/src/native/eventpipe/ep-string.h
+++ b/src/native/eventpipe/ep-string.h
@@ -9,6 +9,24 @@
 #ifdef ENABLE_PERFTRACING
 #include "ep-types.h"
 
+#include <ctype.h> // isspace
+
+static
+inline
+bool
+ep_rt_utf8_string_is_null_or_empty (const ep_char8_t *str)
+{
+	if (str == NULL)
+		return true;
+
+	while (*str) {
+		if (!isspace(*str))
+			return false;
+		str++;
+	}
+	return true;
+}
+
 ep_char16_t *
 ep_rt_utf8_to_utf16le_string (
 	const ep_char8_t *str,

--- a/src/native/eventpipe/ep-string.h
+++ b/src/native/eventpipe/ep-string.h
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef EVENTPIPE_STRING_H
+#define EVENTPIPE_STRING_H
+
+#include "ep-rt-config.h"
+
+#ifdef ENABLE_PERFTRACING
+#include "ep-types.h"
+
+ep_char16_t *
+ep_rt_utf8_to_utf16le_string (
+	const ep_char8_t *str,
+	size_t len);
+
+ep_char8_t *
+ep_rt_utf16_to_utf8_string (
+	const ep_char16_t *str,
+	size_t len);
+
+ep_char8_t *
+ep_rt_utf16le_to_utf8_string (
+	const ep_char16_t *str,
+	size_t len);
+
+#endif /* ENABLE_PERFTRACING */
+#endif /* EVENTPIPE_STRING_H */

--- a/src/native/eventpipe/eventpipe.cmake
+++ b/src/native/eventpipe/eventpipe.cmake
@@ -40,6 +40,7 @@ if(ENABLE_PERFTRACING OR FEATURE_PERFTRACING)
         ep-session-provider.c
         ep-stack-contents.c
         ep-stream.c
+        ep-string.c
         ep-thread.c
     )
 
@@ -71,6 +72,7 @@ if(ENABLE_PERFTRACING OR FEATURE_PERFTRACING)
         ep-session-provider.h
         ep-stack-contents.h
         ep-stream.h
+        ep-string.h
         ep-thread.h
         ep-types.h
         ep-types-forward.h


### PR DESCRIPTION
The conversion functions all go through the minipal helpers, so they can be implemented in the shared event pipe instead of separately for each runtime.
- ep_rt_utf8_to_utf16le_string
- ep_rt_utf16_to_utf8_string
- ep_rt_utf16le_to_utf8_string

Also moved ep_rt_utf8_string_is_null_or_empty

There's probably more that can be shared, but starting with these for now.