### PR TITLE
[mono] Enable `System.IO.Hashing` tests on ios and disable them on tvos

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -266,6 +266,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Formats.Cbor\tests\System.Formats.Cbor.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.MemoryMappedFiles\tests\System.IO.MemoryMappedFiles.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Numerics\tests\System.Runtime.Numerics.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Hashing\tests\System.IO.Hashing.Tests.csproj" />
 
     <!--
       Test apps that are too large and take too long to build
@@ -640,6 +641,7 @@
     <!-- These crash on tvOS, but do not on iOS. Run these only on the rolling builds -->
     <ProjectReference Include="$(MSBuildThisFileDirectory)System.IO.MemoryMappedFiles\tests\System.IO.MemoryMappedFiles.Tests.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)System.Runtime.Numerics\tests\System.Runtime.Numerics.Tests.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)System.IO.Hashing\tests\System.IO.Hashing.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ArchiveTests)' == 'true' and '$(RunSmokeTestsOnly)' != 'true' and '$(RunGrpcTestsOnly)' != 'true' and '$(TargetOS)' == 'iossimulator'">


### PR DESCRIPTION
As reported in: https://github.com/dotnet/runtime/issues/90499 `System.IO.Hashing.Tests.Crc32Tests` are failing on tvos-arm64 as part of the `runtime-extra-platforms` pipeline.

Due to the facts that:
- I was not able to reproduce the reported failure locally 
- The crash log does not include enough information to demystify what is causing the crash 
- And by verifying that the tests are passing on iOS devices

This PR disables running `System.IO.Hashing` libraries tests on tvos and enables running them on ios platforms, which contributes towards having a green CI by keeping the same test coverage on iOS-like platforms.

---
Fixes: https://github.com/dotnet/runtime/issues/90499