### PR TITLE
[wasm] Fix perf pipeline

### DIFF
--- a/eng/testing/workloads-testing.targets
+++ b/eng/testing/workloads-testing.targets
@@ -190,6 +190,7 @@
                      LocalNuGetsPath="$(LibrariesShippingPackagesDir)"
                      TemplateNuGetConfigPath="$(RepoRoot)NuGet.config"
                      SdkWithNoWorkloadInstalledPath="$(_SdkWithNoWorkloadPath)"
+                     SkipUpdateAppRefPack="true"
       />
 
     <Touch Files="$(_SdkWithNoWorkloadStampPath)" AlwaysCreate="true" />

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -23,6 +23,8 @@ _MSBUILD_WASM_BUILD_ARGS=/p:TargetOS=browser /p:TargetArchitecture=wasm /p:Confi
 XHARNESS_BROWSER?=chrome
 HELIX_TARGET_QUEUE?=Ubuntu.1804.Amd64.Open
 
+LOG_PATH=$(TOP)/artifacts/log/$(CONFIG)
+
 all: build-all
 
 #
@@ -103,7 +105,7 @@ run-tests-%:
 	EMSDK_PATH=$(EMSDK_PATH) PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
 
 run-build-tests:
-	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/mono/wasm/Wasm.Build.Tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
+	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/mono/wasm/Wasm.Build.Tests/ /t:Test /bl:$(LOG_PATH)/Wasm.Build.Tests.binlog $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
 
 run-browser-tests-%:
 	PATH="$(GECKODRIVER):$(CHROMEDRIVER):$(PATH)" XHARNESS_COMMAND="test-browser --browser=$(XHARNESS_BROWSER)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
@@ -112,7 +114,7 @@ build-runtime-tests:
 	$(TOP)/src/tests/build.sh -mono os browser wasm $(CONFIG)
 
 build-debugger-tests-helix:
-	$(DOTNET) build -restore -bl:$(TOP)/artifacts/log/$(CONFIG)/Wasm.Debugger.Tests.binlog \
+	$(DOTNET) build -restore -bl:$(LOG_PATH)/Wasm.Debugger.Tests.binlog \
 	/p:ContinuousIntegrationBuild=true /p:ArchiveTests=true \
 	$(TOP)/src/mono/wasm/debugger/Wasm.Debugger.Tests/Wasm.Debugger.Tests.csproj \
 	$(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
@@ -121,7 +123,7 @@ submit-debugger-tests-helix: build-debugger-tests-helix
 	EMSDK_PATH=$(EMSDK_PATH) BUILD_REASON=wasm-test SYSTEM_TEAMPROJECT=public BUILD_REPOSITORY_NAME=dotnet/runtime BUILD_SOURCEBRANCH=main \
 		$(TOP)/eng/common/msbuild.sh --ci -restore $(TOP)/src/libraries/sendtohelix.proj \
 		/p:TestRunNamePrefixSuffix=WasmDebugger /p:HelixBuild=`date "+%Y%m%d.%H%M"` /p:Creator=`whoami` \
-		/bl:$(TOP)/artifacts/log/$(CONFIG)/SendToHelix.binlog -p:HelixTargetQueue=$(HELIX_TARGET_QUEUE) \
+		/bl:$(LOG_PATH)/SendToHelix.binlog -p:HelixTargetQueue=$(HELIX_TARGET_QUEUE) \
 		/p:RuntimeFlavor=mono /p:TargetRuntimeIdentifier= /p:MonoForceInterpreter= /p:TestScope=innerloop \
 		/p:_Scenarios=wasmdebuggertests \
 		$(_MSBUILD_WASM_BUILD_ARGS) \
@@ -133,7 +135,7 @@ submit-wbt-helix:
 	EMSDK_PATH=$(EMSDK_PATH) BUILD_REASON=wasm-test SYSTEM_TEAMPROJECT=public BUILD_REPOSITORY_NAME=dotnet/runtime BUILD_SOURCEBRANCH=main \
 		$(TOP)/eng/common/msbuild.sh --ci -restore $(TOP)/src/libraries/sendtohelix.proj \
 		/p:TestRunNamePrefixSuffix=WasmBuildTests /p:HelixBuild=`date "+%Y%m%d.%H%M"` /p:Creator=`whoami` \
-		/bl:$(TOP)/artifacts/log/$(CONFIG)/SendToHelix.binlog -v:m -p:HelixTargetQueue=$(HELIX_TARGET_QUEUE) \
+		/bl:$(LOG_PATH)/SendToHelix.binlog -v:m -p:HelixTargetQueue=$(HELIX_TARGET_QUEUE) \
 		/p:RuntimeFlavor=mono /p:TargetRuntimeIdentifier= /p:MonoForceInterpreter= /p:TestScope=innerloop \
 		/p:_Scenarios=buildwasmapps \
 		$(_MSBUILD_WASM_BUILD_ARGS) \
@@ -144,7 +146,7 @@ submit-tests-helix:
 	EMSDK_PATH=$(EMSDK_PATH) BUILD_REASON=wasm-test SYSTEM_TEAMPROJECT=public BUILD_REPOSITORY_NAME=dotnet/runtime BUILD_SOURCEBRANCH=main \
 		$(TOP)/eng/common/msbuild.sh --ci -restore $(TOP)/src/libraries/sendtohelix.proj \
 		/p:TestRunNamePrefixSuffix=WasmTests /p:HelixBuild=`date "+%Y%m%d.%H%M"` /p:Creator=`whoami` \
-		/bl:$(TOP)/artifacts/log/$(CONFIG)/SendToHelix.binlog -v:n -p:HelixTargetQueue=$(HELIX_TARGET_QUEUE) \
+		/bl:$(LOG_PATH)/SendToHelix.binlog -v:n -p:HelixTargetQueue=$(HELIX_TARGET_QUEUE) \
 		/p:RuntimeFlavor=mono /p:TargetRuntimeIdentifier= /p:MonoForceInterpreter= /p:TestScope=innerloop \
 		$(_MSBUILD_WASM_BUILD_ARGS) \
 		$(MSBUILD_ARGS)
@@ -152,9 +154,9 @@ submit-tests-helix:
 run-debugger-tests:
 	rm -f $(TOP)/artifacts/bin/DebuggerTestSuite/x64/Debug/*log; \
 	if [ ! -z "$(TEST_FILTER)" ]; then \
-	$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) "-l:trx;LogFileName=DebuggerTestsResults.xml" --results-directory $(TOP)/artifacts/log/$(CONFIG) --filter "category!=failing&FullyQualifiedName$(TEST_FILTER)" $(TEST_ARGS); \
+	$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) "-l:trx;LogFileName=DebuggerTestsResults.xml" --results-directory $(LOG_PATH) --filter "category!=failing&FullyQualifiedName$(TEST_FILTER)" $(TEST_ARGS); \
 	else \
-		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) "-l:trx;LogFileName=DebuggerTestsResults.xml" --results-directory $(TOP)/artifacts/log/$(CONFIG) --filter "category!=failing" $(TEST_ARGS); \
+		$(DOTNET) test  $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS) "-l:trx;LogFileName=DebuggerTestsResults.xml" --results-directory $(LOG_PATH) --filter "category!=failing" $(TEST_ARGS); \
 	fi
 
 build-dbg-proxy:

--- a/src/mono/wasm/Wasm.Build.Tests/NonWasmTemplateBuildTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NonWasmTemplateBuildTests.cs
@@ -74,7 +74,6 @@ public class NonWasmTemplateBuildTests : TestMainJsTestBase
         .UnwrapItemsAsArrays().ToList();
 
     [Theory, TestCategory("no-workload")]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/91357")]
     [MemberData(nameof(GetTestData))]
     public void NonWasmConsoleBuild_WithoutWorkload(string config, string extraBuildArgs, string targetFramework)
         => NonWasmConsoleBuild(config,
@@ -84,7 +83,6 @@ public class NonWasmTemplateBuildTests : TestMainJsTestBase
                                shouldRun: targetFramework == s_latestTargetFramework);
 
     [Theory]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/91357")]
     [MemberData(nameof(GetTestData))]
     public void NonWasmConsoleBuild_WithWorkload(string config, string extraBuildArgs, string targetFramework)
         => NonWasmConsoleBuild(config,

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Workload.Build.Tasks
         [Required, NotNull]
         public string         SdkWithNoWorkloadInstalledPath { get; set; } = string.Empty;
 
+        public bool           SkipUpdateAppRefPack { get; set; }
         public bool           OnlyUpdateManifests{ get; set; }
 
         private const string s_nugetInsertionTag = "<!-- TEST_RESTORE_SOURCES_INSERTION_LINE -->";
@@ -153,7 +154,10 @@ namespace Microsoft.Workload.Build.Tasks
             if (!InstallPacks(req, nugetConfigContents))
                 return false;
 
-            UpdateAppRef(req.TargetPath, req.Version);
+            if (!SkipUpdateAppRefPack)
+                UpdateAppRef(req.TargetPath, req.Version);
+            else
+                Log.LogMessage(MessageImportance.Low, "Skipping update of app.ref pack");
 
             return !Log.HasLoggedErrors;
         }
@@ -221,6 +225,7 @@ namespace Microsoft.Workload.Build.Tasks
                                                         ["NUGET_PACKAGES"] = _nugetCachePath
                                                     },
                                                     logStdErrAsMessage: req.IgnoreErrors,
+                                                    silent: false,
                                                     debugMessageImportance: MessageImportance.Normal);
             if (exitCode != 0)
             {


### PR DESCRIPTION
dotnet-runtime-perf wasm runs broke after the change to tfm=net9.0, and 9.0 assemblies.

The failures were of two forms:

1. The microbenchmarks project is built as a non-wasm project, and then run. But this failed with the following error because the project was built with 9.0 ref assemblies, but sdk only had 8.0 runtime pack for running the application:

```
Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.

File name: 'System.Runtime, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
```

- this was because while installing the workload for testing, we update the ref pack with the locally built ref assemblies, which is not an issue when the versions match, but breaks in this special case.

2. A native build would fail because `9.0` wasm targets were used from the workload, with 8.0 runtime packs. This is because we have a 9.0 sdk, but with it has 8.0 references for the runtime pack, thus causing this mix up. The solution is to use the same workaround as Wasm.Build.Tests, and explicitly override paths to the various packs, to ensure that the correct ones are used.

`emcc : error : /home/helixbot/work/C6E60A3B/w/BEDB0A92/u/artifacts/packages/microsoft.netcore.app.runtime.mono.browser-wasm/8.0.0-rc.1.23414.4/runtimes/browser-wasm/native/libmono-wasm-simd.a: No such file or directory`

Fixes https://github.com/dotnet/runtime/issues/91442 with https://github.com/dotnet/performance/pull/3311 .

Also, (1) fixes running the non-wasm build tests in WBT, referenced in https://github.com/dotnet/runtime/issues/91357 .