### PR TITLE
[NativeAOT] Missing memory fence before bulk move of objects

### DIFF
--- a/src/coreclr/nativeaot/Runtime/GCMemoryHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/GCMemoryHelpers.cpp
@@ -10,7 +10,6 @@
 #include "PalRedhawkCommon.h"
 #include "CommonMacros.inl"
 
-#include "GCMemoryHelpers.h"
 #include "GCMemoryHelpers.inl"
 
 // This function clears a piece of memory in a GC safe way.

--- a/src/coreclr/nativeaot/Runtime/GCMemoryHelpers.h
+++ b/src/coreclr/nativeaot/Runtime/GCMemoryHelpers.h
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-//
-// Unmanaged GC memory helpers
-//

--- a/src/coreclr/nativeaot/Runtime/GCMemoryHelpers.h
+++ b/src/coreclr/nativeaot/Runtime/GCMemoryHelpers.h
@@ -4,5 +4,3 @@
 //
 // Unmanaged GC memory helpers
 //
-
-EXTERN_C void REDHAWK_CALLCONV RhpBulkWriteBarrier(void* pMemStart, uint32_t cbMemSize);

--- a/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
@@ -35,7 +35,6 @@
 #include "MethodTable.inl"
 #include "CommonMacros.inl"
 #include "volatile.h"
-#include "GCMemoryHelpers.h"
 #include "GCMemoryHelpers.inl"
 #include "yieldprocessornormalized.h"
 #include "RhConfig.h"

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -42,7 +42,6 @@
 
 #include "daccess.h"
 
-#include "GCMemoryHelpers.h"
 #include "interoplibinterface.h"
 
 #include "holder.h"

--- a/src/coreclr/nativeaot/Runtime/portable.cpp
+++ b/src/coreclr/nativeaot/Runtime/portable.cpp
@@ -31,7 +31,6 @@
 #include "MethodTable.inl"
 #include "ObjectLayout.h"
 
-#include "GCMemoryHelpers.h"
 #include "GCMemoryHelpers.inl"
 
 #if defined(USE_PORTABLE_HELPERS)

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -24,7 +24,6 @@
 #include "yieldprocessornormalized.h"
 
 #include "slist.inl"
-#include "GCMemoryHelpers.h"
 
 EXTERN_C volatile uint32_t RhpTrapThreads;
 volatile uint32_t RhpTrapThreads = (uint32_t)TrapThreadsFlags::None;


### PR DESCRIPTION
Memory model requires that the modifications to an object are observable by other threads no later than the reference to the object becomes observable.  
It is possible that `RhBulkMoveWithWriteBarrier` is making the objects shared, thus needs a fence.

See similar fence in CoreCLR `InlinedMemmoveGCRefsHelper`

https://github.com/dotnet/runtime/blob/e18e4aa3b3a914a054752261d136ace6b8bcdd87/src/coreclr/classlibnative/bcltype/arraynative.inl#L310