### PR TITLE
[main] Change OneLocBuild mirror branch to release/8.0 temporarily

### DIFF
--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -4,7 +4,7 @@ parameters:
 
   # Optional: A defined YAML pool - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#pool
   pool: ''
-    
+
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
@@ -21,13 +21,13 @@ parameters:
   RepoType: gitHub
   GitHubOrg: dotnet
   MirrorRepo: ''
-  MirrorBranch: main
+  MirrorBranch: release/8.0
   condition: ''
   JobNameSuffix: ''
 
 jobs:
 - job: OneLocBuild${{ parameters.JobNameSuffix }}
-  
+
   dependsOn: ${{ parameters.dependsOn }}
 
   displayName: OneLocBuild${{ parameters.JobNameSuffix }}

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -21,7 +21,7 @@ parameters:
   RepoType: gitHub
   GitHubOrg: dotnet
   MirrorRepo: ''
-  MirrorBranch: release/8.0
+  MirrorBranch: main
   condition: ''
   JobNameSuffix: ''
 

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -4,7 +4,7 @@ parameters:
 
   # Optional: A defined YAML pool - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#pool
   pool: ''
-
+    
   CeapexPat: $(dn-bot-ceapex-package-r) # PAT for the loc AzDO instance https://dev.azure.com/ceapex
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
@@ -27,7 +27,7 @@ parameters:
 
 jobs:
 - job: OneLocBuild${{ parameters.JobNameSuffix }}
-
+  
   dependsOn: ${{ parameters.dependsOn }}
 
   displayName: OneLocBuild${{ parameters.JobNameSuffix }}

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -45,6 +45,7 @@ extends:
        - template: /eng/common/templates/job/onelocbuild.yml
          parameters:
            MirrorRepo: runtime
+           MirrorBranch: release/8.0
            LclSource: lclFilesfromPackage
            LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
 

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -41,13 +41,12 @@ extends:
       # Localization build
       #
 
-      # disabled due to https://github.com/dotnet/runtime/issues/90466
-      #- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-      #  - template: /eng/common/templates/job/onelocbuild.yml
-      #    parameters:
-      #      MirrorRepo: runtime
-      #      LclSource: lclFilesfromPackage
-      #      LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
+      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+       - template: /eng/common/templates/job/onelocbuild.yml
+         parameters:
+           MirrorRepo: runtime
+           LclSource: lclFilesfromPackage
+           LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
 
       #
       # Source Index Build

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -41,7 +41,7 @@ extends:
       # Localization build
       #
 
-      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/8.0') }}:
        - template: /eng/common/templates/job/onelocbuild.yml
          parameters:
            MirrorRepo: runtime


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/90755

Following the instructions to ensure we localize all the release/8.0 strings: https://github.com/dotnet/arcade/blob/main/Documentation/OneLocBuild.md#if-youre-releasing-from-a-branch-other-than-main-including-servicing-branches

The first change requires changing the main mirror branch to release/8.0 temporarily.

The second change is to backport this to release/8.0.