### PR TITLE
[release/6.0] wasm-tools: Fix workload manifest MSI ProductVersion generation

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -48,7 +48,7 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GetVersionProps;_GenerateMsiVersionString">
+  <Target Name="Build" DependsOnTargets="_GenerateMsiVersionString">
     <ItemGroup>
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
            these must be updated. -->
@@ -181,15 +181,6 @@
     <MSBuild Projects="@(SwixProjects)" BuildInParallel="true" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VisualStudioSetupInsertionPath)" />
   </Target>
 
-  <Target Name="_GetVersionProps">
-    <PropertyGroup>
-      <_MajorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Major)</_MajorVersion>
-      <_MinorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Minor)</_MinorVersion>
-      <_PatchVersion>$([System.Version]::Parse('$(AssemblyVersion)').Build)</_PatchVersion>
-      <_BuildNumber>$([System.Version]::Parse('$(AssemblyVersion)').Revision)</_BuildNumber>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="_GenerateMsiVersionString">
     <PropertyGroup>
       <VersionPadding Condition="'$(VersionPadding)'==''">5</VersionPadding>
@@ -207,9 +198,9 @@
     </GenerateCurrentVersion>
 
     <GenerateMsiVersion
-      Major="$(_MajorVersion)"
-      Minor="$(_MinorVersion)"
-      Patch="$(_PatchVersion)"
+      Major="$(MajorVersion)"
+      Minor="$(MinorVersion)"
+      Patch="$(PatchVersion)"
       BuildNumberMajor="$(BuildNumberMajor)"
       BuildNumberMinor="$(BuildNumberMinor)">
       <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -48,7 +48,7 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <Target Name="Build" DependsOnTargets="_GenerateMsiVersionString">
+  <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GenerateMsiVersionString">
     <ItemGroup>
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
            these must be updated. -->


### PR DESCRIPTION
# Description

Manifest installers for .NET optional workloads rely on performing major upgrades in .NET 6 and 7. This requires that the MSI version increments for new builds. The MSI version was generated using the assembly version. MSI versions should be generated using the major/minor/patch/buildnumber, e.g. 6.0.20.12345. Because the assembly version was being used, the patch value was always set to 0. Due to the bit masking and shift operations used to construct the MSI version, the 3rd part of the version number wrapped around, generating a smaller version for a newer release. MSI [ProductVersion](https://learn.microsoft.com/en-us/windows/win32/msi/productversion) is only 32-bits in size (8-bit major, 8-bit minor and 16-bit build number).

For 6.0.21, the ProductVersion generated using the old method was 48.3.64667 and for 6.0.22 it generated 48.0.763.

# Impact

1. Visual Studio PR checks fail package validation because the new MSI's version is lower than the baseline copy from the previous insertion.
2. The CLI will block installing the newer manifest when trying to update workloads because it will detect a possible downgrade.

# Testing

No unit tests for this. Validated using Orca to ensure the manifest MSI's ProductVersion matches the version we generate for other runtime MSIs.

![image](https://github.com/dotnet/runtime/assets/7409981/33303090-3c3e-4090-816f-dff31841a725)

The generated component manifest for the wasm-tools workload in Visual Studio using an internal build was also validated. The  component uses the runtime's AssemblyFileVersion as it can rely on a standard 4-part version number.

```json
{
  "manifestVersion": "1.1",
  "info": {
    "id": "wasm.tools,version=6.0.2223.42217"
  },
  "packages": [
    {
      "id": "wasm.tools",
      "version": "6.0.2223.42217",
      "type": "Component",
      "dependencies": {
        "microsoft.net.runtime.mono.tooling": {
          "version": "1.0.0.0",
          "behaviors": "IgnoreApplicabilityFailures"
        },
```