### PR TITLE
[wasm] Fix Wasm.Build.Tests build

### DIFF
--- a/eng/testing/workloads-testing.targets
+++ b/eng/testing/workloads-testing.targets
@@ -76,6 +76,7 @@
           Command="chmod +x $(_DotNetInstallScriptPath); $(_DotNetInstallCommand)" />
 
     <Exec Condition="$([MSBuild]::IsOSPlatform('windows'))"
+          IgnoreStandardErrorWarningFormat="true"
           Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallCommand)"' />
   </Target>
 


### PR DESCRIPTION
workloads-testing.targets: Ignore standard error/warning formats

Prompted by the following getting caught as a warning, and converted to
an error, on windows:

```
EXEC : error : dotnet-install: Failed to check the disk space. Installation will continue, but it may fail if you do not have [D:\a\_work\1\s\src\mono\wasm\Wasm.Build.Tests\Wasm.Build.Tests.csproj]
   enough disk space.
  dotnet-install: Extracting the archive.
```
