### PR TITLE
Remove --skip-unresolved from illink

### DIFF
--- a/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -221,7 +221,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <PropertyGroup>
       <ILLinkTreatWarningsAsErrors Condition=" '$(ILLinkTreatWarningsAsErrors)' == '' ">$(TreatWarningsAsErrors)</ILLinkTreatWarningsAsErrors>
-      <_ExtraTrimmerArgs>--skip-unresolved true $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
       <TrimmerSingleWarn Condition=" '$(TrimmerSingleWarn)' == '' ">true</TrimmerSingleWarn>
     </PropertyGroup>
 

--- a/src/tools/illink/src/linker/CompatibilitySuppressions.xml
+++ b/src/tools/illink/src/linker/CompatibilitySuppressions.xml
@@ -1389,12 +1389,6 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Mono.Linker.LinkContext.get_IgnoreUnresolved</Target>
-    <Left>ref/net8.0/illink.dll</Left>
-    <Right>lib/net8.0/illink.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Mono.Linker.LinkContext.get_KeepUsedAttributeTypesOnly</Target>
     <Left>ref/net8.0/illink.dll</Left>
     <Right>lib/net8.0/illink.dll</Right>
@@ -1828,12 +1822,6 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Mono.Linker.LinkContext.set_IgnoreSubstitutions(System.Boolean)</Target>
-    <Left>ref/net8.0/illink.dll</Left>
-    <Right>lib/net8.0/illink.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:Mono.Linker.LinkContext.set_IgnoreUnresolved(System.Boolean)</Target>
     <Left>ref/net8.0/illink.dll</Left>
     <Right>lib/net8.0/illink.dll</Right>
   </Suppression>

--- a/src/tools/illink/src/linker/Linker.Steps/MarkExportedTypesTargetStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkExportedTypesTargetStep.cs
@@ -27,9 +27,7 @@ namespace Mono.Linker.Steps
 
 			TypeDefinition? type = context.TryResolve (exportedType);
 			if (type == null) {
-				if (!context.IgnoreUnresolved)
-					context.LogError (null, DiagnosticId.ExportedTypeCannotBeResolved, exportedType.Name);
-
+				context.LogError (null, DiagnosticId.ExportedTypeCannotBeResolved, exportedType.Name);
 				return;
 			}
 

--- a/src/tools/illink/src/linker/Linker.Steps/MarkExportedTypesTargetStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkExportedTypesTargetStep.cs
@@ -25,7 +25,7 @@ namespace Mono.Linker.Steps
 			if (!context.Annotations.TryGetPreservedMembers (exportedType, out TypePreserveMembers members))
 				return;
 
-			TypeDefinition? type = context.TryResolve (exportedType);
+			TypeDefinition? type = context.TryResolve (exportedType, assembly.MainModule);
 			if (type == null) {
 				context.LogError (null, DiagnosticId.ExportedTypeCannotBeResolved, exportedType.Name);
 				return;

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -1473,7 +1473,10 @@ namespace Mono.Linker.Steps
 			protected override void ProcessExportedType (ExportedType exportedType)
 			{
 				markingHelpers.MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, assembly), new MessageOrigin (assembly));
+
+				markingHelpers.Context.Resolver.IgnoreUnresolved = true;
 				markingHelpers.MarkForwardedScope (CreateTypeReferenceForExportedTypeTarget (exportedType), new MessageOrigin (assembly));
+				markingHelpers.Context.Resolver.IgnoreUnresolved = false;
 			}
 
 			protected override void ProcessExtra ()

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -1473,7 +1473,6 @@ namespace Mono.Linker.Steps
 			protected override void ProcessExportedType (ExportedType exportedType, ModuleDefinition module)
 			{
 				markingHelpers.MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, assembly), new MessageOrigin (assembly));
-
 				markingHelpers.MarkForwardedScope (CreateTypeReferenceForExportedTypeTarget (exportedType), new MessageOrigin (assembly));
 			}
 

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -1470,13 +1470,11 @@ namespace Mono.Linker.Steps
 				markingHelpers.MarkForwardedScope (type, new MessageOrigin (assembly));
 			}
 
-			protected override void ProcessExportedType (ExportedType exportedType)
+			protected override void ProcessExportedType (ExportedType exportedType, ModuleDefinition module)
 			{
 				markingHelpers.MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, assembly), new MessageOrigin (assembly));
 
-				markingHelpers.Context.Resolver.IgnoreUnresolved = true;
 				markingHelpers.MarkForwardedScope (CreateTypeReferenceForExportedTypeTarget (exportedType), new MessageOrigin (assembly));
-				markingHelpers.Context.Resolver.IgnoreUnresolved = false;
 			}
 
 			protected override void ProcessExtra ()

--- a/src/tools/illink/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/ProcessLinkerXmlBase.cs
@@ -191,7 +191,7 @@ namespace Mono.Linker.Steps
 			}
 		}
 
-		protected virtual TypeDefinition? ProcessExportedType (ExportedType exported, AssemblyDefinition assembly, XPathNavigator nav) => _context.TryResolve (exported);
+		protected virtual TypeDefinition? ProcessExportedType (ExportedType exported, AssemblyDefinition assembly, XPathNavigator nav) => _context.TryResolve (exported, assembly.MainModule);
 
 		void MatchType (TypeDefinition type, Regex regex, XPathNavigator nav)
 		{

--- a/src/tools/illink/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/SweepStep.cs
@@ -612,9 +612,8 @@ namespace Mono.Linker.Steps
 #pragma warning restore RS0030
 				if (td == null) {
 					//
-					// This can happen when not all assembly refences were provided and we
-					// run in `--skip-unresolved` mode. We cannot fully sweep and keep the
-					// original assembly reference
+					// This can happen when not all assembly refences were provided.
+					// We cannot fully sweep and keep the original assembly reference.
 					//
 					var anr = (AssemblyNameReference) type.Scope;
 					type.Scope = importer.ImportReference (anr);
@@ -635,8 +634,7 @@ namespace Mono.Linker.Steps
 				TypeDefinition? td = exportedType.Resolve ();
 #pragma warning restore RS0030
 				if (td == null) {
-					// Forwarded type cannot be resolved but it was marked
-					// ILLink is running in --skip-unresolved true mode
+					// Forwarded type cannot be resolved but it was marked.
 					var anr = (AssemblyNameReference) exportedType.Scope;
 					exportedType.Scope = importer.ImportReference (anr);
 					return;

--- a/src/tools/illink/src/linker/Linker.Steps/SweepStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/SweepStep.cs
@@ -628,10 +628,10 @@ namespace Mono.Linker.Steps
 				ChangedAnyScopes = true;
 			}
 
-			protected override void ProcessExportedType (ExportedType exportedType)
+			protected override void ProcessExportedType (ExportedType exportedType, ModuleDefinition module)
 			{
 #pragma warning disable RS0030 // Cecil's Resolve is banned -- it's necessary when the metadata graph is unstable
-				TypeDefinition? td = exportedType.Resolve ();
+				TypeDefinition? td = exportedType.TryResolve (module);
 #pragma warning restore RS0030
 				if (td == null) {
 					// Forwarded type cannot be resolved but it was marked.

--- a/src/tools/illink/src/linker/Linker/AssemblyResolver.cs
+++ b/src/tools/illink/src/linker/Linker/AssemblyResolver.cs
@@ -51,6 +51,8 @@ namespace Mono.Linker
 		HashSet<string>? _unresolvedAssemblies;
 		HashSet<string>? _reportedUnresolvedAssemblies;
 
+		public bool IgnoreUnresolved { get; set; }
+
 		public AssemblyResolver (LinkContext context)
 		{
 			_context = context;
@@ -124,9 +126,7 @@ namespace Mono.Linker
 			if (!_reportedUnresolvedAssemblies.Add (reference.Name))
 				return;
 
-			if (_context.IgnoreUnresolved)
-				_context.LogMessage ($"Ignoring unresolved assembly '{reference.Name}' reference.");
-			else
+			if (!IgnoreUnresolved)
 				_context.LogError (null, DiagnosticId.CouldNotFindAssemblyReference, reference.Name);
 		}
 

--- a/src/tools/illink/src/linker/Linker/AssemblyResolver.cs
+++ b/src/tools/illink/src/linker/Linker/AssemblyResolver.cs
@@ -51,8 +51,6 @@ namespace Mono.Linker
 		HashSet<string>? _unresolvedAssemblies;
 		HashSet<string>? _reportedUnresolvedAssemblies;
 
-		public bool IgnoreUnresolved { get; set; }
-
 		public AssemblyResolver (LinkContext context)
 		{
 			_context = context;
@@ -126,8 +124,7 @@ namespace Mono.Linker
 			if (!_reportedUnresolvedAssemblies.Add (reference.Name))
 				return;
 
-			if (!IgnoreUnresolved)
-				_context.LogError (null, DiagnosticId.CouldNotFindAssemblyReference, reference.Name);
+			_context.LogError (null, DiagnosticId.CouldNotFindAssemblyReference, reference.Name);
 		}
 
 		public void AddSearchDirectory (string directory)

--- a/src/tools/illink/src/linker/Linker/Driver.cs
+++ b/src/tools/illink/src/linker/Linker/Driver.cs
@@ -217,12 +217,6 @@ namespace Mono.Linker
 						Usage ();
 						return 1;
 
-					case "--skip-unresolved":
-						if (!GetBoolParam (token, l => context.IgnoreUnresolved = l))
-							return -1;
-
-						continue;
-
 					case "--verbose":
 						context.LogMessages = true;
 						continue;
@@ -1336,7 +1330,6 @@ namespace Mono.Linker
 			Console.WriteLine ("  --custom-data KEY=VALUE   Populates context data set with user specified key-value pair");
 			Console.WriteLine ("  --deterministic           Produce a deterministic output for modified assemblies");
 			Console.WriteLine ("  --ignore-descriptors      Skips reading embedded descriptors (short -z). Defaults to false");
-			Console.WriteLine ("  --skip-unresolved         Ignore unresolved types, methods, and assemblies. Defaults to false");
 			Console.WriteLine ("  --output-pinvokes PATH    Output a JSON file with all modules and entry points of the P/Invokes found");
 			Console.WriteLine ("  --verbose                 Log messages indicating progress and warnings");
 			Console.WriteLine ("  --nowarn WARN             Disable specific warning messages");

--- a/src/tools/illink/src/linker/Linker/ExportedTypeExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/ExportedTypeExtensions.cs
@@ -1,0 +1,113 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Mono.Cecil;
+
+namespace Mono.Linker;
+
+public static class ExportedTypeExtensions {
+	public static TypeDefinition? TryResolve (this ExportedType exportedType, ModuleDefinition module) {
+		return ((MetadataResolver) module.MetadataResolver).TryResolve (exportedType.CreateReference (module));
+	}
+
+	private static TypeReference CreateReference (this ExportedType exportedType, ModuleDefinition module) {
+		return new TypeReference (exportedType.Namespace, exportedType.Name, module, exportedType.Scope) {
+			DeclaringType = exportedType.DeclaringType?.CreateReference (module),
+		};
+	}
+
+	private static TypeDefinition? TryResolve (this MetadataResolver metadataResolver, TypeReference type) {
+		type = type.GetElementType ();
+
+		var scope = type.Scope;
+
+		if (scope == null)
+			return null;
+
+		switch (scope.MetadataScopeType) {
+		case MetadataScopeType.AssemblyNameReference:
+			var assembly = ((AssemblyResolver) metadataResolver.AssemblyResolver).Resolve ((AssemblyNameReference) scope, probing: true);
+			if (assembly == null)
+				return null;
+
+			return metadataResolver.GetType (assembly.MainModule, type);
+		case MetadataScopeType.ModuleDefinition:
+			return metadataResolver.GetType ((ModuleDefinition) scope, type);
+		case MetadataScopeType.ModuleReference:
+			if (type.Module.Assembly == null)
+				return null;
+
+			var modules = type.Module.Assembly.Modules;
+			var module_ref = (ModuleReference) scope;
+			for (int i = 0; i < modules.Count; i++) {
+				var netmodule = modules [i];
+				if (netmodule.Name == module_ref.Name)
+					return metadataResolver.GetType (netmodule, type);
+			}
+			break;
+		}
+
+		throw new NotSupportedException ();
+	}
+
+	private static TypeDefinition? GetType (this MetadataResolver metadataResolver, ModuleDefinition module, TypeReference reference) {
+		var type = metadataResolver.GetTypeDefinition (module, reference);
+		if (type != null)
+			return type;
+
+		if (!module.HasExportedTypes)
+			return null;
+
+		var exported_types = module.ExportedTypes;
+
+		for (int i = 0; i < exported_types.Count; i++) {
+			var exported_type = exported_types [i];
+			if (exported_type.Name != reference.Name)
+				continue;
+
+			if (exported_type.Namespace != reference.Namespace)
+				continue;
+
+			return exported_type.TryResolve (module);
+		}
+
+		return null;
+	}
+
+	private static TypeDefinition? GetTypeDefinition (this MetadataResolver metadtaaResolver, ModuleDefinition module, TypeReference type)
+	{
+		if (!type.IsNested)
+			return module.GetType (type.Namespace, type.Name);
+
+		var declaring_type = metadtaaResolver.TryResolve (type.DeclaringType);
+		if (declaring_type == null)
+			return null;
+
+		return declaring_type.GetNestedType (type.TypeFullName ());
+	}
+
+	private static string TypeFullName (this TypeReference self)
+	{
+		return string.IsNullOrEmpty (self.Namespace)
+			? self.Name
+			: self.Namespace + '.' + self.Name;
+	}
+
+	private static TypeDefinition? GetNestedType (this TypeDefinition self, string fullname)
+	{
+		if (!self.HasNestedTypes)
+			return null;
+
+		var nested_types = self.NestedTypes;
+
+		for (int i = 0; i < nested_types.Count; i++) {
+			var nested_type = nested_types [i];
+
+			if (nested_type.TypeFullName () == fullname)
+				return nested_type;
+		}
+
+		return null;
+	}
+}

--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -108,8 +108,6 @@ namespace Mono.Linker
 
 		public readonly bool KeepMembersForDebugger = true;
 
-		public bool IgnoreUnresolved { get; set; }
-
 		public bool EnableReducedTracing { get; set; }
 
 		public bool KeepUsedAttributeTypesOnly { get; set; }
@@ -474,7 +472,10 @@ namespace Mono.Linker
 
 			while (toProcess.Count > 0) {
 				var assembly = toProcess.Dequeue ();
-				foreach (var reference in ResolveReferences (assembly)) {
+				Resolver.IgnoreUnresolved = true;
+				var references = ResolveReferences (assembly);
+				Resolver.IgnoreUnresolved = false;
+				foreach (var reference in references) {
 					if (!loaded.Add (reference))
 						continue;
 					yield return reference;
@@ -774,7 +775,7 @@ namespace Mono.Linker
 #pragma warning disable RS0030 // Cecil's resolve is banned -- this provides the wrapper
 			md = methodReference.Resolve ();
 #pragma warning restore RS0030
-			if (md == null && !IgnoreUnresolved)
+			if (md == null)
 				ReportUnresolved (methodReference);
 
 			methodresolveCache.Add (methodReference, md);
@@ -817,7 +818,7 @@ namespace Mono.Linker
 				return fd;
 
 			fd = fieldReference.Resolve ();
-			if (fd == null && !IgnoreUnresolved)
+			if (fd == null)
 				ReportUnresolved (fieldReference);
 
 			fieldresolveCache.Add (fieldReference, fd);
@@ -866,7 +867,7 @@ namespace Mono.Linker
 #pragma warning disable RS0030
 			td = typeReference.Resolve ();
 #pragma warning restore RS0030
-			if (td == null && !IgnoreUnresolved)
+			if (td == null)
 				ReportUnresolved (typeReference);
 
 			typeresolveCache.Add (typeReference, td);

--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -913,9 +913,9 @@ namespace Mono.Linker
 		/// <summary>
 		/// Tries to resolve the ExportedType to a TypeDefinition and logs a warning if it can't
 		/// </summary>
-		public TypeDefinition? Resolve (ExportedType et)
+		public TypeDefinition? Resolve (ExportedType et, ModuleDefinition module)
 		{
-			if (TryResolve (et) is not TypeDefinition td) {
+			if (TryResolve (et, module) is not TypeDefinition td) {
 				ReportUnresolved (et);
 				return null;
 			}
@@ -925,13 +925,13 @@ namespace Mono.Linker
 		/// <summary>
 		/// Tries to resolve the ExportedType to a TypeDefinition and returns null if it can't
 		/// </summary>
-		public TypeDefinition? TryResolve (ExportedType et)
+		public TypeDefinition? TryResolve (ExportedType et, ModuleDefinition module)
 		{
 			if (exportedTypeResolveCache.TryGetValue (et, out var td)) {
 				return td;
 			}
 #pragma warning disable RS0030 // Cecil's Resolve is banned -- this method provides the wrapper
-			td = et.Resolve ();
+			td = et.TryResolve (module);
 #pragma warning restore RS0030
 			exportedTypeResolveCache.Add (et, td);
 			return td;

--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -289,6 +289,12 @@ namespace Mono.Linker
 			return _resolver.Resolve (reference);
 		}
 
+		public AssemblyDefinition? TryResolve (IMetadataScope scope)
+		{
+			AssemblyNameReference reference = GetReference (scope);
+			return _resolver.Resolve (reference, probing: true);
+		}
+
 		public AssemblyDefinition? Resolve (AssemblyNameReference name)
 		{
 			return _resolver.Resolve (name);
@@ -342,7 +348,7 @@ namespace Mono.Linker
 				return references;
 
 			foreach (AssemblyNameReference reference in assembly.MainModule.AssemblyReferences) {
-				AssemblyDefinition? definition = Resolve (reference);
+				AssemblyDefinition? definition = TryResolve (reference);
 				if (definition != null)
 					references.Add (definition);
 			}
@@ -472,9 +478,7 @@ namespace Mono.Linker
 
 			while (toProcess.Count > 0) {
 				var assembly = toProcess.Dequeue ();
-				Resolver.IgnoreUnresolved = true;
 				var references = ResolveReferences (assembly);
-				Resolver.IgnoreUnresolved = false;
 				foreach (var reference in references) {
 					if (!loaded.Add (reference))
 						continue;

--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -478,8 +478,7 @@ namespace Mono.Linker
 
 			while (toProcess.Count > 0) {
 				var assembly = toProcess.Dequeue ();
-				var references = ResolveReferences (assembly);
-				foreach (var reference in references) {
+				foreach (var reference in ResolveReferences (assembly)) {
 					if (!loaded.Add (reference))
 						continue;
 					yield return reference;

--- a/src/tools/illink/src/linker/Linker/MarkingHelpers.cs
+++ b/src/tools/illink/src/linker/Linker/MarkingHelpers.cs
@@ -7,11 +7,11 @@ namespace Mono.Linker
 {
 	public class MarkingHelpers
 	{
-		protected readonly LinkContext _context;
+		public LinkContext Context { get; }
 
 		public MarkingHelpers (LinkContext context)
 		{
-			_context = context;
+			Context = context;
 		}
 
 		public void MarkMatchingExportedType (TypeDefinition typeToMatch, AssemblyDefinition assembly, in DependencyInfo reason, in MessageOrigin origin)
@@ -19,16 +19,16 @@ namespace Mono.Linker
 			if (typeToMatch == null || assembly == null)
 				return;
 
-			if (assembly.MainModule.GetMatchingExportedType (typeToMatch, _context, out var exportedType))
+			if (assembly.MainModule.GetMatchingExportedType (typeToMatch, Context, out var exportedType))
 				MarkExportedType (exportedType, assembly.MainModule, reason, origin);
 		}
 
 		public void MarkExportedType (ExportedType exportedType, ModuleDefinition module, in DependencyInfo reason, in MessageOrigin origin)
 		{
-			if (!_context.Annotations.MarkProcessed (exportedType, reason))
+			if (!Context.Annotations.MarkProcessed (exportedType, reason))
 				return;
 
-			_context.Annotations.Mark (module, reason, origin);
+			Context.Annotations.Mark (module, reason, origin);
 		}
 
 		public void MarkForwardedScope (TypeReference typeReference, in MessageOrigin origin)
@@ -37,10 +37,10 @@ namespace Mono.Linker
 				return;
 
 			if (typeReference.Scope is AssemblyNameReference) {
-				var assembly = _context.Resolve (typeReference.Scope);
+				var assembly = Context.Resolve (typeReference.Scope);
 				if (assembly != null &&
-					_context.TryResolve (typeReference) is TypeDefinition typeDefinition &&
-					assembly.MainModule.GetMatchingExportedType (typeDefinition, _context, out var exportedType))
+					Context.TryResolve (typeReference) is TypeDefinition typeDefinition &&
+					assembly.MainModule.GetMatchingExportedType (typeDefinition, Context, out var exportedType))
 					MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, typeReference), origin);
 			}
 		}

--- a/src/tools/illink/src/linker/Linker/MarkingHelpers.cs
+++ b/src/tools/illink/src/linker/Linker/MarkingHelpers.cs
@@ -7,11 +7,11 @@ namespace Mono.Linker
 {
 	public class MarkingHelpers
 	{
-		public LinkContext Context { get; }
+		protected readonly LinkContext _context;
 
 		public MarkingHelpers (LinkContext context)
 		{
-			Context = context;
+			_context = context;
 		}
 
 		public void MarkMatchingExportedType (TypeDefinition typeToMatch, AssemblyDefinition assembly, in DependencyInfo reason, in MessageOrigin origin)
@@ -19,16 +19,16 @@ namespace Mono.Linker
 			if (typeToMatch == null || assembly == null)
 				return;
 
-			if (assembly.MainModule.GetMatchingExportedType (typeToMatch, Context, out var exportedType))
+			if (assembly.MainModule.GetMatchingExportedType (typeToMatch, _context, out var exportedType))
 				MarkExportedType (exportedType, assembly.MainModule, reason, origin);
 		}
 
 		public void MarkExportedType (ExportedType exportedType, ModuleDefinition module, in DependencyInfo reason, in MessageOrigin origin)
 		{
-			if (!Context.Annotations.MarkProcessed (exportedType, reason))
+			if (!_context.Annotations.MarkProcessed (exportedType, reason))
 				return;
 
-			Context.Annotations.Mark (module, reason, origin);
+			_context.Annotations.Mark (module, reason, origin);
 		}
 
 		public void MarkForwardedScope (TypeReference typeReference, in MessageOrigin origin)
@@ -37,10 +37,10 @@ namespace Mono.Linker
 				return;
 
 			if (typeReference.Scope is AssemblyNameReference) {
-				var assembly = Context.TryResolve (typeReference.Scope);
+				var assembly = _context.TryResolve (typeReference.Scope);
 				if (assembly != null &&
-					Context.TryResolve (typeReference) is TypeDefinition typeDefinition &&
-					assembly.MainModule.GetMatchingExportedType (typeDefinition, Context, out var exportedType))
+					_context.TryResolve (typeReference) is TypeDefinition typeDefinition &&
+					assembly.MainModule.GetMatchingExportedType (typeDefinition, _context, out var exportedType))
 					MarkExportedType (exportedType, assembly.MainModule, new DependencyInfo (DependencyKind.ExportedType, typeReference), origin);
 			}
 		}

--- a/src/tools/illink/src/linker/Linker/MarkingHelpers.cs
+++ b/src/tools/illink/src/linker/Linker/MarkingHelpers.cs
@@ -37,7 +37,7 @@ namespace Mono.Linker
 				return;
 
 			if (typeReference.Scope is AssemblyNameReference) {
-				var assembly = Context.Resolve (typeReference.Scope);
+				var assembly = Context.TryResolve (typeReference.Scope);
 				if (assembly != null &&
 					Context.TryResolve (typeReference) is TypeDefinition typeDefinition &&
 					assembly.MainModule.GetMatchingExportedType (typeDefinition, Context, out var exportedType))

--- a/src/tools/illink/src/linker/Linker/ModuleDefinitionExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/ModuleDefinitionExtensions.cs
@@ -22,10 +22,13 @@ namespace Mono.Linker
 				return false;
 
 			foreach (var et in module.ExportedTypes) {
+				context.Resolver.IgnoreUnresolved = true;
 				if (context.TryResolve (et) == typeDefinition) {
 					exportedType = et;
+					context.Resolver.IgnoreUnresolved = false;
 					return true;
 				}
+				context.Resolver.IgnoreUnresolved = false;
 			}
 
 			return false;

--- a/src/tools/illink/src/linker/Linker/ModuleDefinitionExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/ModuleDefinitionExtensions.cs
@@ -22,7 +22,7 @@ namespace Mono.Linker
 				return false;
 
 			foreach (var et in module.ExportedTypes) {
-				if (et.TryResolve (module) == typeDefinition) {
+				if (context.TryResolve (et, module) == typeDefinition) {
 					exportedType = et;
 					return true;
 				}

--- a/src/tools/illink/src/linker/Linker/ModuleDefinitionExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/ModuleDefinitionExtensions.cs
@@ -22,13 +22,10 @@ namespace Mono.Linker
 				return false;
 
 			foreach (var et in module.ExportedTypes) {
-				context.Resolver.IgnoreUnresolved = true;
-				if (context.TryResolve (et) == typeDefinition) {
+				if (et.TryResolve (module) == typeDefinition) {
 					exportedType = et;
-					context.Resolver.IgnoreUnresolved = false;
 					return true;
 				}
-				context.Resolver.IgnoreUnresolved = false;
 			}
 
 			return false;

--- a/src/tools/illink/src/linker/Linker/TypeReferenceWalker.cs
+++ b/src/tools/illink/src/linker/Linker/TypeReferenceWalker.cs
@@ -45,7 +45,7 @@ namespace Mono.Linker
 			}
 
 			if (mmodule.HasExportedTypes)
-				WalkTypeScope (mmodule.ExportedTypes);
+				WalkTypeScope (mmodule.ExportedTypes, mmodule);
 
 			ProcessExtra ();
 		}
@@ -152,10 +152,10 @@ namespace Mono.Linker
 			}
 		}
 
-		void WalkTypeScope (Collection<ExportedType> forwarders)
+		void WalkTypeScope (Collection<ExportedType> forwarders, ModuleDefinition module)
 		{
 			foreach (var f in forwarders)
-				ProcessExportedType (f);
+				ProcessExportedType (f, module);
 		}
 
 		void WalkTypeScope (MethodBody body)
@@ -373,7 +373,7 @@ namespace Mono.Linker
 
 		protected abstract void ProcessTypeReference (TypeReference type);
 
-		protected abstract void ProcessExportedType (ExportedType exportedType);
+		protected abstract void ProcessExportedType (ExportedType exportedType, ModuleDefinition module);
 	}
 
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/CoreLibraryAssemblyAttributesAreKept.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/CoreLibraryAssemblyAttributesAreKept.cs
@@ -10,7 +10,6 @@ namespace Mono.Linker.Tests.Cases.Attributes
 	[SetupLinkerTrimMode ("link")]
 	// System.dll referenced by a dynamically (for example in TypeConverterAttribute on IComponent)
 	// has unresolved references.
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[KeptAttributeInAssembly (PlatformAssemblies.CoreLib, typeof (AssemblyDescriptionAttribute))]
 	[KeptAttributeInAssembly (PlatformAssemblies.CoreLib, typeof (AssemblyCompanyAttribute))]
 #if !NETCOREAPP

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/IVTUsed.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/IVTUsed.cs
@@ -13,7 +13,6 @@ namespace Mono.Linker.Tests.Cases.Attributes
 
 	// This is a bit fragile but it's used to test that ITV attribute is marked correctly
 	[SetupLinkerTrimMode ("link")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[KeptTypeInAssembly (PlatformAssemblies.CoreLib, typeof (InternalsVisibleToAttribute))]
 	class IVTUsed
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnGenericParameterIsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnGenericParameterIsRemoved.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupLinkerArgument ("--used-attrs-only", "true")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyWithUnusedAttributeOnGenericParameter.il" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnReturnTypeIsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnReturnTypeIsRemoved.cs
@@ -3,8 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
-	[SetupLinkerArgument ("--used-attrs-only", "true")]
+		[SetupLinkerArgument ("--used-attrs-only", "true")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/AssemblyWithUnusedAttributeOnReturnParameterDefinition.il" })]
 	[RemovedTypeInAssembly ("library.dll", "Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed.Dependencies.AssemblyWithUnusedAttributeOnReturnParameterDefinition/FooAttribute")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/ComponentModel/CustomTypeConvertor.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/ComponentModel/CustomTypeConvertor.cs
@@ -57,7 +57,6 @@ namespace Mono.Linker.Tests.Cases.ComponentModel
 	[Reference ("System.dll")]
 	// System.dll referenced by a dynamically (for example in TypeConverterAttribute on IComponent)
 	// has unresolved references.
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	public class CustomTypeConvertor
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CoreLink/CopyOfCoreLibrariesKeepsUnusedTypes.cs
@@ -7,7 +7,6 @@ namespace Mono.Linker.Tests.Cases.CoreLink
 	[SetupLinkerTrimMode ("copy")]
 	// System.dll referenced by a dynamically (for example in TypeConverterAttribute on IComponent)
 	// has unresolved references.
-	[SetupLinkerArgument ("--skip-unresolved")]
 
 	[KeptAssembly (PlatformAssemblies.CoreLib)]
 	[KeptAllTypesAndMembersInAssembly (PlatformAssemblies.CoreLib)]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CppCLI/CppCLIAssemblyIsAnalyzed.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CppCLI/CppCLIAssemblyIsAnalyzed.cs
@@ -9,7 +9,6 @@ namespace Mono.Linker.Tests.Cases.CppCLI
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
 	[ReferenceDependency ("Dependencies/TestLibrary.dll")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 
 	[SetupCompileBefore ("ManagedSide.dll", new[] { "Dependencies/CallCppCLIFromManagedRef.cs" })]
 	[SetupCompileAfter ("ManagedSide.dll", new[] { "Dependencies/CallCppCLIFromManaged.cs" }, references: new[] { "TestLibrary.dll" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CppCLI/NonCopyActionWarnOnCppCLI.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CppCLI/NonCopyActionWarnOnCppCLI.cs
@@ -9,7 +9,6 @@ namespace Mono.Linker.Tests.Cases.CppCLI
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
 	[ReferenceDependency ("Dependencies/TestLibrary.dll")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 
 	[SetupLinkerDefaultAction ("copy")]
 	[SetupLinkerAction ("copyused", "TestLibrary")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
@@ -15,7 +15,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	// it would fail to JIT/run anyway.
 
 	[SkipPeVerify]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupCompileBefore ("UnresolvedLibrary.dll", new[] { "Dependencies/UnresolvedLibrary.cs" }, removeFromLinkerInput: true)]
 	[ExpectedNoWarnings]
 	class UnresolvedMembers

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
@@ -8,6 +8,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
+	[ExpectNonZeroExitCode (1)]
+	[NoLinkedOutput]
 	[IgnoreTestCase ("Ignore in NativeAOT, see https://github.com/dotnet/runtime/issues/82447", IgnoredBy = Tool.NativeAot)]
 	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
 	// NativeAOT will not compile a method with unresolved types in it - it will instead replace it with a throwing method body

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInAssembly.cs
@@ -7,7 +7,6 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyMethodInAssemblyLibrary", ".ctor()")]
 	[KeptMemberInAssembly ("library.dll", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyMethodInAssemblyLibrary", "privateField")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/DynamicDependencyMethodInAssemblyLibrary.cs" })]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	public class DynamicDependencyMethodInAssembly
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/InterfaceWithAttributeOnImplementation.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/InterfaceWithAttributeOnImplementation.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[TestCaseRequirements (TestRunCharacteristics.SupportsDefaultInterfaceMethods, "Requires support for default interface methods")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/InterfaceWithAttributeOnImpl.il" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndAssemblyPreserveAll.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndAssemblyPreserveAll.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 	[KeptInterfaceOnTypeInAssemblyAttribute ("library",

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveAll.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveAll.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 	[KeptInterfaceOnTypeInAssembly ("library",
 		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFields.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFields.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 
 	// The interfaces should be removed because the interface types are not marked

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("IL_ASSEMBLY_COMPILED")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethods.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethods.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 
 	// The interfaces should be removed because the interface types are not marked

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("IL_ASSEMBLY_COMPILED")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveNone.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveNone.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 	[RemovedInterfaceOnTypeInAssembly ("library",
 		"Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/LibraryWithUnresolvedInterfaces.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/LibraryWithUnresolvedInterfaces.cs
@@ -8,7 +8,6 @@ using Mono.Linker.Tests.Cases.Libraries.Dependencies;
 namespace Mono.Linker.Tests.Cases.Libraries
 {
 	[SetupCompileBefore ("copylibrary.dll", new[] { "Dependencies/CopyLibrary.cs" }, removeFromLinkerInput: true)]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupLinkerArgument ("-a", "test.exe", "library")]
 	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]
 	[VerifyMetadataNames]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/LibraryWithUnresolvedInterfaces.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/LibraryWithUnresolvedInterfaces.cs
@@ -7,6 +7,8 @@ using Mono.Linker.Tests.Cases.Libraries.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Libraries
 {
+	[ExpectNonZeroExitCode (1)]
+	[NoLinkedOutput]
 	[SetupCompileBefore ("copylibrary.dll", new[] { "Dependencies/CopyLibrary.cs" }, removeFromLinkerInput: true)]
 	[SetupLinkerArgument ("-a", "test.exe", "library")]
 	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkAttributeErrorCases.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkAttributeErrorCases.cs
@@ -7,7 +7,6 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 {
 	[SetupLinkAttributesFile ("LinkAttributeErrorCases.xml")]
 	[IgnoreLinkAttributes (false)]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupCompileBefore ("library.dll", new string[] { "Dependencies/EmbeddedAttributeErrorCases.cs" },
 		resources: new object[] { new string[] { "Dependencies/EmbeddedAttributeErrorCases.xml", "ILLink.LinkAttributes.xml" } })]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.LinkXml
 {
 	[SetupLinkerDescriptorFile ("LinkXmlErrorCases.xml")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 
 	[ExpectedWarning ("IL2001", "TypeWithNoFields", FileName = "LinkXmlErrorCases.xml", SourceLine = 3, SourceColumn = 6)]
 	[ExpectedWarning ("IL2002", "TypeWithNoMethods", FileName = "LinkXmlErrorCases.xml", SourceLine = 4, SourceColumn = 6)]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyErrorCases.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyErrorCases.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.PreserveDependencies
 {
 	[SetupCompileBefore ("FakeSystemAssembly.dll", new[] { "Dependencies/PreserveDependencyAttribute.cs" })]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	class PreserveDependencyErrorCases
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Individual/CanSkipUnresolved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Individual/CanSkipUnresolved.cs
@@ -5,7 +5,6 @@ namespace Mono.Linker.Tests.Cases.References.Individual
 {
 	[SetupCompileBefore ("library1.dll", new[] { "Dependencies/CanSkipUnresolved_Library.cs" })]
 	[SetupCompileAfter ("library1.dll", new[] { "Dependencies/CanSkipUnresolved_Library.cs" }, defines: new[] { "EXCLUDE_STUFF" })]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	public class CanSkipUnresolved
 	{
 		static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Individual/CanSkipUnresolved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Individual/CanSkipUnresolved.cs
@@ -1,8 +1,11 @@
-﻿using Mono.Linker.Tests.Cases.Expectations.Metadata;
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.References.Individual.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.References.Individual
 {
+	[ExpectNonZeroExitCode (1)]
+	[NoLinkedOutput]
 	[SetupCompileBefore ("library1.dll", new[] { "Dependencies/CanSkipUnresolved_Library.cs" })]
 	[SetupCompileAfter ("library1.dll", new[] { "Dependencies/CanSkipUnresolved_Library.cs" }, defines: new[] { "EXCLUDE_STUFF" })]
 	public class CanSkipUnresolved

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdb.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdb.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("false")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbCopyAction.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbCopyAction.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("false")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteAction.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteAction.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("false")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteActionAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteActionAndSymbolLinkingEnabled.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 	[SetupLinkerLinkSymbols ("true")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdb.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdb.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("false")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabled.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("true")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("true")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndNewMvid.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndNewMvid.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("true")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbCopyAction.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbCopyAction.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("false")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteAction.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteAction.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("false")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteActionAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteActionAndSymbolLinkingEnabled.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 	[SetupLinkerLinkSymbols ("true")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypes.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesAndSymbolLinkingEnabled.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesWithMdbAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesWithMdbAndSymbolLinkingEnabled.cs
@@ -9,7 +9,6 @@ namespace Mono.Linker.Tests.Cases.Symbols
 {
 	[IgnoreTestCase ("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
 	[TestCaseRequirements (TestRunCharacteristics.TargetingNetFramework, "mdb files are not supported with .NET Core")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Reference ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
 	[ReferenceDependency ("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileILAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileILAssembly.cs
@@ -4,7 +4,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TestFramework
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("ILAssembly.dll", new[] { "Dependencies/ILAssemblySample.il" })]
 	[KeptMemberInAssembly ("ILAssembly.dll", "Mono.Linker.Tests.Cases.TestFramework.Dependencies.ILAssemblySample", "GiveMeAValue()")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/SecurityAttributeScope.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/SecurityAttributeScope.cs
@@ -12,7 +12,6 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 	///
 	/// In order words, until https://github.com/dotnet/linker/issues/1703 is addressed this test will pass with or without the fix to update the scope on security attributes
 	/// </summary>
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupLinkerArgument ("--strip-security", "false")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupLinkerAction ("copy", "Library")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardedIsUpdatedForMissingType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardedIsUpdatedForMissingType.cs
@@ -3,6 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TypeForwarding
 {
+	[ExpectNonZeroExitCode (1)]
+	[NoLinkedOutput]
 	[SkipUnresolved (true)]
 	[SetupCompileBefore ("Lib.dll", new[] { "Dependencies/TypeForwardedIsUpdatedForMissingTypeLib.cs" })]
 	[SetupCompileBefore ("AnotherLibrary.dll", new[] { "Dependencies/TypeForwardedIsUpdatedForMissingTypeLib2.cs" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardersModifiers.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardersModifiers.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TypeForwarding
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	// Actions:
 	// link - This assembly, TypeForwarderModifiersLibDef.dll and TypeForwardersModifiersLib.dll
 	[SetupLinkerDefaultAction ("link")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardersRewrite.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardersRewrite.cs
@@ -7,7 +7,6 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
 	// Actions:
 	// link - This assembly, Forwarder.dll and Implementation.dll
 
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 
 	[SetupCompileArgument ("/unsafe")]
 	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/TypeForwardersRewriteLib.cs" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/EndScopeOnMethoEnd.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/EndScopeOnMethoEnd.cs
@@ -5,7 +5,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/EndScopeOnMethod.il" })]
 	public class EndScopeOnMethoEnd

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/UninitializedLocals.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/UninitializedLocals.cs
@@ -5,7 +5,6 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
 	[SetupCSharpCompilerToUse ("csc")]
 	[SetupCompileArgument ("/optimize+")]
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("IL_ASSEMBLY_AVAILABLE")]
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/LocalsWithoutStore.il" })]
 	[SetupLinkerArgument ("--enable-opt", "ipconstprop")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBody/DoesNotApplyToCopiedAssembly2.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBody/DoesNotApplyToCopiedAssembly2.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBody
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("OTHER_INCLUDED")]
 	[SetupLinkerAction ("copy", "other")]
 	[SetupCompileBefore ("other.dll", new[] { "Dependencies/OtherAssemblyNoInstanceCtor.il" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBody/LinkedOtherIncludedLibraryNoInstanceCtor.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBody/LinkedOtherIncludedLibraryNoInstanceCtor.cs
@@ -3,7 +3,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBody
 {
-	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[Define ("OTHER_INCLUDED")]
 #if NETCOREAPP
 	[SetupLinkerArgument ("-a", "other.dll", "visible")]

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCases/IndividualTests.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCases/IndividualTests.cs
@@ -33,8 +33,10 @@ namespace Mono.Linker.Tests.TestCases
 			// We can't use the ResultChecker on the output because there will be unresolved types/methods
 			// Let's just make sure that the output assembly exists.  That's enough to verify that ILLink didn't throw due to the
 			// missing types/methods
-			if (!result.OutputAssemblyPath.Exists ())
-				Assert.Fail ($"The linked assembly is missing.  Should have existed at {result.OutputAssemblyPath}");
+			if (result.OutputAssemblyPath.Exists ())
+				Assert.Fail ($"The linked assembly is present at {result.OutputAssemblyPath}.  Should not have been produced.");
+			if (result.ExitCode != 1)
+				Assert.Fail ($"The linker returned exit code {result.ExitCode}.  Should have returned 1.");
 		}
 
 		[Test]

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/LinkerArgumentBuilder.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/LinkerArgumentBuilder.cs
@@ -113,14 +113,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			Append (assembly);
 		}
 
-		public virtual void AddSkipUnresolved (bool skipUnresolved)
-		{
-			if (skipUnresolved) {
-				Append ("--skip-unresolved");
-				Append ("true");
-			}
-		}
-
 		public virtual void AddStripDescriptors (bool stripDescriptors)
 		{
 			if (!stripDescriptors) {
@@ -212,8 +204,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 			if (!string.IsNullOrEmpty (options.LinkSymbols))
 				AddLinkSymbols (options.LinkSymbols);
-
-			AddSkipUnresolved (options.SkipUnresolved);
 
 			AddStripDescriptors (options.StripDescriptors);
 


### PR DESCRIPTION
After the discussion around https://github.com/dotnet/runtime/pull/90261 and https://github.com/dotnet/runtime/issues/90469, I wanted to see if we could get rid of `--skip-unresolved` entirely by making the `Resolve` behavior always strict (error on resolution failure), and replacing just the callsites where we need to be resilient to failures (mainly when encountering type forwarders to assemblies that aren't present). I'm not sure yet if this is a good idea, so I'm curious what you think of the approach @vitek-karas @mrvoorhe.

When cecil needs to resolve an assembly as part of member resolution, it defers to our AssemblyResolver by calling `Resolve` directly. This change adds extension methods for exported types (unfortunately requiring some code to be duplicated from cecil) that allows resolving them with a call to a different `Resolve` overload that doesn't error on resolution failures.

With these changes, a few testcases that were intentionally written to test the behavior of missing references started failing, so I've changed the expected behavior for those.