### PR TITLE
Include dotnet/hostfxr/hostpolicy symbols in Microsoft.NETCore.App.Host/Runtime packages

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Host.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Host.sfxproj
@@ -53,7 +53,17 @@
                     IsSymbolFile="true"
                     IsNative="true" />
     <_SymbolFiles Condition="'$(TargetOS)' != 'windows'"
-                    Include="@(NativeRuntimeAsset->'%(RootDir)%(Directory)%(Filename)%(Extension)%(SymbolsSuffix)')"
+                    Include="@(NativeRuntimeAsset->'%(RootDir)%(Directory)%(Filename)%(Extension)$(SymbolsSuffix)')"
+                    IsSymbolFile="true"
+                    IsNative="true" />
+
+    <!-- dotnet doesn't have its own package, so it uses this one as a means to publish to symbol servers -->
+    <_SymbolFiles Condition="'$(TargetOS)' == 'windows'"
+                    Include="$(DotNetHostBinDir)PDB/dotnet.pdb"
+                    IsSymbolFile="true"
+                    IsNative="true" />
+    <_SymbolFiles Condition="'$(TargetOS)' != 'windows'"
+                    Include="$(DotNetHostBinDir)dotnet$(ExeSuffix)$(SymbolsSuffix)"
                     IsSymbolFile="true"
                     IsNative="true" />
 

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
@@ -66,8 +66,13 @@
 
   <!-- Mobile and NativeAOT use a different hosting model, so we don't include the .NET host components. -->
   <ItemGroup Condition="'$(TargetsMobile)' != 'true' and '$(BuildNativeAOTRuntimePack)' != 'true'">
-    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibPrefix)hostpolicy$(LibSuffix)" />
-    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibPrefix)hostfxr$(LibSuffix)" PackOnly="true" />
+    <_HostFiles Include="$(DotNetHostBinDir)/$(LibPrefix)hostpolicy$(LibSuffix)" />
+    <_HostFiles Include="$(DotNetHostBinDir)/$(LibPrefix)hostfxr$(LibSuffix)" PackOnly="true" />
+    <NativeRuntimeAsset Include="@(_HostFiles)" />
+
+    <_HostSymbolFiles Include="@(_HostFiles->'%(RootDir)%(Directory)PDB/%(Filename)$(SymbolsSuffix)')" Condition="'$(TargetOS)' == 'windows'" />
+    <_HostSymbolFiles Include="@(_HostFiles->'%(RootDir)%(Directory)%(Filename)%(Extension)$(SymbolsSuffix)')" Condition="'$(TargetOS)' != 'windows'" />
+    <_SymbolFilesToPackage Include="@(_HostSymbolFiles->Exists())" IsNative="true" />
   </ItemGroup>
 
   <Target Name="AddRuntimeFilesToPackage" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
@@ -114,7 +119,7 @@
       <CoreCLRCrossTargetFiles Condition="'%(FileName)%(Extension)' == 'mscordbi.dll' and '$(TargetsWindows)' == 'true'">
         <TargetPath>tools/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)</TargetPath>
       </CoreCLRCrossTargetFiles>
-      <CoreCLROptimizationFiles Include="$(CoreCLRArtifactsPath)StandardOptimizationData.mibc" 
+      <CoreCLROptimizationFiles Include="$(CoreCLRArtifactsPath)StandardOptimizationData.mibc"
                                 Condition="Exists('$(CoreCLRArtifactsPath)StandardOptimizationData.mibc')">
         <TargetPath>tools</TargetPath>
       </CoreCLROptimizationFiles>


### PR DESCRIPTION
We're currently relying on some old host packages to get symbols published. This adds those symbols to existing shipping packages.

- Add symbols for hostfxr and hostpolicy to the Microsoft.NETCore.App.Runtime package
- Add symbols for dotnet to the Microsoft.NETCore.App.Host package
- Fix non-Windows symbols not being included in Microsoft.NETCore.App.Host package

This should allow us to remove the old packages: https://github.com/dotnet/runtime/issues/35244