### PR TITLE
Improve usage of hashing for trimmer friendliness

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Windows.cs
@@ -86,25 +86,20 @@ namespace System.Security.Cryptography
                 switch (hashAlgorithmName)
                 {
                     case HashAlgorithmNames.SHA1:
-                        hashBufferSize = SHA1.HashData(password, hashBuffer);
-                        break;
                     case HashAlgorithmNames.SHA256:
-                        hashBufferSize = SHA256.HashData(password, hashBuffer);
-                        break;
                     case HashAlgorithmNames.SHA384:
-                        hashBufferSize = SHA384.HashData(password, hashBuffer);
-                        break;
                     case HashAlgorithmNames.SHA512:
-                        hashBufferSize = SHA512.HashData(password, hashBuffer);
+                        hashBufferSize = HashProviderDispenser.OneShotHashProvider.HashData(hashAlgorithmName, password, hashBuffer);
                         break;
                     case HashAlgorithmNames.SHA3_256:
-                        hashBufferSize = SHA3_256.HashData(password, hashBuffer);
-                        break;
                     case HashAlgorithmNames.SHA3_384:
-                        hashBufferSize = SHA3_384.HashData(password, hashBuffer);
-                        break;
                     case HashAlgorithmNames.SHA3_512:
-                        hashBufferSize = SHA3_512.HashData(password, hashBuffer);
+                        if (!HashProviderDispenser.HashSupported(hashAlgorithmName))
+                        {
+                            throw new PlatformNotSupportedException();
+                        }
+
+                        hashBufferSize = HashProviderDispenser.OneShotHashProvider.HashData(hashAlgorithmName, password, hashBuffer);
                         break;
                     default:
                         Debug.Fail($"Unexpected hash algorithm '{hashAlgorithmName}'");


### PR DESCRIPTION
Currently, when we want one-shot hashes, we offer, in our public API, `HashType.HashData`. Often enough we expose other APIs that operate off of `HashAlgorithmName` which is a strongly-typed string. When we wanted to one-shot with `HashAlgorithmName` were switching over the name, and calling the appropriate static method.

This however is not trimmer friendly. Those APIs that accept a HashAlgorithmName were pulling in all of the hash types, even if `HashAlgorithmName.SHA256` (for example) is the only one used.

Our actual one-shot implementations want string of the hash algorithm name. So we were doing something like this:

```mermaid
graph LR
    HAN[HashAlgorithmName]
    subgraph Switch
        HAN --> MD5
        HAN --> SHA1
        HAN --> SHA256
        HAN --> SHA384
        HAN --> SHA512
        HAN --> SHA3_256
        HAN --> SHA3_384
        HAN --> SHA3_512
    end

    MD5 --> HashProviderDispenser
    SHA1 --> HashProviderDispenser
    SHA256 --> HashProviderDispenser
    SHA384 --> HashProviderDispenser
    SHA512 --> HashProviderDispenser
    SHA3_256 --> HashProviderDispenser
    SHA3_384 --> HashProviderDispenser
    SHA3_512 --> HashProviderDispenser
```

Now we are doing

```mermaid
graph LR
    HashAlgorithmName --> HashProviderDispenser
```

We still need to do some switching to determine hash algorithm sizes, however we are not rooting any types. The only thing we are using are public constants off of the types, which the compiler will inline.

This also, as a small matter of performance, reduces some indirection as well.

Fixes #91181.