### PR TITLE
Fix usage of load library

### DIFF
--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -181,7 +181,7 @@ STDAPI DLLEXPORT OpenVirtualProcessImpl2(
     CLR_DEBUGGING_PROCESS_FLAGS* pFlagsOut)
 {
 #ifdef TARGET_WINDOWS
-    HMODULE hDac = LoadLibraryExW(pDacModulePath, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    HMODULE hDac = LoadLibraryExW(pDacModulePath, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
 #else
     HMODULE hDac = LoadLibraryW(pDacModulePath);
 #endif // !TARGET_WINDOWS

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -180,7 +180,11 @@ STDAPI DLLEXPORT OpenVirtualProcessImpl2(
     IUnknown ** ppInstance,
     CLR_DEBUGGING_PROCESS_FLAGS* pFlagsOut)
 {
+#ifdef TARGET_WINDOWS
+    HMODULE hDac = LoadLibraryExW(pDacModulePath, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+#else
     HMODULE hDac = LoadLibraryW(pDacModulePath);
+#endif // !TARGET_WINDOWS
     if (hDac == NULL)
     {
         return HRESULT_FROM_WIN32(GetLastError());


### PR DESCRIPTION
Use `LoadLibraryExW` instead of `LoadLibraryW` on Windows.