### PR TITLE
Fix the VN for xor operation

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7883,7 +7883,7 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(var_types      type,
 #endif
             {
                 // Handle `x ^ x == 0`
-                return arg0VN;
+                return VNZeroForType(type);
             }
 
             default:

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91252/Runtime_91252.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91252/Runtime_91252.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+// This test verifies if we correctly value number the operation of 
+// x ^ x to zero.
+//
+// Found by Antigen
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Issue_91252
+{
+    static Vector64<int> s_v64_int_22 = Vector64.Create(-5);
+    Vector64<int> v64_int_72 = Vector64.Create(-1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int Repro()
+    {
+        s_v64_int_22 = v64_int_72;
+        return Check(v64_int_72 ^ v64_int_72);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int Check(Vector64<int> a)
+    {
+        return (a == Vector64<int>.Zero) ? 100 : 101;
+    }
+
+    [Fact]
+    public static int EntryPoint()
+    {
+        var obj = new Issue_91252();
+        return obj.Repro();
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91252/Runtime_91252.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91252/Runtime_91252.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Seems there was a typo introduced by https://github.com/dotnet/runtime/pull/82190 where we were not returning ZeroVN for `x ^ x` operation.

Fixes: #91252 
