### PR TITLE
Adding missing System.Buffers documentation

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.ReadBigEndian.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.ReadBigEndian.cs
@@ -238,7 +238,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="double" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="double" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -260,7 +260,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="Half" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="Half" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -282,7 +282,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="short" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="short" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -304,7 +304,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="int" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="int" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -326,7 +326,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="long" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="long" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -348,7 +348,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="Int128" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="Int128" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -370,7 +370,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="nint" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="nint" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -392,7 +392,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="float" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="float" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -413,7 +413,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="ushort" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="ushort" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -436,7 +436,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="uint" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="uint" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -459,7 +459,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="ulong" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="ulong" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -482,7 +482,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="UInt128" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="UInt128" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -506,7 +506,7 @@ namespace System.Buffers.Binary
         /// </summary>
 
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as big endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="nuint" />; otherwise, <see langword="false" />.
         /// </returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.ReadBigEndian.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.ReadBigEndian.cs
@@ -45,6 +45,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="short" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The big endian value.</returns>
+        /// <remarks>Reads exactly 2 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="short" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short ReadInt16BigEndian(ReadOnlySpan<byte> source)
         {
@@ -56,6 +62,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="int" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The big endian value.</returns>
+        /// <remarks>Reads exactly 4 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="int" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ReadInt32BigEndian(ReadOnlySpan<byte> source)
         {
@@ -67,6 +79,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="long" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The big endian value.</returns>
+        /// <remarks>Reads exactly 8 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="long" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long ReadInt64BigEndian(ReadOnlySpan<byte> source)
         {
@@ -78,6 +96,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="Int128" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The big endian value.</returns>
+        /// <remarks>Reads exactly 16 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="Int128" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Int128 ReadInt128BigEndian(ReadOnlySpan<byte> source)
         {
@@ -89,6 +113,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="nint" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The big endian value.</returns>
+        /// <remarks>Reads exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="nint" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nint ReadIntPtrBigEndian(ReadOnlySpan<byte> source)
         {
@@ -117,6 +147,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="ushort" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The big endian value.</returns>
+        /// <remarks>Reads exactly 2 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="ushort" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ReadUInt16BigEndian(ReadOnlySpan<byte> source)
@@ -129,6 +165,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="uint" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The big endian value.</returns>
+        /// <remarks>Reads exactly 4 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="uint" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ReadUInt32BigEndian(ReadOnlySpan<byte> source)
@@ -141,6 +183,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="ulong" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The big endian value.</returns>
+        /// <remarks>Reads exactly 8 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="ulong" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ReadUInt64BigEndian(ReadOnlySpan<byte> source)
@@ -153,6 +201,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="UInt128" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The big endian value.</returns>
+        /// <remarks>Reads exactly 16 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="UInt128" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static UInt128 ReadUInt128BigEndian(ReadOnlySpan<byte> source)
@@ -165,6 +219,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="nuint" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The big endian value.</returns>
+        /// <remarks>Reads exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="nuint" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nuint ReadUIntPtrBigEndian(ReadOnlySpan<byte> source)
@@ -221,7 +281,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="short" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="short" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="short" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 2 bytes from the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadInt16BigEndian(ReadOnlySpan<byte> source, out short value)
         {
@@ -238,7 +303,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="int" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="int" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="int" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 4 bytes from the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadInt32BigEndian(ReadOnlySpan<byte> source, out int value)
         {
@@ -255,7 +325,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="long" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="long" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="long" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 8 bytes from the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadInt64BigEndian(ReadOnlySpan<byte> source, out long value)
         {
@@ -272,7 +347,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="Int128" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="Int128" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="Int128" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 16 bytes from the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadInt128BigEndian(ReadOnlySpan<byte> source, out Int128 value)
         {
@@ -289,7 +369,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="nint" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="nint" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="nint" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms from the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadIntPtrBigEndian(ReadOnlySpan<byte> source, out nint value)
         {
@@ -327,7 +412,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="ushort" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="ushort" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="ushort" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 2 bytes from the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt16BigEndian(ReadOnlySpan<byte> source, out ushort value)
@@ -345,7 +435,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="uint" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="uint" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="uint" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 4 bytes from the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt32BigEndian(ReadOnlySpan<byte> source, out uint value)
@@ -363,7 +458,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="ulong" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="ulong" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="ulong" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 8 bytes from the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt64BigEndian(ReadOnlySpan<byte> source, out ulong value)
@@ -381,7 +481,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="UInt128" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="UInt128" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="UInt128" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 16 bytes from the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt128BigEndian(ReadOnlySpan<byte> source, out UInt128 value)
@@ -399,7 +504,13 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="nuint" /> from the beginning of a read-only span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="nuint" />, return false.</returns>
+
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as big endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="nuint" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms from the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUIntPtrBigEndian(ReadOnlySpan<byte> source, out nuint value)

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.ReadLittleEndian.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.ReadLittleEndian.cs
@@ -238,7 +238,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="double" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="double" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -260,7 +260,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="Half" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="Half" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -282,7 +282,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="short" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="short" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -304,7 +304,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="int" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="int" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -326,7 +326,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="long" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="long" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -348,7 +348,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="Int128" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="Int128" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -370,7 +370,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="nint" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="nint" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -392,7 +392,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="float" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="float" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -413,7 +413,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="ushort" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="ushort" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -436,7 +436,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="uint" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="uint" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -459,7 +459,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="ulong" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="ulong" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -482,7 +482,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="UInt128" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="UInt128" />; otherwise, <see langword="false" />.
         /// </returns>
@@ -505,7 +505,7 @@ namespace System.Buffers.Binary
         /// Reads a <see cref="nuint" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
         /// <param name="source">The read-only span of bytes to read.</param>
-        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <param name="value">When this method returns, contains the value read out of the read-only span of bytes, as little endian.</param>
         /// <returns>
         /// <see langword="true" /> if the span is large enough to contain a <see cref="nuint" />; otherwise, <see langword="false" />.
         /// </returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.ReadLittleEndian.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.ReadLittleEndian.cs
@@ -45,6 +45,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="short" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The little endian value.</returns>
+        /// <remarks>Reads exactly 2 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="short" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short ReadInt16LittleEndian(ReadOnlySpan<byte> source)
         {
@@ -56,6 +62,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="int" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The little endian value.</returns>
+        /// <remarks>Reads exactly 4 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="int" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ReadInt32LittleEndian(ReadOnlySpan<byte> source)
         {
@@ -67,6 +79,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="long" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The little endian value.</returns>
+        /// <remarks>Reads exactly 8 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="long" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long ReadInt64LittleEndian(ReadOnlySpan<byte> source)
         {
@@ -78,6 +96,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="Int128" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The little endian value.</returns>
+        /// <remarks>Reads exactly 16 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="Int128" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Int128 ReadInt128LittleEndian(ReadOnlySpan<byte> source)
         {
@@ -89,6 +113,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="nint" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The little endian value.</returns>
+        /// <remarks>Reads exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="nint" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nint ReadIntPtrLittleEndian(ReadOnlySpan<byte> source)
         {
@@ -117,6 +147,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="ushort" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The little endian value.</returns>
+        /// <remarks>Reads exactly 2 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="ushort" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ReadUInt16LittleEndian(ReadOnlySpan<byte> source)
@@ -129,6 +165,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="uint" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The little endian value.</returns>
+        /// <remarks>Reads exactly 4 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="uint" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ReadUInt32LittleEndian(ReadOnlySpan<byte> source)
@@ -141,6 +183,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="ulong" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The little endian value.</returns>
+        /// <remarks>Reads exactly 8 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="ulong" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ReadUInt64LittleEndian(ReadOnlySpan<byte> source)
@@ -153,6 +201,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="UInt128" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The little endian value.</returns>
+        /// <remarks>Reads exactly 16 bytes from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="UInt128" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static UInt128 ReadUInt128LittleEndian(ReadOnlySpan<byte> source)
@@ -165,6 +219,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="nuint" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
+        /// <param name="source">The read-only span to read.</param>
+        /// <returns>The little endian value.</returns>
+        /// <remarks>Reads exactly 4 bytes on 32-bit platforms or 8 bytes on 64-bit platforms from the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="source"/> is too small to contain a <see cref="nuint" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nuint ReadUIntPtrLittleEndian(ReadOnlySpan<byte> source)
@@ -221,7 +281,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="short" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="short" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="short" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 2 bytes from the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadInt16LittleEndian(ReadOnlySpan<byte> source, out short value)
         {
@@ -238,7 +303,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="int" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="int" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="int" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 4 bytes from the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadInt32LittleEndian(ReadOnlySpan<byte> source, out int value)
         {
@@ -255,7 +325,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="long" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="long" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="long" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 8 bytes from the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadInt64LittleEndian(ReadOnlySpan<byte> source, out long value)
         {
@@ -272,7 +347,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="Int128" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="Int128" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="Int128" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 16 bytes from the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadInt128LittleEndian(ReadOnlySpan<byte> source, out Int128 value)
         {
@@ -289,7 +369,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="nint" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="nint" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="nint" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 4 bytes on 32-bit platforms or 8 bytes on 64-bit platforms from the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadIntPtrLittleEndian(ReadOnlySpan<byte> source, out nint value)
         {
@@ -327,7 +412,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="ushort" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="ushort" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="ushort" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 2 bytes from the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt16LittleEndian(ReadOnlySpan<byte> source, out ushort value)
@@ -345,7 +435,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="uint" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="uint" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="uint" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 4 bytes from the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt32LittleEndian(ReadOnlySpan<byte> source, out uint value)
@@ -363,7 +458,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="ulong" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="ulong" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="ulong" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 8 bytes from the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt64LittleEndian(ReadOnlySpan<byte> source, out ulong value)
@@ -381,7 +481,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="UInt128" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="UInt128" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="UInt128" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 16 bytes from the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUInt128LittleEndian(ReadOnlySpan<byte> source, out UInt128 value)
@@ -399,7 +504,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Reads a <see cref="nuint" /> from the beginning of a read-only span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain a <see cref="nuint" />, return false.</returns>
+        /// <param name="source">The read-only span of bytes to read.</param>
+        /// <param name="value">When this method returns, the value read out of the read-only span of bytes, as little endian.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="nuint" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Reads exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms from the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReadUIntPtrLittleEndian(ReadOnlySpan<byte> source, out nuint value)

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.ReverseEndianness.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.ReverseEndianness.cs
@@ -22,42 +22,53 @@ namespace System.Buffers.Binary
     public static partial class BinaryPrimitives
     {
         /// <summary>
-        /// This is a no-op and added only for consistency.
-        /// This allows the caller to read a struct of numeric primitives and reverse each field
-        /// rather than having to skip sbyte fields.
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="sbyte" /> value, which effectively does nothing for an <see cref="sbyte" />.
         /// </summary>
+        /// <param name="value">The value to reverse.</param>
+        /// <returns>The passed-in value, unmodified.</returns>
+        /// <remarks>This method effectively does nothing and was added only for consistency.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static sbyte ReverseEndianness(sbyte value) => value;
 
         /// <summary>
-        /// Reverses a primitive value - performs an endianness swap
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="short" /> value.
         /// </summary>
+        /// <param name="value">The value to reverse.</param>
+        /// <returns>The reversed value.</returns>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short ReverseEndianness(short value) => (short)ReverseEndianness((ushort)value);
 
         /// <summary>
-        /// Reverses a primitive value - performs an endianness swap
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="int" /> value.
         /// </summary>
+        /// <param name="value">The value to reverse.</param>
+        /// <returns>The reversed value.</returns>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ReverseEndianness(int value) => (int)ReverseEndianness((uint)value);
 
         /// <summary>
-        /// Reverses a primitive value - performs an endianness swap
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="long" /> value.
         /// </summary>
+        /// <param name="value">The value to reverse.</param>
+        /// <returns>The reversed value.</returns>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long ReverseEndianness(long value) => (long)ReverseEndianness((ulong)value);
 
-        /// <summary>Reverses a primitive value by performing an endianness swap of the specified <see cref="nint"/> value.</summary>
+        /// <summary>
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="nint" /> value.
+        /// </summary>
         /// <param name="value">The value to reverse.</param>
         /// <returns>The reversed value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nint ReverseEndianness(nint value) => (nint)ReverseEndianness((nint_t)value);
 
-        /// <summary>Reverses a primitive value by performing an endianness swap of the specified <see cref="Int128"/> value.</summary>
+        /// <summary>
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="Int128" /> value.
+        /// </summary>
         /// <param name="value">The value to reverse.</param>
         /// <returns>The reversed value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -70,16 +81,19 @@ namespace System.Buffers.Binary
         }
 
         /// <summary>
-        /// This is a no-op and added only for consistency.
-        /// This allows the caller to read a struct of numeric primitives and reverse each field
-        /// rather than having to skip byte fields.
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="byte" /> value, which effectively does nothing for an <see cref="byte" />.
         /// </summary>
+        /// <param name="value">The value to reverse.</param>
+        /// <returns>The passed-in value, unmodified.</returns>
+        /// <remarks>This method effectively does nothing and was added only for consistency.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte ReverseEndianness(byte value) => value;
 
         /// <summary>
-        /// Reverses a primitive value - performs an endianness swap
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="ushort" /> value.
         /// </summary>
+        /// <param name="value">The value to reverse.</param>
+        /// <returns>The reversed value.</returns>
         [CLSCompliant(false)]
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -96,14 +110,18 @@ namespace System.Buffers.Binary
         }
 
         /// <summary>
-        /// Reverses a 16-bit character value - performs an endianness swap
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="char" /> value.
         /// </summary>
+        /// <param name="value">The value to reverse.</param>
+        /// <returns>The reversed value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static char ReverseEndianness(char value) => (char)ReverseEndianness((ushort)value);
 
         /// <summary>
-        /// Reverses a primitive value - performs an endianness swap
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="uint" /> value.
         /// </summary>
+        /// <param name="value">The value to reverse.</param>
+        /// <returns>The reversed value.</returns>
         [CLSCompliant(false)]
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -134,8 +152,10 @@ namespace System.Buffers.Binary
         }
 
         /// <summary>
-        /// Reverses a primitive value - performs an endianness swap
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="ulong" /> value.
         /// </summary>
+        /// <param name="value">The value to reverse.</param>
+        /// <returns>The reversed value.</returns>
         [CLSCompliant(false)]
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -148,14 +168,18 @@ namespace System.Buffers.Binary
                 + ReverseEndianness((uint)(value >> 32));
         }
 
-        /// <summary>Reverses a primitive value by performing an endianness swap of the specified <see cref="nuint"/> value.</summary>
+        /// <summary>
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="nuint" /> value.
+        /// </summary>
         /// <param name="value">The value to reverse.</param>
         /// <returns>The reversed value.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nuint ReverseEndianness(nuint value) => (nuint)ReverseEndianness((nuint_t)value);
 
-        /// <summary>Reverses a primitive value by performing an endianness swap of the specified <see cref="UInt128"/> value.</summary>
+        /// <summary>
+        /// Reverses a primitive value by performing an endianness swap of the specified <see cref="UInt128" /> value.
+        /// </summary>
         /// <param name="value">The value to reverse.</param>
         /// <returns>The reversed value.</returns>
         [CLSCompliant(false)]

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.WriteBigEndian.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.WriteBigEndian.cs
@@ -57,6 +57,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="short" /> into a span of bytes, as big endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 2 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="short" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteInt16BigEndian(Span<byte> destination, short value)
         {
@@ -74,6 +80,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="int" /> into a span of bytes, as big endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 4 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="int" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteInt32BigEndian(Span<byte> destination, int value)
         {
@@ -91,6 +103,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="long" /> into a span of bytes, as big endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 8 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="long" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteInt64BigEndian(Span<byte> destination, long value)
         {
@@ -108,6 +126,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="Int128" /> into a span of bytes, as big endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 16 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="Int128" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteInt128BigEndian(Span<byte> destination, Int128 value)
         {
@@ -125,6 +149,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="nint" /> into a span of bytes, as big endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="nint" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteIntPtrBigEndian(Span<byte> destination, nint value)
         {
@@ -165,6 +195,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a <see cref="ushort" /> into a span of bytes, as big endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 2 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="ushort" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt16BigEndian(Span<byte> destination, ushort value)
@@ -183,6 +219,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a <see cref="uint" /> into a span of bytes, as big endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 4 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="uint" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt32BigEndian(Span<byte> destination, uint value)
@@ -201,6 +243,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a <see cref="ulong" /> into a span of bytes, as big endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 8 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="ulong" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt64BigEndian(Span<byte> destination, ulong value)
@@ -219,6 +267,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="UInt128" /> into a span of bytes, as big endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 16 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="UInt128" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt128BigEndian(Span<byte> destination, UInt128 value)
@@ -237,6 +291,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="nuint" /> into a span of bytes, as big endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="nuint" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUIntPtrBigEndian(Span<byte> destination, nuint value)
@@ -297,7 +357,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="short" /> into a span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="short" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 2 bytes to the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteInt16BigEndian(Span<byte> destination, short value)
         {
@@ -313,7 +378,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="int" /> into a span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="int" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 4 bytes to the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteInt32BigEndian(Span<byte> destination, int value)
         {
@@ -329,7 +399,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="long" /> into a span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="long" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 8 bytes to the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteInt64BigEndian(Span<byte> destination, long value)
         {
@@ -345,7 +420,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="Int128" /> into a span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="Int128" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 16 bytes to the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteInt128BigEndian(Span<byte> destination, Int128 value)
         {
@@ -361,7 +441,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="nint" /> into a span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="nint" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms to the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteIntPtrBigEndian(Span<byte> destination, nint value)
         {
@@ -398,7 +483,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a <see cref="ushort" /> into a span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="ushort" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 2 bytes to the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt16BigEndian(Span<byte> destination, ushort value)
@@ -415,7 +505,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a <see cref="uint" /> into a span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="uint" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 4 bytes to the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt32BigEndian(Span<byte> destination, uint value)
@@ -432,7 +527,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a <see cref="ulong" /> into a span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="ulong" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 8 bytes to the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt64BigEndian(Span<byte> destination, ulong value)
@@ -449,7 +549,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="UInt128" /> into a span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="UInt128" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 16 bytes to the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt128BigEndian(Span<byte> destination, UInt128 value)
@@ -466,7 +571,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="nuint" /> into a span of bytes, as big endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as big endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="nuint" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms to the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUIntPtrBigEndian(Span<byte> destination, nuint value)

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.WriteLittleEndian.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Binary/BinaryPrimitives.WriteLittleEndian.cs
@@ -57,6 +57,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="short" /> into a span of bytes, as little endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 2 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="short" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteInt16LittleEndian(Span<byte> destination, short value)
         {
@@ -74,6 +80,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="int" /> into a span of bytes, as little endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 4 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="int" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteInt32LittleEndian(Span<byte> destination, int value)
         {
@@ -91,6 +103,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="long" /> into a span of bytes, as little endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 8 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="long" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteInt64LittleEndian(Span<byte> destination, long value)
         {
@@ -108,6 +126,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="Int128" /> into a span of bytes, as little endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 16 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="Int128" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteInt128LittleEndian(Span<byte> destination, Int128 value)
         {
@@ -125,6 +149,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="nint" /> into a span of bytes, as little endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="nint" />.
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteIntPtrLittleEndian(Span<byte> destination, nint value)
         {
@@ -165,6 +195,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a <see cref="ushort" /> into a span of bytes, as little endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 2 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="ushort" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt16LittleEndian(Span<byte> destination, ushort value)
@@ -183,6 +219,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a <see cref="uint" /> into a span of bytes, as little endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 4 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="uint" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt32LittleEndian(Span<byte> destination, uint value)
@@ -201,6 +243,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a <see cref="ulong" /> into a span of bytes, as little endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 8 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="ulong" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt64LittleEndian(Span<byte> destination, ulong value)
@@ -219,6 +267,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="UInt128" /> into a span of bytes, as little endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 16 bytes to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="UInt128" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUInt128LittleEndian(Span<byte> destination, UInt128 value)
@@ -237,6 +291,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="nuint" /> into a span of bytes, as little endian.
         /// </summary>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <remarks>Writes exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms to the beginning of the span.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="destination" /> is too small to contain a <see cref="nuint" />.
+        /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUIntPtrLittleEndian(Span<byte> destination, nuint value)
@@ -297,7 +357,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="short" /> into a span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="short" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 2 bytes to the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteInt16LittleEndian(Span<byte> destination, short value)
         {
@@ -313,7 +378,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="int" /> into a span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="int" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 4 bytes to the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteInt32LittleEndian(Span<byte> destination, int value)
         {
@@ -329,7 +399,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="long" /> into a span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="long" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 8 bytes to the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteInt64LittleEndian(Span<byte> destination, long value)
         {
@@ -345,7 +420,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="Int128" /> into a span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="Int128" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 16 bytes to the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteInt128LittleEndian(Span<byte> destination, Int128 value)
         {
@@ -361,7 +441,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="nint" /> into a span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="nint" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms to the beginning of the span.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteIntPtrLittleEndian(Span<byte> destination, nint value)
         {
@@ -398,7 +483,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a <see cref="ushort" /> into a span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="ushort" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 2 bytes to the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt16LittleEndian(Span<byte> destination, ushort value)
@@ -415,7 +505,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a <see cref="uint" /> into a span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="uint" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 4 bytes to the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt32LittleEndian(Span<byte> destination, uint value)
@@ -432,7 +527,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Write a <see cref="ulong" /> into a span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="ulong" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 8 bytes to the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt64LittleEndian(Span<byte> destination, ulong value)
@@ -449,7 +549,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="UInt128" /> into a span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="UInt128" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 16 bytes to the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUInt128LittleEndian(Span<byte> destination, UInt128 value)
@@ -466,7 +571,12 @@ namespace System.Buffers.Binary
         /// <summary>
         /// Writes a <see cref="nuint" /> into a span of bytes, as little endian.
         /// </summary>
-        /// <returns>If the span is too small to contain the value, return false.</returns>
+        /// <param name="destination">The span of bytes where the value is to be written, as little endian.</param>
+        /// <param name="value">The value to write into the span of bytes.</param>
+        /// <returns>
+        /// <see langword="true" /> if the span is large enough to contain a <see cref="nuint" />; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <remarks>Writes exactly 4 bytes on 32-bit platforms -or- 8 bytes on 64-bit platforms to the beginning of the span.</remarks>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWriteUIntPtrLittleEndian(Span<byte> destination, nuint value)

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
@@ -24,6 +24,7 @@ namespace System.Buffers
         /// Creates an optimized representation of <paramref name="values"/> used for efficient searching.
         /// </summary>
         /// <param name="values">The set of values.</param>
+        /// <returns>The optimized representation of <paramref name="values"/> used for efficient searching.</returns>
         public static SearchValues<byte> Create(ReadOnlySpan<byte> values)
         {
             if (values.IsEmpty)
@@ -66,6 +67,7 @@ namespace System.Buffers
         /// Creates an optimized representation of <paramref name="values"/> used for efficient searching.
         /// </summary>
         /// <param name="values">The set of values.</param>
+        /// /// <returns>The optimized representation of <paramref name="values"/> used for efficient searching.</returns>
         public static SearchValues<char> Create(ReadOnlySpan<char> values)
         {
             if (values.IsEmpty)
@@ -167,10 +169,11 @@ namespace System.Buffers
 
         /// <summary>
         /// Creates an optimized representation of <paramref name="values"/> used for efficient searching.
-        /// <para>Only <see cref="StringComparison.Ordinal"/> or <see cref="StringComparison.OrdinalIgnoreCase"/> may be used.</para>
         /// </summary>
         /// <param name="values">The set of values.</param>
         /// <param name="comparisonType">Specifies whether to use <see cref="StringComparison.Ordinal"/> or <see cref="StringComparison.OrdinalIgnoreCase"/> search semantics.</param>
+        /// <returns>The optimized representation of <paramref name="values"/> used for efficient searching.</returns>
+        /// <remarks>Only <see cref="StringComparison.Ordinal"/> or <see cref="StringComparison.OrdinalIgnoreCase"/> may be used.</remarks>
         public static SearchValues<string> Create(ReadOnlySpan<string> values, StringComparison comparisonType)
         {
             if (comparisonType is not (StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
This covers the APIs that were missing docs from #88564

The corresponding docs PR is https://github.com/dotnet/dotnet-api-docs/pull/9206