### PR TITLE
Enable interceptors implicitly in binder gen nupkg when generator is enabled

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/buildTransitive/Microsoft.Extensions.Configuration.Binder.targets
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/buildTransitive/Microsoft.Extensions.Configuration.Binder.targets
@@ -1,4 +1,9 @@
 <Project InitialTargets="NETStandardCompatError_Microsoft_Extensions_Configuration_Binder">
+    <PropertyGroup Condition="'$(EnableConfigurationBindingGenerator)' == 'true'">
+        <!-- The configuration binding source generator uses a preview version of the compiler interceptors feature. Enable it implicitly when the generator is enabled. -->
+        <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Extensions.Configuration.Binder.SourceGeneration</InterceptorsPreviewNamespaces>
+    </PropertyGroup>
+
     <Target Name="_Microsoft_Extensions_Configuration_Binder_RemoveAnalyzer"
             Condition="'$(EnableConfigurationBindingGenerator)' != 'true'"
             AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets">
@@ -8,18 +13,8 @@
         </ItemGroup>
     </Target>
 
-    <Target Name="_Microsoft_Extensions_Configuration_Binder_EnableInterceptors"
-            Condition="'$(EnableConfigurationBindingGenerator)' == 'true'"
-            AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets">
-
-        <PropertyGroup>
-            <!-- The configuration binding source generator uses a preview version of the compiler interceptors feature. Enable it implicitly when the generator is enabled. -->
-            <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Extensions.Configuration.Binder.SourceGeneration</InterceptorsPreviewNamespaces>
-        </PropertyGroup>
-    </Target>
-
-     <Target Name="NETStandardCompatError_Microsoft_Extensions_Configuration_Binder"
-          Condition="'$(SuppressTfmSupportBuildWarnings)' == ''">
+    <Target Name="NETStandardCompatError_Microsoft_Extensions_Configuration_Binder"
+            Condition="'$(SuppressTfmSupportBuildWarnings)' == ''">
         <PropertyGroup>
             <_Microsoft_Extensions_Configuration_Binder_Compatible_TargetFramework
                 Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp2.0')) AND

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/buildTransitive/Microsoft.Extensions.Configuration.Binder.targets
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/buildTransitive/Microsoft.Extensions.Configuration.Binder.targets
@@ -1,11 +1,21 @@
 <Project InitialTargets="NETStandardCompatError_Microsoft_Extensions_Configuration_Binder">
-    <Target Name="_Microsoft_Extensions_Configuration_BinderRemoveAnalyzer" 
+    <Target Name="_Microsoft_Extensions_Configuration_Binder_RemoveAnalyzer"
             Condition="'$(EnableConfigurationBindingGenerator)' != 'true'"
             AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets">
 
         <ItemGroup>
             <Analyzer Remove="@(Analyzer->WithMetadataValue('NuGetPackageId', 'Microsoft.Extensions.Configuration.Binder'))" />
         </ItemGroup>
+    </Target>
+
+    <Target Name="_Microsoft_Extensions_Configuration_Binder_EnableInterceptors"
+            Condition="'$(EnableConfigurationBindingGenerator)' == 'true'"
+            AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets">
+
+        <PropertyGroup>
+            <!-- The configuration binding source generator uses a preview version of the compiler interceptors feature. Enable it implicitly when the generator is enabled. -->
+            <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Extensions.Configuration.Binder.SourceGeneration</InterceptorsPreviewNamespaces>
+        </PropertyGroup>
     </Target>
 
      <Target Name="NETStandardCompatError_Microsoft_Extensions_Configuration_Binder"


### PR DESCRIPTION
- Fixes https://github.com/dotnet/runtime/issues/91419. RC-2 candidate.
- Interceptors feature is required for source-gen to work; enable it implicitly using granular opt-in (i.e only for the namespace that we emit binding logic into)
- Corresponding web SDK change https://github.com/dotnet/sdk/pull/35024/
- Not blocked on the new Roslyn version that contains the granular feature flowing into the SDK (https://github.com/dotnet/sdk/pull/35018).

@dotnet/area-extensions-configuration @dotnet/area-infrastructure-libraries  @captainsafia