### PR TITLE
[RISC-V, LoongArch64] Fix assert(!regArgMaskLive) in genFnPrologCalleeRegArgs

### DIFF
--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -8625,6 +8625,7 @@ void CodeGen::genFnPrologCalleeRegArgs()
                                                           (regNumber)regArg[i]);
                                 regArgNum--;
                                 regArgMaskLive &= ~genRegMask((regNumber)regArg[j]);
+                                regArg[j] = 0;
                                 if (regArgNum == 0)
                                 {
                                     break;

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -7989,6 +7989,7 @@ void CodeGen::genFnPrologCalleeRegArgs()
                                                         0);
                             regArgNum--;
                             regArgMaskLive &= ~genRegMask((regNumber)regArg[j]);
+                            regArg[j] = 0;
                         }
                         else if (k == i)
                         {
@@ -8066,6 +8067,7 @@ void CodeGen::genFnPrologCalleeRegArgs()
                                                             (regNumber)regArg[i], (regNumber)regArg[i]);
                                 regArgNum--;
                                 regArgMaskLive &= ~genRegMask((regNumber)regArg[j]);
+                                regArg[j] = 0;
                                 if (regArgNum == 0)
                                 {
                                     break;


### PR DESCRIPTION
Fixes one of asserts in System.Text.RegularExpressions.Tests.

Part of https://github.com/dotnet/runtime/issues/84834
cc @alpencolt @gbalykov @ashaurtaev @clamp03 @tomeksowi