### PR TITLE
Fix config names for CallCountThreshold and CallCountingDelayMs

### DIFF
--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -721,7 +721,7 @@ HRESULT EEConfig::sync()
         fTieredCompilation_CallCounting = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_TC_CallCounting) != 0;
 
         DWORD tieredCompilation_ConfiguredCallCountThreshold =
-            Configuration::GetKnobDWORDValue(W("System.Runtime.TC_CallCountThreshold"), CLRConfig::EXTERNAL_TC_CallCountThreshold);
+            Configuration::GetKnobDWORDValue(W("System.Runtime.TieredCompilation.CallCountThreshold"), CLRConfig::EXTERNAL_TC_CallCountThreshold);
 
         if (tieredCompilation_ConfiguredCallCountThreshold == 0)
         {
@@ -737,7 +737,7 @@ HRESULT EEConfig::sync()
         }
 
         tieredCompilation_CallCountingDelayMs =
-            Configuration::GetKnobDWORDValue(W("System.Runtime.TC_CallCountingDelayMs"), CLRConfig::EXTERNAL_TC_CallCountingDelayMs);
+            Configuration::GetKnobDWORDValue(W("System.Runtime.TieredCompilation.CallCountingDelayMs"), CLRConfig::EXTERNAL_TC_CallCountingDelayMs);
         
         bool hasSingleProcessor = GetCurrentProcessCpuCount() == 1;
         if (hasSingleProcessor)


### PR DESCRIPTION
I was preparing a PR to dotnet/sdk to surface these and noticed that these names are inconsistent with other tiered compilation settings, namely, https://github.com/dotnet/sdk/blob/62d3e897cce38a3df8d0ff4eb489a3f2e16f6dce/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L604-L611. Turns out we already have `System.Runtime.TieredCompilation.*` and we don't use `TC_` for it.

PTAL @mangod9 