### PR TITLE
Reduce startup overhead from jiterp thread safety

### DIFF
--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -146,8 +146,11 @@ DEFINE_INT(jiterpreter_interp_entry_queue_flush_threshold, "jiterpreter-interp-e
 // In degenerate cases the jiterpreter could end up generating lots of WASM, so shut off jitting once it reaches this limit
 // Each wasm byte likely maps to multiple bytes of native code, so it's important for this limit not to be too high
 DEFINE_INT(jiterpreter_wasm_bytes_limit, "jiterpreter-wasm-bytes-limit", 6 * 1024 * 1024, "Disable jiterpreter code generation once this many bytes of WASM have been generated")
-DEFINE_INT(jiterpreter_table_size, "jiterpreter-table-size", 8 * 1024, "Size of the jiterpreter trace function table")
-DEFINE_INT(jiterpreter_aot_table_size, "jiterpreter-aot-table-size", 5 * 1024, "Size of the jiterpreter AOT trampoline function tables")
+DEFINE_INT(jiterpreter_table_size, "jiterpreter-table-size", 5 * 1024, "Size of the jiterpreter trace function table")
+// In real-world scenarios these tables can fill up at this size, but making them bigger causes startup time
+//  to bloat to an unacceptable degree. In practice this is still better than nothing.
+// FIXME: In the future if we find a way to reduce the number of unique tables we can raise this constant
+DEFINE_INT(jiterpreter_aot_table_size, "jiterpreter-aot-table-size", 3 * 1024, "Size of the jiterpreter AOT trampoline function tables")
 #endif // HOST_BROWSER
 
 #if defined(TARGET_WASM) || defined(TARGET_IOS)  || defined(TARGET_TVOS) || defined (TARGET_MACCAT)

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -1947,8 +1947,17 @@ function jiterpreter_allocate_table(type: JiterpreterTable, base: number, size: 
     const wasmTable = getWasmFunctionTable();
     const firstIndex = base, lastIndex = firstIndex + size - 1;
     mono_assert(lastIndex < wasmTable.length, () => `Last index out of range: ${lastIndex} >= ${wasmTable.length}`);
-    for (let i = firstIndex; i <= lastIndex; i++)
-        wasmTable.set(i, fillValue);
+    // In threaded builds we need to populate all the reserved slots with safe placeholder functions
+    // This operation is expensive in v8, so avoid doing it in single-threaded builds (which SHOULD
+    //  be safe, since it was previously not necessary)
+    if (MonoWasmThreads) {
+        wasmTable.set(firstIndex, fillValue);
+        // HACK: If possible, we want to copy any backing state associated with the first placeholder item,
+        //  so that additional work doesn't have to be done by the runtime for the following table sets
+        const preparedValue = wasmTable.get(firstIndex);
+        for (let i = firstIndex + 1; i <= lastIndex; i++)
+            wasmTable.set(i, preparedValue);
+    }
     cwraps.mono_jiterp_initialize_table(type, firstIndex, lastIndex);
     return base + size;
 }
@@ -1972,7 +1981,9 @@ export function jiterpreter_allocate_tables(module: any) {
         totalSize = (tableSize * 2) + (numInterpEntryTables * interpEntryTableSize) + 1,
         wasmTable = getWasmFunctionTable(module);
     let base = wasmTable.length;
+    const beforeGrow = performance.now();
     wasmTable.grow(totalSize);
+    const afterGrow = performance.now();
     if (options.enableStats)
         mono_log_info(`Allocated ${totalSize} function table entries for jiterpreter, bringing total table size to ${wasmTable.length}`);
     base = jiterpreter_allocate_table(JiterpreterTable.Trace, base, tableSize, getRawCwrap("mono_jiterp_placeholder_trace"));
@@ -1981,4 +1992,7 @@ export function jiterpreter_allocate_tables(module: any) {
     base = jiterpreter_allocate_table(JiterpreterTable.JitCall, base, tableSize, getRawCwrap("mono_jiterp_placeholder_jit_call"));
     for (let table = JiterpreterTable.InterpEntryStatic0; table <= JiterpreterTable.LAST; table++)
         base = jiterpreter_allocate_table(table, base, interpEntryTableSize, wasmTable.get(cwraps.mono_jiterp_get_interp_entry_func(table)));
+    const afterTables = performance.now();
+    if (options.enableStats)
+        mono_log_info(`Growing wasm function table took ${afterGrow - beforeGrow}. Filling table took ${afterTables - afterGrow}.`);
 }


### PR DESCRIPTION
The jiterpreter multithreading support increased startup time, and in v8 the penalty is especially bad due to overhead in their implementation of the function table. This PR reduces the overhead through a few steps:

* Reducing the default table size
* Not filling the table with placeholder values in single-threaded builds (the placeholders are only necessary for thread safety)
* Using a more efficient method of filling the table