### PR TITLE
Fix SuperPMI assertion call in `MethodContext::recGetHelperFtn()`

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/errorhandling.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/errorhandling.h
@@ -34,7 +34,7 @@ void MSC_ONLY(__declspec(noreturn)) ThrowRecordedException(DWORD innerExceptionC
     do                                                                                                                 \
     {                                                                                                                  \
         if (!(expr))                                                                                                   \
-            LogException(exCode, "SuperPMI assertion '%s' failed (" #msg ")", #expr, ##__VA_ARGS__);                   \
+            LogException(exCode, "SuperPMI assertion '%s' failed (" msg ")", #expr, ##__VA_ARGS__);                    \
     } while (0)
 
 #define AssertCode(expr, exCode)                                                                                       \

--- a/src/coreclr/tools/superpmi/superpmi-shared/logging.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/logging.h
@@ -30,7 +30,7 @@
     do                                                                                                                 \
     {                                                                                                                  \
         Logger::LogExceptionMessage(__FUNCTION__, __FILE__, __LINE__, exCode, msg, __VA_ARGS__);                       \
-        ThrowSpmiException(exCode, msg, __VA_ARGS__);                                                                      \
+        ThrowSpmiException(exCode, msg, __VA_ARGS__);                                                                  \
     } while (0)
 
 // These are specified as flags so subsets of the logging functionality can be enabled/disabled at once

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -2364,9 +2364,11 @@ void MethodContext::recGetHelperFtn(CorInfoHelpFunc ftnNum, void** ppIndirection
     {
         DLDL oldValue = GetHelperFtn->Get(key);
 
-        AssertCodeMsg(oldValue.A == value.A && oldValue.B == oldValue.B, EXCEPTIONCODE_MC,
-                      "collision! old: %016" PRIX64 " %016" PRIX64 ", new: %016" PRIX64 " %016" PRIX64 " \n", oldValue.A, oldValue.B, value.A,
-                      value.B);
+        // We can't use string concatenation in an argument to the `AssertCodeMsg` macro, so construct the string here.
+        char assertMsgBuff[200];
+        sprintf_s(assertMsgBuff, sizeof(assertMsgBuff), "old: %016" PRIX64 " %016" PRIX64 ", new: %016" PRIX64 " %016" PRIX64,
+            oldValue.A, oldValue.B, value.A, value.B);
+        AssertCodeMsg(oldValue.A == value.A && oldValue.B == oldValue.B, EXCEPTIONCODE_MC, "collision! %s", assertMsgBuff);
     }
 
     GetHelperFtn->Add(key, value);

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -2364,11 +2364,9 @@ void MethodContext::recGetHelperFtn(CorInfoHelpFunc ftnNum, void** ppIndirection
     {
         DLDL oldValue = GetHelperFtn->Get(key);
 
-        // We can't use string concatenation in an argument to the `AssertCodeMsg` macro, so construct the string here.
-        char assertMsgBuff[200];
-        sprintf_s(assertMsgBuff, sizeof(assertMsgBuff), "old: %016" PRIX64 " %016" PRIX64 ", new: %016" PRIX64 " %016" PRIX64,
-            oldValue.A, oldValue.B, value.A, value.B);
-        AssertCodeMsg(oldValue.A == value.A && oldValue.B == oldValue.B, EXCEPTIONCODE_MC, "collision! %s", assertMsgBuff);
+        AssertCodeMsg(oldValue.A == value.A && oldValue.B == oldValue.B, EXCEPTIONCODE_MC,
+                      "collision! old: %016" PRIX64 " %016" PRIX64 ", new: %016" PRIX64 " %016" PRIX64, oldValue.A, oldValue.B, value.A,
+                      value.B);
     }
 
     GetHelperFtn->Add(key, value);


### PR DESCRIPTION
We can't use string concatenation in an argument to the `AssertCodeMsg` macro, so construct the string we want to print first.