### PR TITLE
Activate Quic Alpn Narrowing Test

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -473,7 +473,6 @@ namespace System.Net.Quic.Tests
             Assert.Equal(new SslApplicationProtocol("test"), clientConnection2.NegotiatedApplicationProtocol);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/86701")]
         [Theory]
         [InlineData("foo")]
         [InlineData("not_existing")]

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -509,8 +509,7 @@ namespace System.Net.Quic.Tests
             {
                 new SslApplicationProtocol(alpn),
             };
-            ValueTask<QuicConnection> connectTask = CreateQuicConnection(clientOptions);
-            await Assert.ThrowsAsync<AuthenticationException>(() => connectTask.AsTask().WaitAsync(timeoutToken));
+            await Assert.ThrowsAsync<AuthenticationException>(() => CreateQuicConnection(clientOptions).AsTask().WaitAsync(timeoutToken));
         }
     }
 }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -502,7 +502,7 @@ namespace System.Net.Quic.Tests
                     return ValueTask.FromResult(options);
                 }
             };
-            bool isAlpnPresentOnInitialAlpnList = listenerOptions.ApplicationProtocols.Exists(x => x.Protocol.Equals(new SslApplicationProtocol(alpn))); // If the ALPN is not present on initial list, AcceptConnectionAsync will not throw AuthenticationException.
+            bool isAlpnPresentOnInitialAlpnList = listenerOptions.ApplicationProtocols.Contains(new SslApplicationProtocol(alpn)); // If the ALPN is not present on initial list, AcceptConnectionAsync will not throw AuthenticationException.
             await using QuicListener listener = await CreateQuicListener(listenerOptions);
             QuicClientConnectionOptions clientOptions = CreateQuicClientOptions(listener.LocalEndPoint);
             clientOptions.ClientAuthenticationOptions.ApplicationProtocols = new()

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -475,7 +475,7 @@ namespace System.Net.Quic.Tests
 
         [Theory]
         [InlineData("foo")]
-        // [InlineData("not_existing")]
+        [InlineData("not_existing")]
         public async Task Listener_AlpnNarrowingDown_Failure(string alpn)
         {
             using CancellationTokenSource testTimeoutCts = new CancellationTokenSource(PassingTestTimeout);
@@ -510,7 +510,6 @@ namespace System.Net.Quic.Tests
                 new SslApplicationProtocol(alpn),
             };
             ValueTask<QuicConnection> connectTask = CreateQuicConnection(clientOptions);
-            await Assert.ThrowsAsync<AuthenticationException>(() => listener.AcceptConnectionAsync().AsTask().WaitAsync(timeoutToken));
             await Assert.ThrowsAsync<AuthenticationException>(() => connectTask.AsTask().WaitAsync(timeoutToken));
         }
     }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -475,7 +475,7 @@ namespace System.Net.Quic.Tests
 
         [Theory]
         [InlineData("foo")]
-        [InlineData("not_existing")]
+        // [InlineData("not_existing")]
         public async Task Listener_AlpnNarrowingDown_Failure(string alpn)
         {
             using CancellationTokenSource testTimeoutCts = new CancellationTokenSource(PassingTestTimeout);


### PR DESCRIPTION
Fixes #86701

Looks like `QuicListener.AcceptConnectionAsync` doesn't throw `AuthenticationException` when the client's alpn is not present on the initial alpn list.