### PR TITLE
[PERF] Remove browser wasm from perf_slow

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -74,27 +74,6 @@ extends:
               logicalmachine: 'perfampere'
               timeoutInMinutes: 720
 
-        # build mono on wasm
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/common/global-build-job.yml
-            buildConfig: release
-            runtimeFlavor: mono
-            platforms:
-            - browser_wasm
-            jobParameters:
-              buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-              nameSuffix: wasm
-              isOfficialBuild: false
-              extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-              extraStepsParameters:
-                rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-                includeRootFolder: true
-                displayName: Browser Wasm Artifacts
-                artifactName: BrowserWasm
-                archiveType: zip
-                archiveExtension: .zip
-
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
         # build coreclr and libraries
@@ -109,22 +88,6 @@ extends:
             - windows_arm64
             jobParameters:
               testGroup: perf
-
-        # build mono on wasm
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/common/global-build-job.yml
-            buildConfig: Release
-            runtimeFlavor: mono
-            platforms:
-            - browser_wasm
-            jobParameters:
-              buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=arm64 /p:AotHostOS=$(_hostedOS)
-              nameSuffix: wasm
-              isOfficialBuild: false
-              extraStepsTemplate: /eng/pipelines/coreclr/perf-wasm-prepare-artifacts-steps.yml
-              extraStepsParameters:
-                configForBuild: Release
 
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -35,7 +35,7 @@ extends:
       jobs:
 
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
-        
+
         # build mono
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
@@ -114,22 +114,17 @@ extends:
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
             jobTemplate: /eng/pipelines/common/global-build-job.yml
-            buildConfig: release
+            buildConfig: Release
             runtimeFlavor: mono
             platforms:
             - browser_wasm
             jobParameters:
-              buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+              buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=arm64 /p:AotHostOS=$(_hostedOS)
               nameSuffix: wasm
               isOfficialBuild: false
-              extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+              extraStepsTemplate: /eng/pipelines/coreclr/perf-wasm-prepare-artifacts-steps.yml
               extraStepsParameters:
-                rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-                includeRootFolder: true
-                displayName: Browser Wasm Artifacts
-                artifactName: BrowserWasm
-                archiveType: zip
-                archiveExtension: .zip
+                configForBuild: Release
 
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:


### PR DESCRIPTION
Looking into an error with build Browser Wasm on our Linux arm64 machines, I found that the build was not being used. While this PR removes the build from perf_slow, this is also a PR to verify that we are running the correct cases for perf_slow. Here is a test run verifying that the pipeline does not have any further dependency on the BrowserWasm build by being able to start the pipeline at all: https://dev.azure.com/dnceng/internal/_build/results?buildId=2256450&view=results. @radical do you know if running through v8 on the arm machines is something we want coverage for?