### PR TITLE
Fix diagnostic creation to ensure including the URI

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/DiagnosticDescriptors.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/DiagnosticDescriptors.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Extensions.Logging.Generators
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static DiagnosticDescriptor LoggingUnsupportedLanguageVersion { get; } = new DiagnosticDescriptor(
+        public static DiagnosticDescriptor LoggingUnsupportedLanguageVersion { get; } = DiagnosticDescriptorHelper.Create(
             id: "SYSLIB1026",
             title: new LocalizableResourceString(nameof(SR.LoggingUnsupportedLanguageVersionTitle), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.LoggingUnsupportedLanguageVersionMessageFormat), SR.ResourceManager, typeof(FxResources.Microsoft.Extensions.Logging.Generators.SR)),

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/GeneratorDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/GeneratorDiagnostics.cs
@@ -477,7 +477,7 @@ namespace Microsoft.Interop
 
         /// <inheritdoc cref="SR.HResultTypeWillBeTreatedAsStructMessage"/>
         public static readonly DiagnosticDescriptor HResultTypeWillBeTreatedAsStruct =
-            new DiagnosticDescriptor(
+            DiagnosticDescriptorHelper.Create(
                 Ids.NotRecommendedGeneratedComInterfaceUsage,
                 GetResourceString(nameof(SR.HResultTypeWillBeTreatedAsStructTitle)),
                 GetResourceString(nameof(SR.HResultTypeWillBeTreatedAsStructMessage)),


### PR DESCRIPTION
The creation of `LoggingUnsupportedLanguageVersion` in logging source gen was missing the URI link. The fix is to use the Create helper method to ensure adding the URI to the diagnostics. 