### PR TITLE
chore: optimize using of color console output

### DIFF
--- a/src/mono/sample/wasm/node-webpack/app.js
+++ b/src/mono/sample/wasm/node-webpack/app.js
@@ -1,5 +1,5 @@
 import { dotnet } from '@microsoft/dotnet-runtime'
-import { color } from 'console-log-colors'
+import { red, blue } from 'ansis/colors'
 
 async function dotnetMeaning() {
     try {
@@ -15,5 +15,5 @@ async function dotnetMeaning() {
 
 export async function main() {
     const meaning = await dotnetMeaning()
-    console.log(color.blue("Answer to the Ultimate Question of Life, the Universe, and Everything is: ") + color.red(`${meaning}`));
+    console.log(blue`Answer to the Ultimate Question of Life, the Universe, and Everything is: ${red`${meaning}`}`);
 }

--- a/src/mono/sample/wasm/node-webpack/package.json
+++ b/src/mono/sample/wasm/node-webpack/package.json
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "@microsoft/dotnet-runtime": "file:bin/dotnet-runtime",
-    "console-log-colors": "0.2.3"
+    "ansis": "1.5.5"
   }
 }


### PR DESCRIPTION
Hello,

this PR replaces the use of `console-log-colors`  with the tiny and fast [ansis](https://github.com/webdiscus/ansis) package.
Using the `ansis` you can very easy and clean colorise the console output without using the brackets.
The `ansis` supports the chalk API and is faster and tiny than chalk and has many cool features, e.g. you can use nested  template literals like:
```
red`R ${cyan`C`} R`
```
You can  import only used colors and styles to avoid using any namespace, e.g. instead of `console.log(color.red('text'))` you can use clean syntax of `ansis`:
```js
import { red, blue } from 'ansis/colors';

console.log(red`text`);
console.log(blue`Some blue text: ${red`red error`} next blue text`);
```


Of cause you can use a namespace:

```js
import color from 'ansis';

console.log(color.red('text')); // use with brackets
console.log(color.red`text`); // use clean syntax with template literals
```