### PR TITLE
Case: The method has not been jitted yet

### DIFF
--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1575,7 +1575,11 @@ DebuggerJitInfo *DebuggerMethodInfo::FindOrCreateInitAndAddJitInfo(MethodDesc* f
     if (startAddr == NULL)
     {
         startAddr = g_pEEInterface->GetFunctionAddress(fd);
-        _ASSERTE(startAddr != NULL);
+        if (startAddr == NULL)
+        {
+            //The only case this should happen is if we are trying to get the DJI for a method that has not been jitted yet.
+            return NULL;
+        }
     }
     else
     {


### PR DESCRIPTION
This fixes the error introduced by [this commit](https://github.com/dotnet/runtime/commit/eacb32e400b3f9d3522bed193bd534d02e8b170a) (which was [reverted](https://github.com/dotnet/runtime/pull/90696)). The case that was missed was attempting to get the DJI for a method that had not yet been jitted. 