### PR TITLE
Perf optimized find last non-zero element

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -422,9 +422,16 @@ namespace System.Numerics
                     NumericsHelpers.DangerousMakeTwosComplement(val); // Mutates val
 
                     // Pack _bits to remove any wasted space after the twos complement
-                    int len = val.Length - 1;
-                    while (len >= 0 && val[len] == 0) len--;
-                    len++;
+                    int len = val.Length;
+                    if (val[len - 1] == 0)
+                    {
+                        len--;
+                        if (len > 0 && val[len - 1] == 0)
+                        {
+                            len = val.AsSpan().LastIndexOfAnyExcept((uint)0);
+                            len++;
+                        }
+                    }
 
                     if (len == 1)
                     {


### PR DESCRIPTION
Optimized for the "no zeroes" and "only 1 zero" cases (the most common). If at least 2 zeroes, use Span.LastIndexOfAnyExcept().

Performance is same as current implementation for "no zeroes". Slightly faster for "1 zero" (by about 0.3ns).
Switching to Span method, cases of 2 through 4 zeroes are slower than current implementation (by 1 to 1.5ns for 2 zeroes, decreasing). 5 zeroes have same performance as current.
Starting from 6 zeroes the Span method gains ever greater advantage.

Most numbers will have "no zeroes" or "1 zero" and so are covered by the 2 ifs.
However some methods often produce numbers with
large numbers of zeroes (>100).
Notable here is the test System.Numerics.Tests.op_orTest.RunOrTests(). First loop ("Or Method - Two Large BigIntegers"), the fixed seed gives a sample with 136 zeroes.
Non-seeded Random produces similar number of zeroes in a few attemps.

This deals with the first example given in issue #84855

<details>
<summary>Details about benchmarking</summary>

Benchmarks run in codespaces. So not ideal, but repeated runs show consistent results.  
Code for benchmarks available: https://github.com/tommysor/runtime/pull/1

``` ini

BenchmarkDotNet=v0.13.5, OS=ubuntu 22.04 (container)
AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
.NET SDK=8.0.100-preview.7.23376.3
  [Host]     : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX2


```
|          Method | NumberOfZeroElements |       Mean |     Error |    StdDev | Ratio | RatioSD | Allocated | Alloc Ratio |
|---------------- |--------------------- |-----------:|----------:|----------:|------:|--------:|----------:|------------:|
|         **Current** |                    **0** |  **0.3202 ns** | **0.0117 ns** | **0.0098 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
| SpanIndexOfOpt1 |                    0 |  0.3232 ns | 0.0184 ns | 0.0163 ns |  1.01 |    0.07 |         - |          NA |
|                 |                      |            |           |           |       |         |           |             |
|         **Current** |                    **1** |  **1.2657 ns** | **0.0261 ns** | **0.0244 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
| SpanIndexOfOpt1 |                    1 |  0.9467 ns | 0.0335 ns | 0.0280 ns |  0.75 |    0.02 |         - |          NA |
|                 |                      |            |           |           |       |         |           |             |
|         **Current** |                    **2** |  **1.5951 ns** | **0.0319 ns** | **0.0266 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
| SpanIndexOfOpt1 |                    2 |  2.7486 ns | 0.0399 ns | 0.0353 ns |  1.72 |    0.03 |         - |          NA |
|                 |                      |            |           |           |       |         |           |             |
|         **Current** |                    **3** |  **1.9624 ns** | **0.0354 ns** | **0.0331 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
| SpanIndexOfOpt1 |                    3 |  2.7550 ns | 0.0400 ns | 0.0313 ns |  1.40 |    0.03 |         - |          NA |
|                 |                      |            |           |           |       |         |           |             |
|         **Current** |                    **4** |  **2.4562 ns** | **0.0637 ns** | **0.0596 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
| SpanIndexOfOpt1 |                    4 |  2.8010 ns | 0.0610 ns | 0.0571 ns |  1.14 |    0.03 |         - |          NA |
|                 |                      |            |           |           |       |         |           |             |
|         **Current** |                    **5** |  **2.7807 ns** | **0.0303 ns** | **0.0269 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
| SpanIndexOfOpt1 |                    5 |  2.7308 ns | 0.0379 ns | 0.0336 ns |  0.98 |    0.01 |         - |          NA |
|                 |                      |            |           |           |       |         |           |             |
|         **Current** |                    **6** |  **3.3972 ns** | **0.0281 ns** | **0.0249 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
| SpanIndexOfOpt1 |                    6 |  2.7412 ns | 0.0374 ns | 0.0332 ns |  0.81 |    0.01 |         - |          NA |
|                 |                      |            |           |           |       |         |           |             |
|         **Current** |                    **7** |  **3.8105 ns** | **0.0429 ns** | **0.0401 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
| SpanIndexOfOpt1 |                    7 |  2.7314 ns | 0.0262 ns | 0.0233 ns |  0.72 |    0.01 |         - |          NA |
|                 |                      |            |           |           |       |         |           |             |
|         **Current** |                    **8** |  **4.3534 ns** | **0.0381 ns** | **0.0318 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
| SpanIndexOfOpt1 |                    8 |  3.5180 ns | 0.0443 ns | 0.0370 ns |  0.81 |    0.01 |         - |          NA |
|                 |                      |            |           |           |       |         |           |             |
|         **Current** |                   **16** |  **9.1069 ns** | **0.0786 ns** | **0.0735 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
| SpanIndexOfOpt1 |                   16 |  3.7178 ns | 0.0559 ns | 0.0523 ns |  0.41 |    0.01 |         - |          NA |
|                 |                      |            |           |           |       |         |           |             |
|         **Current** |                   **24** | **12.8790 ns** | **0.1493 ns** | **0.1247 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
| SpanIndexOfOpt1 |                   24 |  4.1652 ns | 0.1011 ns | 0.0946 ns |  0.32 |    0.01 |         - |          NA |
</details>

<details>
<summary>Details about frequency of zeroes</summary>

For frequency in unit tests I modified the code to fail the test if the number of zeroes was equal to X.
"failed" is the number of unit tests where at least 1 sample produced X zeroes.

0 => failed="321"
1 => failed="211"
2 => failed="2"
3 => failed="3"
4 => failed="7"
5 => failed="5"
6 => failed="7"
7 => failed="3"
8 => failed="1"
9 => failed="7"
10 => failed="2"
11 => failed="4"
12 => failed="4"
13 => failed="2"
14 => failed="6"
15 => failed="1"
16 => failed="5"
17 => failed="5"
18 => failed="3"
19 => failed="3"
20 => failed="7"
21 => failed="6"
22 => failed="1"
23 => failed="4"
24 => failed="2"
more than 24 => failed="1" (136 zeroes)

The final one (136 zeroes) comes from a test that is very good at producing lots of zeroes.

https://github.com/dotnet/runtime/blob/c59aef7622c9a2499abb1b7d262ed0c90f4b0c7f/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_or.cs#L19-L25

</details>