### PR TITLE
Implement IDirectoryContents on PhysicalDirectoryInfo

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/ref/Microsoft.Extensions.FileProviders.Physical.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/ref/Microsoft.Extensions.FileProviders.Physical.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         System = 4,
         Sensitive = 7,
     }
-    public partial class PhysicalDirectoryInfo : Microsoft.Extensions.FileProviders.IFileInfo
+    public partial class PhysicalDirectoryInfo : Microsoft.Extensions.FileProviders.IFileInfo, Microsoft.Extensions.FileProviders.IDirectoryContents, System.Collections.Generic.IEnumerable<Microsoft.Extensions.FileProviders.IFileInfo>, System.Collections.IEnumerable
     {
         public PhysicalDirectoryInfo(System.IO.DirectoryInfo info) { }
         public bool Exists { get { throw null; } }
@@ -53,6 +53,8 @@ namespace Microsoft.Extensions.FileProviders.Physical
         public string Name { get { throw null; } }
         public string PhysicalPath { get { throw null; } }
         public System.IO.Stream CreateReadStream() { throw null; }
+        public System.Collections.Generic.IEnumerator<IFileInfo> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
     }
     public partial class PhysicalFileInfo : Microsoft.Extensions.FileProviders.IFileInfo
     {

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PhysicalDirectoryContents.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/PhysicalDirectoryContents.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using Microsoft.Extensions.FileProviders.Physical;
 
 namespace Microsoft.Extensions.FileProviders.Internal
@@ -16,9 +14,7 @@ namespace Microsoft.Extensions.FileProviders.Internal
     /// </summary>
     public class PhysicalDirectoryContents : IDirectoryContents
     {
-        private IEnumerable<IFileInfo>? _entries;
-        private readonly string _directory;
-        private readonly ExclusionFilters _filters;
+        private readonly PhysicalDirectoryInfo _info;
 
         /// <summary>
         /// Initializes an instance of <see cref="PhysicalDirectoryContents"/>
@@ -37,52 +33,14 @@ namespace Microsoft.Extensions.FileProviders.Internal
         {
             ThrowHelper.ThrowIfNull(directory);
 
-            _directory = directory;
-            _filters = filters;
+            _info = new PhysicalDirectoryInfo(new DirectoryInfo(directory), filters);
         }
 
-        /// <inheritdoc />
-        public bool Exists => Directory.Exists(_directory);
+        /// <inheritdoc/>
+        public bool Exists => _info.Exists;
 
-        /// <inheritdoc />
-        public IEnumerator<IFileInfo> GetEnumerator()
-        {
-            EnsureInitialized();
-            return _entries.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            EnsureInitialized();
-            return _entries.GetEnumerator();
-        }
-
-        [MemberNotNull(nameof(_entries))]
-        private void EnsureInitialized()
-        {
-            try
-            {
-                _entries = new DirectoryInfo(_directory)
-                    .EnumerateFileSystemInfos()
-                    .Where(info => !FileSystemInfoHelper.IsExcluded(info, _filters))
-                    .Select<FileSystemInfo, IFileInfo>(info =>
-                    {
-                        if (info is FileInfo file)
-                        {
-                            return new PhysicalFileInfo(file);
-                        }
-                        else if (info is DirectoryInfo dir)
-                        {
-                            return new PhysicalDirectoryInfo(dir);
-                        }
-                        // shouldn't happen unless BCL introduces new implementation of base type
-                        throw new InvalidOperationException(SR.UnexpectedFileSystemInfo);
-                    });
-            }
-            catch (Exception ex) when (ex is DirectoryNotFoundException || ex is IOException)
-            {
-                _entries = Enumerable.Empty<IFileInfo>();
-            }
-        }
+        /// <inheritdoc/>
+        public IEnumerator<IFileInfo> GetEnumerator() => _info.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => _info.GetEnumerator();
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalDirectoryInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalDirectoryInfo.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
                         _ => throw new InvalidOperationException(SR.UnexpectedFileSystemInfo)
                     });
             }
-            catch (Exception ex) when (ex is DirectoryNotFoundException || ex is IOException)
+            catch (Exception ex) when (ex is DirectoryNotFoundException or IOException)
             {
                 _entries = Enumerable.Empty<IFileInfo>();
             }

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalDirectoryInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalDirectoryInfo.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
     {
         private readonly DirectoryInfo _info;
         private IEnumerable<IFileInfo>? _entries;
+        private readonly ExclusionFilters _filters;
 
         /// <summary>
         /// Initializes an instance of <see cref="PhysicalDirectoryInfo"/> that wraps an instance of <see cref="System.IO.DirectoryInfo"/>
@@ -25,6 +26,12 @@ namespace Microsoft.Extensions.FileProviders.Physical
         public PhysicalDirectoryInfo(DirectoryInfo info)
         {
             _info = info;
+        }
+
+        internal PhysicalDirectoryInfo(DirectoryInfo info, ExclusionFilters filters)
+        {
+            _info = info;
+            _filters = filters;
         }
 
         /// <inheritdoc />
@@ -61,7 +68,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
             throw new InvalidOperationException(SR.CannotCreateStream);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public IEnumerator<IFileInfo> GetEnumerator()
         {
             EnsureInitialized();
@@ -81,6 +88,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
             {
                 _entries = _info
                     .EnumerateFileSystemInfos()
+                    .Where(info => !FileSystemInfoHelper.IsExcluded(info, _filters))
                     .Select<FileSystemInfo, IFileInfo>(info => info switch
                     {
                         FileInfo file => new PhysicalFileInfo(file),


### PR DESCRIPTION
Closes #86354

Also introduces a refactoring of the internal (but publicly exposed) `PhysicalDirectoryContents` class, in order to avoid code duplication.