### PR TITLE
[mono] Fix summary label not being visible on Catalyst library tests

### DIFF
--- a/src/tasks/AppleAppBuilder/Templates/main-console.m
+++ b/src/tasks/AppleAppBuilder/Templates/main-console.m
@@ -36,10 +36,15 @@ UITextView* logLabel;
 - (void)viewDidLoad {
     [super viewDidLoad];
 
+#if TARGET_OS_MACCATALYST
+    CGFloat summaryLabelHeight = 150.0;
+#else
+    CGFloat summaryLabelHeight = 50.0;
+#endif
     CGRect applicationFrame = [[UIScreen mainScreen] bounds];
     logLabel = [[UITextView alloc] initWithFrame:
-        CGRectMake(2.0, 50.0, applicationFrame.size.width - 2.0, applicationFrame.size.height - 50.0)];
-    logLabel.font = [UIFont systemFontOfSize:9.0];
+        CGRectMake(10.0, summaryLabelHeight, applicationFrame.size.width - 10.0, applicationFrame.size.height - summaryLabelHeight)];
+    logLabel.font = [UIFont systemFontOfSize: 9.0];
     logLabel.backgroundColor = [UIColor blackColor];
     logLabel.textColor = [UIColor greenColor];
     logLabel.scrollEnabled = YES;
@@ -49,9 +54,10 @@ UITextView* logLabel;
 #endif
     logLabel.clipsToBounds = YES;
 
-    summaryLabel = [[UILabel alloc] initWithFrame: CGRectMake(10.0, 0.0, applicationFrame.size.width - 10.0, 50)];
+    summaryLabel = [[UILabel alloc] initWithFrame: CGRectMake(10.0, 0, applicationFrame.size.width - 10.0, summaryLabelHeight)];
+    summaryLabel.font = [UIFont boldSystemFontOfSize: 12.0];
+    summaryLabel.backgroundColor = [UIColor blackColor];
     summaryLabel.textColor = [UIColor whiteColor];
-    summaryLabel.font = [UIFont boldSystemFontOfSize: 12];
     summaryLabel.numberOfLines = 2;
     summaryLabel.textAlignment = NSTextAlignmentLeft;
 #if !TARGET_OS_SIMULATOR || FORCE_AOT

--- a/src/tests/FunctionalTests/iOS/Device/ExportManagedSymbols/Program.cs
+++ b/src/tests/FunctionalTests/iOS/Device/ExportManagedSymbols/Program.cs
@@ -8,15 +8,11 @@ using System.Runtime.InteropServices;
 
 public static class Program
 {
-    [DllImport("__Internal")]
-    public static extern void mono_ios_set_summary (string value);
-
     [UnmanagedCallersOnly(EntryPoint="exposed_managed_method")]
     public static int ManagedMethod() => 42;
 
     public static async Task<int> Main(string[] args)
     {
-        mono_ios_set_summary($"Starting functional test");
         Console.WriteLine("Done!");
         await Task.Delay(5000);
 

--- a/src/tests/FunctionalTests/iOS/Device/ExportManagedSymbols/main.m
+++ b/src/tests/FunctionalTests/iOS/Device/ExportManagedSymbols/main.m
@@ -24,39 +24,10 @@
 }
 @end
 
-UILabel *summaryLabel;
-UITextView* logLabel;
-
 @implementation ViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-
-    CGRect applicationFrame = [[UIScreen mainScreen] bounds];
-    logLabel = [[UITextView alloc] initWithFrame:
-        CGRectMake(2.0, 50.0, applicationFrame.size.width - 2.0, applicationFrame.size.height - 50.0)];
-    logLabel.font = [UIFont systemFontOfSize:9.0];
-    logLabel.backgroundColor = [UIColor blackColor];
-    logLabel.textColor = [UIColor greenColor];
-    logLabel.scrollEnabled = YES;
-    logLabel.alwaysBounceVertical = YES;
-#ifndef TARGET_OS_TV
-    logLabel.editable = NO;
-#endif
-    logLabel.clipsToBounds = YES;
-
-    summaryLabel = [[UILabel alloc] initWithFrame: CGRectMake(10.0, 0.0, applicationFrame.size.width - 10.0, 50)];
-    summaryLabel.textColor = [UIColor whiteColor];
-    summaryLabel.font = [UIFont boldSystemFontOfSize: 12];
-    summaryLabel.numberOfLines = 2;
-    summaryLabel.textAlignment = NSTextAlignmentLeft;
-#if !TARGET_OS_SIMULATOR || FORCE_AOT
-    summaryLabel.text = @"Loading...";
-#else
-    summaryLabel.text = @"Jitting...";
-#endif
-    [self.view addSubview:logLabel];
-    [self.view addSubview:summaryLabel];
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         void *del = dlsym (RTLD_DEFAULT, "exposed_managed_method");
@@ -66,38 +37,6 @@ UITextView* logLabel;
 }
 
 @end
-
-// called from C#
-void
-invoke_external_native_api (void (*callback)(void))
-{
-    if (callback)
-        callback();
-}
-
-// can be called from C# to update UI
-void
-mono_ios_set_summary (const char* value)
-{
-    NSString* nsstr = [NSString stringWithUTF8String:value];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        summaryLabel.text = nsstr;
-    });
-}
-
-// can be called from C# to update UI
-void
-mono_ios_append_output (const char* value)
-{
-    NSString* nsstr = [NSString stringWithUTF8String:value];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        logLabel.text = [logLabel.text stringByAppendingString:nsstr];
-        CGRect caretRect = [logLabel caretRectForPosition:logLabel.endOfDocument];
-        [logLabel scrollRectToVisible:caretRect animated:NO];
-        [logLabel setScrollEnabled:NO];
-        [logLabel setScrollEnabled:YES];
-    });
-}
 
 int main(int argc, char * argv[]) {
     @autoreleasepool {


### PR DESCRIPTION
The label was too small and didn't have the correct background color so it wasn't visible.
Remove UI code from a functional test, it doesn't need it.

Before:

![image](https://github.com/dotnet/runtime/assets/1376924/38da6ee5-ff4f-447e-b254-349cf2ce4e67)

After:

![image](https://github.com/dotnet/runtime/assets/1376924/ed6951ab-cdf7-4e1e-a9d7-3763c645aa63)
