### PR TITLE
[browser] Print message arguments in forwarded console

### DIFF
--- a/src/mono/wasm/host/WasmLogMessage.cs
+++ b/src/mono/wasm/host/WasmLogMessage.cs
@@ -9,5 +9,5 @@ internal sealed class WasmLogMessage
 {
     public string? method { get; set; }
     public string? payload { get; set; }
-    public string[]? arguments { get; set; }
+    public object[]? arguments { get; set; }
 }

--- a/src/mono/wasm/host/WasmLogMessage.cs
+++ b/src/mono/wasm/host/WasmLogMessage.cs
@@ -9,4 +9,5 @@ internal sealed class WasmLogMessage
 {
     public string? method { get; set; }
     public string? payload { get; set; }
+    public string[]? arguments { get; set; }
 }

--- a/src/mono/wasm/host/WasmTestMessagesProcessor.cs
+++ b/src/mono/wasm/host/WasmTestMessagesProcessor.cs
@@ -31,7 +31,7 @@ internal sealed class WasmTestMessagesProcessor
                 logMessage = JsonSerializer.Deserialize<WasmLogMessage>(message);
                 if (logMessage != null)
                 {
-                    line = logMessage.payload + " " + string.Join(" ", logMessage.arguments ?? Enumerable.Empty<string>());
+                    line = logMessage.payload + " " + string.Join(" ", logMessage.arguments ?? Enumerable.Empty<object>());
                 }
                 else
                 {

--- a/src/mono/wasm/host/WasmTestMessagesProcessor.cs
+++ b/src/mono/wasm/host/WasmTestMessagesProcessor.cs
@@ -40,14 +40,15 @@ internal sealed class WasmTestMessagesProcessor
             }
             catch (JsonException)
             {
-                line = message.TrimEnd();
+                line = message;
             }
         }
         else
         {
-            line = message.TrimEnd();
+            line = message;
         }
 
+        line = line.TrimEnd();
         switch (logMessage?.method?.ToLowerInvariant())
         {
             case "console.debug": _logger.LogDebug(line); break;

--- a/src/mono/wasm/host/WasmTestMessagesProcessor.cs
+++ b/src/mono/wasm/host/WasmTestMessagesProcessor.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Linq;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
@@ -27,7 +29,14 @@ internal sealed class WasmTestMessagesProcessor
             try
             {
                 logMessage = JsonSerializer.Deserialize<WasmLogMessage>(message);
-                line = logMessage?.payload ?? message.TrimEnd();
+                if (logMessage != null)
+                {
+                    line = logMessage.payload + " " + string.Join(" ", logMessage.arguments ?? Enumerable.Empty<string>());
+                }
+                else
+                {
+                    line = message;
+                }
             }
             catch (JsonException)
             {

--- a/src/mono/wasm/runtime/loader/logging.ts
+++ b/src/mono/wasm/runtime/loader/logging.ts
@@ -73,7 +73,7 @@ export function setup_proxy_console(id: string, console: Console, origin: string
                     func(JSON.stringify({
                         method: prefix,
                         payload: payload,
-                        arguments: args
+                        arguments: args.slice(1)
                     }));
                 } else {
                     func([prefix + payload, ...args.slice(1)]);


### PR DESCRIPTION
- Print arguments for forwarded console messages from browser to apphost console
- It matches the behavior with log to actual browser console

Previous
```
MONO_WASM [0xf390c-main]: Error in bindings_init
MONO_WASM [0xf390c-main]: onRuntimeInitializedAsync() failed
MONO_WASM [0x5f4244-main]: afterLoadWasmModuleToWorker added message event handler
```
New
```
MONO_WASM [0x5f4244-main]: Error in bindings_init Can't find method System.Runtime.InteropServices.JavaScript.JavaScriptExports.InstallSynchronizationContext
MONO_WASM [0x5f4244-main]: onRuntimeInitializedAsync() failed Can't find method System.Runtime.InteropServices.JavaScript.JavaScriptExports.InstallSynchronizationContext
MONO_WASM [0x5f4244-main]: afterLoadWasmModuleToWorker added message event handler {"workerID":1}
```