### PR TITLE
[wasm] Upgrade wasm helix VMs to ubuntu 22.04

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -52,7 +52,7 @@ jobs:
 
     # Browser wasm
     - ${{ if eq(parameters.platform, 'browser_wasm') }}:
-      - (Ubuntu.1804.Amd64)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-webassembly
+      - (Ubuntu.2204.Amd64)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-webassembly
 
     # iOS devices
     - ${{ if in(parameters.platform, 'ios_arm64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -173,15 +173,15 @@ jobs:
 
     # WASI
     - ${{ if eq(parameters.platform, 'wasi_wasm') }}:
-      - (Ubuntu.2004.Amd64)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-helix-wasm-amd64
+      - (Ubuntu.2204.Amd64)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-webassembly
 
     # Browser WebAssembly
     - ${{ if eq(parameters.platform, 'browser_wasm') }}:
-      - (Ubuntu.1804.Amd64)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-webassembly
+      - (Ubuntu.2204.Amd64)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-webassembly
 
     # Browser WebAssembly Firefox
     - ${{ if eq(parameters.platform, 'browser_wasm_firefox') }}:
-      - (Ubuntu.1804.Amd64)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-webassembly
+      - (Ubuntu.2004.Amd64)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-webassembly
 
     # Browser WebAssembly windows
     - ${{ if in(parameters.platform, 'browser_wasm_win', 'wasi_wasm_win') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -181,7 +181,7 @@ jobs:
 
     # Browser WebAssembly Firefox
     - ${{ if eq(parameters.platform, 'browser_wasm_firefox') }}:
-      - (Ubuntu.2004.Amd64)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-webassembly
+      - (Ubuntu.2204.Amd64)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-webassembly
 
     # Browser WebAssembly windows
     - ${{ if in(parameters.platform, 'browser_wasm_win', 'wasi_wasm_win') }}:

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedDayNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedDayNames.cs
@@ -37,10 +37,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, new string[] { "রবি", "সোম", "মঙ্গল", "বুধ", "বৃহস্পতি", "শুক্র", "শনি" } };
             yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, new string[] { "dg.", "dl.", "dt.", "dc.", "dj.", "dv.", "ds." } };
             yield return new object[] { new CultureInfo("cs-CZ").DateTimeFormat, new string[] { "ne", "po", "út", "st", "čt", "pá", "so" } };
-            string[] dannishDays = PlatformDetection.IsNodeJS ?
-                new string[] { "søn", "man", "tir", "ons", "tor", "fre", "lør" } :
-                new string[] { "søn.", "man.", "tirs.", "ons.", "tors.", "fre.", "lør." };
-            yield return new object[] { new CultureInfo("da-DK").DateTimeFormat, dannishDays };
+            yield return new object[] { new CultureInfo("da-DK").DateTimeFormat, new string[] { "søn.", "man.", "tirs.", "ons.", "tors.", "fre.", "lør." } };
             yield return new object[] { new CultureInfo("de-DE").DateTimeFormat, new string[] { "So", "Mo", "Di", "Mi", "Do", "Fr", "Sa" } };
             yield return new object[] { new CultureInfo("el-GR").DateTimeFormat, new string[] { "Κυρ", "Δευ", "Τρί", "Τετ", "Πέμ", "Παρ", "Σάβ" } };
             yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, new string[] { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" } }; // should be with dots

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthGenitiveNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthGenitiveNames.cs
@@ -14,14 +14,8 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("ar-SA").DateTimeFormat, new string[] { "محرم", "صفر", "ربيع الأول", "ربيع الآخر", "جمادى الأولى", "جمادى الآخرة", "رجب", "شعبان", "رمضان", "شوال", "ذو القعدة", "ذو الحجة", "" } };
             yield return new object[] { new CultureInfo("am-ET").DateTimeFormat, new string[] { "ጃንዩ", "ፌብሩ", "ማርች", "ኤፕሪ", "ሜይ", "ጁን", "ጁላይ", "ኦገስ", "ሴፕቴ", "ኦክቶ", "ኖቬም", "ዲሴም", "" } };
             yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, new string[] { "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "" } }; //"яну", "фев", "март", "апр", "май", "юни", "юли", "авг", "сеп", "окт", "ное", "дек", ""
-            yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat,
-                PlatformDetection.IsNodeJS ? // NodeJs responds like dotnet
-                    new string[] { "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", "" } :
-                    new string[] { "জানু", "ফেব", "মার্চ", "এপ্রি", "মে", "জুন", "জুল", "আগ", "সেপ", "অক্টো", "নভে", "ডিসে", "" } };
-            yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat,
-                PlatformDetection.IsNodeJS ? // NodeJs responds like dotnet
-                    new string[] { "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", "" } :
-                    new string[] { "জানু", "ফেব", "মার্চ", "এপ্রি", "মে", "জুন", "জুল", "আগ", "সেপ্টেঃ", "অক্টোঃ", "নভেঃ", "ডিসেঃ", "" } };
+            yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, new string[] { "জানু", "ফেব", "মার্চ", "এপ্রি", "মে", "জুন", "জুল", "আগ", "সেপ", "অক্টো", "নভে", "ডিসে", "" } }; //  "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", ""
+            yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, new string[] { "জানু", "ফেব", "মার্চ", "এপ্রি", "মে", "জুন", "জুল", "আগ", "সেপ্টেঃ", "অক্টোঃ", "নভেঃ", "ডিসেঃ", "" } }; //  "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", ""
             yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, new string[] { "gen.", "febr.", "març", "abr.", "maig", "juny", "jul.", "ag.", "set.", "oct.", "nov.", "des.", "" } }; // "de gen.", "de febr.", "de març", "d’abr.", "de maig", "de juny", "de jul.", "d’ag.", "de set.", "d’oct.", "de nov.", "de des.", ""
             yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, new string[] { "gen.", "febr.", "març", "abr.", "maig", "juny", "jul.", "ag.", "set.", "oct.", "nov.", "des.", "" } };
             yield return new object[] { new CultureInfo("cs-CZ").DateTimeFormat, new string[] { "led", "úno", "bře", "dub", "kvě", "čvn", "čvc", "srp", "zář", "říj", "lis", "pro", "" } };
@@ -48,7 +42,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-BS").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-BW").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-BZ").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
-            yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", PlatformDetection.IsNodeJS ? "Sept" : "Sep", "Oct", "Nov", "Dec", "" } }; // "Jan.", "Feb.", "Mar.", "Apr.", "May", "Jun.", "Jul.", "Aug.", "Sep.", "Oct.", "Nov.", "Dec.", ""
+            yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "" } }; // "Jan.", "Feb.", "Mar.", "Apr.", "May", "Jun.", "Jul.", "Aug.", "Sep.", "Oct.", "Nov.", "Dec.", ""
             yield return new object[] { new CultureInfo("en-CC").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-CH").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-CK").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
@@ -158,10 +152,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("it-CH").DateTimeFormat, new string[] { "gen", "feb", "mar", "apr", "mag", "giu", "lug", "ago", "set", "ott", "nov", "dic", "" } };
             yield return new object[] { new CultureInfo("it-IT").DateTimeFormat, new string[] { "gen", "feb", "mar", "apr", "mag", "giu", "lug", "ago", "set", "ott", "nov", "dic", "" } };
             yield return new object[] { new CultureInfo("ja-JP").DateTimeFormat, new string[] { "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月", "" } };
-            string[] kannadianMonths = PlatformDetection.IsNodeJS ? // NodeJs responds like dotnet
-                new string[] { "ಜನವರಿ", "ಫೆಬ್ರವರಿ", "ಮಾರ್ಚ್", "ಏಪ್ರಿ", "ಮೇ", "ಜೂನ್", "ಜುಲೈ", "ಆಗ", "ಸೆಪ್ಟೆಂ", "ಅಕ್ಟೋ", "ನವೆಂ", "ಡಿಸೆಂ", "" } :
-                new string[] { "ಜನವರಿ", "ಫೆಬ್ರವರಿ", "ಮಾರ್ಚ್", "ಏಪ್ರಿ", "ಮೇ", "ಜೂನ್", "ಜುಲೈ", "ಆಗಸ್ಟ್", "ಸೆಪ್ಟೆಂ", "ಅಕ್ಟೋ", "ನವೆಂ", "ಡಿಸೆಂ", "" };
-            yield return new object[] { new CultureInfo("kn-IN").DateTimeFormat, kannadianMonths };
+            yield return new object[] { new CultureInfo("kn-IN").DateTimeFormat, new string[] { "ಜನವರಿ", "ಫೆಬ್ರವರಿ", "ಮಾರ್ಚ್", "ಏಪ್ರಿ", "ಮೇ", "ಜೂನ್", "ಜುಲೈ", "ಆಗಸ್ಟ್", "ಸೆಪ್ಟೆಂ", "ಅಕ್ಟೋ", "ನವೆಂ", "ಡಿಸೆಂ", "" } }; // "ಜನವರಿ", "ಫೆಬ್ರವರಿ", "ಮಾರ್ಚ್", "ಏಪ್ರಿ", "ಮೇ", "ಜೂನ್", "ಜುಲೈ", "ಆಗ", "ಸೆಪ್ಟೆಂ", "ಅಕ್ಟೋ", "ನವೆಂ", "ಡಿಸೆಂ", ""
             yield return new object[] { new CultureInfo("ko-KR").DateTimeFormat, new string[] { "1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월", "" } };
             yield return new object[] { new CultureInfo("lt-LT").DateTimeFormat, new string[] { "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "" } }; // "saus.", "vas.", "kov.", "bal.", "geg.", "birž.", "liep.", "rugp.", "rugs.", "spal.", "lapkr.", "gruod."
             yield return new object[] { new CultureInfo("lv-LV").DateTimeFormat, new string[] { "janv.", "febr.", "marts", "apr.", "maijs", "jūn.", "jūl.", "aug.", "sept.", "okt.", "nov.", "dec.", "" } };
@@ -170,14 +161,10 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("ms-BN").DateTimeFormat, new string[] { "Jan", "Feb", "Mac", "Apr", "Mei", "Jun", "Jul", "Ogo", "Sep", "Okt", "Nov", "Dis", "" } };
             yield return new object[] { new CultureInfo("ms-MY").DateTimeFormat, new string[] { "Jan", "Feb", "Mac", "Apr", "Mei", "Jun", "Jul", "Ogo", "Sep", "Okt", "Nov", "Dis", "" } };
             yield return new object[] { new CultureInfo("ms-SG").DateTimeFormat, new string[] { "Jan", "Feb", "Mac", "Apr", "Mei", "Jun", "Jul", "Ogo", "Sep", "Okt", "Nov", "Dis", "" } };
-            string[] norwegianMonths = PlatformDetection.IsBrowserDomSupported ? // dotnet responds like non-browser
-                new string [] { "jan.", "feb.", "mars", "apr.", "mai", "juni", "juli", "aug.", "sep.", "okt.", "nov.", "des.", "" } :
-                new string [] { "jan.", "feb.", "mar.", "apr.", "mai", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "des.", "" };
+            string[] norwegianMonths = new string [] { "jan.", "feb.", "mars", "apr.", "mai", "juni", "juli", "aug.", "sep.", "okt.", "nov.", "des.", "" }; // "jan.", "feb.", "mar.", "apr.", "mai", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "des.", "
             yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, norwegianMonths };
             yield return new object[] { new CultureInfo("no-NO").DateTimeFormat, norwegianMonths };
-            string[] dutchMonths = PlatformDetection.IsNodeJS ? // NodeJs responds like dotnet
-                new string[] { "jan.", "feb.", "mrt.", "apr.", "mei", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "dec.", "" } :
-                new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" };
+            string[] dutchMonths = new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" }; // "jan.", "feb.", "mrt.", "apr.", "mei", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "dec.", ""
             yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, dutchMonths };
             yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, dutchMonths };
             yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, dutchMonths };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthNames.cs
@@ -34,14 +34,8 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("ar-SA").DateTimeFormat, new string[] { "محرم", "صفر", "ربيع الأول", "ربيع الآخر", "جمادى الأولى", "جمادى الآخرة", "رجب", "شعبان", "رمضان", "شوال", "ذو القعدة", "ذو الحجة", "" } };
             yield return new object[] { new CultureInfo("am-ET").DateTimeFormat, new string[] { "ጃንዩ", "ፌብሩ", "ማርች", "ኤፕሪ", "ሜይ", "ጁን", "ጁላይ", "ኦገስ", "ሴፕቴ", "ኦክቶ", "ኖቬም", "ዲሴም", "" } };
             yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, new string[] { "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "" } }; // "яну", "фев", "март", "апр", "май", "юни", "юли", "авг", "сеп", "окт", "ное", "дек", ""
-            yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, 
-                PlatformDetection.IsNodeJS ?
-                    new string[] { "জানুয়ারী", "ফেব্রুয়ারী", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", "" } :
-                    new string[] { "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", "" } }; // NodeJS responds like dotnet
-            yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 
-                PlatformDetection.IsNodeJS ?
-                    new string[] { "জানুয়ারী", "ফেব্রুয়ারী", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", "" } :
-                    new string[] { "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেঃ", "অক্টোঃ", "নভেঃ", "ডিসেঃ", "" } }; // BUG. JS returns Genitive even though we expect Nominative; NodeJS responds like dotnet
+            yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, new string[] { "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", "" } }; //  "জানুয়ারী", "ফেব্রুয়ারী", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", ""
+            yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, new string[] { "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেঃ", "অক্টোঃ", "নভেঃ", "ডিসেঃ", "" } }; // BUG. JS returns Genitive even though we expect Nominative; "জানু", "ফেব", "মার্চ", "এপ্রিল", "মে", "জুন", "জুলাই", "আগস্ট", "সেপ্টেম্বর", "অক্টোবর", "নভেম্বর", "ডিসেম্বর", ""
             yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, new string[] { "gen.", "febr.", "març", "abr.", "maig", "juny", "jul.", "ag.", "set.", "oct.", "nov.", "des.", "" } };
             yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, new string[] { "gen.", "febr.", "març", "abr.", "maig", "juny", "jul.", "ag.", "set.", "oct.", "nov.", "des.", "" } };
             yield return new object[] { new CultureInfo("cs-CZ").DateTimeFormat, new string[] { "led", "úno", "bře", "dub", "kvě", "čvn", "čvc", "srp", "zář", "říj", "lis", "pro", "" } };
@@ -60,7 +54,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-AI").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-AS").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "" } };
             yield return new object[] { new CultureInfo("en-AT").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
-            yield return new object[] { new CultureInfo("en-AU").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", PlatformDetection.IsNodeJS ? "Sep" : "Sept", "Oct", "Nov", "Dec", "" } }; // v8/Browser responds like dotnet
+            yield return new object[] { new CultureInfo("en-AU").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } };
             yield return new object[] { new CultureInfo("en-BB").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-BE").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-BI").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "" } };
@@ -68,7 +62,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-BS").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-BW").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-BZ").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
-            yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", PlatformDetection.IsNodeJS ? "Sept" : "Sep", "Oct", "Nov", "Dec", "" } }; // "Jan.", "Feb.", "Mar.", "Apr.", "May", "Jun.", "Jul.", "Aug.", "Sep.", "Oct.", "Nov.", "Dec.", ""
+            yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "" } }; // "Jan.", "Feb.", "Mar.", "Apr.", "May", "Jun.", "Jul.", "Aug.", "Sep.", "Oct.", "Nov.", "Dec.", ""
             yield return new object[] { new CultureInfo("en-CC").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-CH").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
             yield return new object[] { new CultureInfo("en-CK").DateTimeFormat, new string[] { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec", "" } }; // "Sep"
@@ -190,12 +184,9 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, new string[] { "jan", "feb", "mar", "apr", "mai", "jun", "jul", "aug", "sep", "okt", "nov", "des", "" } };
             yield return new object[] { new CultureInfo("no").DateTimeFormat, new string[] { "jan", "feb", "mar", "apr", "mai", "jun", "jul", "aug", "sep", "okt", "nov", "des", "" } };
             yield return new object[] { new CultureInfo("no-NO").DateTimeFormat, new string[] { "jan", "feb", "mar", "apr", "mai", "jun", "jul", "aug", "sep", "okt", "nov", "des", "" } };
-            string [] dutchMonths = PlatformDetection.IsNodeJS ?
-                new string [] { "jan.", "feb.", "mrt.", "apr.", "mei", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "dec.", ""} :
-                new string [] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" };
-            yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, dutchMonths };
-            yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, dutchMonths };
-            yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, dutchMonths };
+            yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" } }; // "jan.", "feb.", "mrt.", "apr.", "mei", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "dec.", ""
+            yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" } }; // "jan.", "feb.", "mrt.", "apr.", "mei", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "dec.", ""
+            yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" } }; // "jan.", "feb.", "mrt.", "apr.", "mei", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "dec.", ""
             yield return new object[] { new CultureInfo("pl-PL").DateTimeFormat, new string[] { "sty", "lut", "mar", "kwi", "maj", "cze", "lip", "sie", "wrz", "paź", "lis", "gru", "" } };
             yield return new object[] { new CultureInfo("pt-BR").DateTimeFormat, new string[] { "jan.", "fev.", "mar.", "abr.", "mai.", "jun.", "jul.", "ago.", "set.", "out.", "nov.", "dez.", "" } };
             yield return new object[] { new CultureInfo("pt-PT").DateTimeFormat, new string[] { "jan.", "fev.", "mar.", "abr.", "mai.", "jun.", "jul.", "ago.", "set.", "out.", "nov.", "dez.", "" } };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoCalendarWeekRule.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoCalendarWeekRule.cs
@@ -176,9 +176,9 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("ms-BN").DateTimeFormat, CalendarWeekRule.FirstDay };
                 yield return new object[] { new CultureInfo("ms-MY").DateTimeFormat, CalendarWeekRule.FirstDay };
                 yield return new object[] { new CultureInfo("ms-SG").DateTimeFormat, CalendarWeekRule.FirstDay };
-                yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, PlatformDetection.IsNodeJS ? CalendarWeekRule.FirstDay : CalendarWeekRule.FirstFourDayWeek }; // v8/Browser responds like dotnet
+                yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, CalendarWeekRule.FirstFourDayWeek };
                 yield return new object[] { new CultureInfo("no-NO").DateTimeFormat, CalendarWeekRule.FirstFourDayWeek };
-                yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, PlatformDetection.IsNodeJS ? CalendarWeekRule.FirstFourDayWeek : CalendarWeekRule.FirstDay }; // v8/Browser responds like dotnet
+                yield return new object[] { new CultureInfo("nl-AW").DateTimeFormat, CalendarWeekRule.FirstDay };
                 yield return new object[] { new CultureInfo("nl-BE").DateTimeFormat, CalendarWeekRule.FirstFourDayWeek };
                 yield return new object[] { new CultureInfo("nl-NL").DateTimeFormat, CalendarWeekRule.FirstFourDayWeek };
                 yield return new object[] { new CultureInfo("pl-PL").DateTimeFormat, CalendarWeekRule.FirstFourDayWeek };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoDayNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoDayNames.cs
@@ -42,10 +42,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("es-419").DateTimeFormat, new string[] { "domingo", "lunes", "martes", "miércoles", "jueves", "viernes", "sábado" } };
             yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, new string[] { "domingo", "lunes", "martes", "miércoles", "jueves", "viernes", "sábado" } };
             yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, new string[] { "domingo", "lunes", "martes", "miércoles", "jueves", "viernes", "sábado" } };
-            yield return new object[] { new CultureInfo("et-EE").DateTimeFormat,
-                PlatformDetection.IsNodeJS ?
-                new string[] { "Pühapäev", "Esmaspäev", "Teisipäev", "Kolmapäev", "Neljapäev", "Reede", "Laupäev" } :
-                new string[] { "pühapäev", "esmaspäev", "teisipäev", "kolmapäev", "neljapäev", "reede", "laupäev" } };
+            yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, new string[] { "pühapäev", "esmaspäev", "teisipäev", "kolmapäev", "neljapäev", "reede", "laupäev" } };
             yield return new object[] { new CultureInfo("fa-IR").DateTimeFormat, new string[] { "یکشنبه", "دوشنبه", "سه‌شنبه", "چهارشنبه", "پنجشنبه", "جمعه", "شنبه" } };
             yield return new object[] { new CultureInfo("fi-FI").DateTimeFormat, new string[] { "sunnuntai", "maanantai", "tiistai", "keskiviikko", "torstai", "perjantai", "lauantai" } };
             yield return new object[] { new CultureInfo("fil-PH").DateTimeFormat, new string[] { "Linggo", "Lunes", "Martes", "Miyerkules", "Huwebes", "Biyernes", "Sabado" } };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoFirstDayOfWeek.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoFirstDayOfWeek.cs
@@ -42,7 +42,7 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("en-AI").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("en-AS").DateTimeFormat, DayOfWeek.Sunday };
                 yield return new object[] { new CultureInfo("en-AT").DateTimeFormat, DayOfWeek.Monday };
-                yield return new object[] { new CultureInfo("en-AU").DateTimeFormat, PlatformDetection.IsNodeJS ? DayOfWeek.Sunday : DayOfWeek.Monday }; // originally in ICU: Sunday, even though ISO 8601 states: Monday 
+                yield return new object[] { new CultureInfo("en-AU").DateTimeFormat, DayOfWeek.Monday }; // originally in ICU: Sunday, even though ISO 8601 states: Monday
                 yield return new object[] { new CultureInfo("en-BB").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("en-BE").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("en-BI").DateTimeFormat, DayOfWeek.Monday };
@@ -194,13 +194,13 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("ta-LK").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("ta-MY").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("ta-SG").DateTimeFormat, DayOfWeek.Sunday };
-                yield return new object[] { new CultureInfo("te-IN").DateTimeFormat, PlatformDetection.IsNodeJS ? DayOfWeek.Monday : DayOfWeek.Sunday }; // Browser/V8 responds like dotnet
+                yield return new object[] { new CultureInfo("te-IN").DateTimeFormat, DayOfWeek.Sunday };
                 yield return new object[] { new CultureInfo("th-TH").DateTimeFormat, DayOfWeek.Sunday };
                 yield return new object[] { new CultureInfo("tr-CY").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("tr-TR").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("uk-UA").DateTimeFormat, DayOfWeek.Monday };
                 yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, DayOfWeek.Monday };
-                yield return new object[] { new CultureInfo("zh-CN").DateTimeFormat, PlatformDetection.IsNodeJS ? DayOfWeek.Sunday : DayOfWeek.Monday  }; // NodeJS responds like dotnet
+                yield return new object[] { new CultureInfo("zh-CN").DateTimeFormat, DayOfWeek.Monday  };
                 yield return new object[] { new CultureInfo("zh-Hans-HK").DateTimeFormat, DayOfWeek.Sunday };
                 yield return new object[] { new CultureInfo("zh-SG").DateTimeFormat, DayOfWeek.Sunday };
                 yield return new object[] { new CultureInfo("zh-HK").DateTimeFormat, DayOfWeek.Sunday };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedEraName.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedEraName.cs
@@ -23,7 +23,7 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("am-ET").DateTimeFormat, 1, "ዓ/ም" };
                 yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, 1, "сл.Хр." };
                 yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, 1, "খৃষ্টাব্দ" };
-                yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 1, PlatformDetection.IsNodeJS ? "খৃষ্টাব্দ" : "খ্রিঃ" }; // NodeJS responses like dotnet
+                yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 1, "খ্রিঃ" }; // "খৃষ্টাব্দ"
                 yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, 1, "dC" };
                 yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, 1, "dC" };
                 yield return new object[] { new CultureInfo("cs-CZ").DateTimeFormat, 1, "n.l." };
@@ -140,9 +140,8 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("en-ZM").DateTimeFormat, 1, "A" }; // AD
                 yield return new object[] { new CultureInfo("en-ZW").DateTimeFormat, 1, "A" }; // AD
                 yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, 1, "d. C." };
-                string spanishEra = PlatformDetection.IsNodeJS ? "d. C." : "d.C."; // NodeJS responses like dotnet
-                yield return new object[] { new CultureInfo("es-419").DateTimeFormat, 1, spanishEra };
-                yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, 1, spanishEra };
+                yield return new object[] { new CultureInfo("es-419").DateTimeFormat, 1, "d.C." }; // "d. C."
+                yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, 1, "d.C." }; // "d. C."
                 yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, 1, "pKr" };
                 yield return new object[] { new CultureInfo("fa-IR").DateTimeFormat, 1, "ه.ش" }; // ه‍.ش.
                 yield return new object[] { new CultureInfo("fi-FI").DateTimeFormat, 1, "jKr" };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEraName.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEraName.cs
@@ -12,7 +12,7 @@ namespace System.Globalization.Tests
         {
             yield return new object[] { DateTimeFormatInfo.InvariantInfo, 1, "A.D." };
             yield return new object[] { DateTimeFormatInfo.InvariantInfo, 0, "A.D." };
-            
+
             if (!PlatformDetection.IsHybridGlobalizationOnBrowser)
             {
                 var enUSFormat = new CultureInfo("en-US").DateTimeFormat;
@@ -33,9 +33,8 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, 1, "сл.Хр." };
                 yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, 0, "খৃষ্টাব্দ" };
                 yield return new object[] { new CultureInfo("bn-BD").DateTimeFormat, 1, "খৃষ্টাব্দ" };
-                string bangladeshEra = PlatformDetection.IsNodeJS ? "খৃষ্টাব্দ" : "খ্রিঃ";
-                yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 0, bangladeshEra };
-                yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 1, bangladeshEra };
+                yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 0, "খ্রিঃ" };
+                yield return new object[] { new CultureInfo("bn-IN").DateTimeFormat, 1, "খ্রিঃ" };
                 yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, 0, "dC" };
                 yield return new object[] { new CultureInfo("ca-AD").DateTimeFormat, 1, "dC" };
                 yield return new object[] { new CultureInfo("ca-ES").DateTimeFormat, 0, "dC" };
@@ -270,11 +269,10 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("en-US").DateTimeFormat, 1, "AD" };
                 yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, 0, "d. C." };
                 yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, 1, "d. C." };
-                string spanishEra = PlatformDetection.IsNodeJS ? "d. C." : "d.C.";
-                yield return new object[] { new CultureInfo("es-419").DateTimeFormat, 0, spanishEra };
-                yield return new object[] { new CultureInfo("es-419").DateTimeFormat, 1, spanishEra};
-                yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, 0, spanishEra };
-                yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, 1, spanishEra };
+                yield return new object[] { new CultureInfo("es-419").DateTimeFormat, 0, "d.C." };
+                yield return new object[] { new CultureInfo("es-419").DateTimeFormat, 1, "d.C."};
+                yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, 0, "d.C." };
+                yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, 1, "d.C." };
                 yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, 0, "pKr" };
                 yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, 1, "pKr" };
                 yield return new object[] { new CultureInfo("fa-IR").DateTimeFormat, 0, "ه.ش" }; // ه‍.ش.
@@ -389,9 +387,8 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("tr-TR").DateTimeFormat, 1, "MS" };
                 yield return new object[] { new CultureInfo("uk-UA").DateTimeFormat, 0, "н. е." };
                 yield return new object[] { new CultureInfo("uk-UA").DateTimeFormat, 1, "н. е." };
-                string vietnameseEra = PlatformDetection.IsNodeJS ? "Sau CN" : "CN"; // dotnet: sau CN
-                yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, 0, vietnameseEra };
-                yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, 1, vietnameseEra };
+                yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, 0, "CN" }; // sau CN
+                yield return new object[] { new CultureInfo("vi-VN").DateTimeFormat, 1, "CN" }; // sau CN
                 yield return new object[] { new CultureInfo("zh-CN").DateTimeFormat, 0, "公元" };
                 yield return new object[] { new CultureInfo("zh-CN").DateTimeFormat, 1, "公元" };
                 yield return new object[] { new CultureInfo("zh-Hans-HK").DateTimeFormat, 0, "公元" };

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoNativeCalendarName.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoNativeCalendarName.cs
@@ -11,10 +11,10 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> NativeCalendarName_Get_TestData_HybridGlobalization()
         {
             // see the comments on the right to check the non-Hybrid result, in this collection it always differs
-            string islamicName = PlatformDetection.IsNodeJS ? "UMALQURA" : "islamic-umalqura";
-            string gregorianName = PlatformDetection.IsNodeJS ? "GREGORIAN" : "gregory";
-            string persianName = PlatformDetection.IsNodeJS ? "PERSIAN" : "persian";
-            string bhuddistName = PlatformDetection.IsNodeJS ? "THAI" : "buddhist";
+            string islamicName = "islamic-umalqura";
+            string gregorianName = "gregory";
+            string persianName = "persian";
+            string bhuddistName = "buddhist";
             yield return new object[] { new CultureInfo("ar-SA").DateTimeFormat, islamicName }; // التقويم الإسلامي (أم القرى)
             yield return new object[] { new CultureInfo("am-ET").DateTimeFormat, gregorianName }; // የግሪጎሪያን የቀን አቆጣጠር
             yield return new object[] { new CultureInfo("bg-BG").DateTimeFormat, gregorianName }; // григориански календар
@@ -203,7 +203,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("zh-HK").DateTimeFormat, gregorianName }; // 公曆
             yield return new object[] { new CultureInfo("zh-TW").DateTimeFormat, gregorianName };
         }
-        
+
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnBrowser))]
         [MemberData(nameof(NativeCalendarName_Get_TestData_HybridGlobalization))]
         public void NativeCalendarName_Get_ReturnsExpected_HybridGlobalization(DateTimeFormatInfo format, string expected)

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortDatePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortDatePattern.cs
@@ -44,7 +44,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-BZ").DateTimeFormat, "dd/MM/yyyy" };
             yield return new object[] { new CultureInfo("en-CA").DateTimeFormat, "yyyy-MM-dd" };
             yield return new object[] { new CultureInfo("en-CC").DateTimeFormat, "dd/MM/yyyy" };
-            yield return new object[] { new CultureInfo("en-CH").DateTimeFormat, PlatformDetection.IsNodeJS ? "dd/MM/yyyy" : "dd.MM.yyyy" }; // NodeJS responds like dotnet
+            yield return new object[] { new CultureInfo("en-CH").DateTimeFormat, "dd.MM.yyyy" }; // "dd/MM/yyyy"
             yield return new object[] { new CultureInfo("en-CK").DateTimeFormat, "dd/MM/yyyy" };
             yield return new object[] { new CultureInfo("en-CM").DateTimeFormat, "dd/MM/yyyy" };
             yield return new object[] { new CultureInfo("en-CX").DateTimeFormat, "dd/MM/yyyy" };
@@ -138,7 +138,7 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("et-EE").DateTimeFormat, "dd.MM.yyyy" };
             yield return new object[] { new CultureInfo("fa-IR").DateTimeFormat, "yyyy/M/d" }; // "yyyy/M/d"
             yield return new object[] { new CultureInfo("fi-FI").DateTimeFormat, "d.M.yyyy" };
-            yield return new object[] { new CultureInfo("fil-PH").DateTimeFormat, "M/d/yyyy" }; 
+            yield return new object[] { new CultureInfo("fil-PH").DateTimeFormat, "M/d/yyyy" };
             yield return new object[] { new CultureInfo("fr-BE").DateTimeFormat, "d/MM/yyyy" };
             yield return new object[] { new CultureInfo("fr-CA").DateTimeFormat, "yyyy-MM-dd" };
             yield return new object[] { new CultureInfo("fr-CH").DateTimeFormat, "dd.MM.yyyy" };

--- a/src/mono/wasm/runtime/hybrid-globalization/culture-info.ts
+++ b/src/mono/wasm/runtime/hybrid-globalization/culture-info.ts
@@ -47,8 +47,8 @@ export function mono_wasm_get_culture_info(culture: MonoStringRef, dst: number, 
 
 function getAmPmDesignators(locale: any)
 {
-    const pmTime = new Date("August 19, 1975 12:15:30"); // do not change, some PM hours result in hour digits change, e.g. 13 -> 01 or 1
-    const amTime = new Date("August 19, 1975 11:15:30"); // do not change, some AM hours result in hour digits change, e.g. 9 -> 09
+    const pmTime = new Date("August 19, 1975 12:15:33"); // do not change, some PM hours result in hour digits change, e.g. 13 -> 01 or 1
+    const amTime = new Date("August 19, 1975 11:15:33"); // do not change, some AM hours result in hour digits change, e.g. 9 -> 09
     const pmDesignator = getDesignator(pmTime, locale);
     const amDesignator = getDesignator(amTime, locale);
     return {
@@ -59,7 +59,14 @@ function getAmPmDesignators(locale: any)
 
 function getDesignator(time: Date, locale: string)
 {
-    const withDesignator = time.toLocaleTimeString(locale, { hourCycle: "h12"});
+    let withDesignator = time.toLocaleTimeString(locale, { hourCycle: "h12"});
+    const localizedZero = (0).toLocaleString(locale);
+    if (withDesignator.includes(localizedZero))
+    {
+        // in v8>=11.8 "12" changes to "0" for ja-JP
+        const localizedTwelve = (12).toLocaleString(locale);
+        withDesignator = withDesignator.replace(localizedZero, localizedTwelve);
+    }
     const withoutDesignator = time.toLocaleTimeString(locale, { hourCycle: "h24"});
     const designator = withDesignator.replace(withoutDesignator, "").trim();
     if (new RegExp("[0-9]$").test(designator)){


### PR DESCRIPTION
And revert earlier workarounds for icu tests, as the image now uses *latest* v8. - Ilona Tomkowicz

The v8 version will be pinned to a corresponding version for chrome in a follow up PR.

Fixes https://github.com/dotnet/runtime/issues/86480