### PR TITLE
[mini] Fix typo in mono_decompose_vtype_opts

### DIFF
--- a/src/mono/mono/mini/decompose.c
+++ b/src/mono/mono/mini/decompose.c
@@ -1226,7 +1226,7 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 					dest_var = get_vreg_to_inst (cfg, ins->dreg);
 
 					if (!src_var)
-						src_var = mono_compile_create_var_for_vreg (cfg, m_class_get_byval_arg (ins->klass), OP_LOCAL, ins->dreg);
+						src_var = mono_compile_create_var_for_vreg (cfg, m_class_get_byval_arg (ins->klass), OP_LOCAL, ins->sreg1);
 
 					if (!dest_var)
 						dest_var = mono_compile_create_var_for_vreg (cfg, m_class_get_byval_arg (ins->klass), OP_LOCAL, ins->dreg);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -10840,12 +10840,15 @@ field_access_end:
 					EMIT_NEW_TEMPLOADA (cfg, addr, vtvar->inst_c0);
 					MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORE_MEMBASE_REG, addr->dreg, 0, ins->dreg);
 					EMIT_NEW_TEMPLOAD (cfg, ins, vtvar->inst_c0);
-					ins->opcode = OP_LDTOKEN_FIELD;
-					ins->inst_c0 = n;
-					ins->inst_p1 = handle;
+					if (handle_class == mono_defaults.fieldhandle_class) {
+						ins->opcode = OP_LDTOKEN_FIELD;
+						ins->inst_c0 = n;
+						ins->inst_p1 = handle;
 
-					cfg->flags |= MONO_CFG_NEEDS_DECOMPOSE;
-					cfg->cbb->needs_decompose = TRUE;
+						cfg->flags |= MONO_CFG_NEEDS_DECOMPOSE;
+						cfg->cbb->needs_decompose = TRUE;
+					}
+
 				}
 			}
 


### PR DESCRIPTION
Without this, if some previous instruction already created a vreg for `ins->dest` (for example if we are doing multiple passes over the basic block because `restart == TRUE`) we will use an incorrect vreg for the `src` when decomposing the current VMOVE

---

Additionally, only emit `OP_LDTOKEN_FIELD` if we loaded a field token

This is used by a CreateSpan intrinsic https://github.com/dotnet/runtime/pull/81695 that needs access to the `MonoClassField*`

For other cases of a bare LDTOKEN (such as hand-written IL that calls LDTOKEN on a type but doesn't follow it up with a call to `GetTypeFromHandle` leave the opcode as a VMOVE (from the `EMIT_NEW_TEMPLOAD` above))

Fixes #90800 