### PR TITLE
[release/8.0] Update binder gen emitted-interceptor nullability to match framework impl

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Emitter.cs
@@ -96,19 +96,19 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     EmitBindCoreCall(memberAccessExpr, initKind);
                 }
 
-                void EmitBindCoreCall(string objExpression, InitializationKind initKind)
+                void EmitBindCoreCall(string instanceExpr, InitializationKind initKind)
                 {
-                    string bindCoreCall = $@"{nameof(MethodsToGen_CoreBindingHelper.BindCore)}({configArgExpr}, ref {objExpression}, {Identifier.binderOptions});";
-                    EmitObjectInit(objExpression, initKind);
+                    string bindCoreCall = $@"{nameof(MethodsToGen_CoreBindingHelper.BindCore)}({configArgExpr}, ref {instanceExpr}, {Identifier.binderOptions});";
+                    EmitObjectInit(instanceExpr, initKind);
                     _writer.WriteLine(bindCoreCall);
-                    writeOnSuccess?.Invoke(objExpression);
+                    writeOnSuccess?.Invoke(instanceExpr);
                 }
 
-                void EmitObjectInit(string objExpression, InitializationKind initKind)
+                void EmitObjectInit(string instanceExpr, InitializationKind initKind)
                 {
                     if (initKind is not InitializationKind.None)
                     {
-                        this.EmitObjectInit(type, objExpression, initKind, configArgExpr);
+                        this.EmitObjectInit(type, instanceExpr, initKind, configArgExpr);
                     }
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/ConfigurationBinder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using SourceGenerators;
 
 namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 {
@@ -101,13 +100,13 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     return;
                 }
 
-                string objParamExpr = $"object? {Identifier.obj}";
+                string instanceParamExpr = $"object? {Identifier.instance}";
 
                 if (ShouldEmitMethods(MethodsToGen_ConfigurationBinder.Bind_instance))
                 {
                     EmitMethods(
                         MethodsToGen_ConfigurationBinder.Bind_instance,
-                        additionalParams: objParamExpr,
+                        additionalParams: instanceParamExpr,
                         configExpression: Identifier.configuration,
                         configureOptions: false);
                 }
@@ -116,7 +115,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 {
                     EmitMethods(
                         MethodsToGen_ConfigurationBinder.Bind_instance_BinderOptions,
-                        additionalParams: $"{objParamExpr}, {TypeDisplayString.NullableActionOfBinderOptions} {Identifier.configureOptions}",
+                        additionalParams: $"{instanceParamExpr}, {TypeDisplayString.NullableActionOfBinderOptions} {Identifier.configureOptions}",
                         configExpression: Identifier.configuration,
                         configureOptions: true);
                 }
@@ -125,7 +124,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 {
                     EmitMethods(
                         MethodsToGen_ConfigurationBinder.Bind_key_instance,
-                        additionalParams: $"string {Identifier.key}, {objParamExpr}",
+                        additionalParams: $"string {Identifier.key}, {instanceParamExpr}",
                         configExpression: $"{Expression.configurationGetSection}({Identifier.key})",
                         configureOptions: false);
                 }
@@ -141,17 +140,17 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         EmitInterceptsLocationAnnotations(interceptorInfoList);
                         EmitStartBlock($"public static void {Identifier.Bind}_{type.DisplayString.ToIdentifierSubstring()}(this {Identifier.IConfiguration} {Identifier.configuration}, {additionalParams})");
 
-                        if (!EmitInitException(type) && type.NeedsMemberBinding)
+                        if (type.NeedsMemberBinding)
                         {
                             string binderOptionsArg = configureOptions ? $"{Identifier.GetBinderOptions}({Identifier.configureOptions})" : $"{Identifier.binderOptions}: null";
 
                             EmitCheckForNullArgument_WithBlankLine(Identifier.configuration);
                             if (!type.IsValueType)
                             {
-                                EmitCheckForNullArgument_WithBlankLine(Identifier.obj);
+                                EmitCheckForNullArgument_WithBlankLine(Identifier.instance, voidReturn: true);
                             }
                             _writer.WriteLine($$"""
-                                var {{Identifier.typedObj}} = ({{type.EffectiveType.DisplayString}}){{Identifier.obj}};
+                                var {{Identifier.typedObj}} = ({{type.EffectiveType.DisplayString}}){{Identifier.instance}};
                                 {{nameof(MethodsToGen_CoreBindingHelper.BindCore)}}({{configExpression}}, ref {{Identifier.typedObj}}, {{binderOptionsArg}});
                                 """);
                         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/Helpers.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             private static class Identifier
             {
                 public const string binderOptions = nameof(binderOptions);
+                public const string config = nameof(config);
+                public const string configureBinder = nameof(configureBinder);
                 public const string configureOptions = nameof(configureOptions);
                 public const string configuration = nameof(configuration);
                 public const string configSectionPath = nameof(configSectionPath);
@@ -55,7 +57,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 public const string getPath = nameof(getPath);
                 public const string key = nameof(key);
                 public const string name = nameof(name);
-                public const string obj = nameof(obj);
+                public const string instance = nameof(instance);
                 public const string optionsBuilder = nameof(optionsBuilder);
                 public const string originalCount = nameof(originalCount);
                 public const string section = nameof(section);
@@ -211,12 +213,16 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 _emitBlankLineBeforeNextStatement = true;
             }
 
-            private void EmitCheckForNullArgument_WithBlankLine(string paramName)
+            private void EmitCheckForNullArgument_WithBlankLine(string paramName, bool voidReturn = false)
             {
+                string returnExpr = voidReturn
+                    ? "return"
+                    : $"throw new ArgumentNullException(nameof({paramName}))";
+
                 _writer.WriteLine($$"""
                     if ({{paramName}} is null)
                     {
-                        throw new ArgumentNullException(nameof({{paramName}}));
+                        {{returnExpr}};
                     }
                     """);
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/OptionsBuilderConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/OptionsBuilderConfigurationExtensions.cs
@@ -30,25 +30,25 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 }
 
                 const string documentation = @"/// <summary>Registers a configuration instance which <typeparamref name=""TOptions""/> will bind against.</summary>";
-                const string paramList = $"{Identifier.IConfiguration} {Identifier.configuration}";
+                const string paramList = $"{Identifier.IConfiguration} {Identifier.config}";
 
                 if (ShouldEmitMethods(MethodsToGen_Extensions_OptionsBuilder.Bind_T))
                 {
                     EmitMethodStartBlock(MethodsToGen_Extensions_OptionsBuilder.Bind_T, "Bind", paramList, documentation);
-                    _writer.WriteLine($"return Bind({Identifier.optionsBuilder}, {Identifier.configuration}, {Identifier.configureOptions}: null);");
+                    _writer.WriteLine($"return Bind({Identifier.optionsBuilder}, {Identifier.config}, {Identifier.configureBinder}: null);");
                     EmitEndBlock();
                 }
 
                 EmitMethodStartBlock(
                     MethodsToGen_Extensions_OptionsBuilder.Bind_T_BinderOptions,
                     "Bind",
-                    paramList + $", {TypeDisplayString.NullableActionOfBinderOptions} {Identifier.configureOptions}",
+                    paramList + $", {TypeDisplayString.NullableActionOfBinderOptions} {Identifier.configureBinder}",
                     documentation);
 
                 EmitCheckForNullArgument_WithBlankLine(Identifier.optionsBuilder);
 
                 _writer.WriteLine($$"""
-                    {{Identifier.Configure}}<{{Identifier.TOptions}}>({{Identifier.optionsBuilder}}.{{Identifier.Services}}, {{Identifier.optionsBuilder}}.Name, {{Identifier.configuration}}, {{Identifier.configureOptions}});
+                    {{Identifier.Configure}}<{{Identifier.TOptions}}>({{Identifier.optionsBuilder}}.{{Identifier.Services}}, {{Identifier.optionsBuilder}}.Name, {{Identifier.config}}, {{Identifier.configureBinder}});
                     return {{Identifier.optionsBuilder}};
                     """);
 
@@ -63,19 +63,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 }
 
                 const string documentation = $@"/// <summary>Registers the dependency injection container to bind <typeparamref name=""TOptions""/> against the <see cref=""{Identifier.IConfiguration}""/> obtained from the DI service provider.</summary>";
-                string paramList = $"string {Identifier.configSectionPath}, {TypeDisplayString.NullableActionOfBinderOptions} {Identifier.configureOptions} = null";
+                string paramList = $"string {Identifier.configSectionPath}, {TypeDisplayString.NullableActionOfBinderOptions} {Identifier.configureBinder} = null";
 
                 EmitMethodStartBlock(MethodsToGen_Extensions_OptionsBuilder.BindConfiguration, "BindConfiguration", paramList, documentation);
 
                 EmitCheckForNullArgument_WithBlankLine(Identifier.optionsBuilder);
                 EmitCheckForNullArgument_WithBlankLine(Identifier.configSectionPath);
 
-                EmitStartBlock($"{Identifier.optionsBuilder}.{Identifier.Configure}<{Identifier.IConfiguration}>(({Identifier.obj}, {Identifier.configuration}) =>");
-                EmitCheckForNullArgument_WithBlankLine(Identifier.obj);
-                EmitCheckForNullArgument_WithBlankLine(Identifier.configuration);
+                EmitStartBlock($"{Identifier.optionsBuilder}.{Identifier.Configure}<{Identifier.IConfiguration}>(({Identifier.instance}, {Identifier.config}) =>");
+                EmitCheckForNullArgument_WithBlankLine(Identifier.config);
                 _writer.WriteLine($$"""
-                    {{Identifier.IConfiguration}} {{Identifier.section}} = string.Equals(string.Empty, {{Identifier.configSectionPath}}, StringComparison.OrdinalIgnoreCase) ? {{Identifier.configuration}} : {{Identifier.configuration}}.{{Identifier.GetSection}}({{Identifier.configSectionPath}});
-                    {{nameof(MethodsToGen_CoreBindingHelper.BindCoreMain)}}({{Identifier.section}}, {{Identifier.obj}}, typeof({{Identifier.TOptions}}), {{Identifier.configureOptions}});
+                    {{Identifier.IConfiguration}} {{Identifier.section}} = string.Equals(string.Empty, {{Identifier.configSectionPath}}, StringComparison.OrdinalIgnoreCase) ? {{Identifier.config}} : {{Identifier.config}}.{{Identifier.GetSection}}({{Identifier.configSectionPath}});
+                    {{nameof(MethodsToGen_CoreBindingHelper.BindCoreMain)}}({{Identifier.section}}, {{Identifier.instance}}, typeof({{Identifier.TOptions}}), {{Identifier.configureBinder}});
                     """);
 
                 EmitEndBlock(endBraceTrailingSource: ");");

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/OptionsConfigurationServiceCollectionExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/OptionsConfigurationServiceCollectionExtensions.cs
@@ -24,12 +24,12 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             private void EmitConfigureMethods()
             {
                 const string defaultNameExpr = "string.Empty";
-                string configParam = $"{Identifier.IConfiguration} {Identifier.configuration}";
+                string configParam = $"{Identifier.IConfiguration} {Identifier.config}";
 
                 if (ShouldEmitMethods(MethodsToGen_Extensions_ServiceCollection.Configure_T))
                 {
                     EmitStartMethod(MethodsToGen_Extensions_ServiceCollection.Configure_T, configParam);
-                    _writer.WriteLine($"return {Identifier.Configure}<{Identifier.TOptions}>({Identifier.services}, {defaultNameExpr}, {Identifier.configuration}, {Identifier.configureOptions}: null);");
+                    _writer.WriteLine($"return {Identifier.Configure}<{Identifier.TOptions}>({Identifier.services}, {defaultNameExpr}, {Identifier.config}, {Identifier.configureOptions}: null);");
                     EmitEndBlock();
                 }
 
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     EmitStartMethod(
                         MethodsToGen_Extensions_ServiceCollection.Configure_T_name,
                         paramList: $"string? {Identifier.name}, " + configParam);
-                    _writer.WriteLine($"return {Identifier.Configure}<{Identifier.TOptions}>({Identifier.services}, {Identifier.name}, {Identifier.configuration}, {Identifier.configureOptions}: null);");
+                    _writer.WriteLine($"return {Identifier.Configure}<{Identifier.TOptions}>({Identifier.services}, {Identifier.name}, {Identifier.config}, {Identifier.configureOptions}: null);");
                     EmitEndBlock();
                 }
 
@@ -47,22 +47,20 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     EmitStartMethod(
                         MethodsToGen_Extensions_ServiceCollection.Configure_T_BinderOptions,
                         paramList: configParam + $", {TypeDisplayString.NullableActionOfBinderOptions} {Identifier.configureOptions}");
-                    _writer.WriteLine($"return {Identifier.Configure}<{Identifier.TOptions}>({Identifier.services}, {defaultNameExpr}, {Identifier.configuration}, {Identifier.configureOptions});");
+                    _writer.WriteLine($"return {Identifier.Configure}<{Identifier.TOptions}>({Identifier.services}, {defaultNameExpr}, {Identifier.config}, {Identifier.configureOptions});");
                     EmitEndBlock();
                 }
 
                 // Core Configure method that the other overloads call.
                 // Like the others, it is public API that could be called directly by users.
                 // So, it is always generated whenever a Configure overload is called.
-                string optionsNamespaceName = "Microsoft.Extensions.Options";
-
                 EmitStartMethod(MethodsToGen_Extensions_ServiceCollection.Configure_T_name_BinderOptions, paramList: $"string? {Identifier.name}, " + configParam + $", {TypeDisplayString.NullableActionOfBinderOptions} {Identifier.configureOptions}");
                 EmitCheckForNullArgument_WithBlankLine(Identifier.services);
-                EmitCheckForNullArgument_WithBlankLine(Identifier.configuration);
+                EmitCheckForNullArgument_WithBlankLine(Identifier.config);
                 _writer.WriteLine($$"""
                     OptionsServiceCollectionExtensions.AddOptions({{Identifier.services}});
-                    {{Identifier.services}}.{{Identifier.AddSingleton}}<{{Identifier.IOptionsChangeTokenSource}}<{{Identifier.TOptions}}>>(new {{Identifier.ConfigurationChangeTokenSource}}<{{Identifier.TOptions}}>({{Identifier.name}}, {{Identifier.configuration}}));
-                    return {{Identifier.services}}.{{Identifier.AddSingleton}}<{{optionsNamespaceName}}.IConfigureOptions<{{Identifier.TOptions}}>>(new {{optionsNamespaceName}}.ConfigureNamedOptions<{{Identifier.TOptions}}>({{Identifier.name}}, {{Identifier.obj}} => {{nameof(MethodsToGen_CoreBindingHelper.BindCoreMain)}}({{Identifier.configuration}}, {{Identifier.obj}}, typeof({{Identifier.TOptions}}), {{Identifier.configureOptions}})));
+                    {{Identifier.services}}.{{Identifier.AddSingleton}}<{{Identifier.IOptionsChangeTokenSource}}<{{Identifier.TOptions}}>>(new {{Identifier.ConfigurationChangeTokenSource}}<{{Identifier.TOptions}}>({{Identifier.name}}, {{Identifier.config}}));
+                    return {{Identifier.services}}.{{Identifier.AddSingleton}}<IConfigureOptions<{{Identifier.TOptions}}>>(new ConfigureNamedOptions<{{Identifier.TOptions}}>({{Identifier.name}}, {{Identifier.instance}} => {{nameof(MethodsToGen_CoreBindingHelper.BindCoreMain)}}({{Identifier.config}}, {{Identifier.instance}}, typeof({{Identifier.TOptions}}), {{Identifier.configureOptions}})));
                     """);
                 EmitEndBlock();
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/MethodsToGen.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/MethodsToGen.cs
@@ -27,17 +27,17 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         None = 0x0,
 
         /// <summary>
-        /// Bind(IConfiguration, object).
+        /// Bind(IConfiguration, object?).
         /// </summary>
         Bind_instance = 0x1,
 
         /// <summary>
-        /// Bind(IConfiguration, object, Action<BinderOptions>).
+        /// Bind(IConfiguration, object?, Action<BinderOptions>?).
         /// </summary>
         Bind_instance_BinderOptions = 0x2,
 
         /// <summary>
-        /// Bind(IConfiguration, string, object).
+        /// Bind(IConfiguration, string, object?).
         /// </summary>
         Bind_key_instance = 0x4,
 
@@ -47,17 +47,17 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         Get_T = 0x8,
 
         /// <summary>
-        /// Get<T>(IConfiguration, Action<BinderOptions>).
+        /// Get<T>(IConfiguration, Action<BinderOptions>?).
         /// </summary>
         Get_T_BinderOptions = 0x10,
 
         /// <summary>
-        /// Get<T>(IConfiguration, Type).
+        /// Get(IConfiguration, Type).
         /// </summary>
         Get_TypeOf = 0x20,
 
         /// <summary>
-        /// Get<T>(IConfiguration, Type, Action<BinderOptions>).
+        /// Get(IConfiguration, Type, Action<BinderOptions>?).
         /// </summary>
         Get_TypeOf_BinderOptions = 0x40,
 
@@ -67,7 +67,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         GetValue_TypeOf_key = 0x80,
 
         /// <summary>
-        /// GetValue(IConfiguration, Type, object).
+        /// GetValue(IConfiguration, Type, object?).
         /// </summary>
         GetValue_TypeOf_key_defaultValue = 0x100,
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/ConfigurationBinder.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     return;
                 }
 
-                int objectIndex = overload switch
+                int instanceIndex = overload switch
                 {
                     MethodsToGen_ConfigurationBinder.Bind_instance => 1,
                     MethodsToGen_ConfigurationBinder.Bind_instance_BinderOptions => 1,
@@ -80,13 +80,13 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     _ => throw new InvalidOperationException()
                 };
 
-                IArgumentOperation objectArg = operation.Arguments[objectIndex];
-                if (objectArg.Parameter.Type.SpecialType != SpecialType.System_Object)
+                IArgumentOperation instanceArg = operation.Arguments[instanceIndex];
+                if (instanceArg.Parameter.Type.SpecialType != SpecialType.System_Object)
                 {
                     return;
                 }
 
-                ITypeSymbol? type = ResolveType(objectArg.Value)?.WithNullableAnnotation(NullableAnnotation.None);
+                ITypeSymbol? type = ResolveType(instanceArg.Value)?.WithNullableAnnotation(NullableAnnotation.None);
 
                 if (!IsValidRootConfigType(type))
                 {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/OptionsBuilderConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/OptionsBuilderConfigurationExtensions.cs
@@ -25,9 +25,11 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     return;
                 }
 
-                TypeSpec typeSpec = GetTargetTypeForRootInvocation(
-                    type: targetMethod.TypeArguments[0].WithNullableAnnotation(NullableAnnotation.None),
-                    invocation.Location);
+
+                ITypeSymbol? typeSymbol = targetMethod.TypeArguments[0].WithNullableAnnotation(NullableAnnotation.None);
+                // This would violate generic type constraint; any such invocation could not have been included in the initial parser.
+                Debug.Assert(typeSymbol?.IsValueType is not true);
+                TypeSpec typeSpec = GetTargetTypeForRootInvocation(typeSymbol, invocation.Location);
 
                 if (typeSpec is null)
                 {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/OptionsConfigurationServiceCollectionExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Parser/OptionsConfigurationServiceCollectionExtensions.cs
@@ -69,9 +69,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     return;
                 }
 
-                TypeSpec typeSpec = GetTargetTypeForRootInvocation(
-                    type: targetMethod.TypeArguments[0].WithNullableAnnotation(NullableAnnotation.None),
-                    invocation.Location);
+                ITypeSymbol? typeSymbol = targetMethod.TypeArguments[0].WithNullableAnnotation(NullableAnnotation.None);
+                // This would violate generic type constraint; any such invocation could not have been included in the initial parser.
+                Debug.Assert(typeSymbol?.IsValueType is not true);
+                TypeSpec typeSpec = GetTargetTypeForRootInvocation(typeSymbol, invocation.Location);
 
                 if (typeSpec is null)
                 {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Model/ObjectSpec.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Model/ObjectSpec.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
         public List<ParameterSpec> ConstructorParameters { get; } = new();
 
-        public override bool NeedsMemberBinding => CanInitialize &&
-            Properties.Values.Count > 0 &&
-            Properties.Values.Any(p => p.ShouldBind());
+        public override bool NeedsMemberBinding => Properties.Values.Any(p => p.ShouldBind());
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Extensions.Configuration
             Action<BinderOptions>? configureOptions)
         {
             ThrowHelper.ThrowIfNull(configuration);
+            ThrowHelper.ThrowIfNull(type);
 
             var options = new BinderOptions();
             configureOptions?.Invoke(options);
@@ -108,7 +109,10 @@ namespace Microsoft.Extensions.Configuration
         [RequiresDynamicCode(DynamicCodeWarningMessage)]
         [RequiresUnreferencedCode(InstanceGetTypeTrimmingWarningMessage)]
         public static void Bind(this IConfiguration configuration, string key, object? instance)
-            => configuration.GetSection(key).Bind(instance);
+        {
+            ThrowHelper.ThrowIfNull(configuration);
+            configuration.GetSection(key).Bind(instance);
+        }
 
         /// <summary>
         /// Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.
@@ -200,6 +204,9 @@ namespace Microsoft.Extensions.Configuration
             Type type, string key,
             object? defaultValue)
         {
+            ThrowHelper.ThrowIfNull(configuration);
+            ThrowHelper.ThrowIfNull(type);
+
             IConfigurationSection section = configuration.GetSection(key);
             string? value = section.Value;
             if (value != null)
@@ -305,123 +312,120 @@ namespace Microsoft.Extensions.Configuration
                 return;
             }
 
-            if (config != null)
+            if (config.GetChildren().Any())
             {
-                if (config.GetChildren().Any())
+                // for arrays and read-only list-like interfaces, we concatenate on to what is already there, if we can
+                if (type.IsArray || IsImmutableArrayCompatibleInterface(type))
                 {
-                    // for arrays and read-only list-like interfaces, we concatenate on to what is already there, if we can
-                    if (type.IsArray || IsImmutableArrayCompatibleInterface(type))
+                    if (!bindingPoint.IsReadOnly)
                     {
-                        if (!bindingPoint.IsReadOnly)
-                        {
-                            bindingPoint.SetValue(BindArray(type, (IEnumerable?)bindingPoint.Value, config, options));
-                        }
+                        bindingPoint.SetValue(BindArray(type, (IEnumerable?)bindingPoint.Value, config, options));
+                    }
 
-                        // for getter-only collection properties that we can't add to, nothing more we can do
+                    // for getter-only collection properties that we can't add to, nothing more we can do
+                    return;
+                }
+
+                // -----------------------------------------------------------------------------------------------------------------------------
+                //                  |  bindingPoint |  bindingPoint |
+                //     Interface    |     Value     |   IsReadOnly  |  Behavior
+                // -----------------------------------------------------------------------------------------------------------------------------
+                //  ISet<T>         |   not null    |  true/false   | Use the Value instance to populate the configuration
+                //  ISet<T>         |     null      |     false     | Create HashSet<T> instance to populate the configuration
+                //  ISet<T>         |     null      |     true      | nothing
+                //  IReadOnlySet<T> | null/not null |     false     | Create HashSet<T> instance, copy over existing values, and populate the configuration
+                //  IReadOnlySet<T> | null/not null |     true      | nothing
+                // -----------------------------------------------------------------------------------------------------------------------------
+                if (TypeIsASetInterface(type))
+                {
+                    if (!bindingPoint.IsReadOnly || bindingPoint.Value is not null)
+                    {
+                        object? newValue = BindSet(type, (IEnumerable?)bindingPoint.Value, config, options);
+                        if (!bindingPoint.IsReadOnly && newValue != null)
+                        {
+                            bindingPoint.SetValue(newValue);
+                        }
+                    }
+
+                    return;
+                }
+
+                // -----------------------------------------------------------------------------------------------------------------------------
+                //                         |  bindingPoint |  bindingPoint |
+                //       Interface         |     Value     |   IsReadOnly  |  Behavior
+                // -----------------------------------------------------------------------------------------------------------------------------
+                //  IDictionary<T>         |   not null    |  true/false   | Use the Value instance to populate the configuration
+                //  IDictionary<T>         |     null      |     false     | Create Dictionary<T> instance to populate the configuration
+                //  IDictionary<T>         |     null      |     true      | nothing
+                //  IReadOnlyDictionary<T> | null/not null |     false     | Create Dictionary<K,V> instance, copy over existing values, and populate the configuration
+                //  IReadOnlyDictionary<T> | null/not null |     true      | nothing
+                // -----------------------------------------------------------------------------------------------------------------------------
+                if (TypeIsADictionaryInterface(type))
+                {
+                    if (!bindingPoint.IsReadOnly || bindingPoint.Value is not null)
+                    {
+                        object? newValue = BindDictionaryInterface(bindingPoint.Value, type, config, options);
+                        if (!bindingPoint.IsReadOnly && newValue != null)
+                        {
+                            bindingPoint.SetValue(newValue);
+                        }
+                    }
+
+                    return;
+                }
+
+                // If we don't have an instance, try to create one
+                if (bindingPoint.Value is null)
+                {
+                    // if the binding point doesn't let us set a new instance, there's nothing more we can do
+                    if (bindingPoint.IsReadOnly)
+                    {
                         return;
                     }
 
-                    // -----------------------------------------------------------------------------------------------------------------------------
-                    //                  |  bindingPoint |  bindingPoint |
-                    //     Interface    |     Value     |   IsReadOnly  |  Behavior
-                    // -----------------------------------------------------------------------------------------------------------------------------
-                    //  ISet<T>         |   not null    |  true/false   | Use the Value instance to populate the configuration
-                    //  ISet<T>         |     null      |     false     | Create HashSet<T> instance to populate the configuration
-                    //  ISet<T>         |     null      |     true      | nothing
-                    //  IReadOnlySet<T> | null/not null |     false     | Create HashSet<T> instance, copy over existing values, and populate the configuration
-                    //  IReadOnlySet<T> | null/not null |     true      | nothing
-                    // -----------------------------------------------------------------------------------------------------------------------------
-                    if (TypeIsASetInterface(type))
+                    Type? interfaceGenericType = type.IsInterface && type.IsConstructedGenericType ? type.GetGenericTypeDefinition() : null;
+
+                    if (interfaceGenericType is not null &&
+                        (interfaceGenericType == typeof(ICollection<>) || interfaceGenericType == typeof(IList<>)))
                     {
-                        if (!bindingPoint.IsReadOnly || bindingPoint.Value is not null)
-                        {
-                            object? newValue = BindSet(type, (IEnumerable?)bindingPoint.Value, config, options);
-                            if (!bindingPoint.IsReadOnly && newValue != null)
-                            {
-                                bindingPoint.SetValue(newValue);
-                            }
-                        }
-
-                        return;
-                    }
-
-                    // -----------------------------------------------------------------------------------------------------------------------------
-                    //                         |  bindingPoint |  bindingPoint |
-                    //       Interface         |     Value     |   IsReadOnly  |  Behavior
-                    // -----------------------------------------------------------------------------------------------------------------------------
-                    //  IDictionary<T>         |   not null    |  true/false   | Use the Value instance to populate the configuration
-                    //  IDictionary<T>         |     null      |     false     | Create Dictionary<T> instance to populate the configuration
-                    //  IDictionary<T>         |     null      |     true      | nothing
-                    //  IReadOnlyDictionary<T> | null/not null |     false     | Create Dictionary<K,V> instance, copy over existing values, and populate the configuration
-                    //  IReadOnlyDictionary<T> | null/not null |     true      | nothing
-                    // -----------------------------------------------------------------------------------------------------------------------------
-                    if (TypeIsADictionaryInterface(type))
-                    {
-                        if (!bindingPoint.IsReadOnly || bindingPoint.Value is not null)
-                        {
-                            object? newValue = BindDictionaryInterface(bindingPoint.Value, type, config, options);
-                            if (!bindingPoint.IsReadOnly && newValue != null)
-                            {
-                                bindingPoint.SetValue(newValue);
-                            }
-                        }
-
-                        return;
-                    }
-
-                    // If we don't have an instance, try to create one
-                    if (bindingPoint.Value is null)
-                    {
-                        // if the binding point doesn't let us set a new instance, there's nothing more we can do
-                        if (bindingPoint.IsReadOnly)
-                        {
-                            return;
-                        }
-
-                        Type? interfaceGenericType = type.IsInterface && type.IsConstructedGenericType ? type.GetGenericTypeDefinition() : null;
-
-                        if (interfaceGenericType is not null &&
-                            (interfaceGenericType == typeof(ICollection<>) || interfaceGenericType == typeof(IList<>)))
-                        {
-                            // For ICollection<T> and IList<T> we bind them to mutable List<T> type.
-                            Type genericType = typeof(List<>).MakeGenericType(type.GenericTypeArguments);
-                            bindingPoint.SetValue(Activator.CreateInstance(genericType));
-                        }
-                        else
-                        {
-                            bindingPoint.SetValue(CreateInstance(type, config, options));
-                        }
-                    }
-
-                    Debug.Assert(bindingPoint.Value is not null);
-
-                    // At this point we know that we have a non-null bindingPoint.Value, we just have to populate the items
-                    // using the IDictionary<> or ICollection<> interfaces, or properties using reflection.
-                    Type? dictionaryInterface = FindOpenGenericInterface(typeof(IDictionary<,>), type);
-
-                    if (dictionaryInterface != null)
-                    {
-                        BindDictionary(bindingPoint.Value, dictionaryInterface, config, options);
+                        // For ICollection<T> and IList<T> we bind them to mutable List<T> type.
+                        Type genericType = typeof(List<>).MakeGenericType(type.GenericTypeArguments);
+                        bindingPoint.SetValue(Activator.CreateInstance(genericType));
                     }
                     else
                     {
-                        Type? collectionInterface = FindOpenGenericInterface(typeof(ICollection<>), type);
-                        if (collectionInterface != null)
-                        {
-                            BindCollection(bindingPoint.Value, collectionInterface, config, options);
-                        }
-                        else
-                        {
-                            BindProperties(bindingPoint.Value, config, options);
-                        }
+                        bindingPoint.SetValue(CreateInstance(type, config, options));
                     }
+                }
+
+                Debug.Assert(bindingPoint.Value is not null);
+
+                // At this point we know that we have a non-null bindingPoint.Value, we just have to populate the items
+                // using the IDictionary<> or ICollection<> interfaces, or properties using reflection.
+                Type? dictionaryInterface = FindOpenGenericInterface(typeof(IDictionary<,>), type);
+
+                if (dictionaryInterface != null)
+                {
+                    BindDictionary(bindingPoint.Value, dictionaryInterface, config, options);
                 }
                 else
                 {
-                    if (isParentCollection)
+                    Type? collectionInterface = FindOpenGenericInterface(typeof(ICollection<>), type);
+                    if (collectionInterface != null)
                     {
-                        bindingPoint.TrySetValue(CreateInstance(type, config, options));
+                        BindCollection(bindingPoint.Value, collectionInterface, config, options);
                     }
+                    else
+                    {
+                        BindProperties(bindingPoint.Value, config, options);
+                    }
+                }
+            }
+            else
+            {
+                if (isParentCollection)
+                {
+                    bindingPoint.TrySetValue(CreateInstance(type, config, options));
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -2098,14 +2098,9 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             TestBind(options => config.GetSection("Local").Bind(RemoteAuthenticationOptions<OidcProviderOptions>.s_NonGenericField), obj => RemoteAuthenticationOptions<OidcProviderOptions>.s_NonGenericField);
 
             // No null refs.
-#if BUILDING_SOURCE_GENERATOR_TESTS
-
-            Assert.Throws<ArgumentNullException>(() => config.GetSection("Local").Bind(new RemoteAuthenticationOptions<OidcProviderOptions>().NullGenericProp));
-            Assert.Throws<ArgumentNullException>(() => config.GetSection("Local").Bind(RemoteAuthenticationOptions<OidcProviderOptions>.s_NullNonGenericField));
-#else
             config.GetSection("Local").Bind(new RemoteAuthenticationOptions<OidcProviderOptions>().NullGenericProp);
             config.GetSection("Local").Bind(RemoteAuthenticationOptions<OidcProviderOptions>.s_NullNonGenericField);
-#endif
+
             static void TestBind(Action<RemoteAuthenticationOptions<OidcProviderOptions>> configure, Func<RemoteAuthenticationOptions<OidcProviderOptions>, OidcProviderOptions> getBindedProp)
             {
                 var obj = new RemoteAuthenticationOptions<OidcProviderOptions>();
@@ -2120,6 +2115,82 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             var configuration = new ConfigurationBuilder().Build();
             // No diagnostic warning SYSLIB1104.
             configuration.Bind(new GraphWithUnsupportedMember());
+        }
+
+        [Fact]
+        public void TestNullHandling_Get()
+        {
+            // Null configuration.
+            IConfiguration? configuration = null;
+
+            Assert.Throws<ArgumentNullException>(() => configuration.Get<GeolocationClass>());
+            Assert.Throws<ArgumentNullException>(() => configuration.Get<GeolocationClass>(_ => { }));
+            Assert.Throws<ArgumentNullException>(() => configuration.Get<Geolocation>());
+            Assert.Throws<ArgumentNullException>(() => configuration.Get<Geolocation>(_ => { }));
+
+            // Null Type.
+            configuration = TestHelpers.GetConfigurationFromJsonString(@"{""Longitude"":1,""Latitude"":2}");
+#pragma warning disable SYSLIB1104 // The target type for a binder call could not be determined
+            Assert.Throws<ArgumentNullException>(() => configuration.Get(type: null));
+            Assert.Throws<ArgumentNullException>(() => configuration.Get(type: null, _ => { }));
+#pragma warning restore SYSLIB1104 // The target type for a binder call could not be determined
+        }
+
+        [Fact]
+        public void TestNullHandling_GetValue()
+        {
+            string key = "Longitude";
+
+            // Null configuration.
+            Test(configuration: null, key);
+
+            // Null type.
+            IConfiguration configuration = TestHelpers.GetConfigurationFromJsonString(@"{""Longitude"":1,""Latitude"":2}");
+#pragma warning disable SYSLIB1104 // The target type for a binder call could not be determined
+            Assert.Throws<ArgumentNullException>(() => configuration.GetValue(type: null, key));
+            Assert.Throws<ArgumentNullException>(() => configuration.GetValue(type: null, key, defaultValue: null));
+#pragma warning restore SYSLIB1104 // The target type for a binder call could not be determined
+
+            // Null key.
+            Test(configuration: configuration, key: null);
+
+            void Test(IConfiguration? configuration, string? key)
+            {
+                Assert.Throws<ArgumentNullException>(() => configuration.GetValue<GeolocationClass>(key));
+                Assert.Throws<ArgumentNullException>(() => configuration.GetValue<GeolocationClass>(key, defaultValue: null));
+                Assert.Throws<ArgumentNullException>(() => configuration.GetValue<Geolocation>(key));
+                Assert.Throws<ArgumentNullException>(() => configuration.GetValue<Geolocation>(key, defaultValue: default));
+                TestUntypedOverloads(configuration: null, key);
+            }
+
+            void TestUntypedOverloads(IConfiguration? configuration, string? key)
+            {
+                Assert.Throws<ArgumentNullException>(() => configuration.GetValue(typeof(GeolocationClass), key));
+                Assert.Throws<ArgumentNullException>(() => configuration.GetValue(typeof(GeolocationClass), key, defaultValue: null));
+                Assert.Throws<ArgumentNullException>(() => configuration.GetValue(typeof(GeolocationClass), key, new GeolocationClass()));
+                Assert.Throws<ArgumentNullException>(() => configuration.GetValue(typeof(Geolocation), key));
+                Assert.Throws<ArgumentNullException>(() => configuration.GetValue(typeof(Geolocation), key, defaultValue: null));
+                Assert.Throws<ArgumentNullException>(() => configuration.GetValue(typeof(Geolocation), key, default(Geolocation)));    
+            }
+        }
+
+        [Fact]
+        public void TestNullHandling_Bind()
+        {
+            // Null configuration.
+            IConfiguration? configuration = null;
+            GeolocationClass? location = new();
+            Assert.Throws<ArgumentNullException>(() => configuration.Bind(location));
+            Assert.Throws<ArgumentNullException>(() => configuration.Bind(location, _ => { }));
+            Assert.Throws<ArgumentNullException>(() => configuration.Bind("", location));
+
+            // Null object.
+            configuration = TestHelpers.GetConfigurationFromJsonString(@"{""Longitude"":1,""Latitude"":2}");
+            location = null;
+            // Expect no exceptions.
+            configuration.Bind(location);
+            configuration.Bind(location, _ => { });
+            configuration.Bind("", location);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Collections.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Collections.generated.txt
@@ -55,61 +55,61 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClassWithCustomCollections))
             {
-                var obj = new Program.MyClassWithCustomCollections();
-                BindCore(configuration, ref obj, binderOptions);
-                return obj;
+                var instance = new Program.MyClassWithCustomCollections();
+                BindCore(configuration, ref instance, binderOptions);
+                return instance;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.CustomDictionary<string, int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.CustomDictionary<string, int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = ParseInt(value, () => section.Path);
+                    instance[section.Key] = ParseInt(value, () => section.Path);
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.CustomList obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.CustomList instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(value);
+                    instance.Add(value);
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref ICollection<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref ICollection<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref IReadOnlyList<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref IReadOnlyList<int> instance, BinderOptions? binderOptions)
         {
-            if (obj is not ICollection<int> temp)
+            if (instance is not ICollection<int> temp)
             {
                 return;
             }
@@ -123,31 +123,31 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = ParseInt(value, () => section.Path);
+                    instance[section.Key] = ParseInt(value, () => section.Path);
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref IDictionary<string, int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref IDictionary<string, int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = ParseInt(value, () => section.Path);
+                    instance[section.Key] = ParseInt(value, () => section.Path);
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref IReadOnlyDictionary<string, int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref IReadOnlyDictionary<string, int> instance, BinderOptions? binderOptions)
         {
-            if (obj is not IDictionary<string, int> temp)
+            if (instance is not IDictionary<string, int> temp)
             {
                 return;
             }
@@ -161,40 +161,40 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClassWithCustomCollections obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClassWithCustomCollections instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClassWithCustomCollections), s_configKeys_ProgramMyClassWithCustomCollections, configuration, binderOptions);
 
             if (AsConfigWithChildren(configuration.GetSection("CustomDictionary")) is IConfigurationSection section1)
             {
-                Program.CustomDictionary<string, int>? temp3 = obj.CustomDictionary;
+                Program.CustomDictionary<string, int>? temp3 = instance.CustomDictionary;
                 temp3 ??= new Program.CustomDictionary<string, int>();
                 BindCore(section1, ref temp3, binderOptions);
-                obj.CustomDictionary = temp3;
+                instance.CustomDictionary = temp3;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("CustomList")) is IConfigurationSection section4)
             {
-                Program.CustomList? temp6 = obj.CustomList;
+                Program.CustomList? temp6 = instance.CustomList;
                 temp6 ??= new Program.CustomList();
                 BindCore(section4, ref temp6, binderOptions);
-                obj.CustomList = temp6;
+                instance.CustomList = temp6;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("IReadOnlyList")) is IConfigurationSection section7)
             {
-                IReadOnlyList<int>? temp9 = obj.IReadOnlyList;
+                IReadOnlyList<int>? temp9 = instance.IReadOnlyList;
                 temp9 = temp9 is null ? new List<int>() : new List<int>(temp9);
                 BindCore(section7, ref temp9, binderOptions);
-                obj.IReadOnlyList = temp9;
+                instance.IReadOnlyList = temp9;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("IReadOnlyDictionary")) is IConfigurationSection section10)
             {
-                IReadOnlyDictionary<string, int>? temp12 = obj.IReadOnlyDictionary;
+                IReadOnlyDictionary<string, int>? temp12 = instance.IReadOnlyDictionary;
                 temp12 = temp12 is null ? new Dictionary<string, int>() : temp12.ToDictionary(pair => pair.Key, pair => pair.Value);
                 BindCore(section10, ref temp12, binderOptions);
-                obj.IReadOnlyDictionary = temp12;
+                instance.IReadOnlyDictionary = temp12;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind.generated.txt
@@ -32,55 +32,55 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region IConfiguration extensions.
         /// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 13, 18)]
-        public static void Bind_ProgramMyClass(this IConfiguration configuration, object? obj)
+        public static void Bind_ProgramMyClass(this IConfiguration configuration, object? instance)
         {
             if (configuration is null)
             {
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            if (obj is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
-            var typedObj = (Program.MyClass)obj;
+            var typedObj = (Program.MyClass)instance;
             BindCore(configuration, ref typedObj, binderOptions: null);
         }
 
         /// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 14, 24)]
-        public static void Bind_ProgramMyClass(this IConfiguration configuration, object? obj, Action<BinderOptions>? configureOptions)
+        public static void Bind_ProgramMyClass(this IConfiguration configuration, object? instance, Action<BinderOptions>? configureOptions)
         {
             if (configuration is null)
             {
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            if (obj is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
-            var typedObj = (Program.MyClass)obj;
+            var typedObj = (Program.MyClass)instance;
             BindCore(configuration, ref typedObj, GetBinderOptions(configureOptions));
         }
 
         /// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 15, 24)]
-        public static void Bind_ProgramMyClass(this IConfiguration configuration, string key, object? obj)
+        public static void Bind_ProgramMyClass(this IConfiguration configuration, string key, object? instance)
         {
             if (configuration is null)
             {
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            if (obj is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
-            var typedObj = (Program.MyClass)obj;
+            var typedObj = (Program.MyClass)instance;
             BindCore(configuration.GetSection(key), ref typedObj, binderOptions: null);
         }
         #endregion IConfiguration extensions.
@@ -88,73 +88,73 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList", "MyDictionary", "MyComplexDictionary" });
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = value;
+                    instance[section.Key] = value;
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
-                if (!(obj.TryGetValue(section.Key, out Program.MyClass2? element) && element is not null))
+                if (!(instance.TryGetValue(section.Key, out Program.MyClass2? element) && element is not null))
                 {
                     element = new Program.MyClass2();
                 }
-                obj[section.Key] = element;
+                instance[section.Key] = element;
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value1)
             {
-                obj.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section2)
             {
-                List<int>? temp4 = obj.MyList;
+                List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
                 BindCore(section2, ref temp4, binderOptions);
-                obj.MyList = temp4;
+                instance.MyList = temp4;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyDictionary")) is IConfigurationSection section5)
             {
-                Dictionary<string, string>? temp7 = obj.MyDictionary;
+                Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
                 BindCore(section5, ref temp7, binderOptions);
-                obj.MyDictionary = temp7;
+                instance.MyDictionary = temp7;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyComplexDictionary")) is IConfigurationSection section8)
             {
-                Dictionary<string, Program.MyClass2>? temp10 = obj.MyComplexDictionary;
+                Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
                 BindCore(section8, ref temp10, binderOptions);
-                obj.MyComplexDictionary = temp10;
+                instance.MyComplexDictionary = temp10;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance.generated.txt
@@ -32,19 +32,19 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region IConfiguration extensions.
         /// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 12, 20)]
-        public static void Bind_ProgramMyClass(this IConfiguration configuration, object? obj)
+        public static void Bind_ProgramMyClass(this IConfiguration configuration, object? instance)
         {
             if (configuration is null)
             {
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            if (obj is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
-            var typedObj = (Program.MyClass)obj;
+            var typedObj = (Program.MyClass)instance;
             BindCore(configuration, ref typedObj, binderOptions: null);
         }
         #endregion IConfiguration extensions.
@@ -52,73 +52,73 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList", "MyDictionary", "MyComplexDictionary" });
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = value;
+                    instance[section.Key] = value;
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
-                if (!(obj.TryGetValue(section.Key, out Program.MyClass2? element) && element is not null))
+                if (!(instance.TryGetValue(section.Key, out Program.MyClass2? element) && element is not null))
                 {
                     element = new Program.MyClass2();
                 }
-                obj[section.Key] = element;
+                instance[section.Key] = element;
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value1)
             {
-                obj.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section2)
             {
-                List<int>? temp4 = obj.MyList;
+                List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
                 BindCore(section2, ref temp4, binderOptions);
-                obj.MyList = temp4;
+                instance.MyList = temp4;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyDictionary")) is IConfigurationSection section5)
             {
-                Dictionary<string, string>? temp7 = obj.MyDictionary;
+                Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
                 BindCore(section5, ref temp7, binderOptions);
-                obj.MyDictionary = temp7;
+                instance.MyDictionary = temp7;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyComplexDictionary")) is IConfigurationSection section8)
             {
-                Dictionary<string, Program.MyClass2>? temp10 = obj.MyComplexDictionary;
+                Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
                 BindCore(section8, ref temp10, binderOptions);
-                obj.MyComplexDictionary = temp10;
+                instance.MyComplexDictionary = temp10;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance_BinderOptions.generated.txt
@@ -32,19 +32,19 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region IConfiguration extensions.
         /// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 12, 20)]
-        public static void Bind_ProgramMyClass(this IConfiguration configuration, object? obj, Action<BinderOptions>? configureOptions)
+        public static void Bind_ProgramMyClass(this IConfiguration configuration, object? instance, Action<BinderOptions>? configureOptions)
         {
             if (configuration is null)
             {
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            if (obj is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
-            var typedObj = (Program.MyClass)obj;
+            var typedObj = (Program.MyClass)instance;
             BindCore(configuration, ref typedObj, GetBinderOptions(configureOptions));
         }
         #endregion IConfiguration extensions.
@@ -52,73 +52,73 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList", "MyDictionary", "MyComplexDictionary" });
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = value;
+                    instance[section.Key] = value;
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
-                if (!(obj.TryGetValue(section.Key, out Program.MyClass2? element) && element is not null))
+                if (!(instance.TryGetValue(section.Key, out Program.MyClass2? element) && element is not null))
                 {
                     element = new Program.MyClass2();
                 }
-                obj[section.Key] = element;
+                instance[section.Key] = element;
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value1)
             {
-                obj.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section2)
             {
-                List<int>? temp4 = obj.MyList;
+                List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
                 BindCore(section2, ref temp4, binderOptions);
-                obj.MyList = temp4;
+                instance.MyList = temp4;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyDictionary")) is IConfigurationSection section5)
             {
-                Dictionary<string, string>? temp7 = obj.MyDictionary;
+                Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
                 BindCore(section5, ref temp7, binderOptions);
-                obj.MyDictionary = temp7;
+                instance.MyDictionary = temp7;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyComplexDictionary")) is IConfigurationSection section8)
             {
-                Dictionary<string, Program.MyClass2>? temp10 = obj.MyComplexDictionary;
+                Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
                 BindCore(section8, ref temp10, binderOptions);
-                obj.MyComplexDictionary = temp10;
+                instance.MyComplexDictionary = temp10;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Key_Instance.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Key_Instance.generated.txt
@@ -32,19 +32,19 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region IConfiguration extensions.
         /// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 12, 20)]
-        public static void Bind_ProgramMyClass(this IConfiguration configuration, string key, object? obj)
+        public static void Bind_ProgramMyClass(this IConfiguration configuration, string key, object? instance)
         {
             if (configuration is null)
             {
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            if (obj is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
-            var typedObj = (Program.MyClass)obj;
+            var typedObj = (Program.MyClass)instance;
             BindCore(configuration.GetSection(key), ref typedObj, binderOptions: null);
         }
         #endregion IConfiguration extensions.
@@ -52,73 +52,73 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList", "MyDictionary", "MyComplexDictionary" });
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = value;
+                    instance[section.Key] = value;
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
-                if (!(obj.TryGetValue(section.Key, out Program.MyClass2? element) && element is not null))
+                if (!(instance.TryGetValue(section.Key, out Program.MyClass2? element) && element is not null))
                 {
                     element = new Program.MyClass2();
                 }
-                obj[section.Key] = element;
+                instance[section.Key] = element;
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value1)
             {
-                obj.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section2)
             {
-                List<int>? temp4 = obj.MyList;
+                List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
                 BindCore(section2, ref temp4, binderOptions);
-                obj.MyList = temp4;
+                instance.MyList = temp4;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyDictionary")) is IConfigurationSection section5)
             {
-                Dictionary<string, string>? temp7 = obj.MyDictionary;
+                Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
                 BindCore(section5, ref temp7, binderOptions);
-                obj.MyDictionary = temp7;
+                instance.MyDictionary = temp7;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyComplexDictionary")) is IConfigurationSection section8)
             {
-                Dictionary<string, Program.MyClass2>? temp10 = obj.MyComplexDictionary;
+                Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
                 BindCore(section8, ref temp10, binderOptions);
-                obj.MyComplexDictionary = temp10;
+                instance.MyComplexDictionary = temp10;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get.generated.txt
@@ -67,94 +67,94 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClass))
             {
-                var obj = new Program.MyClass();
-                BindCore(configuration, ref obj, binderOptions);
-                return obj;
+                var instance = new Program.MyClass();
+                BindCore(configuration, ref instance, binderOptions);
+                return instance;
             }
             else if (type == typeof(Program.MyClass2))
             {
-                var obj = new Program.MyClass2();
-                BindCore(configuration, ref obj, binderOptions);
-                return obj;
+                var instance = new Program.MyClass2();
+                BindCore(configuration, ref instance, binderOptions);
+                return instance;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref int[] obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref int[] instance, BinderOptions? binderOptions)
         {
             var temp2 = new List<int>();
             BindCore(configuration, ref temp2, binderOptions);
-            int originalCount = obj.Length;
-            Array.Resize(ref obj, originalCount + temp2.Count);
-            temp2.CopyTo(obj, originalCount);
+            int originalCount = instance.Length;
+            Array.Resize(ref instance, originalCount + temp2.Count);
+            temp2.CopyTo(instance, originalCount);
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = value;
+                    instance[section.Key] = value;
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value5)
             {
-                obj.MyInt = ParseInt(value5, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value5, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section6)
             {
-                List<int>? temp8 = obj.MyList;
+                List<int>? temp8 = instance.MyList;
                 temp8 ??= new List<int>();
                 BindCore(section6, ref temp8, binderOptions);
-                obj.MyList = temp8;
+                instance.MyList = temp8;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyArray")) is IConfigurationSection section9)
             {
-                int[]? temp11 = obj.MyArray;
+                int[]? temp11 = instance.MyArray;
                 temp11 ??= new int[0];
                 BindCore(section9, ref temp11, binderOptions);
-                obj.MyArray = temp11;
+                instance.MyArray = temp11;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyDictionary")) is IConfigurationSection section12)
             {
-                Dictionary<string, string>? temp14 = obj.MyDictionary;
+                Dictionary<string, string>? temp14 = instance.MyDictionary;
                 temp14 ??= new Dictionary<string, string>();
                 BindCore(section12, ref temp14, binderOptions);
-                obj.MyDictionary = temp14;
+                instance.MyDictionary = temp14;
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
             if (configuration["MyInt"] is string value15)
             {
-                obj.MyInt = ParseInt(value15, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value15, () => configuration.GetSection("MyInt").Path);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T.generated.txt
@@ -54,78 +54,78 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClass))
             {
-                var obj = new Program.MyClass();
-                BindCore(configuration, ref obj, binderOptions);
-                return obj;
+                var instance = new Program.MyClass();
+                BindCore(configuration, ref instance, binderOptions);
+                return instance;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref int[] obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref int[] instance, BinderOptions? binderOptions)
         {
             var temp1 = new List<int>();
             BindCore(configuration, ref temp1, binderOptions);
-            int originalCount = obj.Length;
-            Array.Resize(ref obj, originalCount + temp1.Count);
-            temp1.CopyTo(obj, originalCount);
+            int originalCount = instance.Length;
+            Array.Resize(ref instance, originalCount + temp1.Count);
+            temp1.CopyTo(instance, originalCount);
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = value;
+                    instance[section.Key] = value;
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value4)
             {
-                obj.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section5)
             {
-                List<int>? temp7 = obj.MyList;
+                List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
                 BindCore(section5, ref temp7, binderOptions);
-                obj.MyList = temp7;
+                instance.MyList = temp7;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyArray")) is IConfigurationSection section8)
             {
-                int[]? temp10 = obj.MyArray;
+                int[]? temp10 = instance.MyArray;
                 temp10 ??= new int[0];
                 BindCore(section8, ref temp10, binderOptions);
-                obj.MyArray = temp10;
+                instance.MyArray = temp10;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyDictionary")) is IConfigurationSection section11)
             {
-                Dictionary<string, string>? temp13 = obj.MyDictionary;
+                Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
                 BindCore(section11, ref temp13, binderOptions);
-                obj.MyDictionary = temp13;
+                instance.MyDictionary = temp13;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T_BinderOptions.generated.txt
@@ -54,78 +54,78 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClass))
             {
-                var obj = new Program.MyClass();
-                BindCore(configuration, ref obj, binderOptions);
-                return obj;
+                var instance = new Program.MyClass();
+                BindCore(configuration, ref instance, binderOptions);
+                return instance;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref int[] obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref int[] instance, BinderOptions? binderOptions)
         {
             var temp1 = new List<int>();
             BindCore(configuration, ref temp1, binderOptions);
-            int originalCount = obj.Length;
-            Array.Resize(ref obj, originalCount + temp1.Count);
-            temp1.CopyTo(obj, originalCount);
+            int originalCount = instance.Length;
+            Array.Resize(ref instance, originalCount + temp1.Count);
+            temp1.CopyTo(instance, originalCount);
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = value;
+                    instance[section.Key] = value;
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value4)
             {
-                obj.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section5)
             {
-                List<int>? temp7 = obj.MyList;
+                List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
                 BindCore(section5, ref temp7, binderOptions);
-                obj.MyList = temp7;
+                instance.MyList = temp7;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyArray")) is IConfigurationSection section8)
             {
-                int[]? temp10 = obj.MyArray;
+                int[]? temp10 = instance.MyArray;
                 temp10 ??= new int[0];
                 BindCore(section8, ref temp10, binderOptions);
-                obj.MyArray = temp10;
+                instance.MyArray = temp10;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyDictionary")) is IConfigurationSection section11)
             {
-                Dictionary<string, string>? temp13 = obj.MyDictionary;
+                Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
                 BindCore(section11, ref temp13, binderOptions);
-                obj.MyDictionary = temp13;
+                instance.MyDictionary = temp13;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf.generated.txt
@@ -54,21 +54,21 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClass2))
             {
-                var obj = new Program.MyClass2();
-                BindCore(configuration, ref obj, binderOptions);
-                return obj;
+                var instance = new Program.MyClass2();
+                BindCore(configuration, ref instance, binderOptions);
+                return instance;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
             if (configuration["MyInt"] is string value1)
             {
-                obj.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf_BinderOptions.generated.txt
@@ -54,21 +54,21 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClass2))
             {
-                var obj = new Program.MyClass2();
-                BindCore(configuration, ref obj, binderOptions);
-                return obj;
+                var instance = new Program.MyClass2();
+                BindCore(configuration, ref instance, binderOptions);
+                return instance;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
             if (configuration["MyInt"] is string value1)
             {
-                obj.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/BindConfiguration.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/BindConfiguration.generated.txt
@@ -34,7 +34,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region OptionsBuilder<TOptions> extensions.
         /// <summary>Registers the dependency injection container to bind <typeparamref name="TOptions"/> against the <see cref="IConfiguration"/> obtained from the DI service provider.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 12, 24)]
-        public static OptionsBuilder<TOptions> BindConfiguration<TOptions>(this OptionsBuilder<TOptions> optionsBuilder, string configSectionPath, Action<BinderOptions>? configureOptions = null) where TOptions : class
+        public static OptionsBuilder<TOptions> BindConfiguration<TOptions>(this OptionsBuilder<TOptions> optionsBuilder, string configSectionPath, Action<BinderOptions>? configureBinder = null) where TOptions : class
         {
             if (optionsBuilder is null)
             {
@@ -46,20 +46,15 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 throw new ArgumentNullException(nameof(configSectionPath));
             }
 
-            optionsBuilder.Configure<IConfiguration>((obj, configuration) =>
+            optionsBuilder.Configure<IConfiguration>((instance, config) =>
             {
-                if (obj is null)
+                if (config is null)
                 {
-                    throw new ArgumentNullException(nameof(obj));
+                    throw new ArgumentNullException(nameof(config));
                 }
 
-                if (configuration is null)
-                {
-                    throw new ArgumentNullException(nameof(configuration));
-                }
-
-                IConfiguration section = string.Equals(string.Empty, configSectionPath, StringComparison.OrdinalIgnoreCase) ? configuration : configuration.GetSection(configSectionPath);
-                BindCoreMain(section, obj, typeof(TOptions), configureOptions);
+                IConfiguration section = string.Equals(string.Empty, configSectionPath, StringComparison.OrdinalIgnoreCase) ? config : config.GetSection(configSectionPath);
+                BindCoreMain(section, instance, typeof(TOptions), configureBinder);
             });
 
             optionsBuilder.Services.AddSingleton<IOptionsChangeTokenSource<TOptions>, ConfigurationChangeTokenSource<TOptions>>();
@@ -70,16 +65,11 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList" });
 
-        public static void BindCoreMain(IConfiguration configuration, object obj, Type type, Action<BinderOptions>? configureOptions)
+        public static void BindCoreMain(IConfiguration configuration, object instance, Type type, Action<BinderOptions>? configureOptions)
         {
-            if (configuration is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
             if (!HasValueOrChildren(configuration))
@@ -91,7 +81,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClass))
             {
-                var temp = (Program.MyClass)obj;
+                var temp = (Program.MyClass)instance;
                 BindCore(configuration, ref temp, binderOptions);
                 return;
             }
@@ -99,34 +89,34 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value2)
             {
-                obj.MyInt = ParseInt(value2, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value2, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section3)
             {
-                List<int>? temp5 = obj.MyList;
+                List<int>? temp5 = instance.MyList;
                 temp5 ??= new List<int>();
                 BindCore(section3, ref temp5, binderOptions);
-                obj.MyList = temp5;
+                instance.MyList = temp5;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T.generated.txt
@@ -34,57 +34,52 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region OptionsBuilder<TOptions> extensions.
         /// <summary>Registers a configuration instance which <typeparamref name="TOptions"/> will bind against.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 15, 24)]
-        public static OptionsBuilder<TOptions> Bind<TOptions>(this OptionsBuilder<TOptions> optionsBuilder, IConfiguration configuration) where TOptions : class
+        public static OptionsBuilder<TOptions> Bind<TOptions>(this OptionsBuilder<TOptions> optionsBuilder, IConfiguration config) where TOptions : class
         {
-            return Bind(optionsBuilder, configuration, configureOptions: null);
+            return Bind(optionsBuilder, config, configureBinder: null);
         }
 
         /// <summary>Registers a configuration instance which <typeparamref name="TOptions"/> will bind against.</summary>
-        public static OptionsBuilder<TOptions> Bind<TOptions>(this OptionsBuilder<TOptions> optionsBuilder, IConfiguration configuration, Action<BinderOptions>? configureOptions) where TOptions : class
+        public static OptionsBuilder<TOptions> Bind<TOptions>(this OptionsBuilder<TOptions> optionsBuilder, IConfiguration config, Action<BinderOptions>? configureBinder) where TOptions : class
         {
             if (optionsBuilder is null)
             {
                 throw new ArgumentNullException(nameof(optionsBuilder));
             }
 
-            Configure<TOptions>(optionsBuilder.Services, optionsBuilder.Name, configuration, configureOptions);
+            Configure<TOptions>(optionsBuilder.Services, optionsBuilder.Name, config, configureBinder);
             return optionsBuilder;
         }
         #endregion OptionsBuilder<TOptions> extensions.
 
         #region IServiceCollection extensions.
         /// <summary>Registers a configuration instance which TOptions will bind against.</summary>
-        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration configuration, Action<BinderOptions>? configureOptions) where TOptions : class
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration config, Action<BinderOptions>? configureOptions) where TOptions : class
         {
             if (services is null)
             {
                 throw new ArgumentNullException(nameof(services));
             }
 
-            if (configuration is null)
+            if (config is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
+                throw new ArgumentNullException(nameof(config));
             }
 
             OptionsServiceCollectionExtensions.AddOptions(services);
-            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(name, configuration));
-            return services.AddSingleton<Microsoft.Extensions.Options.IConfigureOptions<TOptions>>(new Microsoft.Extensions.Options.ConfigureNamedOptions<TOptions>(name, obj => BindCoreMain(configuration, obj, typeof(TOptions), configureOptions)));
+            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(name, config));
+            return services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureNamedOptions<TOptions>(name, instance => BindCoreMain(config, instance, typeof(TOptions), configureOptions)));
         }
         #endregion IServiceCollection extensions.
 
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList" });
 
-        public static void BindCoreMain(IConfiguration configuration, object obj, Type type, Action<BinderOptions>? configureOptions)
+        public static void BindCoreMain(IConfiguration configuration, object instance, Type type, Action<BinderOptions>? configureOptions)
         {
-            if (configuration is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
             if (!HasValueOrChildren(configuration))
@@ -96,7 +91,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClass))
             {
-                var temp = (Program.MyClass)obj;
+                var temp = (Program.MyClass)instance;
                 BindCore(configuration, ref temp, binderOptions);
                 return;
             }
@@ -104,34 +99,34 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value2)
             {
-                obj.MyInt = ParseInt(value2, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value2, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section3)
             {
-                List<int>? temp5 = obj.MyList;
+                List<int>? temp5 = instance.MyList;
                 temp5 ??= new List<int>();
                 BindCore(section3, ref temp5, binderOptions);
-                obj.MyList = temp5;
+                instance.MyList = temp5;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T_BinderOptions.generated.txt
@@ -34,51 +34,46 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region OptionsBuilder<TOptions> extensions.
         /// <summary>Registers a configuration instance which <typeparamref name="TOptions"/> will bind against.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 15, 24)]
-        public static OptionsBuilder<TOptions> Bind<TOptions>(this OptionsBuilder<TOptions> optionsBuilder, IConfiguration configuration, Action<BinderOptions>? configureOptions) where TOptions : class
+        public static OptionsBuilder<TOptions> Bind<TOptions>(this OptionsBuilder<TOptions> optionsBuilder, IConfiguration config, Action<BinderOptions>? configureBinder) where TOptions : class
         {
             if (optionsBuilder is null)
             {
                 throw new ArgumentNullException(nameof(optionsBuilder));
             }
 
-            Configure<TOptions>(optionsBuilder.Services, optionsBuilder.Name, configuration, configureOptions);
+            Configure<TOptions>(optionsBuilder.Services, optionsBuilder.Name, config, configureBinder);
             return optionsBuilder;
         }
         #endregion OptionsBuilder<TOptions> extensions.
 
         #region IServiceCollection extensions.
         /// <summary>Registers a configuration instance which TOptions will bind against.</summary>
-        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration configuration, Action<BinderOptions>? configureOptions) where TOptions : class
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration config, Action<BinderOptions>? configureOptions) where TOptions : class
         {
             if (services is null)
             {
                 throw new ArgumentNullException(nameof(services));
             }
 
-            if (configuration is null)
+            if (config is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
+                throw new ArgumentNullException(nameof(config));
             }
 
             OptionsServiceCollectionExtensions.AddOptions(services);
-            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(name, configuration));
-            return services.AddSingleton<Microsoft.Extensions.Options.IConfigureOptions<TOptions>>(new Microsoft.Extensions.Options.ConfigureNamedOptions<TOptions>(name, obj => BindCoreMain(configuration, obj, typeof(TOptions), configureOptions)));
+            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(name, config));
+            return services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureNamedOptions<TOptions>(name, instance => BindCoreMain(config, instance, typeof(TOptions), configureOptions)));
         }
         #endregion IServiceCollection extensions.
 
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList" });
 
-        public static void BindCoreMain(IConfiguration configuration, object obj, Type type, Action<BinderOptions>? configureOptions)
+        public static void BindCoreMain(IConfiguration configuration, object instance, Type type, Action<BinderOptions>? configureOptions)
         {
-            if (configuration is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
             if (!HasValueOrChildren(configuration))
@@ -90,7 +85,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClass))
             {
-                var temp = (Program.MyClass)obj;
+                var temp = (Program.MyClass)instance;
                 BindCore(configuration, ref temp, binderOptions);
                 return;
             }
@@ -98,34 +93,34 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value2)
             {
-                obj.MyInt = ParseInt(value2, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value2, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section3)
             {
-                List<int>? temp5 = obj.MyList;
+                List<int>? temp5 = instance.MyList;
                 temp5 ??= new List<int>();
                 BindCore(section3, ref temp5, binderOptions);
-                obj.MyList = temp5;
+                instance.MyList = temp5;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Primitives.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Primitives.generated.txt
@@ -32,19 +32,19 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region IConfiguration extensions.
         /// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 13, 16)]
-        public static void Bind_ProgramMyClass(this IConfiguration configuration, object? obj)
+        public static void Bind_ProgramMyClass(this IConfiguration configuration, object? instance)
         {
             if (configuration is null)
             {
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            if (obj is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
-            var typedObj = (Program.MyClass)obj;
+            var typedObj = (Program.MyClass)instance;
             BindCore(configuration, ref typedObj, binderOptions: null);
         }
         #endregion IConfiguration extensions.
@@ -52,142 +52,142 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Prop0", "Prop1", "Prop2", "Prop3", "Prop4", "Prop5", "Prop6", "Prop8", "Prop9", "Prop10", "Prop13", "Prop14", "Prop15", "Prop16", "Prop17", "Prop19", "Prop20", "Prop21", "Prop23", "Prop24", "Prop25", "Prop26", "Prop27", "Prop7", "Prop11", "Prop12", "Prop18", "Prop22" });
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
             if (configuration["Prop0"] is string value0)
             {
-                obj.Prop0 = ParseBool(value0, () => configuration.GetSection("Prop0").Path);
+                instance.Prop0 = ParseBool(value0, () => configuration.GetSection("Prop0").Path);
             }
 
             if (configuration["Prop1"] is string value1)
             {
-                obj.Prop1 = ParseByte(value1, () => configuration.GetSection("Prop1").Path);
+                instance.Prop1 = ParseByte(value1, () => configuration.GetSection("Prop1").Path);
             }
 
             if (configuration["Prop2"] is string value2)
             {
-                obj.Prop2 = ParseSbyte(value2, () => configuration.GetSection("Prop2").Path);
+                instance.Prop2 = ParseSbyte(value2, () => configuration.GetSection("Prop2").Path);
             }
 
             if (configuration["Prop3"] is string value3)
             {
-                obj.Prop3 = ParseChar(value3, () => configuration.GetSection("Prop3").Path);
+                instance.Prop3 = ParseChar(value3, () => configuration.GetSection("Prop3").Path);
             }
 
             if (configuration["Prop4"] is string value4)
             {
-                obj.Prop4 = ParseDouble(value4, () => configuration.GetSection("Prop4").Path);
+                instance.Prop4 = ParseDouble(value4, () => configuration.GetSection("Prop4").Path);
             }
 
-            obj.Prop5 = configuration["Prop5"]!;
+            instance.Prop5 = configuration["Prop5"]!;
 
             if (configuration["Prop6"] is string value6)
             {
-                obj.Prop6 = ParseInt(value6, () => configuration.GetSection("Prop6").Path);
+                instance.Prop6 = ParseInt(value6, () => configuration.GetSection("Prop6").Path);
             }
 
             if (configuration["Prop8"] is string value7)
             {
-                obj.Prop8 = ParseShort(value7, () => configuration.GetSection("Prop8").Path);
+                instance.Prop8 = ParseShort(value7, () => configuration.GetSection("Prop8").Path);
             }
 
             if (configuration["Prop9"] is string value8)
             {
-                obj.Prop9 = ParseLong(value8, () => configuration.GetSection("Prop9").Path);
+                instance.Prop9 = ParseLong(value8, () => configuration.GetSection("Prop9").Path);
             }
 
             if (configuration["Prop10"] is string value9)
             {
-                obj.Prop10 = ParseFloat(value9, () => configuration.GetSection("Prop10").Path);
+                instance.Prop10 = ParseFloat(value9, () => configuration.GetSection("Prop10").Path);
             }
 
             if (configuration["Prop13"] is string value10)
             {
-                obj.Prop13 = ParseUshort(value10, () => configuration.GetSection("Prop13").Path);
+                instance.Prop13 = ParseUshort(value10, () => configuration.GetSection("Prop13").Path);
             }
 
             if (configuration["Prop14"] is string value11)
             {
-                obj.Prop14 = ParseUint(value11, () => configuration.GetSection("Prop14").Path);
+                instance.Prop14 = ParseUint(value11, () => configuration.GetSection("Prop14").Path);
             }
 
             if (configuration["Prop15"] is string value12)
             {
-                obj.Prop15 = ParseUlong(value12, () => configuration.GetSection("Prop15").Path);
+                instance.Prop15 = ParseUlong(value12, () => configuration.GetSection("Prop15").Path);
             }
 
-            obj.Prop16 = configuration["Prop16"]!;
+            instance.Prop16 = configuration["Prop16"]!;
 
             if (configuration["Prop17"] is string value14)
             {
-                obj.Prop17 = ParseCultureInfo(value14, () => configuration.GetSection("Prop17").Path);
+                instance.Prop17 = ParseCultureInfo(value14, () => configuration.GetSection("Prop17").Path);
             }
 
             if (configuration["Prop19"] is string value15)
             {
-                obj.Prop19 = ParseDateTime(value15, () => configuration.GetSection("Prop19").Path);
+                instance.Prop19 = ParseDateTime(value15, () => configuration.GetSection("Prop19").Path);
             }
 
             if (configuration["Prop20"] is string value16)
             {
-                obj.Prop20 = ParseDateTimeOffset(value16, () => configuration.GetSection("Prop20").Path);
+                instance.Prop20 = ParseDateTimeOffset(value16, () => configuration.GetSection("Prop20").Path);
             }
 
             if (configuration["Prop21"] is string value17)
             {
-                obj.Prop21 = ParseDecimal(value17, () => configuration.GetSection("Prop21").Path);
+                instance.Prop21 = ParseDecimal(value17, () => configuration.GetSection("Prop21").Path);
             }
 
             if (configuration["Prop23"] is string value18)
             {
-                obj.Prop23 = ParseInt(value18, () => configuration.GetSection("Prop23").Path);
+                instance.Prop23 = ParseInt(value18, () => configuration.GetSection("Prop23").Path);
             }
 
             if (configuration["Prop24"] is string value19)
             {
-                obj.Prop24 = ParseDateTime(value19, () => configuration.GetSection("Prop24").Path);
+                instance.Prop24 = ParseDateTime(value19, () => configuration.GetSection("Prop24").Path);
             }
 
             if (configuration["Prop25"] is string value20)
             {
-                obj.Prop25 = ParseUri(value20, () => configuration.GetSection("Prop25").Path);
+                instance.Prop25 = ParseUri(value20, () => configuration.GetSection("Prop25").Path);
             }
 
             if (configuration["Prop26"] is string value21)
             {
-                obj.Prop26 = ParseVersion(value21, () => configuration.GetSection("Prop26").Path);
+                instance.Prop26 = ParseVersion(value21, () => configuration.GetSection("Prop26").Path);
             }
 
             if (configuration["Prop27"] is string value22)
             {
-                obj.Prop27 = ParseEnum<DayOfWeek>(value22, () => configuration.GetSection("Prop27").Path);
+                instance.Prop27 = ParseEnum<DayOfWeek>(value22, () => configuration.GetSection("Prop27").Path);
             }
 
             if (configuration["Prop7"] is string value23)
             {
-                obj.Prop7 = ParseInt128(value23, () => configuration.GetSection("Prop7").Path);
+                instance.Prop7 = ParseInt128(value23, () => configuration.GetSection("Prop7").Path);
             }
 
             if (configuration["Prop11"] is string value24)
             {
-                obj.Prop11 = ParseHalf(value24, () => configuration.GetSection("Prop11").Path);
+                instance.Prop11 = ParseHalf(value24, () => configuration.GetSection("Prop11").Path);
             }
 
             if (configuration["Prop12"] is string value25)
             {
-                obj.Prop12 = ParseUInt128(value25, () => configuration.GetSection("Prop12").Path);
+                instance.Prop12 = ParseUInt128(value25, () => configuration.GetSection("Prop12").Path);
             }
 
             if (configuration["Prop18"] is string value26)
             {
-                obj.Prop18 = ParseDateOnly(value26, () => configuration.GetSection("Prop18").Path);
+                instance.Prop18 = ParseDateOnly(value26, () => configuration.GetSection("Prop18").Path);
             }
 
             if (configuration["Prop22"] is string value27)
             {
-                obj.Prop22 = ParseByteArray(value27, () => configuration.GetSection("Prop22").Path);
+                instance.Prop22 = ParseByteArray(value27, () => configuration.GetSection("Prop22").Path);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T.generated.txt
@@ -33,27 +33,27 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region IServiceCollection extensions.
         /// <summary>Registers a configuration instance which TOptions will bind against.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 14, 18)]
-        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, IConfiguration configuration) where TOptions : class
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, IConfiguration config) where TOptions : class
         {
-            return Configure<TOptions>(services, string.Empty, configuration, configureOptions: null);
+            return Configure<TOptions>(services, string.Empty, config, configureOptions: null);
         }
 
         /// <summary>Registers a configuration instance which TOptions will bind against.</summary>
-        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration configuration, Action<BinderOptions>? configureOptions) where TOptions : class
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration config, Action<BinderOptions>? configureOptions) where TOptions : class
         {
             if (services is null)
             {
                 throw new ArgumentNullException(nameof(services));
             }
 
-            if (configuration is null)
+            if (config is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
+                throw new ArgumentNullException(nameof(config));
             }
 
             OptionsServiceCollectionExtensions.AddOptions(services);
-            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(name, configuration));
-            return services.AddSingleton<Microsoft.Extensions.Options.IConfigureOptions<TOptions>>(new Microsoft.Extensions.Options.ConfigureNamedOptions<TOptions>(name, obj => BindCoreMain(configuration, obj, typeof(TOptions), configureOptions)));
+            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(name, config));
+            return services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureNamedOptions<TOptions>(name, instance => BindCoreMain(config, instance, typeof(TOptions), configureOptions)));
         }
         #endregion IServiceCollection extensions.
 
@@ -61,16 +61,11 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass2 = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyInt" });
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList", "MyList2", "MyDictionary" });
 
-        public static void BindCoreMain(IConfiguration configuration, object obj, Type type, Action<BinderOptions>? configureOptions)
+        public static void BindCoreMain(IConfiguration configuration, object instance, Type type, Action<BinderOptions>? configureOptions)
         {
-            if (configuration is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
             if (!HasValueOrChildren(configuration))
@@ -82,7 +77,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClass))
             {
-                var temp = (Program.MyClass)obj;
+                var temp = (Program.MyClass)instance;
                 BindCore(configuration, ref temp, binderOptions);
                 return;
             }
@@ -90,81 +85,81 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
             if (configuration["MyInt"] is string value1)
             {
-                obj.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
                 BindCore(section, ref value, binderOptions);
-                obj.Add(value);
+                instance.Add(value);
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = value;
+                    instance[section.Key] = value;
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value4)
             {
-                obj.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section5)
             {
-                List<int>? temp7 = obj.MyList;
+                List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
                 BindCore(section5, ref temp7, binderOptions);
-                obj.MyList = temp7;
+                instance.MyList = temp7;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList2")) is IConfigurationSection section8)
             {
-                List<Program.MyClass2>? temp10 = obj.MyList2;
+                List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
                 BindCore(section8, ref temp10, binderOptions);
-                obj.MyList2 = temp10;
+                instance.MyList2 = temp10;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyDictionary")) is IConfigurationSection section11)
             {
-                Dictionary<string, string>? temp13 = obj.MyDictionary;
+                Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
                 BindCore(section11, ref temp13, binderOptions);
-                obj.MyDictionary = temp13;
+                instance.MyDictionary = temp13;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_BinderOptions.generated.txt
@@ -33,27 +33,27 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region IServiceCollection extensions.
         /// <summary>Registers a configuration instance which TOptions will bind against.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 14, 18)]
-        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, IConfiguration configuration, Action<BinderOptions>? configureOptions) where TOptions : class
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, IConfiguration config, Action<BinderOptions>? configureOptions) where TOptions : class
         {
-            return Configure<TOptions>(services, string.Empty, configuration, configureOptions);
+            return Configure<TOptions>(services, string.Empty, config, configureOptions);
         }
 
         /// <summary>Registers a configuration instance which TOptions will bind against.</summary>
-        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration configuration, Action<BinderOptions>? configureOptions) where TOptions : class
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration config, Action<BinderOptions>? configureOptions) where TOptions : class
         {
             if (services is null)
             {
                 throw new ArgumentNullException(nameof(services));
             }
 
-            if (configuration is null)
+            if (config is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
+                throw new ArgumentNullException(nameof(config));
             }
 
             OptionsServiceCollectionExtensions.AddOptions(services);
-            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(name, configuration));
-            return services.AddSingleton<Microsoft.Extensions.Options.IConfigureOptions<TOptions>>(new Microsoft.Extensions.Options.ConfigureNamedOptions<TOptions>(name, obj => BindCoreMain(configuration, obj, typeof(TOptions), configureOptions)));
+            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(name, config));
+            return services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureNamedOptions<TOptions>(name, instance => BindCoreMain(config, instance, typeof(TOptions), configureOptions)));
         }
         #endregion IServiceCollection extensions.
 
@@ -61,16 +61,11 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass2 = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyInt" });
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList", "MyList2", "MyDictionary" });
 
-        public static void BindCoreMain(IConfiguration configuration, object obj, Type type, Action<BinderOptions>? configureOptions)
+        public static void BindCoreMain(IConfiguration configuration, object instance, Type type, Action<BinderOptions>? configureOptions)
         {
-            if (configuration is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
             if (!HasValueOrChildren(configuration))
@@ -82,7 +77,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClass))
             {
-                var temp = (Program.MyClass)obj;
+                var temp = (Program.MyClass)instance;
                 BindCore(configuration, ref temp, binderOptions);
                 return;
             }
@@ -90,81 +85,81 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
             if (configuration["MyInt"] is string value1)
             {
-                obj.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
                 BindCore(section, ref value, binderOptions);
-                obj.Add(value);
+                instance.Add(value);
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = value;
+                    instance[section.Key] = value;
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value4)
             {
-                obj.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section5)
             {
-                List<int>? temp7 = obj.MyList;
+                List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
                 BindCore(section5, ref temp7, binderOptions);
-                obj.MyList = temp7;
+                instance.MyList = temp7;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList2")) is IConfigurationSection section8)
             {
-                List<Program.MyClass2>? temp10 = obj.MyList2;
+                List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
                 BindCore(section8, ref temp10, binderOptions);
-                obj.MyList2 = temp10;
+                instance.MyList2 = temp10;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyDictionary")) is IConfigurationSection section11)
             {
-                Dictionary<string, string>? temp13 = obj.MyDictionary;
+                Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
                 BindCore(section11, ref temp13, binderOptions);
-                obj.MyDictionary = temp13;
+                instance.MyDictionary = temp13;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name.generated.txt
@@ -33,27 +33,27 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region IServiceCollection extensions.
         /// <summary>Registers a configuration instance which TOptions will bind against.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 14, 18)]
-        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration configuration) where TOptions : class
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration config) where TOptions : class
         {
-            return Configure<TOptions>(services, name, configuration, configureOptions: null);
+            return Configure<TOptions>(services, name, config, configureOptions: null);
         }
 
         /// <summary>Registers a configuration instance which TOptions will bind against.</summary>
-        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration configuration, Action<BinderOptions>? configureOptions) where TOptions : class
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration config, Action<BinderOptions>? configureOptions) where TOptions : class
         {
             if (services is null)
             {
                 throw new ArgumentNullException(nameof(services));
             }
 
-            if (configuration is null)
+            if (config is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
+                throw new ArgumentNullException(nameof(config));
             }
 
             OptionsServiceCollectionExtensions.AddOptions(services);
-            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(name, configuration));
-            return services.AddSingleton<Microsoft.Extensions.Options.IConfigureOptions<TOptions>>(new Microsoft.Extensions.Options.ConfigureNamedOptions<TOptions>(name, obj => BindCoreMain(configuration, obj, typeof(TOptions), configureOptions)));
+            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(name, config));
+            return services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureNamedOptions<TOptions>(name, instance => BindCoreMain(config, instance, typeof(TOptions), configureOptions)));
         }
         #endregion IServiceCollection extensions.
 
@@ -61,16 +61,11 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass2 = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyInt" });
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList", "MyList2", "MyDictionary" });
 
-        public static void BindCoreMain(IConfiguration configuration, object obj, Type type, Action<BinderOptions>? configureOptions)
+        public static void BindCoreMain(IConfiguration configuration, object instance, Type type, Action<BinderOptions>? configureOptions)
         {
-            if (configuration is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
             if (!HasValueOrChildren(configuration))
@@ -82,7 +77,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClass))
             {
-                var temp = (Program.MyClass)obj;
+                var temp = (Program.MyClass)instance;
                 BindCore(configuration, ref temp, binderOptions);
                 return;
             }
@@ -90,81 +85,81 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
             if (configuration["MyInt"] is string value1)
             {
-                obj.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
                 BindCore(section, ref value, binderOptions);
-                obj.Add(value);
+                instance.Add(value);
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = value;
+                    instance[section.Key] = value;
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value4)
             {
-                obj.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section5)
             {
-                List<int>? temp7 = obj.MyList;
+                List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
                 BindCore(section5, ref temp7, binderOptions);
-                obj.MyList = temp7;
+                instance.MyList = temp7;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList2")) is IConfigurationSection section8)
             {
-                List<Program.MyClass2>? temp10 = obj.MyList2;
+                List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
                 BindCore(section8, ref temp10, binderOptions);
-                obj.MyList2 = temp10;
+                instance.MyList2 = temp10;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyDictionary")) is IConfigurationSection section11)
             {
-                Dictionary<string, string>? temp13 = obj.MyDictionary;
+                Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
                 BindCore(section11, ref temp13, binderOptions);
-                obj.MyDictionary = temp13;
+                instance.MyDictionary = temp13;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
@@ -33,21 +33,21 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #region IServiceCollection extensions.
         /// <summary>Registers a configuration instance which TOptions will bind against.</summary>
         [InterceptsLocationAttribute(@"src-0.cs", 14, 18)]
-        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration configuration, Action<BinderOptions>? configureOptions) where TOptions : class
+        public static IServiceCollection Configure<TOptions>(this IServiceCollection services, string? name, IConfiguration config, Action<BinderOptions>? configureOptions) where TOptions : class
         {
             if (services is null)
             {
                 throw new ArgumentNullException(nameof(services));
             }
 
-            if (configuration is null)
+            if (config is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
+                throw new ArgumentNullException(nameof(config));
             }
 
             OptionsServiceCollectionExtensions.AddOptions(services);
-            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(name, configuration));
-            return services.AddSingleton<Microsoft.Extensions.Options.IConfigureOptions<TOptions>>(new Microsoft.Extensions.Options.ConfigureNamedOptions<TOptions>(name, obj => BindCoreMain(configuration, obj, typeof(TOptions), configureOptions)));
+            services.AddSingleton<IOptionsChangeTokenSource<TOptions>>(new ConfigurationChangeTokenSource<TOptions>(name, config));
+            return services.AddSingleton<IConfigureOptions<TOptions>>(new ConfigureNamedOptions<TOptions>(name, instance => BindCoreMain(config, instance, typeof(TOptions), configureOptions)));
         }
         #endregion IServiceCollection extensions.
 
@@ -55,16 +55,11 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass2 = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyInt" });
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList", "MyList2", "MyDictionary" });
 
-        public static void BindCoreMain(IConfiguration configuration, object obj, Type type, Action<BinderOptions>? configureOptions)
+        public static void BindCoreMain(IConfiguration configuration, object instance, Type type, Action<BinderOptions>? configureOptions)
         {
-            if (configuration is null)
+            if (instance is null)
             {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
+                return;
             }
 
             if (!HasValueOrChildren(configuration))
@@ -76,7 +71,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (type == typeof(Program.MyClass))
             {
-                var temp = (Program.MyClass)obj;
+                var temp = (Program.MyClass)instance;
                 BindCore(configuration, ref temp, binderOptions);
                 return;
             }
@@ -84,81 +79,81 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj.Add(ParseInt(value, () => section.Path));
+                    instance.Add(ParseInt(value, () => section.Path));
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
             if (configuration["MyInt"] is string value1)
             {
-                obj.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
                 BindCore(section, ref value, binderOptions);
-                obj.Add(value);
+                instance.Add(value);
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 if (section.Value is string value)
                 {
-                    obj[section.Key] = value;
+                    instance[section.Key] = value;
                 }
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass obj, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            obj.MyString = configuration["MyString"]!;
+            instance.MyString = configuration["MyString"]!;
 
             if (configuration["MyInt"] is string value4)
             {
-                obj.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
+                instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section5)
             {
-                List<int>? temp7 = obj.MyList;
+                List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
                 BindCore(section5, ref temp7, binderOptions);
-                obj.MyList = temp7;
+                instance.MyList = temp7;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList2")) is IConfigurationSection section8)
             {
-                List<Program.MyClass2>? temp10 = obj.MyList2;
+                List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
                 BindCore(section8, ref temp10, binderOptions);
-                obj.MyList2 = temp10;
+                instance.MyList2 = temp10;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyDictionary")) is IConfigurationSection section11)
             {
-                Dictionary<string, string>? temp13 = obj.MyDictionary;
+                Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
                 BindCore(section11, ref temp13, binderOptions);
-                obj.MyDictionary = temp13;
+                instance.MyDictionary = temp13;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -253,9 +253,9 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             Assert.Single(r);
 
             string generatedSource = string.Join('\n', r[0].SourceText.Lines.Select(x => x.ToString()));
-            Assert.Contains("public static void Bind_ProgramMyClass0(this IConfiguration configuration, object? obj)", generatedSource);
-            Assert.Contains("public static void Bind_ProgramMyClass1(this IConfiguration configuration, object? obj, Action<BinderOptions>? configureOptions)", generatedSource);
-            Assert.Contains("public static void Bind_ProgramMyClass2(this IConfiguration configuration, string key, object? obj)", generatedSource);
+            Assert.Contains("public static void Bind_ProgramMyClass0(this IConfiguration configuration, object? instance)", generatedSource);
+            Assert.Contains("public static void Bind_ProgramMyClass1(this IConfiguration configuration, object? instance, Action<BinderOptions>? configureOptions)", generatedSource);
+            Assert.Contains("public static void Bind_ProgramMyClass2(this IConfiguration configuration, string key, object? instance)", generatedSource);
 
             Assert.Empty(d);
         }

--- a/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/tests/Common/ConfigurationExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/tests/Common/ConfigurationExtensionsTests.cs
@@ -12,6 +12,61 @@ namespace Microsoft.Extensions.Options.ConfigurationExtensions.Tests
     {
         private static IConfiguration s_emptyConfig { get; } = new ConfigurationBuilder().Build();
 
+        [Fact]
+        public void TestNullHandling_OptionsBuilderExt_Bind()
+        {
+            // Null options builder.
+            OptionsBuilder<FakeOptions>? optionsBuilder = null;
+            Assert.Throws<ArgumentNullException>(() => optionsBuilder!.Bind(s_emptyConfig));
+            Assert.Throws<ArgumentNullException>(() => optionsBuilder!.Bind(s_emptyConfig, _ => { }));
+
+            // Null configuration.
+            optionsBuilder = CreateOptionsBuilder();
+            Assert.Throws<ArgumentNullException>(() => optionsBuilder.Bind(config: null!));
+            Assert.Throws<ArgumentNullException>(() => optionsBuilder.Bind(config: null!, _ => { }));
+
+            // Null configureBinder.
+            optionsBuilder.Bind(s_emptyConfig, configureBinder: null);
+        }
+
+        [Fact]
+        public void TestNullHandling_OptionsBuilderExt_BindConfiguration()
+        {
+            // Null options builder.
+            string configSectionPath = "FakeSectionPath";
+            OptionsBuilder<FakeOptions>? optionsBuilder = null;
+            Assert.Throws<ArgumentNullException>(() => optionsBuilder!.BindConfiguration(configSectionPath));
+
+            // Null config section path.
+            optionsBuilder = CreateOptionsBuilder();
+            Assert.Throws<ArgumentNullException>(() => optionsBuilder.BindConfiguration(configSectionPath: null!));
+
+            // Null configureBinder.
+            optionsBuilder.BindConfiguration(configSectionPath, configureBinder: null);
+        }
+
+        [Fact]
+        public void TestNullHandling_IServiceCollectionExt_Configure()
+        {
+            // Null services
+            IServiceCollection? services = null;
+            string name = "Name";
+            Assert.Throws<ArgumentNullException>(() => services!.Configure<FakeOptions>(s_emptyConfig));
+            Assert.Throws<ArgumentNullException>(() => services!.Configure<FakeOptions>(name, s_emptyConfig));
+
+            // Null config.
+            services = new ServiceCollection();
+            Assert.Throws<ArgumentNullException>(() => services.Configure<FakeOptions>(config: null!));
+            Assert.Throws<ArgumentNullException>(() => services.Configure<FakeOptions>(name, config: null!));
+
+            // Null name.
+            services.Configure<FakeOptions>(name: null!, s_emptyConfig);
+
+            // Null configureBinder.
+            services.Configure<FakeOptions>(s_emptyConfig, configureBinder: null);
+            services.Configure<FakeOptions>(name, s_emptyConfig, configureBinder: null);
+        }
+
         private static OptionsBuilder<FakeOptions> CreateOptionsBuilder()
         {
             var services = new ServiceCollection();

--- a/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/tests/UnitTests/Microsoft.Extensions.Options.ConfigurationExtensions.UnitTests.csproj
+++ b/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/tests/UnitTests/Microsoft.Extensions.Options.ConfigurationExtensions.UnitTests.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\ConfigurationExtensionsTests.cs" Link="Common\ConfigurationExtensionsTests.cs" />
     <Compile Include="..\Common\FakeConfigurationProvider.cs" Link="Common\FakeConfigurationProvider.cs" />
     <Compile Include="..\Common\FakeConfigurationSource.cs" Link="Common\FakeConfigurationSource.cs" />
     <Compile Include="..\Common\FakeOptions.cs" Link="Common\FakeOptions.cs" />


### PR DESCRIPTION
Backport of #91180 to release/8.0
Fixes #90987 for 8.0.

## Customer Impact

Updates null input handling by the generated replacement binding methods to align with the reflection-based implementation. This follows the general user expectation of consistency between the two implementations.

## Testing

Automated null handling tests have been added for all parameters of all binder methods. They assert the same behavior for source-gen and reflection. Some null refs in the reflection binder were fixed as well. This also provides complete build coverage for all binding inputs.

## Risk

Low. It's a contained fix for an off-by-default component.

cc @carlossanlop.