### PR TITLE
Start running the SharedLibrary test again

### DIFF
--- a/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.csproj
+++ b/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NativeLib>Shared</NativeLib>


### PR DESCRIPTION
#89696 removed the ClrTestKind and we stopped running the test.

Bad helix log from a different PR today: https://helix.dot.net/api/jobs/606118f0-c03b-4809-9529-6565ecdd4429/workitems/nativeaot.SmokeTests?api-version=2019-06-17
Good helix log from this PR: https://helix.dot.net/api/jobs/5fb0c447-5166-4092-8ab9-e92164a64de5/workitems/nativeaot.SmokeTests?api-version=2019-06-17

Cc @dotnet/ilc-contrib 