### PR TITLE
Making installer tests pass on OSX-arm64 in Release build

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/RidAssetResolution.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/RidAssetResolution.cs
@@ -139,6 +139,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 excludedPath);
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Theory]
         // RID is computed at run-time
         [InlineData(null, true, true)]
@@ -238,6 +239,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                 includedPath, excludedPath);
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Theory]
         // RID is computed at run-time
         [InlineData(null, true, true)]

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/MultipleHives.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             SharedState = sharedState;
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Theory]
         // MLL (where global hive has better match) with various TFMs
         [InlineData("5.0.0", "netcoreapp3.1", true, "5.1.2")]
@@ -69,6 +70,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .ShouldHaveResolvedFramework(MicrosoftNETCoreApp, "5.1.2");
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Theory]
         [InlineData("6.1.2", "net6.0", true, "6.1.2", false)] // No roll forward if --fx-version is used
         [InlineData("6.1.2", "net6.0", null, "6.1.2", false)]
@@ -137,6 +139,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
             return expectedList;
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Theory]
         [InlineData(true)]
         [InlineData(null)]
@@ -162,6 +165,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .And.HaveStdErrContaining("Ignoring FX version [9999.9.9] without .deps.json");
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Theory]
         [InlineData(true)]
         [InlineData(null)]
@@ -186,6 +190,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
                 .And.HaveStdErrContaining("Ignoring FX version [9999.9.9] without .deps.json");
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Theory]
         [InlineData("net6.0", true, true)]
         [InlineData("net6.0", null, true)]

--- a/src/installer/tests/HostActivation.Tests/MockCoreClrSanity.cs
+++ b/src/installer/tests/HostActivation.Tests/MockCoreClrSanity.cs
@@ -30,6 +30,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             _dotnetDirArtifact.Dispose();
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Fact]
         public void Muxer_ListRuntimes()
         {

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -72,6 +72,7 @@ namespace HostActivation.Tests
                 .And.NotHaveStdErrContaining("Using environment variable DOTNET_ROOT=");
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Fact]
         public void EnvironmentVariable_DotNetRootIsUsedOverInstallLocationIfSet()
         {
@@ -97,6 +98,7 @@ namespace HostActivation.Tests
             }
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Fact]
         public void EnvironmentVariable_DotnetRootPathDoesNotExist()
         {
@@ -122,6 +124,7 @@ namespace HostActivation.Tests
             }
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Fact]
         public void EnvironmentVariable_DotnetRootPathExistsButHasNoHost()
         {
@@ -185,6 +188,7 @@ namespace HostActivation.Tests
             }
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Fact]
         public void RegisteredInstallLocation_ArchSpecificLocationIsPickedFirst()
         {
@@ -223,6 +227,7 @@ namespace HostActivation.Tests
             }
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Fact]
         [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         public void InstallLocationFile_ReallyLongInstallPathIsParsedCorrectly()
@@ -280,6 +285,7 @@ namespace HostActivation.Tests
             }
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Fact]
         public void RegisteredInstallLocation_DotNetInfo_ListOtherArchitectures()
         {

--- a/src/installer/tests/HostActivation.Tests/MultilevelSDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/MultilevelSDKLookup.cs
@@ -463,6 +463,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             return expectedList;
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Theory]
         [InlineData(true)]
         [InlineData(null)]
@@ -483,6 +484,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.HaveStdOut(expectedOutput);
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Theory]
         [InlineData(true)]
         [InlineData(null)]
@@ -507,6 +509,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.HaveStdOutContaining(expectedOutput);
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Theory]
         [InlineData(true)]
         [InlineData(null)]

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -163,6 +163,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Copy();
 
             string appExe = fixture.TestProject.AppExe;
-            fixture.TestProject.BuiltApp.CreateAppHost();
+            fixture.TestProject.BuiltApp.CreateAppHost(enableMacOSCodeSign: true);
 
             // Get the framework location that was built
             string builtDotnet = fixture.BuiltDotnet.BinPath;
@@ -172,7 +172,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Copy();
 
             string appExe = fixture.TestProject.AppExe;
-            fixture.TestProject.BuiltApp.CreateAppHost();
+            fixture.TestProject.BuiltApp.CreateAppHost(enableMacOSCodeSign: true);
 
             // Get the framework location that was built
             string builtDotnet = fixture.BuiltDotnet.BinPath;
@@ -325,7 +325,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Copy();
 
             string appExe = fixture.TestProject.AppExe;
-            fixture.TestProject.BuiltApp.CreateAppHost();
+            fixture.TestProject.BuiltApp.CreateAppHost(enableMacOSCodeSign: true);
 
             string invalidDotNet = SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "cliErrors"));
             using (new TestArtifact(invalidDotNet))
@@ -553,7 +553,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 MockApp = new TestApp(SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "portableAppActivation")), "App");
                 Directory.CreateDirectory(MockApp.Location);
                 File.WriteAllText(MockApp.AppDll, string.Empty);
-                MockApp.CreateAppHost(copyResources: false);
+                MockApp.CreateAppHost(copyResources: false, enableMacOSCodeSign: true);
             }
 
             public void Dispose()

--- a/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
@@ -158,6 +158,7 @@ namespace HostActivation.Tests
                 .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
         }
 
+        [SkipOnPlatform(TestPlatforms.OSX, "https://github.com/dotnet/runtime/issues/91486")]
         [Fact]
         public void Running_Publish_Output_Standalone_EXE_With_Relative_Embedded_Path_Succeeds()
         {

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleTestBase.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleTestBase.cs
@@ -23,7 +23,8 @@ namespace AppHost.Bundle.Tests
             HostWriter.CreateAppHost(Binaries.SingleFileHost.FilePath,
                                      publishedHostPath,
                                      BundleHelper.GetAppName(testFixture),
-                                     assemblyToCopyResourcesFrom: BundleHelper.GetAppPath(testFixture));
+                                     assemblyToCopyResourcesFrom: BundleHelper.GetAppPath(testFixture),
+                                     enableMacOSCodeSign: true);
             return publishedHostPath;
         }
 

--- a/src/installer/tests/TestUtils/TestApp.cs
+++ b/src/installer/tests/TestUtils/TestApp.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             builder.Build(this);
         }
 
-        public void CreateAppHost(bool isWindowsGui = false, bool copyResources = true)
+        public void CreateAppHost(bool isWindowsGui = false, bool copyResources = true, bool enableMacOSCodeSign = true)
         {
             // Use the live-built apphost and HostModel to create the apphost to run
             HostWriter.CreateAppHost(
@@ -74,7 +74,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 AppExe,
                 Path.GetFileName(AppDll),
                 windowsGraphicalUserInterface: isWindowsGui,
-                assemblyToCopyResourcesFrom: copyResources ? AppDll : null);
+                assemblyToCopyResourcesFrom: copyResources ? AppDll : null,
+                enableMacOSCodeSign);
         }
 
         public enum MockedComponent


### PR DESCRIPTION
These are tests/infra changes mostly dealing with codesign issues that crept up over time.

It is enough to pass tests in Release
As in `./build.sh clr+libs+host+packs+host.tests -c Release -rc Release -lc Release -test`

