### PR TITLE
Slightly reduce the Depth3Test that often times out on Linux

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -72,9 +72,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_82535/Runtime_82535/*">
           <Issue>https://github.com/dotnet/runtime/issues/89585</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/readytorun/GenericCycleDetection/Depth3Test/*">
-          <Issue>https://github.com/dotnet/runtime/issues/88586</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets on all runtimes -->

--- a/src/tests/readytorun/GenericCycleDetection/Depth3Test.cs
+++ b/src/tests/readytorun/GenericCycleDetection/Depth3Test.cs
@@ -23,7 +23,6 @@ internal class Program
             if (result < count) result = Depth1<Depth2<T>>.TypeNestedFactorial(count - 1);
             if (result < count) result = Depth1<Depth3<T>>.TypeNestedFactorial(count - 1);
             if (result < count) result = Depth1<Depth4<T>>.TypeNestedFactorial(count - 1);
-            if (result < count) result = Depth1<Depth5<T>>.TypeNestedFactorial(count - 1);
             return count * result;
         }
     }
@@ -31,7 +30,6 @@ internal class Program
     private struct Depth2<T> {}
     private struct Depth3<T> {}
     private struct Depth4<T> {}
-    private struct Depth5<T> {}
     
     [Fact]
     public static int DepthTest()


### PR DESCRIPTION
This is one of the regression tests I introduced as part of implementing protection against infinite generic recursion in Crossgen2. Turns out that on the relatively slow Helix Linux VMs the test often times out due to compilation time exceeding 10 minutes. I propose slightly trimming down the test so that it uses less time in Helix.

Thanks

Tomas

/cc @dotnet/crossgen-contrib, @dotnet/runtime-infrastructure 