### PR TITLE
[browser] [wasm] Request Streaming upload

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1904,7 +1904,7 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            if (enableWasmStreaming && PlatformDetection.IsBrowser && UseVersion < HttpVersion.Version20)
+            if (enableWasmStreaming && PlatformDetection.IsBrowser && UseVersion < HttpVersion20.Value)
             {
                 // Browser request streaming is only supported on HTTP/2 or higher
                 return;

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1886,13 +1886,27 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task PostAsync_ThrowFromContentCopy_RequestFails(bool syncFailure)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task PostAsync_ThrowFromContentCopy_RequestFails(bool syncFailure, bool enableWasmStreaming)
         {
             if (UseVersion == HttpVersion30)
             {
                 // TODO: Make this version-indepdendent
+                return;
+            }
+
+            if (enableWasmStreaming && PlatformDetection.IsBrowser && UseVersion < HttpVersion.Version20)
+            {
+                // Browser request streaming is only supported on HTTP/2 or higher
+                return;
+            }
+
+            if (enableWasmStreaming && !PlatformDetection.IsBrowser)
+            {
+                // enableWasmStreaming makes only sense on Browser platform
                 return;
             }
 
@@ -1914,8 +1928,20 @@ namespace System.Net.Http.Functional.Tests
                         canReadFunc: () => true,
                         readFunc: (buffer, offset, count) => throw error,
                         readAsyncFunc: (buffer, offset, count, cancellationToken) => syncFailure ? throw error : Task.Delay(1).ContinueWith<int>(_ => throw error)));
+                    var request = new HttpRequestMessage(HttpMethod.Post, uri);
+                    request.Content = content;
 
-                    Assert.Same(error, await Assert.ThrowsAsync<FormatException>(() => client.PostAsync(uri, content)));
+                    if (PlatformDetection.IsBrowser)
+                    {
+                        if (enableWasmStreaming)
+                        {
+#if !NETFRAMEWORK
+                            request.Options.Set(new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingRequest"), true);
+#endif
+                        }
+                    }
+
+                    Assert.Same(error, await Assert.ThrowsAsync<FormatException>(() => client.SendAsync(request)));
                 }
             });
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1898,15 +1898,15 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            if (enableWasmStreaming && PlatformDetection.IsBrowser && UseVersion < HttpVersion.Version20)
-            {
-                // Browser request streaming is only supported on HTTP/2 or higher
-                return;
-            }
-
             if (enableWasmStreaming && !PlatformDetection.IsBrowser)
             {
                 // enableWasmStreaming makes only sense on Browser platform
+                return;
+            }
+
+            if (enableWasmStreaming && PlatformDetection.IsBrowser && UseVersion < HttpVersion.Version20)
+            {
+                // Browser request streaming is only supported on HTTP/2 or higher
                 return;
             }
 

--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -230,7 +230,6 @@ namespace System.Net.Http.Functional.Tests
 
 #if NETCOREAPP
 
-        [OuterLoop]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
         public async Task BrowserHttpHandler_Streaming()
         {

--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -261,7 +261,8 @@ namespace System.Net.Http.Functional.Tests
                 }));
 
             using (HttpClient client = CreateHttpClientForRemoteServer(Configuration.Http.RemoteHttp2Server))
-            using (HttpResponseMessage response = await client.SendAsync(req))
+            // we need to switch off Response buffering of default ResponseContentRead option
+            using (HttpResponseMessage response = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead))
             {
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 // Streaming requests can't set Content-Length
@@ -270,6 +271,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal(typeof(StreamContent), response.Content.GetType());
 
                 var stream = await response.Content.ReadAsStreamAsync();
+                Assert.Equal("ReadOnlyStream", stream.GetType().Name);
                 var buffer = new byte[1024 * 1024];
                 int totalCount = 0;
                 int fetchedCount = 0;

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/GenericHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/GenericHandler.cs
@@ -88,6 +88,11 @@ namespace NetCoreServer
                 await LargeResponseHandler.InvokeAsync(context);
                 return;
             }
+            if (path.Equals(new PathString("/echobody.ashx")))
+            {
+                await EchoBodyHandler.InvokeAsync(context);
+                return;
+            }
 
             // Default handling.
             await EchoHandler.InvokeAsync(context);

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/EchoBodyHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/EchoBodyHandler.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace NetCoreServer
+{
+    public class EchoBodyHandler
+    {
+        public static async Task InvokeAsync(HttpContext context)
+        {
+            context.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize = null;
+
+            // Report back original request method verb.
+            context.Response.Headers["X-HttpRequest-Method"] = context.Request.Method;
+
+            // Report back original entity-body related request headers.
+            string contentLength = context.Request.Headers["Content-Length"];
+            if (!string.IsNullOrEmpty(contentLength))
+            {
+                context.Response.Headers["X-HttpRequest-Headers-ContentLength"] = contentLength;
+            }
+
+            string transferEncoding = context.Request.Headers["Transfer-Encoding"];
+            if (!string.IsNullOrEmpty(transferEncoding))
+            {
+                context.Response.Headers["X-HttpRequest-Headers-TransferEncoding"] = transferEncoding;
+            }
+
+            context.Response.StatusCode = 200;
+            context.Response.ContentType = context.Request.ContentType;
+            await context.Request.Body.CopyToAsync(context.Response.Body);
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/NetCoreServer.csproj
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/NetCoreServer.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <Compile Include="Handlers\DeflateHandler.cs" />
     <Compile Include="Handlers\EchoHandler.cs" />
+    <Compile Include="Handlers\EchoBodyHandler.cs" />
     <Compile Include="Handlers\EchoWebSocketHandler.cs" />
     <Compile Include="Handlers\EchoWebSocketHeadersHandler.cs" />
     <Compile Include="Handlers\EmptyContentHandler.cs" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -343,7 +343,7 @@ namespace System.Net.Http
     {
         private readonly Stream _stream;
         private readonly CancellationToken _cancellationToken;
-        private byte[]? _buffer;
+        private readonly byte[] _buffer;
 
         public ReadableStreamPullState(Stream stream, CancellationToken cancellationToken)
         {
@@ -362,7 +362,7 @@ namespace System.Net.Http
                 int length = await _stream.ReadAsync(view, _cancellationToken).ConfigureAwait(true);
                 using (Buffers.MemoryHandle handle = view.Pin())
                 {
-                    ReadableStreamControllerEnqueueUnsafe(this, handle, view.Length);
+                    ReadableStreamControllerEnqueueUnsafe(this, handle, length);
                 }
             }
             catch (Exception ex)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -359,6 +359,7 @@ namespace System.Net.Http
             try
             {
                 int length = await _stream.ReadAsync(_buffer, _cancellationToken).ConfigureAwait(true);
+                ReadableStreamControllerEnqueueUnsafe(this, _buffer, length);
             }
             catch (Exception ex)
             {
@@ -366,11 +367,11 @@ namespace System.Net.Http
             }
         }
 
-        private unsafe void ReadableStreamControllerEnqueueUnsafe(object pullState, int length)
+        private static unsafe void ReadableStreamControllerEnqueueUnsafe(object pullState, byte[] buffer, int length)
         {
-            fixed (byte* ptr = _buffer)
+            fixed (byte* ptr = buffer)
             {
-                BrowserHttpInterop.ReadableStreamControllerEnqueue(this, (nint)ptr, length);
+                BrowserHttpInterop.ReadableStreamControllerEnqueue(pullState, (nint)ptr, length);
             }
         }
     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -253,17 +253,20 @@ namespace System.Net.Http
                                     view = buffer ??= new byte[65536];
                                 }
 
-                                try
+                                using (controller)
                                 {
-                                    int length = await stream.ReadAsync(view, cancellationToken).ConfigureAwait(true);
-                                    using (Buffers.MemoryHandle handle = view.Pin())
+                                    try
                                     {
-                                        ReadableStreamControllerEnqueueUnsafe(controller, handle, length);
+                                        int length = await stream.ReadAsync(view, cancellationToken).ConfigureAwait(true);
+                                        using (Buffers.MemoryHandle handle = view.Pin())
+                                        {
+                                            ReadableStreamControllerEnqueueUnsafe(controller, handle, length);
+                                        }
                                     }
-                                }
-                                catch (Exception ex)
-                                {
-                                    BrowserHttpInterop.ReadableStreamControllerError(controller, ex);
+                                    catch (Exception ex)
+                                    {
+                                        BrowserHttpInterop.ReadableStreamControllerError(controller, ex);
+                                    }
                                 }
                             };
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -250,7 +250,7 @@ namespace System.Net.Http
                                 }
                                 else
                                 {
-                                    view = buffer ??= new byte[500];
+                                    view = buffer ??= new byte[65536];
                                 }
 
                                 try
@@ -258,17 +258,17 @@ namespace System.Net.Http
                                     int length = await stream.ReadAsync(view, cancellationToken).ConfigureAwait(true);
                                     using (Buffers.MemoryHandle handle = view.Pin())
                                     {
-                                        ReadableStreamControllerEnqueueUnsafe(controller, handle, length, null);
+                                        ReadableStreamControllerEnqueueUnsafe(controller, handle, length);
                                     }
                                 }
                                 catch (Exception ex)
                                 {
-                                    BrowserHttpInterop.ReadableStreamControllerEnqueue(controller, IntPtr.Zero, 0, ex.Message);
+                                    BrowserHttpInterop.ReadableStreamControllerError(controller, ex);
                                 }
                             };
 
-                            unsafe static void ReadableStreamControllerEnqueueUnsafe(JSObject controller, Buffers.MemoryHandle handle, int length, string? error) =>
-                                BrowserHttpInterop.ReadableStreamControllerEnqueue(controller, (IntPtr)handle.Pointer, length, error);
+                            unsafe static void ReadableStreamControllerEnqueueUnsafe(JSObject controller, Buffers.MemoryHandle handle, int length) =>
+                                BrowserHttpInterop.ReadableStreamControllerEnqueue(controller, (IntPtr)handle.Pointer, length);
 
                             promise = BrowserHttpInterop.Fetch(uri, headerNames.ToArray(), headerValues.ToArray(), optionNames, optionValues, abortController, pull);
                         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -11,6 +11,9 @@ namespace System.Net.Http
 {
     internal static partial class BrowserHttpInterop
     {
+        [JSImport("INTERNAL.http_wasm_supports_streaming_request")]
+        public static partial bool SupportsStreamingRequest();
+
         [JSImport("INTERNAL.http_wasm_supports_streaming_response")]
         public static partial bool SupportsStreamingResponse();
 
@@ -24,6 +27,9 @@ namespace System.Net.Http
         [JSImport("INTERNAL.http_wasm_abort_response")]
         public static partial void AbortResponse(
             JSObject fetchResponse);
+
+        [JSImport("INTERNAL.http_wasm_pull_readable_stream")]
+        public static partial bool PullReadableStream(JSObject controller, IntPtr bodyPtr, int length, string? error);
 
         [JSImport("INTERNAL.http_wasm_get_response_header_names")]
         private static partial string[] _GetResponseHeaderNames(
@@ -58,6 +64,16 @@ namespace System.Net.Http
             JSObject abortControler,
             string? body = null);
 
+        [JSImport("INTERNAL.http_wasm_fetch_stream")]
+        public static partial Task<JSObject> Fetch(
+            string uri,
+            string[] headerNames,
+            string[] headerValues,
+            string[] optionNames,
+            [JSMarshalAs<JSType.Array<JSType.Any>>] object?[] optionValues,
+            JSObject abortControler,
+            [JSMarshalAs<JSType.Function<JSType.Object>>] Action<JSObject> pull);
+
         [JSImport("INTERNAL.http_wasm_fetch_bytes")]
         private static partial Task<JSObject> FetchBytes(
             string uri,
@@ -67,8 +83,7 @@ namespace System.Net.Http
             [JSMarshalAs<JSType.Array<JSType.Any>>] object?[] optionValues,
             JSObject abortControler,
             IntPtr bodyPtr,
-            int bodyLength
-            );
+            int bodyLength);
 
         public static unsafe Task<JSObject> Fetch(string uri, string[] headerNames, string[] headerValues, string[] optionNames, object?[] optionValues, JSObject abortControler, byte[] body)
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -28,8 +28,12 @@ namespace System.Net.Http
         public static partial void AbortResponse(
             JSObject fetchResponse);
 
-        [JSImport("INTERNAL.http_wasm_pull_readable_stream")]
-        public static partial bool PullReadableStream(JSObject controller, IntPtr bodyPtr, int length, string? error);
+        [JSImport("INTERNAL.http_wasm_readable_stream_controller_buffer")]
+        [return: JSMarshalAs<JSType.MemoryView>]
+        public static partial ArraySegment<byte> GetReadableStreamBuffer(JSObject controller);
+
+        [JSImport("INTERNAL.http_wasm_readable_stream_controller_written")]
+        public static partial void ReadableStreamBufferWritten(JSObject controller, int bytesWritten, string? error);
 
         [JSImport("INTERNAL.http_wasm_get_response_header_names")]
         private static partial string[] _GetResponseHeaderNames(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -32,8 +32,12 @@ namespace System.Net.Http
         public static partial void ReadableStreamControllerEnqueue(
             JSObject controller,
             IntPtr bufferPtr,
-            int bufferLength,
-            string? error);
+            int bufferLength);
+
+        [JSImport("INTERNAL.http_wasm_readable_stream_controller_error")]
+        public static partial void ReadableStreamControllerError(
+            JSObject controller,
+            Exception error);
 
         [JSImport("INTERNAL.http_wasm_get_response_header_names")]
         private static partial string[] _GetResponseHeaderNames(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -76,7 +76,7 @@ namespace System.Net.Http
             string[] optionNames,
             [JSMarshalAs<JSType.Array<JSType.Any>>] object?[] optionValues,
             JSObject abortControler,
-            [JSMarshalAs<JSType.Function<JSType.Object>>] Action<JSObject> pull);
+            [JSMarshalAs<JSType.Function<JSType.Object, JSType.Number>>] Action<JSObject, int> pull);
 
         [JSImport("INTERNAL.http_wasm_fetch_bytes")]
         private static partial Task<JSObject> FetchBytes(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -28,12 +28,12 @@ namespace System.Net.Http
         public static partial void AbortResponse(
             JSObject fetchResponse);
 
-        [JSImport("INTERNAL.http_wasm_readable_stream_controller_buffer")]
-        [return: JSMarshalAs<JSType.MemoryView>]
-        public static partial ArraySegment<byte> GetReadableStreamBuffer(JSObject controller);
-
-        [JSImport("INTERNAL.http_wasm_readable_stream_controller_written")]
-        public static partial void ReadableStreamBufferWritten(JSObject controller, int bytesWritten, string? error);
+        [JSImport("INTERNAL.http_wasm_readable_stream_controller_enqueue")]
+        public static partial void ReadableStreamControllerEnqueue(
+            JSObject controller,
+            IntPtr bufferPtr,
+            int bufferLength,
+            string? error);
 
         [JSImport("INTERNAL.http_wasm_get_response_header_names")]
         private static partial string[] _GetResponseHeaderNames(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -30,13 +30,13 @@ namespace System.Net.Http
 
         [JSImport("INTERNAL.http_wasm_readable_stream_controller_enqueue")]
         public static partial void ReadableStreamControllerEnqueue(
-            JSObject controller,
+            [JSMarshalAs<JSType.Any>] object pullState,
             IntPtr bufferPtr,
             int bufferLength);
 
         [JSImport("INTERNAL.http_wasm_readable_stream_controller_error")]
         public static partial void ReadableStreamControllerError(
-            JSObject controller,
+            [JSMarshalAs<JSType.Any>] object pullState,
             Exception error);
 
         [JSImport("INTERNAL.http_wasm_get_response_header_names")]
@@ -80,7 +80,7 @@ namespace System.Net.Http
             string[] optionNames,
             [JSMarshalAs<JSType.Array<JSType.Any>>] object?[] optionValues,
             JSObject abortControler,
-            [JSMarshalAs<JSType.Function<JSType.Object, JSType.Number, JSType.Any>>] Action<JSObject, int, object> pull,
+            [JSMarshalAs<JSType.Function<JSType.Any>>] Action<object> pull,
             [JSMarshalAs<JSType.Any>] object pullState);
 
         [JSImport("INTERNAL.http_wasm_fetch_bytes")]

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -80,7 +80,8 @@ namespace System.Net.Http
             string[] optionNames,
             [JSMarshalAs<JSType.Array<JSType.Any>>] object?[] optionValues,
             JSObject abortControler,
-            [JSMarshalAs<JSType.Function<JSType.Object, JSType.Number>>] Action<JSObject, int> pull);
+            [JSMarshalAs<JSType.Function<JSType.Object, JSType.Number, JSType.Any>>] Action<JSObject, int, object> pull,
+            [JSMarshalAs<JSType.Any>] object pullState);
 
         [JSImport("INTERNAL.http_wasm_fetch_bytes")]
         private static partial Task<JSObject> FetchBytes(

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -4,7 +4,7 @@
 import { mono_wasm_cancel_promise } from "./cancelable-promise";
 import cwraps, { profiler_c_functions } from "./cwraps";
 import { mono_wasm_send_dbg_command_with_parms, mono_wasm_send_dbg_command, mono_wasm_get_dbg_command_info, mono_wasm_get_details, mono_wasm_release_object, mono_wasm_call_function_on, mono_wasm_debugger_resume, mono_wasm_detach_debugger, mono_wasm_raise_debug_event, mono_wasm_change_debugger_log_level, mono_wasm_debugger_attached } from "./debug";
-import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_pull_readable_stream, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
+import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_readable_stream_controller_buffer, http_wasm_readable_stream_controller_written, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
 import { exportedRuntimeAPI, Module, runtimeHelpers } from "./globals";
 import { get_property, set_property, has_property, get_typeof_property, get_global_this, dynamic_import } from "./invoke-js";
 import { mono_wasm_stringify_as_error_with_stack } from "./logging";
@@ -66,10 +66,11 @@ export function export_internal(): any {
         // BrowserHttpHandler
         http_wasm_supports_streaming_request,
         http_wasm_supports_streaming_response,
-        http_wasm_pull_readable_stream,
         http_wasm_create_abort_controler,
         http_wasm_abort_request,
         http_wasm_abort_response,
+        http_wasm_readable_stream_controller_buffer,
+        http_wasm_readable_stream_controller_written,
         http_wasm_fetch,
         http_wasm_fetch_stream,
         http_wasm_fetch_bytes,

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -4,7 +4,7 @@
 import { mono_wasm_cancel_promise } from "./cancelable-promise";
 import cwraps, { profiler_c_functions } from "./cwraps";
 import { mono_wasm_send_dbg_command_with_parms, mono_wasm_send_dbg_command, mono_wasm_get_dbg_command_info, mono_wasm_get_details, mono_wasm_release_object, mono_wasm_call_function_on, mono_wasm_debugger_resume, mono_wasm_detach_debugger, mono_wasm_raise_debug_event, mono_wasm_change_debugger_log_level, mono_wasm_debugger_attached } from "./debug";
-import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_readable_stream_controller_enqueue, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
+import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_readable_stream_controller_enqueue, http_wasm_readable_stream_controller_error, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
 import { exportedRuntimeAPI, Module, runtimeHelpers } from "./globals";
 import { get_property, set_property, has_property, get_typeof_property, get_global_this, dynamic_import } from "./invoke-js";
 import { mono_wasm_stringify_as_error_with_stack } from "./logging";
@@ -70,6 +70,7 @@ export function export_internal(): any {
         http_wasm_abort_request,
         http_wasm_abort_response,
         http_wasm_readable_stream_controller_enqueue,
+        http_wasm_readable_stream_controller_error,
         http_wasm_fetch,
         http_wasm_fetch_stream,
         http_wasm_fetch_bytes,

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -4,7 +4,7 @@
 import { mono_wasm_cancel_promise } from "./cancelable-promise";
 import cwraps, { profiler_c_functions } from "./cwraps";
 import { mono_wasm_send_dbg_command_with_parms, mono_wasm_send_dbg_command, mono_wasm_get_dbg_command_info, mono_wasm_get_details, mono_wasm_release_object, mono_wasm_call_function_on, mono_wasm_debugger_resume, mono_wasm_detach_debugger, mono_wasm_raise_debug_event, mono_wasm_change_debugger_log_level, mono_wasm_debugger_attached } from "./debug";
-import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_readable_stream_controller_buffer, http_wasm_readable_stream_controller_written, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
+import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_readable_stream_controller_enqueue, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
 import { exportedRuntimeAPI, Module, runtimeHelpers } from "./globals";
 import { get_property, set_property, has_property, get_typeof_property, get_global_this, dynamic_import } from "./invoke-js";
 import { mono_wasm_stringify_as_error_with_stack } from "./logging";
@@ -69,8 +69,7 @@ export function export_internal(): any {
         http_wasm_create_abort_controler,
         http_wasm_abort_request,
         http_wasm_abort_response,
-        http_wasm_readable_stream_controller_buffer,
-        http_wasm_readable_stream_controller_written,
+        http_wasm_readable_stream_controller_enqueue,
         http_wasm_fetch,
         http_wasm_fetch_stream,
         http_wasm_fetch_bytes,

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -4,7 +4,7 @@
 import { mono_wasm_cancel_promise } from "./cancelable-promise";
 import cwraps, { profiler_c_functions } from "./cwraps";
 import { mono_wasm_send_dbg_command_with_parms, mono_wasm_send_dbg_command, mono_wasm_get_dbg_command_info, mono_wasm_get_details, mono_wasm_release_object, mono_wasm_call_function_on, mono_wasm_debugger_resume, mono_wasm_detach_debugger, mono_wasm_raise_debug_event, mono_wasm_change_debugger_log_level, mono_wasm_debugger_attached } from "./debug";
-import { http_wasm_supports_streaming_response, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_fetch, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
+import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_pull_readable_stream, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
 import { exportedRuntimeAPI, Module, runtimeHelpers } from "./globals";
 import { get_property, set_property, has_property, get_typeof_property, get_global_this, dynamic_import } from "./invoke-js";
 import { mono_wasm_stringify_as_error_with_stack } from "./logging";
@@ -64,11 +64,14 @@ export function export_internal(): any {
         ws_wasm_abort,
 
         // BrowserHttpHandler
+        http_wasm_supports_streaming_request,
         http_wasm_supports_streaming_response,
+        http_wasm_pull_readable_stream,
         http_wasm_create_abort_controler,
         http_wasm_abort_request,
         http_wasm_abort_response,
         http_wasm_fetch,
+        http_wasm_fetch_stream,
         http_wasm_fetch_bytes,
         http_wasm_get_response_header_names,
         http_wasm_get_response_header_values,

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -81,7 +81,7 @@ export function http_wasm_readable_stream_controller_error(controller: ReadableB
     controller.__resolve_pull();
 }
 
-export function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, pull: (controller: ReadableByteStreamControllerExtension, desired_size: number) => void): Promise<ResponseExtension> {
+export function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, pull: (controller: ReadableByteStreamControllerExtension, desired_size: number, pull_state: any) => void, pull_state: any): Promise<ResponseExtension> {
     return new Promise((resolve_fetch, reject_fetch) => {
         const body = new ReadableStream({
             type: "bytes",
@@ -95,7 +95,7 @@ export function http_wasm_fetch_stream(url: string, header_names: string[], head
                 }
                 c.__resolve_pull = pull_promise_control.resolve;
                 c.__reject_fetch = reject_fetch;
-                pull(c, desired_size || 0);
+                pull(c, desired_size || 0, pull_state);
                 return pull_promise;
             },
             cancel(reason) {

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -125,7 +125,6 @@ export function http_wasm_fetch_stream(url: string, header_names: string[], head
 
     const body = new ReadableStream({
         type: "bytes",
-        autoAllocateChunkSize: 65536,
         pull,
         cancel
     });

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -81,7 +81,7 @@ export function http_wasm_readable_stream_controller_error(controller: ReadableB
     controller.__resolve_pull();
 }
 
-export function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, pull: (controller: ReadableByteStreamControllerExtension, desired_size: number, pull_state: any) => void, pull_state: any): Promise<ResponseExtension> {
+export function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, pull_delegate: (controller: ReadableByteStreamControllerExtension, desired_size: number, pull_state: any) => void, pull_state: any): Promise<ResponseExtension> {
     return new Promise((resolve_fetch, reject_fetch) => {
         const body = new ReadableStream({
             type: "bytes",
@@ -95,7 +95,7 @@ export function http_wasm_fetch_stream(url: string, header_names: string[], head
                 }
                 c.__resolve_pull = pull_promise_control.resolve;
                 c.__reject_fetch = reject_fetch;
-                pull(c, desired_size || 0, pull_state);
+                pull_delegate(c, desired_size || 0, pull_state);
                 return pull_promise;
             },
             cancel(reason) {

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -101,7 +101,7 @@ export function http_wasm_readable_stream_controller_error(pull_state: PullState
 export function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController,
     pull_delegate: (pull_state: PullStateExtension) => void,
     pull_state: PullStateExtension): Promise<ResponseExtension> {
-    function pull(controller: ReadableByteStreamController): Promise<void> {
+    function pull(controller: ReadableStreamDefaultController<Uint8Array>): Promise<void> {
         const { promise, promise_control } = createPromiseController<void>();
         try {
             mono_assert(!pull_state.__pull_promise_control, "expected pull_promise_control to be null");
@@ -123,8 +123,7 @@ export function http_wasm_fetch_stream(url: string, header_names: string[], head
         pull_state.__fetch_promise_control?.reject(error);
     }
 
-    const body = new ReadableStream({
-        type: "bytes",
+    const body = new ReadableStream<Uint8Array>({
         pull,
         cancel
     });
@@ -248,7 +247,7 @@ export function http_wasm_get_streamed_response_bytes(res: ResponseExtension, bu
 interface PullStateExtension extends ManagedObject {
     __pull_promise_control: PromiseController<void> | null
     __fetch_promise_control: PromiseController<ResponseExtension> | null
-    __controller: ReadableByteStreamController | null
+    __controller: ReadableStreamDefaultController<Uint8Array> | null
 }
 
 interface ResponseExtension extends Response {

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -18,6 +18,13 @@ function verifyEnvironment() {
 }
 
 export function http_wasm_supports_streaming_request(): boolean {
+    // Detecting streaming request support works like this:
+    // If the browser doesn't support a particular body type, it calls toString() on the object and uses the result as the body.
+    // So, if the browser doesn't support request streams, the request body becomes the string "[object ReadableStream]".
+    // When a string is used as a body, it conveniently sets the Content-Type header to text/plain;charset=UTF-8.
+    // So, if that header is set, then we know the browser doesn't support streams in request objects, and we can exit early.
+    // Safari does support streams in request objects, but doesn't allow them to be used with fetch, so the duplex option is tested, which Safari doesn't currently support.
+    // See https://developer.chrome.com/articles/fetch-streaming-requests/
     if (typeof Request !== "undefined" && "body" in Request.prototype && typeof ReadableStream === "function") {
         let duplexAccessed = false;
         const hasContentType = new Request("", {

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -81,36 +81,30 @@ export function http_wasm_readable_stream_controller_error(controller: ReadableB
     controller.__resolve_pull();
 }
 
-export async function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, pull: (controller: ReadableByteStreamControllerExtension, desired_size: number, pull_state: any) => void, pull_state: any): Promise<ResponseExtension> {
-    const { promise: fetch_promise, promise_control: fetch_promise_control } = createPromiseController<ResponseExtension>();
-    const body = new ReadableStream({
-        type: "bytes",
-        autoAllocateChunkSize: 65536,
-        pull(controller: ReadableByteStreamController) {
-            const { promise: pull_promise, promise_control: pull_promise_control } = createPromiseController<void>();
-            const c = controller as ReadableByteStreamControllerExtension;
-            let desired_size = c.desiredSize;
-            if (c.byobRequest && c.byobRequest.view) { // waiting on https://github.com/WebAssembly/design/issues/1162 so we can pass the view to .net
-                desired_size = c.byobRequest.view.byteLength;
-            }
-            c.__resolve_pull = pull_promise_control.resolve;
-            c.__reject_fetch = fetch_promise_control.reject;
-            pull(c, desired_size || 0, pull_state);
-            return pull_promise;
-        },
-        cancel(reason) {
-            fetch_promise_control.reject(reason);
-        },
+export function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, pull: (controller: ReadableByteStreamControllerExtension, desired_size: number, pull_state: any) => void, pull_state: any): Promise<ResponseExtension> {
+    return new Promise((resolve_fetch, reject_fetch) => {
+        const body = new ReadableStream({
+            type: "bytes",
+            autoAllocateChunkSize: 65536,
+            pull(controller: ReadableByteStreamController) {
+                const { promise: pull_promise, promise_control: pull_promise_control } = createPromiseController<void>();
+                const c = controller as ReadableByteStreamControllerExtension;
+                let desired_size = c.desiredSize;
+                if (c.byobRequest && c.byobRequest.view) { // waiting on https://github.com/WebAssembly/design/issues/1162 so we can pass the view to .net
+                    desired_size = c.byobRequest.view.byteLength;
+                }
+                c.__resolve_pull = pull_promise_control.resolve;
+                c.__reject_fetch = reject_fetch;
+                pull(c, desired_size || 0, pull_state);
+                return pull_promise;
+            },
+            cancel(reason) {
+                reject_fetch(reason);
+            },
+        });
+
+        http_wasm_fetch(url, header_names, header_values, option_names, option_values, abort_controller, body).then(resolve_fetch, reject_fetch);
     });
-
-    try {
-        const response = await http_wasm_fetch(url, header_names, header_values, option_names, option_values, abort_controller, body);
-        fetch_promise_control.resolve(response);
-    } catch (e) {
-        fetch_promise_control.reject(e);
-    }
-
-    return await fetch_promise;
 }
 
 export function http_wasm_fetch_bytes(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, bodyPtr: VoidPtr, bodyLength: number): Promise<ResponseExtension> {

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -101,7 +101,7 @@ export function http_wasm_readable_stream_controller_error(pull_state: PullState
 export function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController,
     pull_delegate: (pull_state: PullStateExtension) => void,
     pull_state: PullStateExtension): Promise<ResponseExtension> {
-    function pull(controller: ReadableStreamDefaultController<Uint8Array>): Promise<void> {
+    function pull(controller: ReadableByteStreamController): Promise<void> {
         const { promise, promise_control } = createPromiseController<void>();
         try {
             mono_assert(!pull_state.__pull_promise_control, "expected pull_promise_control to be null");
@@ -123,7 +123,8 @@ export function http_wasm_fetch_stream(url: string, header_names: string[], head
         pull_state.__fetch_promise_control?.reject(error);
     }
 
-    const body = new ReadableStream<Uint8Array>({
+    const body = new ReadableStream({
+        type: "bytes",
         pull,
         cancel
     });
@@ -247,7 +248,7 @@ export function http_wasm_get_streamed_response_bytes(res: ResponseExtension, bu
 interface PullStateExtension extends ManagedObject {
     __pull_promise_control: PromiseController<void> | null
     __fetch_promise_control: PromiseController<ResponseExtension> | null
-    __controller: ReadableStreamDefaultController<Uint8Array> | null
+    __controller: ReadableByteStreamController | null
 }
 
 interface ResponseExtension extends Response {


### PR DESCRIPTION
Uses a `ReadableStream` as fetch request body and reads chunks from .NET `HttpContent` stream.
The feature needs to be enabled via `HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingRequest")`. A helper could be added to [`WebAssemblyHttpRequestMessageExtensions`](https://github.com/dotnet/aspnetcore/blob/9402bfac90a695bb732dff17ba624801076df77f/src/Components/WebAssembly/WebAssembly/src/Http/WebAssemblyHttpRequestMessageExtensions.cs#L134-L151).
It is only supported using HTTP/2 or higher and is currently only implemented in Chromium (Chrome / Edge) (see https://github.com/dotnet/runtime/issues/36634#issuecomment-1418701286).

~It currently tries to get the buffer size from the browser via [`desiredSize`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableByteStreamController/desiredSize) which in my testing was always `0`. We can also remove this detection and just use the fixed default buffer size.
I also enabled [`autoAllocateChunkSize`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/ReadableStream#autoallocatechunksize) which provides us a [`byobRequest`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableByteStreamController/byobRequest) so we can copy directly into the browsers request buffer. Unfortunately https://github.com/WebAssembly/design/issues/1162 is not yet implemented which means we can't do a zero-byte transfer by passing the `ArrayBuffer` to .NET and avoid any buffers in  .NET.~
The default buffer size is currently set to `65536`. Maybe it should also be made configurable via a `HttpRequestOptionsKey`?

Exceptions from reading the `HttpContent` stream will fail the request with the thrown exception.
The special case for `StringContent` is still preferred and bypasses streaming.

I added some `BrowserHttpHandler_*` tests to `ResponseStreamTest.cs` analog to the `WebAssemblyEnableStreamingResponse` one. Maybe these `BrowserHttpHandler_*` test should be moved in their own file?
I duplicated the `PostAsync_ThrowFromContentCopy_RequsetFails` tests to use remote server, as the `Http2LoopbackServer` does not work in the browser.

Do I need to adjust something regarding `FEATURE_WASM_THREADS`?

Fixes https://github.com/dotnet/runtime/issues/36634