### PR TITLE
[Mono] Fix unsafe accessor related issue for full AOT

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -3844,10 +3844,12 @@ encode_method_ref (MonoAotCompile *acfg, MonoMethod *method, guint8 *buf, guint8
 			else if (info->subtype == WRAPPER_SUBTYPE_UNSAFE_ACCESSOR) {
 				encode_method_ref (acfg, info->d.unsafe_accessor.method, p, &p);
 				encode_value (info->d.unsafe_accessor.kind, p, &p);
-				/* WISH: is there some kind of string heap token we could use here? */
-				uint32_t len = (uint32_t) strlen (info->d.unsafe_accessor.member_name);
-				encode_value (len, p, &p);
-				encode_string (info->d.unsafe_accessor.member_name, p, &p);
+				if (info->d.unsafe_accessor.member_name) {
+					/* WISH: is there some kind of string heap token we could use here? */
+					uint32_t len = (uint32_t) strlen (info->d.unsafe_accessor.member_name);
+					encode_value (len, p, &p);
+					encode_string (info->d.unsafe_accessor.member_name, p, &p);
+				}
 			}
 			else if (info->subtype == WRAPPER_SUBTYPE_INTERP_IN)
 				encode_signature (acfg, info->d.interp_in.sig, p, &p);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -6453,7 +6453,15 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 	cfg->generic_context = generic_context;
 
 	if (!cfg->gshared) {
-		if (method->wrapper_type != MONO_WRAPPER_OTHER)
+		gboolean check_type_parameter = TRUE;
+		if (method->wrapper_type == MONO_WRAPPER_OTHER) {
+			WrapperInfo *info = mono_marshal_get_wrapper_info (method);
+			g_assert (info);
+			if (info->subtype == WRAPPER_SUBTYPE_UNSAFE_ACCESSOR)
+				check_type_parameter = FALSE;
+		}
+
+		if (check_type_parameter)
 			g_assert (!sig->has_type_parameters);
 	}
 

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -6452,8 +6452,10 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		generic_context = &generic_container->context;
 	cfg->generic_context = generic_context;
 
-	if (!cfg->gshared)
-		g_assert (!sig->has_type_parameters);
+	if (!cfg->gshared) {
+		if (method->wrapper_type != MONO_WRAPPER_OTHER)
+			g_assert (!sig->has_type_parameters);
+	}
 
 	if (sig->generic_param_count && method->wrapper_type == MONO_WRAPPER_NONE) {
 		g_assert (method->is_inflated);


### PR DESCRIPTION
Fixes #91066

This PR fixed two issues:

1. Skip type parameter check, when it is a wrapper of `WRAPPER_SUBTYPE_UNSAFE_ACCESSOR`
2. Only encode when `member_name` is not NULL