### PR TITLE
Fix deprecated usages of FindPythonInterp CMake module

### DIFF
--- a/src/coreclr/pal/src/eventprovider/lttngprovider/CMakeLists.txt
+++ b/src/coreclr/pal/src/eventprovider/lttngprovider/CMakeLists.txt
@@ -1,7 +1,7 @@
-include(FindPythonInterp)
+include(FindPython)
 set (GENERATE_SCRIPT ${CLR_DIR}/scripts/genLttngProvider.py)
 
-set(GENERATE_COMMAND ${PYTHON_EXECUTABLE} ${GENERATE_SCRIPT} --man ${EVENT_MANIFEST} --intermediate ${CMAKE_CURRENT_BINARY_DIR})
+set(GENERATE_COMMAND ${Python_EXECUTABLE} ${GENERATE_SCRIPT} --man ${EVENT_MANIFEST} --intermediate ${CMAKE_CURRENT_BINARY_DIR})
 
 execute_process(
   COMMAND ${GENERATE_COMMAND} --dry-run

--- a/src/coreclr/pal/tests/palsuite/eventprovider/CMakeLists.txt
+++ b/src/coreclr/pal/tests/palsuite/eventprovider/CMakeLists.txt
@@ -6,10 +6,10 @@ set(SOURCES
 set(EVENT_MANIFEST ${VM_DIR}/ClrEtwAll.man)
 set(TEST_GENERATOR ${CLR_DIR}/scripts/genEventingTests.py)
 
-include(FindPythonInterp)
+include(FindPython)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/clralltestevents.cpp
-  COMMAND ${PYTHON_EXECUTABLE} ${TEST_GENERATOR} --testdir "${CMAKE_CURRENT_BINARY_DIR}" --man "${EVENT_MANIFEST}"
+  COMMAND ${Python_EXECUTABLE} ${TEST_GENERATOR} --testdir "${CMAKE_CURRENT_BINARY_DIR}" --man "${EVENT_MANIFEST}"
   DEPENDS ${EVENT_MANIFEST} ${TEST_GENERATOR}
   COMMENT "Updating clralltestevents.cpp"
 )

--- a/src/coreclr/vm/eventing/EtwProvider/CMakeLists.txt
+++ b/src/coreclr/vm/eventing/EtwProvider/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(FindPythonInterp)
+include(FindPython)
 
 set(ETW_PROVIDER_SCRIPT ${CLR_DIR}/scripts/genEtwProvider.py)
 
@@ -15,7 +15,7 @@ set_source_files_properties(${ETW_PROVIDER_OUTPUTS} PROPERTIES GENERATED TRUE)
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/eventprovider.timestamp
-  COMMAND ${PYTHON_EXECUTABLE} ${ETW_PROVIDER_SCRIPT} --man ${EVENT_MANIFEST} --exc ${EVENT_EXCLUSIONS} --intermediate ${GENERATED_INCLUDE_DIR}
+  COMMAND ${Python_EXECUTABLE} ${ETW_PROVIDER_SCRIPT} --man ${EVENT_MANIFEST} --exc ${EVENT_EXCLUSIONS} --intermediate ${GENERATED_INCLUDE_DIR}
   COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/eventprovider.timestamp
   DEPENDS ${EVENT_MANIFEST} ${EVENT_EXCLUSIONS} ${ETW_PROVIDER_SCRIPT})
 


### PR DESCRIPTION
Similar to https://github.com/dotnet/runtime/pull/89546

Fixes https://github.com/dotnet/runtime/issues/89424