### PR TITLE
Update CustomValidationAttribute ref to include missing properties

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -65,6 +65,8 @@ namespace System.ComponentModel.DataAnnotations
     {
         public CustomValidationAttribute([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)] System.Type validatorType, string method) { }
         public string Method { get { throw null; } }
+        public override bool RequiresValidationContext { get { throw null; } }
+        public override object TypeId { get { throw null; } }
         [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]
         public System.Type ValidatorType { get { throw null; } }
         public override string FormatErrorMessage(string name) { throw null; }
@@ -359,8 +361,8 @@ namespace System.ComponentModel.DataAnnotations
     {
         public ValidationException() { }
         public ValidationException(System.ComponentModel.DataAnnotations.ValidationResult validationResult, System.ComponentModel.DataAnnotations.ValidationAttribute? validatingAttribute, object? value) { }
-        [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         protected ValidationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ValidationException(string? message) { }
         public ValidationException(string? errorMessage, System.ComponentModel.DataAnnotations.ValidationAttribute? validatingAttribute, object? value) { }


### PR DESCRIPTION
After applying [Fix nullable annotation for Validator.ValidateValue ref source · Pull Request #91351](https://github.com/dotnet/runtime/pull/91351), I reran `dotnet msbuild /t:GenerateReferenceAssemblySource`, and it picked up on 2 properties missing from the ref source for `CustomValidationAttribute`.

Since this is a pretty esoteric scenario and not reported by any customers, I figured we'd just fix this in net9.