### PR TITLE
Use RuntimeIdentifierGraphPath if available in pretest.proj

### DIFF
--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -102,7 +102,7 @@
           Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or '$(BuildTargetFramework)' == ''">
     <!-- Shared framework deps file generation. Produces a test shared-framework deps file. -->
     <GenerateTestSharedFrameworkDepsFile SharedFrameworkDirectory="$(NetCoreAppCurrentTestHostSharedFrameworkPath)"
-                                         RuntimeGraphFiles="$(BundledRuntimeIdentifierGraphFile)"
+                                         RuntimeGraphFiles="$([MSBuild]::ValueOrDefault('$(RuntimeIdentifierGraphPath)', '$(BundledRuntimeIdentifierGraphFile)'))"
                                          TargetRuntimeIdentifier="$(OutputRID)" />
   </Target>
 


### PR DESCRIPTION
Update pretest.proj such that it will use `RuntimeIdentifierGraphPath` if available. It is set to the trimmed down RID graph by default starting with .NET 8 RC1 in the SDK.