### PR TITLE
Regression test for issue #86993

### DIFF
--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_86993.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_86993.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Numerics;
+
+// This regression test tracks the issue where explicit static interface
+// method implementation compiles but program crashes with "Fatal error"
+// (tested with .NET 7 and .NET 8 Preview 4). The test couldn't compile
+// prior to 7.0.5 due to incomplete support for default interface implementations
+// of static virtual methods.
+
+public sealed class Program
+{
+    public interface IValue<TSelf, T> : IModulusOperators<TSelf, TSelf, int>
+        where T : struct
+        where TSelf : IValue<TSelf, T>
+    {
+        static int IModulusOperators<TSelf, TSelf, int>.operator %(TSelf left, TSelf right) => 0;
+    }
+    
+    public readonly record struct Int32Value(int Value) : IValue<Int32Value, int>;
+
+    public static int Main()
+    {
+        const string ExpectedValue = "Int32Value { Value = 1 }";
+        string actualValue = new Int32Value(1).ToString();
+        Console.WriteLine("Actual value = '{0}', expected value = '{1}'", actualValue, ExpectedValue);
+        return actualValue == ExpectedValue ? 100 : 101;
+    }
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_86993.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_86993.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I have created a regression test based on the customer report in the quoted issue. The issue no longer reproes with current main (basically .NET 8 RC1), I believe it was fixed as part of David's and my own fixes for various default SVM implementation deficiencies. Merging this change in will close the issue per the below annotation.

Thanks

Tomas

Fixes: #86993