### PR TITLE
[wasm] Perf pipeline - use `stable` version of `v8`

### DIFF
--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -64,12 +64,14 @@ jobs:
     - ${{ if eq(parameters.runtimeType, 'wasm') }}:
       - HelixPreCommandsWasmOnLinux: >-
           sudo apt-get -y remove nodejs &&
-          curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - &&
+          curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - &&
           sudo apt-get -y install nodejs &&
+          test -n "$(V8Version)" &&
           npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
-          $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 --engines=v8 &&
+          $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 v8@$(V8Version) &&
           find ~/.jsvu -ls &&
-          ~/.jsvu/bin/v8 -e 'console.log(`V8 version: ${this.version()}`)'
+          export V8_ENGINE_PATH=~/.jsvu/bin/v8-$(V8Version) &&
+          ${V8_ENGINE_PATH} -e 'console.log(`V8 version: ${this.version()}`)'
     - ${{ if ne(parameters.runtimeType, 'wasm') }}:
       - HelixPreCommandsWasmOnLinux: echo
     - HelixPreCommandStemWindows: 'set ORIGPYPATH=%PYTHONPATH%;py -m pip install -U pip;py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install -U pip;py -3 -m pip install urllib3==1.26.15;py -3 -m pip install azure.storage.blob==12.0.0;py -3 -m pip install azure.storage.queue==12.0.0;set "PERFLAB_UPLOAD_TOKEN=$(HelixPerfUploadTokenValue)"'

--- a/eng/testing/ChromeVersions.props
+++ b/eng/testing/ChromeVersions.props
@@ -3,9 +3,11 @@
       <linux_ChromeVersion>116.0.5845.96</linux_ChromeVersion>
       <linux_ChromeRevision>1160321</linux_ChromeRevision>
       <linux_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1160321</linux_ChromeBaseSnapshotUrl>
+      <linux_V8Version>11.6.189.18</linux_V8Version>
 
       <win_ChromeVersion>116.0.5845.97</win_ChromeVersion>
       <win_ChromeRevision>1160321</win_ChromeRevision>
       <win_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1160375</win_ChromeBaseSnapshotUrl>
+      <win_V8Version>11.6.189.18</win_V8Version>
   </PropertyGroup>
 </Project>

--- a/eng/testing/bump-chrome-version.proj
+++ b/eng/testing/bump-chrome-version.proj
@@ -41,10 +41,12 @@
       &lt;linux_ChromeVersion&gt;$(linux_ChromeVersion)&lt;/linux_ChromeVersion&gt;
       &lt;linux_ChromeRevision&gt;$(linux_ChromeRevision)&lt;/linux_ChromeRevision&gt;
       &lt;linux_ChromeBaseSnapshotUrl&gt;$(linux_ChromeBaseSnapshotUrl)&lt;/linux_ChromeBaseSnapshotUrl&gt;
+      &lt;linux_V8Version&gt;$(linux_V8Version)&lt;/linux_V8Version&gt;
 
       &lt;win_ChromeVersion&gt;$(win_ChromeVersion)&lt;/win_ChromeVersion&gt;
       &lt;win_ChromeRevision&gt;$(win_ChromeRevision)&lt;/win_ChromeRevision&gt;
       &lt;win_ChromeBaseSnapshotUrl&gt;$(win_ChromeBaseSnapshotUrl)&lt;/win_ChromeBaseSnapshotUrl&gt;
+      &lt;win_V8Version&gt;$(win_V8Version)&lt;/win_V8Version&gt;
   &lt;/PropertyGroup&gt;
 &lt;/Project&gt;
       </_PropsContent>

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -35,6 +35,7 @@ using_wasm=false
 use_latest_dotnet=false
 logical_machine=
 javascript_engine="v8"
+javascript_engine_path=""
 iosmono=false
 iosnativeaot=false
 runtimetype=""
@@ -44,6 +45,7 @@ maui_version=""
 use_local_commit_time=false
 only_sanity=false
 dotnet_versions=""
+v8_version=""
 
 while (($# > 0)); do
   lowerI="$(echo $1 | tr "[:upper:]" "[:lower:]")"
@@ -94,6 +96,10 @@ while (($# > 0)); do
       ;;
     --javascriptengine)
       javascript_engine=$2
+      shift 2
+      ;;
+    --javascriptenginepath)
+      javascript_engine_path=$2
       shift 2
       ;;
     --kind)
@@ -404,15 +410,27 @@ if [[ -n "$wasm_bundle_directory" ]]; then
     using_wasm=true
     wasm_bundle_directory_path=$payload_directory
     mv $wasm_bundle_directory/* $wasm_bundle_directory_path
-    find $wasm_bundle_directory_path -type d
     wasm_args="--experimental-wasm-eh --expose_wasm"
     if [ "$javascript_engine" == "v8" ]; then
         # for es6 module support
         wasm_args="$wasm_args --module"
+
+        # get required version
+        if [[ -z "$v8_version" ]]; then
+            v8_version=`grep linux_V8Version $source_directory/eng/testing/ChromeVersions.props | sed -e 's,.*>\([^\<]*\)<.*,\1,g' | cut -d. -f 1-3`
+            echo "V8 version: $v8_version"
+        fi
+        if [[ -z "$javascript_engine_path" ]]; then
+            javascript_engine_path="/home/helixbot/.jsvu/bin/v8-${v8_version}"
+        fi
+    fi
+
+    if [[ -z "$javascript_engine_path" ]]; then
+        javascript_engine_path="/home/helixbot/.jsvu/bin/$javascript_engine"
     fi
 
     # Workaround: escaping the quotes around `--wasmArgs=..` so they get retained for the actual command line
-    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --wasmEngine /home/helixbot/.jsvu/bin/$javascript_engine --wasmArgs \\\"$wasm_args\\\" --cli \$HELIX_CORRELATION_PAYLOAD/dotnet/dotnet --wasmDataDir \$HELIX_CORRELATION_PAYLOAD/wasm-data"
+    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --wasmEngine $javascript_engine_path --wasmArgs \\\"$wasm_args\\\" --cli \$HELIX_CORRELATION_PAYLOAD/dotnet/dotnet --wasmDataDir \$HELIX_CORRELATION_PAYLOAD/wasm-data"
     if [[ "$wasmaot" == "true" ]]; then
         extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --aotcompilermode wasm --buildTimeout 3600"
     fi
@@ -496,6 +514,7 @@ Write-PipelineSetVariable -Name 'iOSLlvmBuild' -Value "$iosllvmbuild" -is_multi_
 Write-PipelineSetVariable -Name 'iOSStripSymbols' -Value "$iosstripsymbols" -is_multi_job_variable false
 Write-PipelineSetVariable -Name 'RuntimeType' -Value "$runtimetype" -is_multi_job_variable false
 Write-PipelineSetVariable -name "OnlySanityCheck" -value "$only_sanity" -is_multi_job_variable false
+Write-PipelineSetVariable -name "V8Version" -value "$v8_version" -is_multi_job_variable false
 
 # Put it back to what was set on top of this script
 set -x


### PR DESCRIPTION
- Use V8 version from ChromeVersions.props
  - This affects only the perf pipelines
  - V8 with the given version is installed, and then used on helix
  - The version will be updated with the chrome browser versions, in
    `eng/testing/ChromeVersions.props`.

**Note**: The perf pipelines were running with `v8` from the `dev` channel
earlier, but with this change `v8` from the `stable` channel will be
used instead.

- Emit V8 version also in ChromeVersions.props