### PR TITLE
Add DebuggerTypeProxy to ListDictionaryInternal

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/ListDictionaryInternal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/ListDictionaryInternal.cs
@@ -10,6 +10,7 @@ namespace System.Collections
     /// Recommended for collections that typically include fewer than 10 items.
     /// </summary>
     [DebuggerDisplay("Count = {count}")]
+    [DebuggerTypeProxy(typeof(ListDictionaryInternalDebugView))]
     [Serializable]
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     // Needs to be public to support binary serialization compatibility
@@ -200,6 +201,17 @@ namespace System.Collections
                 last!.next = node.next;
             }
             count--;
+        }
+
+        internal KeyValuePairs[] ToKeyValuePairsArray()
+        {
+            var array = new KeyValuePairs[count];
+            int index = 0;
+            for (DictionaryNode? node = head; node != null; node = node.next)
+            {
+                array[index++] = new KeyValuePairs(node.key, node.value);
+            }
+            return array;
         }
 
         private sealed class NodeEnumerator : IDictionaryEnumerator
@@ -404,6 +416,20 @@ namespace System.Collections
             public object key = null!;
             public object? value;
             public DictionaryNode? next;
+        }
+
+        internal sealed class ListDictionaryInternalDebugView
+        {
+            private readonly ListDictionaryInternal list;
+
+            public ListDictionaryInternalDebugView(ListDictionaryInternal list)
+            {
+                ArgumentNullException.ThrowIfNull(list);
+                this.list = list;
+            }
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public KeyValuePairs[] Items => list.ToKeyValuePairsArray();
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/ListDictionaryInternal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/ListDictionaryInternal.cs
@@ -203,7 +203,7 @@ namespace System.Collections
             count--;
         }
 
-        internal KeyValuePairs[] ToKeyValuePairsArray()
+        private KeyValuePairs[] ToKeyValuePairsArray()
         {
             var array = new KeyValuePairs[count];
             int index = 0;
@@ -418,18 +418,18 @@ namespace System.Collections
             public DictionaryNode? next;
         }
 
-        internal sealed class ListDictionaryInternalDebugView
+        private sealed class ListDictionaryInternalDebugView
         {
-            private readonly ListDictionaryInternal list;
+            private readonly ListDictionaryInternal _list;
 
             public ListDictionaryInternalDebugView(ListDictionaryInternal list)
             {
                 ArgumentNullException.ThrowIfNull(list);
-                this.list = list;
+                _list = list;
             }
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public KeyValuePairs[] Items => list.ToKeyValuePairsArray();
+            public KeyValuePairs[] Items => _list.ToKeyValuePairsArray();
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/ListDictionaryInternal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/ListDictionaryInternal.cs
@@ -203,17 +203,6 @@ namespace System.Collections
             count--;
         }
 
-        private KeyValuePairs[] ToKeyValuePairsArray()
-        {
-            var array = new KeyValuePairs[count];
-            int index = 0;
-            for (DictionaryNode? node = head; node != null; node = node.next)
-            {
-                array[index++] = new KeyValuePairs(node.key, node.value);
-            }
-            return array;
-        }
-
         private sealed class NodeEnumerator : IDictionaryEnumerator
         {
             private readonly ListDictionaryInternal list;
@@ -429,7 +418,19 @@ namespace System.Collections
             }
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public KeyValuePairs[] Items => _list.ToKeyValuePairsArray();
+            public KeyValuePairs[] Items
+            {
+                get
+                {
+                    var array = new KeyValuePairs[_list.count];
+                    int index = 0;
+                    for (DictionaryNode? node = _list.head; node != null; node = node.next)
+                    {
+                        array[index++] = new KeyValuePairs(node.key, node.value);
+                    }
+                    return array;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The ListDictionaryInternalDebugView class improves the debug view of ListDictionaryInternal instances which are used to implement the Data property of the Exception class.

fixes #91254

The old debugger view:
![Screenshot Current](https://github.com/dotnet/runtime/assets/381257/8d2be66c-db27-40cb-a850-7b90a5f8aede)


The new debugger view:
![Screenshot Updated ](https://github.com/dotnet/runtime/assets/381257/9cf022db-b43c-4f6d-a8de-a8e8bbe526ef)
