### PR TITLE
Remove DirectoryInfo.ToString() from ref assembly

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
@@ -9,7 +9,7 @@ using System.IO.Enumeration;
 
 namespace System.IO
 {
-    public sealed partial class DirectoryInfo : FileSystemInfo
+    public sealed class DirectoryInfo : FileSystemInfo
     {
         private bool _isNormalized;
 

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9606,7 +9606,6 @@ namespace System.IO
         public System.IO.FileSystemInfo[] GetFileSystemInfos(string searchPattern, System.IO.EnumerationOptions enumerationOptions) { throw null; }
         public System.IO.FileSystemInfo[] GetFileSystemInfos(string searchPattern, System.IO.SearchOption searchOption) { throw null; }
         public void MoveTo(string destDirName) { }
-        public override string ToString() { throw null; }
     }
     public partial class DirectoryNotFoundException : System.IO.IOException
     {


### PR DESCRIPTION
ToString() was removed long ago (https://github.com/dotnet/runtime/commit/1ba1a9f26b120146df2a3b0a61bd94f43af033c2) and we rely on the virtual implementation from FileSystemInfo, however the ref wasn't updated and continues to show as overridden in the [`DirectoryInfo.ToString()`](https://learn.microsoft.com/dotnet/api/system.io.directoryinfo.tostring?view=net-8.0#system-io-directoryinfo-tostring) documentation.

This was discovered on https://github.com/dotnet/dotnet-api-docs/pull/9213#discussion_r1310512011.