### PR TITLE
Remove libraries_tests PMI collection

### DIFF
--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -110,26 +110,6 @@ extends:
           jobParameters:
             testGroup: outerloop
             liveLibrariesBuildConfig: Release
-            collectionType: pmi
-            collectionName: libraries_tests
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-          buildConfig: checked
-          platforms:
-          - osx_arm64
-          - linux_arm
-          - linux_arm64
-          - linux_x64
-          - windows_x64
-          - windows_x86
-          - windows_arm64
-          helixQueueGroup: ci
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testGroup: outerloop
-            liveLibrariesBuildConfig: Release
             collectionType: crossgen2
             collectionName: libraries
 


### PR DESCRIPTION
With #91101 we have a SuperPMI collection of the libraries tests being run, so the existing PMI-based collection is someone duplicative: remove the PMI collection.

It's arguable that the PMI collection of the libraries themselves is also duplicative, but we can decide whether to remove that one separately.