### PR TITLE
Error out when NativeLib has EventPipe enabled

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -50,7 +50,7 @@
       Text="RuntimeIdentifier is required for native compilation. Try running dotnet publish with the -r option value specified." />
     <Error Condition="'$(GeneratePackageOnBuild)' == 'true'" Text="GeneratePackageOnBuild is not supported for native compilation." />
     <Error Condition="'$(OutputType)' != 'Library' and '$(NativeLib)' != '' and '$(CustomNativeMain)' != 'true'" Text="NativeLib requires OutputType=Library." />
-    <Error Condition="'$(NativeLib)' != '' and '$(EventSourceSupport)' == 'true'" Text="EventPipe library is not supported in NativeLib" />
+    <Error Condition="'$(NativeLib)' != '' and '$(EventSourceSupport)' == 'true'" Text="EventSource is not supported when compiling to a native library. Set EventSourceSupport to false." />
 
     <Error Condition="'$(PublishTrimmed)' == 'false'" Text="PublishTrimmed is implied by native compilation and cannot be disabled." />
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -50,6 +50,7 @@
       Text="RuntimeIdentifier is required for native compilation. Try running dotnet publish with the -r option value specified." />
     <Error Condition="'$(GeneratePackageOnBuild)' == 'true'" Text="GeneratePackageOnBuild is not supported for native compilation." />
     <Error Condition="'$(OutputType)' != 'Library' and '$(NativeLib)' != '' and '$(CustomNativeMain)' != 'true'" Text="NativeLib requires OutputType=Library." />
+    <Error Condition="'$(NativeLib)' != '' and '$(EventSourceSupport)' == 'true'" Text="EventPipe library is not supported in NativeLib" />
 
     <Error Condition="'$(PublishTrimmed)' == 'false'" Text="PublishTrimmed is implied by native compilation and cannot be disabled." />
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -50,6 +50,7 @@
       Text="RuntimeIdentifier is required for native compilation. Try running dotnet publish with the -r option value specified." />
     <Error Condition="'$(GeneratePackageOnBuild)' == 'true'" Text="GeneratePackageOnBuild is not supported for native compilation." />
     <Error Condition="'$(OutputType)' != 'Library' and '$(NativeLib)' != '' and '$(CustomNativeMain)' != 'true'" Text="NativeLib requires OutputType=Library." />
+    <!-- See https://github.com/dotnet/runtime/issues/89346 for details -->
     <Error Condition="'$(NativeLib)' != '' and '$(EventSourceSupport)' == 'true'" Text="EventSource is not supported when compiling to a native library. Set EventSourceSupport to false." />
 
     <Error Condition="'$(PublishTrimmed)' == 'false'" Text="PublishTrimmed is implied by native compilation and cannot be disabled." />


### PR DESCRIPTION
EventPipe does not work correctly with native AOT library (#89346). We will generate an error when `EventSourceSupport` property is set for native aot library.