### PR TITLE
Fix official builds for NativeAOT

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -6,12 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- SkipGetTargetFrameworkProperties builds ILLink.Tasks without any TargetFramework settings
-         based on the referencing project, preventing errors when illink.targets is imported by a
-         project with TargetFrameworks that are incompatible with those of ILLink.Tasks. -->
+    <!-- THe assembly shouldn't be referenced, nor promoted to a package dependency, nor copied to the output directory. -->
     <ProjectReference Include="$(_ILLinkTasksSourceDir)ILLink.Tasks.csproj"
                       ReferenceOutputAssembly="false"
                       PrivateAssets="all"
+                      Private="false"
                       SetConfiguration="Configuration=$(ToolsConfiguration)">
         <!-- Keep TFMs in sync with ILLink.Tasks.csproj -->
         <SetTargetFramework Condition="'$(MSBuildRuntimeType)' == 'Core'">TargetFramework=$(NetCoreAppToolCurrent)</SetTargetFramework>

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- THe assembly shouldn't be referenced, nor promoted to a package dependency, nor copied to the output directory. -->
+    <!-- The assembly shouldn't be referenced, nor promoted to a package dependency, nor copied to the output directory. -->
     <ProjectReference Include="$(_ILLinkTasksSourceDir)ILLink.Tasks.csproj"
                       ReferenceOutputAssembly="false"
                       PrivateAssets="all"


### PR DESCRIPTION
Fixes regression introduced in https://github.com/dotnet/runtime/pull/91233

The ILLink ProjectReference output shouldn't be copied to consuming projects.

From the docs:
> Private	Optional boolean. Specifies whether the reference should be copied to the output folder. This attribute matches the Copy Local property of the reference that's in the Visual Studio IDE.

From what I can see, this is only happening on NativeAOT legs because of this glob: https://github.com/dotnet/runtime/blob/91ac6b3544d53fcf9e6962575813c1cd54aa27bd/eng/liveBuilds.targets#L82-L87