### PR TITLE
Fix Dispose and SendData Race on Http3 Test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -1626,6 +1626,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task ServerSendsTrailingHeaders_Success()
         {
             using Http3LoopbackServer server = CreateHttp3LoopbackServer();
+            SemaphoreSlim semaphore = new SemaphoreSlim(0);
 
             Task serverTask = Task.Run(async () =>
             {
@@ -1636,6 +1637,7 @@ namespace System.Net.Http.Functional.Tests
                 await requestStream.ReadRequestDataAsync();
                 await requestStream.SendResponseAsync(isFinal: false);
                 await requestStream.SendResponseHeadersAsync(null, new[] { new HttpHeaderData("MyHeader", "MyValue") });
+                await semaphore.WaitAsync();
             });
 
             Task clientTask = Task.Run(async () =>
@@ -1655,6 +1657,7 @@ namespace System.Net.Http.Functional.Tests
                 (string key, IEnumerable<string> value) = Assert.Single(response.TrailingHeaders);
                 Assert.Equal("MyHeader", key);
                 Assert.Equal("MyValue", Assert.Single(value));
+                semaphore.Release();
             });
 
             await new[] { clientTask, serverTask }.WhenAllOrAnyFailed(200_000);


### PR DESCRIPTION
Fixes #87552

When the server task was completed, the stream was getting disposed of before the sent data arrived. So with this fix, we're waiting until the client task is completed on the server task before we complete the server task.