### PR TITLE
Remove crossgen2 from source build intermediate package

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -62,11 +62,6 @@
 
       <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\*Microsoft.DotNet.ILCompiler.*.nupkg" Category="ILCompiler" />
 
-      <IntermediateNupkgArtifactFile
-        Include="
-          $(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\dotnet-crossgen2-*.tar.gz;
-          $(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\Microsoft.NETCore.App.Crossgen2.*.nupkg"
-        Category="Crossgen2Pack" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Symbol size is causing the package to blow feed size limit restrictions