### PR TITLE
[wasm] Add link to docs to interop error messages

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Resources/Strings.resx
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Resources/Strings.resx
@@ -118,112 +118,112 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ConfigurationNotSupportedTitle" xml:space="preserve">
-    <value>Specified configuration is not supported by source-generated JavaScript interop.</value>
+    <value>Specified configuration is not supported by source-generated JavaScript interop. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="ConfigurationNotSupportedMessage" xml:space="preserve">
-    <value>The '{0}' configuration is not supported by source-generated JavaScript interop.</value>
+    <value>The '{0}' configuration is not supported by source-generated JavaScript interop. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="ConfigurationNotSupportedDescription" xml:space="preserve">
-    <value>Source-generated JavaScript interop will ignore any configuration that is not supported.</value>
+    <value>Source-generated JavaScript interop will ignore any configuration that is not supported. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="ConfigurationNotSupportedMessageValue" xml:space="preserve">
-    <value>The specified value '{0}' for '{1}' is not supported by source-generated JavaScript interop.</value>
+    <value>The specified value '{0}' for '{1}' is not supported by source-generated JavaScript interop. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="ConfigurationNotSupportedMessageMarshallingInfo" xml:space="preserve">
-    <value>The specified marshalling configuration is not supported by source-generated JavaScript interop. {0}.</value>
+    <value>The specified marshalling configuration is not supported by source-generated JavaScript interop. {0}. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="TypeNotSupportedTitle" xml:space="preserve">
     <value>Specified type is not supported by source-generated JavaScript interop.</value>
   </data>
   <data name="TypeNotSupportedMessageReturnWithDetails" xml:space="preserve">
-    <value>{0} The generated source will not handle marshalling of the return value of method '{1}'.</value>
+    <value>{0} The generated source will not handle marshalling of the return value of method '{1}'. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
     <comment>{0} is a message containing additional details about what is not supported
 {1} is the name of the method</comment>
   </data>
   <data name="TypeNotSupportedDescription" xml:space="preserve">
-    <value>Type is not supported by source-generated JavaScript interop.</value>
+    <value>Type is not supported by source-generated JavaScript interop. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="TypeNotSupportedMessageParameter" xml:space="preserve">
-    <value>The type '{0}' is not supported by source-generated JavaScript interop. The generated source will not handle marshalling of parameter '{1}'.</value>
+    <value>The type '{0}' is not supported by source-generated JavaScript interop. The generated source will not handle marshalling of parameter '{1}'. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="TypeNotSupportedMessageReturn" xml:space="preserve">
-    <value>The type '{0}' is not supported by source-generated JavaScript interop. The generated source will not handle marshalling of the return value of method '{1}'.</value>
+    <value>The type '{0}' is not supported by source-generated JavaScript interop. The generated source will not handle marshalling of the return value of method '{1}'. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="TypeNotSupportedMessageParameterWithDetails" xml:space="preserve">
-    <value>{0} The generated source will not handle marshalling of parameter '{1}'.</value>
+    <value>{0} The generated source will not handle marshalling of parameter '{1}'. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
     <comment>{0} is a message containing additional details about what is not supported
 {1} is the name of the parameter</comment>
   </data>
   <data name="ConfigurationNotSupportedMessageReturn" xml:space="preserve">
-    <value>The specified '{0}' configuration for the return value of method '{1}' is not supported by source-generated JavaScript interop.</value>
+    <value>The specified '{0}' configuration for the return value of method '{1}' is not supported by source-generated JavaScript interop. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="ConfigurationNotSupportedMessageParameter" xml:space="preserve">
-    <value>The specified '{0}' configuration for parameter '{1}' is not supported by source-generated JavaScript interop.</value>
+    <value>The specified '{0}' configuration for parameter '{1}' is not supported by source-generated JavaScript interop. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="InvalidJSImportAttributeUsageTitle" xml:space="preserve">
-    <value>Invalid 'JSImportAttribute' usage</value>
+    <value>Invalid 'JSImportAttribute' usage. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="InvalidJSExportAttributeUsageTitle" xml:space="preserve">
-    <value>Invalid 'JSExportAttribute' usage</value>
+    <value>Invalid 'JSExportAttribute' usage. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="InvalidJSImportAttributedMethodSignatureMessage" xml:space="preserve">
-    <value>Method '{0}' should be 'static', 'partial', and non-generic when marked with 'JSImportAttribute'. JavaScript interop source generation will ignore method '{0}'.</value>
+    <value>Method '{0}' should be 'static', 'partial', and non-generic when marked with 'JSImportAttribute'. JavaScript interop source generation will ignore method '{0}'. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="InvalidJSExportAttributedMethodSignatureMessage" xml:space="preserve">
-    <value>Method '{0}' should be 'static', non-partial and non-generic when marked with 'JSExportAttribute'. JavaScript interop source generation will ignore method '{0}'.</value>
+    <value>Method '{0}' should be 'static', non-partial and non-generic when marked with 'JSExportAttribute'. JavaScript interop source generation will ignore method '{0}'. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="InvalidJSImportAttributedMethodDescription" xml:space="preserve">
-    <value>Methods marked with 'JSImportAttribute' should be 'static', 'partial', and non-generic. JavaScript interop source generation will ignore methods that are non-'static', non-'partial', or generic.</value>
+    <value>Methods marked with 'JSImportAttribute' should be 'static', 'partial', and non-generic. JavaScript interop source generation will ignore methods that are non-'static', non-'partial', or generic. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="InvalidJSExportAttributedMethodDescription" xml:space="preserve">
-    <value>Methods marked with 'JSImportAttribute' should be 'static', non-partial, and non-generic. JavaScript interop source generation will ignore methods that are non-'static', 'partial', or generic.</value>
+    <value>Methods marked with 'JSImportAttribute' should be 'static', non-partial, and non-generic. JavaScript interop source generation will ignore methods that are non-'static', 'partial', or generic. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="InvalidAttributedMethodContainingTypeMissingModifiersMessage" xml:space="preserve">
-    <value>Method '{0}' is contained in a type '{1}' that is not marked 'partial'. JavaScript interop source generation will ignore method '{0}'.</value>
+    <value>Method '{0}' is contained in a type '{1}' that is not marked 'partial'. JavaScript interop source generation will ignore method '{0}'. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="DiscardOnlyVoid" xml:space="preserve">
-    <value>'JSType.Discard' could be only used with void return argument.</value>
+    <value>'JSType.Discard' could be only used with void return argument. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="FuncArgumentNotSupported" xml:space="preserve">
-    <value>Type {0} is not supported as argument of marshaled function.</value>
+    <value>Type {0} is not supported as argument of marshaled function. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
     <comment>{0} is a type of the argument</comment>
   </data>
   <data name="FuncTooManyArgs" xml:space="preserve">
-    <value>Only functions with up to 3 arguments are currently supported by source-generated JavaScript interop.</value>
+    <value>Only functions with up to 3 arguments are currently supported by source-generated JavaScript interop. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="FuncWrongArgumentCount" xml:space="preserve">
-    <value>'JSType.Function' should have same number of generic arguments as the marshaled managed type.</value>
+    <value>'JSType.Function' should have same number of generic arguments as the marshaled managed type. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="InOutRefNotSupported" xml:space="preserve">
-    <value>Parameters with 'in', 'out' and 'ref' modifiers are not supported by source-generated JavaScript interop.</value>
+    <value>Parameters with 'in', 'out' and 'ref' modifiers are not supported by source-generated JavaScript interop. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="SpanAndTaskNotSupported" xml:space="preserve">
-    <value>Marshaling 'Span' on method which returns 'Task' is not supported.</value>
+    <value>Marshaling 'Span' on method which returns 'Task' is not supported. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="TypeNotSupportedName" xml:space="preserve">
-    <value>Type {0} is not supported by source-generated JavaScript interop.</value>
+    <value>Type {0} is not supported by source-generated JavaScript interop. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
     <comment>{0} is a type of the argument</comment>
   </data>
   <data name="UseJSMarshalAsAttribute" xml:space="preserve">
-    <value>Please annotate the argument with 'JSMarshalAsAttribute' to specify marshaling of {0}.</value>
+    <value>Please annotate the argument with 'JSMarshalAsAttribute' to specify marshaling of {0}. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
     <comment>{0} is a type of the argument</comment>
   </data>
   <data name="JSImportRequiresAllowUnsafeBlocksDescription" xml:space="preserve">
-    <value>JSImportAttribute requires unsafe code. Project must be updated with '&lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt;'.</value>
+    <value>JSImportAttribute requires unsafe code. Project must be updated with '&lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt;'. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="JSImportRequiresAllowUnsafeBlocksMessage" xml:space="preserve">
-    <value>JSImportAttribute requires unsafe code. Project must be updated with '&lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt;'.</value>
+    <value>JSImportAttribute requires unsafe code. Project must be updated with '&lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt;'. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="JSImportRequiresAllowUnsafeBlocksTitle" xml:space="preserve">
-    <value>JSImportAttribute requires unsafe code.</value>
+    <value>JSImportAttribute requires unsafe code. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="JSExportRequiresAllowUnsafeBlocksDescription" xml:space="preserve">
-    <value>JSExportAttribute requires unsafe code. Project must be updated with '&lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt;'.</value>
+    <value>JSExportAttribute requires unsafe code. Project must be updated with '&lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt;'. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="JSExportRequiresAllowUnsafeBlocksMessage" xml:space="preserve">
-    <value>JSExportAttribute requires unsafe code. Project must be updated with '&lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt;'.</value>
+    <value>JSExportAttribute requires unsafe code. Project must be updated with '&lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt;'. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
   <data name="JSExportRequiresAllowUnsafeBlocksTitle" xml:space="preserve">
-    <value>JSExportAttribute requires unsafe code.</value>
+    <value>JSExportAttribute requires unsafe code. For more information see https://aka.ms/dotnet-wasm-jsinterop</value>
   </data>
 </root>

--- a/src/mono/wasm/runtime/marshal-to-cs.ts
+++ b/src/mono/wasm/runtime/marshal-to-cs.ts
@@ -389,7 +389,7 @@ export function marshal_js_object_to_cs(arg: JSMarshalerArgument, value: any): v
     }
     else {
         // if value was ManagedObject, it would be double proxied, but the C# signature requires that
-        mono_check(value[js_owned_gc_handle_symbol] === undefined, "JSObject proxy of ManagedObject proxy is not supported");
+        mono_check(value[js_owned_gc_handle_symbol] === undefined, "JSObject proxy of ManagedObject proxy is not supported. For more information see https://aka.ms/dotnet-wasm-jsinterop");
         mono_check(typeof value === "function" || typeof value === "object", () => `JSObject proxy of ${typeof value} is not supported`);
 
         set_arg_type(arg, MarshalerType.JSObject);
@@ -474,7 +474,7 @@ function _marshal_cs_object_to_cs(arg: JSMarshalerArgument, value: any): void {
         else {
             assert_not_disposed(value);
             if (value instanceof ArraySegment) {
-                throw new Error("NotImplementedException: ArraySegment");
+                throw new Error("NotImplementedException: ArraySegment. For more information see https://aka.ms/dotnet-wasm-jsinterop");
             }
             else if (value instanceof ManagedError) {
                 set_arg_type(arg, MarshalerType.Exception);
@@ -484,7 +484,7 @@ function _marshal_cs_object_to_cs(arg: JSMarshalerArgument, value: any): void {
                 set_arg_type(arg, MarshalerType.Object);
                 set_gc_handle(arg, gc_handle);
             } else {
-                throw new Error("NotImplementedException " + js_type);
+                throw new Error("NotImplementedException " + js_type + ". For more information see https://aka.ms/dotnet-wasm-jsinterop");
             }
         }
     }

--- a/src/mono/wasm/runtime/marshal-to-cs.ts
+++ b/src/mono/wasm/runtime/marshal-to-cs.ts
@@ -24,6 +24,7 @@ import { TypedArray } from "./types/emscripten";
 import { addUnsettledPromise, settleUnsettledPromise } from "./pthreads/shared/eventloop";
 import { mono_log_warn } from "./logging";
 
+export const jsinteropDoc = "For more information see https://aka.ms/dotnet-wasm-jsinterop";
 
 export function initialize_marshalers_to_cs(): void {
     if (js_to_cs_marshalers.size == 0) {
@@ -389,7 +390,7 @@ export function marshal_js_object_to_cs(arg: JSMarshalerArgument, value: any): v
     }
     else {
         // if value was ManagedObject, it would be double proxied, but the C# signature requires that
-        mono_check(value[js_owned_gc_handle_symbol] === undefined, "JSObject proxy of ManagedObject proxy is not supported. For more information see https://aka.ms/dotnet-wasm-jsinterop");
+        mono_check(value[js_owned_gc_handle_symbol] === undefined, () => `JSObject proxy of ManagedObject proxy is not supported. ${jsinteropDoc}`);
         mono_check(typeof value === "function" || typeof value === "object", () => `JSObject proxy of ${typeof value} is not supported`);
 
         set_arg_type(arg, MarshalerType.JSObject);
@@ -474,7 +475,7 @@ function _marshal_cs_object_to_cs(arg: JSMarshalerArgument, value: any): void {
         else {
             assert_not_disposed(value);
             if (value instanceof ArraySegment) {
-                throw new Error("NotImplementedException: ArraySegment. For more information see https://aka.ms/dotnet-wasm-jsinterop");
+                throw new Error("NotImplementedException: ArraySegment. " + jsinteropDoc);
             }
             else if (value instanceof ManagedError) {
                 set_arg_type(arg, MarshalerType.Exception);
@@ -484,7 +485,7 @@ function _marshal_cs_object_to_cs(arg: JSMarshalerArgument, value: any): void {
                 set_arg_type(arg, MarshalerType.Object);
                 set_gc_handle(arg, gc_handle);
             } else {
-                throw new Error("NotImplementedException " + js_type + ". For more information see https://aka.ms/dotnet-wasm-jsinterop");
+                throw new Error("NotImplementedException " + js_type + ". " + jsinteropDoc);
             }
         }
     }

--- a/src/mono/wasm/runtime/marshal-to-js.ts
+++ b/src/mono/wasm/runtime/marshal-to-js.ts
@@ -18,7 +18,7 @@ import {
 import { monoStringToString } from "./strings";
 import { JSHandleNull, GCHandleNull, JSMarshalerArgument, JSMarshalerArguments, JSMarshalerType, MarshalerToCs, MarshalerToJs, BoundMarshalerToJs, MarshalerType } from "./types/internal";
 import { TypedArray } from "./types/emscripten";
-import { get_marshaler_to_cs_by_type } from "./marshal-to-cs";
+import { get_marshaler_to_cs_by_type, jsinteropDoc } from "./marshal-to-cs";
 import { localHeapViewF64, localHeapViewI32, localHeapViewU8 } from "./memory";
 
 export function initialize_marshalers_to_js(): void {
@@ -85,7 +85,7 @@ export function get_marshaler_to_js_by_type(marshaler_type: MarshalerType): Mars
         return undefined;
     }
     const converter = cs_to_js_marshalers.get(marshaler_type);
-    mono_assert(converter && typeof converter === "function", () => `ERR41: Unknown converter for type ${marshaler_type}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
+    mono_assert(converter && typeof converter === "function", () => `ERR41: Unknown converter for type ${marshaler_type}. ${jsinteropDoc}`);
     return converter;
 }
 
@@ -224,7 +224,7 @@ export function marshal_task_to_js(arg: JSMarshalerArgument, _?: MarshalerType, 
             // when we arrived here from _marshal_cs_object_to_js
             res_converter = cs_to_js_marshalers.get(type);
         }
-        mono_assert(res_converter, () => `Unknown sub_converter for type ${MarshalerType[type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
+        mono_assert(res_converter, () => `Unknown sub_converter for type ${MarshalerType[type]}. ${jsinteropDoc}`);
 
         // this is already resolved
         const val = res_converter(arg);
@@ -256,7 +256,7 @@ export function marshal_task_to_js(arg: JSMarshalerArgument, _?: MarshalerType, 
             // when we arrived here from _marshal_cs_object_to_js
             res_converter = cs_to_js_marshalers.get(type);
         }
-        mono_assert(res_converter, () => `Unknown sub_converter for type ${MarshalerType[type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
+        mono_assert(res_converter, () => `Unknown sub_converter for type ${MarshalerType[type]}. ${jsinteropDoc}`);
 
         const js_value = res_converter!(argInner);
         orig_resolve(js_value);
@@ -291,7 +291,7 @@ export function mono_wasm_marshal_promise(args: JSMarshalerArguments): void {
         else if (value_type !== MarshalerType.Task) {
             // this is already resolved task
             const sub_converter = cs_to_js_marshalers.get(value_type);
-            mono_assert(sub_converter, () => `Unknown sub_converter for type ${MarshalerType[value_type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
+            mono_assert(sub_converter, () => `Unknown sub_converter for type ${MarshalerType[value_type]}. ${jsinteropDoc}`);
             const data = sub_converter(arg_value);
             promise_control.resolve(data);
         }
@@ -406,7 +406,7 @@ function _marshal_cs_object_to_js(arg: JSMarshalerArgument): any {
 
     // other types
     const converter = cs_to_js_marshalers.get(marshaler_type);
-    mono_assert(converter, () => `Unknown converter for type ${MarshalerType[marshaler_type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
+    mono_assert(converter, () => `Unknown converter for type ${MarshalerType[marshaler_type]}. ${jsinteropDoc}`);
     return converter(arg);
 }
 
@@ -461,7 +461,7 @@ function _marshal_array_to_js_impl(arg: JSMarshalerArgument, element_type: Marsh
         result = sourceView.slice();//copy
     }
     else {
-        throw new Error(`NotImplementedException ${MarshalerType[element_type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
+        throw new Error(`NotImplementedException ${MarshalerType[element_type]}. ${jsinteropDoc}`);
     }
     Module._free(<any>buffer_ptr);
     return result;
@@ -483,7 +483,7 @@ function _marshal_span_to_js(arg: JSMarshalerArgument, element_type?: MarshalerT
         result = new Span(<any>buffer_ptr, length, MemoryViewType.Double);
     }
     else {
-        throw new Error(`NotImplementedException ${MarshalerType[element_type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
+        throw new Error(`NotImplementedException ${MarshalerType[element_type]}. ${jsinteropDoc}`);
     }
     return result;
 }
@@ -504,7 +504,7 @@ function _marshal_array_segment_to_js(arg: JSMarshalerArgument, element_type?: M
         result = new ArraySegment(<any>buffer_ptr, length, MemoryViewType.Double);
     }
     else {
-        throw new Error(`NotImplementedException ${MarshalerType[element_type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
+        throw new Error(`NotImplementedException ${MarshalerType[element_type]}. ${jsinteropDoc}`);
     }
     const gc_handle = get_arg_gc_handle(arg);
     if (BuildConfiguration === "Debug") {

--- a/src/mono/wasm/runtime/marshal-to-js.ts
+++ b/src/mono/wasm/runtime/marshal-to-js.ts
@@ -85,7 +85,7 @@ export function get_marshaler_to_js_by_type(marshaler_type: MarshalerType): Mars
         return undefined;
     }
     const converter = cs_to_js_marshalers.get(marshaler_type);
-    mono_assert(converter && typeof converter === "function", () => `ERR41: Unknown converter for type ${marshaler_type}`);
+    mono_assert(converter && typeof converter === "function", () => `ERR41: Unknown converter for type ${marshaler_type}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
     return converter;
 }
 
@@ -224,7 +224,7 @@ export function marshal_task_to_js(arg: JSMarshalerArgument, _?: MarshalerType, 
             // when we arrived here from _marshal_cs_object_to_js
             res_converter = cs_to_js_marshalers.get(type);
         }
-        mono_assert(res_converter, () => `Unknown sub_converter for type ${MarshalerType[type]} `);
+        mono_assert(res_converter, () => `Unknown sub_converter for type ${MarshalerType[type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
 
         // this is already resolved
         const val = res_converter(arg);
@@ -256,7 +256,7 @@ export function marshal_task_to_js(arg: JSMarshalerArgument, _?: MarshalerType, 
             // when we arrived here from _marshal_cs_object_to_js
             res_converter = cs_to_js_marshalers.get(type);
         }
-        mono_assert(res_converter, () => `Unknown sub_converter for type ${MarshalerType[type]}`);
+        mono_assert(res_converter, () => `Unknown sub_converter for type ${MarshalerType[type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
 
         const js_value = res_converter!(argInner);
         orig_resolve(js_value);
@@ -291,7 +291,7 @@ export function mono_wasm_marshal_promise(args: JSMarshalerArguments): void {
         else if (value_type !== MarshalerType.Task) {
             // this is already resolved task
             const sub_converter = cs_to_js_marshalers.get(value_type);
-            mono_assert(sub_converter, () => `Unknown sub_converter for type ${MarshalerType[value_type]} `);
+            mono_assert(sub_converter, () => `Unknown sub_converter for type ${MarshalerType[value_type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
             const data = sub_converter(arg_value);
             promise_control.resolve(data);
         }
@@ -406,7 +406,7 @@ function _marshal_cs_object_to_js(arg: JSMarshalerArgument): any {
 
     // other types
     const converter = cs_to_js_marshalers.get(marshaler_type);
-    mono_assert(converter, () => `Unknown converter for type ${MarshalerType[marshaler_type]}`);
+    mono_assert(converter, () => `Unknown converter for type ${MarshalerType[marshaler_type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
     return converter(arg);
 }
 
@@ -461,7 +461,7 @@ function _marshal_array_to_js_impl(arg: JSMarshalerArgument, element_type: Marsh
         result = sourceView.slice();//copy
     }
     else {
-        throw new Error(`NotImplementedException ${MarshalerType[element_type]} `);
+        throw new Error(`NotImplementedException ${MarshalerType[element_type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
     }
     Module._free(<any>buffer_ptr);
     return result;
@@ -483,7 +483,7 @@ function _marshal_span_to_js(arg: JSMarshalerArgument, element_type?: MarshalerT
         result = new Span(<any>buffer_ptr, length, MemoryViewType.Double);
     }
     else {
-        throw new Error(`NotImplementedException ${MarshalerType[element_type]} `);
+        throw new Error(`NotImplementedException ${MarshalerType[element_type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
     }
     return result;
 }
@@ -504,7 +504,7 @@ function _marshal_array_segment_to_js(arg: JSMarshalerArgument, element_type?: M
         result = new ArraySegment(<any>buffer_ptr, length, MemoryViewType.Double);
     }
     else {
-        throw new Error(`NotImplementedException ${MarshalerType[element_type]} `);
+        throw new Error(`NotImplementedException ${MarshalerType[element_type]}. For more information see https://aka.ms/dotnet-wasm-jsinterop`);
     }
     const gc_handle = get_arg_gc_handle(arg);
     if (BuildConfiguration === "Debug") {


### PR DESCRIPTION
- Add link to https://aka.ms/dotnet-wasm-jsinterop to interop error messages 

Previous
```
error SYSLIB1072: The type 'Task<int[]>' is not supported by source-generated JavaScript interop. The generated source will not handle marshalling of parameter 'meaning'.
```

New
```
error SYSLIB1072: The type 'Task<int[]>' is not supported by source-generated JavaScript interop. The generated source will not handle marshalling of parameter 'meaning'. For more information see https://aka.ms/dotnet-wasm-jsinterop
```