### PR TITLE
Options Source Gen Fixes

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Extensions.Options.Generators
             else
             {
                 _modifier = "internal";
-                string suffix = $"_{GetNonRandomizedHashCode($"{compilation.SourceModule.Name}"):X8}";
+                string suffix = $"_{GetNonRandomizedHashCode(compilation.SourceModule.Name):X8}";
                 _staticValidationAttributeHolderClassName += suffix;
                 _staticValidatorHolderClassName += suffix;
             }

--- a/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Extensions.Options.Generators
         }
 
         /// <summary>
-        /// Returns the nullable annotation string to use in the code generation according to the first first parameter of
+        /// Returns the nullable annotation string to use in the code generation according to the first parameter of
         /// <see cref="System.ComponentModel.DataAnnotations.Validator.TryValidateValue(object, ValidationContext, ICollection{ValidationResult}, IEnumerable{ValidationAttribute})"/> is nullable annotated.
         /// </summary>
         /// <param name="compilation">The <see cref="Compilation"/> to consider for analysis.</param>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.DotnetRuntime.Extensions;
 
 namespace Microsoft.Extensions.Options.Generators
 {
@@ -25,6 +27,7 @@ namespace Microsoft.Extensions.Options.Generators
         private string _staticValidationAttributeHolderClassFQN;
         private string _staticValidatorHolderClassFQN;
         private string _modifier;
+        private string _TryGetValueNullableAnnotation;
 
         private sealed record StaticFieldInfo(string FieldTypeFQN, int FieldOrder, string FieldName, IList<string> InstantiationLines);
 
@@ -37,13 +40,14 @@ namespace Microsoft.Extensions.Options.Generators
             else
             {
                 _modifier = "internal";
-                string suffix = $"_{new Random().Next():X8}";
+                string suffix = $"_{GetNonRandomizedHashCode($"{compilation.SourceModule.Name}"):X8}";
                 _staticValidationAttributeHolderClassName += suffix;
                 _staticValidatorHolderClassName += suffix;
             }
 
             _staticValidationAttributeHolderClassFQN = $"global::{StaticFieldHolderClassesNamespace}.{_staticValidationAttributeHolderClassName}";
             _staticValidatorHolderClassFQN = $"global::{StaticFieldHolderClassesNamespace}.{_staticValidatorHolderClassName}";
+            _TryGetValueNullableAnnotation = GetNullableAnnotationStringForTryValidateValueToUseInGeneratedCode(compilation);
         }
 
         public string Emit(
@@ -63,6 +67,31 @@ namespace Microsoft.Extensions.Options.Generators
             GenStaticClassWithStaticReadonlyFields(staticValidatorsDict.Values, StaticFieldHolderClassesNamespace, _staticValidatorHolderClassName);
 
             return Capture();
+        }
+
+        /// <summary>
+        /// Returns the nullable annotation string to use in the code generation according to the first first parameter of
+        /// <see cref="System.ComponentModel.DataAnnotations.Validator.TryValidateValue(object, ValidationContext, ICollection{ValidationResult}, IEnumerable{ValidationAttribute})"/> is nullable annotated.
+        /// </summary>
+        /// <param name="compilation">The <see cref="Compilation"/> to consider for analysis.</param>
+        /// <returns>"!" if the first parameter is not nullable annotated, otherwise an empty string.</returns>
+        /// <remarks>
+        /// In .NET 8.0 we have changed the nullable annotation on first parameter of the method cref="System.ComponentModel.DataAnnotations.Validator.TryValidateValue(object, ValidationContext, ICollection{ValidationResult}, IEnumerable{ValidationAttribute})"/>
+        /// The source generator need to detect if we need to append "!" to the first parameter of the method call when running on down-level versions.
+        /// </remarks>
+        private static string GetNullableAnnotationStringForTryValidateValueToUseInGeneratedCode(Compilation compilation)
+        {
+            INamedTypeSymbol? validatorTypeSymbol = compilation.GetBestTypeByMetadataName("System.ComponentModel.DataAnnotations.Validator");
+            if (validatorTypeSymbol is not null)
+            {
+                ImmutableArray<ISymbol> members = validatorTypeSymbol.GetMembers("TryValidateValue");
+                if (members.Length == 1 && members[0] is IMethodSymbol tryValidateValueMethod)
+                {
+                    return tryValidateValueMethod.Parameters[0].NullableAnnotation == NullableAnnotation.NotAnnotated ? "!" : string.Empty;
+                }
+            }
+
+            return "!";
         }
 
         private void GenValidatorType(ValidatorType vt, ref Dictionary<string, StaticFieldInfo> staticValidationAttributesDict, ref Dictionary<string, StaticFieldInfo> staticValidatorsDict)
@@ -161,6 +190,7 @@ namespace Microsoft.Extensions.Options.Generators
         {
             if (modelToValidate.SelfValidates)
             {
+                OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
                 OutLn($"builder.AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));");
                 OutLn();
             }
@@ -182,8 +212,7 @@ namespace Microsoft.Extensions.Options.Generators
 
             OutLn($"public {(makeStatic ? "static " : string.Empty)}global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, {modelToValidate.Name} options)");
             OutOpenBrace();
-            OutLn($"var baseName = (string.IsNullOrEmpty(name) ? \"{modelToValidate.SimpleName}\" : name) + \".\";");
-            OutLn($"var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
+            OutLn($"global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;");
             OutLn($"var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);");
 
             int capacity = modelToValidate.MembersToValidate.Max(static vm => vm.ValidationAttributes.Count);
@@ -199,33 +228,33 @@ namespace Microsoft.Extensions.Options.Generators
             {
                 if (vm.ValidationAttributes.Count > 0)
                 {
-                    GenMemberValidation(vm, ref staticValidationAttributesDict, cleanListsBeforeUse);
+                    GenMemberValidation(vm, modelToValidate.SimpleName, ref staticValidationAttributesDict, cleanListsBeforeUse);
                     cleanListsBeforeUse = true;
                     OutLn();
                 }
 
                 if (vm.TransValidatorType is not null)
                 {
-                    GenTransitiveValidation(vm, ref staticValidatorsDict);
+                    GenTransitiveValidation(vm, modelToValidate.SimpleName, ref staticValidatorsDict);
                     OutLn();
                 }
 
                 if (vm.EnumerationValidatorType is not null)
                 {
-                    GenEnumerationValidation(vm, ref staticValidatorsDict);
+                    GenEnumerationValidation(vm, modelToValidate.SimpleName, ref staticValidatorsDict);
                     OutLn();
                 }
             }
 
             GenModelSelfValidationIfNecessary(modelToValidate);
-            OutLn($"return builder.Build();");
+            OutLn($"return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();");
             OutCloseBrace();
         }
 
-        private void GenMemberValidation(ValidatedMember vm, ref Dictionary<string, StaticFieldInfo> staticValidationAttributesDict, bool cleanListsBeforeUse)
+        private void GenMemberValidation(ValidatedMember vm, string modelName, ref Dictionary<string, StaticFieldInfo> staticValidationAttributesDict, bool cleanListsBeforeUse)
         {
             OutLn($"context.MemberName = \"{vm.Name}\";");
-            OutLn($"context.DisplayName = baseName + \"{vm.Name}\";");
+            OutLn($"context.DisplayName = string.IsNullOrEmpty(name) ? \"{modelName}.{vm.Name}\" : $\"{{name}}.{vm.Name}\";");
 
             if (cleanListsBeforeUse)
             {
@@ -239,8 +268,9 @@ namespace Microsoft.Extensions.Options.Generators
                 OutLn($"validationAttributes.Add({_staticValidationAttributeHolderClassFQN}.{staticValidationAttributeInstance.FieldName});");
             }
 
-            OutLn($"if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.{vm.Name}!, context, validationResults, validationAttributes))");
+            OutLn($"if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.{vm.Name}{_TryGetValueNullableAnnotation}, context, validationResults, validationAttributes))");
             OutOpenBrace();
+            OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
             OutLn($"builder.AddResults(validationResults);");
             OutCloseBrace();
         }
@@ -305,7 +335,7 @@ namespace Microsoft.Extensions.Options.Generators
             return staticValidationAttributeInstance;
         }
 
-        private void GenTransitiveValidation(ValidatedMember vm, ref Dictionary<string, StaticFieldInfo> staticValidatorsDict)
+        private void GenTransitiveValidation(ValidatedMember vm, string modelName, ref Dictionary<string, StaticFieldInfo> staticValidatorsDict)
         {
             string callSequence;
             if (vm.TransValidateTypeIsSynthetic)
@@ -321,20 +351,24 @@ namespace Microsoft.Extensions.Options.Generators
 
             var valueAccess = (vm.IsNullable && vm.IsValueType) ? ".Value" : string.Empty;
 
+            var baseName = $"string.IsNullOrEmpty(name) ? \"{modelName}.{vm.Name}\" : $\"{{name}}.{vm.Name}\"";
+
             if (vm.IsNullable)
             {
                 OutLn($"if (options.{vm.Name} is not null)");
                 OutOpenBrace();
-                OutLn($"builder.AddResult({callSequence}.Validate(baseName + \"{vm.Name}\", options.{vm.Name}{valueAccess}));");
+                OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
+                OutLn($"builder.AddResult({callSequence}.Validate({baseName}, options.{vm.Name}{valueAccess}));");
                 OutCloseBrace();
             }
             else
             {
-                OutLn($"builder.AddResult({callSequence}.Validate(baseName + \"{vm.Name}\", options.{vm.Name}{valueAccess}));");
+                OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
+                OutLn($"builder.AddResult({callSequence}.Validate({baseName}, options.{vm.Name}{valueAccess}));");
             }
         }
 
-        private void GenEnumerationValidation(ValidatedMember vm, ref Dictionary<string, StaticFieldInfo> staticValidatorsDict)
+        private void GenEnumerationValidation(ValidatedMember vm, string modelName, ref Dictionary<string, StaticFieldInfo> staticValidatorsDict)
         {
             var valueAccess = (vm.IsValueType && vm.IsNullable) ? ".Value" : string.Empty;
             var enumeratedValueAccess = (vm.EnumeratedIsNullable && vm.EnumeratedIsValueType) ? ".Value" : string.Empty;
@@ -365,14 +399,18 @@ namespace Microsoft.Extensions.Options.Generators
             {
                 OutLn($"if (o is not null)");
                 OutOpenBrace();
-                OutLn($"builder.AddResult({callSequence}.Validate(baseName + $\"{vm.Name}[{{count}}]\", o{enumeratedValueAccess}));");
+                var propertyName = $"string.IsNullOrEmpty(name) ? $\"{modelName}.{vm.Name}[{{count}}]\" : $\"{{name}}.{vm.Name}[{{count}}]\"";
+                OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
+                OutLn($"builder.AddResult({callSequence}.Validate({propertyName}, o{enumeratedValueAccess}));");
                 OutCloseBrace();
 
                 if (!vm.EnumeratedMayBeNull)
                 {
                     OutLn($"else");
                     OutOpenBrace();
-                    OutLn($"builder.AddError(baseName + $\"{vm.Name}[{{count}}] is null\");");
+                    var error = $"string.IsNullOrEmpty(name) ? $\"{modelName}.{vm.Name}[{{count}}] is null\" : $\"{{name}}.{vm.Name}[{{count}}] is null\"";
+                    OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
+                    OutLn($"builder.AddError({error});");
                     OutCloseBrace();
                 }
 
@@ -380,7 +418,9 @@ namespace Microsoft.Extensions.Options.Generators
             }
             else
             {
-                OutLn($"builder.AddResult({callSequence}.Validate(baseName + $\"{vm.Name}[{{count++}}]\", o{enumeratedValueAccess}));");
+                var propertyName = $"string.IsNullOrEmpty(name) ? $\"{modelName}.{vm.Name}[{{count++}}] is null\" : $\"{{name}}.{vm.Name}[{{count++}}] is null\"";
+                OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
+                OutLn($"builder.AddResult({callSequence}.Validate({propertyName}, o{enumeratedValueAccess}));");
             }
 
             OutCloseBrace();
@@ -404,6 +444,20 @@ namespace Microsoft.Extensions.Options.Generators
             }
 
             return staticValidatorInstance;
+        }
+
+        /// <summary>
+        /// Returns a non-randomized hash code for the given string.
+        /// We always return a positive value.
+        /// </summary>
+        internal static int GetNonRandomizedHashCode(string s)
+        {
+            uint result = 2166136261u;
+            foreach (char c in s)
+            {
+                result = (c ^ result) * 16777619;
+            }
+            return Math.Abs((int)result);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
@@ -190,8 +190,7 @@ namespace Microsoft.Extensions.Options.Generators
         {
             if (modelToValidate.SelfValidates)
             {
-                OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
-                OutLn($"builder.AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));");
+                OutLn($"(builder ??= new()).AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));");
                 OutLn();
             }
         }
@@ -270,8 +269,7 @@ namespace Microsoft.Extensions.Options.Generators
 
             OutLn($"if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.{vm.Name}{_TryGetValueNullableAnnotation}, context, validationResults, validationAttributes))");
             OutOpenBrace();
-            OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
-            OutLn($"builder.AddResults(validationResults);");
+            OutLn($"(builder ??= new()).AddResults(validationResults);");
             OutCloseBrace();
         }
 
@@ -357,14 +355,12 @@ namespace Microsoft.Extensions.Options.Generators
             {
                 OutLn($"if (options.{vm.Name} is not null)");
                 OutOpenBrace();
-                OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
-                OutLn($"builder.AddResult({callSequence}.Validate({baseName}, options.{vm.Name}{valueAccess}));");
+                OutLn($"(builder ??= new()).AddResult({callSequence}.Validate({baseName}, options.{vm.Name}{valueAccess}));");
                 OutCloseBrace();
             }
             else
             {
-                OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
-                OutLn($"builder.AddResult({callSequence}.Validate({baseName}, options.{vm.Name}{valueAccess}));");
+                OutLn($"(builder ??= new()).AddResult({callSequence}.Validate({baseName}, options.{vm.Name}{valueAccess}));");
             }
         }
 
@@ -400,8 +396,7 @@ namespace Microsoft.Extensions.Options.Generators
                 OutLn($"if (o is not null)");
                 OutOpenBrace();
                 var propertyName = $"string.IsNullOrEmpty(name) ? $\"{modelName}.{vm.Name}[{{count}}]\" : $\"{{name}}.{vm.Name}[{{count}}]\"";
-                OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
-                OutLn($"builder.AddResult({callSequence}.Validate({propertyName}, o{enumeratedValueAccess}));");
+                OutLn($"(builder ??= new()).AddResult({callSequence}.Validate({propertyName}, o{enumeratedValueAccess}));");
                 OutCloseBrace();
 
                 if (!vm.EnumeratedMayBeNull)
@@ -409,8 +404,7 @@ namespace Microsoft.Extensions.Options.Generators
                     OutLn($"else");
                     OutOpenBrace();
                     var error = $"string.IsNullOrEmpty(name) ? $\"{modelName}.{vm.Name}[{{count}}] is null\" : $\"{{name}}.{vm.Name}[{{count}}] is null\"";
-                    OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
-                    OutLn($"builder.AddError({error});");
+                    OutLn($"(builder ??= new()).AddError({error});");
                     OutCloseBrace();
                 }
 
@@ -419,8 +413,7 @@ namespace Microsoft.Extensions.Options.Generators
             else
             {
                 var propertyName = $"string.IsNullOrEmpty(name) ? $\"{modelName}.{vm.Name}[{{count++}}] is null\" : $\"{{name}}.{vm.Name}[{{count++}}] is null\"";
-                OutLn($"builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();");
-                OutLn($"builder.AddResult({callSequence}.Validate({propertyName}, o{enumeratedValueAccess}));");
+                OutLn($"(builder ??= new()).AddResult({callSequence}.Validate({propertyName}, o{enumeratedValueAccess}));");
             }
 
             OutCloseBrace();

--- a/src/libraries/Microsoft.Extensions.Options/gen/Microsoft.Extensions.Options.SourceGeneration.csproj
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Microsoft.Extensions.Options.SourceGeneration.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
+    <Compile Include="$(CommonPath)\Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
     <Compile Include="DiagDescriptors.cs" />
     <Compile Include="DiagDescriptorsBase.cs" />
     <Compile Include="Emitter.cs" />

--- a/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
@@ -240,6 +240,13 @@ namespace Microsoft.Extensions.Options.Generators
                 type = ((INamedTypeSymbol)type).TypeArguments[0];
             }
 
+            // Check first if the type is IEnumerable<T> interface
+            if (SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, _symbolHolder.GenericIEnumerableSymbol))
+            {
+                return ((INamedTypeSymbol)type).TypeArguments[0];
+            }
+
+            // Check first if the type implement IEnumerable<T> interface
             foreach (var implementingInterface in type.AllInterfaces)
             {
                 if (SymbolEqualityComparer.Default.Equals(implementingInterface.OriginalDefinition, _compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T)))

--- a/src/libraries/Microsoft.Extensions.Options/gen/SymbolHolder.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/SymbolHolder.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Extensions.Options.Generators
         INamedTypeSymbol DataTypeAttributeSymbol,
         INamedTypeSymbol ValidateOptionsSymbol,
         INamedTypeSymbol IValidatableObjectSymbol,
+        INamedTypeSymbol GenericIEnumerableSymbol,
         INamedTypeSymbol TypeSymbol,
-        INamedTypeSymbol? ValidateObjectMembersAttributeSymbol,
-        INamedTypeSymbol? ValidateEnumeratedItemsAttributeSymbol);
+        INamedTypeSymbol ValidateObjectMembersAttributeSymbol,
+        INamedTypeSymbol ValidateEnumeratedItemsAttributeSymbol);
 }

--- a/src/libraries/Microsoft.Extensions.Options/gen/SymbolLoader.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/SymbolLoader.cs
@@ -15,19 +15,11 @@ namespace Microsoft.Extensions.Options.Generators
         internal const string TypeOfType = "System.Type";
         internal const string ValidateObjectMembersAttribute = "Microsoft.Extensions.Options.ValidateObjectMembersAttribute";
         internal const string ValidateEnumeratedItemsAttribute = "Microsoft.Extensions.Options.ValidateEnumeratedItemsAttribute";
+        internal const string GenericIEnumerableType = "System.Collections.Generic.IEnumerable`1";
 
         public static bool TryLoad(Compilation compilation, out SymbolHolder? symbolHolder)
         {
-            INamedTypeSymbol? GetSymbol(string metadataName, bool optional = false)
-            {
-                var symbol = compilation.GetTypeByMetadataName(metadataName);
-                if (symbol == null && !optional)
-                {
-                    return null;
-                }
-
-                return symbol;
-            }
+            INamedTypeSymbol? GetSymbol(string metadataName) => compilation.GetTypeByMetadataName(metadataName);
 
             // required
             var optionsValidatorSymbol = GetSymbol(OptionsValidatorAttribute);
@@ -35,7 +27,10 @@ namespace Microsoft.Extensions.Options.Generators
             var dataTypeAttributeSymbol = GetSymbol(DataTypeAttribute);
             var ivalidatableObjectSymbol = GetSymbol(IValidatableObjectType);
             var validateOptionsSymbol = GetSymbol(IValidateOptionsType);
+            var genericIEnumerableSymbol = GetSymbol(GenericIEnumerableType);
             var typeSymbol = GetSymbol(TypeOfType);
+            var validateObjectMembersAttribute = GetSymbol(ValidateObjectMembersAttribute);
+            var validateEnumeratedItemsAttribute = GetSymbol(ValidateEnumeratedItemsAttribute);
 
     #pragma warning disable S1067 // Expressions should not be too complex
             if (optionsValidatorSymbol == null ||
@@ -43,7 +38,10 @@ namespace Microsoft.Extensions.Options.Generators
                 dataTypeAttributeSymbol == null ||
                 ivalidatableObjectSymbol == null ||
                 validateOptionsSymbol == null ||
-                typeSymbol == null)
+                genericIEnumerableSymbol == null ||
+                typeSymbol == null ||
+                validateObjectMembersAttribute == null ||
+                validateEnumeratedItemsAttribute == null)
             {
                 symbolHolder = default;
                 return false;
@@ -56,11 +54,10 @@ namespace Microsoft.Extensions.Options.Generators
                 dataTypeAttributeSymbol,
                 validateOptionsSymbol,
                 ivalidatableObjectSymbol,
+                genericIEnumerableSymbol,
                 typeSymbol,
-
-                // optional
-                GetSymbol(ValidateObjectMembersAttribute, optional: true),
-                GetSymbol(ValidateEnumeratedItemsAttribute, optional: true));
+                validateObjectMembersAttribute,
+                validateEnumeratedItemsAttribute);
 
             return true;
         }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
@@ -70,31 +70,32 @@ public class EmitterTests
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::HelloWorld.MyOptions options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "MyOptions" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val1";
-            context.DisplayName = baseName + "Val1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "MyOptions.Val1" : $"{name}.Val1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
-            context.DisplayName = baseName + "Val2";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "MyOptions.Val2" : $"{name}.Val2";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
@@ -80,8 +80,7 @@ public class EmitterTests
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
@@ -91,8 +90,7 @@ public class EmitterTests
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
@@ -25,10 +25,15 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
                 {
                     Tall = 10,
                     Id = "1",
-                    Children = new()
+                    Children1 = new()
                     {
-                        new ChildOptions() { Name = "C1" },
-                        new ChildOptions() { Name = "C2" }
+                        new ChildOptions() { Name = "C1-1" },
+                        new ChildOptions() { Name = "C1-2" }
+                    },
+                    Children2 = new List<ChildOptions>()
+                    {
+                        new ChildOptions() { Name = "C2-1" },
+                        new ChildOptions() { Name = "C2-2" }
                     },
                     NestedList = new()
                     {
@@ -126,12 +131,19 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
                 {
                     Tall = 10,
                     Id = "1",
-                    Children = new()
+                    Children1 = new()
                     {
                         new ChildOptions(),
                         new ChildOptions(),
                         new ChildOptions()
-                    }
+                    },
+                    Children2 = new List<ChildOptions>()
+                    {
+                        new ChildOptions(),
+                        new ChildOptions(),
+                        new ChildOptions()
+                    },
+
                 }
             };
 
@@ -142,9 +154,12 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
             Assert.True(result1.Failed);
             Assert.Equal(new List<string>
                         {
-                            "Name: The MyOptions.Nested.Children[0].Name field is required.",
-                            "Name: The MyOptions.Nested.Children[1].Name field is required.",
-                            "Name: The MyOptions.Nested.Children[2].Name field is required.",
+                            "Name: The MyOptions.Nested.Children1[0].Name field is required.",
+                            "Name: The MyOptions.Nested.Children1[1].Name field is required.",
+                            "Name: The MyOptions.Nested.Children1[2].Name field is required.",
+                            "Name: The MyOptions.Nested.Children2[0].Name field is required.",
+                            "Name: The MyOptions.Nested.Children2[1].Name field is required.",
+                            "Name: The MyOptions.Nested.Children2[2].Name field is required.",
                         },
                         result1.Failures);
 
@@ -152,9 +167,12 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
             Assert.True(result2.Failed);
             Assert.Equal(new List<string>
                         {
-                            "DataAnnotation validation failed for 'MyOptions.Nested.Children[0]' members: 'Name' with the error: 'The Name field is required.'.",
-                            "DataAnnotation validation failed for 'MyOptions.Nested.Children[1]' members: 'Name' with the error: 'The Name field is required.'.",
-                            "DataAnnotation validation failed for 'MyOptions.Nested.Children[2]' members: 'Name' with the error: 'The Name field is required.'.",
+                            "DataAnnotation validation failed for 'MyOptions.Nested.Children1[0]' members: 'Name' with the error: 'The Name field is required.'.",
+                            "DataAnnotation validation failed for 'MyOptions.Nested.Children1[1]' members: 'Name' with the error: 'The Name field is required.'.",
+                            "DataAnnotation validation failed for 'MyOptions.Nested.Children1[2]' members: 'Name' with the error: 'The Name field is required.'.",
+                            "DataAnnotation validation failed for 'MyOptions.Nested.Children2[0]' members: 'Name' with the error: 'The Name field is required.'.",
+                            "DataAnnotation validation failed for 'MyOptions.Nested.Children2[1]' members: 'Name' with the error: 'The Name field is required.'.",
+                            "DataAnnotation validation failed for 'MyOptions.Nested.Children2[2]' members: 'Name' with the error: 'The Name field is required.'.",
                         },
                         result2.Failures);
         }
@@ -219,7 +237,10 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
         public string? Id { get; set; }
 
         [ValidateEnumeratedItems]
-        public List<ChildOptions>? Children { get; set; }
+        public List<ChildOptions>? Children1 { get; set; }
+
+        [ValidateEnumeratedItems]
+        public IEnumerable<ChildOptions>? Children2 { get; set; }
 
 #pragma warning disable SYSLIB1211 // Source gen does static analysis for circular reference. We need to disable it for this test.
         [ValidateEnumeratedItems]

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetCoreApp/Validators.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetCoreApp/Validators.g.cs
@@ -25,8 +25,7 @@ internal sealed partial class __ThirdModelNoNamespaceValidator__
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
         if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
         {
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResults(validationResults);
+            (builder ??= new()).AddResults(validationResults);
         }
 
         return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -54,20 +53,17 @@ partial class FirstValidatorNoNamespace
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
         if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
         {
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResults(validationResults);
+            (builder ??= new()).AddResults(validationResults);
         }
 
         if (options.P2 is not null)
         {
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V1.Validate(string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P2" : $"{name}.P2", options.P2));
+            (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V1.Validate(string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P2" : $"{name}.P2", options.P2));
         }
 
         if (options.P3 is not null)
         {
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResult(global::__ThirdModelNoNamespaceValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P3" : $"{name}.P3", options.P3));
+            (builder ??= new()).AddResult(global::__ThirdModelNoNamespaceValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P3" : $"{name}.P3", options.P3));
         }
 
         return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -95,8 +91,7 @@ partial class SecondValidatorNoNamespace
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
         if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
         {
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResults(validationResults);
+            (builder ??= new()).AddResults(validationResults);
         }
 
         return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -125,8 +120,7 @@ namespace CustomAttr
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A3);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "P2";
@@ -136,8 +130,7 @@ namespace CustomAttr
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A4);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P2, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -169,8 +162,7 @@ namespace Enumeration
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -201,8 +193,7 @@ namespace Enumeration
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A5);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Value, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -232,13 +223,11 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P1[{count}]" : $"{name}.P1[{count}]", o));
+                        (builder ??= new()).AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P1[{count}]" : $"{name}.P1[{count}]", o));
                     }
                     else
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P1[{count}] is null" : $"{name}.P1[{count}] is null");
+                        (builder ??= new()).AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P1[{count}] is null" : $"{name}.P1[{count}] is null");
                     }
                     count++;
                 }
@@ -251,13 +240,11 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V2.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P2[{count}]" : $"{name}.P2[{count}]", o));
+                        (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V2.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P2[{count}]" : $"{name}.P2[{count}]", o));
                     }
                     else
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P2[{count}] is null" : $"{name}.P2[{count}] is null");
+                        (builder ??= new()).AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P2[{count}] is null" : $"{name}.P2[{count}] is null");
                     }
                     count++;
                 }
@@ -270,8 +257,7 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P3[{count}]" : $"{name}.P3[{count}]", o));
+                        (builder ??= new()).AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P3[{count}]" : $"{name}.P3[{count}]", o));
                     }
                     count++;
                 }
@@ -282,8 +268,7 @@ namespace Enumeration
                 var count = 0;
                 foreach (var o in options.P4)
                 {
-                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                    builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P4[{count++}] is null" : $"{name}.P4[{count++}] is null", o));
+                    (builder ??= new()).AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P4[{count++}] is null" : $"{name}.P4[{count++}] is null", o));
                 }
             }
 
@@ -294,8 +279,7 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P5[{count}]" : $"{name}.P5[{count}]", o.Value));
+                        (builder ??= new()).AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P5[{count}]" : $"{name}.P5[{count}]", o.Value));
                     }
                     count++;
                 }
@@ -308,8 +292,7 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P51[{count}]" : $"{name}.P51[{count}]", o.Value));
+                        (builder ??= new()).AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P51[{count}]" : $"{name}.P51[{count}]", o.Value));
                     }
                     count++;
                 }
@@ -322,13 +305,11 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P6[{count}]" : $"{name}.P6[{count}]", o));
+                        (builder ??= new()).AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P6[{count}]" : $"{name}.P6[{count}]", o));
                     }
                     else
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P6[{count}] is null" : $"{name}.P6[{count}] is null");
+                        (builder ??= new()).AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P6[{count}] is null" : $"{name}.P6[{count}] is null");
                     }
                     count++;
                 }
@@ -340,13 +321,11 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P7[{count}]" : $"{name}.P7[{count}]", o));
+                        (builder ??= new()).AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P7[{count}]" : $"{name}.P7[{count}]", o));
                     }
                     else
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P7[{count}] is null" : $"{name}.P7[{count}] is null");
+                        (builder ??= new()).AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P7[{count}] is null" : $"{name}.P7[{count}] is null");
                     }
                     count++;
                 }
@@ -359,13 +338,11 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P8[{count}]" : $"{name}.P8[{count}]", o));
+                        (builder ??= new()).AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P8[{count}]" : $"{name}.P8[{count}]", o));
                     }
                     else
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P8[{count}] is null" : $"{name}.P8[{count}] is null");
+                        (builder ??= new()).AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P8[{count}] is null" : $"{name}.P8[{count}] is null");
                     }
                     count++;
                 }
@@ -399,8 +376,7 @@ namespace Enumeration
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -431,8 +407,7 @@ namespace FileScopedNamespace
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -462,8 +437,7 @@ namespace FunnyStrings
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A6);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -495,8 +469,7 @@ namespace Generics
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -527,14 +500,12 @@ namespace Generics
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P3 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::Generics.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
+                (builder ??= new()).AddResult(global::Generics.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -565,14 +536,12 @@ namespace MultiModelValidator
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V3.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
+                (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V3.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -597,8 +566,7 @@ namespace MultiModelValidator
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P3, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -630,8 +598,7 @@ namespace Nested
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -664,8 +631,7 @@ namespace Nested
                 validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
                 if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                 {
-                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                    builder.AddResults(validationResults);
+                    (builder ??= new()).AddResults(validationResults);
                 }
 
                 return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -701,23 +667,19 @@ namespace Nested
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
                     if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResults(validationResults);
+                        (builder ??= new()).AddResults(validationResults);
                     }
 
                     if (options.P2 is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V4.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
+                        (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V4.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
                     }
 
-                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                    builder.AddResult(global::Nested.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
+                    (builder ??= new()).AddResult(global::Nested.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
 
                     if (options.P4 is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V5.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4));
+                        (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V5.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4));
                     }
 
                     return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -752,8 +714,7 @@ namespace Nested
                 validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
                 if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                 {
-                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                    builder.AddResults(validationResults);
+                    (builder ??= new()).AddResults(validationResults);
                 }
 
                 return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -789,8 +750,7 @@ namespace Nested
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
                     if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResults(validationResults);
+                        (builder ??= new()).AddResults(validationResults);
                     }
 
                     return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -827,8 +787,7 @@ namespace Nested
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
                     if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResults(validationResults);
+                        (builder ??= new()).AddResults(validationResults);
                     }
 
                     return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -861,8 +820,7 @@ namespace RandomMembers
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -894,8 +852,7 @@ namespace RecordTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -926,24 +883,20 @@ namespace RecordTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V6.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
+                (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V6.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
             if (options.P3 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V7.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
+                (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V7.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
             }
 
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResult(global::RecordTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4));
+            (builder ??= new()).AddResult(global::RecordTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4));
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
@@ -973,8 +926,7 @@ namespace RecordTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1005,8 +957,7 @@ namespace RecordTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1037,14 +988,12 @@ namespace RepeatedTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P4 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "SecondModel.P4" : $"{name}.P4", options.P4));
+                (builder ??= new()).AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "SecondModel.P4" : $"{name}.P4", options.P4));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1076,8 +1025,7 @@ namespace RepeatedTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1107,14 +1055,12 @@ namespace RepeatedTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P1 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1", options.P1));
+                (builder ??= new()).AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1", options.P1));
             }
 
             context.MemberName = "P2";
@@ -1124,14 +1070,12 @@ namespace RepeatedTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P2, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
+                (builder ??= new()).AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
             context.MemberName = "P3";
@@ -1141,14 +1085,12 @@ namespace RepeatedTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P3, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P3 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
+                (builder ??= new()).AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1178,12 +1120,10 @@ namespace SelfValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));
+            (builder ??= new()).AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
@@ -1213,8 +1153,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A7);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1245,8 +1184,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1277,8 +1215,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
@@ -1288,14 +1225,12 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A8);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.YetAnotherComplexVal is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::TestClasses.OptionsValidation.__RangeAttributeModelDoubleValidator__.Validate(string.IsNullOrEmpty(name) ? "TypeWithoutOptionsValidator.YetAnotherComplexVal" : $"{name}.YetAnotherComplexVal", options.YetAnotherComplexVal));
+                (builder ??= new()).AddResult(global::TestClasses.OptionsValidation.__RangeAttributeModelDoubleValidator__.Validate(string.IsNullOrEmpty(name) ? "TypeWithoutOptionsValidator.YetAnotherComplexVal" : $"{name}.YetAnotherComplexVal", options.YetAnotherComplexVal));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1325,8 +1260,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A9);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
@@ -1336,8 +1270,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A10);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1362,14 +1295,12 @@ namespace TestClasses.OptionsValidation
 
             if (options.ComplexVal is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::TestClasses.OptionsValidation.__RequiredAttributeModelValidator__.Validate(string.IsNullOrEmpty(name) ? "ComplexModel.ComplexVal" : $"{name}.ComplexVal", options.ComplexVal));
+                (builder ??= new()).AddResult(global::TestClasses.OptionsValidation.__RequiredAttributeModelValidator__.Validate(string.IsNullOrEmpty(name) ? "ComplexModel.ComplexVal" : $"{name}.ComplexVal", options.ComplexVal));
             }
 
             if (options.ValWithoutOptionsValidator is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::TestClasses.OptionsValidation.__TypeWithoutOptionsValidatorValidator__.Validate(string.IsNullOrEmpty(name) ? "ComplexModel.ValWithoutOptionsValidator" : $"{name}.ValWithoutOptionsValidator", options.ValWithoutOptionsValidator));
+                (builder ??= new()).AddResult(global::TestClasses.OptionsValidation.__TypeWithoutOptionsValidatorValidator__.Validate(string.IsNullOrEmpty(name) ? "ComplexModel.ValWithoutOptionsValidator" : $"{name}.ValWithoutOptionsValidator", options.ValWithoutOptionsValidator));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1399,8 +1330,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A11);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1430,8 +1360,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A12);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1461,8 +1390,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A13);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1492,8 +1420,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.DerivedVal, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "VirtualValWithAttr";
@@ -1503,8 +1430,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.VirtualValWithAttr, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val";
@@ -1514,8 +1440,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1545,8 +1470,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A14);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1576,8 +1500,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.VirtualValWithoutAttr, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "DerivedVal";
@@ -1587,8 +1510,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.DerivedVal, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val";
@@ -1598,8 +1520,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1630,8 +1551,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A15);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
@@ -1641,8 +1561,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A16);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val3";
@@ -1652,8 +1571,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A17);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val3, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val4";
@@ -1663,8 +1581,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A18);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val4, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1694,8 +1611,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A19);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1725,8 +1641,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A7);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1756,8 +1671,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A16);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1787,8 +1701,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A20);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1818,8 +1731,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1851,8 +1763,7 @@ namespace ValueTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1883,23 +1794,19 @@ namespace ValueTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2.Value));
+                (builder ??= new()).AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2.Value));
             }
 
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
+            (builder ??= new()).AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
 
             if (options.P4 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4.Value));
+                (builder ??= new()).AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4.Value));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetCoreApp/Validators.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetCoreApp/Validators.g.cs
@@ -14,22 +14,22 @@ internal sealed partial class __ThirdModelNoNamespaceValidator__
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::ThirdModelNoNamespace options)
     {
-        var baseName = (string.IsNullOrEmpty(name) ? "ThirdModelNoNamespace" : name) + ".";
-        var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+        global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
         var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
         var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
         var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
         context.MemberName = "P5";
-        context.DisplayName = baseName + "P5";
+        context.DisplayName = string.IsNullOrEmpty(name) ? "ThirdModelNoNamespace.P5" : $"{name}.P5";
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-        if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+        if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
         {
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
             builder.AddResults(validationResults);
         }
 
-        return builder.Build();
+        return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
     }
 }
 partial class FirstValidatorNoNamespace
@@ -43,32 +43,34 @@ partial class FirstValidatorNoNamespace
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::FirstModelNoNamespace options)
     {
-        var baseName = (string.IsNullOrEmpty(name) ? "FirstModelNoNamespace" : name) + ".";
-        var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+        global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
         var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
         var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
         var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
         context.MemberName = "P1";
-        context.DisplayName = baseName + "P1";
+        context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P1" : $"{name}.P1";
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-        if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+        if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
         {
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
             builder.AddResults(validationResults);
         }
 
         if (options.P2 is not null)
         {
-            builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V1.Validate(baseName + "P2", options.P2));
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V1.Validate(string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P2" : $"{name}.P2", options.P2));
         }
 
         if (options.P3 is not null)
         {
-            builder.AddResult(global::__ThirdModelNoNamespaceValidator__.Validate(baseName + "P3", options.P3));
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            builder.AddResult(global::__ThirdModelNoNamespaceValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P3" : $"{name}.P3", options.P3));
         }
 
-        return builder.Build();
+        return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
     }
 }
 partial class SecondValidatorNoNamespace
@@ -82,22 +84,22 @@ partial class SecondValidatorNoNamespace
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::SecondModelNoNamespace options)
     {
-        var baseName = (string.IsNullOrEmpty(name) ? "SecondModelNoNamespace" : name) + ".";
-        var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+        global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
         var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
         var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
         var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
         context.MemberName = "P4";
-        context.DisplayName = baseName + "P4";
+        context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModelNoNamespace.P4" : $"{name}.P4";
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-        if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4!, context, validationResults, validationAttributes))
+        if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
         {
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
             builder.AddResults(validationResults);
         }
 
-        return builder.Build();
+        return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
     }
 }
 namespace CustomAttr
@@ -113,31 +115,32 @@ namespace CustomAttr
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::CustomAttr.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A3);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "P2";
-            context.DisplayName = baseName + "P2";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A4);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P2!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P2, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -155,22 +158,22 @@ namespace Enumeration
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Enumeration.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P6";
-            context.DisplayName = baseName + "P6";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P6" : $"{name}.P6";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -188,21 +191,21 @@ namespace Enumeration
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Enumeration.ThirdModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "ThirdModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Value";
-            context.DisplayName = baseName + "Value";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "ThirdModel.Value" : $"{name}.Value";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A5);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Value!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Value, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -219,8 +222,7 @@ namespace Enumeration
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Enumeration.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
 
             if (options.P1 is not null)
@@ -230,11 +232,13 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(baseName + $"P1[{count}]", o));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P1[{count}]" : $"{name}.P1[{count}]", o));
                     }
                     else
                     {
-                        builder.AddError(baseName + $"P1[{count}] is null");
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P1[{count}] is null" : $"{name}.P1[{count}] is null");
                     }
                     count++;
                 }
@@ -247,11 +251,13 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V2.Validate(baseName + $"P2[{count}]", o));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V2.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P2[{count}]" : $"{name}.P2[{count}]", o));
                     }
                     else
                     {
-                        builder.AddError(baseName + $"P2[{count}] is null");
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P2[{count}] is null" : $"{name}.P2[{count}] is null");
                     }
                     count++;
                 }
@@ -264,7 +270,8 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(baseName + $"P3[{count}]", o));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P3[{count}]" : $"{name}.P3[{count}]", o));
                     }
                     count++;
                 }
@@ -275,7 +282,8 @@ namespace Enumeration
                 var count = 0;
                 foreach (var o in options.P4)
                 {
-                    builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(baseName + $"P4[{count++}]", o));
+                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                    builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P4[{count++}] is null" : $"{name}.P4[{count++}] is null", o));
                 }
             }
 
@@ -286,7 +294,8 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(baseName + $"P5[{count}]", o.Value));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P5[{count}]" : $"{name}.P5[{count}]", o.Value));
                     }
                     count++;
                 }
@@ -299,7 +308,8 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(baseName + $"P51[{count}]", o.Value));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P51[{count}]" : $"{name}.P51[{count}]", o.Value));
                     }
                     count++;
                 }
@@ -312,11 +322,13 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(baseName + $"P6[{count}]", o));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P6[{count}]" : $"{name}.P6[{count}]", o));
                     }
                     else
                     {
-                        builder.AddError(baseName + $"P6[{count}] is null");
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P6[{count}] is null" : $"{name}.P6[{count}] is null");
                     }
                     count++;
                 }
@@ -328,11 +340,13 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(baseName + $"P7[{count}]", o));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P7[{count}]" : $"{name}.P7[{count}]", o));
                     }
                     else
                     {
-                        builder.AddError(baseName + $"P7[{count}] is null");
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P7[{count}] is null" : $"{name}.P7[{count}] is null");
                     }
                     count++;
                 }
@@ -345,17 +359,19 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(baseName + $"P8[{count}]", o));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P8[{count}]" : $"{name}.P8[{count}]", o));
                     }
                     else
                     {
-                        builder.AddError(baseName + $"P8[{count}] is null");
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P8[{count}] is null" : $"{name}.P8[{count}] is null");
                     }
                     count++;
                 }
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -372,22 +388,22 @@ namespace Enumeration
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Enumeration.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P6";
-            context.DisplayName = baseName + "P6";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P6" : $"{name}.P6";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -404,22 +420,22 @@ namespace FileScopedNamespace
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::FileScopedNamespace.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -436,21 +452,21 @@ namespace FunnyStrings
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::FunnyStrings.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A6);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -468,22 +484,22 @@ namespace Generics
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Generics.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P4";
-            context.DisplayName = baseName + "P4";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P4" : $"{name}.P4";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -500,27 +516,28 @@ namespace Generics
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Generics.FirstModel<T> options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P3 is not null)
             {
-                builder.AddResult(global::Generics.__SecondModelValidator__.Validate(baseName + "P3", options.P3));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::Generics.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -537,27 +554,28 @@ namespace MultiModelValidator
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::MultiModelValidator.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V3.Validate(baseName + "P2", options.P2));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V3.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
         /// <summary>
         /// Validates a specific named options instance (or all when <paramref name="name"/> is <see langword="null" />).
@@ -568,22 +586,22 @@ namespace MultiModelValidator
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::MultiModelValidator.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P3";
-            context.DisplayName = baseName + "P3";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P3" : $"{name}.P3";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P3!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P3, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -601,22 +619,22 @@ namespace Nested
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Nested.Container1.ThirdModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "ThirdModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P6";
-            context.DisplayName = baseName + "P6";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "ThirdModel.P6" : $"{name}.P6";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -635,22 +653,22 @@ namespace Nested
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
             public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Nested.Container1.SecondModel options)
             {
-                var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-                var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
                 var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
                 var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
                 var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
                 context.MemberName = "P5";
-                context.DisplayName = baseName + "P5";
+                context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P5" : $"{name}.P5";
                 validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
                 validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-                if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+                if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                 {
+                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                     builder.AddResults(validationResults);
                 }
 
-                return builder.Build();
+                return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
             }
         }
     }
@@ -672,34 +690,37 @@ namespace Nested
                 [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
                 public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Nested.Container1.FirstModel options)
                 {
-                    var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-                    var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                    global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
                     var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
                     var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
                     var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
                     context.MemberName = "P1";
-                    context.DisplayName = baseName + "P1";
+                    context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-                    if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+                    if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
                     {
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                         builder.AddResults(validationResults);
                     }
 
                     if (options.P2 is not null)
                     {
-                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V4.Validate(baseName + "P2", options.P2));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V4.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
                     }
 
-                    builder.AddResult(global::Nested.__ThirdModelValidator__.Validate(baseName + "P3", options.P3));
+                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                    builder.AddResult(global::Nested.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
 
                     if (options.P4 is not null)
                     {
-                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V5.Validate(baseName + "P4", options.P4));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V5.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4));
                     }
 
-                    return builder.Build();
+                    return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
                 }
             }
         }
@@ -720,22 +741,22 @@ namespace Nested
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
             public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Nested.Container1.SecondModel options)
             {
-                var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-                var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
                 var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
                 var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
                 var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
                 context.MemberName = "P5";
-                context.DisplayName = baseName + "P5";
+                context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P5" : $"{name}.P5";
                 validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
                 validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-                if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+                if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                 {
+                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                     builder.AddResults(validationResults);
                 }
 
-                return builder.Build();
+                return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
             }
         }
     }
@@ -757,22 +778,22 @@ namespace Nested
                 [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
                 public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Nested.Container1.SecondModel options)
                 {
-                    var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-                    var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                    global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
                     var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
                     var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
                     var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
                     context.MemberName = "P5";
-                    context.DisplayName = baseName + "P5";
+                    context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P5" : $"{name}.P5";
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-                    if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+                    if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                     {
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                         builder.AddResults(validationResults);
                     }
 
-                    return builder.Build();
+                    return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
                 }
             }
         }
@@ -795,22 +816,22 @@ namespace Nested
                 [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
                 public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Nested.Container1.SecondModel options)
                 {
-                    var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-                    var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                    global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
                     var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
                     var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
                     var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
                     context.MemberName = "P5";
-                    context.DisplayName = baseName + "P5";
+                    context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P5" : $"{name}.P5";
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-                    if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+                    if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                     {
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                         builder.AddResults(validationResults);
                     }
 
-                    return builder.Build();
+                    return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
                 }
             }
         }
@@ -829,22 +850,22 @@ namespace RandomMembers
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RandomMembers.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -862,22 +883,22 @@ namespace RecordTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RecordTypes.ThirdModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "ThirdModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P6";
-            context.DisplayName = baseName + "P6";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "ThirdModel.P6" : $"{name}.P6";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -894,34 +915,37 @@ namespace RecordTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RecordTypes.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V6.Validate(baseName + "P2", options.P2));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V6.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
             if (options.P3 is not null)
             {
-                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V7.Validate(baseName + "P3", options.P3));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V7.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
             }
 
-            builder.AddResult(global::RecordTypes.__ThirdModelValidator__.Validate(baseName + "P4", options.P4));
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            builder.AddResult(global::RecordTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4));
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -938,22 +962,22 @@ namespace RecordTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RecordTypes.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P5";
-            context.DisplayName = baseName + "P5";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P5" : $"{name}.P5";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -970,22 +994,22 @@ namespace RecordTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RecordTypes.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P5";
-            context.DisplayName = baseName + "P5";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P5" : $"{name}.P5";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1003,26 +1027,27 @@ namespace RepeatedTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RepeatedTypes.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "P4";
-            context.DisplayName = baseName + "P4";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P4" : $"{name}.P4";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P4 is not null)
             {
-                builder.AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(baseName + "P4", options.P4));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "SecondModel.P4" : $"{name}.P4", options.P4));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1040,22 +1065,22 @@ namespace RepeatedTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RepeatedTypes.ThirdModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "ThirdModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P5";
-            context.DisplayName = baseName + "P5";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "ThirdModel.P5" : $"{name}.P5";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1072,56 +1097,61 @@ namespace RepeatedTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RepeatedTypes.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P1 is not null)
             {
-                builder.AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(baseName + "P1", options.P1));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1", options.P1));
             }
 
             context.MemberName = "P2";
-            context.DisplayName = baseName + "P2";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P2!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P2, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder.AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(baseName + "P2", options.P2));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
             context.MemberName = "P3";
-            context.DisplayName = baseName + "P3";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P3!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P3, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P3 is not null)
             {
-                builder.AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(baseName + "P3", options.P3));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1138,23 +1168,24 @@ namespace SelfValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::SelfValidation.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
             builder.AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1172,21 +1203,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RangeAttributeModelDouble options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RangeAttributeModelDouble" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RangeAttributeModelDouble.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A7);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1204,21 +1235,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RequiredAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RequiredAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RequiredAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1236,36 +1267,38 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.TypeWithoutOptionsValidator options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "TypeWithoutOptionsValidator" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val1";
-            context.DisplayName = baseName + "Val1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "TypeWithoutOptionsValidator.Val1" : $"{name}.Val1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
-            context.DisplayName = baseName + "Val2";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "TypeWithoutOptionsValidator.Val2" : $"{name}.Val2";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A8);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.YetAnotherComplexVal is not null)
             {
-                builder.AddResult(global::TestClasses.OptionsValidation.__RangeAttributeModelDoubleValidator__.Validate(baseName + "YetAnotherComplexVal", options.YetAnotherComplexVal));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::TestClasses.OptionsValidation.__RangeAttributeModelDoubleValidator__.Validate(string.IsNullOrEmpty(name) ? "TypeWithoutOptionsValidator.YetAnotherComplexVal" : $"{name}.YetAnotherComplexVal", options.YetAnotherComplexVal));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1282,31 +1315,32 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.AttributePropertyModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "AttributePropertyModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val1";
-            context.DisplayName = baseName + "Val1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "AttributePropertyModel.Val1" : $"{name}.Val1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A9);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
-            context.DisplayName = baseName + "Val2";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "AttributePropertyModel.Val2" : $"{name}.Val2";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A10);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1323,21 +1357,22 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.ComplexModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "ComplexModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
 
             if (options.ComplexVal is not null)
             {
-                builder.AddResult(global::TestClasses.OptionsValidation.__RequiredAttributeModelValidator__.Validate(baseName + "ComplexVal", options.ComplexVal));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::TestClasses.OptionsValidation.__RequiredAttributeModelValidator__.Validate(string.IsNullOrEmpty(name) ? "ComplexModel.ComplexVal" : $"{name}.ComplexVal", options.ComplexVal));
             }
 
             if (options.ValWithoutOptionsValidator is not null)
             {
-                builder.AddResult(global::TestClasses.OptionsValidation.__TypeWithoutOptionsValidatorValidator__.Validate(baseName + "ValWithoutOptionsValidator", options.ValWithoutOptionsValidator));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::TestClasses.OptionsValidation.__TypeWithoutOptionsValidatorValidator__.Validate(string.IsNullOrEmpty(name) ? "ComplexModel.ValWithoutOptionsValidator" : $"{name}.ValWithoutOptionsValidator", options.ValWithoutOptionsValidator));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1354,21 +1389,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.CustomTypeCustomValidationAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "CustomTypeCustomValidationAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "CustomTypeCustomValidationAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A11);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1385,21 +1420,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.CustomValidationAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "CustomValidationAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "CustomValidationAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A12);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1416,21 +1451,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.DataTypeAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "DataTypeAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "DataTypeAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A13);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1447,41 +1482,43 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.DerivedModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "DerivedModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "DerivedVal";
-            context.DisplayName = baseName + "DerivedVal";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "DerivedModel.DerivedVal" : $"{name}.DerivedVal";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.DerivedVal!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.DerivedVal, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "VirtualValWithAttr";
-            context.DisplayName = baseName + "VirtualValWithAttr";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "DerivedModel.VirtualValWithAttr" : $"{name}.VirtualValWithAttr";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.VirtualValWithAttr!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.VirtualValWithAttr, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "DerivedModel.Val" : $"{name}.Val";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1498,21 +1535,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.EmailAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "EmailAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "EmailAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A14);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1529,41 +1566,43 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.LeafModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "LeafModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "VirtualValWithoutAttr";
-            context.DisplayName = baseName + "VirtualValWithoutAttr";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "LeafModel.VirtualValWithoutAttr" : $"{name}.VirtualValWithoutAttr";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.VirtualValWithoutAttr!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.VirtualValWithoutAttr, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "DerivedVal";
-            context.DisplayName = baseName + "DerivedVal";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "LeafModel.DerivedVal" : $"{name}.DerivedVal";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.DerivedVal!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.DerivedVal, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "LeafModel.Val" : $"{name}.Val";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1580,52 +1619,55 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.MultipleAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "MultipleAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "Val1";
-            context.DisplayName = baseName + "Val1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "MultipleAttributeModel.Val1" : $"{name}.Val1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A15);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
-            context.DisplayName = baseName + "Val2";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "MultipleAttributeModel.Val2" : $"{name}.Val2";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A16);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val3";
-            context.DisplayName = baseName + "Val3";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "MultipleAttributeModel.Val3" : $"{name}.Val3";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A17);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val3!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val3, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val4";
-            context.DisplayName = baseName + "Val4";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "MultipleAttributeModel.Val4" : $"{name}.Val4";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A18);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val4!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val4, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1642,21 +1684,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RangeAttributeModelDate options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RangeAttributeModelDate" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RangeAttributeModelDate.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A19);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1673,21 +1715,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RangeAttributeModelDouble options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RangeAttributeModelDouble" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RangeAttributeModelDouble.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A7);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1704,21 +1746,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RangeAttributeModelInt options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RangeAttributeModelInt" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RangeAttributeModelInt.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A16);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1735,21 +1777,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RegularExpressionAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RegularExpressionAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RegularExpressionAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A20);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1766,21 +1808,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RequiredAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RequiredAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RequiredAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1798,22 +1840,22 @@ namespace ValueTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::ValueTypes.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P4";
-            context.DisplayName = baseName + "P4";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P4" : $"{name}.P4";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1830,34 +1872,37 @@ namespace ValueTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::ValueTypes.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(baseName + "P2", options.P2.Value));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2.Value));
             }
 
-            builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(baseName + "P3", options.P3));
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
 
             if (options.P4 is not null)
             {
-                builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(baseName + "P4", options.P4.Value));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4.Value));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetFX/Validators.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetFX/Validators.g.cs
@@ -25,8 +25,7 @@ internal sealed partial class __ThirdModelNoNamespaceValidator__
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
         if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
         {
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResults(validationResults);
+            (builder ??= new()).AddResults(validationResults);
         }
 
         return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -54,20 +53,17 @@ partial class FirstValidatorNoNamespace
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
         if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
         {
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResults(validationResults);
+            (builder ??= new()).AddResults(validationResults);
         }
 
         if (options.P2 is not null)
         {
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V1.Validate(string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P2" : $"{name}.P2", options.P2));
+            (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V1.Validate(string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P2" : $"{name}.P2", options.P2));
         }
 
         if (options.P3 is not null)
         {
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResult(global::__ThirdModelNoNamespaceValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P3" : $"{name}.P3", options.P3));
+            (builder ??= new()).AddResult(global::__ThirdModelNoNamespaceValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P3" : $"{name}.P3", options.P3));
         }
 
         return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -95,8 +91,7 @@ partial class SecondValidatorNoNamespace
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
         if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
         {
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResults(validationResults);
+            (builder ??= new()).AddResults(validationResults);
         }
 
         return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -125,8 +120,7 @@ namespace CustomAttr
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A3);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "P2";
@@ -136,8 +130,7 @@ namespace CustomAttr
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A4);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P2, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -169,8 +162,7 @@ namespace Enumeration
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -201,8 +193,7 @@ namespace Enumeration
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A5);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Value, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -232,13 +223,11 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P1[{count}]" : $"{name}.P1[{count}]", o));
+                        (builder ??= new()).AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P1[{count}]" : $"{name}.P1[{count}]", o));
                     }
                     else
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P1[{count}] is null" : $"{name}.P1[{count}] is null");
+                        (builder ??= new()).AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P1[{count}] is null" : $"{name}.P1[{count}] is null");
                     }
                     count++;
                 }
@@ -251,13 +240,11 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V2.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P2[{count}]" : $"{name}.P2[{count}]", o));
+                        (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V2.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P2[{count}]" : $"{name}.P2[{count}]", o));
                     }
                     else
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P2[{count}] is null" : $"{name}.P2[{count}] is null");
+                        (builder ??= new()).AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P2[{count}] is null" : $"{name}.P2[{count}] is null");
                     }
                     count++;
                 }
@@ -270,8 +257,7 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P3[{count}]" : $"{name}.P3[{count}]", o));
+                        (builder ??= new()).AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P3[{count}]" : $"{name}.P3[{count}]", o));
                     }
                     count++;
                 }
@@ -282,8 +268,7 @@ namespace Enumeration
                 var count = 0;
                 foreach (var o in options.P4)
                 {
-                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                    builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P4[{count++}] is null" : $"{name}.P4[{count++}] is null", o));
+                    (builder ??= new()).AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P4[{count++}] is null" : $"{name}.P4[{count++}] is null", o));
                 }
             }
 
@@ -294,8 +279,7 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P5[{count}]" : $"{name}.P5[{count}]", o.Value));
+                        (builder ??= new()).AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P5[{count}]" : $"{name}.P5[{count}]", o.Value));
                     }
                     count++;
                 }
@@ -308,8 +292,7 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P51[{count}]" : $"{name}.P51[{count}]", o.Value));
+                        (builder ??= new()).AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P51[{count}]" : $"{name}.P51[{count}]", o.Value));
                     }
                     count++;
                 }
@@ -322,13 +305,11 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P6[{count}]" : $"{name}.P6[{count}]", o));
+                        (builder ??= new()).AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P6[{count}]" : $"{name}.P6[{count}]", o));
                     }
                     else
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P6[{count}] is null" : $"{name}.P6[{count}] is null");
+                        (builder ??= new()).AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P6[{count}] is null" : $"{name}.P6[{count}] is null");
                     }
                     count++;
                 }
@@ -340,13 +321,11 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P7[{count}]" : $"{name}.P7[{count}]", o));
+                        (builder ??= new()).AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P7[{count}]" : $"{name}.P7[{count}]", o));
                     }
                     else
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P7[{count}] is null" : $"{name}.P7[{count}] is null");
+                        (builder ??= new()).AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P7[{count}] is null" : $"{name}.P7[{count}] is null");
                     }
                     count++;
                 }
@@ -359,13 +338,11 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P8[{count}]" : $"{name}.P8[{count}]", o));
+                        (builder ??= new()).AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P8[{count}]" : $"{name}.P8[{count}]", o));
                     }
                     else
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P8[{count}] is null" : $"{name}.P8[{count}] is null");
+                        (builder ??= new()).AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P8[{count}] is null" : $"{name}.P8[{count}] is null");
                     }
                     count++;
                 }
@@ -399,8 +376,7 @@ namespace Enumeration
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -431,8 +407,7 @@ namespace FileScopedNamespace
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -462,8 +437,7 @@ namespace FunnyStrings
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A6);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -495,8 +469,7 @@ namespace Generics
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -527,14 +500,12 @@ namespace Generics
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P3 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::Generics.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
+                (builder ??= new()).AddResult(global::Generics.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -565,14 +536,12 @@ namespace MultiModelValidator
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V3.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
+                (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V3.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -597,8 +566,7 @@ namespace MultiModelValidator
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P3, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -630,8 +598,7 @@ namespace Nested
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -664,8 +631,7 @@ namespace Nested
                 validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
                 if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                 {
-                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                    builder.AddResults(validationResults);
+                    (builder ??= new()).AddResults(validationResults);
                 }
 
                 return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -701,23 +667,19 @@ namespace Nested
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
                     if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResults(validationResults);
+                        (builder ??= new()).AddResults(validationResults);
                     }
 
                     if (options.P2 is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V4.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
+                        (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V4.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
                     }
 
-                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                    builder.AddResult(global::Nested.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
+                    (builder ??= new()).AddResult(global::Nested.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
 
                     if (options.P4 is not null)
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V5.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4));
+                        (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V5.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4));
                     }
 
                     return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -752,8 +714,7 @@ namespace Nested
                 validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
                 if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                 {
-                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                    builder.AddResults(validationResults);
+                    (builder ??= new()).AddResults(validationResults);
                 }
 
                 return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -789,8 +750,7 @@ namespace Nested
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
                     if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResults(validationResults);
+                        (builder ??= new()).AddResults(validationResults);
                     }
 
                     return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -827,8 +787,7 @@ namespace Nested
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
                     if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                     {
-                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                        builder.AddResults(validationResults);
+                        (builder ??= new()).AddResults(validationResults);
                     }
 
                     return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -861,8 +820,7 @@ namespace RandomMembers
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -894,8 +852,7 @@ namespace RecordTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -926,24 +883,20 @@ namespace RecordTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V6.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
+                (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V6.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
             if (options.P3 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V7.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
+                (builder ??= new()).AddResult(global::__OptionValidationStaticInstances.__Validators.V7.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
             }
 
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResult(global::RecordTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4));
+            (builder ??= new()).AddResult(global::RecordTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4));
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
@@ -973,8 +926,7 @@ namespace RecordTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1005,8 +957,7 @@ namespace RecordTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1037,14 +988,12 @@ namespace RepeatedTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P4 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "SecondModel.P4" : $"{name}.P4", options.P4));
+                (builder ??= new()).AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "SecondModel.P4" : $"{name}.P4", options.P4));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1076,8 +1025,7 @@ namespace RepeatedTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1107,14 +1055,12 @@ namespace RepeatedTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P1 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1", options.P1));
+                (builder ??= new()).AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1", options.P1));
             }
 
             context.MemberName = "P2";
@@ -1124,14 +1070,12 @@ namespace RepeatedTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P2, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
+                (builder ??= new()).AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
             context.MemberName = "P3";
@@ -1141,14 +1085,12 @@ namespace RepeatedTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P3, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P3 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
+                (builder ??= new()).AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1178,12 +1120,10 @@ namespace SelfValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));
+            (builder ??= new()).AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
@@ -1213,8 +1153,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A7);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1245,8 +1184,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1277,8 +1215,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
@@ -1288,14 +1225,12 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A8);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.YetAnotherComplexVal is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::TestClasses.OptionsValidation.__RangeAttributeModelDoubleValidator__.Validate(string.IsNullOrEmpty(name) ? "TypeWithoutOptionsValidator.YetAnotherComplexVal" : $"{name}.YetAnotherComplexVal", options.YetAnotherComplexVal));
+                (builder ??= new()).AddResult(global::TestClasses.OptionsValidation.__RangeAttributeModelDoubleValidator__.Validate(string.IsNullOrEmpty(name) ? "TypeWithoutOptionsValidator.YetAnotherComplexVal" : $"{name}.YetAnotherComplexVal", options.YetAnotherComplexVal));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1325,8 +1260,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A9);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
@@ -1336,8 +1270,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A10);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1362,14 +1295,12 @@ namespace TestClasses.OptionsValidation
 
             if (options.ComplexVal is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::TestClasses.OptionsValidation.__RequiredAttributeModelValidator__.Validate(string.IsNullOrEmpty(name) ? "ComplexModel.ComplexVal" : $"{name}.ComplexVal", options.ComplexVal));
+                (builder ??= new()).AddResult(global::TestClasses.OptionsValidation.__RequiredAttributeModelValidator__.Validate(string.IsNullOrEmpty(name) ? "ComplexModel.ComplexVal" : $"{name}.ComplexVal", options.ComplexVal));
             }
 
             if (options.ValWithoutOptionsValidator is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::TestClasses.OptionsValidation.__TypeWithoutOptionsValidatorValidator__.Validate(string.IsNullOrEmpty(name) ? "ComplexModel.ValWithoutOptionsValidator" : $"{name}.ValWithoutOptionsValidator", options.ValWithoutOptionsValidator));
+                (builder ??= new()).AddResult(global::TestClasses.OptionsValidation.__TypeWithoutOptionsValidatorValidator__.Validate(string.IsNullOrEmpty(name) ? "ComplexModel.ValWithoutOptionsValidator" : $"{name}.ValWithoutOptionsValidator", options.ValWithoutOptionsValidator));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1399,8 +1330,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A11);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1430,8 +1360,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A12);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1461,8 +1390,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A13);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1492,8 +1420,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.DerivedVal, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "VirtualValWithAttr";
@@ -1503,8 +1430,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.VirtualValWithAttr, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val";
@@ -1514,8 +1440,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1545,8 +1470,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A14);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1576,8 +1500,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.VirtualValWithoutAttr, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "DerivedVal";
@@ -1587,8 +1510,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.DerivedVal, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val";
@@ -1598,8 +1520,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1630,8 +1551,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A15);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
@@ -1641,8 +1561,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A16);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val3";
@@ -1652,8 +1571,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A17);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val3, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             context.MemberName = "Val4";
@@ -1663,8 +1581,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A18);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val4, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1694,8 +1611,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A8);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1725,8 +1641,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A7);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1756,8 +1671,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A16);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1787,8 +1701,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A19);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1818,8 +1731,7 @@ namespace TestClasses.OptionsValidation
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1851,8 +1763,7 @@ namespace ValueTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1883,23 +1794,19 @@ namespace ValueTypes
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
             if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResults(validationResults);
+                (builder ??= new()).AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2.Value));
+                (builder ??= new()).AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2.Value));
             }
 
-            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-            builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
+            (builder ??= new()).AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
 
             if (options.P4 is not null)
             {
-                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
-                builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4.Value));
+                (builder ??= new()).AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4.Value));
             }
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetFX/Validators.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetFX/Validators.g.cs
@@ -14,22 +14,22 @@ internal sealed partial class __ThirdModelNoNamespaceValidator__
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::ThirdModelNoNamespace options)
     {
-        var baseName = (string.IsNullOrEmpty(name) ? "ThirdModelNoNamespace" : name) + ".";
-        var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+        global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
         var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
         var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
         var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
         context.MemberName = "P5";
-        context.DisplayName = baseName + "P5";
+        context.DisplayName = string.IsNullOrEmpty(name) ? "ThirdModelNoNamespace.P5" : $"{name}.P5";
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-        if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+        if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
         {
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
             builder.AddResults(validationResults);
         }
 
-        return builder.Build();
+        return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
     }
 }
 partial class FirstValidatorNoNamespace
@@ -43,32 +43,34 @@ partial class FirstValidatorNoNamespace
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::FirstModelNoNamespace options)
     {
-        var baseName = (string.IsNullOrEmpty(name) ? "FirstModelNoNamespace" : name) + ".";
-        var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+        global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
         var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
         var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
         var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
         context.MemberName = "P1";
-        context.DisplayName = baseName + "P1";
+        context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P1" : $"{name}.P1";
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-        if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+        if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
         {
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
             builder.AddResults(validationResults);
         }
 
         if (options.P2 is not null)
         {
-            builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V1.Validate(baseName + "P2", options.P2));
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V1.Validate(string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P2" : $"{name}.P2", options.P2));
         }
 
         if (options.P3 is not null)
         {
-            builder.AddResult(global::__ThirdModelNoNamespaceValidator__.Validate(baseName + "P3", options.P3));
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            builder.AddResult(global::__ThirdModelNoNamespaceValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModelNoNamespace.P3" : $"{name}.P3", options.P3));
         }
 
-        return builder.Build();
+        return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
     }
 }
 partial class SecondValidatorNoNamespace
@@ -82,22 +84,22 @@ partial class SecondValidatorNoNamespace
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::SecondModelNoNamespace options)
     {
-        var baseName = (string.IsNullOrEmpty(name) ? "SecondModelNoNamespace" : name) + ".";
-        var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+        global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
         var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
         var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
         var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
         context.MemberName = "P4";
-        context.DisplayName = baseName + "P4";
+        context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModelNoNamespace.P4" : $"{name}.P4";
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
         validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-        if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4!, context, validationResults, validationAttributes))
+        if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
         {
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
             builder.AddResults(validationResults);
         }
 
-        return builder.Build();
+        return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
     }
 }
 namespace CustomAttr
@@ -113,31 +115,32 @@ namespace CustomAttr
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::CustomAttr.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A3);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "P2";
-            context.DisplayName = baseName + "P2";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A4);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P2!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P2, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -155,22 +158,22 @@ namespace Enumeration
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Enumeration.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P6";
-            context.DisplayName = baseName + "P6";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P6" : $"{name}.P6";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -188,21 +191,21 @@ namespace Enumeration
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Enumeration.ThirdModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "ThirdModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Value";
-            context.DisplayName = baseName + "Value";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "ThirdModel.Value" : $"{name}.Value";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A5);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Value!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Value, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -219,8 +222,7 @@ namespace Enumeration
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Enumeration.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
 
             if (options.P1 is not null)
@@ -230,11 +232,13 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(baseName + $"P1[{count}]", o));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P1[{count}]" : $"{name}.P1[{count}]", o));
                     }
                     else
                     {
-                        builder.AddError(baseName + $"P1[{count}] is null");
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P1[{count}] is null" : $"{name}.P1[{count}] is null");
                     }
                     count++;
                 }
@@ -247,11 +251,13 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V2.Validate(baseName + $"P2[{count}]", o));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V2.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P2[{count}]" : $"{name}.P2[{count}]", o));
                     }
                     else
                     {
-                        builder.AddError(baseName + $"P2[{count}] is null");
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P2[{count}] is null" : $"{name}.P2[{count}] is null");
                     }
                     count++;
                 }
@@ -264,7 +270,8 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(baseName + $"P3[{count}]", o));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P3[{count}]" : $"{name}.P3[{count}]", o));
                     }
                     count++;
                 }
@@ -275,7 +282,8 @@ namespace Enumeration
                 var count = 0;
                 foreach (var o in options.P4)
                 {
-                    builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(baseName + $"P4[{count++}]", o));
+                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                    builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P4[{count++}] is null" : $"{name}.P4[{count++}] is null", o));
                 }
             }
 
@@ -286,7 +294,8 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(baseName + $"P5[{count}]", o.Value));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P5[{count}]" : $"{name}.P5[{count}]", o.Value));
                     }
                     count++;
                 }
@@ -299,7 +308,8 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(baseName + $"P51[{count}]", o.Value));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P51[{count}]" : $"{name}.P51[{count}]", o.Value));
                     }
                     count++;
                 }
@@ -312,11 +322,13 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(baseName + $"P6[{count}]", o));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P6[{count}]" : $"{name}.P6[{count}]", o));
                     }
                     else
                     {
-                        builder.AddError(baseName + $"P6[{count}] is null");
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P6[{count}] is null" : $"{name}.P6[{count}] is null");
                     }
                     count++;
                 }
@@ -328,11 +340,13 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(baseName + $"P7[{count}]", o));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P7[{count}]" : $"{name}.P7[{count}]", o));
                     }
                     else
                     {
-                        builder.AddError(baseName + $"P7[{count}] is null");
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P7[{count}] is null" : $"{name}.P7[{count}] is null");
                     }
                     count++;
                 }
@@ -345,17 +359,19 @@ namespace Enumeration
                 {
                     if (o is not null)
                     {
-                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(baseName + $"P8[{count}]", o));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::Enumeration.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? $"FirstModel.P8[{count}]" : $"{name}.P8[{count}]", o));
                     }
                     else
                     {
-                        builder.AddError(baseName + $"P8[{count}] is null");
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddError(string.IsNullOrEmpty(name) ? $"FirstModel.P8[{count}] is null" : $"{name}.P8[{count}] is null");
                     }
                     count++;
                 }
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -372,22 +388,22 @@ namespace Enumeration
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Enumeration.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P6";
-            context.DisplayName = baseName + "P6";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P6" : $"{name}.P6";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -404,22 +420,22 @@ namespace FileScopedNamespace
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::FileScopedNamespace.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -436,21 +452,21 @@ namespace FunnyStrings
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::FunnyStrings.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A6);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -468,22 +484,22 @@ namespace Generics
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Generics.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P4";
-            context.DisplayName = baseName + "P4";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P4" : $"{name}.P4";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -500,27 +516,28 @@ namespace Generics
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Generics.FirstModel<T> options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P3 is not null)
             {
-                builder.AddResult(global::Generics.__SecondModelValidator__.Validate(baseName + "P3", options.P3));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::Generics.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -537,27 +554,28 @@ namespace MultiModelValidator
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::MultiModelValidator.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V3.Validate(baseName + "P2", options.P2));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V3.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
         /// <summary>
         /// Validates a specific named options instance (or all when <paramref name="name"/> is <see langword="null" />).
@@ -568,22 +586,22 @@ namespace MultiModelValidator
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::MultiModelValidator.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P3";
-            context.DisplayName = baseName + "P3";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P3" : $"{name}.P3";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P3!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P3, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -601,22 +619,22 @@ namespace Nested
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Nested.Container1.ThirdModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "ThirdModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P6";
-            context.DisplayName = baseName + "P6";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "ThirdModel.P6" : $"{name}.P6";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -635,22 +653,22 @@ namespace Nested
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
             public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Nested.Container1.SecondModel options)
             {
-                var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-                var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
                 var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
                 var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
                 var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
                 context.MemberName = "P5";
-                context.DisplayName = baseName + "P5";
+                context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P5" : $"{name}.P5";
                 validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
                 validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-                if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+                if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                 {
+                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                     builder.AddResults(validationResults);
                 }
 
-                return builder.Build();
+                return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
             }
         }
     }
@@ -672,34 +690,37 @@ namespace Nested
                 [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
                 public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Nested.Container1.FirstModel options)
                 {
-                    var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-                    var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                    global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
                     var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
                     var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
                     var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
                     context.MemberName = "P1";
-                    context.DisplayName = baseName + "P1";
+                    context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-                    if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+                    if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
                     {
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                         builder.AddResults(validationResults);
                     }
 
                     if (options.P2 is not null)
                     {
-                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V4.Validate(baseName + "P2", options.P2));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V4.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
                     }
 
-                    builder.AddResult(global::Nested.__ThirdModelValidator__.Validate(baseName + "P3", options.P3));
+                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                    builder.AddResult(global::Nested.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
 
                     if (options.P4 is not null)
                     {
-                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V5.Validate(baseName + "P4", options.P4));
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                        builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V5.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4));
                     }
 
-                    return builder.Build();
+                    return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
                 }
             }
         }
@@ -720,22 +741,22 @@ namespace Nested
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
             public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Nested.Container1.SecondModel options)
             {
-                var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-                var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
                 var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
                 var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
                 var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
                 context.MemberName = "P5";
-                context.DisplayName = baseName + "P5";
+                context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P5" : $"{name}.P5";
                 validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
                 validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-                if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+                if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                 {
+                    builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                     builder.AddResults(validationResults);
                 }
 
-                return builder.Build();
+                return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
             }
         }
     }
@@ -757,22 +778,22 @@ namespace Nested
                 [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
                 public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Nested.Container1.SecondModel options)
                 {
-                    var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-                    var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                    global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
                     var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
                     var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
                     var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
                     context.MemberName = "P5";
-                    context.DisplayName = baseName + "P5";
+                    context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P5" : $"{name}.P5";
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-                    if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+                    if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                     {
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                         builder.AddResults(validationResults);
                     }
 
-                    return builder.Build();
+                    return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
                 }
             }
         }
@@ -795,22 +816,22 @@ namespace Nested
                 [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
                 public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::Nested.Container1.SecondModel options)
                 {
-                    var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-                    var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                    global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
                     var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
                     var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
                     var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
                     context.MemberName = "P5";
-                    context.DisplayName = baseName + "P5";
+                    context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P5" : $"{name}.P5";
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
                     validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-                    if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+                    if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
                     {
+                        builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                         builder.AddResults(validationResults);
                     }
 
-                    return builder.Build();
+                    return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
                 }
             }
         }
@@ -829,22 +850,22 @@ namespace RandomMembers
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RandomMembers.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -862,22 +883,22 @@ namespace RecordTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RecordTypes.ThirdModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "ThirdModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P6";
-            context.DisplayName = baseName + "P6";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "ThirdModel.P6" : $"{name}.P6";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P6, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -894,34 +915,37 @@ namespace RecordTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RecordTypes.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V6.Validate(baseName + "P2", options.P2));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V6.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
             if (options.P3 is not null)
             {
-                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V7.Validate(baseName + "P3", options.P3));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::__OptionValidationStaticInstances.__Validators.V7.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
             }
 
-            builder.AddResult(global::RecordTypes.__ThirdModelValidator__.Validate(baseName + "P4", options.P4));
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            builder.AddResult(global::RecordTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4));
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -938,22 +962,22 @@ namespace RecordTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RecordTypes.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P5";
-            context.DisplayName = baseName + "P5";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P5" : $"{name}.P5";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -970,22 +994,22 @@ namespace RecordTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RecordTypes.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P5";
-            context.DisplayName = baseName + "P5";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P5" : $"{name}.P5";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1003,26 +1027,27 @@ namespace RepeatedTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RepeatedTypes.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "P4";
-            context.DisplayName = baseName + "P4";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P4" : $"{name}.P4";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P4 is not null)
             {
-                builder.AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(baseName + "P4", options.P4));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "SecondModel.P4" : $"{name}.P4", options.P4));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1040,22 +1065,22 @@ namespace RepeatedTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RepeatedTypes.ThirdModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "ThirdModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P5";
-            context.DisplayName = baseName + "P5";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "ThirdModel.P5" : $"{name}.P5";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P5, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1072,56 +1097,61 @@ namespace RepeatedTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::RepeatedTypes.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P1 is not null)
             {
-                builder.AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(baseName + "P1", options.P1));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1", options.P1));
             }
 
             context.MemberName = "P2";
-            context.DisplayName = baseName + "P2";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P2!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P2, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder.AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(baseName + "P2", options.P2));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::RepeatedTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
             context.MemberName = "P3";
-            context.DisplayName = baseName + "P3";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P3!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P3, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P3 is not null)
             {
-                builder.AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(baseName + "P3", options.P3));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::RepeatedTypes.__ThirdModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1138,23 +1168,24 @@ namespace SelfValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::SelfValidation.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
             builder.AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1172,21 +1203,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RangeAttributeModelDouble options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RangeAttributeModelDouble" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RangeAttributeModelDouble.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A7);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1204,21 +1235,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RequiredAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RequiredAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RequiredAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1236,36 +1267,38 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.TypeWithoutOptionsValidator options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "TypeWithoutOptionsValidator" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val1";
-            context.DisplayName = baseName + "Val1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "TypeWithoutOptionsValidator.Val1" : $"{name}.Val1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
-            context.DisplayName = baseName + "Val2";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "TypeWithoutOptionsValidator.Val2" : $"{name}.Val2";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A8);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.YetAnotherComplexVal is not null)
             {
-                builder.AddResult(global::TestClasses.OptionsValidation.__RangeAttributeModelDoubleValidator__.Validate(baseName + "YetAnotherComplexVal", options.YetAnotherComplexVal));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::TestClasses.OptionsValidation.__RangeAttributeModelDoubleValidator__.Validate(string.IsNullOrEmpty(name) ? "TypeWithoutOptionsValidator.YetAnotherComplexVal" : $"{name}.YetAnotherComplexVal", options.YetAnotherComplexVal));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1282,31 +1315,32 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.AttributePropertyModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "AttributePropertyModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val1";
-            context.DisplayName = baseName + "Val1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "AttributePropertyModel.Val1" : $"{name}.Val1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A9);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
-            context.DisplayName = baseName + "Val2";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "AttributePropertyModel.Val2" : $"{name}.Val2";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A10);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1323,21 +1357,22 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.ComplexModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "ComplexModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
 
             if (options.ComplexVal is not null)
             {
-                builder.AddResult(global::TestClasses.OptionsValidation.__RequiredAttributeModelValidator__.Validate(baseName + "ComplexVal", options.ComplexVal));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::TestClasses.OptionsValidation.__RequiredAttributeModelValidator__.Validate(string.IsNullOrEmpty(name) ? "ComplexModel.ComplexVal" : $"{name}.ComplexVal", options.ComplexVal));
             }
 
             if (options.ValWithoutOptionsValidator is not null)
             {
-                builder.AddResult(global::TestClasses.OptionsValidation.__TypeWithoutOptionsValidatorValidator__.Validate(baseName + "ValWithoutOptionsValidator", options.ValWithoutOptionsValidator));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::TestClasses.OptionsValidation.__TypeWithoutOptionsValidatorValidator__.Validate(string.IsNullOrEmpty(name) ? "ComplexModel.ValWithoutOptionsValidator" : $"{name}.ValWithoutOptionsValidator", options.ValWithoutOptionsValidator));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1354,21 +1389,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.CustomTypeCustomValidationAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "CustomTypeCustomValidationAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "CustomTypeCustomValidationAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A11);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1385,21 +1420,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.CustomValidationAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "CustomValidationAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "CustomValidationAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A12);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1416,21 +1451,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.DataTypeAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "DataTypeAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "DataTypeAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A13);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1447,41 +1482,43 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.DerivedModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "DerivedModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "DerivedVal";
-            context.DisplayName = baseName + "DerivedVal";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "DerivedModel.DerivedVal" : $"{name}.DerivedVal";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.DerivedVal!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.DerivedVal, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "VirtualValWithAttr";
-            context.DisplayName = baseName + "VirtualValWithAttr";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "DerivedModel.VirtualValWithAttr" : $"{name}.VirtualValWithAttr";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.VirtualValWithAttr!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.VirtualValWithAttr, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "DerivedModel.Val" : $"{name}.Val";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1498,21 +1535,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.EmailAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "EmailAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "EmailAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A14);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1529,41 +1566,43 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.LeafModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "LeafModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "VirtualValWithoutAttr";
-            context.DisplayName = baseName + "VirtualValWithoutAttr";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "LeafModel.VirtualValWithoutAttr" : $"{name}.VirtualValWithoutAttr";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.VirtualValWithoutAttr!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.VirtualValWithoutAttr, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "DerivedVal";
-            context.DisplayName = baseName + "DerivedVal";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "LeafModel.DerivedVal" : $"{name}.DerivedVal";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.DerivedVal!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.DerivedVal, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "LeafModel.Val" : $"{name}.Val";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1580,52 +1619,55 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.MultipleAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "MultipleAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "Val1";
-            context.DisplayName = baseName + "Val1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "MultipleAttributeModel.Val1" : $"{name}.Val1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A15);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val2";
-            context.DisplayName = baseName + "Val2";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "MultipleAttributeModel.Val2" : $"{name}.Val2";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A16);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val2, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val3";
-            context.DisplayName = baseName + "Val3";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "MultipleAttributeModel.Val3" : $"{name}.Val3";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A17);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val3!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val3, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             context.MemberName = "Val4";
-            context.DisplayName = baseName + "Val4";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "MultipleAttributeModel.Val4" : $"{name}.Val4";
             validationResults.Clear();
             validationAttributes.Clear();
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A18);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val4!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val4, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1642,21 +1684,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RangeAttributeModelDate options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RangeAttributeModelDate" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RangeAttributeModelDate.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A8);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1673,21 +1715,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RangeAttributeModelDouble options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RangeAttributeModelDouble" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RangeAttributeModelDouble.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A7);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1704,21 +1746,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RangeAttributeModelInt options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RangeAttributeModelInt" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RangeAttributeModelInt.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A16);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1735,21 +1777,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RegularExpressionAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RegularExpressionAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RegularExpressionAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A19);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1766,21 +1808,21 @@ namespace TestClasses.OptionsValidation
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::TestClasses.OptionsValidation.RequiredAttributeModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "RequiredAttributeModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(1);
 
             context.MemberName = "Val";
-            context.DisplayName = baseName + "Val";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "RequiredAttributeModel.Val" : $"{name}.Val";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.Val, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1798,22 +1840,22 @@ namespace ValueTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public static global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::ValueTypes.SecondModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "SecondModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P4";
-            context.DisplayName = baseName + "P4";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.P4" : $"{name}.P4";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P4, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }
@@ -1830,34 +1872,37 @@ namespace ValueTypes
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
         public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::ValueTypes.FirstModel options)
         {
-            var baseName = (string.IsNullOrEmpty(name) ? "FirstModel" : name) + ".";
-            var builder = new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
             var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
             var validationResults = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationResult>();
             var validationAttributes = new global::System.Collections.Generic.List<global::System.ComponentModel.DataAnnotations.ValidationAttribute>(2);
 
             context.MemberName = "P1";
-            context.DisplayName = baseName + "P1";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.P1" : $"{name}.P1";
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A1);
             validationAttributes.Add(global::__OptionValidationStaticInstances.__Attributes.A2);
-            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1!, context, validationResults, validationAttributes))
+            if (!global::System.ComponentModel.DataAnnotations.Validator.TryValidateValue(options.P1, context, validationResults, validationAttributes))
             {
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
                 builder.AddResults(validationResults);
             }
 
             if (options.P2 is not null)
             {
-                builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(baseName + "P2", options.P2.Value));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2.Value));
             }
 
-            builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(baseName + "P3", options.P3));
+            builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+            builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P3" : $"{name}.P3", options.P3));
 
             if (options.P4 is not null)
             {
-                builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(baseName + "P4", options.P4.Value));
+                builder ??= new global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder();
+                builder.AddResult(global::ValueTypes.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P4" : $"{name}.P4", options.P4.Value));
             }
 
-            return builder.Build();
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
         }
     }
 }


### PR DESCRIPTION
Planning to port these fixes to rc2

The changes in this PR fix the following issues:

- Remove using `Random` in the source generator and instead use the module name hash. https://github.com/dotnet/runtime/issues/90990
- Address the optimization requested in the issue: https://github.com/dotnet/runtime/issues/91073.
- Detection when need to emit the nullable `!` when calling `Validator.TryValidateValue`
- Allow generating code for properties of type `IEnumerable<T>` and tagged with the attribute `ValidateEnumeratedItems`

