### PR TITLE
Bring AggressiveOptimization back on AwaitUnsafeOnCompleted

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -93,6 +93,9 @@ namespace System.Runtime.CompilerServices
             AwaitUnsafeOnCompleted(ref awaiter, box);
         }
 
+        // Tier0 codegen for this function may still allocate (while FullOpts won't).
+        // TODO: remove once https://github.com/dotnet/runtime/issues/90965 is implemented
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         internal static void AwaitUnsafeOnCompleted<TAwaiter>(
             ref TAwaiter awaiter, IAsyncStateMachineBox box)
             where TAwaiter : ICriticalNotifyCompletion


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/90899

When T awaiter implements `IStateMachineBoxAwareAwaiter` (`ValueTask`) this function still emits allocations in Tier0. A minimal repro is illustrated in https://github.com/dotnet/runtime/issues/90965