### PR TITLE
Reduce work done by RuntimeHelpers.TryGetHashCode on Mono

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
@@ -48,9 +48,6 @@ namespace System.Runtime.CompilerServices
             return InternalGetHashCode(o);
         }
 
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern int InternalTryGetHashCode(object? o);
-
         /// <summary>
         /// If a hash code has been assigned to the object, it is returned. Otherwise zero is
         /// returned.
@@ -65,7 +62,7 @@ namespace System.Runtime.CompilerServices
             // NOTE: the interpreter does not run this code.  It intrinsifies the whole RuntimeHelpers.TryGetHashCode function
             if (Threading.ObjectHeader.TryGetHashCode (o, out int hash))
                 return hash;
-            return InternalTryGetHashCode(o);
+            return 0;
         }
 
         public static new bool Equals(object? o1, object? o2)

--- a/src/mono/System.Private.CoreLib/src/System/Threading/ObjectHeader.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/ObjectHeader.Mono.cs
@@ -255,7 +255,7 @@ internal static class ObjectHeader
             if (lw.IsInflated) {
                 ref MonoThreadsSync mon = ref lw.GetInflatedLock();
                 hash = SyncBlock.HashCode(ref mon);
-                return false;
+                return true;
             } else {
                 hash = lw.FlatHash;
                 return true;

--- a/src/mono/mono/metadata/icall-def.h
+++ b/src/mono/mono/metadata/icall-def.h
@@ -436,7 +436,6 @@ HANDLES(RUNH_6, "GetSpanDataFrom", ves_icall_System_Runtime_CompilerServices_Run
 HANDLES(RUNH_2, "GetUninitializedObjectInternal", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetUninitializedObjectInternal, MonoObject, 1, (MonoType_ptr))
 HANDLES(RUNH_3, "InitializeArray", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray, void, 2, (MonoArray, MonoClassField_ptr))
 HANDLES(RUNH_7, "InternalGetHashCode", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InternalGetHashCode, int, 1, (MonoObject))
-HANDLES(RUNH_8, "InternalTryGetHashCode", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InternalTryGetHashCode, int, 1, (MonoObject))
 HANDLES(RUNH_3a, "PrepareMethod", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_PrepareMethod, void, 3, (MonoMethod_ptr, gpointer, int))
 HANDLES(RUNH_4, "RunClassConstructor", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_RunClassConstructor, void, 1, (MonoType_ptr))
 HANDLES(RUNH_5, "RunModuleConstructor", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_RunModuleConstructor, void, 1, (MonoImage_ptr))

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -1077,12 +1077,6 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InternalGetHashCode (Mo
 	return mono_object_hash_internal (MONO_HANDLE_RAW (obj));
 }
 
-int
-ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InternalTryGetHashCode (MonoObjectHandle obj, MonoError* error)
-{
-	return mono_object_try_get_hash_internal (MONO_HANDLE_RAW (obj));
-}
-
 MonoObjectHandle
 ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetObjectValue (MonoObjectHandle obj, MonoError *error)
 {

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2316,7 +2316,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 			return TRUE;
 		} else if (!strcmp (tm, "GetHashCode") || !strcmp (tm, "InternalGetHashCode")) {
 			*op = MINT_INTRINS_GET_HASHCODE;
-		} else if (!strcmp (tm, "TryGetHashCode") || !strcmp (tm, "InternalTryGetHashCode")) {
+		} else if (!strcmp (tm, "TryGetHashCode")) {
 			*op = MINT_INTRINS_TRY_GET_HASHCODE;
 		} else if (!strcmp (tm, "GetRawData")) {
 			interp_add_ins (td, MINT_LDFLDA_UNSAFE);


### PR DESCRIPTION
Following up from #81380 which implemented some fast paths for Mono's sync blocks in managed code.

* First correct `ObjectHeader.TryGetHashCode` to return true when it finds the hash code in the inflated lock word. This matches [the unmanaged implementation](https://github.com/dotnet/runtime/blob/907d0946162e302800495cce312c54f0e659db8c/src/mono/mono/metadata/monitor.c#L615-L621).
* Change `RuntimeHelpers.TryGetHashCode` to no longer make an icall if `ObjectHeader.TryGetHashCode` returns false. The icall does the same checks as `ObjectHeader.TryGetHashCode`. (see above unmanaged link).
* Remove the now unused icall `InternalTryGetHashCode`.