### PR TITLE
[RISC-V] Implement ThisPtrRetBufPrecode::Init

### DIFF
--- a/src/coreclr/vm/riscv64/cgencpu.h
+++ b/src/coreclr/vm/riscv64/cgencpu.h
@@ -425,7 +425,7 @@ struct HijackArgs
 // Precode to shuffle this and retbuf for closed delegates over static methods with return buffer
 struct ThisPtrRetBufPrecode {
 
-    static const int Type = 0x2;
+    static const int Type = 0x93;
 
     UINT32  m_rgCode[6];
     TADDR   m_pTarget;

--- a/src/coreclr/vm/riscv64/stubs.cpp
+++ b/src/coreclr/vm/riscv64/stubs.cpp
@@ -476,7 +476,23 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 #ifndef DACCESS_COMPILE
 void ThisPtrRetBufPrecode::Init(MethodDesc* pMD, LoaderAllocator *pLoaderAllocator)
 {
-    _ASSERTE(!"RISCV64: not implementation on riscv64!!!");
+    WRAPPER_NO_CONTRACT;
+
+    //Initially
+    //a0 -This ptr
+    //a1 -ReturnBuffer
+    m_rgCode[0] = 0x00050f93; // addi  t6, a0, 0x0
+    m_rgCode[1] = 0x00058513; // addi  a0, a1, 0x0
+    m_rgCode[2] = 0x000f8593; // addi  a1, t6, 0x0
+    m_rgCode[3] = 0x00000f97; // auipc t6, 0
+    m_rgCode[4] = 0x00cfbf83; // ld    t6, 12(t6)
+    m_rgCode[5] = 0x000f8067; // jalr  x0, 0(t6)
+
+    _ASSERTE((UINT32*)&m_pTarget == &m_rgCode[6]);
+    _ASSERTE(6 == ARRAY_SIZE(m_rgCode));
+
+    m_pTarget = GetPreStubEntryPoint();
+    m_pMethodDesc = (TADDR)pMD;
 }
 
 #endif // !DACCESS_COMPILE


### PR DESCRIPTION
Fix `"RISCV64: not implementation on riscv64!!!"` assertion in corefx tests
```
System.Dynamic.Runtime.Tests
System.Linq.Queryable.Tests
Microsoft.CSharp.Tests
```

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov @tomeksowi