### PR TITLE
Use SequenceEqual in BigInteger.Equals

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -1137,19 +1137,7 @@ namespace System.Numerics
             AssertValid();
             other.AssertValid();
 
-            if (_sign != other._sign)
-                return false;
-            if (_bits == other._bits)
-                // _sign == other._sign && _bits == null && other._bits == null
-                return true;
-
-            if (_bits == null || other._bits == null)
-                return false;
-            int cu = _bits.Length;
-            if (cu != other._bits.Length)
-                return false;
-            int cuDiff = GetDiffLength(_bits, other._bits, cu);
-            return cuDiff == 0;
+            return _sign == other._sign && _bits.AsSpan().SequenceEqual(other._bits);
         }
 
         public int CompareTo(long other)


### PR DESCRIPTION
The current implementation is a loop through the `_bits` array from end to beginning (most significant bytes to least).

The benchmarks are an attempt to represent the worst case for `SequenceEqual` in the comparison: lengths with a remainder for vectorization; difference at the most significant byte. I am not aware of a reason to search MSB->LSB, other than the convenience of using a helper which does so (for the purpose of `CompareTo`).

```

BenchmarkDotNet v0.13.7, Windows 11 (10.0.22621.2283/22H2/2022Update/SunValley2)
AMD Ryzen 7 5700U with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.100-rc.1.23455.8
  [Host]     : .NET 7.0.11 (7.0.1123.42427), X64 RyuJIT AVX2
  pr : .NET 9.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  main : .NET 9.0.0 (42.42.42.42424), X64 RyuJIT AVX2


```
| Method |        Job |               args |      Mean |     Error |    StdDev | Ratio | RatioSD |
|------- |----------- |------------------- |----------:|----------:|----------:|------:|--------:|
|  **Equal** | **pr** |   **5 bytes, DiffMSB** |  **4.048 ns** | **0.1106 ns** | **0.1787 ns** |  **1.79** |    **0.07** |
|  Equal | main |   5 bytes, DiffMSB |  2.258 ns | 0.0074 ns | 0.0058 ns |  1.00 |    0.00 |
|        |            |                    |           |           |           |       |         |
|  **Equal** | **pr** |      **5 bytes, Same** |  **4.054 ns** | **0.1100 ns** | **0.1897 ns** |  **1.39** |    **0.07** |
|  Equal | main |      5 bytes, Same |  2.951 ns | 0.0027 ns | 0.0024 ns |  1.00 |    0.00 |
|        |            |                    |           |           |           |       |         |
|  **Equal** | **pr** |  **19 bytes, DiffMSB** |  **4.257 ns** | **0.1144 ns** | **0.1848 ns** |  **1.86** |    **0.09** |
|  Equal | main |  19 bytes, DiffMSB |  2.303 ns | 0.0035 ns | 0.0027 ns |  1.00 |    0.00 |
|        |            |                    |           |           |           |       |         |
|  **Equal** | **pr** |     **19 bytes, Same** |  **4.179 ns** | **0.1120 ns** | **0.1931 ns** |  **0.91** |    **0.04** |
|  Equal | main |     19 bytes, Same |  4.738 ns | 0.0066 ns | 0.0062 ns |  1.00 |    0.00 |
|        |            |                    |           |           |           |       |         |
|  **Equal** | **pr** |  **67 bytes, DiffMSB** |  **4.536 ns** | **0.1185 ns** | **0.1108 ns** |  **1.82** |    **0.05** |
|  Equal | main |  67 bytes, DiffMSB |  2.486 ns | 0.0018 ns | 0.0016 ns |  1.00 |    0.00 |
|        |            |                    |           |           |           |       |         |
|  **Equal** | **pr** |     **67 bytes, Same** |  **4.296 ns** | **0.0229 ns** | **0.0179 ns** |  **0.36** |    **0.00** |
|  Equal | main |     67 bytes, Same | 11.991 ns | 0.0173 ns | 0.0162 ns |  1.00 |    0.00 |
|        |            |                    |           |           |           |       |         |
|  **Equal** | **pr** | **259 bytes, DiffMSB** |  **9.818 ns** | **0.2209 ns** | **0.2268 ns** |  **4.32** |    **0.11** |
|  Equal | main | 259 bytes, DiffMSB |  2.278 ns | 0.0328 ns | 0.0291 ns |  1.00 |    0.00 |
|        |            |                    |           |           |           |       |         |
|  **Equal** | **pr** |    **259 bytes, Same** |  **9.697 ns** | **0.0599 ns** | **0.0561 ns** |  **0.28** |    **0.00** |
|  Equal | main |    259 bytes, Same | 35.024 ns | 0.0513 ns | 0.0454 ns |  1.00 |    0.00 |


<details>

```csharp

public class Benchmarks
{
    public IEnumerable<object> GetArguments()
    {            
        Random rnd = new Random(123456);

        foreach (int byteCount in new[] { 5, 19, 67, 259 })
        {
            byte[] bytes = new byte[byteCount];

            do
            {
                rnd.NextBytes(bytes);
            } while (bytes[^1] is not (> 0 and < 128));

            BigInteger b1 = new(bytes);

            yield return new Arguments(b1, new BigInteger(bytes), $"{byteCount} bytes, Same");

            bytes[^1] = (byte)(~bytes[^1] & 0x7F);

            yield return new Arguments(b1, new BigInteger(bytes), $"{byteCount} bytes, DiffMSB");
        }
    }

    public class Arguments
    {
        private readonly BigInteger _b1;
        private readonly BigInteger _b2;
        private readonly string _description;

        public Arguments(BigInteger b1, BigInteger b2, string description)
        {
            _b1 = b1;
            _b2 = b2;
            _description = description;
        }

        public bool AreEqual() => _b1 == _b2;

        public override string ToString() => _description;
    }

    [Benchmark]
    [ArgumentsSource(nameof(GetArguments))]
    public bool Equal(Arguments args) => args.AreEqual();
}

```

</details>