### PR TITLE
JIT: Fix physical promotion creating overlapping local uses

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_85088/Runtime_85088.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_85088/Runtime_85088.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91056/Runtime_91056.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91056/Runtime_91056.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using System.Runtime.CompilerServices;
+
+public class Runtime_91056
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        S s = default;
+        if (False())
+        {
+            s.A = 1234;
+        }
+
+        Foo(0, 0, s, s);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool False() => false;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Foo(int a, int b, S s1, S s2)
+    {
+    }
+
+    public struct S
+    {
+        public int A;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91056/Runtime_91056.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91056/Runtime_91056.csproj
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
-    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_FOLD" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_PHYSICAL_PROMOTION STRESS_PHYSICAL_PROMOTION_COST STRESS_NO_OLD_PROMOTION" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitNoCSE" Value="1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Physical promotion could in some cases create uses overlapping illegally with defs when faced with seemingly last uses of structs. This is a result of a mismatch between our model for liveness and the actual model of local uses in the backend. In the actual model, the uses of LCL_VARs occur at the user, which means that it is possible for there to be no place at which to insert IR between two local uses.

The example looks like the following. Physical promotion would be faced with a tree like

```
▌  CALL      void   Program:Foo(Program+S,Program+S)
├──▌  LCL_VAR   struct<Program+S, 4> V01 loc0
└──▌  LCL_VAR   struct<Program+S, 4> V01 loc0
```

When V01 was fully promoted, both of these are logically last uses since all state of V01 is stored in promoted field locals. Because of that we would make the following transformation:

```
▌  CALL      void   Program:Foo(Program+S,Program+S)
├──▌  LCL_VAR   struct<Program+S, 4> V01 loc0          (last use)
└──▌  COMMA     struct
   ├──▌  STORE_LCL_FLD int    V01 loc0         [+0]
   │  └──▌  LCL_VAR   int    V02 tmp0
   └──▌  LCL_VAR   struct<Program+S, 4> V01 loc0          (last use)
```

This creates an illegally overlapping use and def; additionally, it is correct only in a world where the store actually would happen between the two uses. It is also moderately dangerous to mark both of these as last uses given the implicit byref transformation.

The fix is to avoid marking a struct use as a last use if we see more struct uses in the same statement.

Fix #91056