### PR TITLE
Use AVX512 to zero locals

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -10894,9 +10894,12 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
         assert((blkSize + alignmentHiBlkSize) == (untrLclHi - untrLclLo));
 #endif // !defined(TARGET_AMD64)
 
+        const int maxSimdSize = (int)compiler->roundDownSIMDSize(blkSize);
+        assert((maxSimdSize >= XMM_REGSIZE_BYTES) && (maxSimdSize <= ZMM_REGSIZE_BYTES));
+
         // The loop is unrolled 3 times so we do not move to the loop block until it
         // will loop at least once so the threshold is 6.
-        if (blkSize < (6 * XMM_REGSIZE_BYTES))
+        if (blkSize < (6 * maxSimdSize))
         {
             // Generate the following code:
             //
@@ -10905,10 +10908,21 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
             //   ...
             //   movups  xmmword ptr [ebp/esp-OFFS], xmm4
             //   mov      qword ptr [ebp/esp-OFFS], rax
-
+            //
+            // NOTE: it implicitly zeroes YMM4 and ZMM4 as well.
             emit->emitIns_SIMD_R_R_R(INS_xorps, EA_16BYTE, zeroSIMDReg, zeroSIMDReg, zeroSIMDReg);
 
             int i = 0;
+            if (maxSimdSize > XMM_REGSIZE_BYTES)
+            {
+                for (; i < blkSize - maxSimdSize; i += maxSimdSize)
+                {
+                    // We previously aligned data to 16 bytes which might not be aligned to maxSimdSize
+                    emit->emitIns_AR_R(simdUnalignedMovIns(), EA_ATTR(maxSimdSize), zeroSIMDReg, frameReg,
+                                       alignedLclLo + i);
+                }
+            }
+
             for (; i < blkSize; i += XMM_REGSIZE_BYTES)
             {
                 emit->emitIns_AR_R(simdMov, EA_ATTR(XMM_REGSIZE_BYTES), zeroSIMDReg, frameReg, alignedLclLo + i);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -10915,12 +10915,13 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
             int i = 0;
             if (maxSimdSize > XMM_REGSIZE_BYTES)
             {
-                for (; i < blkSize - maxSimdSize; i += maxSimdSize)
+                for (; i <= blkSize - maxSimdSize; i += maxSimdSize)
                 {
                     // We previously aligned data to 16 bytes which might not be aligned to maxSimdSize
                     emit->emitIns_AR_R(simdUnalignedMovIns(), EA_ATTR(maxSimdSize), zeroSIMDReg, frameReg,
                                        alignedLclLo + i);
                 }
+                // Remainder will be handled by the xmm loop below
             }
 
             for (; i < blkSize; i += XMM_REGSIZE_BYTES)


### PR DESCRIPTION
Extends https://github.com/dotnet/runtime/pull/32538 to use AVX-512 (and AVX1) to zero locals for non-loop path. I am going to slightly refactor it to use AVX in the loop path too but later, this seems to be a low-hanging fruit with [nice diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=387354&view=ms.vss-build-web.run-extensions-tab).

Diff example:

```diff
@@ -17,17 +17,13 @@ G_M59697_IG01:        ; bbWeight=1, gcrefRegs=0000 {}, byrefRegs=0000 {}, byref,
        push     rbx
        sub      rsp, 160
        vxorps   xmm4, xmm4, xmm4
-       vmovdqa  xmmword ptr [rsp+0x20], xmm4
-       vmovdqa  xmmword ptr [rsp+0x30], xmm4
-       mov      rax, -96
-       vmovdqa  xmmword ptr [rsp+rax+0xA0], xmm4
-       vmovdqa  xmmword ptr [rsp+rax+0xB0], xmm4
-       vmovdqa  xmmword ptr [rsp+rax+0xC0], xmm4
-       add      rax, 48
-       jne      SHORT  -5 instr
+       vmovdqu  ymmword ptr [rsp+0x20], ymm4
+       vmovdqu  ymmword ptr [rsp+0x40], ymm4
+       vmovdqu  ymmword ptr [rsp+0x60], ymm4
+       vmovdqu  ymmword ptr [rsp+0x80], ymm4
        mov      rbx, rcx
        ; gcrRegs +[rbx]
-						;; size=70 bbWeight=1 PerfScore 13.33
+						;; size=42 bbWeight=1 PerfScore 9.83
 G_M59697_IG02:        ; bbWeight=1, gcrefRegs=0008 {rbx}, byrefRegs=0000 {}, byref
        lea      rcx, [rsp+0x20]
        call     [<unknown method>]
@@ -46,7 +42,7 @@ G_M59697_IG03:        ; bbWeight=1, epilog, nogc, extend
        ret      
 						;; size=9 bbWeight=1 PerfScore 1.75
```
(apparently this collection has no avx-512, but still looks better)