### PR TITLE
Add regression test for GitHub issue #74132

### DIFF
--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_74132.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_74132.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+// This regression test tracks the issue where GetInterfaceMap returns incorrect
+// non-generic entries for generic static virtual methods.
+
+public interface I<T> where T : I<T>
+{
+    public void Instance<M>(M m);
+    public static abstract void Static<M>(M m);
+}
+
+public readonly struct C : I<C>
+{
+    public void Instance<M>(M m) { }
+    public static void Static<M>(M m) { }
+}
+
+internal class Program
+{
+    static int Main(string[] args)
+    {
+        var interfaceMap = typeof(C).GetInterfaceMap(typeof(I<C>));
+        bool allMethodsAreGeneric = true;
+        for (int i = 0; i < interfaceMap.InterfaceMethods.Length; i++)
+        {
+            var imethod = interfaceMap.InterfaceMethods[i];
+            var tmethod = interfaceMap.TargetMethods[i];
+            Console.WriteLine($"Interface.{imethod.Name} is generic method def: {imethod.IsGenericMethodDefinition}");
+            Console.WriteLine($"Target.{tmethod.Name} is generic method def: {tmethod.IsGenericMethodDefinition}");
+            if (!imethod.IsGenericMethodDefinition || !tmethod.IsGenericMethodDefinition)
+            {
+                allMethodsAreGeneric = false;
+            }
+        }
+        
+        if (!allMethodsAreGeneric)
+        {
+            throw new Exception("Test failed, all above methods should be reported as generic!");
+        }
+        
+        return 100;
+    }
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_74132.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_74132.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I have verified locally that the problem described in the issue no longer exists in .NET 8 RC1, the bug was probably fixed earlier this year by David Wrighton. I think the regression test described in the issue is useful so I'm proposing to merge it in; this PR will then close the issue.

Fixes: #74132

Thanks

Tomas