### PR TITLE
invalid assert for segments

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -16688,10 +16688,12 @@ void gc_heap::adjust_limit_clr (uint8_t* start, size_t limit_size, size_t size,
 
     size_t aligned_min_obj_size = Align(min_obj_size, align_const);
 
+#ifdef USE_REGIONS
     if (seg)
     {
         assert (heap_segment_used (seg) <= heap_segment_committed (seg));
     }
+#endif //USE_REGIONS
 
 #ifdef MULTIPLE_HEAPS
     if (gen_number == 0)


### PR DESCRIPTION
while testing [PR#91445](https://github.com/dotnet/runtime/pull/91445) for segments I noticed an assert - 

```
Program: ...oreclr\windows.x64.Debug\Tests\Core_Root\clrgc.dll
File: D:\runtime-scratch\src\coreclr\gc\gc.cpp
Line: 16693

Expression: heap_segment_used (seg) <= heap_segment_committed (seg)

For information on how your program can cause an assertion
failure, see the Visual C++ documentation on asserts

(Press Retry to debug the application - JIT must be enabled)
---------------------------
Abort   Retry   Ignore   
---------------------------
```
callstack
```
0:042> k
 # Child-SP          RetAddr               Call Site
00 00000047`e97fd580 00007ffd`4db9cc53     clrgc!common_assert_to_message_box<wchar_t>+0xd5 [minkernel\crts\ucrt\src\appcrt\startup\assert.cpp @ 388] 
01 00000047`e97fda70 00007ffd`4db9f8bf     clrgc!common_assert<wchar_t>+0x83 [minkernel\crts\ucrt\src\appcrt\startup\assert.cpp @ 424] 
02 00000047`e97fdab0 00007ffd`4da855c7     clrgc!_wassert+0x2f [minkernel\crts\ucrt\src\appcrt\startup\assert.cpp @ 444] 
03 00000047`e97fdae0 00007ffd`4da840de     clrgc!SVR::gc_heap::adjust_limit_clr+0x167 [D:\runtime-scratch\src\coreclr\gc\gc.cpp @ 16695] 
04 00000047`e97fdc60 00007ffd`4dad5145     clrgc!SVR::gc_heap::a_fit_segment_end_p+0x6ce [D:\runtime-scratch\src\coreclr\gc\gc.cpp @ 17715] 
05 00000047`e97fdd50 00007ffd`4da89b50     clrgc!SVR::gc_heap::soh_try_fit+0x105 [D:\runtime-scratch\src\coreclr\gc\gc.cpp @ 17870] 
06 00000047`e97fddb0 00007ffd`4dad840e     clrgc!SVR::gc_heap::allocate_soh+0x110 [D:\runtime-scratch\src\coreclr\gc\gc.cpp @ 17989] 
07 00000047`e97fdfb0 00007ffd`4da898f2     clrgc!SVR::gc_heap::try_allocate_more_space+0x38e [D:\runtime-scratch\src\coreclr\gc\gc.cpp @ 19018] 
08 00000047`e97fe040 00007ffd`4da86a08     clrgc!SVR::gc_heap::allocate_more_space+0x82 [D:\runtime-scratch\src\coreclr\gc\gc.cpp @ 19467] 
09 00000047`e97fe0c0 00007ffd`4da78f9b     clrgc!SVR::gc_heap::allocate+0xf8 [D:\runtime-scratch\src\coreclr\gc\gc.cpp @ 19541] 
0a 00000047`e97fe110 00007ffc`77d4d27c     clrgc!SVR::GCHeap::Alloc+0x1eb [D:\runtime-scratch\src\coreclr\gc\gc.cpp @ 49322] 
```

it's hitting this assert in 

```cplusplus
void gc_heap::adjust_limit_clr (uint8_t* start, size_t limit_size, size_t size,
                                alloc_context* acontext, uint32_t flags,
                                heap_segment* seg, int align_const, int gen_number)
{
   // [omitted]
    if (seg)
    {
        assert (heap_segment_used (seg) <= heap_segment_committed (seg));
    }
```
if you look at these 2 fields they are the same so it would see a bit odd that we are triggering this assert

0:042> ?? seg->used
unsigned char * 0x00000235`42c24000
 "--- memory read error at address 0x00000235`42c24000 ---"
0:042> ?? seg->committed
unsigned char * 0x00000235`42c24000
 "--- memory read error at address 0x00000235`42c24000 ---"

but this is because we are doing decommit on Server GC thread for heap0. in `decommit_heap_segment_pages_worker` -
```cplusplus
            if (heap_segment_used (seg) > heap_segment_committed (seg))
            {
                heap_segment_used (seg) = heap_segment_committed (seg);
            }
```
but you may or may not see this if you look at all the other threads since it might've alrady finished running. however, I can observe a larger used value if I read them into local values - 

```cplusplus
    if (seg)
    {
        current_used = heap_segment_used (seg);
        current_committed = heap_segment_committed (seg);
        if (current_used > current_committed)
        {
            assert (current_used <= current_committed);
        }
    }
```
```
0:045> ?? current_used
unsigned char * 0x0000024e`07e80000
 "--- memory read error at address 0x0000024e`07e80000 ---"
0:045> ?? current_committed
unsigned char * 0x0000024e`07e03000
 "--- memory read error at address 0x0000024e`07e03000 ---"
```
this doesn't happen with regions because we take the msl when we decommit. but we don't do this for segments. it doesn't cause any funcational problems - we just can't assert this.  