### PR TITLE
Bump Microsoft.Private.Intellisense package version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -206,7 +206,7 @@
     <GrpcToolsVersion>2.45.0</GrpcToolsVersion>
     <CompilerPlatformTestingVersion>1.1.2-beta1.23323.1</CompilerPlatformTestingVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20221010.1</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>8.0.0-preview-20230828.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>9.0.0-alpha.1.23426.3</MicrosoftNETILLinkTasksVersion>
     <!-- Mono Cecil -->


### PR DESCRIPTION
Generated it via the dotnet-api-docs pipeline: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=382697&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=11e7ea89-affe-5194-cdc6-0171c3394706

This is not the latest version of the package but adds docs for more than half of the APIs added in .NET 8.

Will backport.