### PR TITLE
[wasm] Fix perf pipeline build with 9.0 sdk

### DIFF
--- a/eng/pipelines/coreclr/perf-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-wasm-jobs.yml
@@ -115,8 +115,8 @@ jobs:
         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
         logicalmachine: 'perftiger'
         javascriptEngine: 'v8'
-        # passed to ci_setup.py to work with 8.0 sdk when using tfm!=net8.0
-        #additionalSetupParameters: '--dotnet-versions 8.0.0'
+        # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+        additionalSetupParameters: '--dotnet-versions 8.0.0'
         collectHelixLogsScript: ${{ parameters.collectHelixLogsScript }}
         compare: ${{ parameters.compare }}
         onlySanityCheck: ${{ parameters.onlySanityCheck }}
@@ -142,8 +142,8 @@ jobs:
         runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
         logicalmachine: 'perftiger'
         javascriptEngine: 'v8'
-        # passed to ci_setup.py to work with 8.0 sdk when using tfm!=net8.0
-        #additionalSetupParameters: '--dotnet-versions 8.0.0' # passed to ci_setup.py
+        # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+        additionalSetupParameters: '--dotnet-versions 8.0.0' # passed to ci_setup.py
         collectHelixLogsScript: ${{ parameters.collectHelixLogsScript }}
         compare: ${{ parameters.compare }}
         onlySanityCheck: ${{ parameters.onlySanityCheck }}
@@ -166,8 +166,8 @@ jobs:
         projectFile: blazor_perf.proj
         runKind: blazor_scenarios
         runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        # passed to ci_setup.py to work with 8.0 sdk when using tfm!=net8.0
-        # additionalSetupParameters: '--dotnetversions 8.0.0' # passed to performance-setup.sh
+        # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+        additionalSetupParameters: '--dotnetversions 8.0.0' # passed to performance-setup.sh
         logicalmachine: 'perftiger'
         downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
         perfForkToUse: ${{ parameters.perfForkToUse }}


### PR DESCRIPTION
We are building with 9.0 sdk now, but for tfm=net8.0 and that confuses
the setup script. So, explicitly pass `--dotnet-versions 9.0.0`, so it
can resolve to the available sdk.

```
Traceback (most recent call last):
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/ci_setup.py", line 487, in <module>
    __main(sys.argv[1:])
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/ci_setup.py", line 483, in __main
    main(CiSetupArgs(**vars(args)))
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/ci_setup.py", line 411, in main
    dotnet_version = dotnet.get_dotnet_version(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/dotnet.py", line 582, in get_dotnet_version
    "Unable to determine the .NET SDK used for {}".format(framework)
RuntimeError: Unable to determine the .NET SDK used for net8.0
```

Fixes https://github.com/dotnet/runtime/issues/91011