### PR TITLE
Fix runtime dispatch to static virtuals on interface types

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -614,6 +614,8 @@ namespace Internal.TypeSystem
         {
             Debug.Assert(!interfaceMethod.Signature.IsStatic);
 
+            // This would be a default interface method resolution. The algorithm below would sort of work, but doesn't handle
+            // things like diamond cases and it's better not to let it resolve as such.
             if (currentType.IsInterface)
                 return null;
 
@@ -781,7 +783,7 @@ namespace Internal.TypeSystem
                 // If we're asking about an interface, include the interface in the list.
                 consideredInterfaces = new DefType[currentType.RuntimeInterfaces.Length + 1];
                 Array.Copy(currentType.RuntimeInterfaces, consideredInterfaces, currentType.RuntimeInterfaces.Length);
-                consideredInterfaces[consideredInterfaces.Length - 1] = (DefType)currentType.InstantiateAsOpen();
+                consideredInterfaces[consideredInterfaces.Length - 1] = currentType.IsGenericDefinition ? (DefType)currentType.InstantiateAsOpen() : currentType;
             }
 
             foreach (MetadataType runtimeInterface in consideredInterfaces)
@@ -921,6 +923,11 @@ namespace Internal.TypeSystem
         /// <returns>MethodDesc of the resolved virtual static method, null when not found (runtime lookup must be used)</returns>
         public static MethodDesc ResolveInterfaceMethodToStaticVirtualMethodOnType(MethodDesc interfaceMethod, MetadataType currentType)
         {
+            // This would be a default interface method resolution. The algorithm below would sort of work, but doesn't handle
+            // things like diamond cases and it's better not to let it resolve as such.
+            if (currentType.IsInterface)
+                return null;
+
             // Search for match on a per-level in the type hierarchy
             for (MetadataType typeToCheck = currentType; typeToCheck != null; typeToCheck = typeToCheck.MetadataBaseType)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -73,7 +73,7 @@ namespace ILCompiler.DependencyAnalysis
             if (!type.IsArray && !type.IsDefType)
                 return false;
 
-            // Interfaces don't have a dispatch map because we dispatch them based on the
+            // Interfaces don't have a dispatch map for instance methods because we dispatch them based on the
             // dispatch map of the implementing class.
             // The only exception are IDynamicInterfaceCastable scenarios that dispatch
             // using the interface dispatch map.
@@ -83,8 +83,9 @@ namespace ILCompiler.DependencyAnalysis
             // wasn't marked as [DynamicInterfaceCastableImplementation]" and "we couldn't find an
             // implementation". We don't want to use the custom attribute for that at runtime because
             // that's reflection and this should work without reflection.
-            if (type.IsInterface)
-                return ((MetadataType)type).IsDynamicInterfaceCastableImplementation();
+            bool isInterface = type.IsInterface;
+            if (isInterface && ((MetadataType)type).IsDynamicInterfaceCastableImplementation())
+                return true;
 
             DefType declType = type.GetClosestDefType();
 
@@ -111,6 +112,11 @@ namespace ILCompiler.DependencyAnalysis
                     MethodDesc declMethod = slotMethod;
 
                     Debug.Assert(declMethod.IsVirtual);
+
+                    // Only static methods get placed in dispatch maps of interface types (modulo
+                    // IDynamicInterfaceCastable we already handled above).
+                    if (isInterface && !declMethod.Signature.IsStatic)
+                        continue;
 
                     if (interfaceOnDefinitionType != null)
                         declMethod = factory.TypeSystemContext.GetMethodForInstantiatedType(declMethod.GetTypicalMethodDefinition(), interfaceOnDefinitionType);
@@ -154,6 +160,10 @@ namespace ILCompiler.DependencyAnalysis
             var staticImplementations = new List<(int InterfaceIndex, int InterfaceMethodSlot, int ImplMethodSlot, int Context)>();
             var staticDefaultImplementations = new List<(int InterfaceIndex, int InterfaceMethodSlot, int ImplMethodSlot, int Context)>();
 
+            bool isInterface = declType.IsInterface;
+            bool needsEntriesForInstanceInterfaceMethodImpls = !isInterface
+                    || ((MetadataType)declType).IsDynamicInterfaceCastableImplementation();
+
             // Resolve all the interfaces, but only emit non-static and non-default implementations
             for (int interfaceIndex = 0; interfaceIndex < declTypeRuntimeInterfaces.Length; interfaceIndex++)
             {
@@ -166,6 +176,10 @@ namespace ILCompiler.DependencyAnalysis
                 for (int interfaceMethodSlot = 0; interfaceMethodSlot < virtualSlots.Count; interfaceMethodSlot++)
                 {
                     MethodDesc declMethod = virtualSlots[interfaceMethodSlot];
+
+                    if (!declMethod.Signature.IsStatic && !needsEntriesForInstanceInterfaceMethodImpls)
+                        continue;
+
                     if(!interfaceType.IsTypeDefinition)
                         declMethod = factory.TypeSystemContext.GetMethodForInstantiatedType(declMethod.GetTypicalMethodDefinition(), (InstantiatedType)interfaceDefinitionType);
 
@@ -244,9 +258,17 @@ namespace ILCompiler.DependencyAnalysis
                                     // For default interface methods, the generic context is acquired by indexing
                                     // into the interface list of the owning type.
                                     Debug.Assert(providingInterfaceDefinitionType != null);
-                                    int indexOfInterface = Array.IndexOf(declTypeDefinitionRuntimeInterfaces, providingInterfaceDefinitionType);
-                                    Debug.Assert(indexOfInterface >= 0);
-                                    genericContext = StaticVirtualMethodContextSource.ContextFromFirstInterface + indexOfInterface;
+                                    if (declTypeDefinition.HasSameTypeDefinition(providingInterfaceDefinitionType) &&
+                                        providingInterfaceDefinitionType == declTypeDefinition.InstantiateAsOpen())
+                                    {
+                                        genericContext = StaticVirtualMethodContextSource.ContextFromThisClass;
+                                    }
+                                    else
+                                    {
+                                        int indexOfInterface = Array.IndexOf(declTypeDefinitionRuntimeInterfaces, providingInterfaceDefinitionType);
+                                        Debug.Assert(indexOfInterface >= 0);
+                                        genericContext = StaticVirtualMethodContextSource.ContextFromFirstInterface + indexOfInterface;
+                                    }
                                 }
                                 staticDefaultImplementations.Add((
                                     interfaceIndex,

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/VirtualMethodCallHelper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/VirtualMethodCallHelper.cs
@@ -93,9 +93,8 @@ namespace ILCompiler
         {
             if (implType.IsInterface)
             {
-                // We normally don't need to ask about vtable slots of interfaces. It's not wrong to ask
-                // that question, but we currently only ask it for IDynamicInterfaceCastable implementations.
-                Debug.Assert(((MetadataType)implType).IsDynamicInterfaceCastableImplementation());
+                // Interface types don't have physically assigned virtual slots, so the number of slots
+                // is always 0. They may have sealed slots.
                 return (implType.HasGenericDictionarySlot() && countDictionarySlots) ? 1 : 0;
             }
 

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -52,6 +52,8 @@ public class Interfaces
         TestMoreConstraints.Run();
         TestSimpleNonGeneric.Run();
         TestSimpleGeneric.Run();
+        TestDefaultDynamicStaticNonGeneric.Run();
+        TestDefaultDynamicStaticGeneric.Run();
         TestDynamicStaticGenericVirtualMethods.Run();
 
         return Pass;
@@ -1499,6 +1501,77 @@ public class Interfaces
                 throw new Exception();
             if (CallIndirect<SimpleStruct>(2) != (1236, typeof(IBar<Atom2>)))
                 throw new Exception();
+        }
+    }
+
+    class TestDefaultDynamicStaticNonGeneric
+    {
+        interface IFoo
+        {
+            abstract static string ImHungryGiveMeCookie();
+        }
+
+        interface IBar : IFoo
+        {
+            static string IFoo.ImHungryGiveMeCookie() => "IBar";
+        }
+
+        class Baz : IBar
+        {
+        }
+
+        class Gen<T> where T : IFoo
+        {
+            public static string GrabCookie() => T.ImHungryGiveMeCookie();
+        }
+
+        public static void Run()
+        {
+            var r = (string)typeof(Gen<>).MakeGenericType(typeof(Baz)).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
+            if (r != "IBar")
+                throw new Exception(r);
+
+            r = (string)typeof(Gen<>).MakeGenericType(typeof(IBar)).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
+            if (r != "IBar")
+                throw new Exception(r);
+        }
+    }
+
+    class TestDefaultDynamicStaticGeneric
+    {
+        class Atom1 { }
+        class Atom2 { }
+
+        interface IFoo
+        {
+            abstract static string ImHungryGiveMeCookie();
+        }
+
+        interface IBar<T> : IFoo
+        {
+            static string IFoo.ImHungryGiveMeCookie() => $"IBar<{typeof(T).Name}>";
+        }
+
+        class Baz<T> : IBar<T>
+        {
+        }
+
+        class Gen<T> where T : IFoo
+        {
+            public static string GrabCookie() => T.ImHungryGiveMeCookie();
+        }
+
+        public static void Run()
+        {
+            Activator.CreateInstance(typeof(Baz<>).MakeGenericType(typeof(Atom1)));
+
+            var r = (string)typeof(Gen<>).MakeGenericType(typeof(Baz<>).MakeGenericType(typeof(Atom1))).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
+            if (r != "IBar<Atom1>")
+                throw new Exception(r);
+
+            r = (string)typeof(Gen<>).MakeGenericType(typeof(IBar<>).MakeGenericType(typeof(Atom2))).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
+            if (r != "IBar<Atom2>")
+                throw new Exception(r);
         }
     }
 


### PR DESCRIPTION
Fixes #90333.

We were not generating information about static virtuals on interface types. Information about default interface methods normally goes to the class, but if the T we're dispatching on is an interface, this information wasn't generated. The fix is to put this information into dispatch maps and sealed vtables, same way we do for classes.

The test shows what the problem is - if we change `IBar` to be a class, things would work even before this PR.

Cc @dotnet/ilc-contrib 