### PR TITLE
Fix implementation of NegotiateAuthentication.Wrap for Kerberos on Windows

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Windows.cs
@@ -421,28 +421,32 @@ namespace System.Net
                 Debug.Assert(success);
 
                 // alloc new output buffer if not supplied or too small
-                int resultSize = input.Length + sizes.cbMaxSignature;
+                int resultSize = input.Length + sizes.cbSecurityTrailer + sizes.cbBlockSize;
                 Span<byte> outputBuffer = outputWriter.GetSpan(resultSize);
 
                 // make a copy of user data for in-place encryption
-                input.CopyTo(outputBuffer.Slice(sizes.cbMaxSignature, input.Length));
+                input.CopyTo(outputBuffer.Slice(sizes.cbSecurityTrailer, input.Length));
 
                 isEncrypted = requestEncryption;
 
                 fixed (byte* outputPtr = outputBuffer)
                 {
                     // Prepare buffers TOKEN(signature), DATA and Padding.
-                    Interop.SspiCli.SecBuffer* unmanagedBuffer = stackalloc Interop.SspiCli.SecBuffer[2];
+                    Interop.SspiCli.SecBuffer* unmanagedBuffer = stackalloc Interop.SspiCli.SecBuffer[3];
                     Interop.SspiCli.SecBuffer* tokenBuffer = &unmanagedBuffer[0];
                     Interop.SspiCli.SecBuffer* dataBuffer = &unmanagedBuffer[1];
+                    Interop.SspiCli.SecBuffer* paddingBuffer = &unmanagedBuffer[2];
                     tokenBuffer->BufferType = SecurityBufferType.SECBUFFER_TOKEN;
                     tokenBuffer->pvBuffer = (IntPtr)(outputPtr);
-                    tokenBuffer->cbBuffer = sizes.cbMaxSignature;
+                    tokenBuffer->cbBuffer = sizes.cbSecurityTrailer;
                     dataBuffer->BufferType = SecurityBufferType.SECBUFFER_DATA;
-                    dataBuffer->pvBuffer = (IntPtr)(outputPtr + sizes.cbMaxSignature);
+                    dataBuffer->pvBuffer = (IntPtr)(outputPtr + sizes.cbSecurityTrailer);
                     dataBuffer->cbBuffer = input.Length;
+                    paddingBuffer->BufferType = SecurityBufferType.SECBUFFER_PADDING;
+                    paddingBuffer->pvBuffer = (IntPtr)(outputPtr + sizes.cbSecurityTrailer + input.Length);
+                    paddingBuffer->cbBuffer = sizes.cbBlockSize;
 
-                    Interop.SspiCli.SecBufferDesc sdcInOut = new Interop.SspiCli.SecBufferDesc(2)
+                    Interop.SspiCli.SecBufferDesc sdcInOut = new Interop.SspiCli.SecBufferDesc(3)
                     {
                         pBuffers = unmanagedBuffer
                     };
@@ -460,7 +464,20 @@ namespace System.Net
                         };
                     }
 
-                    outputWriter.Advance(tokenBuffer->cbBuffer + dataBuffer->cbBuffer);
+                    // Compact the result
+                    if (tokenBuffer->cbBuffer != sizes.cbSecurityTrailer)
+                    {
+                        outputBuffer.Slice(sizes.cbSecurityTrailer, dataBuffer->cbBuffer).CopyTo(
+                            outputBuffer.Slice(tokenBuffer->cbBuffer, dataBuffer->cbBuffer));
+                    }
+                    if (tokenBuffer->cbBuffer != sizes.cbSecurityTrailer ||
+                        paddingBuffer->cbBuffer != sizes.cbBlockSize)
+                    {
+                        outputBuffer.Slice(sizes.cbSecurityTrailer + input.Length, paddingBuffer->cbBuffer).CopyTo(
+                            outputBuffer.Slice(tokenBuffer->cbBuffer + dataBuffer->cbBuffer, paddingBuffer->cbBuffer));
+                    }
+
+                    outputWriter.Advance(tokenBuffer->cbBuffer + dataBuffer->cbBuffer + paddingBuffer->cbBuffer);
                     return NegotiateAuthenticationStatusCode.Completed;
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/PowerShell/PowerShell/issues/20168

The bug existed in .NET 7 but it was not uncovered until #86948 exposed it through `NegotiateStream` APIs.

Unfortunately, we lack testing infrastructure for testing Kerberos on Windows. [NegotiateStreamKerberosTest](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs) **outer loop** test is supposed to cover it but I am not sure if it's even executed in any reasonable fashion. Thanks to @jborean93 for manually testing it on the affected use case in PowerShell.