### PR TITLE
[LoongArch64, RISC-V] Fix handling ThreadAbortException at the end of catch for LoongArch64 and RISC-V.

### DIFF
--- a/src/coreclr/pal/inc/unixasmmacrosloongarch64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosloongarch64.inc
@@ -447,7 +447,7 @@ __RedirectionFuncName SETS "|?RedirectedHandledJITCaseFor":CC:"$reason":CC:"@Thr
 
         // Stack alignment. This check is necessary as this function can be
         // entered before complete execution of the prolog of another function.
-        andi $t4, $fp, 15
+        andi $t4, $fp, 0xf
         sub.d  $sp, $sp, $t4
 
 
@@ -480,5 +480,21 @@ $__RedirectionStubEndFuncName
         NESTED_END
 #else
         EMIT_BREAKPOINT
+#endif
+.endm
+
+//-----------------------------------------------------------------------------
+// Macro used to check (in debug builds only) whether the stack is 16-bytes aligned (a requirement before calling
+// out into C++/OS code). Invoke this directly after your prolog (if the stack frame size is fixed) or directly
+// before a call (if you have a frame pointer and a dynamic stack). A breakpoint will be invoked if the stack
+// is misaligned.
+//
+.macro  CHECK_STACK_ALIGNMENT
+
+#ifdef _DEBUG
+        andi    $t4, $sp, 0xf
+        beq     $t4, $r0, 0f
+        EMIT_BREAKPOINT
+0:
 #endif
 .endm

--- a/src/coreclr/pal/inc/unixasmmacrosriscv64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosriscv64.inc
@@ -323,3 +323,19 @@ C_FUNC(\Name\()_End):
 // TODO RISCV NYI
     sw  ra, 0(zero)
 .endm
+
+//-----------------------------------------------------------------------------
+// Macro used to check (in debug builds only) whether the stack is 16-bytes aligned (a requirement before calling
+// out into C++/OS code). Invoke this directly after your prolog (if the stack frame size is fixed) or directly
+// before a call (if you have a frame pointer and a dynamic stack). A breakpoint will be invoked if the stack
+// is misaligned.
+//
+.macro  CHECK_STACK_ALIGNMENT
+
+#ifdef _DEBUG
+        andi    t4, sp, 0xf
+        beq     t4, zero, 0f
+        EMIT_BREAKPOINT
+0:
+#endif
+.endm

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -808,7 +808,7 @@ UINT_PTR ExceptionTracker::FinishSecondPass(
     {
         CopyOSContext(pThread->m_OSContext, pContextRecord);
         SetIP(pThread->m_OSContext, (PCODE)uResumePC);
-#if defined(TARGET_UNIX) && !(defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_ARM) || defined(TARGET_LOONGARCH64))
+#if defined(TARGET_UNIX) && !(defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_ARM) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64))
         uAbortAddr = NULL;
 #else
         uAbortAddr = (UINT_PTR)COMPlusCheckForAbort(uResumePC);

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -808,7 +808,7 @@ UINT_PTR ExceptionTracker::FinishSecondPass(
     {
         CopyOSContext(pThread->m_OSContext, pContextRecord);
         SetIP(pThread->m_OSContext, (PCODE)uResumePC);
-#if defined(TARGET_UNIX) && !(defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_ARM) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64))
+#if defined(TARGET_UNIX) && defined(TARGET_X86)
         uAbortAddr = NULL;
 #else
         uAbortAddr = (UINT_PTR)COMPlusCheckForAbort(uResumePC);

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -808,7 +808,7 @@ UINT_PTR ExceptionTracker::FinishSecondPass(
     {
         CopyOSContext(pThread->m_OSContext, pContextRecord);
         SetIP(pThread->m_OSContext, (PCODE)uResumePC);
-#if defined(TARGET_UNIX) && !(defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_ARM))
+#if defined(TARGET_UNIX) && !(defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_ARM) || defined(TARGET_LOONGARCH64))
         uAbortAddr = NULL;
 #else
         uAbortAddr = (UINT_PTR)COMPlusCheckForAbort(uResumePC);

--- a/src/coreclr/vm/loongarch64/asmhelpers.S
+++ b/src/coreclr/vm/loongarch64/asmhelpers.S
@@ -669,29 +669,7 @@ LEAF_END JIT_GetSharedGCStaticBase_SingleAppDomain, _TEXT
 
 .endm
 
-// ------------------------------------------------------------------
-//
-// Helpers for ThreadAbort exceptions
-//
-        NESTED_ENTRY RedirectForThreadAbort2, _TEXT, NoHandler
-        PROLOG_SAVE_REG_PAIR_INDEXED  22, 1, 16
-
-        // stack must be 16 byte aligned
-        CHECK_STACK_ALIGNMENT
-
-        // On entry:
-        //
-        // a0 = address of FaultingExceptionFrame
-        //
-        // Invoke the helper to setup the FaultingExceptionFrame and raise the exception
-        bl    C_FUNC(ThrowControlForThread)
-
-        // ThrowControlForThread doesn't return.
-        EMIT_BREAKPOINT
-
-        NESTED_END RedirectForThreadAbort2, _TEXT
-
-GenerateRedirectedStubWithFrame RedirectForThreadAbort, RedirectForThreadAbort2
+GenerateRedirectedStubWithFrame RedirectForThreadAbort, ThrowControlForThread
 
 // ------------------------------------------------------------------
 // ResolveWorkerChainLookupAsmStub

--- a/src/coreclr/vm/loongarch64/asmhelpers.S
+++ b/src/coreclr/vm/loongarch64/asmhelpers.S
@@ -631,6 +631,68 @@ LEAF_ENTRY JIT_GetSharedGCStaticBase_SingleAppDomain, _TEXT
     bl  JIT_GetSharedGCStaticBase_Helper
 LEAF_END JIT_GetSharedGCStaticBase_SingleAppDomain, _TEXT
 
+// Make sure the `FaultingExceptionFrame_StackAlloc` is 16-byte aligned.
+#define FaultingExceptionFrame_StackAlloc (SIZEOF__GSCookie + SIZEOF__FaultingExceptionFrame + 0x8)
+#define FaultingExceptionFrame_FrameOffset SIZEOF__GSCookie
+
+.macro GenerateRedirectedStubWithFrame stub, target
+
+    //
+    // This is the primary function to which execution will be redirected to.
+    //
+    NESTED_ENTRY \stub, _TEXT, NoHandler
+
+        //
+        // IN: ra: original IP before redirect
+        //
+
+        PROLOG_SAVE_REG_PAIR_INDEXED  22, 1, 16
+
+        // alloc stack for FaultingExceptionFrame.
+        addi.d  $sp, $sp, -FaultingExceptionFrame_StackAlloc
+
+        // stack must be 16 bytes aligned
+        CHECK_STACK_ALIGNMENT
+
+        // Save pointer to FEF for GetFrameFromRedirectedStubStackFrame
+        addi.d  $a0, $sp, FaultingExceptionFrame_FrameOffset
+
+        // Prepare to initialize to NULL
+        st.d    $r0, $a0, 0  // Initialize vtbl (it is not strictly necessary)
+        st.d    $r0, $a0, FaultingExceptionFrame__m_fFilterExecuted  // Initialize BOOL for personality routine
+
+        bl   C_FUNC(\target)
+        // Target should not return.
+        EMIT_BREAKPOINT
+
+    NESTED_END \stub, _TEXT
+
+.endm
+
+// ------------------------------------------------------------------
+//
+// Helpers for ThreadAbort exceptions
+//
+        NESTED_ENTRY RedirectForThreadAbort2, _TEXT, NoHandler
+        PROLOG_SAVE_REG_PAIR_INDEXED  22, 1, 16
+
+        // stack must be 16 byte aligned
+        CHECK_STACK_ALIGNMENT
+
+        // On entry:
+        //
+        // a0 = address of FaultingExceptionFrame
+        //
+        // Invoke the helper to setup the FaultingExceptionFrame and raise the exception
+        bl    C_FUNC(ThrowControlForThread)
+
+        // ThrowControlForThread doesn't return.
+        EMIT_BREAKPOINT
+
+        NESTED_END RedirectForThreadAbort2, _TEXT
+
+GenerateRedirectedStubWithFrame RedirectForThreadAbort, RedirectForThreadAbort2
+
 // ------------------------------------------------------------------
 // ResolveWorkerChainLookupAsmStub
 //

--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -952,12 +952,6 @@ PTR_CONTEXT GetCONTEXTFromRedirectedStubStackFrame(T_CONTEXT * pContext)
     return *ppContext;
 }
 
-void RedirectForThreadAbort()
-{
-    // ThreadAbort is not supported in .net core
-    throw "NYI";
-}
-
 #if !defined(DACCESS_COMPILE)
 FaultingExceptionFrame *GetFrameFromRedirectedStubStackFrame (DISPATCHER_CONTEXT *pDispatcherContext)
 {

--- a/src/coreclr/vm/loongarch64/unixstubs.cpp
+++ b/src/coreclr/vm/loongarch64/unixstubs.cpp
@@ -2,11 +2,3 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "common.h"
-
-extern "C"
-{
-    void RedirectForThrowControl()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-};

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -566,8 +566,8 @@ LEAF_END JIT_GetSharedGCStaticBase_SingleAppDomain, _TEXT
         addi  a0, sp, FaultingExceptionFrame_FrameOffset
 
         // Prepare to initialize to NULL
-        sd    zero, a0, 0  // Initialize vtbl (it is not strictly necessary)
-        sd    zero, a0, FaultingExceptionFrame__m_fFilterExecuted  // Initialize BOOL for personality routine
+        sd    zero, 0(a0)  // Initialize vtbl (it is not strictly necessary)
+        sd    zero, FaultingExceptionFrame__m_fFilterExecuted(a0)  // Initialize BOOL for personality routine
 
         call   C_FUNC(\target)
         // Target should not return.

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -539,6 +539,68 @@ LOCAL_LABEL(JIT_GetSharedGCStaticBase_SingleAppDomain_CallHelper):
     call  JIT_GetSharedGCStaticBase_Helper
 LEAF_END JIT_GetSharedGCStaticBase_SingleAppDomain, _TEXT
 
+// Make sure the `FaultingExceptionFrame_StackAlloc` is 16-byte aligned.
+#define FaultingExceptionFrame_StackAlloc (SIZEOF__GSCookie + SIZEOF__FaultingExceptionFrame + 0x8)
+#define FaultingExceptionFrame_FrameOffset SIZEOF__GSCookie
+
+.macro GenerateRedirectedStubWithFrame stub, target
+
+    //
+    // This is the primary function to which execution will be redirected to.
+    //
+    NESTED_ENTRY \stub, _TEXT, NoHandler
+
+        //
+        // IN: ra: original IP before redirect
+        //
+
+        PROLOG_SAVE_REG_PAIR_INDEXED  fp, ra, 16
+
+        // alloc stack for FaultingExceptionFrame.
+        addi  sp, sp, -FaultingExceptionFrame_StackAlloc
+
+        // stack must be 16 bytes aligned
+        CHECK_STACK_ALIGNMENT
+
+        // Save pointer to FEF for GetFrameFromRedirectedStubStackFrame
+        addi  a0, sp, FaultingExceptionFrame_FrameOffset
+
+        // Prepare to initialize to NULL
+        sd    zero, a0, 0  // Initialize vtbl (it is not strictly necessary)
+        sd    zero, a0, FaultingExceptionFrame__m_fFilterExecuted  // Initialize BOOL for personality routine
+
+        call   C_FUNC(\target)
+        // Target should not return.
+        EMIT_BREAKPOINT
+
+    NESTED_END \stub, _TEXT
+
+.endm
+
+// ------------------------------------------------------------------
+//
+// Helpers for ThreadAbort exceptions
+//
+        NESTED_ENTRY RedirectForThreadAbort2, _TEXT, NoHandler
+        PROLOG_SAVE_REG_PAIR_INDEXED  fp, ra, 16
+
+        // stack must be 16 byte aligned
+        CHECK_STACK_ALIGNMENT
+
+        // On entry:
+        //
+        // a0 = address of FaultingExceptionFrame
+        //
+        // Invoke the helper to setup the FaultingExceptionFrame and raise the exception
+        call    C_FUNC(ThrowControlForThread)
+
+        // ThrowControlForThread doesn't return.
+        EMIT_BREAKPOINT
+
+        NESTED_END RedirectForThreadAbort2, _TEXT
+
+GenerateRedirectedStubWithFrame RedirectForThreadAbort, RedirectForThreadAbort2
+
 // ------------------------------------------------------------------
 // ResolveWorkerChainLookupAsmStub
 //

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -577,29 +577,7 @@ LEAF_END JIT_GetSharedGCStaticBase_SingleAppDomain, _TEXT
 
 .endm
 
-// ------------------------------------------------------------------
-//
-// Helpers for ThreadAbort exceptions
-//
-        NESTED_ENTRY RedirectForThreadAbort2, _TEXT, NoHandler
-        PROLOG_SAVE_REG_PAIR_INDEXED  fp, ra, 16
-
-        // stack must be 16 byte aligned
-        CHECK_STACK_ALIGNMENT
-
-        // On entry:
-        //
-        // a0 = address of FaultingExceptionFrame
-        //
-        // Invoke the helper to setup the FaultingExceptionFrame and raise the exception
-        call    C_FUNC(ThrowControlForThread)
-
-        // ThrowControlForThread doesn't return.
-        EMIT_BREAKPOINT
-
-        NESTED_END RedirectForThreadAbort2, _TEXT
-
-GenerateRedirectedStubWithFrame RedirectForThreadAbort, RedirectForThreadAbort2
+GenerateRedirectedStubWithFrame RedirectForThreadAbort, ThrowControlForThread
 
 // ------------------------------------------------------------------
 // ResolveWorkerChainLookupAsmStub

--- a/src/coreclr/vm/riscv64/stubs.cpp
+++ b/src/coreclr/vm/riscv64/stubs.cpp
@@ -849,12 +849,6 @@ PTR_CONTEXT GetCONTEXTFromRedirectedStubStackFrame(T_CONTEXT * pContext)
     return *ppContext;
 }
 
-void RedirectForThreadAbort()
-{
-    // ThreadAbort is not supported in .net core
-    throw "NYI";
-}
-
 #if !defined(DACCESS_COMPILE)
 FaultingExceptionFrame *GetFrameFromRedirectedStubStackFrame (DISPATCHER_CONTEXT *pDispatcherContext)
 {

--- a/src/coreclr/vm/riscv64/unixstubs.cpp
+++ b/src/coreclr/vm/riscv64/unixstubs.cpp
@@ -2,11 +2,3 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "common.h"
-
-extern "C"
-{
-    void RedirectForThrowControl()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-};


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

Fix handling ThreadAbortException at the end of catch for LoongArch64 and RISC-V. 