### PR TITLE
Enable rule CA1869 - Cache and reuse 'JsonSerializerOptions'

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -486,6 +486,9 @@ dotnet_diagnostic.CA1864.severity = warning
 # CA1868: Unnecessary call to 'Contains' for sets
 dotnet_diagnostic.CA1868.severity = warning
 
+# CA1869: Cache and reuse 'JsonSerializerOptions' instances
+dotnet_diagnostic.CA1869.severity = warning
+
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none
 

--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -483,6 +483,9 @@ dotnet_diagnostic.CA1864.severity = none
 # CA1868: Unnecessary call to 'Contains' for sets
 dotnet_diagnostic.CA1868.severity = none
 
+# CA1869: Cache and reuse 'JsonSerializerOptions' instances
+dotnet_diagnostic.CA1869.severity = none
+
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none
 

--- a/src/installer/managed/Microsoft.NET.HostModel/ComHost/ClsidMap.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/ComHost/ClsidMap.cs
@@ -18,6 +18,8 @@ namespace Microsoft.NET.HostModel.ComHost
 {
     public static class ClsidMap
     {
+        private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+
         private struct ClsidEntry
         {
             [JsonPropertyName("type")]
@@ -65,7 +67,7 @@ namespace Microsoft.NET.HostModel.ComHost
 
             using (StreamWriter writer = File.CreateText(clsidMapPath))
             {
-                writer.Write(JsonSerializer.Serialize(clsidMap, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull }));
+                writer.Write(JsonSerializer.Serialize(clsidMap, s_jsonOptions));
             }
         }
 

--- a/src/mono/wasm/host/CommonConfiguration.cs
+++ b/src/mono/wasm/host/CommonConfiguration.cs
@@ -26,7 +26,14 @@ internal sealed class CommonConfiguration
     public string? RuntimeConfigPath { get; private set; }
 
     private string? hostArg;
+    private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    {
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        PropertyNameCaseInsensitive = true
+    };
 
+    public static JsonSerializerOptions JsonOptions => s_jsonOptions;
     public static CommonConfiguration FromCommandLineArguments(string[] args) => new CommonConfiguration(args);
 
     private CommonConfiguration(string[] args)
@@ -62,12 +69,7 @@ internal sealed class CommonConfiguration
 
         RuntimeConfig? rconfig = JsonSerializer.Deserialize<RuntimeConfig>(
                                                 File.ReadAllText(RuntimeConfigPath),
-                                                new JsonSerializerOptions(JsonSerializerDefaults.Web)
-                                                {
-                                                    AllowTrailingCommas = true,
-                                                    ReadCommentHandling = JsonCommentHandling.Skip,
-                                                    PropertyNameCaseInsensitive = true
-                                                });
+                                                JsonOptions);
         if (rconfig == null)
             throw new CommandLineException($"Failed to deserialize {RuntimeConfigPath}");
 

--- a/src/mono/wasm/host/RunArgumentsJson.cs
+++ b/src/mono/wasm/host/RunArgumentsJson.cs
@@ -18,17 +18,19 @@ internal sealed record RunArgumentsJson(
     bool debugging = false
 )
 {
+    private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
     // using an explicit property because the deserializer doesn't like
     // extension data in the record constructor
     [property: JsonExtensionData] public Dictionary<string, JsonElement>? Extra { get; set; }
 
     public void Save(string file)
     {
-        string json = JsonSerializer.Serialize(this, new JsonSerializerOptions
-        {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-        });
+        string json = JsonSerializer.Serialize(this, s_jsonOptions);
         File.WriteAllText(file, json);
     }
 }

--- a/src/mono/wasm/host/RunConfiguration.cs
+++ b/src/mono/wasm/host/RunConfiguration.cs
@@ -27,12 +27,7 @@ internal sealed class RunConfiguration
 
         RuntimeConfig? rconfig = JsonSerializer.Deserialize<RuntimeConfig>(
                                                 File.ReadAllText(runtimeConfigPath),
-                                                new JsonSerializerOptions(JsonSerializerDefaults.Web)
-                                                {
-                                                    AllowTrailingCommas = true,
-                                                    ReadCommentHandling = JsonCommentHandling.Skip,
-                                                    PropertyNameCaseInsensitive = true
-                                                });
+                                                CommonConfiguration.JsonOptions);
         if (rconfig == null)
             throw new Exception($"Failed to deserialize {runtimeConfigPath}");
 

--- a/src/tasks/Common/FileCache.cs
+++ b/src/tasks/Common/FileCache.cs
@@ -16,6 +16,7 @@ internal sealed class FileCache
 {
     private CompilerCache? _newCache;
     private CompilerCache? _oldCache;
+    private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions { WriteIndented = true };
 
     public bool Enabled { get; }
     public TaskLoggingHelper Log { get; }
@@ -34,7 +35,7 @@ internal sealed class FileCache
         {
             _oldCache = (CompilerCache?)JsonSerializer.Deserialize(File.ReadAllText(cacheFilePath),
                                                                     typeof(CompilerCache),
-                                                                    new JsonSerializerOptions());
+                                                                    s_jsonOptions);
         }
 
         _oldCache ??= new();
@@ -84,7 +85,7 @@ internal sealed class FileCache
         if (!Enabled || string.IsNullOrEmpty(cacheFilePath))
             return false;
 
-        var json = JsonSerializer.Serialize (_newCache, new JsonSerializerOptions { WriteIndented = true });
+        var json = JsonSerializer.Serialize (_newCache, s_jsonOptions);
         File.WriteAllText(cacheFilePath!, json);
         return true;
     }

--- a/src/tasks/MonoTargetsTasks/RuntimeConfigParser/RuntimeConfigParser.cs
+++ b/src/tasks/MonoTargetsTasks/RuntimeConfigParser/RuntimeConfigParser.cs
@@ -30,6 +30,16 @@ public class RuntimeConfigParserTask : Task
     /// </summary>
     public ITaskItem[] RuntimeConfigReservedProperties { get; set; } = Array.Empty<ITaskItem>();
 
+    private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions
+    {
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        Converters =
+        {
+            new StringConverter()
+        }
+    };
+
     public override bool Execute()
     {
         if (string.IsNullOrEmpty(RuntimeConfigFile))
@@ -72,17 +82,8 @@ public class RuntimeConfigParserTask : Task
     {
         result = null;
 
-        var options = new JsonSerializerOptions {
-            AllowTrailingCommas = true,
-            ReadCommentHandling = JsonCommentHandling.Skip,
-            Converters =
-            {
-                new StringConverter()
-            }
-        };
-
         var jsonString = File.ReadAllText(inputFilePath);
-        var parsedJson = JsonSerializer.Deserialize<Root>(jsonString, options);
+        var parsedJson = JsonSerializer.Deserialize<Root>(jsonString, s_jsonOptions);
 
         if (parsedJson == null)
         {

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -29,6 +29,14 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
     public string? RuntimeAssetsLocation { get; set; }
     public bool CacheBootResources { get; set; }
 
+    private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        WriteIndented = true
+    };
+
+
     // <summary>
     // Extra json elements to add to _framework/blazor.boot.json
     //
@@ -368,13 +376,7 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
         {
             helper.ComputeResourcesHash(bootConfig);
 
-            var jsonOptions = new JsonSerializerOptions
-            {
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-                WriteIndented = true
-            };
-            var json = JsonSerializer.Serialize(bootConfig, jsonOptions);
+            var json = JsonSerializer.Serialize(bootConfig, s_jsonOptions);
             sw.Write(json);
         }
 

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -48,6 +48,11 @@ namespace Microsoft.Workload.Build.Tasks
         private string AllManifestsStampPath => Path.Combine(SdkWithNoWorkloadInstalledPath, ".all-manifests.stamp");
         private string _tempDir = string.Empty;
         private string _nugetCachePath = string.Empty;
+        private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            AllowTrailingCommas = true,
+            ReadCommentHandling = JsonCommentHandling.Skip
+        };
 
         [GeneratedRegex(@"^\d+\.\d+\.\d+(-[A-z]*\.*\d*)?")]
         private static partial Regex bandVersionRegex();
@@ -325,11 +330,7 @@ namespace Microsoft.Workload.Build.Tasks
             {
                 manifest = JsonSerializer.Deserialize<ManifestInformation>(
                                                     File.ReadAllBytes(jsonPath),
-                                                    new JsonSerializerOptions(JsonSerializerDefaults.Web)
-                                                    {
-                                                        AllowTrailingCommas = true,
-                                                        ReadCommentHandling = JsonCommentHandling.Skip
-                                                    });
+                                                    s_jsonOptions);
 
                 if (manifest == null)
                 {


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn-analyzers/pull/6850.

Found 102 hits on test projects, 1 in [FunctionalTests\System.Text.RegularExpressions.Tests](https://github.com/dotnet/runtime/blob/24c4b563c334aae47e520b3f5c684f5e3ebe664c/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.KnownPattern.Tests.cs#L1514). The rest were in System.Text.Json.Tests, which is unsurprising.

Also found 5 occurrences in src/tasks projects which should be fixed.