### PR TITLE
JIT: Skip Create(ToScalar(Dot(...))) transformation on mismatched types

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10760,6 +10760,12 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
                 break;
             }
 
+            // Must be working with the same types of vectors.
+            if (hwop1->TypeGet() != node->TypeGet())
+            {
+                break;
+            }
+
             if (toScalar != nullptr)
             {
                 DEBUG_DESTROY_NODE(toScalar);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91062/Runtime_91062.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91062/Runtime_91062.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.aa
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Numerics;
+using Xunit;
+
+public class Runtime_91062
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Foo(default, default);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector2 Foo(Vector128<float> v1, Vector128<float> v2)
+    {
+        return Vector2.Lerp(default, default, Vector128.Dot(v1, v2));
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91062/Runtime_91062.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91062/Runtime_91062.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix #91062