### PR TITLE
[NativeAOT] Fix `--make-repro-path` ILC option

### DIFF
--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -210,7 +210,7 @@ namespace System.CommandLine
                 foreach (CliOption option in res.CommandResult.Command.Options)
                 {
                     OptionResult optionResult = res.GetResult(option);
-                    if (optionResult is null || option.Name == "make-repro-path")
+                    if (optionResult is null || option.Name == "--make-repro-path")
                     {
                         continue;
                     }
@@ -233,7 +233,7 @@ namespace System.CommandLine
                                 }
                                 foreach (string inputFile in dictionary.Values)
                                 {
-                                    rspFile.Add($"--{option.Name}:{ConvertFromOriginalPathToReproPackagePath(input: true, inputFile)}");
+                                    rspFile.Add($"{option.Name}:{ConvertFromOriginalPathToReproPackagePath(input: true, inputFile)}");
                                 }
                             }
                             else
@@ -241,7 +241,7 @@ namespace System.CommandLine
                                 foreach (string optInList in values)
                                 {
                                     if (!string.IsNullOrEmpty(optInList))
-                                        rspFile.Add($"--{option.Name}:{optInList}");
+                                        rspFile.Add($"{option.Name}:{optInList}");
                                 }
                             }
                         }
@@ -254,11 +254,11 @@ namespace System.CommandLine
                                     // if output option is used, overwrite the path to the repro package
                                     stringVal = ConvertFromOriginalPathToReproPackagePath(input: false, stringVal);
                                 }
-                                rspFile.Add($"--{option.Name}:{stringVal}");
+                                rspFile.Add($"{option.Name}:{stringVal}");
                             }
                             else
                             {
-                                rspFile.Add($"--{option.Name}:{val}");
+                                rspFile.Add($"{option.Name}:{val}");
                             }
                         }
                     }


### PR DESCRIPTION
This PR fixes a regression with `--make-repro-path` command line option which was caused by upgrading the `System.CommandLine` version in: https://github.com/dotnet/runtime/pull/84229

The issue is related to the fact that `CliOption.Name` now includes `--` (eg: option.Name == `--targetos:OSX`) causing `--make-repro-path` to generate extra hyphens in the `repro.rsp` file, for example:
```
----reference:0/WindowsBase.dll
----reference:1/System.Private.CoreLib.dll
----reference:2/System.Private.DisabledReflection.dll
...
```

Tested manually by:
1. Creating a `repro.zip` by including the `--make-repro-path` option during compilation
2. Unzipping the repro.zip
3. Compiling the assemblies from the unzipped folder by passing the generated `repro.rsp`
