### PR TITLE
Disable RemoteExecutor SearchValues tests on LinuxBionic

### DIFF
--- a/src/libraries/System.Memory/tests/Span/StringSearchValues.cs
+++ b/src/libraries/System.Memory/tests/Span/StringSearchValues.cs
@@ -197,6 +197,7 @@ namespace System.Memory.Tests.Span
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "Remote executor has problems with exit codes")]
         public static void IndexOfAny_CanProduceDifferentResultsUnderNls()
         {
             if (CanTestInvariantCulture)
@@ -253,6 +254,7 @@ namespace System.Memory.Tests.Span
         }
 
         [ConditionalFact(nameof(CanTestInvariantCulture))]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "Remote executor has problems with exit codes")]
         public static void TestIndexOfAny_RandomInputs_InvariantCulture()
         {
             RunUsingInvariantCulture(static () =>
@@ -275,6 +277,7 @@ namespace System.Memory.Tests.Span
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "Remote executor has problems with exit codes")]
         [ActiveIssue("Manual execution only. Worth running any time SearchValues<string> logic is modified.")]
         public static void TestIndexOfAny_RandomInputs_Stress()
         {


### PR DESCRIPTION
Closes #90945
Context: https://github.com/dotnet/runtime/issues/90945#issuecomment-1688916733

Similar `RemoteExecutor` tests are already disabled on this platform, e.g. https://github.com/dotnet/runtime/blob/6b67caaedfbfeaf7707478e50ccc9e8bc929e591/src/libraries/System.Globalization/tests/CultureInfo/GetCultureInfo.cs#L160C9-L160C100