### PR TITLE
Remove implicit narrowing conversions from zlib

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -15,6 +15,9 @@ if (MSVC)
   if(EXISTS ${CLR_SOURCELINK_FILE_PATH})
     add_link_options("/sourcelink:${CLR_SOURCELINK_FILE_PATH}")
   endif()
+
+  # FIXME: Remove the line below when https://github.com/dotnet/runtime/issues/91249 is fixed.
+  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4244>) # conversion from 'type1' to 'type2', possible loss of data
 endif(MSVC)
 
 set(CROSS_ROOTFS $ENV{ROOTFS_DIR})

--- a/src/native/external/patches/zlib-intel/0001-Make-zlib-intel-compile-clean-against-C4244.patch
+++ b/src/native/external/patches/zlib-intel/0001-Make-zlib-intel-compile-clean-against-C4244.patch
@@ -1,0 +1,75 @@
+From edabaf799fd071a328e0adb743a98628df6649f0 Mon Sep 17 00:00:00 2001
+From: Levi Broderick <levib@microsoft.com>
+Date: Mon, 28 Aug 2023 15:26:38 -0700
+Subject: [PATCH] Make zlib-intel compile clean against C4244 clang equivalent
+ is "implicit-int-conversion" warning
+
+The change to deflate.c is legal because 'len' has an upper bound of
+MAX_STORED, which means it fits cleanly into a 16-bit integer. So
+writing out 2x 8-bit values will not result in data loss.
+
+The change to trees.c is legal because within this loop, 'count' is
+intended to have an upper bound of 138, with the target assignment
+only executing if 'count' is bounded by 4. Neither the 'count' local
+in isolation nor the addition that's part of the target line is
+expected to result in integer overflow. But even if it did, that's a
+matter for a different warning code and doesn't impact the correctness
+of the narrowing cast being considered here.
+
+The change to slide_sse.c is legal because 'w_size' is limited to
+1 << 15 (see deflateInit2_ in deflate.c), so this fits cleanly into
+a 16-bit value.
+---
+ src/native/external/zlib-intel/deflate.c   | 8 ++++----
+ src/native/external/zlib-intel/slide_sse.c | 2 +-
+ src/native/external/zlib-intel/trees.c     | 2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/native/external/zlib-intel/deflate.c b/src/native/external/zlib-intel/deflate.c
+index bd5e95774a6..108b1a187af 100644
+--- a/src/native/external/zlib-intel/deflate.c
++++ b/src/native/external/zlib-intel/deflate.c
+@@ -1553,10 +1553,10 @@ local block_state deflate_stored(s, flush)
+         _tr_stored_block(s, (char *)0, 0L, last);
+ 
+         /* Replace the lengths in the dummy stored block with len. */
+-        s->pending_buf[s->pending - 4] = len;
+-        s->pending_buf[s->pending - 3] = len >> 8;
+-        s->pending_buf[s->pending - 2] = ~len;
+-        s->pending_buf[s->pending - 1] = ~len >> 8;
++        s->pending_buf[s->pending - 4] = (Bytef)len;
++        s->pending_buf[s->pending - 3] = (Bytef)(len >> 8);
++        s->pending_buf[s->pending - 2] = (Bytef)~len;
++        s->pending_buf[s->pending - 1] = (Bytef)(~len >> 8);
+ 
+         /* Write the stored block header bytes. */
+         flush_pending(s->strm);
+diff --git a/src/native/external/zlib-intel/slide_sse.c b/src/native/external/zlib-intel/slide_sse.c
+index 342fd562dd1..eb74202c5a0 100644
+--- a/src/native/external/zlib-intel/slide_sse.c
++++ b/src/native/external/zlib-intel/slide_sse.c
+@@ -18,7 +18,7 @@ void slide_hash_sse(deflate_state *s)
+     unsigned n;
+     Posf *p;
+     uInt wsize = s->w_size;
+-    z_const __m128i xmm_wsize = _mm_set1_epi16(s->w_size);
++    z_const __m128i xmm_wsize = _mm_set1_epi16((short)s->w_size);
+ 
+     n = s->hash_size;
+     p = &s->head[n] - 8;
+diff --git a/src/native/external/zlib-intel/trees.c b/src/native/external/zlib-intel/trees.c
+index 35462a1313a..f78b7d8c63e 100644
+--- a/src/native/external/zlib-intel/trees.c
++++ b/src/native/external/zlib-intel/trees.c
+@@ -717,7 +717,7 @@ local void scan_tree(s, tree, max_code)
+         if (++count < max_count && curlen == nextlen) {
+             continue;
+         } else if (count < min_count) {
+-            s->bl_tree[curlen].Freq += count;
++            s->bl_tree[curlen].Freq += (ush)count;
+         } else if (curlen != 0) {
+             if (curlen != prevlen) s->bl_tree[curlen].Freq++;
+             s->bl_tree[REP_3_6].Freq++;
+-- 
+2.42.0.windows.1
+

--- a/src/native/external/patches/zlib/0001-Make-zlib-compile-clean-against-C4244.patch
+++ b/src/native/external/patches/zlib/0001-Make-zlib-compile-clean-against-C4244.patch
@@ -1,0 +1,57 @@
+From 86d96652ddd60f61dc7b0c94b601f6d156d34632 Mon Sep 17 00:00:00 2001
+From: Levi Broderick <levib@microsoft.com>
+Date: Mon, 28 Aug 2023 15:26:38 -0700
+Subject: [PATCH] Make zlib compile clean against C4244 clang equivalent is
+ "implicit-int-conversion" warning
+
+The change to deflate.c is legal because 'len' has an upper bound of
+MAX_STORED, which means it fits cleanly into a 16-bit integer. So
+writing out 2x 8-bit values will not result in data loss.
+
+The change to trees.c is legal because within this loop, 'count' is
+intended to have an upper bound of 138, with the target assignment
+only executing if 'count' is bounded by 4. Neither the 'count' local
+in isolation nor the addition that's part of the target line is
+expected to result in integer overflow. But even if it did, that's a
+matter for a different warning code and doesn't impact the correctness
+of the narrowing cast being considered here.
+---
+ src/native/external/zlib/deflate.c | 8 ++++----
+ src/native/external/zlib/trees.c   | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/native/external/zlib/deflate.c b/src/native/external/zlib/deflate.c
+index d2e1106ef5d..b7636639754 100644
+--- a/src/native/external/zlib/deflate.c
++++ b/src/native/external/zlib/deflate.c
+@@ -1738,10 +1738,10 @@ local block_state deflate_stored(s, flush)
+         _tr_stored_block(s, (char *)0, 0L, last);
+ 
+         /* Replace the lengths in the dummy stored block with len. */
+-        s->pending_buf[s->pending - 4] = len;
+-        s->pending_buf[s->pending - 3] = len >> 8;
+-        s->pending_buf[s->pending - 2] = ~len;
+-        s->pending_buf[s->pending - 1] = ~len >> 8;
++        s->pending_buf[s->pending - 4] = (Bytef)len;
++        s->pending_buf[s->pending - 3] = (Bytef)(len >> 8);
++        s->pending_buf[s->pending - 2] = (Bytef)~len;
++        s->pending_buf[s->pending - 1] = (Bytef)(~len >> 8);
+ 
+         /* Write the stored block header bytes. */
+         flush_pending(s->strm);
+diff --git a/src/native/external/zlib/trees.c b/src/native/external/zlib/trees.c
+index 5f305c47221..8a3eec559e5 100644
+--- a/src/native/external/zlib/trees.c
++++ b/src/native/external/zlib/trees.c
+@@ -721,7 +721,7 @@ local void scan_tree(s, tree, max_code)
+         if (++count < max_count && curlen == nextlen) {
+             continue;
+         } else if (count < min_count) {
+-            s->bl_tree[curlen].Freq += count;
++            s->bl_tree[curlen].Freq += (ush)count;
+         } else if (curlen != 0) {
+             if (curlen != prevlen) s->bl_tree[curlen].Freq++;
+             s->bl_tree[REP_3_6].Freq++;
+-- 
+2.42.0.windows.1
+

--- a/src/native/external/zlib-intel-version.txt
+++ b/src/native/external/zlib-intel-version.txt
@@ -12,3 +12,5 @@ copied into our repo in order to build. Since then, we've just updated only
 those files in-place, ignoring other files in the intel/zlib repo. If new files
 are introduced which are necessary for building the product, feel free to bring
 those down as well.
+
+We have also applied the custom patches under the patches/zlib-intel folder.

--- a/src/native/external/zlib-intel.cmake
+++ b/src/native/external/zlib-intel.cmake
@@ -1,9 +1,3 @@
-if(MSVC)
-    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4244>) # conversion from 'type1' to 'type2', possible loss of data
-else(CMAKE_C_COMPILER_ID MATCHES "Clang")
-    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-implicit-int-conversion>)
-endif()
-
 set(ZLIB_SOURCES_BASE
     adler32.c
     compress.c

--- a/src/native/external/zlib-intel/deflate.c
+++ b/src/native/external/zlib-intel/deflate.c
@@ -1553,10 +1553,10 @@ local block_state deflate_stored(s, flush)
         _tr_stored_block(s, (char *)0, 0L, last);
 
         /* Replace the lengths in the dummy stored block with len. */
-        s->pending_buf[s->pending - 4] = len;
-        s->pending_buf[s->pending - 3] = len >> 8;
-        s->pending_buf[s->pending - 2] = ~len;
-        s->pending_buf[s->pending - 1] = ~len >> 8;
+        s->pending_buf[s->pending - 4] = (Bytef)len;
+        s->pending_buf[s->pending - 3] = (Bytef)(len >> 8);
+        s->pending_buf[s->pending - 2] = (Bytef)~len;
+        s->pending_buf[s->pending - 1] = (Bytef)(~len >> 8);
 
         /* Write the stored block header bytes. */
         flush_pending(s->strm);

--- a/src/native/external/zlib-intel/slide_sse.c
+++ b/src/native/external/zlib-intel/slide_sse.c
@@ -18,7 +18,7 @@ void slide_hash_sse(deflate_state *s)
     unsigned n;
     Posf *p;
     uInt wsize = s->w_size;
-    z_const __m128i xmm_wsize = _mm_set1_epi16(s->w_size);
+    z_const __m128i xmm_wsize = _mm_set1_epi16((short)s->w_size);
 
     n = s->hash_size;
     p = &s->head[n] - 8;

--- a/src/native/external/zlib-intel/trees.c
+++ b/src/native/external/zlib-intel/trees.c
@@ -717,7 +717,7 @@ local void scan_tree(s, tree, max_code)
         if (++count < max_count && curlen == nextlen) {
             continue;
         } else if (count < min_count) {
-            s->bl_tree[curlen].Freq += count;
+            s->bl_tree[curlen].Freq += (ush)count;
         } else if (curlen != 0) {
             if (curlen != prevlen) s->bl_tree[curlen].Freq++;
             s->bl_tree[REP_3_6].Freq++;

--- a/src/native/external/zlib-version.txt
+++ b/src/native/external/zlib-version.txt
@@ -13,3 +13,5 @@ We have also cherry-picked into our local copy:
   This patch only affects memLevel 9 compression. .NET doesn't currently use this
   memLevel, but we'll take this patch out of an abundance of caution just in case
   we enable this functionality in a future release.
+
+We have also applied the custom patches under the patches/zlib folder.

--- a/src/native/external/zlib.cmake
+++ b/src/native/external/zlib.cmake
@@ -1,9 +1,3 @@
-if(MSVC)
-    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4244>) # conversion from 'type1' to 'type2', possible loss of data
-else(CMAKE_C_COMPILER_ID MATCHES "Clang")
-    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-implicit-int-conversion>)
-endif()
-
 set(ZLIB_SOURCES_BASE
     adler32.c
     compress.c

--- a/src/native/external/zlib/deflate.c
+++ b/src/native/external/zlib/deflate.c
@@ -1738,10 +1738,10 @@ local block_state deflate_stored(s, flush)
         _tr_stored_block(s, (char *)0, 0L, last);
 
         /* Replace the lengths in the dummy stored block with len. */
-        s->pending_buf[s->pending - 4] = len;
-        s->pending_buf[s->pending - 3] = len >> 8;
-        s->pending_buf[s->pending - 2] = ~len;
-        s->pending_buf[s->pending - 1] = ~len >> 8;
+        s->pending_buf[s->pending - 4] = (Bytef)len;
+        s->pending_buf[s->pending - 3] = (Bytef)(len >> 8);
+        s->pending_buf[s->pending - 2] = (Bytef)~len;
+        s->pending_buf[s->pending - 1] = (Bytef)(~len >> 8);
 
         /* Write the stored block header bytes. */
         flush_pending(s->strm);

--- a/src/native/external/zlib/trees.c
+++ b/src/native/external/zlib/trees.c
@@ -721,7 +721,7 @@ local void scan_tree(s, tree, max_code)
         if (++count < max_count && curlen == nextlen) {
             continue;
         } else if (count < min_count) {
-            s->bl_tree[curlen].Freq += count;
+            s->bl_tree[curlen].Freq += (ush)count;
         } else if (curlen != 0) {
             if (curlen != prevlen) s->bl_tree[curlen].Freq++;
             s->bl_tree[REP_3_6].Freq++;


### PR DESCRIPTION
Allows us to reenable mandatory MSVC C4244 compiler warning and clang's "implicit-int-conversion" warning.

See the individual .patch files for a description of the changes and justification of their correctness.
