### PR TITLE
Treat *.lss files as plain text in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,8 @@
 *.png 	binary
 *.gif 	binary
 
+*.lss 	text
+
 # Force bash scripts to always use lf line endings so that if a repo is accessed
 # in Unix via a file share from Windows, the scripts will work.
 *.in text eol=lf


### PR DESCRIPTION
Follow up of https://github.com/dotnet/arcade/pull/13992#issuecomment-1688680674

We need to make sure the lss file does not revert back to binary formatting.