### PR TITLE
Use RuntimeIdentifierGraphPath if available in runtime copy of Microsoft.NET.CrossGen.targets

### DIFF
--- a/src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets
+++ b/src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets
@@ -443,7 +443,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ResolveReadyToRunCompilers RuntimePacks="@(ResolvedRuntimePack)"
                                 Crossgen2Packs="@(ResolvedCrossgen2Pack)"
                                 TargetingPacks="@(ResolvedTargetingPack)"
-                                RuntimeGraphPath="$(BundledRuntimeIdentifierGraphFile)"
+                                RuntimeGraphPath="$([MSBuild]::ValueOrDefault('$(RuntimeIdentifierGraphPath)', '$(BundledRuntimeIdentifierGraphFile)'))"
                                 NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
                                 EmitSymbols="$(PublishReadyToRunEmitSymbols)"
                                 ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)"


### PR DESCRIPTION
The sdk (shipping) version of this target was updated to use the new trimmed graph as part of https://github.com/dotnet/sdk/pull/34279. This makes the equivalent change here such that it uses the `RuntimeIdentifierGraphPath` if set (SDK always sets starting with .NET 8 RC1), otherwise `BundledRuntimeIdentifierGraphFile`.

From what I can tell, the runtime repo does not actually use this particular `ResolveReadyToRunCompilers` target right now. The only place I found pulling in this target file is https://github.com/dotnet/runtime/blob/658bdd0376326f43cc8a6f316b2e01cacdcc688d/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props#L176
but the project also pulls in ReadyToRun.targets
https://github.com/dotnet/runtime/blob/658bdd0376326f43cc8a6f316b2e01cacdcc688d/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj#L29
which overrides `ResolveReadyToRunCompilers`
https://github.com/dotnet/runtime/blob/658bdd0376326f43cc8a6f316b2e01cacdcc688d/src/installer/pkg/sfx/Microsoft.NETCore.App/ReadyToRun.targets#L2

Fixes #90977 

cc @dsplaisted @tmds 