### PR TITLE
Prevent restore from deleting mibc cache file

### DIFF
--- a/eng/restore/optimizationData.targets
+++ b/eng/restore/optimizationData.targets
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <ItemGroup>
     <!-- Mibc data to use when exact architecture match is available -->
     <MIBCPackageDef Include="optimization.windows_nt-x86.mibc.runtime" Version="$(optimizationwindows_ntx86MIBCRuntimeVersion)" MibcArchitecture="windows/x86"/>
@@ -25,6 +25,9 @@
   <Target Name="GetMIBCData"
           AfterTargets="Restore">
 
+    <PropertyGroup>
+      <_MergeMibcFilesCacheFile>$(MibcOptimizationDataDir)/$(TargetOS)/$(TargetArchitecture)/merge_mibc_files.cache</_MergeMibcFilesCacheFile>
+    </PropertyGroup>
     <ItemGroup>
       <MIBCPackage>
         <PackagePath>$(NuGetPackageRoot)%(MIBCPackage.Identity)/%(MIBCPackage.Version)</PackagePath>
@@ -32,7 +35,7 @@
       <_optimizationMibcFile Include="%(MIBCPackage.PackagePath)/**/*.mibc" SubdirectoryName="$(TargetOS)/$(TargetArchitecture)" />
       <_optimizationMibcDestinationFile Include="@(_optimizationMibcFile->'$(MibcOptimizationDataDir)%(SubdirectoryName)/%(RecursiveDir)%(Filename)%(Extension)')" />
       <ExcessFilesCurrentlyPresent Include="$(MibcOptimizationDataDir)/**" 
-                                   Exclude="@(_optimizationMibcDestinationFile)"/>
+                                   Exclude="@(_optimizationMibcDestinationFile);$(_MergeMibcFilesCacheFile)"/>
     </ItemGroup>
 
     <Error Condition="'@(_optimizationMibcFile)' == ''" Text="Failed to restore Mibc optimization data" />


### PR DESCRIPTION
Restore should not remove the mibc cache file that is used to enable incrementalism when merging mibc files.

This fixes an issue with the logic introduced in
https://github.com/dotnet/runtime/pull/87336, which was tested on incremental builds without restore.