### PR TITLE
Add Retry and Task.Delay to WinHttpHandler AfterReadResponseServerError_ClientWrite test

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -143,6 +143,8 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 // Server sends RST_STREAM.
                 await connection.WriteFrameAsync(new RstStreamFrame(FrameFlags.EndStream, 0, streamId));
 
+                await Task.Delay(15);
+
                 await Assert.ThrowsAsync<IOException>(() => requestStream.WriteAsync(new byte[50]).AsTask());
             }
         }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/BidirectionStreamingTest.cs
@@ -143,9 +143,17 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
                 // Server sends RST_STREAM.
                 await connection.WriteFrameAsync(new RstStreamFrame(FrameFlags.EndStream, 0, streamId));
 
-                await Task.Delay(15);
+                await Assert.ThrowsAsync<IOException>(async () =>
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        await requestStream.WriteAsync(new byte[50]);
 
-                await Assert.ThrowsAsync<IOException>(() => requestStream.WriteAsync(new byte[50]).AsTask());
+                        // WriteAsync succeeded because handler hasn't processed RST_STREAM yet.
+                        // Small wait before trying again.
+                        await Task.Delay(50);
+                    }
+                });
             }
         }
 


### PR DESCRIPTION
Fixes #86262