### PR TITLE
Make handling of DefaultCredentials in NegotiateAuthentication/SocketsHttpHandler more consistent

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -217,6 +217,12 @@ namespace System.Net.Http
                             needDrain = true;
                         }
                     }
+                    catch (PlatformNotSupportedException)
+                    {
+                        // Ignore PNSE from NegotiateAuthentication with unsupported parameters
+                        // and treat it the same way as if we didn't support the authentication
+                        // in the first place.
+                    }
                     finally
                     {
                         if (isNewConnection)

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.FakeServer.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.FakeServer.cs
@@ -139,5 +139,33 @@ namespace System.Net.Http.Functional.Tests
                     }).ConfigureAwait(false);
                 });
         }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.Windows, "DefaultCredentials are unsupported for NTLM on Unix / Managed implementation")]
+        public async Task DefaultHandler_FakeServer_DefaultCredentials()
+        {
+            await LoopbackServer.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
+                    requestMessage.Version = new Version(1, 1);
+
+                    HttpMessageHandler handler = new HttpClientHandler() { Credentials = CredentialCache.DefaultCredentials };
+                    using (var client = new HttpClient(handler))
+                    {
+                        HttpResponseMessage response = await client.SendAsync(requestMessage);
+                        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+                    }
+                },
+                async server =>
+                {
+                    await server.AcceptConnectionAsync(async connection =>
+                    {
+                        var authHeader = "WWW-Authenticate: NTLM\r\n";
+                        await connection.SendResponseAsync(HttpStatusCode.Unauthorized, authHeader).ConfigureAwait(false);
+                        connection.CompleteRequestProcessing();
+                    }).ConfigureAwait(false);
+                });
+        }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
@@ -222,13 +222,16 @@ namespace System.Net
             {
                 Debug.Assert(clientOptions.Package == NegotiationInfoClass.NTLM);
 
-                _credential = clientOptions.Credential;
-                if (string.IsNullOrWhiteSpace(_credential.UserName) || string.IsNullOrWhiteSpace(_credential.Password))
+                if (clientOptions.Credential == CredentialCache.DefaultNetworkCredentials ||
+                    string.IsNullOrWhiteSpace(clientOptions.Credential.UserName) ||
+                    string.IsNullOrWhiteSpace(clientOptions.Credential.Password))
                 {
                     // NTLM authentication is not possible with default credentials which are no-op
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, SR.net_ntlm_not_possible_default_cred);
                     throw new PlatformNotSupportedException(SR.net_ntlm_not_possible_default_cred);
                 }
 
+                _credential = clientOptions.Credential;
                 _spn = clientOptions.TargetName;
                 _channelBinding = clientOptions.Binding;
                 _protectionLevel = clientOptions.RequiredProtectionLevel;

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
@@ -42,13 +42,15 @@ namespace System.Net
             {
                 return new UnixNegotiateAuthenticationPal(clientOptions);
             }
-            catch (Win32Exception)
+            catch (Interop.NetSecurityNative.GssApiException gex)
             {
-                return new UnsupportedNegotiateAuthenticationPal(clientOptions);
-            }
-            catch (PlatformNotSupportedException)
-            {
-                return new UnsupportedNegotiateAuthenticationPal(clientOptions);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, gex);
+                NegotiateAuthenticationStatusCode statusCode = UnixNegotiateAuthenticationPal.GetErrorCode(gex);
+                if (statusCode <= NegotiateAuthenticationStatusCode.GenericFailure)
+                {
+                    statusCode = NegotiateAuthenticationStatusCode.Unsupported;
+                }
+                return new UnsupportedNegotiateAuthenticationPal(clientOptions, statusCode);
             }
             catch (EntryPointNotFoundException)
             {
@@ -63,13 +65,15 @@ namespace System.Net
             {
                 return new UnixNegotiateAuthenticationPal(serverOptions);
             }
-            catch (Win32Exception)
+            catch (Interop.NetSecurityNative.GssApiException gex)
             {
-                return new UnsupportedNegotiateAuthenticationPal(serverOptions);
-            }
-            catch (PlatformNotSupportedException)
-            {
-                return new UnsupportedNegotiateAuthenticationPal(serverOptions);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, gex);
+                NegotiateAuthenticationStatusCode statusCode = UnixNegotiateAuthenticationPal.GetErrorCode(gex);
+                if (statusCode <= NegotiateAuthenticationStatusCode.GenericFailure)
+                {
+                    statusCode = NegotiateAuthenticationStatusCode.Unsupported;
+                }
+                return new UnsupportedNegotiateAuthenticationPal(serverOptions, statusCode);
             }
             catch (EntryPointNotFoundException)
             {
@@ -184,22 +188,25 @@ namespace System.Net
 
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Peer SPN-> '{_spn}'");
 
-                if (clientOptions.Credential == CredentialCache.DefaultCredentials ||
+                if (clientOptions.Credential == CredentialCache.DefaultNetworkCredentials ||
                     string.IsNullOrWhiteSpace(clientOptions.Credential.UserName) ||
                     string.IsNullOrWhiteSpace(clientOptions.Credential.Password))
                 {
                     if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "using DefaultCredentials");
-                    _credentialsHandle = AcquireDefaultCredential();
 
                     if (_packageType == Interop.NetSecurityNative.PackageType.NTLM)
                     {
                         // NTLM authentication is not possible with default credentials which are no-op
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, SR.net_ntlm_not_possible_default_cred);
                         throw new PlatformNotSupportedException(SR.net_ntlm_not_possible_default_cred);
                     }
                     if (string.IsNullOrEmpty(_spn))
                     {
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, SR.net_nego_not_supported_empty_target_with_defaultcreds);
                         throw new PlatformNotSupportedException(SR.net_nego_not_supported_empty_target_with_defaultcreds);
                     }
+
+                    _credentialsHandle = SafeGssCredHandle.Create(string.Empty, string.Empty, _packageType);
                 }
                 else
                 {
@@ -229,7 +236,7 @@ namespace System.Net
 
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Peer SPN-> '{_spn}'");
 
-                if (serverOptions.Credential == CredentialCache.DefaultCredentials ||
+                if (serverOptions.Credential == CredentialCache.DefaultNetworkCredentials ||
                     string.IsNullOrWhiteSpace(serverOptions.Credential.UserName) ||
                     string.IsNullOrWhiteSpace(serverOptions.Credential.Password))
                 {
@@ -462,24 +469,7 @@ namespace System.Net
                 else
                 {
                     // Native shim currently supports only NTLM, Negotiate and Kerberos
-                    throw new PlatformNotSupportedException(SR.net_securitypackagesupport);
-                }
-            }
-
-            private SafeGssCredHandle AcquireDefaultCredential()
-            {
-                try
-                {
-                    return SafeGssCredHandle.Create(string.Empty, string.Empty, _packageType);
-                }
-                catch (Exception ex)
-                {
-                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, ex);
-
-                    // NOTE: We throw PlatformNotSupportedException which is caught in
-                    // NegotiateAuthenticationPal.Create and transformed into instantiation of
-                    // UnsupportedNegotiateAuthenticationPal.
-                    throw new PlatformNotSupportedException(ex.Message, ex);
+                    throw new Interop.NetSecurityNative.GssApiException(Interop.NetSecurityNative.Status.GSS_S_UNAVAILABLE, 0);
                 }
             }
 
@@ -511,14 +501,10 @@ namespace System.Net
 
                     return SafeGssCredHandle.Create(username, password, _packageType);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not Interop.NetSecurityNative.GssApiException)
                 {
                     if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, ex);
-
-                    // NOTE: We throw PlatformNotSupportedException which is caught in
-                    // NegotiateAuthenticationPal.Create and transformed into instantiation of
-                    // UnsupportedNegotiateAuthenticationPal.
-                    throw new PlatformNotSupportedException(ex.Message, ex);
+                    throw new Interop.NetSecurityNative.GssApiException(Interop.NetSecurityNative.Status.GSS_S_BAD_NAME, 0);
                 }
             }
 
@@ -753,7 +739,7 @@ namespace System.Net
             }
 
             // https://www.gnu.org/software/gss/reference/gss.pdf (page 25)
-            private static NegotiateAuthenticationStatusCode GetErrorCode(Interop.NetSecurityNative.GssApiException exception)
+            internal static NegotiateAuthenticationStatusCode GetErrorCode(Interop.NetSecurityNative.GssApiException exception)
             {
                 switch (exception.MajorStatus)
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unsupported.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unsupported.cs
@@ -15,6 +15,7 @@ namespace System.Net
         {
             private string _package;
             private string? _targetName;
+            private NegotiateAuthenticationStatusCode _statusCode;
 
             public override bool IsAuthenticated => false;
             public override bool IsSigned => false;
@@ -25,15 +26,17 @@ namespace System.Net
             public override IIdentity RemoteIdentity => throw new InvalidOperationException();
             public override System.Security.Principal.TokenImpersonationLevel ImpersonationLevel => System.Security.Principal.TokenImpersonationLevel.Impersonation;
 
-            public UnsupportedNegotiateAuthenticationPal(NegotiateAuthenticationClientOptions clientOptions)
+            public UnsupportedNegotiateAuthenticationPal(NegotiateAuthenticationClientOptions clientOptions, NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported)
             {
                 _package = clientOptions.Package;
                 _targetName = clientOptions.TargetName;
+                _statusCode = statusCode;
             }
 
-            public UnsupportedNegotiateAuthenticationPal(NegotiateAuthenticationServerOptions serverOptions)
+            public UnsupportedNegotiateAuthenticationPal(NegotiateAuthenticationServerOptions serverOptions, NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported)
             {
                 _package = serverOptions.Package;
+                _statusCode = statusCode;
             }
 
             public override void Dispose()
@@ -42,7 +45,7 @@ namespace System.Net
 
             public override byte[]? GetOutgoingBlob(ReadOnlySpan<byte> incomingBlob, out NegotiateAuthenticationStatusCode statusCode)
             {
-                statusCode = NegotiateAuthenticationStatusCode.Unsupported;
+                statusCode = _statusCode;
                 return null;
             }
 

--- a/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
@@ -95,6 +95,14 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Windows, "The test is specific to GSSAPI / Managed implementations of NegotiateAuthentication")]
+        public void DefaultNetworkCredentials_NTLM_Throws()
+        {
+            NegotiateAuthenticationClientOptions clientOptions = new NegotiateAuthenticationClientOptions { Package = "NTLM", Credential = CredentialCache.DefaultNetworkCredentials, TargetName = "HTTP/foo" };
+            Assert.Throws<PlatformNotSupportedException>(() => new NegotiateAuthentication(clientOptions));
+        }
+
+        [Fact]
         public void NtlmProtocolExampleTest()
         {
             // Mirrors the NTLMv2 example in the NTLM specification:


### PR DESCRIPTION
*See PR #91160 for alternative approach.*

### Throw PNSE on Unix/Managed NegotiateAuthenticationPal implementation for NTLM w/ default credentials
- This was handled inconsistently between the managed NTLM implementation and the GSSAPI one. Let's standardize on throwing `PlatformNotSupportedException` with a useful message that explains which parameters are unsupported.
- Adjust managed SPNEGO implementation to handle `PlatformNotSupportedException` correctly.
- Add test for the behavior.

### SocketsHttpHandler: Handle PNSE from NegotiateAuthentication as unsupported authentication and return server's response instead of passing the exception
- Treat PNSE from `NegotiateAuthentication` the same way as if the authentication scheme was unsupported, and return the Unauthorized response from server.
- Add test for the behavior.

Fixes #91131

