### PR TITLE
Condition EnableSingleFileAnalyzer

### DIFF
--- a/eng/Analyzers.targets
+++ b/eng/Analyzers.targets
@@ -14,7 +14,7 @@
   <PropertyGroup Condition="'$(RunAnalyzers)' != 'false'">
     <EnableSingleFileAnalyzer Condition="
       '$(EnableSingleFileAnalyzer)' == '' And
-      '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</EnableSingleFileAnalyzer>
+      $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</EnableSingleFileAnalyzer>
   </PropertyGroup>
   <ItemGroup Condition="'$(RunAnalyzers)' != 'false'">
     <EditorConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.src.globalconfig" />

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -12,7 +12,6 @@
     <WorkloadOutputPath Condition="'$(workloadArtifactsPath)' != ''">$(workloadArtifactsPath)/</WorkloadOutputPath>
     <PackageSource>$(ArtifactsShippingPackagesDir)</PackageSource>
     <PackageSource Condition="'$(workloadPackagesPath)' != ''">$(workloadPackagesPath)/</PackageSource>
-    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <!-- Arcade -->


### PR DESCRIPTION
With the latest SDK, a warning is generated if the analyzer is enabled on an unsupported SDK.