### PR TITLE
HTTP & SSL Stress: Run nightlies against release/8.0

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -13,6 +13,7 @@ schedules:
     - main
     - release/6.0
     - release/7.0
+    - release/8.0
 
 variables:
   - template: ../variables.yml

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -13,6 +13,7 @@ schedules:
     - main
     - release/6.0
     - release/7.0
+    - release/8.0
 
 variables:
   - template: ../variables.yml


### PR DESCRIPTION
This has to be backported after merging.