### PR TITLE
Fix a deadlock in NonGC + Profiler API

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Monitor.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Monitor.CoreCLR.cs
@@ -41,9 +41,6 @@ namespace System.Threading
         // in the typical case. Note that the method has to be transparent for inlining to be allowed by the VM.
         public static void Enter(object obj, ref bool lockTaken)
         {
-            if (lockTaken)
-                ThrowLockTakenException();
-
             ReliableEnter(obj, ref lockTaken);
             Debug.Assert(lockTaken);
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Monitor.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Monitor.CoreCLR.cs
@@ -41,6 +41,9 @@ namespace System.Threading
         // in the typical case. Note that the method has to be transparent for inlining to be allowed by the VM.
         public static void Enter(object obj, ref bool lockTaken)
         {
+            if (lockTaken)
+                ThrowLockTakenException();
+
             ReliableEnter(obj, ref lockTaken);
             Debug.Assert(lockTaken);
         }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -9960,7 +9960,9 @@ void gc_heap::update_ro_segment (heap_segment* seg, uint8_t* allocated, uint8_t*
     enter_spin_lock (&gc_heap::gc_lock);
 
     assert (use_frozen_segments_p);
-    assert (heap_segment_read_only_p(seg));
+    assert (heap_segment_read_only_p (seg));
+    assert (allocated <= committed);
+    assert (committed <= heap_segment_reserved (seg));
     heap_segment_allocated (seg) = allocated;
     heap_segment_committed (seg) = committed;
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -9955,6 +9955,18 @@ BOOL gc_heap::insert_ro_segment (heap_segment* seg)
     return TRUE;
 }
 
+void gc_heap::update_ro_segment (heap_segment* seg, uint8_t* allocated, uint8_t* committed)
+{
+    enter_spin_lock (&gc_heap::gc_lock);
+
+    assert (use_frozen_segments_p);
+    assert (heap_segment_read_only_p(seg));
+    heap_segment_allocated (seg) = allocated;
+    heap_segment_committed (seg) = committed;
+
+    leave_spin_lock (&gc_heap::gc_lock);
+}
+
 // No one is calling this function right now. If this is getting called we need
 // to take care of decommitting the mark array for it - we will need to remember
 // which portion of the mark array was committed and only decommit that.

--- a/src/coreclr/gc/gcee.cpp
+++ b/src/coreclr/gc/gcee.cpp
@@ -510,9 +510,12 @@ bool GCHeap::IsInFrozenSegment(Object *object)
 void GCHeap::UpdateFrozenSegment(segment_handle seg, uint8_t* allocated, uint8_t* committed)
 {
 #ifdef FEATURE_BASICFREEZE
-    heap_segment* heap_seg = reinterpret_cast<heap_segment*>(seg);
-    heap_segment_committed(heap_seg) = committed;
-    heap_segment_allocated(heap_seg) = allocated;
+#ifdef MULTIPLE_HEAPS
+    gc_heap* heap = gc_heap::g_heaps[0];
+#else
+    gc_heap* heap = pGenGCHeap;
+#endif //MULTIPLE_HEAPS
+    heap->update_ro_segment (reinterpret_cast<heap_segment*>(seg), allocated, committed);
 #endif // FEATURE_BASICFREEZE
 }
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2380,6 +2380,7 @@ private:
 #ifdef FEATURE_BASICFREEZE
     PER_HEAP_METHOD BOOL insert_ro_segment (heap_segment* seg);
     PER_HEAP_METHOD void remove_ro_segment (heap_segment* seg);
+    PER_HEAP_METHOD void update_ro_segment (heap_segment* seg, uint8_t* allocated, uint8_t* committed);
 #endif //FEATURE_BASICFREEZE
     PER_HEAP_METHOD BOOL set_ro_segment_in_range (heap_segment* seg);
 #ifndef USE_REGIONS

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -2449,20 +2449,25 @@ public:
         _ASSERTE(m_pGlobalStringLiteralMap);
         return m_pGlobalStringLiteralMap;
     }
-    static FrozenObjectHeapManager* GetFrozenObjectHeapManager(bool initialize = true)
+    static FrozenObjectHeapManager* GetFrozenObjectHeapManager()
     {
-        WRAPPER_NO_CONTRACT;
+        CONTRACTL
+        {
+            THROWS;
+            MODE_COOPERATIVE;
+        }
+        CONTRACTL_END;
+
         if (VolatileLoad(&m_FrozenObjectHeapManager) == nullptr)
         {
-            if (initialize)
-            {
-                LazyInitFrozenObjectsHeap();
-            }
-            else
-            {
-                return nullptr;
-            }
+            LazyInitFrozenObjectsHeap();
         }
+        return VolatileLoad(&m_FrozenObjectHeapManager);
+    }
+    static FrozenObjectHeapManager* GetFrozenObjectHeapManagerNoThrow()
+    {
+        LIMITED_METHOD_CONTRACT;
+
         return VolatileLoad(&m_FrozenObjectHeapManager);
     }
 #endif // DACCESS_COMPILE

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -2449,14 +2449,21 @@ public:
         _ASSERTE(m_pGlobalStringLiteralMap);
         return m_pGlobalStringLiteralMap;
     }
-    static FrozenObjectHeapManager* GetFrozenObjectHeapManager()
+    static FrozenObjectHeapManager* GetFrozenObjectHeapManager(bool initialize = true)
     {
         WRAPPER_NO_CONTRACT;
-        if (m_FrozenObjectHeapManager == NULL)
+        if (VolatileLoad(&m_FrozenObjectHeapManager) == nullptr)
         {
-            LazyInitFrozenObjectsHeap();
+            if (initialize)
+            {
+                LazyInitFrozenObjectsHeap();
+            }
+            else
+            {
+                return nullptr;
+            }
         }
-        return m_FrozenObjectHeapManager;
+        return VolatileLoad(&m_FrozenObjectHeapManager);
     }
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -10,9 +10,9 @@
 #define FOH_COMMIT_SIZE (64 * 1024)
 
 FrozenObjectHeapManager::FrozenObjectHeapManager():
-    // This lock is used in both COOP and PREEMP (by profiler) modes
+    // This lock is used in PREEMP mode
     m_Crst(CrstFrozenObjectHeap, CRST_UNSAFE_ANYMODE),
-    // This lock is used only in COOP mode
+    // This lock is used in COOP mode
     m_SegmentRegistrationCrst(CrstFrozenObjectHeap, CRST_UNSAFE_COOPGC),
     m_CurrentSegment(nullptr)
 {
@@ -180,7 +180,6 @@ void FrozenObjectSegment::Register()
     m_SegmentHandle = GCHeapUtilities::GetGCHeap()->RegisterFrozenSegment(&si);
     if (m_SegmentHandle == nullptr)
     {
-        ClrVirtualFree(m_pStart, 0, MEM_RELEASE);
         ThrowOutOfMemory();
     }
     VolatileStore(&m_IsRegistered, true);

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -11,7 +11,7 @@
 
 FrozenObjectHeapManager::FrozenObjectHeapManager():
     m_Crst(CrstFrozenObjectHeap, CRST_UNSAFE_ANYMODE),
-    m_SegmentRegistrationCrst(CrstFrozenObjectHeap, CRST_UNSAFE_ANYMODE),
+    m_SegmentRegistrationCrst(CrstFrozenObjectHeap),
     m_CurrentSegment(nullptr)
 {
 }

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -10,10 +10,8 @@
 #define FOH_COMMIT_SIZE (64 * 1024)
 
 FrozenObjectHeapManager::FrozenObjectHeapManager():
-    // This lock is used in PREEMP mode
     m_Crst(CrstFrozenObjectHeap, CRST_UNSAFE_ANYMODE),
-    // This lock is used in COOP mode
-    m_SegmentRegistrationCrst(CrstFrozenObjectHeap, CRST_UNSAFE_COOPGC),
+    m_SegmentRegistrationCrst(CrstFrozenObjectHeap, CRST_UNSAFE_ANYMODE),
     m_CurrentSegment(nullptr)
 {
 }
@@ -35,14 +33,14 @@ Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t 
     return nullptr;
 #else // FEATURE_BASICFREEZE
 
+    GCX_PREEMP();
+
     Object* obj = nullptr;
     FrozenObjectSegment* curSeg = nullptr;
     uint8_t* curSegmentCurrent = nullptr;
     size_t curSegSizeCommitted = 0;
 
     {
-        GCX_PREEMP();
-
         CrstHolder ch(&m_Crst);
 
         _ASSERT(type != nullptr);

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -225,7 +225,7 @@ Object* FrozenObjectSegment::TryAllocateObject(PTR_MethodTable type, size_t obje
 
     m_pCurrent += objectSize;
 
-    if (!IsRegistered())
+    if (IsRegistered())
     {
         // Notify GC that we bumped the pointer and, probably, committed more memory in the reserved part
         // NOTE: UpdateFrozenSegment is not expected to take any lock inside

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -165,7 +165,7 @@ FrozenObjectSegment::FrozenObjectSegment(size_t sizeHint) :
 void FrozenObjectSegment::Register()
 {
     // Caller is expected to make sure it's not registered twice
-    _ASSERT(!VolatileLoad(&m_IsInitialized));
+    _ASSERT(!VolatileLoad(&m_IsRegistered));
 
     segment_info si;
     si.pvMem = m_pStart;

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -165,6 +165,13 @@ FrozenObjectSegment::FrozenObjectSegment(size_t sizeHint) :
 
 void FrozenObjectSegment::RegisterOrUpdate(uint8_t* current, size_t sizeCommited)
 {
+    CONTRACTL
+    {
+        THROWS;
+        MODE_PREEMPTIVE;
+    }
+    CONTRACTL_END
+
     if (!IsRegistered())
     {
         // Other threads won't touch these fields until we set m_IsRegistered to true

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -175,12 +175,12 @@ void FrozenObjectSegment::RegisterOrUpdate(uint8_t* current, size_t sizeCommited
     }
     CONTRACTL_END
 
-    if (VolatileLoad(&m_pCurrentRegistered) == nullptr)
+    if (m_pCurrentRegistered == nullptr)
     {
         segment_info si;
         si.pvMem = m_pStart;
         si.ibFirstObject = sizeof(ObjHeader);
-        si.ibAllocated = (size_t)m_pCurrentRegistered;
+        si.ibAllocated = (size_t)current;
         si.ibCommit = sizeCommited;
         si.ibReserved = m_Size;
 
@@ -190,15 +190,15 @@ void FrozenObjectSegment::RegisterOrUpdate(uint8_t* current, size_t sizeCommited
         {
             ThrowOutOfMemory();
         }
-        VolatileStore(&m_pCurrentRegistered, current);
+        m_pCurrentRegistered = current;
     }
     else
     {
-        if (current > VolatileLoad(&m_pCurrentRegistered))
+        if (current > m_pCurrentRegistered)
         {
             GCHeapUtilities::GetGCHeap()->UpdateFrozenSegment(
                 m_SegmentHandle, current, m_pStart + sizeCommited);
-            VolatileStore(&m_pCurrentRegistered, current);
+            m_pCurrentRegistered = current;
         }
         else
         {

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -38,6 +38,8 @@ Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t 
     Object* obj = nullptr;
     FrozenObjectSegment* currentSegment = nullptr;
     {
+        GCX_PREEMP();
+
         CrstHolder ch(&m_Crst);
 
         _ASSERT(type != nullptr);

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -186,7 +186,7 @@ void FrozenObjectSegment::Register()
 
 Object* FrozenObjectSegment::TryAllocateObject(PTR_MethodTable type, size_t objectSize)
 {
-    _ASSERT(m_pStart != nullptr && m_Size > 0 && m_SegmentHandle != nullptr); // Expected to be inited
+    _ASSERT((m_pStart != nullptr) && (m_Size > 0));
     _ASSERT(IS_ALIGNED(m_pCurrent, DATA_ALIGNMENT));
     _ASSERT(IS_ALIGNED(objectSize, DATA_ALIGNMENT));
     _ASSERT(objectSize <= FOH_COMMIT_SIZE);

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -165,7 +165,7 @@ FrozenObjectSegment::FrozenObjectSegment(size_t sizeHint) :
 void FrozenObjectSegment::Register()
 {
     // Caller is expected to make sure it's not registered twice
-    _ASSERT(!VolatileLoad(&m_IsRegistered));
+    _ASSERT(!IsRegistered());
 
     segment_info si;
     si.pvMem = m_pStart;
@@ -225,7 +225,7 @@ Object* FrozenObjectSegment::TryAllocateObject(PTR_MethodTable type, size_t obje
 
     m_pCurrent += objectSize;
 
-    if (m_IsRegistered)
+    if (!IsRegistered())
     {
         // Notify GC that we bumped the pointer and, probably, committed more memory in the reserved part
         // NOTE: UpdateFrozenSegment is not expected to take any lock inside

--- a/src/coreclr/vm/frozenobjectheap.h
+++ b/src/coreclr/vm/frozenobjectheap.h
@@ -31,6 +31,7 @@ public:
 
 private:
     Crst m_Crst;
+    Crst m_SegmentRegistrationCrst;
     SArray<FrozenObjectSegment*> m_FrozenSegments;
     FrozenObjectSegment* m_CurrentSegment;
 
@@ -47,6 +48,11 @@ public:
     {
         return m_Size;
     }
+    bool IsRegistered() const
+    {
+        return VolatileLoad(&m_IsRegistered);
+    }
+    void Register();
 
 private:
     Object* GetFirstObject() const;
@@ -68,6 +74,9 @@ private:
 
     // Total memory reserved for the current segment
     size_t m_Size;
+
+    // Whether GC knows about this segment already or it hasn't been registered yet
+    bool m_IsRegistered;
 
     segment_handle m_SegmentHandle;
     INDEBUG(size_t m_ObjectsCount);

--- a/src/coreclr/vm/frozenobjectheap.h
+++ b/src/coreclr/vm/frozenobjectheap.h
@@ -52,7 +52,7 @@ public:
     {
         return VolatileLoad(&m_IsRegistered);
     }
-    void Register();
+    void RegisterOrUpdate();
 
 private:
     Object* GetFirstObject() const;
@@ -66,11 +66,13 @@ private:
     //
     // m_pCurrent <= m_SizeCommitted
     uint8_t* m_pCurrent;
+    uint8_t* m_pCurrentRegistered;
 
     // Memory committed in the current segment
     //
     // m_SizeCommitted <= m_pStart + FOH_SIZE_RESERVED
     size_t m_SizeCommitted;
+    size_t m_SizeCommittedRegistered;
 
     // Total memory reserved for the current segment
     size_t m_Size;

--- a/src/coreclr/vm/frozenobjectheap.h
+++ b/src/coreclr/vm/frozenobjectheap.h
@@ -45,10 +45,6 @@ class FrozenObjectSegment
 public:
     FrozenObjectSegment(size_t sizeHint);
     Object* TryAllocateObject(PTR_MethodTable type, size_t objectSize);
-    bool IsRegistered() const
-    {
-        return VolatileLoad(&m_IsRegistered);
-    }
     void RegisterOrUpdate(uint8_t* current, size_t sizeCommited);
 
 private:
@@ -66,19 +62,19 @@ private:
     //
     // m_pCurrent <= m_SizeCommitted
     uint8_t* m_pCurrent;
+
+    // Last known value of m_pCurrent that GC is aware of.
+    //
+    // m_pCurrentRegistered <= m_pCurrent
     uint8_t* m_pCurrentRegistered;
 
     // Memory committed in the current segment
     //
     // m_SizeCommitted <= m_pStart + FOH_SIZE_RESERVED
     size_t m_SizeCommitted;
-    size_t m_SizeCommittedRegistered;
 
     // Total memory reserved for the current segment
     size_t m_Size;
-
-    // Whether GC knows about this segment already or it hasn't been registered yet
-    bool m_IsRegistered;
 
     segment_handle m_SegmentHandle;
 

--- a/src/coreclr/vm/frozenobjectheap.h
+++ b/src/coreclr/vm/frozenobjectheap.h
@@ -27,7 +27,8 @@ class FrozenObjectHeapManager
 {
 public:
     FrozenObjectHeapManager();
-    Object* TryAllocateObject(PTR_MethodTable type, size_t objectSize, bool publish = true);
+    Object* TryAllocateObject(PTR_MethodTable type, size_t objectSize,
+        void(*initFunc)(Object*,void*) = nullptr, void* pParam = nullptr);
 
 private:
     Crst m_Crst;

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -555,18 +555,18 @@ OBJECTREF TryAllocateFrozenSzArray(MethodTable* pArrayMT, INT32 cElements)
 #endif
 
     FrozenObjectHeapManager* foh = SystemDomain::GetFrozenObjectHeapManager();
-    ArrayBase* orArray = static_cast<ArrayBase*>(foh->TryAllocateObject(pArrayMT, PtrAlign(totalSize), /*publish*/ false));
+    ArrayBase* orArray = static_cast<ArrayBase*>(
+        foh->TryAllocateObject(pArrayMT, PtrAlign(totalSize), [](Object* obj, void* elemCntPtr){
+            // Initialize newly allocated object before publish
+            static_cast<ArrayBase*>(obj)->m_NumComponents = *static_cast<DWORD*>(elemCntPtr);
+        }, &cElements));
+
     if (orArray == nullptr)
     {
         // We failed to allocate on a frozen segment, fallback to AllocateSzArray
         // E.g. if the array is too big to fit on a frozen segment
         return NULL;
     }
-    orArray->m_NumComponents = cElements;
-
-    // Publish needs to be postponed in this case because we need to specify array length 
-    PublishObjectAndNotify(orArray, GC_ALLOC_NO_FLAGS);
-
     return ObjectToOBJECTREF(orArray);
 }
 
@@ -968,12 +968,15 @@ STRINGREF AllocateString(DWORD cchStringLength, bool preferFrozenHeap, bool* pIs
     if (preferFrozenHeap)
     {
         FrozenObjectHeapManager* foh = SystemDomain::GetFrozenObjectHeapManager();
-        orString = static_cast<StringObject*>(foh->TryAllocateObject(g_pStringClass, totalSize, /* publish = */false));
+
+        orString = static_cast<StringObject*>(foh->TryAllocateObject(
+            g_pStringClass, totalSize, [](Object* obj, void* pStrLen) {
+                // Initialize newly allocated object before publish
+                static_cast<StringObject*>(obj)->SetStringLength(*static_cast<DWORD*>(pStrLen));
+            }, &cchStringLength));
+
         if (orString != nullptr)
         {
-            orString->SetStringLength(cchStringLength);
-            // Publish needs to be postponed in this case because we need to specify string length 
-            PublishObjectAndNotify(orString, GC_ALLOC_NO_FLAGS);
             _ASSERTE(orString->GetBuffer()[cchStringLength] == W('\0'));
             orStringRef = ObjectToSTRINGREF(orString);
             *pIsFrozen = true;

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -1142,7 +1142,7 @@ OBJECTREF TryAllocateFrozenObject(MethodTable* pObjMT)
 #endif // FEATURE_64BIT_ALIGNMENT
 
     FrozenObjectHeapManager* foh = SystemDomain::GetFrozenObjectHeapManager();
-    Object* orObject = foh->TryAllocateObject(pObjMT, PtrAlign(pObjMT->GetBaseSize()), /*publish*/ true);
+    Object* orObject = foh->TryAllocateObject(pObjMT, PtrAlign(pObjMT->GetBaseSize()));
 
     return ObjectToOBJECTREF(orObject);
 }

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -4187,8 +4187,9 @@ void MethodTable::AllocateRegularStaticBox(FieldDesc* pField, Object** boxedStat
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
-        CONTRACTL_END;
     }
+    CONTRACTL_END
+
     _ASSERT(pField->IsStatic() && !pField->IsSpecialStatic() && pField->IsByValue());
 
     // Static fields are not pinned in collectible types so we need to protect the address
@@ -4222,8 +4223,8 @@ OBJECTREF MethodTable::AllocateStaticBox(MethodTable* pFieldMT, BOOL fPinned, OB
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
-        CONTRACTL_END;
     }
+    CONTRACTL_END
 
     _ASSERTE(pFieldMT->IsValueType());
 

--- a/src/coreclr/vm/profilingenumerators.cpp
+++ b/src/coreclr/vm/profilingenumerators.cpp
@@ -103,8 +103,7 @@ BOOL ProfilerObjectEnum::Init()
     }
     CONTRACTL_END;
 
-    // initialize = false to avoid breaking the NOTHROW contract
-    FrozenObjectHeapManager* foh = SystemDomain::GetFrozenObjectHeapManager(/*initialize*/ false);
+    FrozenObjectHeapManager* foh = SystemDomain::GetFrozenObjectHeapManagerNoThrow();
     if (foh == nullptr)
     {
         return TRUE;
@@ -119,6 +118,10 @@ BOOL ProfilerObjectEnum::Init()
         for (unsigned segmentIdx = 0; segmentIdx < segmentsCount; segmentIdx++)
         {
             const FrozenObjectSegment* segment = segments[segmentIdx];
+            if (!segment->IsRegistered())
+            {
+                continue;
+            }
 
             Object* currentObj = segment->GetFirstObject();
             while (currentObj != nullptr)

--- a/src/coreclr/vm/profilingenumerators.cpp
+++ b/src/coreclr/vm/profilingenumerators.cpp
@@ -103,7 +103,13 @@ BOOL ProfilerObjectEnum::Init()
     }
     CONTRACTL_END;
 
-    FrozenObjectHeapManager* foh = SystemDomain::GetFrozenObjectHeapManager();
+    // initialize = false to avoid breaking the NOTHROW contract
+    FrozenObjectHeapManager* foh = SystemDomain::GetFrozenObjectHeapManager(/*initialize*/ false);
+    if (foh == nullptr)
+    {
+        return TRUE;
+    }
+
     CrstHolder ch(&foh->m_Crst);
 
     const unsigned segmentsCount = foh->m_FrozenSegments.GetCount();

--- a/src/coreclr/vm/profilingenumerators.cpp
+++ b/src/coreclr/vm/profilingenumerators.cpp
@@ -118,11 +118,6 @@ BOOL ProfilerObjectEnum::Init()
         for (unsigned segmentIdx = 0; segmentIdx < segmentsCount; segmentIdx++)
         {
             const FrozenObjectSegment* segment = segments[segmentIdx];
-            if (!segment->IsRegistered())
-            {
-                continue;
-            }
-
             Object* currentObj = segment->GetFirstObject();
             while (currentObj != nullptr)
             {

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -7684,37 +7684,25 @@ HRESULT ProfToEEInterfaceImpl::GetNonGCHeapBounds(ULONG cObjectRanges,
     FrozenObjectSegment** segments = foh->m_FrozenSegments.GetElements();
     if (segments != nullptr && segmentsCount > 0)
     {
-        unsigned totalRegisteredSegments = 0;
+        const ULONG segmentsToInspect = min(cObjectRanges, (ULONG)segmentsCount);
 
-        for (unsigned segIdx = 0; segIdx < segmentsCount; segIdx++)
+        for (unsigned segIdx = 0; segIdx < segmentsToInspect; segIdx++)
         {
-            if (segIdx >= cObjectRanges)
-            {
-                break;
-            }
-
-            FrozenObjectSegment* segment = segments[segIdx];
-            if (!segment->IsRegistered())
-            {
-                continue;
-            }
-            totalRegisteredSegments++;
-
-            uint8_t* firstObj = segment->m_pStart + sizeof(ObjHeader);
+            uint8_t* firstObj = segments[segIdx]->m_pStart + sizeof(ObjHeader);
 
             // Start of the segment (first object)
             ranges[segIdx].rangeStart = (ObjectID)firstObj;
 
             // Total size reserved for a segment
-            ranges[segIdx].rangeLengthReserved = (UINT_PTR)segment->m_Size - sizeof(ObjHeader);
+            ranges[segIdx].rangeLengthReserved = (UINT_PTR)segments[segIdx]->m_Size - sizeof(ObjHeader);
 
             // Size of the segment that is currently in use
-            ranges[segIdx].rangeLength = (UINT_PTR)(segment->m_pCurrentRegistered - firstObj);
+            ranges[segIdx].rangeLength = (UINT_PTR)(segments[segIdx]->m_pCurrent - firstObj);
         }
 
         if (pcObjectRanges != nullptr)
         {
-            *pcObjectRanges = (ULONG)totalRegisteredSegments;
+            *pcObjectRanges = (ULONG)segmentsCount;
         }
     }
     else

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -7672,7 +7672,13 @@ HRESULT ProfToEEInterfaceImpl::GetNonGCHeapBounds(ULONG cObjectRanges,
         return E_INVALIDARG;
     }
 
-    FrozenObjectHeapManager* foh = SystemDomain::GetFrozenObjectHeapManager();
+    // initialize = false to avoid breaking the NOTHROW contract
+    FrozenObjectHeapManager* foh = SystemDomain::GetFrozenObjectHeapManager(/*initialize*/ false);
+    if (foh == nullptr)
+    {
+        *pcObjectRanges = 0;
+        return S_OK;
+    }
     CrstHolder ch(&foh->m_Crst);
 
     const unsigned segmentsCount = foh->m_FrozenSegments.GetCount();

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -7709,7 +7709,7 @@ HRESULT ProfToEEInterfaceImpl::GetNonGCHeapBounds(ULONG cObjectRanges,
             ranges[segIdx].rangeLengthReserved = (UINT_PTR)segment->m_Size - sizeof(ObjHeader);
 
             // Size of the segment that is currently in use
-            ranges[segIdx].rangeLength = (UINT_PTR)(segment->m_pCurrent - firstObj);
+            ranges[segIdx].rangeLength = (UINT_PTR)(segment->m_pCurrentRegistered - firstObj);
         }
 
         if (pcObjectRanges != nullptr)

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -7709,7 +7709,7 @@ HRESULT ProfToEEInterfaceImpl::GetNonGCHeapBounds(ULONG cObjectRanges,
             ranges[segIdx].rangeLengthReserved = (UINT_PTR)segment->m_Size - sizeof(ObjHeader);
 
             // Size of the segment that is currently in use
-            ranges[segIdx].rangeLength = (UINT_PTR)segment->m_pCurrent - firstObj);
+            ranges[segIdx].rangeLength = (UINT_PTR)(segment->m_pCurrent - firstObj);
         }
 
         if (pcObjectRanges != nullptr)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/90830

Quick explanation how's the dead-lock happening:
**Thread1:**
Someone (typically, JIT) tries to allocate an object on NonGC heap. `FrozenObjectHeapManager` (FOHM) acquires its lock and calls GC's API `RegisterNewSegment`. That API internally **can** hit a case when a GC is happening so it has to wait for GC to complete.

**Thread2 (GC's):**
GC is executing a callback (e.g. `GarbageCollectionFinished` or `*Started`) and Profiler uses that callback to enumerate objects on NonGC heap via `ICorProfilerInfo14::GetNonGCHeapBounds` thus, it also tries to acquire FOHM's lock (to be able to safely enumerate the objects). Thus, GC's thread (Thread2) is wating for FOHM's lock to release (it's taken by Thread1) while Thread1 is waiting for GC to finish.

The fix is https://github.com/dotnet/runtime/issues/90830#issuecomment-1684841908
