### PR TITLE
JIT: Fix various HW intrinsic lowerings for unused values

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1900,6 +1900,10 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
     {
         use.ReplaceWith(tmp2);
     }
+    else
+    {
+        tmp2->SetUnusedValue();
+    }
 
     BlockRange().Remove(node);
     return tmp2->gtNext;

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5314,6 +5314,10 @@ GenTree* Lowering::LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node)
             {
                 use.ReplaceWith(newIndir);
             }
+            else
+            {
+                newIndir->SetUnusedValue();
+            }
 
             BlockRange().Remove(op1);
             BlockRange().Remove(node);
@@ -5341,6 +5345,10 @@ GenTree* Lowering::LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node)
                 if (BlockRange().TryGetUse(node, &use))
                 {
                     use.ReplaceWith(lclFld);
+                }
+                else
+                {
+                    lclFld->SetUnusedValue();
                 }
 
                 BlockRange().Remove(op1);
@@ -5425,6 +5433,11 @@ GenTree* Lowering::LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node)
         if (foundUse)
         {
             use.ReplaceWith(cast);
+        }
+        else
+        {
+            node->ClearUnusedValue();
+            cast->SetUnusedValue();
         }
         next = LowerNode(cast);
     }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3868,6 +3868,10 @@ GenTree* Lowering::LowerHWIntrinsicGetElement(GenTreeHWIntrinsic* node)
         {
             use.ReplaceWith(newIndir);
         }
+        else
+        {
+            newIndir->SetUnusedValue();
+        }
 
         BlockRange().Remove(op1);
         BlockRange().Remove(node);
@@ -3915,6 +3919,10 @@ GenTree* Lowering::LowerHWIntrinsicGetElement(GenTreeHWIntrinsic* node)
                 if (BlockRange().TryGetUse(node, &use))
                 {
                     use.ReplaceWith(lclFld);
+                }
+                else
+                {
+                    lclFld->SetUnusedValue();
                 }
 
                 BlockRange().Remove(op1);
@@ -4157,6 +4165,11 @@ GenTree* Lowering::LowerHWIntrinsicGetElement(GenTreeHWIntrinsic* node)
         if (foundUse)
         {
             use.ReplaceWith(cast);
+        }
+        else
+        {
+            node->ClearUnusedValue();
+            cast->SetUnusedValue();
         }
         next = LowerNode(cast);
     }
@@ -4737,6 +4750,10 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
                 {
                     use.ReplaceWith(tmp1);
                 }
+                else
+                {
+                    tmp1->SetUnusedValue();
+                }
 
                 BlockRange().Remove(node);
                 return LowerNode(tmp1);
@@ -5266,6 +5283,10 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
     if (BlockRange().TryGetUse(node, &use))
     {
         use.ReplaceWith(tmp1);
+    }
+    else
+    {
+        tmp1->SetUnusedValue();
     }
 
     BlockRange().Remove(node);
@@ -8345,8 +8366,15 @@ void Lowering::TryFoldCnsVecForEmbeddedBroadcast(GenTreeHWIntrinsic* parentNode,
         BlockRange().InsertBefore(broadcastNode, createScalar);
         BlockRange().InsertBefore(createScalar, constScalar);
         LIR::Use use;
-        BlockRange().TryGetUse(childNode, &use);
-        use.ReplaceWith(broadcastNode);
+        if (BlockRange().TryGetUse(childNode, &use))
+        {
+            use.ReplaceWith(broadcastNode);
+        }
+        else
+        {
+            broadcastNode->SetUnusedValue();
+        }
+
         BlockRange().Remove(childNode);
         LowerNode(createScalar);
         LowerNode(broadcastNode);


### PR DESCRIPTION
Fix #91173

In the test case we disable CSE but then hoisting hoists out a `HWINTRINSIC` node that ends up not CSE'd. This results in a top level unused `HWINTRINSIC` node that lowering didn't handle in a transformation. There's a bunch of transformations that do not handle this correctly, so fix it in all of them.

I couldn't find a test case that does not require disabling CSE (and I didn't include the existing one since it never finishes with the bug fixed), but I wouldn't bet on that one doesn't exist, so I think we should backport this anyway.