### PR TITLE
[release/8.0] [browser] download sequence optimization

### DIFF
--- a/src/mono/sample/wasm/browser-advanced/index.html
+++ b/src/mono/sample/wasm/browser-advanced/index.html
@@ -13,10 +13,7 @@
   <link rel="preload" href="./blazor.boot.json" as="fetch" crossorigin="use-credentials">
   <link rel="prefetch" href="./dotnet.native.js" as="fetch" crossorigin="anonymous">
   <link rel="prefetch" href="./dotnet.runtime.js" as="fetch" crossorigin="anonymous">
-  <link rel="prefetch" href="./dotnet.native.wasm" as="fetch" crossorigin="anonymous">
-  <!-- users should consider if they optimize for the first load or subsequent load from memory snapshot -->
-  <link rel="prefetch" href="./icudt.dat" as="fetch" crossorigin="anonymous">
-  <link rel="prefetch" href="./System.Private.CoreLib.wasm" as="fetch" crossorigin="anonymous">
+  <link rel="prefetch" href="./advanced-sample.lib.module.js" as="fetch" crossorigin="anonymous">
 </head>
 
 <body>

--- a/src/mono/sample/wasm/browser-advanced/main.js
+++ b/src/mono/sample/wasm/browser-advanced/main.js
@@ -31,6 +31,7 @@ try {
         // here we show how emscripten could be further configured
         // It is preferred to use specific 'with***' methods instead in all other cases.
         .withConfig({
+            startupMemoryCache: true,
             resources: {
                 modulesAfterConfigLoaded: {
                     "advanced-sample.lib.module.js": ""

--- a/src/mono/sample/wasm/browser-bench/appstart-frame.html
+++ b/src/mono/sample/wasm/browser-bench/appstart-frame.html
@@ -12,9 +12,6 @@
   <link rel="preload" href="./_framework/blazor.boot.json" as="fetch" crossorigin="use-credentials">
   <link rel="prefetch" href="./_framework/dotnet.native.js" as="fetch" crossorigin="anonymous">
   <link rel="prefetch" href="./_framework/dotnet.runtime.js" as="fetch" crossorigin="anonymous">
-  <link rel="prefetch" href="./_framework/dotnet.native.wasm" as="fetch" crossorigin="anonymous">
-  <!-- users should consider if they optimize for the first load or subsequent load from memory snapshot -->
-  <link rel="prefetch" href="./_framework/System.Private.CoreLib.dll" as="fetch" crossorigin="anonymous">
 </head>
 
 <body>

--- a/src/mono/sample/wasm/browser-bench/frame-main.js
+++ b/src/mono/sample/wasm/browser-bench/frame-main.js
@@ -31,6 +31,10 @@ try {
     }
 
     const runtime = await dotnet
+        .withConfig({
+            maxParallelDownloads: 10000,
+            // diagnosticTracing:true,
+        })
         .withModuleConfig({
             printErr: () => undefined,
             print: () => undefined,
@@ -38,7 +42,6 @@ try {
                 if (window.parent != window) {
                     window.parent.resolveAppStartEvent("onConfigLoaded");
                 }
-                // config.diagnosticTracing = true;
             }
         })
         .create();

--- a/src/mono/wasm/features.md
+++ b/src/mono/wasm/features.md
@@ -193,12 +193,13 @@ See also [fetch integrity on MDN](https://developer.mozilla.org/en-US/docs/Web/A
 
 ### Pre-fetching
 In order to start downloading application resources as soon as possible you can add HTML elements to `<head>` of your page similar to:
+Adding too many files into prefetch could be counterproductive.
+Please benchmark your startup performance on real target devices and with realistic network conditions.
 
 ```html
 <link rel="preload" href="./_framework/blazor.boot.json" as="fetch" crossorigin="use-credentials">
 <link rel="prefetch" href="./_framework/dotnet.native.js" as="fetch" crossorigin="anonymous">
 <link rel="prefetch" href="./_framework/dotnet.runtime.js" as="fetch" crossorigin="anonymous">
-<link rel="prefetch" href="./_framework/dotnet.native.wasm" as="fetch" crossorigin="anonymous">
 ```
 
 See also [link rel prefetch on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/prefetch)

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -8,7 +8,7 @@ import type { RuntimeAPI } from "./types";
 
 import { Module, linkerDisableLegacyJsInterop, exportedRuntimeAPI, passEmscriptenInternals, runtimeHelpers, setRuntimeGlobals, } from "./globals";
 import { GlobalObjects, is_nullish } from "./types/internal";
-import { configureEmscriptenStartup, configureWorkerStartup } from "./startup";
+import { configureEmscriptenStartup, configureRuntimeStartup, configureWorkerStartup } from "./startup";
 
 import { create_weak_ref } from "./weak-ref";
 import { export_internal } from "./exports-internal";
@@ -143,5 +143,5 @@ class RuntimeList {
 
 // export external API
 export {
-    passEmscriptenInternals, initializeExports, initializeReplacements, configureEmscriptenStartup, configureWorkerStartup, setRuntimeGlobals
+    passEmscriptenInternals, initializeExports, initializeReplacements, configureRuntimeStartup, configureEmscriptenStartup, configureWorkerStartup, setRuntimeGlobals
 };

--- a/src/mono/wasm/runtime/globals.ts
+++ b/src/mono/wasm/runtime/globals.ts
@@ -59,7 +59,6 @@ export function setRuntimeGlobals(globalObjects: GlobalObjects) {
         gitHash,
         allAssetsInMemory: createPromiseController<void>(),
         dotnetReady: createPromiseController<any>(),
-        memorySnapshotSkippedOrDone: createPromiseController<void>(),
         afterInstantiateWasm: createPromiseController<void>(),
         beforePreInit: createPromiseController<void>(),
         afterPreInit: createPromiseController<void>(),

--- a/src/mono/wasm/runtime/loader/exit.ts
+++ b/src/mono/wasm/runtime/loader/exit.ts
@@ -122,9 +122,9 @@ function abort_promises(reason: any) {
     loaderHelpers.afterConfigLoaded.promise_control.reject(reason);
     loaderHelpers.wasmDownloadPromise.promise_control.reject(reason);
     loaderHelpers.runtimeModuleLoaded.promise_control.reject(reason);
+    loaderHelpers.memorySnapshotSkippedOrDone.promise_control.reject(reason);
     if (runtimeHelpers.dotnetReady) {
         runtimeHelpers.dotnetReady.promise_control.reject(reason);
-        runtimeHelpers.memorySnapshotSkippedOrDone.promise_control.reject(reason);
         runtimeHelpers.afterInstantiateWasm.promise_control.reject(reason);
         runtimeHelpers.beforePreInit.promise_control.reject(reason);
         runtimeHelpers.afterPreInit.promise_control.reject(reason);

--- a/src/mono/wasm/runtime/loader/globals.ts
+++ b/src/mono/wasm/runtime/loader/globals.ts
@@ -87,6 +87,7 @@ export function setLoaderGlobals(
         allDownloadsQueued: createPromiseController<void>(),
         wasmDownloadPromise: createPromiseController<AssetEntryInternal>(),
         runtimeModuleLoaded: createPromiseController<void>(),
+        memorySnapshotSkippedOrDone: createPromiseController<void>(),
 
         is_exited,
         is_runtime_running,

--- a/src/mono/wasm/runtime/loader/run.ts
+++ b/src/mono/wasm/runtime/loader/run.ts
@@ -454,10 +454,11 @@ function importModules() {
 }
 
 async function initializeModules(es6Modules: [RuntimeModuleExportsInternal, NativeModuleExportsInternal]) {
-    const { initializeExports, initializeReplacements, configureEmscriptenStartup, configureWorkerStartup, setRuntimeGlobals, passEmscriptenInternals } = es6Modules[0];
+    const { initializeExports, initializeReplacements, configureRuntimeStartup, configureEmscriptenStartup, configureWorkerStartup, setRuntimeGlobals, passEmscriptenInternals } = es6Modules[0];
     const { default: emscriptenFactory } = es6Modules[1];
     setRuntimeGlobals(globalObjectsRoot);
     initializeExports(globalObjectsRoot);
+    await configureRuntimeStartup();
     loaderHelpers.runtimeModuleLoaded.promise_control.resolve();
 
     emscriptenFactory((originalModule: EmscriptenModuleInternal) => {
@@ -494,9 +495,8 @@ async function createEmscriptenMain(): Promise<RuntimeAPI> {
         mono_exit(1, err);
     });
 
-    init_globalization();
-
     setTimeout(() => {
+        init_globalization();
         mono_download_assets(); // intentionally not awaited
     }, 0);
 

--- a/src/mono/wasm/runtime/snapshot.ts
+++ b/src/mono/wasm/runtime/snapshot.ts
@@ -44,22 +44,35 @@ async function openCache(): Promise<Cache | null> {
     }
 }
 
-export async function getMemorySnapshotSize(): Promise<number | undefined> {
+export async function checkMemorySnapshotSize(): Promise<void> {
     try {
+        if (!runtimeHelpers.config.startupMemoryCache) {
+            // we could start downloading DLLs because snapshot is disabled
+            return;
+        }
+
         const cacheKey = await getCacheKey();
         if (!cacheKey) {
-            return undefined;
+            return;
         }
         const cache = await openCache();
         if (!cache) {
-            return undefined;
+            return;
         }
         const res = await cache.match(cacheKey);
         const contentLength = res?.headers.get("content-length");
-        return contentLength ? parseInt(contentLength) : undefined;
+        const memorySize = contentLength ? parseInt(contentLength) : undefined;
+
+        runtimeHelpers.loadedMemorySnapshotSize = memorySize;
+        runtimeHelpers.storeMemorySnapshotPending = !memorySize;
     } catch (ex) {
         mono_log_warn("Failed find memory snapshot in the cache", ex);
-        return undefined;
+    }
+    finally {
+        if (!runtimeHelpers.loadedMemorySnapshotSize) {
+            // we could start downloading DLLs because there is no snapshot yet
+            loaderHelpers.memorySnapshotSkippedOrDone.promise_control.resolve();
+        }
     }
 }
 

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -21,7 +21,7 @@ import { instantiate_wasm_asset, wait_for_all_assets } from "./assets";
 import { mono_wasm_init_diagnostics } from "./diagnostics";
 import { replace_linker_placeholders } from "./exports-binding";
 import { endMeasure, MeasuredBlock, startMeasure } from "./profiler";
-import { getMemorySnapshot, storeMemorySnapshot, getMemorySnapshotSize } from "./snapshot";
+import { checkMemorySnapshotSize, getMemorySnapshot, storeMemorySnapshot } from "./snapshot";
 import { mono_log_debug, mono_log_error, mono_log_warn, mono_set_thread_id } from "./logging";
 
 // threads
@@ -38,6 +38,19 @@ import { assertNoProxies } from "./gc-handles";
 
 // default size if MonoConfig.pthreadPoolSize is undefined
 const MONO_PTHREAD_POOL_SIZE = 4;
+
+export async function configureRuntimeStartup(): Promise<void> {
+    if (linkerWasmEnableSIMD) {
+        mono_assert(await loaderHelpers.simd(), "This browser/engine doesn't support WASM SIMD. Please use a modern version. See also https://aka.ms/dotnet-wasm-features");
+    }
+    if (linkerWasmEnableEH) {
+        mono_assert(await loaderHelpers.exceptions(), "This browser/engine doesn't support WASM exception handling. Please use a modern version. See also https://aka.ms/dotnet-wasm-features");
+    }
+
+    await init_polyfills_async();
+
+    await checkMemorySnapshotSize();
+}
 
 // we are making emscripten startup async friendly
 // emscripten is executing the events without awaiting it and so we need to block progress via PromiseControllers above
@@ -117,8 +130,6 @@ function instantiateWasm(
 
     const mark = startMeasure();
     if (userInstantiateWasm) {
-        // user wasm instantiation doesn't support memory snapshots
-        runtimeHelpers.memorySnapshotSkippedOrDone.promise_control.resolve();
         const exports = userInstantiateWasm(imports, (instance: WebAssembly.Instance, module: WebAssembly.Module | undefined) => {
             endMeasure(mark, MeasuredBlock.instantiateWasm);
             runtimeHelpers.afterInstantiateWasm.promise_control.resolve();
@@ -375,14 +386,6 @@ async function mono_wasm_pre_init_essential_async(): Promise<void> {
     mono_log_debug("mono_wasm_pre_init_essential_async");
     Module.addRunDependency("mono_wasm_pre_init_essential_async");
 
-    if (linkerWasmEnableSIMD) {
-        mono_assert(await loaderHelpers.simd(), "This browser/engine doesn't support WASM SIMD. Please use a modern version. See also https://aka.ms/dotnet-wasm-features");
-    }
-    if (linkerWasmEnableEH) {
-        mono_assert(await loaderHelpers.exceptions(), "This browser/engine doesn't support WASM exception handling. Please use a modern version. See also https://aka.ms/dotnet-wasm-features");
-    }
-
-    await init_polyfills_async();
 
     if (MonoWasmThreads) {
         preAllocatePThreadWorkerPool(MONO_PTHREAD_POOL_SIZE, runtimeHelpers.config);
@@ -457,19 +460,8 @@ async function instantiate_wasm_module(
 ): Promise<void> {
     // this is called so early that even Module exports like addRunDependency don't exist yet
     try {
-        let memorySize: number | undefined = undefined;
         await loaderHelpers.afterConfigLoaded;
         mono_log_debug("instantiate_wasm_module");
-
-        if (runtimeHelpers.config.startupMemoryCache) {
-            memorySize = await getMemorySnapshotSize();
-            runtimeHelpers.loadedMemorySnapshot = !!memorySize;
-            runtimeHelpers.storeMemorySnapshotPending = !runtimeHelpers.loadedMemorySnapshot;
-        }
-        if (!runtimeHelpers.loadedMemorySnapshot) {
-            // we should start downloading DLLs etc as they are not in the snapshot
-            runtimeHelpers.memorySnapshotSkippedOrDone.promise_control.resolve();
-        }
 
         await runtimeHelpers.beforePreInit.promise;
         Module.addRunDependency("instantiate_wasm_module");
@@ -484,19 +476,19 @@ async function instantiate_wasm_module(
 
         mono_log_debug("instantiate_wasm_module done");
 
-        if (runtimeHelpers.loadedMemorySnapshot) {
+        if (runtimeHelpers.loadedMemorySnapshotSize) {
             try {
                 const wasmMemory = (Module.asm?.memory || Module.wasmMemory)!;
 
                 // .grow() takes a delta compared to the previous size
-                wasmMemory.grow((memorySize! - wasmMemory.buffer.byteLength + 65535) >>> 16);
+                wasmMemory.grow((runtimeHelpers.loadedMemorySnapshotSize! - wasmMemory.buffer.byteLength + 65535) >>> 16);
                 runtimeHelpers.updateMemoryViews();
             } catch (err) {
                 mono_log_warn("failed to resize memory for the snapshot", err);
-                runtimeHelpers.loadedMemorySnapshot = false;
+                runtimeHelpers.loadedMemorySnapshotSize = undefined;
             }
             // now we know if the loading of memory succeeded or not, we can start loading the rest of the assets
-            runtimeHelpers.memorySnapshotSkippedOrDone.promise_control.resolve();
+            loaderHelpers.memorySnapshotSkippedOrDone.promise_control.resolve();
         }
         runtimeHelpers.afterInstantiateWasm.promise_control.resolve();
     } catch (err) {
@@ -509,7 +501,7 @@ async function instantiate_wasm_module(
 
 async function mono_wasm_before_memory_snapshot() {
     const mark = startMeasure();
-    if (runtimeHelpers.loadedMemorySnapshot) {
+    if (runtimeHelpers.loadedMemorySnapshotSize) {
         // get the bytes after we re-sized the memory, so that we don't have too much memory in use at the same time
         const memoryBytes = await getMemorySnapshot();
         const heapU8 = localHeapViewU8();

--- a/src/mono/wasm/runtime/types/internal.ts
+++ b/src/mono/wasm/runtime/types/internal.ts
@@ -128,6 +128,7 @@ export type LoaderHelpers = {
     allDownloadsQueued: PromiseAndController<void>,
     wasmDownloadPromise: PromiseAndController<AssetEntryInternal>,
     runtimeModuleLoaded: PromiseAndController<void>,
+    memorySnapshotSkippedOrDone: PromiseAndController<void>,
 
     is_exited: () => boolean,
     is_runtime_running: () => boolean,
@@ -176,7 +177,7 @@ export type RuntimeHelpers = {
     mono_wasm_runtime_is_ready: boolean;
     mono_wasm_bindings_is_ready: boolean;
 
-    loadedMemorySnapshot: boolean,
+    loadedMemorySnapshotSize?: number,
     enablePerfMeasure: boolean;
     waitForDebugger?: number;
     ExitStatus: ExitStatusError;
@@ -194,7 +195,6 @@ export type RuntimeHelpers = {
 
     allAssetsInMemory: PromiseAndController<void>,
     dotnetReady: PromiseAndController<any>,
-    memorySnapshotSkippedOrDone: PromiseAndController<void>,
     afterInstantiateWasm: PromiseAndController<void>,
     beforePreInit: PromiseAndController<void>,
     afterPreInit: PromiseAndController<void>,
@@ -490,6 +490,7 @@ export type setGlobalObjectsType = (globalObjects: GlobalObjects) => void;
 export type initializeExportsType = (globalObjects: GlobalObjects) => RuntimeAPI;
 export type initializeReplacementsType = (replacements: EmscriptenReplacements) => void;
 export type configureEmscriptenStartupType = (module: DotnetModuleInternal) => void;
+export type configureRuntimeStartupType = () => Promise<void>;
 export type configureWorkerStartupType = (module: DotnetModuleInternal) => Promise<void>
 
 
@@ -497,6 +498,7 @@ export type RuntimeModuleExportsInternal = {
     setRuntimeGlobals: setGlobalObjectsType,
     initializeExports: initializeExportsType,
     initializeReplacements: initializeReplacementsType,
+    configureRuntimeStartup: configureRuntimeStartupType,
     configureEmscriptenStartup: configureEmscriptenStartupType,
     configureWorkerStartup: configureWorkerStartupType,
     passEmscriptenInternals: passEmscriptenInternalsType,


### PR DESCRIPTION
Backport of #90388 to release/8.0

- when `startupMemoryCache` false or memory cache is empty, we could fetch DLLs earlier
- fixed HTML prefetch in samples
- disabled throttling on perf bench
- moved checking for memory snapshot to `configureRuntimeStartup`
- fixed loading .wasm always
- calling library initializers and `onConfigLoaded` for manual config too

## Customer Impact

Related 
https://github.com/dotnet/runtime/issues/89631 
https://github.com/dotnet/aspnetcore/issues/49909

## Testing

Manual and automated tests pass.

## Risk

Low: The changes are related to WASM/Blazor startup. It's well covered in automated tests.
