### PR TITLE
Use live illink to trim framework

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -136,6 +136,7 @@
     <LibrariesConfiguration Condition="'$(LibrariesConfiguration)' == ''">$(Configuration)</LibrariesConfiguration>
     <HostConfiguration Condition="'$(HostConfiguration)' == ''">$(Configuration)</HostConfiguration>
     <TasksConfiguration Condition="'$(TasksConfiguration)' == ''">$(Configuration)</TasksConfiguration>
+    <ToolsConfiguration Condition="'$(ToolsConfiguration)' == ''">$(Configuration)</ToolsConfiguration>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -408,7 +408,6 @@
                                 '$(IsTestSupportProject)' != 'true' and
                                 '$(UsingMicrosoftDotNetSharedFrameworkSdk)' != 'true' and
                                 '$(MSBuildProjectExtension)' != '.pkgproj' and
-                                '$(MSBuildProjectExtension)' != '.proj' and
                                 '$(UsingMicrosoftNoTargetsSdk)' != 'true' and
                                 '$(UsingMicrosoftTraversalSdk)' != 'true'">true</IsSourceProject>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -407,6 +407,7 @@
                                 '$(IsTestSupportProject)' != 'true' and
                                 '$(UsingMicrosoftDotNetSharedFrameworkSdk)' != 'true' and
                                 '$(MSBuildProjectExtension)' != '.pkgproj' and
+                                '$(MSBuildProjectExtension)' != '.proj' and
                                 '$(UsingMicrosoftNoTargetsSdk)' != 'true' and
                                 '$(UsingMicrosoftTraversalSdk)' != 'true'">true</IsSourceProject>
   </PropertyGroup>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -558,6 +558,7 @@
       <AdditionalProperties Condition="'%(ProjectToBuild.Category)' == 'libs'">%(AdditionalProperties);Configuration=$(LibrariesConfiguration)</AdditionalProperties>
       <AdditionalProperties Condition="'%(ProjectToBuild.Category)' == 'host'">%(AdditionalProperties);Configuration=$(HostConfiguration)</AdditionalProperties>
       <AdditionalProperties Condition="'%(ProjectToBuild.Category)' == 'tasks'">%(AdditionalProperties);Configuration=$(TasksConfiguration)</AdditionalProperties>
+      <AdditionalProperties Condition="'%(ProjectToBuild.Category)' == 'tools'">%(AdditionalProperties);Configuration=$(ToolsConfiguration)</AdditionalProperties>
 
       <!-- Propagate configurations for cross-subset builds -->
       <AdditionalProperties>%(AdditionalProperties);LibrariesConfiguration=$(LibrariesConfiguration)</AdditionalProperties>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -206,7 +206,6 @@
 
   <!-- CoreClr sets -->
   <ItemGroup Condition="$(_subset.Contains('+clr.corelib+'))">
-    <ProjectToBuild Include="$(ToolsProjectRoot)illink\src\ILLink.Tasks\ILLink.Tasks.csproj" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)System.Private.CoreLib\System.Private.CoreLib.csproj" Category="clr" />
   </ItemGroup>
 
@@ -417,7 +416,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+mono.corelib+'))">
-    <ProjectToBuild Include="$(ToolsProjectRoot)illink\src\ILLink.Tasks\ILLink.Tasks.csproj" />
     <ProjectToBuild Include="$(MonoProjectRoot)System.Private.CoreLib\System.Private.CoreLib.csproj" Category="mono" />
   </ItemGroup>
 
@@ -455,7 +453,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+libs.ref+')) or $(_subset.Contains('+libs.src+')) or $(_subset.Contains('+libs.sfx+'))">
-    <ProjectToBuild Include="$(ToolsProjectRoot)illink\src\ILLink.Tasks\ILLink.Tasks.csproj" />
     <ProjectToBuild Include="$(LibrariesProjectRoot)sfx.proj"
                     Category="libs"
                     Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or
@@ -466,7 +463,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+libs.ref+')) or $(_subset.Contains('+libs.src+')) or $(_subset.Contains('+libs.oob+'))">
-    <ProjectToBuild Include="$(ToolsProjectRoot)illink\src\ILLink.Tasks\ILLink.Tasks.csproj" />
     <ProjectToBuild Include="$(LibrariesProjectRoot)oob.proj" Category="libs">
       <AdditionalProperties Condition="$(_subset.Contains('+libs.ref+'))">%(AdditionalProperties);RefOnly=true</AdditionalProperties>
     </ProjectToBuild>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -563,6 +563,7 @@
       <AdditionalProperties>%(AdditionalProperties);LibrariesConfiguration=$(LibrariesConfiguration)</AdditionalProperties>
       <AdditionalProperties>%(AdditionalProperties);HostConfiguration=$(HostConfiguration)</AdditionalProperties>
       <AdditionalProperties>%(AdditionalProperties);TasksConfiguration=$(TasksConfiguration)</AdditionalProperties>
+      <AdditionalProperties>%(AdditionalProperties);ToolsConfiguration=$(ToolsConfiguration)</AdditionalProperties>
     </ProjectToBuild>
   </ItemGroup>
 

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -206,6 +206,7 @@
 
   <!-- CoreClr sets -->
   <ItemGroup Condition="$(_subset.Contains('+clr.corelib+'))">
+    <ProjectToBuild Include="$(ToolsProjectRoot)illink\src\ILLink.Tasks\ILLink.Tasks.csproj" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)System.Private.CoreLib\System.Private.CoreLib.csproj" Category="clr" />
   </ItemGroup>
 
@@ -416,6 +417,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+mono.corelib+'))">
+    <ProjectToBuild Include="$(ToolsProjectRoot)illink\src\ILLink.Tasks\ILLink.Tasks.csproj" />
     <ProjectToBuild Include="$(MonoProjectRoot)System.Private.CoreLib\System.Private.CoreLib.csproj" Category="mono" />
   </ItemGroup>
 
@@ -453,6 +455,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+libs.ref+')) or $(_subset.Contains('+libs.src+')) or $(_subset.Contains('+libs.sfx+'))">
+    <ProjectToBuild Include="$(ToolsProjectRoot)illink\src\ILLink.Tasks\ILLink.Tasks.csproj" />
     <ProjectToBuild Include="$(LibrariesProjectRoot)sfx.proj"
                     Category="libs"
                     Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or
@@ -463,6 +466,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+libs.ref+')) or $(_subset.Contains('+libs.src+')) or $(_subset.Contains('+libs.oob+'))">
+    <ProjectToBuild Include="$(ToolsProjectRoot)illink\src\ILLink.Tasks\ILLink.Tasks.csproj" />
     <ProjectToBuild Include="$(LibrariesProjectRoot)oob.proj" Category="libs">
       <AdditionalProperties Condition="$(_subset.Contains('+libs.ref+'))">%(AdditionalProperties);RefOnly=true</AdditionalProperties>
     </ProjectToBuild>

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -1,6 +1,16 @@
 <Project>
 
-  <Import Project="$(ToolsILLinkDir)$(NetCoreAppToolCurrent)/build/Microsoft.NET.ILLink.Tasks.props" />
+  <PropertyGroup>
+    <_ILLinkTasksSourceDir>$(ToolsProjectRoot)illink/src/ILLink.Tasks/</_ILLinkTasksSourceDir>
+    <ILLinkAnalyzersPropsPath>$(ToolsProjectRoot)illink/src/ILLink.RoslynAnalyzer/build/Microsoft.NET.ILLink.Analyzers.props</ILLinkAnalyzersPropsPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(_ILLinkTasksSourceDir)ILLink.Tasks.csproj"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <Import Project="$(_ILLinkTasksSourceDir)build/Microsoft.NET.ILLink.Tasks.props" />
 
   <PropertyGroup>
     <IsTrimmable Condition="'$(IsTrimmable)' == ''">true</IsTrimmable>

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <_ILLinkTasksSourceDir>$(ToolsProjectRoot)illink/src/ILLink.Tasks/</_ILLinkTasksSourceDir>
-    <ILLinkAnalyzersPropsPath>$(ToolsProjectRoot)illink/src/ILLink.RoslynAnalyzer/build/Microsoft.NET.ILLink.Analyzers.props</ILLinkAnalyzersPropsPath>
+    <_ILLinkTasksSourceDir>$(ToolsProjectRoot)illink\src\ILLink.Tasks\</_ILLinkTasksSourceDir>
+    <ILLinkAnalyzersPropsPath>$(ToolsProjectRoot)illink\src\ILLink.RoslynAnalyzer\build\Microsoft.NET.ILLink.Analyzers.props</ILLinkAnalyzersPropsPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,7 +19,7 @@
     </ProjectReference>
   </ItemGroup>
 
-  <Import Project="$(_ILLinkTasksSourceDir)build/Microsoft.NET.ILLink.Tasks.props" />
+  <Import Project="$(_ILLinkTasksSourceDir)build\Microsoft.NET.ILLink.Tasks.props" />
 
   <PropertyGroup>
     <IsTrimmable Condition="'$(IsTrimmable)' == ''">true</IsTrimmable>

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -12,8 +12,11 @@
     <ProjectReference Include="$(_ILLinkTasksSourceDir)ILLink.Tasks.csproj"
                       ReferenceOutputAssembly="false"
                       PrivateAssets="all"
-                      SkipGetTargetFrameworkProperties="true"
-                      SetConfiguration="Configuration=$(ToolsConfiguration)" />
+                      SetConfiguration="Configuration=$(ToolsConfiguration)">
+        <!-- Keep TFMs in sync with ILLink.Tasks.csproj -->
+        <SetTargetFramework Condition="'$(MSBuildRuntimeType)' == 'Core'">TargetFramework=$(NetCoreAppToolCurrent)</SetTargetFramework>
+        <SetTargetFramework Condition="'$(MSBuildRuntimeType)' != 'Core'">TargetFramework=$(NetFrameworkToolCurrent)</SetTargetFramework>
+    </ProjectReference>
   </ItemGroup>
 
   <Import Project="$(_ILLinkTasksSourceDir)build/Microsoft.NET.ILLink.Tasks.props" />

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -1,5 +1,7 @@
 <Project>
 
+  <Import Project="$(ToolsILLinkDir)$(NetCoreAppToolCurrent)/build/Microsoft.NET.ILLink.Tasks.props" />
+
   <PropertyGroup>
     <IsTrimmable Condition="'$(IsTrimmable)' == ''">true</IsTrimmable>
     <!-- Don't use SDK's trimming functionality.
@@ -10,6 +12,7 @@
          we might be able to use built-in functionality instead of a packagereference.
          -->
     <_RequiresILLinkPack>false</_RequiresILLinkPack>
+    <ILLinkTasksAssembly>$(ToolsILLinkDir)$(NetCoreAppToolCurrent)/ILLink.Tasks.dll</ILLinkTasksAssembly>
     <PrepareResourcesDependsOn>_EmbedILLinkXmls;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
     <TargetsTriggeredByCompilation Condition="'$(DesignTimeBuild)' != 'true'">$(TargetsTriggeredByCompilation);ILLinkTrimAssembly</TargetsTriggeredByCompilation>
 
@@ -42,14 +45,6 @@
     <ILLinkResourcesSubstitutionIntermediatePath>$(IntermediateOutputPath)ILLink.Resources.Substitutions.xml</ILLinkResourcesSubstitutionIntermediatePath>
     <GenerateResourcesSubstitutions Condition="'$(GenerateResourcesSubstitutions)' == '' and '$(StringResourcesPath)' != ''">true</GenerateResourcesSubstitutions>
   </PropertyGroup>
-
-  <!-- Use ILLink.Tasks version matching the SDK used to build. See comment about _RequiresILLinkPack. -->
-  <PropertyGroup>
-    <SuppressILLinkExplicitPackageReferenceWarning>true</SuppressILLinkExplicitPackageReferenceWarning>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="$(BundledNETCoreAppPackageVersion)" PrivateAssets="all" />
-  </ItemGroup>
 
   <ItemGroup>
     <ILLinkSuppressionsXmls Include="$(ILLinkSuppressionsXmlFile)"

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -6,8 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- SkipGetTargetFrameworkProperties builds ILLink.Tasks without any TargetFramework settings
+         based on the referencing project, preventing errors when illink.targets is imported by a
+         project with TargetFrameworks that are incompatible with those of ILLink.Tasks. -->
     <ProjectReference Include="$(_ILLinkTasksSourceDir)ILLink.Tasks.csproj"
-                      ReferenceOutputAssembly="false" />
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all"
+                      SkipGetTargetFrameworkProperties="true"
+                      SetConfiguration="Configuration=$(ToolsConfiguration)" />
   </ItemGroup>
 
   <Import Project="$(_ILLinkTasksSourceDir)build/Microsoft.NET.ILLink.Tasks.props" />

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -29,7 +29,7 @@
     <CoreCLRAotSdkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'aotsdk'))</CoreCLRAotSdkDir>
     <CoreCLRBuildIntegrationDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'build'))</CoreCLRBuildIntegrationDir>
 
-    <ToolsILLinkDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'ILLink.Tasks', '$(Configuration)'))</ToolsILLinkDir>
+    <ToolsILLinkDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'ILLink.Tasks', '$(ToolsConfiguration)'))</ToolsILLinkDir>
 
     <MonoAotCrossDir>$([MSBuild]::NormalizeDirectory('$(MonoArtifactsPath)', 'cross', $(TargetOS)-$(TargetArchitecture.ToLowerInvariant())))</MonoAotCrossDir>
     <GrpcServerDockerImageDir>$([MSBuild]::NormalizeDirectory('$(LibrariesArtifactsPath)', 'obj', 'grpcserver', 'docker'))</GrpcServerDockerImageDir>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -127,7 +127,7 @@
   <Import Project="$(RepositoryEngineeringDir)testing\coverage.targets" Condition="'$(EnableRunSettingsSupport)' == 'true' or '$(EnableCoverageSupport)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)slngen.targets" Condition="'$(IsSlnGen)' == 'true'" />
 
-  <Import Project="$(RepositoryEngineeringDir)illink.targets" Condition="'$(IsSourceProject)' == 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)illink.targets" Condition="'$(IsSourceProject)' == 'true' or '$(ExplicitlyImportCustomILLinkTargets)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)AvoidRestoreCycleOnSelfReference.targets" Condition="'$(AvoidRestoreCycleOnSelfReference)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)nativeSanitizers.targets" />
 

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -127,7 +127,7 @@
   <Import Project="$(RepositoryEngineeringDir)testing\coverage.targets" Condition="'$(EnableRunSettingsSupport)' == 'true' or '$(EnableCoverageSupport)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)slngen.targets" Condition="'$(IsSlnGen)' == 'true'" />
 
-  <Import Project="$(RepositoryEngineeringDir)illink.targets" Condition="'$(IsSourceProject)' == 'true' and '$(MSBuildProjectExtension)' != '.proj'" />
+  <Import Project="$(RepositoryEngineeringDir)illink.targets" Condition="'$(IsSourceProject)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)AvoidRestoreCycleOnSelfReference.targets" Condition="'$(AvoidRestoreCycleOnSelfReference)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)nativeSanitizers.targets" />
 

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -127,7 +127,7 @@
   <Import Project="$(RepositoryEngineeringDir)testing\coverage.targets" Condition="'$(EnableRunSettingsSupport)' == 'true' or '$(EnableCoverageSupport)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)slngen.targets" Condition="'$(IsSlnGen)' == 'true'" />
 
-  <Import Project="$(RepositoryEngineeringDir)illink.targets" Condition="'$(IsSourceProject)' == 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)illink.targets" Condition="'$(IsSourceProject)' == 'true' and '$(MSBuildProjectExtension)' != '.proj'" />
   <Import Project="$(RepositoryEngineeringDir)AvoidRestoreCycleOnSelfReference.targets" Condition="'$(AvoidRestoreCycleOnSelfReference)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)nativeSanitizers.targets" />
 

--- a/src/libraries/oob.proj
+++ b/src/libraries/oob.proj
@@ -1,4 +1,4 @@
-<Project Sdk=="Microsoft.Build.NoTargets">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)-$(TargetOS)</TargetFramework>

--- a/src/libraries/oob.proj
+++ b/src/libraries/oob.proj
@@ -1,11 +1,11 @@
-<Project>
-
-  <Import Project="Sdk.props" Sdk="Microsoft.Build.NoTargets" />
+<Project Sdk=="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)-$(TargetOS)</TargetFramework>
     <!-- By default, build the NetCoreAppCurrent vertical only. -->
     <BuildTargetFramework Condition="'$(BuildAllConfigurations)' != 'true'">$(NetCoreAppCurrent)</BuildTargetFramework>
+     <!-- Import the illink file which contains some of the logic required to illink the out-of-band assemblies. -->
+    <ExplicitlyImportCustomILLinkTargets Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or '$(BuildTargetFramework)' == ''">true</ExplicitlyImportCustomILLinkTargets>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or '$(BuildTargetFramework)' == ''">
@@ -77,13 +77,5 @@
           AfterTargets="Build;Pack">
     <Message Condition="Exists('$(ArtifactsDir)packages')" Importance="High" Text="##vso[task.setvariable variable=_librariesBuildProducedPackages]true" />
   </Target>
-
-  <Import Project="Sdk.targets" Sdk="Microsoft.Build.NoTargets" />
-
-  <!-- Must be imported AFTER liveBuilds.targets (imported by Directory.Build.targets) which defines the ToolsILLinkDir. -->
-  <ImportGroup Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or '$(BuildTargetFramework)' == ''">
-    <!-- Import the illink file which contains some of the logic required to illink the out-of-band assemblies. -->
-    <Import Project="$(RepositoryEngineeringDir)illink.targets" />
-  </ImportGroup>
 
 </Project>

--- a/src/libraries/oob.proj
+++ b/src/libraries/oob.proj
@@ -1,4 +1,6 @@
-<Project Sdk="Microsoft.Build.NoTargets">
+<Project>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.Build.NoTargets" />
 
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)-$(TargetOS)</TargetFramework>
@@ -24,11 +26,6 @@
     <ProjectReference Include="sfx-ref.proj" OutputItemType="SharedFrameworkAssembly" />
     <ProjectReference Include="oob-ref.proj" />
   </ItemGroup>
-
-  <ImportGroup Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or '$(BuildTargetFramework)' == ''">
-    <!-- Import the illink file which contains some of the logic required to illink the out-of-band assemblies. -->
-    <Import Project="$(RepositoryEngineeringDir)illink.targets" />
-  </ImportGroup>
 
   <Target Name="GetTrimOOBAssembliesInputs"
           DependsOnTargets="ResolveProjectReferences">
@@ -80,5 +77,13 @@
           AfterTargets="Build;Pack">
     <Message Condition="Exists('$(ArtifactsDir)packages')" Importance="High" Text="##vso[task.setvariable variable=_librariesBuildProducedPackages]true" />
   </Target>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.Build.NoTargets" />
+
+  <!-- Must be imported AFTER liveBuilds.targets (imported by Directory.Build.targets) which defines the ToolsILLinkDir. -->
+  <ImportGroup Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or '$(BuildTargetFramework)' == ''">
+    <!-- Import the illink file which contains some of the logic required to illink the out-of-band assemblies. -->
+    <Import Project="$(RepositoryEngineeringDir)illink.targets" />
+  </ImportGroup>
 
 </Project>

--- a/src/libraries/sfx.proj
+++ b/src/libraries/sfx.proj
@@ -1,4 +1,6 @@
-<Project Sdk="Microsoft.Build.NoTargets">
+<Project>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.Build.NoTargets" />
 
   <Sdk Name="Microsoft.DotNet.SharedFramework.Sdk" />
 
@@ -71,9 +73,6 @@
           UseHardlinksIfPossible="true" />
   </Target>
 
-  <!-- Import the illink file which contains some of the logic required to illink the shared framework assemblies. -->
-  <Import Project="$(RepositoryEngineeringDir)illink.targets" />
-
   <Target Name="GetTrimSharedFrameworkAssembliesInputs"
           DependsOnTargets="ResolveProjectReferences">
     <PropertyGroup>
@@ -118,5 +117,11 @@
     <Touch Files="$(SharedFrameworkAssembliesTrimMarkerFile)"
            AlwaysCreate="true" />
   </Target>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.Build.NoTargets" />
+
+  <!-- Import the illink file which contains some of the logic required to illink the shared framework assemblies. -->
+  <!-- Must be imported AFTER liveBuilds.targets (imported by Directory.Build.targets) which defines the ToolsILLinkDir. -->
+  <Import Project="$(RepositoryEngineeringDir)illink.targets" />
 
 </Project>

--- a/src/libraries/sfx.proj
+++ b/src/libraries/sfx.proj
@@ -1,6 +1,4 @@
-<Project>
-
-  <Import Project="Sdk.props" Sdk="Microsoft.Build.NoTargets" />
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <Sdk Name="Microsoft.DotNet.SharedFramework.Sdk" />
 
@@ -9,6 +7,8 @@
     <BuildInParallel>false</BuildInParallel>
     <IsPackable>false</IsPackable>
     <FrameworkListOutputPath>$(MicrosoftNetCoreAppRefPackDataDir)FrameworkList.xml</FrameworkListOutputPath>
+    <!-- Import the illink file which contains some of the logic required to illink the shared framework assemblies. -->
+    <ExplicitlyImportCustomILLinkTargets>true</ExplicitlyImportCustomILLinkTargets>
   </PropertyGroup>
 
   <ItemGroup>
@@ -117,11 +117,5 @@
     <Touch Files="$(SharedFrameworkAssembliesTrimMarkerFile)"
            AlwaysCreate="true" />
   </Target>
-
-  <Import Project="Sdk.targets" Sdk="Microsoft.Build.NoTargets" />
-
-  <!-- Import the illink file which contains some of the logic required to illink the shared framework assemblies. -->
-  <!-- Must be imported AFTER liveBuilds.targets (imported by Directory.Build.targets) which defines the ToolsILLinkDir. -->
-  <Import Project="$(RepositoryEngineeringDir)illink.targets" />
 
 </Project>

--- a/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
+++ b/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.Tasks.props
@@ -14,14 +14,16 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <!-- N.B. The ILLinkTargetsPath is used as a sentinel to indicate a version of this file has already been imported. It will also be the path
          used to import the targets later in the SDK. -->
-    <ILLinkTargetsPath>$(MSBuildThisFileDirectory)Microsoft.NET.ILLink.targets</ILLinkTargetsPath>
+    <ILLinkTargetsPath Condition="'$(ILLinkTargetsPath)' == ''">$(MSBuildThisFileDirectory)Microsoft.NET.ILLink.targets</ILLinkTargetsPath>
     <!-- Older SDKs used this property as a sentinel instead, to control the import of this file 
          (but not the targets, which were included with the SDK). -->
     <UsingILLinkTasksSdk>true</UsingILLinkTasksSdk>
     <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\net8.0\ILLink.Tasks.dll</ILLinkTasksAssembly>
     <ILLinkTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net472\ILLink.Tasks.dll</ILLinkTasksAssembly>
+
+    <ILLinkAnalyzersPropsPath Condition="'$(ILLinkAnalyzersPropsPath)' == ''">$(MSBuildThisFileDirectory)Microsoft.NET.ILLink.Analyzers.props</ILLinkAnalyzersPropsPath>
   </PropertyGroup>
 
-  <Import Project="Microsoft.NET.ILLink.Analyzers.props" />
+  <Import Project="$(ILLinkAnalyzersPropsPath)" />
 
 </Project>


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/90517 added a workaround to trim the framework using the SDK's version of ILLink.Tasks (see https://github.com/dotnet/runtime/pull/90517#issuecomment-1677995252 for context). This removes the workaround and replaces it with logic to use the live build of ILLink.Tasks.

The dependency on ILLink.Tasks is expressed via a magical `ProjectReference` that @ViktorHofer kindly helped me construct.

Unfortunately I had to add a small extension point to `Microsoft.NET.ILLink.Tasks.props`, to allow overriding the analyzer props path. This lets it be imported right out of the source tree, instead of from the build output of ILLink.Tasks.