### PR TITLE
Upgrade MicrosoftCodeAnalysisVersion_LatestVS version to 4.7.0

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -9,7 +9,6 @@
     <UsagePattern IdentityGlob="System.Composition*/*6.*" />
     <UsagePattern IdentityGlob="System.Composition*/*7.*" />
     <UsagePattern IdentityGlob="Microsoft.CodeAnalysis*/*4.4.*" />
-    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis*/*4.5.*" />
     <UsagePattern IdentityGlob="Microsoft.CodeAnalysis*/*4.7.*" />
 
     <!-- Allowed and pinned to major version due to https://github.com/dotnet/source-build/issues/3228 -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
       Source-build builds the product with the most recent previously source-built release. Thankfully, these two requirements line up nicely
       such that any version that satisfies the VS version requirement will also satisfy the .NET SDK version requirement because of how we ship.
     -->
-    <MicrosoftCodeAnalysisVersion_LatestVS>4.5.0</MicrosoftCodeAnalysisVersion_LatestVS>
+    <MicrosoftCodeAnalysisVersion_LatestVS>4.7.0</MicrosoftCodeAnalysisVersion_LatestVS>
     <!-- Some of the analyzer dependencies used by ILLink project -->
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.5-beta1.23270.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
   </PropertyGroup>

--- a/src/coreclr/tools/Directory.Build.props
+++ b/src/coreclr/tools/Directory.Build.props
@@ -18,6 +18,7 @@
     at the same cadance as the MicrosoftCodeAnalysisVersion_LatestVS version.
     This property is set eng/Versions.props but we override it because the current
     version 4.7.0 flags several warnings that need area-owner expertise to resolve.
+    TODO: https://github.com/dotnet/runtime/issues/91028.
   -->
   <PropertyGroup>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.5.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>

--- a/src/coreclr/tools/Directory.Build.props
+++ b/src/coreclr/tools/Directory.Build.props
@@ -12,4 +12,14 @@
     <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
     <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+
+  <!--
+    These packages affect the design-time experience in VS, we update them
+    at the same cadance as the MicrosoftCodeAnalysisVersion_LatestVS version.
+    This property is set eng/Versions.props but we override it because the current
+    version 4.7.0 flags several warnings that need area-owner expertise to resolve.
+  -->
+  <PropertyGroup>
+    <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.5.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
+  </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0-3.23314.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
@@ -210,8 +210,10 @@ namespace System.Text.RegularExpressions.Generator
             // it in as a parameter. If the user specified IgnoreCase, but also selected CultureInvariant, then we skip as the default is to use Invariant culture.
             if ((regexOptions & RegexOptions.IgnoreCase) != 0 && (regexOptions & RegexOptions.CultureInvariant) == 0)
             {
+#pragma warning disable RS1035 // The symbol 'CultureInfo.CurrentCulture' is banned for use by analyzers.
                 // If CultureInvariant wasn't specified as options, we default to the current culture.
                 cultureNameValue = generator.LiteralExpression(CultureInfo.CurrentCulture.Name);
+#pragma warning restore RS1035
 
                 // If options weren't passed in, then we need to define it as well in order to use the three parameter constructor.
                 regexOptionsValue ??= generator.MemberAccessExpression(SyntaxFactory.IdentifierName("RegexOptions"), "None");

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -83,7 +83,9 @@ namespace System.Text.RegularExpressions
 
         /// <summary>Gets the culture to use based on the specified options.</summary>
         internal static CultureInfo GetTargetCulture(RegexOptions options) =>
+#pragma warning disable RS1035 // The symbol 'CultureInfo.CurrentCulture' is banned for use by analyzers.
             (options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture;
+#pragma warning restore RS1035
 
         public static RegexOptions ParseOptionsInPattern(string pattern, RegexOptions options)
         {
@@ -134,7 +136,9 @@ namespace System.Text.RegularExpressions
         /// <summary>This static call constructs a flat concatenation node given a replacement pattern.</summary>
         public static RegexReplacement ParseReplacement(string pattern, RegexOptions options, Hashtable caps, int capsize, Hashtable capnames)
         {
+#pragma warning disable RS1035 // The symbol 'CultureInfo.CurrentCulture' is banned for use by analyzers.
             CultureInfo culture = (options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture;
+#pragma warning restore RS1035
             using var parser = new RegexParser(pattern, options, culture, caps, capsize, capnames, stackalloc int[OptionStackDefaultSize]);
 
             RegexNode root = parser.ScanReplacement();

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/Directory.Build.props
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/Directory.Build.props
@@ -5,4 +5,14 @@
   </PropertyGroup>
 
   <Import Project="..\Directory.Build.props" />
+
+  <!--
+    These packages affect the design-time experience in VS, we update them
+    at the same cadance as the MicrosoftCodeAnalysisVersion_LatestVS version.
+    This property is set eng/Versions.props but we override it because the current
+    version 4.7.0 flags several warnings that need area-owner expertise to resolve.
+  -->
+  <PropertyGroup>
+    <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.5.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
+  </PropertyGroup>
 </Project>

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/Directory.Build.props
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/Directory.Build.props
@@ -11,6 +11,7 @@
     at the same cadance as the MicrosoftCodeAnalysisVersion_LatestVS version.
     This property is set eng/Versions.props but we override it because the current
     version 4.7.0 flags several warnings that need area-owner expertise to resolve.
+    TODO: https://github.com/dotnet/runtime/issues/91030.
   -->
   <PropertyGroup>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.5.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/90340 (for main/.NET9) the config binding generator alone upgraded to 4.7.0, required to use the interceptors feature. This PR applies the upgrade to the entire repo to avoid source-build pre-built [issues](https://github.com/dotnet/runtime/pull/90835#discussion_r1299011313).

Fixes https://github.com/dotnet/runtime/issues/90849.