### PR TITLE
Add a test case for copy propagation

### DIFF
--- a/src/tests/JIT/opt/AssertionPropagation/CopyProp.cs
+++ b/src/tests/JIT/opt/AssertionPropagation/CopyProp.cs
@@ -22,6 +22,21 @@ public class Sample2
         return (sbyte)res;
     }
 
+    [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static int func(int y)
+    {
+        int sum = 0;
+        int x = y;
+        y = 4;
+        for (int i = 0; i < x; i++)
+            sum++;
+        use(x);
+        return sum;
+    }
+
+    [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static void use(int x) { }
+
     [Fact]
     public static int TestEntryPoint()
     {
@@ -31,6 +46,8 @@ public class Sample2
         if (func(3, 2) != +1)
             failed = true;
         if (func(2, 2) != 0)
+            failed = true;
+        if (func(2) != 2)
             failed = true;
         if (failed)
         {


### PR DESCRIPTION
It was hit when I was investigating propagation for loop bound in #90622, where I incorrectly substitute `4` into `x`.

![image](https://github.com/dotnet/runtime/assets/14960345/5477e0fe-3854-4d6d-94a7-7e6dbc81dabf)

Which results in bad codegen.

![image](https://github.com/dotnet/runtime/assets/14960345/deec72d7-4bc4-4a37-8512-9370c2b338f6)

Add a test case for it.