### PR TITLE
[PERF] Revert perfowl runs back to ubuntu.1804 as they are not on ubuntu 2204

### DIFF
--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -290,7 +290,7 @@ if [[ "$internal" == true ]]; then
         queue=Ubuntu.1804.Arm64.Perf
     else
         if [[ "$logical_machine" == "perfowl" ]]; then
-            queue=Ubuntu.2204.Amd64.Owl.Perf
+            queue=Ubuntu.1804.Amd64.Owl.Perf
         elif [[ "$logical_machine" == "perftiger_crossgen" ]]; then
             queue=Ubuntu.1804.Amd64.Tiger.Perf
         else


### PR DESCRIPTION
Revert perfowl run queue back to ubuntu.1804 as they are not on ubuntu 2204 yet. Queue was updated as part of https://github.com/dotnet/runtime/commit/658bdd0376326f43cc8a6f316b2e01cacdcc688d