### PR TITLE
Fix nullability annotations of MemberDescriptor.AttributeArray

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -993,7 +993,8 @@ namespace System.ComponentModel
         protected MemberDescriptor(System.ComponentModel.MemberDescriptor oldMemberDescriptor, System.Attribute[]? newAttributes) { }
         protected MemberDescriptor(string name) { }
         protected MemberDescriptor(string name, System.Attribute[]? attributes) { }
-        protected virtual System.Attribute[]? AttributeArray { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.AllowNull]
+        protected virtual System.Attribute[] AttributeArray { get { throw null; } set { } }
         public virtual System.ComponentModel.AttributeCollection Attributes { get { throw null; } }
         public virtual string Category { get { throw null; } }
         public virtual string Description { get { throw null; } }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -120,7 +121,8 @@ namespace System.ComponentModel
         /// <summary>
         /// Gets or sets an array of attributes.
         /// </summary>
-        protected virtual Attribute[]? AttributeArray
+        [AllowNull]
+        protected virtual Attribute[] AttributeArray
         {
             get
             {
@@ -320,6 +322,7 @@ namespace System.ComponentModel
             }
         }
 
+        [MemberNotNull(nameof(_attributes))]
         private void FilterAttributesIfNeeded()
         {
             if (!_attributesFiltered)
@@ -374,6 +377,8 @@ namespace System.ComponentModel
                     _metadataVersion = TypeDescriptor.MetadataVersion;
                 }
             }
+
+            Debug.Assert(_attributes is not null);
         }
 
         /// <summary>


### PR DESCRIPTION
I detected what seems to be a slight error in the nullability annotation of the `AttributeArray` property of the `System.ComponentModel.MemberDescriptor` class. Here is a proposed fix.