### PR TITLE
[mono] Change debugger listening port in samples to an unused one

### DIFF
--- a/src/tasks/AndroidAppBuilder/Templates/monodroid.c
+++ b/src/tasks/AndroidAppBuilder/Templates/monodroid.c
@@ -285,7 +285,7 @@ mono_droid_runtime_init (const char* executable, int managed_argc, char* managed
     mono_set_crash_chaining (true);
 
     if (wait_for_debugger) {
-        char* options[] = { "--debugger-agent=transport=dt_socket,server=y,address=0.0.0.0:55555" };
+        char* options[] = { "--debugger-agent=transport=dt_socket,server=y,address=0.0.0.0:55556" };
         mono_jit_parse_options (1, options);
     }
 

--- a/src/tasks/AppleAppBuilder/Templates/runtime.m
+++ b/src/tasks/AppleAppBuilder/Templates/runtime.m
@@ -375,7 +375,7 @@ mono_ios_runtime_init (void)
     mono_set_crash_chaining (TRUE);
 
     if (wait_for_debugger) {
-        char* options[] = { "--debugger-agent=transport=dt_socket,server=y,address=0.0.0.0:55555" };
+        char* options[] = { "--debugger-agent=transport=dt_socket,server=y,address=0.0.0.0:55556" };
         mono_jit_parse_options (1, options);
     }
 


### PR DESCRIPTION
The port 55555 is used by the OS on recent macOS/iOS releases, change to an unused one: 55556. Also change it on Android so we use the same one.