### PR TITLE
Strip singlefilehost before publishing if it was built with symbols

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -37,6 +37,10 @@
           DestinationFolder="$(MicrosoftNetCoreAppRuntimePackNativeDir)"
           SkipUnchangedFiles="true" />
 
+    <!-- Run strip on the singlefilehost, in case it was built with symbols -->
+    <Exec Condition="'$(KeepNativeSymbols)' == 'true' and '$(HostOS)' != 'windows'"
+          Command="strip $(SingleFileHostSourcePath)" />
+
     <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2.csproj"
              Targets="Restore"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())


### PR DESCRIPTION
You can't strip the binary afterwards, and the symbols may be very large.