### PR TITLE
Split crossgen2 into two source build intermediates

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -63,10 +63,12 @@
       <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\*Microsoft.DotNet.ILCompiler.*.nupkg" Category="ILCompiler" />
 
       <IntermediateNupkgArtifactFile
-        Include="
-          $(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\dotnet-crossgen2-*.tar.gz;
-          $(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\Microsoft.NETCore.App.Crossgen2.*.nupkg"
+        Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\Microsoft.NETCore.App.Crossgen2.*.nupkg"
         Category="Crossgen2Pack" />
+        
+        <IntermediateNupkgArtifactFile
+        Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\dotnet-crossgen2-*.tar.gz;"
+        Category="Crossgen2Archive" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This _may_ cause downstream repo source-build breaks, though I think it's unlikely. There is no downstream evidence in aspnetcore at least of usage of the crossgen2 source build intermediate.