### PR TITLE
[FileSystemWatcher] Linux - Null out 'watcher' variable when continuing to process events to prevent strong reference

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -596,6 +596,7 @@ namespace System.IO
                                 // like IN_IGNORED.  In any case, just ignore it... even if for some reason we
                                 // should have the value, there's little we can do about it at this point,
                                 // and there's no more processing of this event we can do without it.
+                                watcher = null;
                                 continue;
                             }
                         }
@@ -667,6 +668,7 @@ namespace System.IO
                             (isDir && ((_notifyFilters & NotifyFilters.DirectoryName) == 0) ||
                             (!isDir && ((_notifyFilters & NotifyFilters.FileName) == 0))))
                         {
+                            watcher = null;
                             continue;
                         }
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/86564

## Description

The test in question was this:
```csharp
        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
        public void DroppedWatcher_Collectible()
        {
            WeakReference watcher = CreateEnabledWatcher(TestDirectory);
            File.Create(GetTestFilePath()).Dispose();
            Assert.True(SpinWait.SpinUntil(() =>
            {
                GC.Collect();
                return !watcher.IsAlive;
            }, LongWaitTimeout));

        }
```
This was failing because the watcher was still *alive*.  However, it was only failing on arm32-linux when `DOTNET_JitStress=272` was set **and** if you ran the full FileSystemWatcher test suite. Running the test by itself will result in a success. 

The exact mechanics of this is well beyond complicated. So, my thought was to check the linux implementation and see where `FileSystemWatcher` could potentially be strongly held.

The linux impl spins up a new thread per `FileSystemWatcher` and that thread calls `ProcessEvents`. Inside, there is a `WeakReference` to the watcher. There is a loop that blocks waiting for new events. If there are events to process, it will try to grab the `FileSystemWatcher` reference and store it in the `watcher` variable. However, if we continue looping, we need to null out the `watcher` to avoid strongly holding on to it while we are blocked waiting for the next set of events. I found two places where we didn't null out the `watcher` variable on `continue`.

Once I did that, the test started passing with JitStress=272 and when running the suite.