### PR TITLE
[release/7.0] wasm-tools: Fix workload manifest MSI ProductVersion generation

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -37,7 +37,7 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GetVersionProps;_GenerateMsiVersionString">
+  <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GenerateMsiVersionString">
     <ItemGroup>
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
            these must be updated. -->
@@ -197,15 +197,6 @@
     <MSBuild Projects="@(SwixProjects)" BuildInParallel="true" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VisualStudioSetupInsertionPath)" />
   </Target>
 
-  <Target Name="_GetVersionProps">
-    <PropertyGroup>
-      <_MajorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Major)</_MajorVersion>
-      <_MinorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Minor)</_MinorVersion>
-      <_PatchVersion>$([System.Version]::Parse('$(AssemblyVersion)').Build)</_PatchVersion>
-      <_BuildNumber>$([System.Version]::Parse('$(AssemblyVersion)').Revision)</_BuildNumber>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="_GenerateMsiVersionString">
     <PropertyGroup>
       <VersionPadding Condition="'$(VersionPadding)'==''">5</VersionPadding>
@@ -223,9 +214,9 @@
     </GenerateCurrentVersion>
 
     <GenerateMsiVersion
-      Major="$(_MajorVersion)"
-      Minor="$(_MinorVersion)"
-      Patch="$(_PatchVersion)"
+      Major="$(MajorVersion)"
+      Minor="$(MinorVersion)"
+      Patch="$(PatchVersion)"
       BuildNumberMajor="$(BuildNumberMajor)"
       BuildNumberMinor="$(BuildNumberMinor)">
       <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />


### PR DESCRIPTION
# Description
Manifest installers for .NET optional workloads rely on performing major upgrades in .NET 6 and 7. This requires that the MSI version increments for new builds. The MSI version was generated using the assembly version. MSI versions should be generated using the major/minor/patch/buildnumber, e.g. 7.0.11.12345. Because the assembly version was being used, the patch value was always set to 0. Due to the bit masking and shift operations used to construct the MSI version, the 3rd part of the version number wrapped around, generating a smaller version for a newer release. MSI [ProductVersion](https://learn.microsoft.com/en-us/windows/win32/msi/productversion) is only 32-bits in size (8-bit major, 8-bit minor and 16-bit build number).

For 7.0.10, the ProductVersion generated using the old method was 56.3.64668 and for 7.0.11 it generated 56.0.812.

# Impact
- Visual Studio PR checks fail package validation because the new MSI's version is lower than the baseline copy from the previous insertion.
- The CLI will block installing the newer manifest when trying to update workloads because it will detect a possible downgrade.

# Testing
No unit tests for this. Need to manually verify the manifest MSI's ProductVersion matches the version we generate for other runtime MSIs as well as the workload component version.