### PR TITLE
Allow superpmi.exe to find a default JIT

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.cpp
@@ -676,54 +676,54 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
 
         bool allowDefaultJIT = true;
 
-        const char* host_os_tag = "";
-        const char* jit_host_os_prefix = "";
-        const char* jit_host_os_extension = "";
+        const char* hostOSTag = "";
+        const char* jitHostOSPrefix = "";
+        const char* jitHostOSExtension = "";
 
 #if defined(HOST_OSX) // NOTE: HOST_UNIX is also defined for HOST_OSX
-        host_os_tag = "unix";
-        jit_host_os_prefix = "lib";
-        jit_host_os_extension = ".dylib";
+        hostOSTag = "unix";
+        jitHostOSPrefix = "lib";
+        jitHostOSExtension = ".dylib";
 #elif defined(HOST_UNIX)
-        host_os_tag = "unix";
-        jit_host_os_prefix = "lib";
-        jit_host_os_extension = ".so";
+        hostOSTag = "unix";
+        jitHostOSPrefix = "lib";
+        jitHostOSExtension = ".so";
 #elif defined(HOST_WINDOWS)
-        host_os_tag = "win";
-        jit_host_os_extension = ".dll";
+        hostOSTag = "win";
+        jitHostOSExtension = ".dll";
 #else
         allowDefaultJIT = false;
 #endif
 
-        const char* host_arch = "";
+        const char* hostArch = "";
 
 #if defined(HOST_AMD64)
-        host_arch = "x64";
+        hostArch = "x64";
 #elif defined(HOST_X86)
-        host_arch = "x86";
+        hostArch = "x86";
 #elif defined(HOST_ARM)
-        host_arch = "arm";
+        hostArch = "arm";
 #elif defined(HOST_ARM64)
-        host_arch = "arm64";
+        hostArch = "arm64";
 #else
         allowDefaultJIT = false;
 #endif
 
-        const char* target_arch = "";
+        const char* targetArch = "";
 
         switch (GetSpmiTargetArchitecture())
         {
             case SPMI_TARGET_ARCHITECTURE_AMD64:
-                target_arch = "x64";
+                targetArch = "x64";
                 break;
             case SPMI_TARGET_ARCHITECTURE_X86:
-                target_arch = "x86";
+                targetArch = "x86";
                 break;
             case SPMI_TARGET_ARCHITECTURE_ARM:
-                target_arch = "arm";
+                targetArch = "arm";
                 break;
             case SPMI_TARGET_ARCHITECTURE_ARM64:
-                target_arch = "arm64";
+                targetArch = "arm64";
                 break;
             default:
                 allowDefaultJIT = false;
@@ -746,7 +746,7 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
 
         if (allowDefaultJIT)
         {
-            const char* jit_os_name = nullptr;
+            const char* jitOSName = nullptr;
 
             if (defaultSpmiTargetArchitecture != GetSpmiTargetArchitecture())
             {
@@ -756,11 +756,11 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
                 {
                     case SPMI_TARGET_ARCHITECTURE_AMD64:
                     case SPMI_TARGET_ARCHITECTURE_X86:
-                        jit_os_name = host_os_tag;
+                        jitOSName = hostOSTag;
                         break;
                     case SPMI_TARGET_ARCHITECTURE_ARM:
                     case SPMI_TARGET_ARCHITECTURE_ARM64:
-                        jit_os_name = "universal";
+                        jitOSName = "universal";
                         break;
                     default:
                         // Can't get here if `allowDefaultJIT` was properly set above.
@@ -768,33 +768,33 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
                 }
             }
 
-            const char* jit_base_name = "clrjit";
-            size_t len = programPathLen + strlen(jit_host_os_prefix) + strlen(jit_base_name) + strlen(jit_host_os_extension) + 1;
-            if (jit_os_name != nullptr)
+            const char* const jitBaseName = "clrjit";
+            size_t len = programPathLen + strlen(jitHostOSPrefix) + strlen(jitBaseName) + strlen(jitHostOSExtension) + 1;
+            if (jitOSName != nullptr)
             {
-                len += 3 /* underscores */ + strlen(jit_os_name) + strlen(target_arch) + strlen(host_arch);
+                len += 3 /* underscores */ + strlen(jitOSName) + strlen(targetArch) + strlen(hostArch);
             }
             char* tempStr = new char[len];
-            if (jit_os_name == nullptr)
+            if (jitOSName == nullptr)
             {
                 sprintf_s(tempStr, len, "%s%c%s%s%s",
                     programPath,
                     DIRECTORY_SEPARATOR_CHAR_A,
-                    jit_host_os_prefix,
-                    jit_base_name,
-                    jit_host_os_extension);
+                    jitHostOSPrefix,
+                    jitBaseName,
+                    jitHostOSExtension);
             }
             else
             {
                 sprintf_s(tempStr, len, "%s%c%s%s_%s_%s_%s%s",
                     programPath,
                     DIRECTORY_SEPARATOR_CHAR_A,
-                    jit_host_os_prefix,
-                    jit_base_name,
-                    jit_os_name,
-                    target_arch,
-                    host_arch,
-                    jit_host_os_extension);
+                    jitHostOSPrefix,
+                    jitBaseName,
+                    jitOSName,
+                    targetArch,
+                    hostArch,
+                    jitHostOSExtension);
             }
 
             o->nameOfJit = tempStr;

--- a/src/coreclr/tools/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.cpp
@@ -660,7 +660,7 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
         }
     }
 
-    SPMI_TARGET_ARCHITECTURE DefaultSpmiTargetArchitecture = GetSpmiTargetArchitecture();
+    SPMI_TARGET_ARCHITECTURE defaultSpmiTargetArchitecture = GetSpmiTargetArchitecture();
     SetSuperPmiTargetArchitecture(o->targetArchitecture);
 
     if (o->nameOfInputMethodContextFile == nullptr)
@@ -680,7 +680,11 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
         const char* jit_host_os_prefix = "";
         const char* jit_host_os_extension = "";
 
-#if defined(HOST_UNIX)
+#if defined(HOST_OSX) // NOTE: HOST_UNIX is also defined for HOST_OSX
+        host_os_tag = "unix";
+        jit_host_os_prefix = "lib";
+        jit_host_os_extension = ".dylib";
+#elif defined(HOST_UNIX)
         host_os_tag = "unix";
         jit_host_os_prefix = "lib";
         jit_host_os_extension = ".so";
@@ -688,7 +692,6 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
         host_os_tag = "win";
         jit_host_os_extension = ".dll";
 #else
-        // TODO: handle Mac
         allowDefaultJIT = false;
 #endif
 
@@ -745,7 +748,7 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
         {
             const char* jit_os_name = nullptr;
 
-            if (DefaultSpmiTargetArchitecture != GetSpmiTargetArchitecture())
+            if (defaultSpmiTargetArchitecture != GetSpmiTargetArchitecture())
             {
                 // SuperPMI doesn't know about "target OS" so always assume host OS.
 
@@ -758,6 +761,9 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
                     case SPMI_TARGET_ARCHITECTURE_ARM:
                     case SPMI_TARGET_ARCHITECTURE_ARM64:
                         jit_os_name = "universal";
+                        break;
+                    default:
+                        // Can't get here if `allowDefaultJIT` was properly set above.
                         break;
                 }
             }

--- a/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
@@ -197,8 +197,6 @@ int __cdecl main(int argc, char* argv[])
 
     SetBreakOnException(o.breakOnException);
 
-    SetSuperPmiTargetArchitecture(o.targetArchitecture);
-
     if (o.methodStatsTypes != NULL &&
         (strchr(o.methodStatsTypes, '*') != NULL || strchr(o.methodStatsTypes, 't') != NULL ||
          strchr(o.methodStatsTypes, 'T') != NULL))

--- a/src/coreclr/tools/superpmi/superpmi/superpmi.h
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.h
@@ -22,4 +22,6 @@ enum class SpmiResult
     Misses          = 3
 };
 
+extern void SetSuperPmiTargetArchitecture(const char* targetArchitecture);
+
 #endif


### PR DESCRIPTION
This makes it slightly easier to invoke superpmi.exe manually: most of the time you want to use the clrjit.dll (or similar) in the same directory where superpmi.exe lives (in a Core_Root directory), so use that if not JIT is specified.