### PR TITLE
[mono][jit] Optimize OP_R8CONST and OP_R4CONST on Arm64

### DIFF
--- a/src/mono/mono/arch/arm64/arm64-codegen.h
+++ b/src/mono/mono/arch/arm64/arm64-codegen.h
@@ -770,6 +770,9 @@ arm_encode_arith_imm (int imm, guint32 *shift)
 #define arm_fmovd(p, dd, dn) arm_format_fmov ((p), 0x1, (dn), (dd))
 #define arm_fmovs(p, dd, dn) arm_format_fmov ((p), 0x0, (dn), (dd))
 
+/* C7.2.132 FMOV (scalar, imm) */
+#define arm_fmov_imm(p, type, imm, rd) arm_emit ((p), 0b00011110001000000001000000000000 | ((type) << 22) | ((imm) << 13) | ((rd) << 0))
+
 /* C6.3.54 FCMP */
 #define arm_format_fcmp(p, type, opc, rn, rm) arm_emit ((p), (0x1e << 24) | ((type) << 22) | (0x1 << 21) | ((rm) << 16) | (0x8 << 10) | ((rn) << 5) | ((opc) << 3))
 


### PR DESCRIPTION
Issue description: https://github.com/dotnet/runtime/issues/83717

Adding check to detect immediate constants available in `FMOV (scalar, immediate)` instructions. When possible, the constants are stored directly in FP register using single `fmov` (previously we required `mov` followed by `fmov`).

Unifying float and double zero paths to store both `0.0f` and `0.0` using `fmov dest, xzr`.