### PR TITLE
Fix NativeAOT unhandled exception stack trace

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -708,13 +708,13 @@ namespace System.Runtime
             uint startIdx = MaxTryRegionIdx;
             for (; isValid; isValid = frameIter.Next(&startIdx, &unwoundReversePInvoke))
             {
-                prevControlPC = frameIter.ControlPC;
-                prevOriginalPC = frameIter.OriginalControlPC;
-
                 // For GC stackwalking, we'll happily walk across native code blocks, but for EH dispatch, we
                 // disallow dispatching exceptions across native code.
                 if (unwoundReversePInvoke)
                     break;
+
+                prevControlPC = frameIter.ControlPC;
+                prevOriginalPC = frameIter.OriginalControlPC;
 
                 DebugScanCallFrame(exInfo._passNumber, frameIter.ControlPC, frameIter.SP);
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs
@@ -221,7 +221,7 @@ namespace System
                     string outputMessage;
                     if (exception != null)
                     {
-                        prefix = "Unhandled Exception: ";
+                        prefix = "Unhandled exception. ";
                         outputMessage = exception.ToString();
                     }
                     else

--- a/src/tests/baseservices/exceptions/unhandled/unhandled.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandled.cs
@@ -24,7 +24,6 @@ namespace TestUnhandledException
 
             testProcess.StartInfo.FileName = Environment.ProcessPath;
             testProcess.StartInfo.Arguments = Environment.CommandLine + " throw";
-            testProcess.StartInfo.UseShellExecute = false;
             testProcess.StartInfo.RedirectStandardError = true;
             testProcess.ErrorDataReceived += (sender, line) => 
             {
@@ -41,7 +40,7 @@ namespace TestUnhandledException
             testProcess.CancelErrorRead();
 
             int expectedExitCode;
-            if ((Environment.OSVersion.Platform == PlatformID.Unix) || (Environment.OSVersion.Platform == PlatformID.MacOSX))
+            if (!OperatingSystem.IsWindows())
             {
                 expectedExitCode = 128 + 6;
             }
@@ -60,7 +59,7 @@ namespace TestUnhandledException
                 return 101;
             }
 
-            if (Regex.Match(lines[0], @"Unhandled exception[.:] System\.Exception\: Test", RegexOptions.IgnoreCase) == Match.Empty)
+            if (lines[0] != "Unhandled exception. System.Exception: Test")
             {
                 Console.WriteLine("Missing Unhandled exception header");
                 return 102;

--- a/src/tests/baseservices/exceptions/unhandled/unhandled.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandled.cs
@@ -40,7 +40,11 @@ namespace TestUnhandledException
             testProcess.CancelErrorRead();
 
             int expectedExitCode;
-            if (!OperatingSystem.IsWindows())
+            if (TestLibrary.Utilities.IsMonoRuntime)
+            {
+                expectedExitCode = 1;
+            }
+            else if (!OperatingSystem.IsWindows())
             {
                 expectedExitCode = 128 + 6;
             }
@@ -59,13 +63,33 @@ namespace TestUnhandledException
                 return 101;
             }
 
-            if (lines[0] != "Unhandled exception. System.Exception: Test")
+            int exceptionStackFrameLine = 1;
+            if (TestLibrary.Utilities.IsMonoRuntime)
             {
-                Console.WriteLine("Missing Unhandled exception header");
-                return 102;
+                if (lines[0] != "Unhandled Exception:")
+                {
+                    Console.WriteLine("Missing Unhandled exception header");
+                    return 102;
+                }
+                if (lines[1] != "System.Exception: Test")
+                {
+                    Console.WriteLine("Missing exception type and message");
+                    return 103;
+                }
+
+                exceptionStackFrameLine = 2;
+            }
+            else
+            {
+                if (lines[0] != "Unhandled exception. System.Exception: Test")
+                {
+                    Console.WriteLine("Missing Unhandled exception header");
+                    return 102;
+                }
+
             }
 
-            if (!lines[1].TrimStart().StartsWith("at TestUnhandledException.Program.Main"))
+            if (!lines[exceptionStackFrameLine].TrimStart().StartsWith("at TestUnhandledException.Program.Main"))
             {
                 Console.WriteLine("Missing exception source frame");
                 return 103;

--- a/src/tests/baseservices/exceptions/unhandled/unhandled.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandled.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace TestUnhandledException
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            if (args.Length != 0)
+            {
+                throw new Exception("Test");
+            }
+
+            List<string> lines = new List<string>();
+
+            Process testProcess = new Process();
+
+            testProcess.StartInfo.FileName = Environment.ProcessPath;
+            testProcess.StartInfo.Arguments = Environment.CommandLine + " throw";
+            testProcess.StartInfo.UseShellExecute = false;
+            testProcess.StartInfo.RedirectStandardError = true;
+            testProcess.ErrorDataReceived += (sender, line) => 
+            {
+                Console.WriteLine($"\"{line.Data}\"");
+                if (!string.IsNullOrEmpty(line.Data))
+                {
+                    lines.Add(line.Data);
+                }
+            };
+
+            testProcess.Start();
+            testProcess.BeginErrorReadLine();
+            testProcess.WaitForExit();
+            testProcess.CancelErrorRead();
+
+            int expectedExitCode;
+            if ((Environment.OSVersion.Platform == PlatformID.Unix) || (Environment.OSVersion.Platform == PlatformID.MacOSX))
+            {
+                expectedExitCode = 128 + 6;
+            }
+            else if (TestLibrary.Utilities.IsNativeAot)
+            {
+                expectedExitCode = unchecked((int)0xC0000409);
+            }
+            else
+            {
+                expectedExitCode = unchecked((int)0xE0434352);
+            }
+
+            if (expectedExitCode != testProcess.ExitCode)
+            {
+                Console.WriteLine($"Wrong exit code 0x{testProcess.ExitCode:X8}");
+                return 101;
+            }
+
+            if (Regex.Match(lines[0], @"Unhandled exception[.:] System\.Exception\: Test", RegexOptions.IgnoreCase) == Match.Empty)
+            {
+                Console.WriteLine("Missing Unhandled exception header");
+                return 102;
+            }
+
+            if (!lines[1].TrimStart().StartsWith("at TestUnhandledException.Program.Main"))
+            {
+                Console.WriteLine("Missing exception source frame");
+                return 103;
+            }
+
+            return 100;
+        }
+    }
+}

--- a/src/tests/baseservices/exceptions/unhandled/unhandled.csproj
+++ b/src/tests/baseservices/exceptions/unhandled/unhandled.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="unhandled.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3230,6 +3230,9 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetArchitecture)' == 'wasm'">
+        <ExcludeList Include = "$(XunitTestBinBase)/baseservices/exceptions/unhandled/unhandled/**">
+            <Issue>System.Diagnostics.Process is not supported</Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventcounter/incrementingeventcounter/**">
             <Issue>System.Threading.Thread.UnsafeStart not supported</Issue>
         </ExcludeList>


### PR DESCRIPTION
The recent change to add a new exception handling mechanism to coreclr has broken stack traces on unhandled exceptions in nativeaot.

This change fixes it by reverting the part of the change that caused the problem and that turned out to not to be needed for the new exception handling either.

Close #91298