### PR TITLE
Fix LDTOKEN of methods that have modifiers

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.MetadataSignatureParsing.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.MetadataSignatureParsing.cs
@@ -173,12 +173,23 @@ namespace Internal.Runtime.TypeLoader
 
         private bool CompareTypeSigWithType(ref NativeParser parser, TypeManagerHandle moduleHandle, Handle typeHandle)
         {
-            while (typeHandle.HandleType == HandleType.TypeSpecification)
+            while (typeHandle.HandleType == HandleType.TypeSpecification
+                || typeHandle.HandleType == HandleType.ModifiedType)
             {
-                typeHandle = typeHandle
-                    .ToTypeSpecificationHandle(_metadataReader)
-                    .GetTypeSpecification(_metadataReader)
-                    .Signature;
+                if (typeHandle.HandleType == HandleType.TypeSpecification)
+                {
+                    typeHandle = typeHandle
+                        .ToTypeSpecificationHandle(_metadataReader)
+                        .GetTypeSpecification(_metadataReader)
+                        .Signature;
+                }
+                else
+                {
+                    typeHandle = typeHandle
+                        .ToModifiedTypeHandle(_metadataReader)
+                        .GetModifiedType(_metadataReader)
+                        .Type;
+                }
             }
 
             // startOffset lets us backtrack to the TypeSignatureKind for external types since the TypeLoader


### PR DESCRIPTION
Fixes #91065.

When we started generating custom modifiers into metadata format to support new function pointer APIs in #85504, we should have also added it to native layout format. We currently have a mismatch. This is a low risk bugfix to ignore modifiers on the metadata side that we can take to 8.0. We'll want to do a full fix to actually emit and compare this. Tracked in a .NET 9 bug at #91381.

No regression test because I spent too much time being puzzled at why https://github.com/Handlebars-Net/Handlebars.Net/blob/50614fd844e5360eb10e76154aa74da4d7bf12ce/source/Handlebars/Helpers/IHelperDescriptor.cs#L13 is generated as a custom modifier (`[in] !TOptions& modreq([netstandard]System.Runtime.InteropServices.InAttribute) options`) whereas if I do it, I get `[in] !T& 'value'` with a custom attribute. We'll want to write a proper set of tests with ambiguities for the bug I opened anyway.

Cc @dotnet/ilc-contrib 