### PR TITLE
[ARM64] Add g_GCShadowEnd to JIT_WriteBarrier_Table

### DIFF
--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -208,7 +208,7 @@ LEAF_END ThePreStubPatch, _TEXT
 WRITE_BARRIER_ENTRY JIT_UpdateWriteBarrierState
     PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -16
 
-    // x0-x7 will contain intended new state
+    // x0-x7, x10 will contain intended new state
     // x8 will preserve skipEphemeralCheck
     // x12 will be used for pointers
 
@@ -226,29 +226,32 @@ WRITE_BARRIER_ENTRY JIT_UpdateWriteBarrierState
 #ifdef WRITE_BARRIER_CHECK
     PREPARE_EXTERNAL_VAR g_GCShadow, x12
     ldr  x2, [x12]
+
+    PREPARE_EXTERNAL_VAR g_GCShadowEnd, x12
+    ldr  x3, [x12]
 #endif
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
     PREPARE_EXTERNAL_VAR g_sw_ww_table, x12
-    ldr  x3, [x12]
+    ldr  x4, [x12]
 #endif
 
     PREPARE_EXTERNAL_VAR g_ephemeral_low, x12
-    ldr  x4, [x12]
-
-    PREPARE_EXTERNAL_VAR g_ephemeral_high, x12
     ldr  x5, [x12]
 
+    PREPARE_EXTERNAL_VAR g_ephemeral_high, x12
+    ldr  x6, [x12]
+
     cbz  x8, LOCAL_LABEL(EphemeralCheckEnabled)
-    movz x4, #0
-    movn x5, #0
+    movz x5, #0
+    movn x6, #0
 LOCAL_LABEL(EphemeralCheckEnabled):
 
     PREPARE_EXTERNAL_VAR g_lowest_address, x12
-    ldr  x6, [x12]
+    ldr  x7, [x12]
 
     PREPARE_EXTERNAL_VAR g_highest_address, x12
-    ldr  x7, [x12]
+    ldr  x10, [x12]
 
     // Update wbs state
     PREPARE_EXTERNAL_VAR JIT_WriteBarrier_Table_Loc, x12
@@ -259,6 +262,8 @@ LOCAL_LABEL(EphemeralCheckEnabled):
     stp  x2, x3, [x12], 16
     stp  x4, x5, [x12], 16
     stp  x6, x7, [x12], 16
+    str x10, [x12], 8
+
 
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 16
     EPILOG_RETURN
@@ -367,8 +372,7 @@ WRITE_BARRIER_ENTRY JIT_WriteBarrier
     add  x12, x13, x12
 
     // if (pShadow >= g_GCShadowEnd) goto end
-    PREPARE_EXTERNAL_VAR g_GCShadowEnd, x13
-    ldr  x13, [x13]
+    ldr  x13, LOCAL_LABEL(wbs_GCShadowEnd)
     cmp  x12, x13
     bhs  LOCAL_LABEL(ShadowUpdateEnd)
 
@@ -461,6 +465,8 @@ LOCAL_LABEL(wbs_card_table):
 LOCAL_LABEL(wbs_card_bundle_table):
     .quad 0
 LOCAL_LABEL(wbs_GCShadow):
+    .quad 0
+LOCAL_LABEL(wbs_GCShadowEnd):
     .quad 0
 LOCAL_LABEL(wbs_sw_ww_table):
     .quad 0

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -223,35 +223,35 @@ WRITE_BARRIER_ENTRY JIT_UpdateWriteBarrierState
     ldr  x1, [x12]
 #endif
 
-#ifdef WRITE_BARRIER_CHECK
-    PREPARE_EXTERNAL_VAR g_GCShadow, x12
-    ldr  x2, [x12]
-
-    PREPARE_EXTERNAL_VAR g_GCShadowEnd, x12
-    ldr  x3, [x12]
-#endif
-
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
     PREPARE_EXTERNAL_VAR g_sw_ww_table, x12
-    ldr  x4, [x12]
+    ldr  x2, [x12]
 #endif
 
     PREPARE_EXTERNAL_VAR g_ephemeral_low, x12
-    ldr  x5, [x12]
+    ldr  x3, [x12]
 
     PREPARE_EXTERNAL_VAR g_ephemeral_high, x12
-    ldr  x6, [x12]
+    ldr  x4, [x12]
 
     cbz  x8, LOCAL_LABEL(EphemeralCheckEnabled)
-    movz x5, #0
-    movn x6, #0
+    movz x3, #0
+    movn x4, #0
 LOCAL_LABEL(EphemeralCheckEnabled):
 
     PREPARE_EXTERNAL_VAR g_lowest_address, x12
-    ldr  x7, [x12]
+    ldr  x5, [x12]
 
     PREPARE_EXTERNAL_VAR g_highest_address, x12
+    ldr  x6, [x12]
+
+#ifdef WRITE_BARRIER_CHECK
+    PREPARE_EXTERNAL_VAR g_GCShadow, x12
+    ldr  x7, [x12]
+
+    PREPARE_EXTERNAL_VAR g_GCShadowEnd, x12
     ldr  x10, [x12]
+#endif
 
     // Update wbs state
     PREPARE_EXTERNAL_VAR JIT_WriteBarrier_Table_Loc, x12
@@ -261,8 +261,10 @@ LOCAL_LABEL(EphemeralCheckEnabled):
     stp  x0, x1, [x12], 16
     stp  x2, x3, [x12], 16
     stp  x4, x5, [x12], 16
-    stp  x6, x7, [x12], 16
-    str x10, [x12], 8
+    str  x6, [x12], 8
+#ifdef WRITE_BARRIER_CHECK
+    stp  x7, x10, [x12], 16
+#endif
 
 
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 16
@@ -464,10 +466,6 @@ LOCAL_LABEL(wbs_card_table):
     .quad 0
 LOCAL_LABEL(wbs_card_bundle_table):
     .quad 0
-LOCAL_LABEL(wbs_GCShadow):
-    .quad 0
-LOCAL_LABEL(wbs_GCShadowEnd):
-    .quad 0
 LOCAL_LABEL(wbs_sw_ww_table):
     .quad 0
 LOCAL_LABEL(wbs_ephemeral_low):
@@ -478,6 +476,12 @@ LOCAL_LABEL(wbs_lowest_address):
     .quad 0
 LOCAL_LABEL(wbs_highest_address):
     .quad 0
+#ifdef WRITE_BARRIER_CHECK
+LOCAL_LABEL(wbs_GCShadow):
+    .quad 0
+LOCAL_LABEL(wbs_GCShadowEnd):
+    .quad 0
+#endif
 WRITE_BARRIER_END JIT_WriteBarrier_Table
 
 

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -318,10 +318,10 @@ EphemeralCheckEnabled
 
 #ifdef WRITE_BARRIER_CHECK
         adrp     x12, g_GCShadow
-        ldr      x7, [x12]
+        ldr      x7, [x12, g_GCShadow]
 
         adrp     x12, g_GCShadowEnd
-        ldr      x10, [x12]
+        ldr      x10, [x12, g_GCShadowEnd]
 #endif
 
         ; Update wbs state

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -293,36 +293,36 @@ ThePreStubPatchLabel
         ldr      x1, [x12, g_card_bundle_table]
 #endif
 
-#ifdef WRITE_BARRIER_CHECK
-        adrp     x12, $g_GCShadow
-        ldr      x2, [x12, $g_GCShadow]
-
-        adrp     x12, $g_GCShadowEnd
-        ldr      x3, [x12, $g_GCShadowEnd]
-#endif
-
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         adrp     x12, g_sw_ww_table
-        ldr      x4, [x12, g_sw_ww_table]
+        ldr      x2, [x12, g_sw_ww_table]
 #endif
 
         adrp     x12, g_ephemeral_low
-        ldr      x5, [x12, g_ephemeral_low]
+        ldr      x3, [x12, g_ephemeral_low]
 
         adrp     x12, g_ephemeral_high
-        ldr      x6, [x12, g_ephemeral_high]
+        ldr      x4, [x12, g_ephemeral_high]
 
         ; Check skipEphemeralCheck
         cbz      x8, EphemeralCheckEnabled
-        movz     x5, #0
-        movn     x6, #0
+        movz     x3, #0
+        movn     x4, #0
 
 EphemeralCheckEnabled
         adrp     x12, g_lowest_address
-        ldr      x7, [x12, g_lowest_address]
+        ldr      x5, [x12, g_lowest_address]
 
         adrp     x12, g_highest_address
-        ldr      x10, [x12, g_highest_address]
+        ldr      x6, [x12, g_highest_address]
+
+#ifdef WRITE_BARRIER_CHECK
+        adrp     x12, g_GCShadow
+        ldr      x7, [x12]
+
+        adrp     x12, g_GCShadowEnd
+        ldr      x10, [x12]
+#endif
 
         ; Update wbs state
         adrp     x12, JIT_WriteBarrier_Table_Loc
@@ -331,8 +331,10 @@ EphemeralCheckEnabled
         stp      x0, x1, [x12], 16
         stp      x2, x3, [x12], 16
         stp      x4, x5, [x12], 16
-        stp      x6, x7, [x12], 16
-        str      x10, [x12], 8
+        str      x6, [x12], 8
+#ifdef WRITE_BARRIER_CHECK
+        stp     x7, x10, [x12], 16
+#endif
 
         EPILOG_RESTORE_REG_PAIR fp, lr, #16!
         EPILOG_RETURN
@@ -347,10 +349,6 @@ wbs_card_table
         DCQ 0
 wbs_card_bundle_table
         DCQ 0
-wbs_GCShadow
-        DCQ 0
-wbs_GCShadowEnd
-        DCQ 0
 wbs_sw_ww_table
         DCQ 0
 wbs_ephemeral_low
@@ -361,6 +359,12 @@ wbs_lowest_address
         DCQ 0
 wbs_highest_address
         DCQ 0
+#ifdef WRITE_BARRIER_CHECK
+wbs_GCShadow
+        DCQ 0
+wbs_GCShadowEnd
+        DCQ 0
+#endif
     WRITE_BARRIER_END JIT_WriteBarrier_Table
 
 ; void JIT_ByRefWriteBarrier

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -317,11 +317,11 @@ EphemeralCheckEnabled
         ldr      x6, [x12, g_highest_address]
 
 #ifdef WRITE_BARRIER_CHECK
-        adrp     x12, g_GCShadow
-        ldr      x7, [x12, g_GCShadow]
+        adrp     x12, $g_GCShadow
+        ldr      x7, [x12, $g_GCShadow]
 
-        adrp     x12, g_GCShadowEnd
-        ldr      x10, [x12, g_GCShadowEnd]
+        adrp     x12, $g_GCShadowEnd
+        ldr      x10, [x12, $g_GCShadowEnd]
 #endif
 
         ; Update wbs state


### PR DESCRIPTION
This change moves address of g_GCShadowEnd to JIT_WriteBarrier_Table like others variables used in Write Barrier.

This fix simmilar to RISC-V one https://github.com/dotnet/runtime/pull/90036
cc @jakobbotsch @Maoni0 @wscho77 @HJLeee @JongHeonChoi @t-mustafin @clamp03 @gbalykov @tomeksowi