### PR TITLE
Revert "Fix incomplete type errors when debugging in lldb/gdb (#90873)"

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -23,13 +23,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/configureoptimization.cmake)
 #-----------------------------------------------------
 
 if (CLR_CMAKE_HOST_UNIX)
+    add_compile_options(-g)
     add_compile_options(-Wall)
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         add_compile_options(-Wno-null-conversion)
-        add_compile_options(-glldb)
     else()
         add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=conversion-null>)
-        add_compile_options(-g)
     endif()
 endif()
 


### PR DESCRIPTION
This reverts commit bf05d6460c0db0d8a74f0e29af6dbdc22a01a9ef. Its causing some build failures due to large nuget packages due to additional debugging info. We can make the fix after determining a workaround before making the fix. 