### PR TITLE
catch closing exception in HttpListener

### DIFF
--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
@@ -237,8 +237,17 @@ namespace System.Net
 
         private static void OnRead(IAsyncResult ares)
         {
-            HttpConnection cnc = (HttpConnection)ares.AsyncState!;
-            cnc.OnReadInternal(ares);
+            HttpConnection? cnc = null;
+            try
+            {
+                cnc = (HttpConnection)ares.AsyncState!;
+                cnc.OnReadInternal(ares);
+            }
+            catch
+            {
+                cnc?.Close(true);
+                return;
+            }
         }
 
         private void OnReadInternal(IAsyncResult ares)


### PR DESCRIPTION
I happen to reproduce the failures from #91014 in my local test runs. 
Essentially there is peace condition that when turn HttpListener quickly the init code runs when the listener is already closed. HttpListener is used as AIA responder for certificate fetching - and mostly hidden inside certificate test infrastructure. 

In the particular case, We try to get `LocalEndPoint` but the `_socket` is already `null` after close so we cause exception on thread pool thread and that terminates while process. I was originally thinking about adding some guard agains `null` `_socket` but that also requires more changes to guard against `null` `EndPoint`.

Since throwing on thread pool thread seems generally bad, I decided to simply wrap that whole branch in try/catch.

With this fix I did several thousands local runs and all Security tests are now passing for my on my local VM.  

fixes #91014 
 