### PR TITLE
[browser][MT] enable all MT library tests on the runtime CI pipeline

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -24,462 +24,462 @@ parameters:
 
 jobs:
 
-# # Linux arm
-# - ${{ if or(containsValue(parameters.platforms, 'linux_arm'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: arm
-#       targetRid: linux-arm
-#       platform: linux_arm
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_arm
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+# Linux arm
+- ${{ if or(containsValue(parameters.platforms, 'linux_arm'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: arm
+      targetRid: linux-arm
+      platform: linux_arm
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_arm
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Linux armv6
-# - ${{ if containsValue(parameters.platforms, 'linux_armv6') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: armv6
-#       targetRid: linux-armv6
-#       platform: linux_armv6
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_armv6
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+# Linux armv6
+- ${{ if containsValue(parameters.platforms, 'linux_armv6') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: armv6
+      targetRid: linux-armv6
+      platform: linux_armv6
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_armv6
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Linux arm64
+# Linux arm64
 
-# - ${{ if or(containsValue(parameters.platforms, 'linux_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: arm64
-#       targetRid: linux-arm64
-#       platform: linux_arm64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       ${{ if eq(parameters.container, '') }}:
-#         container: linux_arm64
-#       ${{ if ne(parameters.container, '') }}:
-#         container:
-#           image: ${{ parameters.container }}
-#           registry: mcr
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'linux_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: arm64
+      targetRid: linux-arm64
+      platform: linux_arm64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      ${{ if eq(parameters.container, '') }}:
+        container: linux_arm64
+      ${{ if ne(parameters.container, '') }}:
+        container:
+          image: ${{ parameters.container }}
+          registry: mcr
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Linux musl x64
+# Linux musl x64
 
-# - ${{ if or(containsValue(parameters.platforms, 'linux_musl_x64'), eq(parameters.platformGroup, 'all')) }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       osSubgroup: _musl
-#       archType: x64
-#       targetRid: linux-musl-x64
-#       platform: linux_musl_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_musl_x64
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'linux_musl_x64'), eq(parameters.platformGroup, 'all')) }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      osSubgroup: _musl
+      archType: x64
+      targetRid: linux-musl-x64
+      platform: linux_musl_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_musl_x64
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Linux musl arm
+# Linux musl arm
 
-# - ${{ if or(containsValue(parameters.platforms, 'linux_musl_arm'), eq(parameters.platformGroup, 'all')) }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       osSubgroup: _musl
-#       archType: arm
-#       targetRid: linux-musl-arm
-#       platform: linux_musl_arm
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_musl_arm
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'linux_musl_arm'), eq(parameters.platformGroup, 'all')) }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      osSubgroup: _musl
+      archType: arm
+      targetRid: linux-musl-arm
+      platform: linux_musl_arm
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_musl_arm
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Linux musl arm64
+# Linux musl arm64
 
-# - ${{ if or(containsValue(parameters.platforms, 'linux_musl_arm64'), eq(parameters.platformGroup, 'all')) }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       osSubgroup: _musl
-#       archType: arm64
-#       targetRid: linux-musl-arm64
-#       platform: linux_musl_arm64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_musl_arm64
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'linux_musl_arm64'), eq(parameters.platformGroup, 'all')) }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      osSubgroup: _musl
+      archType: arm64
+      targetRid: linux-musl-arm64
+      platform: linux_musl_arm64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_musl_arm64
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Linux Bionic arm64
+# Linux Bionic arm64
 
-# - ${{ if containsValue(parameters.platforms, 'linux_bionic_arm64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       osSubgroup: _bionic
-#       archType: arm64
-#       targetRid: linux-bionic-arm64
-#       platform: linux_bionic_arm64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_bionic
-#       jobParameters:
-#         runtimeFlavor: mono
-#         # We build on Linux, but the test queue runs Windows, so
-#         # we need to override the test script generation
-#         runScriptWindowsCmd: true
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'linux_bionic_arm64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      osSubgroup: _bionic
+      archType: arm64
+      targetRid: linux-bionic-arm64
+      platform: linux_bionic_arm64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_bionic
+      jobParameters:
+        runtimeFlavor: mono
+        # We build on Linux, but the test queue runs Windows, so
+        # we need to override the test script generation
+        runScriptWindowsCmd: true
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Linux Bionic x64
+# Linux Bionic x64
 
-# - ${{ if containsValue(parameters.platforms, 'linux_bionic_x64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       osSubgroup: _bionic
-#       archType: x64
-#       targetRid: linux-bionic-x64
-#       platform: linux_bionic_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_bionic
-#       jobParameters:
-#         runtimeFlavor: mono
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'linux_bionic_x64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      osSubgroup: _bionic
+      archType: x64
+      targetRid: linux-bionic-x64
+      platform: linux_bionic_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_bionic
+      jobParameters:
+        runtimeFlavor: mono
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Linux x64
+# Linux x64
 
-# - ${{ if or(containsValue(parameters.platforms, 'linux_x64'), containsValue(parameters.platforms, 'CoreClrTestBuildHost'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: x64
-#       targetRid: linux-x64
-#       platform: linux_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       ${{ if eq(parameters.container, '') }}:
-#         container: linux_x64
-#       ${{ if ne(parameters.container, '') }}:
-#         container:
-#           image: ${{ parameters.container }}
-#           registry: mcr
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'linux_x64'), containsValue(parameters.platforms, 'CoreClrTestBuildHost'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: x64
+      targetRid: linux-x64
+      platform: linux_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      ${{ if eq(parameters.container, '') }}:
+        container: linux_x64
+      ${{ if ne(parameters.container, '') }}:
+        container:
+          image: ${{ parameters.container }}
+          registry: mcr
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Linux x86
+# Linux x86
 
-# - ${{ if containsValue(parameters.platforms, 'linux_x86') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: x86
-#       targetRid: linux-x86
-#       platform: linux_x86
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_x86
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         disableClrTest: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'linux_x86') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: x86
+      targetRid: linux-x86
+      platform: linux_x86
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_x86
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        disableClrTest: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Runtime-dev-innerloop build
+# Runtime-dev-innerloop build
 
-# - ${{ if containsValue(parameters.platforms, 'linux_x64_dev_innerloop') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: x64
-#       targetRid: linux-x64
-#       platform: linux_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_x64_dev_innerloop
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'linux_x64_dev_innerloop') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: x64
+      targetRid: linux-x64
+      platform: linux_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_x64_dev_innerloop
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Centos 8 Stream x64 Source Build
+# Centos 8 Stream x64 Source Build
 
-# - ${{ if containsValue(parameters.platforms, 'SourceBuild_centos8_x64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: x64
-#       targetRid: centos.8-x64
-#       platform: centos8_linux_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: SourceBuild_centos_x64
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         isSourceBuild: true
-#         isNonPortableSourceBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'SourceBuild_centos8_x64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: x64
+      targetRid: centos.8-x64
+      platform: centos8_linux_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: SourceBuild_centos_x64
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        isSourceBuild: true
+        isNonPortableSourceBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Non-existent RID Source Build
+# Non-existent RID Source Build
 
-# - ${{ if containsValue(parameters.platforms, 'SourceBuild_banana24_x64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: x64
-#       targetRid: banana.24-x64
-#       platform: banana24_linux_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: SourceBuild_centos_x64 # Run the unknown-rid build on a platform with a known RID so our RID graph tooling can automatically add it to the RID graph.
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         baseOS: linux
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         isSourceBuild: true
-#         isNonPortableSourceBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'SourceBuild_banana24_x64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: x64
+      targetRid: banana.24-x64
+      platform: banana24_linux_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: SourceBuild_centos_x64 # Run the unknown-rid build on a platform with a known RID so our RID graph tooling can automatically add it to the RID graph.
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        baseOS: linux
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        isSourceBuild: true
+        isNonPortableSourceBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Portable Linux x64 Source Build
+# Portable Linux x64 Source Build
 
-# - ${{ if containsValue(parameters.platforms, 'SourceBuild_linux_x64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: x64
-#       targetRid: linux-x64
-#       platform: linux_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: SourceBuild_linux_x64
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         isSourceBuild: true
-#         isNonPortableSourceBuild: false
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'SourceBuild_linux_x64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: x64
+      targetRid: linux-x64
+      platform: linux_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: SourceBuild_linux_x64
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        isSourceBuild: true
+        isNonPortableSourceBuild: false
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # GCC Linux x64 Build
+# GCC Linux x64 Build
 
-# - ${{ if containsValue(parameters.platforms, 'gcc_linux_x64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: x64
-#       targetRid: linux-x64
-#       platform: linux_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: debian-12-gcc13-amd64
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'gcc_linux_x64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: x64
+      targetRid: linux-x64
+      platform: linux_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: debian-12-gcc13-amd64
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Mono LLVMAot test build
+# Mono LLVMAot test build
 
-# - ${{ if containsValue(parameters.platforms, 'linux_x64_llvmaot') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: x64
-#       targetRid: linux-x64
-#       platform: linux_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_x64_llvmaot
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'linux_x64_llvmaot') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: x64
+      targetRid: linux-x64
+      platform: linux_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_x64_llvmaot
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Linux s390x
+# Linux s390x
 
-# - ${{ if containsValue(parameters.platforms, 'linux_s390x') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: s390x
-#       targetRid: linux-s390x
-#       platform: linux_s390x
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_s390x
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'linux_s390x') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: s390x
+      targetRid: linux-s390x
+      platform: linux_s390x
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_s390x
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Linux PPC64le
+# Linux PPC64le
 
-# - ${{ if containsValue(parameters.platforms, 'linux_ppc64le') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: ppc64le
-#       targetRid: linux-ppc64le
-#       platform: linux_ppc64le
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_ppc64le
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'linux_ppc64le') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: ppc64le
+      targetRid: linux-ppc64le
+      platform: linux_ppc64le
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_ppc64le
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Linux RISCV64
+# Linux RISCV64
 
-# - ${{ if containsValue(parameters.platforms, 'linux_riscv64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: linux
-#       archType: riscv64
-#       targetRid: linux-riscv64
-#       platform: linux_riscv64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_riscv64
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         disableClrTest: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'linux_riscv64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: riscv64
+      targetRid: linux-riscv64
+      platform: linux_riscv64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_riscv64
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        disableClrTest: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # WASI WebAssembly
+# WASI WebAssembly
 
-# - ${{ if containsValue(parameters.platforms, 'wasi_wasm') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: wasi
-#       archType: wasm
-#       targetRid: wasi-wasm
-#       platform: wasi_wasm
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: wasi_wasm
-#       jobParameters:
-#         hostedOs: linux
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         stagedBuild: ${{ parameters.stagedBuild }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'wasi_wasm') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: wasi
+      archType: wasm
+      targetRid: wasi-wasm
+      platform: wasi_wasm
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: wasi_wasm
+      jobParameters:
+        hostedOs: linux
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        stagedBuild: ${{ parameters.stagedBuild }}
+        buildConfig: ${{ parameters.buildConfig }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # WASI WebAssembly windows
+# WASI WebAssembly windows
 
-# - ${{ if containsValue(parameters.platforms, 'wasi_wasm_win') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: wasi
-#       archType: wasm
-#       targetRid: wasi-wasm
-#       platform: wasi_wasm_win
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         hostedOs: windows
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         stagedBuild: ${{ parameters.stagedBuild }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'wasi_wasm_win') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: wasi
+      archType: wasm
+      targetRid: wasi-wasm
+      platform: wasi_wasm_win
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        hostedOs: windows
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        stagedBuild: ${{ parameters.stagedBuild }}
+        buildConfig: ${{ parameters.buildConfig }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Browser WebAssembly
 
@@ -540,416 +540,416 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # FreeBSD
-# - ${{ if containsValue(parameters.platforms, 'freebsd_x64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: freebsd
-#       archType: x64
-#       targetRid: freebsd-x64
-#       platform: freebsd_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: freebsd_x64
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+# FreeBSD
+- ${{ if containsValue(parameters.platforms, 'freebsd_x64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: freebsd
+      archType: x64
+      targetRid: freebsd-x64
+      platform: freebsd_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: freebsd_x64
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Android x64
+# Android x64
 
-# - ${{ if containsValue(parameters.platforms, 'android_x64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: android
-#       archType: x64
-#       targetRid: android-x64
-#       platform: android_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_bionic
-#       jobParameters:
-#         runtimeFlavor: mono
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'android_x64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: android
+      archType: x64
+      targetRid: android-x64
+      platform: android_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_bionic
+      jobParameters:
+        runtimeFlavor: mono
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Android x64 with Docker-in-Docker
+# Android x64 with Docker-in-Docker
 
-# - ${{ if containsValue(parameters.platforms, 'android_x64_docker') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: android
-#       archType: x64
-#       targetRid: android-x64
-#       platform: android_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: android_docker
-#       jobParameters:
-#         runtimeFlavor: mono
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'android_x64_docker') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: android
+      archType: x64
+      targetRid: android-x64
+      platform: android_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: android_docker
+      jobParameters:
+        runtimeFlavor: mono
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Android x86
+# Android x86
 
-# - ${{ if containsValue(parameters.platforms, 'android_x86') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: android
-#       archType: x86
-#       targetRid: android-x86
-#       platform: android_x86
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_bionic
-#       jobParameters:
-#         runtimeFlavor: mono
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'android_x86') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: android
+      archType: x86
+      targetRid: android-x86
+      platform: android_x86
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_bionic
+      jobParameters:
+        runtimeFlavor: mono
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Android arm
+# Android arm
 
-# - ${{ if containsValue(parameters.platforms, 'android_arm') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: android
-#       archType: arm
-#       targetRid: android-arm
-#       platform: android_arm
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_bionic
-#       jobParameters:
-#         runtimeFlavor: mono
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'android_arm') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: android
+      archType: arm
+      targetRid: android-arm
+      platform: android_arm
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_bionic
+      jobParameters:
+        runtimeFlavor: mono
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Android arm64
+# Android arm64
 
-# - ${{ if containsValue(parameters.platforms, 'android_arm64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: android
-#       archType: arm64
-#       targetRid: android-arm64
-#       platform: android_arm64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: linux_bionic
-#       jobParameters:
-#         runtimeFlavor: mono
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'android_arm64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: android
+      archType: arm64
+      targetRid: android-arm64
+      platform: android_arm64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_bionic
+      jobParameters:
+        runtimeFlavor: mono
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Mac Catalyst x64
+# Mac Catalyst x64
 
-# - ${{ if containsValue(parameters.platforms, 'maccatalyst_x64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: maccatalyst
-#       archType: x64
-#       targetRid: maccatalyst-x64
-#       platform: maccatalyst_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         ${{ if eq(parameters.runtimeFlavor, '') }}:
-#           runtimeFlavor: mono
-#         ${{ else }}:
-#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'maccatalyst_x64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: maccatalyst
+      archType: x64
+      targetRid: maccatalyst-x64
+      platform: maccatalyst_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        ${{ if eq(parameters.runtimeFlavor, '') }}:
+          runtimeFlavor: mono
+        ${{ else }}:
+          runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Mac Catalyst arm64
+# Mac Catalyst arm64
 
-# - ${{ if containsValue(parameters.platforms, 'maccatalyst_arm64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: maccatalyst
-#       archType: arm64
-#       targetRid: maccatalyst-arm64
-#       platform: maccatalyst_arm64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         ${{ if eq(parameters.runtimeFlavor, '') }}:
-#           runtimeFlavor: mono
-#         ${{ else }}:
-#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'maccatalyst_arm64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: maccatalyst
+      archType: arm64
+      targetRid: maccatalyst-arm64
+      platform: maccatalyst_arm64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        ${{ if eq(parameters.runtimeFlavor, '') }}:
+          runtimeFlavor: mono
+        ${{ else }}:
+          runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # tvOS arm64
+# tvOS arm64
 
-# - ${{ if containsValue(parameters.platforms, 'tvos_arm64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: tvos
-#       archType: arm64
-#       targetRid: tvos-arm64
-#       platform: tvos_arm64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         ${{ if eq(parameters.runtimeFlavor, '') }}:
-#           runtimeFlavor: mono
-#         ${{ else }}:
-#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'tvos_arm64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: tvos
+      archType: arm64
+      targetRid: tvos-arm64
+      platform: tvos_arm64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        ${{ if eq(parameters.runtimeFlavor, '') }}:
+          runtimeFlavor: mono
+        ${{ else }}:
+          runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # tvOS Simulator x64
+# tvOS Simulator x64
 
-# - ${{ if containsValue(parameters.platforms, 'tvossimulator_x64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: tvossimulator
-#       archType: x64
-#       targetRid: tvossimulator-x64
-#       platform: tvossimulator_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         ${{ if eq(parameters.runtimeFlavor, '') }}:
-#           runtimeFlavor: mono
-#         ${{ else }}:
-#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'tvossimulator_x64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: tvossimulator
+      archType: x64
+      targetRid: tvossimulator-x64
+      platform: tvossimulator_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        ${{ if eq(parameters.runtimeFlavor, '') }}:
+          runtimeFlavor: mono
+        ${{ else }}:
+          runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # tvOS Simulator arm64
+# tvOS Simulator arm64
 
-# - ${{ if containsValue(parameters.platforms, 'tvossimulator_arm64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: tvossimulator
-#       archType: arm64
-#       targetRid: tvossimulator-arm64
-#       platform: tvossimulator_arm64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         ${{ if eq(parameters.runtimeFlavor, '') }}:
-#           runtimeFlavor: mono
-#         ${{ else }}:
-#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'tvossimulator_arm64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: tvossimulator
+      archType: arm64
+      targetRid: tvossimulator-arm64
+      platform: tvossimulator_arm64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        ${{ if eq(parameters.runtimeFlavor, '') }}:
+          runtimeFlavor: mono
+        ${{ else }}:
+          runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # iOS arm64
+# iOS arm64
 
-# - ${{ if containsValue(parameters.platforms, 'ios_arm64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: ios
-#       archType: arm64
-#       targetRid: ios-arm64
-#       platform: ios_arm64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         ${{ if eq(parameters.runtimeFlavor, '') }}:
-#           runtimeFlavor: mono
-#         ${{ else }}:
-#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'ios_arm64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: ios
+      archType: arm64
+      targetRid: ios-arm64
+      platform: ios_arm64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        ${{ if eq(parameters.runtimeFlavor, '') }}:
+          runtimeFlavor: mono
+        ${{ else }}:
+          runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # iOS Simulator x64
+# iOS Simulator x64
 
-# - ${{ if containsValue(parameters.platforms, 'iossimulator_x64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: iossimulator
-#       archType: x64
-#       targetRid: iossimulator-x64
-#       platform: iossimulator_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         ${{ if eq(parameters.runtimeFlavor, '') }}:
-#           runtimeFlavor: mono
-#         ${{ else }}:
-#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'iossimulator_x64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: iossimulator
+      archType: x64
+      targetRid: iossimulator-x64
+      platform: iossimulator_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        ${{ if eq(parameters.runtimeFlavor, '') }}:
+          runtimeFlavor: mono
+        ${{ else }}:
+          runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # iOS Simulator arm64
+# iOS Simulator arm64
 
-# - ${{ if containsValue(parameters.platforms, 'iossimulator_arm64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: iossimulator
-#       archType: arm64
-#       targetRid: iossimulator-arm64
-#       platform: iossimulator_arm64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         ${{ if eq(parameters.runtimeFlavor, '') }}:
-#           runtimeFlavor: mono
-#         ${{ else }}:
-#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'iossimulator_arm64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: iossimulator
+      archType: arm64
+      targetRid: iossimulator-arm64
+      platform: iossimulator_arm64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        ${{ if eq(parameters.runtimeFlavor, '') }}:
+          runtimeFlavor: mono
+        ${{ else }}:
+          runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # macOS arm64
+# macOS arm64
 
-# - ${{ if containsValue(parameters.platforms, 'osx_arm64') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: osx
-#       archType: arm64
-#       targetRid: osx-arm64
-#       platform: osx_arm64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'osx_arm64') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: osx
+      archType: arm64
+      targetRid: osx-arm64
+      platform: osx_arm64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # macOS x64
+# macOS x64
 
-# - ${{ if or(containsValue(parameters.platforms, 'osx_x64'), eq(parameters.platformGroup, 'all')) }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: osx
-#       archType: x64
-#       targetRid: osx-x64
-#       platform: osx_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'osx_x64'), eq(parameters.platformGroup, 'all')) }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: osx
+      archType: x64
+      targetRid: osx-x64
+      platform: osx_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Tizen armel
+# Tizen armel
 
-# - ${{ if containsValue(parameters.platforms, 'tizen_armel') }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: tizen
-#       archType: armel
-#       targetRid: tizen-armel
-#       platform: tizen_armel
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       container: tizen_armel
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         crossBuild: true
-#         disableClrTest: true
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if containsValue(parameters.platforms, 'tizen_armel') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: tizen
+      archType: armel
+      targetRid: tizen-armel
+      platform: tizen_armel
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: tizen_armel
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        disableClrTest: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Windows x64
+# Windows x64
 
-# - ${{ if or(containsValue(parameters.platforms, 'windows_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: windows
-#       archType: x64
-#       targetRid: win-x64
-#       platform: windows_x64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'windows_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: windows
+      archType: x64
+      targetRid: win-x64
+      platform: windows_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Windows x86
+# Windows x86
 
-# - ${{ if or(containsValue(parameters.platforms, 'windows_x86'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: windows
-#       archType: x86
-#       targetRid: win-x86
-#       platform: windows_x86
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'windows_x86'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: windows
+      archType: x86
+      targetRid: win-x86
+      platform: windows_x86
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
-# # Windows arm64
+# Windows arm64
 
-# - ${{ if or(containsValue(parameters.platforms, 'windows_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-#   - template: xplat-setup.yml
-#     parameters:
-#       jobTemplate: ${{ parameters.jobTemplate }}
-#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-#       variables: ${{ parameters.variables }}
-#       osGroup: windows
-#       archType: arm64
-#       targetRid: win-arm64
-#       platform: windows_arm64
-#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-#       jobParameters:
-#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-#         buildConfig: ${{ parameters.buildConfig }}
-#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
-#         ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'windows_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: windows
+      archType: arm64
+      targetRid: win-arm64
+      platform: windows_arm64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -24,462 +24,462 @@ parameters:
 
 jobs:
 
-# Linux arm
-- ${{ if or(containsValue(parameters.platforms, 'linux_arm'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: arm
-      targetRid: linux-arm
-      platform: linux_arm
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_arm
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# # Linux arm
+# - ${{ if or(containsValue(parameters.platforms, 'linux_arm'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: arm
+#       targetRid: linux-arm
+#       platform: linux_arm
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_arm
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux armv6
-- ${{ if containsValue(parameters.platforms, 'linux_armv6') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: armv6
-      targetRid: linux-armv6
-      platform: linux_armv6
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_armv6
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# # Linux armv6
+# - ${{ if containsValue(parameters.platforms, 'linux_armv6') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: armv6
+#       targetRid: linux-armv6
+#       platform: linux_armv6
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_armv6
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux arm64
+# # Linux arm64
 
-- ${{ if or(containsValue(parameters.platforms, 'linux_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: arm64
-      targetRid: linux-arm64
-      platform: linux_arm64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      ${{ if eq(parameters.container, '') }}:
-        container: linux_arm64
-      ${{ if ne(parameters.container, '') }}:
-        container:
-          image: ${{ parameters.container }}
-          registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if or(containsValue(parameters.platforms, 'linux_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: arm64
+#       targetRid: linux-arm64
+#       platform: linux_arm64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       ${{ if eq(parameters.container, '') }}:
+#         container: linux_arm64
+#       ${{ if ne(parameters.container, '') }}:
+#         container:
+#           image: ${{ parameters.container }}
+#           registry: mcr
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux musl x64
+# # Linux musl x64
 
-- ${{ if or(containsValue(parameters.platforms, 'linux_musl_x64'), eq(parameters.platformGroup, 'all')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      osSubgroup: _musl
-      archType: x64
-      targetRid: linux-musl-x64
-      platform: linux_musl_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_musl_x64
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if or(containsValue(parameters.platforms, 'linux_musl_x64'), eq(parameters.platformGroup, 'all')) }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       osSubgroup: _musl
+#       archType: x64
+#       targetRid: linux-musl-x64
+#       platform: linux_musl_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_musl_x64
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux musl arm
+# # Linux musl arm
 
-- ${{ if or(containsValue(parameters.platforms, 'linux_musl_arm'), eq(parameters.platformGroup, 'all')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      osSubgroup: _musl
-      archType: arm
-      targetRid: linux-musl-arm
-      platform: linux_musl_arm
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_musl_arm
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if or(containsValue(parameters.platforms, 'linux_musl_arm'), eq(parameters.platformGroup, 'all')) }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       osSubgroup: _musl
+#       archType: arm
+#       targetRid: linux-musl-arm
+#       platform: linux_musl_arm
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_musl_arm
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux musl arm64
+# # Linux musl arm64
 
-- ${{ if or(containsValue(parameters.platforms, 'linux_musl_arm64'), eq(parameters.platformGroup, 'all')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      osSubgroup: _musl
-      archType: arm64
-      targetRid: linux-musl-arm64
-      platform: linux_musl_arm64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_musl_arm64
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if or(containsValue(parameters.platforms, 'linux_musl_arm64'), eq(parameters.platformGroup, 'all')) }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       osSubgroup: _musl
+#       archType: arm64
+#       targetRid: linux-musl-arm64
+#       platform: linux_musl_arm64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_musl_arm64
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux Bionic arm64
+# # Linux Bionic arm64
 
-- ${{ if containsValue(parameters.platforms, 'linux_bionic_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      osSubgroup: _bionic
-      archType: arm64
-      targetRid: linux-bionic-arm64
-      platform: linux_bionic_arm64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_bionic
-      jobParameters:
-        runtimeFlavor: mono
-        # We build on Linux, but the test queue runs Windows, so
-        # we need to override the test script generation
-        runScriptWindowsCmd: true
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'linux_bionic_arm64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       osSubgroup: _bionic
+#       archType: arm64
+#       targetRid: linux-bionic-arm64
+#       platform: linux_bionic_arm64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_bionic
+#       jobParameters:
+#         runtimeFlavor: mono
+#         # We build on Linux, but the test queue runs Windows, so
+#         # we need to override the test script generation
+#         runScriptWindowsCmd: true
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux Bionic x64
+# # Linux Bionic x64
 
-- ${{ if containsValue(parameters.platforms, 'linux_bionic_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      osSubgroup: _bionic
-      archType: x64
-      targetRid: linux-bionic-x64
-      platform: linux_bionic_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_bionic
-      jobParameters:
-        runtimeFlavor: mono
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'linux_bionic_x64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       osSubgroup: _bionic
+#       archType: x64
+#       targetRid: linux-bionic-x64
+#       platform: linux_bionic_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_bionic
+#       jobParameters:
+#         runtimeFlavor: mono
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux x64
+# # Linux x64
 
-- ${{ if or(containsValue(parameters.platforms, 'linux_x64'), containsValue(parameters.platforms, 'CoreClrTestBuildHost'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: x64
-      targetRid: linux-x64
-      platform: linux_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      ${{ if eq(parameters.container, '') }}:
-        container: linux_x64
-      ${{ if ne(parameters.container, '') }}:
-        container:
-          image: ${{ parameters.container }}
-          registry: mcr
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if or(containsValue(parameters.platforms, 'linux_x64'), containsValue(parameters.platforms, 'CoreClrTestBuildHost'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: x64
+#       targetRid: linux-x64
+#       platform: linux_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       ${{ if eq(parameters.container, '') }}:
+#         container: linux_x64
+#       ${{ if ne(parameters.container, '') }}:
+#         container:
+#           image: ${{ parameters.container }}
+#           registry: mcr
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux x86
+# # Linux x86
 
-- ${{ if containsValue(parameters.platforms, 'linux_x86') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: x86
-      targetRid: linux-x86
-      platform: linux_x86
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_x86
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        disableClrTest: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'linux_x86') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: x86
+#       targetRid: linux-x86
+#       platform: linux_x86
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_x86
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         disableClrTest: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Runtime-dev-innerloop build
+# # Runtime-dev-innerloop build
 
-- ${{ if containsValue(parameters.platforms, 'linux_x64_dev_innerloop') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: x64
-      targetRid: linux-x64
-      platform: linux_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_x64_dev_innerloop
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'linux_x64_dev_innerloop') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: x64
+#       targetRid: linux-x64
+#       platform: linux_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_x64_dev_innerloop
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Centos 8 Stream x64 Source Build
+# # Centos 8 Stream x64 Source Build
 
-- ${{ if containsValue(parameters.platforms, 'SourceBuild_centos8_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: x64
-      targetRid: centos.8-x64
-      platform: centos8_linux_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: SourceBuild_centos_x64
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        isSourceBuild: true
-        isNonPortableSourceBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'SourceBuild_centos8_x64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: x64
+#       targetRid: centos.8-x64
+#       platform: centos8_linux_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: SourceBuild_centos_x64
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         isSourceBuild: true
+#         isNonPortableSourceBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Non-existent RID Source Build
+# # Non-existent RID Source Build
 
-- ${{ if containsValue(parameters.platforms, 'SourceBuild_banana24_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: x64
-      targetRid: banana.24-x64
-      platform: banana24_linux_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: SourceBuild_centos_x64 # Run the unknown-rid build on a platform with a known RID so our RID graph tooling can automatically add it to the RID graph.
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        baseOS: linux
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        isSourceBuild: true
-        isNonPortableSourceBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'SourceBuild_banana24_x64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: x64
+#       targetRid: banana.24-x64
+#       platform: banana24_linux_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: SourceBuild_centos_x64 # Run the unknown-rid build on a platform with a known RID so our RID graph tooling can automatically add it to the RID graph.
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         baseOS: linux
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         isSourceBuild: true
+#         isNonPortableSourceBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Portable Linux x64 Source Build
+# # Portable Linux x64 Source Build
 
-- ${{ if containsValue(parameters.platforms, 'SourceBuild_linux_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: x64
-      targetRid: linux-x64
-      platform: linux_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: SourceBuild_linux_x64
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        isSourceBuild: true
-        isNonPortableSourceBuild: false
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'SourceBuild_linux_x64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: x64
+#       targetRid: linux-x64
+#       platform: linux_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: SourceBuild_linux_x64
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         isSourceBuild: true
+#         isNonPortableSourceBuild: false
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# GCC Linux x64 Build
+# # GCC Linux x64 Build
 
-- ${{ if containsValue(parameters.platforms, 'gcc_linux_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: x64
-      targetRid: linux-x64
-      platform: linux_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: debian-12-gcc13-amd64
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'gcc_linux_x64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: x64
+#       targetRid: linux-x64
+#       platform: linux_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: debian-12-gcc13-amd64
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Mono LLVMAot test build
+# # Mono LLVMAot test build
 
-- ${{ if containsValue(parameters.platforms, 'linux_x64_llvmaot') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: x64
-      targetRid: linux-x64
-      platform: linux_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_x64_llvmaot
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'linux_x64_llvmaot') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: x64
+#       targetRid: linux-x64
+#       platform: linux_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_x64_llvmaot
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux s390x
+# # Linux s390x
 
-- ${{ if containsValue(parameters.platforms, 'linux_s390x') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: s390x
-      targetRid: linux-s390x
-      platform: linux_s390x
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_s390x
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'linux_s390x') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: s390x
+#       targetRid: linux-s390x
+#       platform: linux_s390x
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_s390x
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux PPC64le
+# # Linux PPC64le
 
-- ${{ if containsValue(parameters.platforms, 'linux_ppc64le') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: ppc64le
-      targetRid: linux-ppc64le
-      platform: linux_ppc64le
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_ppc64le
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'linux_ppc64le') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: ppc64le
+#       targetRid: linux-ppc64le
+#       platform: linux_ppc64le
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_ppc64le
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux RISCV64
+# # Linux RISCV64
 
-- ${{ if containsValue(parameters.platforms, 'linux_riscv64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: riscv64
-      targetRid: linux-riscv64
-      platform: linux_riscv64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_riscv64
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        disableClrTest: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'linux_riscv64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: linux
+#       archType: riscv64
+#       targetRid: linux-riscv64
+#       platform: linux_riscv64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_riscv64
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         disableClrTest: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# WASI WebAssembly
+# # WASI WebAssembly
 
-- ${{ if containsValue(parameters.platforms, 'wasi_wasm') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: wasi
-      archType: wasm
-      targetRid: wasi-wasm
-      platform: wasi_wasm
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: wasi_wasm
-      jobParameters:
-        hostedOs: linux
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'wasi_wasm') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: wasi
+#       archType: wasm
+#       targetRid: wasi-wasm
+#       platform: wasi_wasm
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: wasi_wasm
+#       jobParameters:
+#         hostedOs: linux
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         stagedBuild: ${{ parameters.stagedBuild }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# WASI WebAssembly windows
+# # WASI WebAssembly windows
 
-- ${{ if containsValue(parameters.platforms, 'wasi_wasm_win') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: wasi
-      archType: wasm
-      targetRid: wasi-wasm
-      platform: wasi_wasm_win
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        hostedOs: windows
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
-        buildConfig: ${{ parameters.buildConfig }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'wasi_wasm_win') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: wasi
+#       archType: wasm
+#       targetRid: wasi-wasm
+#       platform: wasi_wasm_win
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         hostedOs: windows
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         stagedBuild: ${{ parameters.stagedBuild }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Browser WebAssembly
 
@@ -540,416 +540,416 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# FreeBSD
-- ${{ if containsValue(parameters.platforms, 'freebsd_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: freebsd
-      archType: x64
-      targetRid: freebsd-x64
-      platform: freebsd_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: freebsd_x64
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# # FreeBSD
+# - ${{ if containsValue(parameters.platforms, 'freebsd_x64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: freebsd
+#       archType: x64
+#       targetRid: freebsd-x64
+#       platform: freebsd_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: freebsd_x64
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android x64
+# # Android x64
 
-- ${{ if containsValue(parameters.platforms, 'android_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: android
-      archType: x64
-      targetRid: android-x64
-      platform: android_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_bionic
-      jobParameters:
-        runtimeFlavor: mono
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'android_x64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: android
+#       archType: x64
+#       targetRid: android-x64
+#       platform: android_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_bionic
+#       jobParameters:
+#         runtimeFlavor: mono
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android x64 with Docker-in-Docker
+# # Android x64 with Docker-in-Docker
 
-- ${{ if containsValue(parameters.platforms, 'android_x64_docker') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: android
-      archType: x64
-      targetRid: android-x64
-      platform: android_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: android_docker
-      jobParameters:
-        runtimeFlavor: mono
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'android_x64_docker') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: android
+#       archType: x64
+#       targetRid: android-x64
+#       platform: android_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: android_docker
+#       jobParameters:
+#         runtimeFlavor: mono
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android x86
+# # Android x86
 
-- ${{ if containsValue(parameters.platforms, 'android_x86') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: android
-      archType: x86
-      targetRid: android-x86
-      platform: android_x86
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_bionic
-      jobParameters:
-        runtimeFlavor: mono
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'android_x86') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: android
+#       archType: x86
+#       targetRid: android-x86
+#       platform: android_x86
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_bionic
+#       jobParameters:
+#         runtimeFlavor: mono
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android arm
+# # Android arm
 
-- ${{ if containsValue(parameters.platforms, 'android_arm') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: android
-      archType: arm
-      targetRid: android-arm
-      platform: android_arm
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_bionic
-      jobParameters:
-        runtimeFlavor: mono
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'android_arm') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: android
+#       archType: arm
+#       targetRid: android-arm
+#       platform: android_arm
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_bionic
+#       jobParameters:
+#         runtimeFlavor: mono
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android arm64
+# # Android arm64
 
-- ${{ if containsValue(parameters.platforms, 'android_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: android
-      archType: arm64
-      targetRid: android-arm64
-      platform: android_arm64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_bionic
-      jobParameters:
-        runtimeFlavor: mono
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'android_arm64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: android
+#       archType: arm64
+#       targetRid: android-arm64
+#       platform: android_arm64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: linux_bionic
+#       jobParameters:
+#         runtimeFlavor: mono
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Mac Catalyst x64
+# # Mac Catalyst x64
 
-- ${{ if containsValue(parameters.platforms, 'maccatalyst_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: maccatalyst
-      archType: x64
-      targetRid: maccatalyst-x64
-      platform: maccatalyst_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        ${{ if eq(parameters.runtimeFlavor, '') }}:
-          runtimeFlavor: mono
-        ${{ else }}:
-          runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'maccatalyst_x64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: maccatalyst
+#       archType: x64
+#       targetRid: maccatalyst-x64
+#       platform: maccatalyst_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         ${{ if eq(parameters.runtimeFlavor, '') }}:
+#           runtimeFlavor: mono
+#         ${{ else }}:
+#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Mac Catalyst arm64
+# # Mac Catalyst arm64
 
-- ${{ if containsValue(parameters.platforms, 'maccatalyst_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: maccatalyst
-      archType: arm64
-      targetRid: maccatalyst-arm64
-      platform: maccatalyst_arm64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        ${{ if eq(parameters.runtimeFlavor, '') }}:
-          runtimeFlavor: mono
-        ${{ else }}:
-          runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'maccatalyst_arm64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: maccatalyst
+#       archType: arm64
+#       targetRid: maccatalyst-arm64
+#       platform: maccatalyst_arm64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         ${{ if eq(parameters.runtimeFlavor, '') }}:
+#           runtimeFlavor: mono
+#         ${{ else }}:
+#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# tvOS arm64
+# # tvOS arm64
 
-- ${{ if containsValue(parameters.platforms, 'tvos_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: tvos
-      archType: arm64
-      targetRid: tvos-arm64
-      platform: tvos_arm64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        ${{ if eq(parameters.runtimeFlavor, '') }}:
-          runtimeFlavor: mono
-        ${{ else }}:
-          runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'tvos_arm64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: tvos
+#       archType: arm64
+#       targetRid: tvos-arm64
+#       platform: tvos_arm64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         ${{ if eq(parameters.runtimeFlavor, '') }}:
+#           runtimeFlavor: mono
+#         ${{ else }}:
+#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# tvOS Simulator x64
+# # tvOS Simulator x64
 
-- ${{ if containsValue(parameters.platforms, 'tvossimulator_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: tvossimulator
-      archType: x64
-      targetRid: tvossimulator-x64
-      platform: tvossimulator_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        ${{ if eq(parameters.runtimeFlavor, '') }}:
-          runtimeFlavor: mono
-        ${{ else }}:
-          runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'tvossimulator_x64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: tvossimulator
+#       archType: x64
+#       targetRid: tvossimulator-x64
+#       platform: tvossimulator_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         ${{ if eq(parameters.runtimeFlavor, '') }}:
+#           runtimeFlavor: mono
+#         ${{ else }}:
+#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# tvOS Simulator arm64
+# # tvOS Simulator arm64
 
-- ${{ if containsValue(parameters.platforms, 'tvossimulator_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: tvossimulator
-      archType: arm64
-      targetRid: tvossimulator-arm64
-      platform: tvossimulator_arm64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        ${{ if eq(parameters.runtimeFlavor, '') }}:
-          runtimeFlavor: mono
-        ${{ else }}:
-          runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'tvossimulator_arm64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: tvossimulator
+#       archType: arm64
+#       targetRid: tvossimulator-arm64
+#       platform: tvossimulator_arm64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         ${{ if eq(parameters.runtimeFlavor, '') }}:
+#           runtimeFlavor: mono
+#         ${{ else }}:
+#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS arm64
+# # iOS arm64
 
-- ${{ if containsValue(parameters.platforms, 'ios_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: ios
-      archType: arm64
-      targetRid: ios-arm64
-      platform: ios_arm64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        ${{ if eq(parameters.runtimeFlavor, '') }}:
-          runtimeFlavor: mono
-        ${{ else }}:
-          runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'ios_arm64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: ios
+#       archType: arm64
+#       targetRid: ios-arm64
+#       platform: ios_arm64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         ${{ if eq(parameters.runtimeFlavor, '') }}:
+#           runtimeFlavor: mono
+#         ${{ else }}:
+#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS Simulator x64
+# # iOS Simulator x64
 
-- ${{ if containsValue(parameters.platforms, 'iossimulator_x64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: iossimulator
-      archType: x64
-      targetRid: iossimulator-x64
-      platform: iossimulator_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        ${{ if eq(parameters.runtimeFlavor, '') }}:
-          runtimeFlavor: mono
-        ${{ else }}:
-          runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'iossimulator_x64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: iossimulator
+#       archType: x64
+#       targetRid: iossimulator-x64
+#       platform: iossimulator_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         ${{ if eq(parameters.runtimeFlavor, '') }}:
+#           runtimeFlavor: mono
+#         ${{ else }}:
+#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS Simulator arm64
+# # iOS Simulator arm64
 
-- ${{ if containsValue(parameters.platforms, 'iossimulator_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: iossimulator
-      archType: arm64
-      targetRid: iossimulator-arm64
-      platform: iossimulator_arm64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        ${{ if eq(parameters.runtimeFlavor, '') }}:
-          runtimeFlavor: mono
-        ${{ else }}:
-          runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'iossimulator_arm64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: iossimulator
+#       archType: arm64
+#       targetRid: iossimulator-arm64
+#       platform: iossimulator_arm64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         ${{ if eq(parameters.runtimeFlavor, '') }}:
+#           runtimeFlavor: mono
+#         ${{ else }}:
+#           runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# macOS arm64
+# # macOS arm64
 
-- ${{ if containsValue(parameters.platforms, 'osx_arm64') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: osx
-      archType: arm64
-      targetRid: osx-arm64
-      platform: osx_arm64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'osx_arm64') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: osx
+#       archType: arm64
+#       targetRid: osx-arm64
+#       platform: osx_arm64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# macOS x64
+# # macOS x64
 
-- ${{ if or(containsValue(parameters.platforms, 'osx_x64'), eq(parameters.platformGroup, 'all')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: osx
-      archType: x64
-      targetRid: osx-x64
-      platform: osx_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if or(containsValue(parameters.platforms, 'osx_x64'), eq(parameters.platformGroup, 'all')) }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: osx
+#       archType: x64
+#       targetRid: osx-x64
+#       platform: osx_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Tizen armel
+# # Tizen armel
 
-- ${{ if containsValue(parameters.platforms, 'tizen_armel') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: tizen
-      archType: armel
-      targetRid: tizen-armel
-      platform: tizen_armel
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: tizen_armel
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        disableClrTest: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if containsValue(parameters.platforms, 'tizen_armel') }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: tizen
+#       archType: armel
+#       targetRid: tizen-armel
+#       platform: tizen_armel
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       container: tizen_armel
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         crossBuild: true
+#         disableClrTest: true
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows x64
+# # Windows x64
 
-- ${{ if or(containsValue(parameters.platforms, 'windows_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: windows
-      archType: x64
-      targetRid: win-x64
-      platform: windows_x64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if or(containsValue(parameters.platforms, 'windows_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: windows
+#       archType: x64
+#       targetRid: win-x64
+#       platform: windows_x64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows x86
+# # Windows x86
 
-- ${{ if or(containsValue(parameters.platforms, 'windows_x86'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: windows
-      archType: x86
-      targetRid: win-x86
-      platform: windows_x86
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if or(containsValue(parameters.platforms, 'windows_x86'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: windows
+#       archType: x86
+#       targetRid: win-x86
+#       platform: windows_x86
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows arm64
+# # Windows arm64
 
-- ${{ if or(containsValue(parameters.platforms, 'windows_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: windows
-      archType: arm64
-      targetRid: win-arm64
-      platform: windows_arm64
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        ${{ insert }}: ${{ parameters.jobParameters }}
+# - ${{ if or(containsValue(parameters.platforms, 'windows_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+#   - template: xplat-setup.yml
+#     parameters:
+#       jobTemplate: ${{ parameters.jobTemplate }}
+#       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+#       variables: ${{ parameters.variables }}
+#       osGroup: windows
+#       archType: arm64
+#       targetRid: win-arm64
+#       platform: windows_arm64
+#       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+#       jobParameters:
+#         runtimeFlavor: ${{ parameters.runtimeFlavor }}
+#         buildConfig: ${{ parameters.buildConfig }}
+#         helixQueueGroup: ${{ parameters.helixQueueGroup }}
+#         ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -117,6 +117,9 @@ jobs:
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       # Always run for runtime-wasm because tests are not run in runtime
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+
+       # NOTE - Since threading is experimental, we don't want to block mainline work
+      shouldContinueOnError: true
       scenarios:
         - WasmTestOnBrowser
         #- WasmTestOnNodeJS - this is not supported yet, https://github.com/dotnet/runtime/issues/85592

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -105,15 +105,14 @@ jobs:
         - WasmTestOnBrowser
         - WasmTestOnNodeJS
 
-  # Smoke tests only with full threading
+  # Library tests - full threading
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
     parameters:
       platforms:
         - browser_wasm
         #- browser_wasm_win
-      nameSuffix: _Threading_Smoke
+      nameSuffix: _Threading
       extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:WasmEnableThreads=true /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-      shouldRunSmokeOnly: true
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       # Always run for runtime-wasm because browser testing is not on runtime

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -105,21 +105,6 @@ jobs:
         - WasmTestOnBrowser
         - WasmTestOnNodeJS
 
-  # Library tests - full threading
-  - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-    parameters:
-      platforms:
-        - browser_wasm
-        #- browser_wasm_win
-      nameSuffix: _Threading
-      extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:WasmEnableThreads=true /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
-      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
-      # Always run for runtime-wasm because browser testing is not on runtime
-      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
-      scenarios:
-        - WasmTestOnBrowser
-
   # Library tests with full threading
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
     parameters:
@@ -132,9 +117,6 @@ jobs:
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       # Always run for runtime-wasm because tests are not run in runtime
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
-
-      # NOTE - Since threading is experimental, we don't want to block mainline work
-      shouldContinueOnError: true
       scenarios:
         - WasmTestOnBrowser
         #- WasmTestOnNodeJS - this is not supported yet, https://github.com/dotnet/runtime/issues/85592

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -61,300 +61,300 @@ extends:
       - ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
         - template: /eng/pipelines/common/evaluate-default-paths.yml
 
-      # #
-      # # Build CoreCLR checked
-      # # Only when CoreCLR is changed
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-      #     buildConfig: checked
-      #     platforms:
-      #     - linux_x86
-      #     - linux_x64
-      #     - linux_arm
-      #     - linux_arm64
-      #     - linux_riscv64
-      #     - linux_musl_arm
-      #     - linux_musl_arm64
-      #     - linux_musl_x64
-      #     - osx_arm64
-      #     - tizen_armel
-      #     - windows_x86
-      #     - windows_x64
-      #     - windows_arm64
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      #
+      # Build CoreCLR checked
+      # Only when CoreCLR is changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+          buildConfig: checked
+          platforms:
+          - linux_x86
+          - linux_x64
+          - linux_arm
+          - linux_arm64
+          - linux_riscv64
+          - linux_musl_arm
+          - linux_musl_arm64
+          - linux_musl_x64
+          - osx_arm64
+          - tizen_armel
+          - windows_x86
+          - windows_x64
+          - windows_arm64
+          jobParameters:
+            testGroup: innerloop
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # #
-      # # Build the whole product using GNU compiler toolchain
-      # # When CoreCLR, Mono, Libraries, Installer and src/tests are changed
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     buildConfig: checked
-      #     platforms:
-      #     - gcc_linux_x64
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       nameSuffix: Native_GCC
-      #       buildArgs: -s clr.native+libs.native+mono+host.native -c $(_BuildConfig) -gcc
-      #       extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests.yml
-      #       extraStepsParameters:
-      #         testBuildArgs: skipmanaged skipgeneratelayout skiprestorepackages -gcc
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      #
+      # Build the whole product using GNU compiler toolchain
+      # When CoreCLR, Mono, Libraries, Installer and src/tests are changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: checked
+          platforms:
+          - gcc_linux_x64
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: Native_GCC
+            buildArgs: -s clr.native+libs.native+mono+host.native -c $(_BuildConfig) -gcc
+            extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests.yml
+            extraStepsParameters:
+              testBuildArgs: skipmanaged skipgeneratelayout skiprestorepackages -gcc
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # #
-      # # Build CoreCLR osx_x64 checked
-      # # Only when CoreCLR or Libraries is changed
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-      #     buildConfig: checked
-      #     platforms:
-      #     - osx_x64
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      #
+      # Build CoreCLR osx_x64 checked
+      # Only when CoreCLR or Libraries is changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+          buildConfig: checked
+          platforms:
+          - osx_x64
+          jobParameters:
+            testGroup: innerloop
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # #
-      # # Build CoreCLR release
-      # # Always as they are needed by Installer and we always build and test the Installer.
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-      #     buildConfig: release
-      #     platforms:
-      #     - osx_arm64
-      #     - osx_x64
-      #     - linux_x64
-      #     - linux_arm
-      #     - linux_arm64
-      #     - linux_musl_x64
-      #     - linux_musl_arm
-      #     - linux_musl_arm64
-      #     - windows_x64
-      #     - windows_x86
-      #     - windows_arm64
-      #     - freebsd_x64
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       # Mono/runtimetests also need this, but skip for wasm
-      #       condition:
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      #
+      # Build CoreCLR release
+      # Always as they are needed by Installer and we always build and test the Installer.
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+          buildConfig: release
+          platforms:
+          - osx_arm64
+          - osx_x64
+          - linux_x64
+          - linux_arm
+          - linux_arm64
+          - linux_musl_x64
+          - linux_musl_arm
+          - linux_musl_arm64
+          - windows_x64
+          - windows_x86
+          - windows_arm64
+          - freebsd_x64
+          jobParameters:
+            testGroup: innerloop
+            # Mono/runtimetests also need this, but skip for wasm
+            condition:
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # #
-      # # Build CoreCLR Formatting Job
-      # # Only when CoreCLR is changed, and only in the 'main' branch (no release branches;
-      # # both Rolling and PR builds).
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
-      #     platforms:
-      #     - linux_x64
-      #     - windows_x64
-      #     jobParameters:
-      #       condition: >-
-      #         and(
-      #           or(
-      #             eq(variables['Build.SourceBranchName'], 'main'),
-      #             eq(variables['System.PullRequest.TargetBranch'], 'main')),
-      #           or(
-      #             eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_jit.containsChange'], true),
-      #             eq(variables['isRollingBuild'], true)))
+      #
+      # Build CoreCLR Formatting Job
+      # Only when CoreCLR is changed, and only in the 'main' branch (no release branches;
+      # both Rolling and PR builds).
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
+          platforms:
+          - linux_x64
+          - windows_x64
+          jobParameters:
+            condition: >-
+              and(
+                or(
+                  eq(variables['Build.SourceBranchName'], 'main'),
+                  eq(variables['System.PullRequest.TargetBranch'], 'main')),
+                or(
+                  eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_jit.containsChange'], true),
+                  eq(variables['isRollingBuild'], true)))
 
-      # #
-      # # CoreCLR NativeAOT debug build and smoke tests
-      # # Only when CoreCLR is changed
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      #     buildConfig: Debug
-      #     platforms:
-      #     - linux_x64
-      #     - windows_x64
-      #     variables:
-      #     - name: timeoutPerTestInMinutes
-      #       value: 60
-      #     - name: timeoutPerTestCollectionInMinutes
-      #       value: 180
-      #     jobParameters:
-      #       timeoutInMinutes: 120
-      #       nameSuffix: NativeAOT
-      #       buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
-      #       extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
-      #       extraStepsParameters:
-      #         creator: dotnet-bot
-      #         testBuildArgs: nativeaot tree nativeaot
-      #         liveLibrariesBuildConfig: Release
-      #       testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-      #       extraVariablesTemplates:
-      #         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-      #           parameters:
-      #             testGroup: innerloop
-      #             liveLibrariesBuildConfig: Release
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-      #           eq(variables['isFullMatrix'], true))
+      #
+      # CoreCLR NativeAOT debug build and smoke tests
+      # Only when CoreCLR is changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          buildConfig: Debug
+          platforms:
+          - linux_x64
+          - windows_x64
+          variables:
+          - name: timeoutPerTestInMinutes
+            value: 60
+          - name: timeoutPerTestCollectionInMinutes
+            value: 180
+          jobParameters:
+            timeoutInMinutes: 120
+            nameSuffix: NativeAOT
+            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
+            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+            extraStepsParameters:
+              creator: dotnet-bot
+              testBuildArgs: nativeaot tree nativeaot
+              liveLibrariesBuildConfig: Release
+            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+            extraVariablesTemplates:
+              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+                parameters:
+                  testGroup: innerloop
+                  liveLibrariesBuildConfig: Release
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isFullMatrix'], true))
 
-      # #
-      # # CoreCLR NativeAOT checked build and smoke tests
-      # # Only when CoreCLR is changed
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      #     buildConfig: Checked
-      #     platforms:
-      #     - windows_x64
-      #     variables:
-      #     - name: timeoutPerTestInMinutes
-      #       value: 60
-      #     - name: timeoutPerTestCollectionInMinutes
-      #       value: 180
-      #     jobParameters:
-      #       timeoutInMinutes: 180
-      #       nameSuffix: NativeAOT
-      #       buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
-      #       extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
-      #       extraStepsParameters:
-      #         creator: dotnet-bot
-      #         testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing;" /p:BuildNativeAotFrameworkObjects=true'
-      #         liveLibrariesBuildConfig: Release
-      #       testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-      #       extraVariablesTemplates:
-      #         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-      #           parameters:
-      #             testGroup: innerloop
-      #             liveLibrariesBuildConfig: Release
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-      #           eq(variables['isFullMatrix'], true))
+      #
+      # CoreCLR NativeAOT checked build and smoke tests
+      # Only when CoreCLR is changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          buildConfig: Checked
+          platforms:
+          - windows_x64
+          variables:
+          - name: timeoutPerTestInMinutes
+            value: 60
+          - name: timeoutPerTestCollectionInMinutes
+            value: 180
+          jobParameters:
+            timeoutInMinutes: 180
+            nameSuffix: NativeAOT
+            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
+            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+            extraStepsParameters:
+              creator: dotnet-bot
+              testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing;" /p:BuildNativeAotFrameworkObjects=true'
+              liveLibrariesBuildConfig: Release
+            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+            extraVariablesTemplates:
+              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+                parameters:
+                  testGroup: innerloop
+                  liveLibrariesBuildConfig: Release
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isFullMatrix'], true))
 
-      # #
-      # # CoreCLR NativeAOT release build and smoke tests
-      # # Only when CoreCLR is changed
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      #     buildConfig: Release
-      #     platforms:
-      #     - linux_x64
-      #     - windows_x64
-      #     - osx_x64
-      #     - linux_arm64
-      #     - windows_arm64
-      #     - osx_arm64
-      #     variables:
-      #     - name: timeoutPerTestInMinutes
-      #       value: 60
-      #     - name: timeoutPerTestCollectionInMinutes
-      #       value: 180
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       timeoutInMinutes: 120
-      #       nameSuffix: NativeAOT
-      #       buildArgs: -s clr.aot+host.native+libs+tools.illink -c $(_BuildConfig) -rc $(_BuildConfig) -lc Release -hc Release
-      #       extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
-      #       extraStepsParameters:
-      #         creator: dotnet-bot
-      #         testBuildArgs: 'nativeaot tree ";nativeaot;tracing/eventpipe/providervalidation;"'
-      #         liveLibrariesBuildConfig: Release
-      #       testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-      #       extraVariablesTemplates:
-      #         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-      #           parameters:
-      #             testGroup: innerloop
-      #             liveLibrariesBuildConfig: Release
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-      #           eq(variables['isFullMatrix'], true))
+      #
+      # CoreCLR NativeAOT release build and smoke tests
+      # Only when CoreCLR is changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          buildConfig: Release
+          platforms:
+          - linux_x64
+          - windows_x64
+          - osx_x64
+          - linux_arm64
+          - windows_arm64
+          - osx_arm64
+          variables:
+          - name: timeoutPerTestInMinutes
+            value: 60
+          - name: timeoutPerTestCollectionInMinutes
+            value: 180
+          jobParameters:
+            testGroup: innerloop
+            timeoutInMinutes: 120
+            nameSuffix: NativeAOT
+            buildArgs: -s clr.aot+host.native+libs+tools.illink -c $(_BuildConfig) -rc $(_BuildConfig) -lc Release -hc Release
+            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+            extraStepsParameters:
+              creator: dotnet-bot
+              testBuildArgs: 'nativeaot tree ";nativeaot;tracing/eventpipe/providervalidation;"'
+              liveLibrariesBuildConfig: Release
+            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+            extraVariablesTemplates:
+              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+                parameters:
+                  testGroup: innerloop
+                  liveLibrariesBuildConfig: Release
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isFullMatrix'], true))
 
-      # #
-      # # CoreCLR NativeAOT release build and libraries tests
-      # # Only when CoreCLR or library is changed
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-      #     buildConfig: Release
-      #     platforms:
-      #     - windows_arm64
-      #     - linux_arm64
-      #     - osx_arm64
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       isSingleFile: true
-      #       nameSuffix: NativeAOT_Libraries
-      #       buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true /p:ArchiveTests=true
-      #       timeoutInMinutes: 240 # Doesn't actually take long, but we've seen the ARM64 Helix queue often get backlogged for 2+ hours
-      #       # extra steps, run tests
-      #       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      #       extraStepsParameters:
-      #         creator: dotnet-bot
-      #         testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-      #           eq(variables['isFullMatrix'], true))
+      #
+      # CoreCLR NativeAOT release build and libraries tests
+      # Only when CoreCLR or library is changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+          buildConfig: Release
+          platforms:
+          - windows_arm64
+          - linux_arm64
+          - osx_arm64
+          jobParameters:
+            testGroup: innerloop
+            isSingleFile: true
+            nameSuffix: NativeAOT_Libraries
+            buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true /p:ArchiveTests=true
+            timeoutInMinutes: 240 # Doesn't actually take long, but we've seen the ARM64 Helix queue often get backlogged for 2+ hours
+            # extra steps, run tests
+            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+            extraStepsParameters:
+              creator: dotnet-bot
+              testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(variables['isFullMatrix'], true))
 
-      # # Build and test clr tools
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     buildConfig: checked
-      #     platforms:
-      #     - linux_x64
-      #     jobParameters:
-      #       timeoutInMinutes: 120
-      #       nameSuffix: CLR_Tools_Tests
-      #       buildArgs: -s clr.aot+clr.iltools+libs.sfx+clr.toolstests -c $(_BuildConfig) -test
-      #       enablePublishTestResults: true
-      #       testResultsFormat: 'xunit'
-      #       # We want to run AOT tests when illink changes because there's share code and tests from illink which are used by AOT
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      # Build and test clr tools
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: checked
+          platforms:
+          - linux_x64
+          jobParameters:
+            timeoutInMinutes: 120
+            nameSuffix: CLR_Tools_Tests
+            buildArgs: -s clr.aot+clr.iltools+libs.sfx+clr.toolstests -c $(_BuildConfig) -test
+            enablePublishTestResults: true
+            testResultsFormat: 'xunit'
+            # We want to run AOT tests when illink changes because there's share code and tests from illink which are used by AOT
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
       # Build Mono AOT offset headers once, for consumption elsewhere
       # Only when mono changed
@@ -441,77 +441,77 @@ extends:
           scenarios:
             - WasmTestOnBrowser
 
-      # # EAT Library tests - only run on linux
-      # - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
-      #   parameters:
-      #     platforms:
-      #       - browser_wasm
-      #     nameSuffix: _EAT
-      #     runAOT: false
-      #     shouldRunSmokeOnly: false
-      #     alwaysRun: ${{ variables.isRollingBuild }}
-      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      # EAT Library tests - only run on linux
+      - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
+        parameters:
+          platforms:
+            - browser_wasm
+          nameSuffix: _EAT
+          runAOT: false
+          shouldRunSmokeOnly: false
+          alwaysRun: ${{ variables.isRollingBuild }}
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
-      # # AOT Library tests
-      # - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
-      #   parameters:
-      #     platforms:
-      #       - browser_wasm
-      #     nameSuffix: _AOT
-      #     runAOT: true
-      #     shouldRunSmokeOnly: true
-      #     alwaysRun: ${{ variables.isRollingBuild }}
-      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      # AOT Library tests
+      - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
+        parameters:
+          platforms:
+            - browser_wasm
+          nameSuffix: _AOT
+          runAOT: true
+          shouldRunSmokeOnly: true
+          alwaysRun: ${{ variables.isRollingBuild }}
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
-      # - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
-      #   parameters:
-      #     platforms:
-      #       - browser_wasm_win
-      #     nameSuffix: _AOT
-      #     runAOT: true
-      #     shouldRunSmokeOnly: true
-      #     alwaysRun: ${{ variables.isRollingBuild }}
+      - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
+        parameters:
+          platforms:
+            - browser_wasm_win
+          nameSuffix: _AOT
+          runAOT: true
+          shouldRunSmokeOnly: true
+          alwaysRun: ${{ variables.isRollingBuild }}
 
-      # # For Wasm.Build.Tests - runtime pack builds
-      # - template: /eng/pipelines/common/templates/wasm-build-only.yml
-      #   parameters:
-      #     platforms:
-      #       - browser_wasm
-      #       - browser_wasm_win
-      #     condition: or(eq(variables.isRollingBuild, true), eq(variables.wasmSingleThreadedBuildOnlyNeededOnDefaultPipeline, true))
-      #     nameSuffix: SingleThreaded
-      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-      #     publishArtifactsForWorkload: true
-      #     publishWBT: true
+      # For Wasm.Build.Tests - runtime pack builds
+      - template: /eng/pipelines/common/templates/wasm-build-only.yml
+        parameters:
+          platforms:
+            - browser_wasm
+            - browser_wasm_win
+          condition: or(eq(variables.isRollingBuild, true), eq(variables.wasmSingleThreadedBuildOnlyNeededOnDefaultPipeline, true))
+          nameSuffix: SingleThreaded
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+          publishArtifactsForWorkload: true
+          publishWBT: true
 
-      # - template: /eng/pipelines/common/templates/wasm-build-only.yml
-      #   parameters:
-      #     platforms:
-      #       - browser_wasm
-      #       - browser_wasm_win
-      #     condition: or(eq(variables.isRollingBuild, true), eq(variables.wasmSingleThreadedBuildOnlyNeededOnDefaultPipeline, true))
-      #     nameSuffix: MultiThreaded
-      #     extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:WasmEnableThreads=true /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-      #     publishArtifactsForWorkload: true
-      #     publishWBT: false
+      - template: /eng/pipelines/common/templates/wasm-build-only.yml
+        parameters:
+          platforms:
+            - browser_wasm
+            - browser_wasm_win
+          condition: or(eq(variables.isRollingBuild, true), eq(variables.wasmSingleThreadedBuildOnlyNeededOnDefaultPipeline, true))
+          nameSuffix: MultiThreaded
+          extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:WasmEnableThreads=true /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+          publishArtifactsForWorkload: true
+          publishWBT: false
 
-      # # Browser Wasm.Build.Tests
-      # - template: /eng/pipelines/common/templates/browser-wasm-build-tests.yml
-      #   parameters:
-      #     platforms:
-      #       - browser_wasm
-      #       - browser_wasm_win
-      #     alwaysRun: ${{ variables.isRollingBuild }}
-      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      # Browser Wasm.Build.Tests
+      - template: /eng/pipelines/common/templates/browser-wasm-build-tests.yml
+        parameters:
+          platforms:
+            - browser_wasm
+            - browser_wasm_win
+          alwaysRun: ${{ variables.isRollingBuild }}
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
-      # # Wasm Debugger tests
-      # - template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
-      #   parameters:
-      #     platforms:
-      #       - browser_wasm
-      #       - browser_wasm_win
-      #     alwaysRun: ${{ variables.isRollingBuild }}
-      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      # Wasm Debugger tests
+      - template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
+        parameters:
+          platforms:
+            - browser_wasm
+            - browser_wasm_win
+          alwaysRun: ${{ variables.isRollingBuild }}
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
       # Wasm runtime tests
       - template: /eng/pipelines/common/templates/wasm-runtime-tests.yml
@@ -532,238 +532,238 @@ extends:
           scenarios:
             - WasmTestOnBrowser
 
-      # # WASI/WASM
+      # WASI/WASM
 
-      # - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-      #   parameters:
-      #     platforms:
-      #       - wasi_wasm
-      #       - wasi_wasm_win
-      #     nameSuffix: '_Smoke'
-      #     extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-      #     shouldContinueOnError: true
-      #     shouldRunSmokeOnly: true
-      #     alwaysRun: ${{ variables.isRollingBuild }}
-      #     scenarios:
-      #       - normal
+      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+        parameters:
+          platforms:
+            - wasi_wasm
+            - wasi_wasm_win
+          nameSuffix: '_Smoke'
+          extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+          shouldContinueOnError: true
+          shouldRunSmokeOnly: true
+          alwaysRun: ${{ variables.isRollingBuild }}
+          scenarios:
+            - normal
 
-      # - template: /eng/pipelines/common/templates/simple-wasm-build-tests.yml
-      #   parameters:
-      #     platforms:
-      #       - wasi_wasm
-      #       - wasi_wasm_win
-      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-      #     alwaysRun: ${{ variables.isRollingBuild }}
+      - template: /eng/pipelines/common/templates/simple-wasm-build-tests.yml
+        parameters:
+          platforms:
+            - wasi_wasm
+            - wasi_wasm_win
+          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+          alwaysRun: ${{ variables.isRollingBuild }}
 
-      # #
-      # # iOS/tvOS devices - Full AOT + AggressiveTrimming to reduce size
-      # # Build the whole product using Mono and run libraries tests
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-      #     buildConfig: Release
-      #     runtimeFlavor: mono
-      #     platforms:
-      #       - ios_arm64
-      #       - tvos_arm64
-      #     variables:
-      #       # map dependencies variables to local variables
-      #       - name: librariesContainsChange
-      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      #       - name: monoContainsChange
-      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       nameSuffix: AllSubsets_Mono
-      #       buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=true /p:BuildDarwinFrameworks=true
-      #       timeoutInMinutes: 480
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
-      #       # extra steps, run tests
-      #       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      #       extraStepsParameters:
-      #         creator: dotnet-bot
-      #         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-      #         extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
-      #         condition: >-
-      #           or(
-      #           eq(variables['librariesContainsChange'], true),
-      #           eq(variables['monoContainsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      #
+      # iOS/tvOS devices - Full AOT + AggressiveTrimming to reduce size
+      # Build the whole product using Mono and run libraries tests
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+          buildConfig: Release
+          runtimeFlavor: mono
+          platforms:
+            - ios_arm64
+            - tvos_arm64
+          variables:
+            # map dependencies variables to local variables
+            - name: librariesContainsChange
+              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+            - name: monoContainsChange
+              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: AllSubsets_Mono
+            buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=true /p:BuildDarwinFrameworks=true
+            timeoutInMinutes: 480
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
+            # extra steps, run tests
+            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+            extraStepsParameters:
+              creator: dotnet-bot
+              testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+              extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+              condition: >-
+                or(
+                eq(variables['librariesContainsChange'], true),
+                eq(variables['monoContainsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # #
-      # # iOS/tvOS devices
-      # # Build the whole product using Native AOT and run libraries tests
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-      #     buildConfig: Release
-      #     runtimeFlavor: coreclr
-      #     platforms:
-      #       - ios_arm64
-      #       - tvos_arm64
-      #     variables:
-      #       # map dependencies variables to local variables
-      #       - name: librariesContainsChange
-      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      #       - name: coreclrContainsChange
-      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       nameSuffix: AllSubsets_NativeAOT
-      #       buildArgs: --cross -s clr.alljits+clr.tools+clr.nativeaotruntime+clr.nativeaotlibs+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=- /p:BuildTestsOnHelix=true /p:UseNativeAOTRuntime=true /p:RunAOTCompilation=false /p:ContinuousIntegrationBuild=true
-      #       timeoutInMinutes: 180
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
-      #       # extra steps, run tests
-      #       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      #       extraStepsParameters:
-      #         creator: dotnet-bot
-      #         testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-      #         extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
-      #         condition: >-
-      #           or(
-      #           eq(variables['librariesContainsChange'], true),
-      #           eq(variables['coreclrContainsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      #
+      # iOS/tvOS devices
+      # Build the whole product using Native AOT and run libraries tests
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+          buildConfig: Release
+          runtimeFlavor: coreclr
+          platforms:
+            - ios_arm64
+            - tvos_arm64
+          variables:
+            # map dependencies variables to local variables
+            - name: librariesContainsChange
+              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+            - name: coreclrContainsChange
+              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: AllSubsets_NativeAOT
+            buildArgs: --cross -s clr.alljits+clr.tools+clr.nativeaotruntime+clr.nativeaotlibs+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=- /p:BuildTestsOnHelix=true /p:UseNativeAOTRuntime=true /p:RunAOTCompilation=false /p:ContinuousIntegrationBuild=true
+            timeoutInMinutes: 180
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
+            # extra steps, run tests
+            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+            extraStepsParameters:
+              creator: dotnet-bot
+              testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+              extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+              condition: >-
+                or(
+                eq(variables['librariesContainsChange'], true),
+                eq(variables['coreclrContainsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # #
-      # # MacCatalyst interp - requires AOT Compilation and Interp flags
-      # # Build the whole product using Mono and run libraries tests
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-      #     buildConfig: Release
-      #     runtimeFlavor: mono
-      #     platforms:
-      #     - maccatalyst_x64
-      #     - ${{ if eq(variables['isRollingBuild'], true) }}:
-      #       - maccatalyst_arm64
-      #     variables:
-      #       # map dependencies variables to local variables
-      #       - name: librariesContainsChange
-      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      #       - name: monoContainsChange
-      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       nameSuffix: AllSubsets_Mono
-      #       buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true
-      #       timeoutInMinutes: 180
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
-      #       # extra steps, run tests
-      #       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      #       extraStepsParameters:
-      #         creator: dotnet-bot
-      #         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-      #         condition: >-
-      #           or(
-      #             eq(variables['librariesContainsChange'], true),
-      #             eq(variables['monoContainsChange'], true),
-      #             eq(variables['isRollingBuild'], true))
+      #
+      # MacCatalyst interp - requires AOT Compilation and Interp flags
+      # Build the whole product using Mono and run libraries tests
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+          buildConfig: Release
+          runtimeFlavor: mono
+          platforms:
+          - maccatalyst_x64
+          - ${{ if eq(variables['isRollingBuild'], true) }}:
+            - maccatalyst_arm64
+          variables:
+            # map dependencies variables to local variables
+            - name: librariesContainsChange
+              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+            - name: monoContainsChange
+              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: AllSubsets_Mono
+            buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true
+            timeoutInMinutes: 180
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
+            # extra steps, run tests
+            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+            extraStepsParameters:
+              creator: dotnet-bot
+              testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+              condition: >-
+                or(
+                  eq(variables['librariesContainsChange'], true),
+                  eq(variables['monoContainsChange'], true),
+                  eq(variables['isRollingBuild'], true))
 
-      # #
-      # # Build Mono and Installer on LLVMJIT mode
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     buildConfig: Release
-      #     runtimeFlavor: mono
-      #     platforms:
-      #     - osx_x64
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       nameSuffix: AllSubsets_Mono_LLVMJIT
-      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-      #                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      #
+      # Build Mono and Installer on LLVMJIT mode
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: Release
+          runtimeFlavor: mono
+          platforms:
+          - osx_x64
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: AllSubsets_Mono_LLVMJIT
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      #     runtimeFlavor: mono
-      #     platforms:
-      #     - linux_x64
-      #     - linux_arm64
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       nameSuffix: AllSubsets_Mono_LLVMJIT
-      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-      #                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+          runtimeFlavor: mono
+          platforms:
+          - linux_x64
+          - linux_arm64
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: AllSubsets_Mono_LLVMJIT
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # #
-      # # Build Mono and Installer on LLVMAOT mode
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     buildConfig: Release
-      #     runtimeFlavor: mono
-      #     platforms:
-      #     - linux_x64
-      #     - linux_arm64
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       nameSuffix: AllSubsets_Mono_LLVMAOT
-      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-      #                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      #
+      # Build Mono and Installer on LLVMAOT mode
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: Release
+          runtimeFlavor: mono
+          platforms:
+          - linux_x64
+          - linux_arm64
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: AllSubsets_Mono_LLVMAOT
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      #     runtimeFlavor: mono
-      #     platforms:
-      #     - osx_x64
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       nameSuffix: AllSubsets_Mono_LLVMAOT
-      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-      #                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+          runtimeFlavor: mono
+          platforms:
+          - osx_x64
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: AllSubsets_Mono_LLVMAOT
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
       #
       # Build Mono debug
@@ -1023,127 +1023,127 @@ extends:
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
-      # #
-      # # Installer Build and Test
-      # # These are always built since they only take like 15 minutes
-      # # we expect these to be done before we finish libraries or coreclr testing.
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
-      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      #     platforms:
-      #       - linux_musl_arm
-      #       - linux_musl_arm64
-      #       - windows_x86
-      #       - windows_arm64
-      #       - linux_arm
-      #     jobParameters:
-      #       liveRuntimeBuildConfig: release
-      #       liveLibrariesBuildConfig: Release
-      #       runOnlyIfDependenciesSucceeded: true
-      #       condition:
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      #
+      # Installer Build and Test
+      # These are always built since they only take like 15 minutes
+      # we expect these to be done before we finish libraries or coreclr testing.
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
+          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+          platforms:
+            - linux_musl_arm
+            - linux_musl_arm64
+            - windows_x86
+            - windows_arm64
+            - linux_arm
+          jobParameters:
+            liveRuntimeBuildConfig: release
+            liveLibrariesBuildConfig: Release
+            runOnlyIfDependenciesSucceeded: true
+            condition:
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
-      #     buildConfig: Release
-      #     platforms:
-      #       - osx_arm64
-      #       - osx_x64
-      #       - linux_x64
-      #       - linux_arm64
-      #       - linux_musl_x64
-      #       - windows_x64
-      #       - freebsd_x64
-      #     jobParameters:
-      #       liveRuntimeBuildConfig: release
-      #       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      #       runOnlyIfDependenciesSucceeded: true
-      #       condition:
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
+          buildConfig: Release
+          platforms:
+            - osx_arm64
+            - osx_x64
+            - linux_x64
+            - linux_arm64
+            - linux_musl_x64
+            - windows_x64
+            - freebsd_x64
+          jobParameters:
+            liveRuntimeBuildConfig: release
+            liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+            runOnlyIfDependenciesSucceeded: true
+            condition:
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # #
-      # # CoreCLR Test builds using live libraries release build
-      # # Only when CoreCLR is changed
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-      #     buildConfig: checked
-      #     platforms:
-      #     - CoreClrTestBuildHost # Either osx_x64 or linux_x64
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      #
+      # CoreCLR Test builds using live libraries release build
+      # Only when CoreCLR is changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+          buildConfig: checked
+          platforms:
+          - CoreClrTestBuildHost # Either osx_x64 or linux_x64
+          jobParameters:
+            testGroup: innerloop
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # #
-      # # CoreCLR Test executions using live libraries
-      # # Only when CoreCLR is changed
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-      #     buildConfig: checked
-      #     platforms:
-      #     - linux_arm
-      #     - windows_x86
-      #     - windows_arm64
-      #     helixQueueGroup: pr
-      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       liveLibrariesBuildConfig: Release
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      #
+      # CoreCLR Test executions using live libraries
+      # Only when CoreCLR is changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+          buildConfig: checked
+          platforms:
+          - linux_arm
+          - windows_x86
+          - windows_arm64
+          helixQueueGroup: pr
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          jobParameters:
+            testGroup: innerloop
+            liveLibrariesBuildConfig: Release
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-      #     buildConfig: checked
-      #     platforms:
-      #     - osx_x64
-      #     - linux_x64
-      #     - linux_arm64
-      #     - windows_x64
-      #     helixQueueGroup: pr
-      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+          buildConfig: checked
+          platforms:
+          - osx_x64
+          - linux_x64
+          - linux_arm64
+          - windows_x64
+          helixQueueGroup: pr
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          jobParameters:
+            testGroup: innerloop
+            liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-      #     buildConfig: checked
-      #     platforms:
-      #     - osx_arm64
-      #     helixQueueGroup: pr
-      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      #     jobParameters:
-      #       testGroup: innerloop
-      #       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-      #       condition: >-
-      #         or(
-      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_AppleSilicon.containsChange'], true),
-      #           eq(variables['isRollingBuild'], true))
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+          buildConfig: checked
+          platforms:
+          - osx_arm64
+          helixQueueGroup: pr
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          jobParameters:
+            testGroup: innerloop
+            liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_AppleSilicon.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
       #
       # Mono Test builds with CoreCLR runtime tests using live libraries debug build

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -521,14 +521,13 @@ extends:
           alwaysRun: ${{ variables.isRollingBuild }}
           extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
-      # Build and Smoke Tests only - Wasm Threading Legs
+      # Wasm Library tests - Threading Legs
       - template: /eng/pipelines/common/templates/wasm-library-tests.yml
         parameters:
           platforms:
             - browser_wasm
-          nameSuffix: _Threading_Smoke
+          nameSuffix: _Threading
           extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
           scenarios:
             - WasmTestOnBrowser

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -521,13 +521,14 @@ extends:
           alwaysRun: ${{ variables.isRollingBuild }}
           extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
-      # Wasm Library tests - Threading Legs
+      # Build and Smoke Tests only - Wasm Threading Legs
       - template: /eng/pipelines/common/templates/wasm-library-tests.yml
         parameters:
           platforms:
             - browser_wasm
-          nameSuffix: _Threading
+          nameSuffix: _Threading_Smoke
           extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+          shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
           scenarios:
             - WasmTestOnBrowser

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -61,300 +61,300 @@ extends:
       - ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
         - template: /eng/pipelines/common/evaluate-default-paths.yml
 
-      #
-      # Build CoreCLR checked
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-          buildConfig: checked
-          platforms:
-          - linux_x86
-          - linux_x64
-          - linux_arm
-          - linux_arm64
-          - linux_riscv64
-          - linux_musl_arm
-          - linux_musl_arm64
-          - linux_musl_x64
-          - osx_arm64
-          - tizen_armel
-          - windows_x86
-          - windows_x64
-          - windows_arm64
-          jobParameters:
-            testGroup: innerloop
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Build CoreCLR checked
+      # # Only when CoreCLR is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - linux_x86
+      #     - linux_x64
+      #     - linux_arm
+      #     - linux_arm64
+      #     - linux_riscv64
+      #     - linux_musl_arm
+      #     - linux_musl_arm64
+      #     - linux_musl_x64
+      #     - osx_arm64
+      #     - tizen_armel
+      #     - windows_x86
+      #     - windows_x64
+      #     - windows_arm64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # Build the whole product using GNU compiler toolchain
-      # When CoreCLR, Mono, Libraries, Installer and src/tests are changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: checked
-          platforms:
-          - gcc_linux_x64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: Native_GCC
-            buildArgs: -s clr.native+libs.native+mono+host.native -c $(_BuildConfig) -gcc
-            extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests.yml
-            extraStepsParameters:
-              testBuildArgs: skipmanaged skipgeneratelayout skiprestorepackages -gcc
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Build the whole product using GNU compiler toolchain
+      # # When CoreCLR, Mono, Libraries, Installer and src/tests are changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - gcc_linux_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: Native_GCC
+      #       buildArgs: -s clr.native+libs.native+mono+host.native -c $(_BuildConfig) -gcc
+      #       extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests.yml
+      #       extraStepsParameters:
+      #         testBuildArgs: skipmanaged skipgeneratelayout skiprestorepackages -gcc
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # Build CoreCLR osx_x64 checked
-      # Only when CoreCLR or Libraries is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-          buildConfig: checked
-          platforms:
-          - osx_x64
-          jobParameters:
-            testGroup: innerloop
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Build CoreCLR osx_x64 checked
+      # # Only when CoreCLR or Libraries is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - osx_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # Build CoreCLR release
-      # Always as they are needed by Installer and we always build and test the Installer.
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-          buildConfig: release
-          platforms:
-          - osx_arm64
-          - osx_x64
-          - linux_x64
-          - linux_arm
-          - linux_arm64
-          - linux_musl_x64
-          - linux_musl_arm
-          - linux_musl_arm64
-          - windows_x64
-          - windows_x86
-          - windows_arm64
-          - freebsd_x64
-          jobParameters:
-            testGroup: innerloop
-            # Mono/runtimetests also need this, but skip for wasm
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Build CoreCLR release
+      # # Always as they are needed by Installer and we always build and test the Installer.
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+      #     buildConfig: release
+      #     platforms:
+      #     - osx_arm64
+      #     - osx_x64
+      #     - linux_x64
+      #     - linux_arm
+      #     - linux_arm64
+      #     - linux_musl_x64
+      #     - linux_musl_arm
+      #     - linux_musl_arm64
+      #     - windows_x64
+      #     - windows_x86
+      #     - windows_arm64
+      #     - freebsd_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       # Mono/runtimetests also need this, but skip for wasm
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # Build CoreCLR Formatting Job
-      # Only when CoreCLR is changed, and only in the 'main' branch (no release branches;
-      # both Rolling and PR builds).
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
-          platforms:
-          - linux_x64
-          - windows_x64
-          jobParameters:
-            condition: >-
-              and(
-                or(
-                  eq(variables['Build.SourceBranchName'], 'main'),
-                  eq(variables['System.PullRequest.TargetBranch'], 'main')),
-                or(
-                  eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_jit.containsChange'], true),
-                  eq(variables['isRollingBuild'], true)))
+      # #
+      # # Build CoreCLR Formatting Job
+      # # Only when CoreCLR is changed, and only in the 'main' branch (no release branches;
+      # # both Rolling and PR builds).
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
+      #     platforms:
+      #     - linux_x64
+      #     - windows_x64
+      #     jobParameters:
+      #       condition: >-
+      #         and(
+      #           or(
+      #             eq(variables['Build.SourceBranchName'], 'main'),
+      #             eq(variables['System.PullRequest.TargetBranch'], 'main')),
+      #           or(
+      #             eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_jit.containsChange'], true),
+      #             eq(variables['isRollingBuild'], true)))
 
-      #
-      # CoreCLR NativeAOT debug build and smoke tests
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: Debug
-          platforms:
-          - linux_x64
-          - windows_x64
-          variables:
-          - name: timeoutPerTestInMinutes
-            value: 60
-          - name: timeoutPerTestCollectionInMinutes
-            value: 180
-          jobParameters:
-            timeoutInMinutes: 120
-            nameSuffix: NativeAOT
-            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
-            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testBuildArgs: nativeaot tree nativeaot
-              liveLibrariesBuildConfig: Release
-            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            extraVariablesTemplates:
-              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-                parameters:
-                  testGroup: innerloop
-                  liveLibrariesBuildConfig: Release
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
+      # #
+      # # CoreCLR NativeAOT debug build and smoke tests
+      # # Only when CoreCLR is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     buildConfig: Debug
+      #     platforms:
+      #     - linux_x64
+      #     - windows_x64
+      #     variables:
+      #     - name: timeoutPerTestInMinutes
+      #       value: 60
+      #     - name: timeoutPerTestCollectionInMinutes
+      #       value: 180
+      #     jobParameters:
+      #       timeoutInMinutes: 120
+      #       nameSuffix: NativeAOT
+      #       buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
+      #       extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testBuildArgs: nativeaot tree nativeaot
+      #         liveLibrariesBuildConfig: Release
+      #       testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+      #       extraVariablesTemplates:
+      #         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+      #           parameters:
+      #             testGroup: innerloop
+      #             liveLibrariesBuildConfig: Release
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isFullMatrix'], true))
 
-      #
-      # CoreCLR NativeAOT checked build and smoke tests
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: Checked
-          platforms:
-          - windows_x64
-          variables:
-          - name: timeoutPerTestInMinutes
-            value: 60
-          - name: timeoutPerTestCollectionInMinutes
-            value: 180
-          jobParameters:
-            timeoutInMinutes: 180
-            nameSuffix: NativeAOT
-            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
-            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing;" /p:BuildNativeAotFrameworkObjects=true'
-              liveLibrariesBuildConfig: Release
-            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            extraVariablesTemplates:
-              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-                parameters:
-                  testGroup: innerloop
-                  liveLibrariesBuildConfig: Release
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
+      # #
+      # # CoreCLR NativeAOT checked build and smoke tests
+      # # Only when CoreCLR is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     buildConfig: Checked
+      #     platforms:
+      #     - windows_x64
+      #     variables:
+      #     - name: timeoutPerTestInMinutes
+      #       value: 60
+      #     - name: timeoutPerTestCollectionInMinutes
+      #       value: 180
+      #     jobParameters:
+      #       timeoutInMinutes: 180
+      #       nameSuffix: NativeAOT
+      #       buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
+      #       extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing;" /p:BuildNativeAotFrameworkObjects=true'
+      #         liveLibrariesBuildConfig: Release
+      #       testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+      #       extraVariablesTemplates:
+      #         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+      #           parameters:
+      #             testGroup: innerloop
+      #             liveLibrariesBuildConfig: Release
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isFullMatrix'], true))
 
-      #
-      # CoreCLR NativeAOT release build and smoke tests
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: Release
-          platforms:
-          - linux_x64
-          - windows_x64
-          - osx_x64
-          - linux_arm64
-          - windows_arm64
-          - osx_arm64
-          variables:
-          - name: timeoutPerTestInMinutes
-            value: 60
-          - name: timeoutPerTestCollectionInMinutes
-            value: 180
-          jobParameters:
-            testGroup: innerloop
-            timeoutInMinutes: 120
-            nameSuffix: NativeAOT
-            buildArgs: -s clr.aot+host.native+libs+tools.illink -c $(_BuildConfig) -rc $(_BuildConfig) -lc Release -hc Release
-            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testBuildArgs: 'nativeaot tree ";nativeaot;tracing/eventpipe/providervalidation;"'
-              liveLibrariesBuildConfig: Release
-            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            extraVariablesTemplates:
-              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-                parameters:
-                  testGroup: innerloop
-                  liveLibrariesBuildConfig: Release
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
+      # #
+      # # CoreCLR NativeAOT release build and smoke tests
+      # # Only when CoreCLR is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     buildConfig: Release
+      #     platforms:
+      #     - linux_x64
+      #     - windows_x64
+      #     - osx_x64
+      #     - linux_arm64
+      #     - windows_arm64
+      #     - osx_arm64
+      #     variables:
+      #     - name: timeoutPerTestInMinutes
+      #       value: 60
+      #     - name: timeoutPerTestCollectionInMinutes
+      #       value: 180
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       timeoutInMinutes: 120
+      #       nameSuffix: NativeAOT
+      #       buildArgs: -s clr.aot+host.native+libs+tools.illink -c $(_BuildConfig) -rc $(_BuildConfig) -lc Release -hc Release
+      #       extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testBuildArgs: 'nativeaot tree ";nativeaot;tracing/eventpipe/providervalidation;"'
+      #         liveLibrariesBuildConfig: Release
+      #       testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+      #       extraVariablesTemplates:
+      #         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+      #           parameters:
+      #             testGroup: innerloop
+      #             liveLibrariesBuildConfig: Release
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isFullMatrix'], true))
 
-      #
-      # CoreCLR NativeAOT release build and libraries tests
-      # Only when CoreCLR or library is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          buildConfig: Release
-          platforms:
-          - windows_arm64
-          - linux_arm64
-          - osx_arm64
-          jobParameters:
-            testGroup: innerloop
-            isSingleFile: true
-            nameSuffix: NativeAOT_Libraries
-            buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true /p:ArchiveTests=true
-            timeoutInMinutes: 240 # Doesn't actually take long, but we've seen the ARM64 Helix queue often get backlogged for 2+ hours
-            # extra steps, run tests
-            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
+      # #
+      # # CoreCLR NativeAOT release build and libraries tests
+      # # Only when CoreCLR or library is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #     buildConfig: Release
+      #     platforms:
+      #     - windows_arm64
+      #     - linux_arm64
+      #     - osx_arm64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       isSingleFile: true
+      #       nameSuffix: NativeAOT_Libraries
+      #       buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true /p:ArchiveTests=true
+      #       timeoutInMinutes: 240 # Doesn't actually take long, but we've seen the ARM64 Helix queue often get backlogged for 2+ hours
+      #       # extra steps, run tests
+      #       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(variables['isFullMatrix'], true))
 
-      # Build and test clr tools
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: checked
-          platforms:
-          - linux_x64
-          jobParameters:
-            timeoutInMinutes: 120
-            nameSuffix: CLR_Tools_Tests
-            buildArgs: -s clr.aot+clr.iltools+libs.sfx+clr.toolstests -c $(_BuildConfig) -test
-            enablePublishTestResults: true
-            testResultsFormat: 'xunit'
-            # We want to run AOT tests when illink changes because there's share code and tests from illink which are used by AOT
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # # Build and test clr tools
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - linux_x64
+      #     jobParameters:
+      #       timeoutInMinutes: 120
+      #       nameSuffix: CLR_Tools_Tests
+      #       buildArgs: -s clr.aot+clr.iltools+libs.sfx+clr.toolstests -c $(_BuildConfig) -test
+      #       enablePublishTestResults: true
+      #       testResultsFormat: 'xunit'
+      #       # We want to run AOT tests when illink changes because there's share code and tests from illink which are used by AOT
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
       # Build Mono AOT offset headers once, for consumption elsewhere
       # Only when mono changed
@@ -441,77 +441,77 @@ extends:
           scenarios:
             - WasmTestOnBrowser
 
-      # EAT Library tests - only run on linux
-      - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-          nameSuffix: _EAT
-          runAOT: false
-          shouldRunSmokeOnly: false
-          alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      # # EAT Library tests - only run on linux
+      # - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #     nameSuffix: _EAT
+      #     runAOT: false
+      #     shouldRunSmokeOnly: false
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
-      # AOT Library tests
-      - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-          nameSuffix: _AOT
-          runAOT: true
-          shouldRunSmokeOnly: true
-          alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      # # AOT Library tests
+      # - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #     nameSuffix: _AOT
+      #     runAOT: true
+      #     shouldRunSmokeOnly: true
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
-      - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm_win
-          nameSuffix: _AOT
-          runAOT: true
-          shouldRunSmokeOnly: true
-          alwaysRun: ${{ variables.isRollingBuild }}
+      # - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm_win
+      #     nameSuffix: _AOT
+      #     runAOT: true
+      #     shouldRunSmokeOnly: true
+      #     alwaysRun: ${{ variables.isRollingBuild }}
 
-      # For Wasm.Build.Tests - runtime pack builds
-      - template: /eng/pipelines/common/templates/wasm-build-only.yml
-        parameters:
-          platforms:
-            - browser_wasm
-            - browser_wasm_win
-          condition: or(eq(variables.isRollingBuild, true), eq(variables.wasmSingleThreadedBuildOnlyNeededOnDefaultPipeline, true))
-          nameSuffix: SingleThreaded
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          publishArtifactsForWorkload: true
-          publishWBT: true
+      # # For Wasm.Build.Tests - runtime pack builds
+      # - template: /eng/pipelines/common/templates/wasm-build-only.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #       - browser_wasm_win
+      #     condition: or(eq(variables.isRollingBuild, true), eq(variables.wasmSingleThreadedBuildOnlyNeededOnDefaultPipeline, true))
+      #     nameSuffix: SingleThreaded
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      #     publishArtifactsForWorkload: true
+      #     publishWBT: true
 
-      - template: /eng/pipelines/common/templates/wasm-build-only.yml
-        parameters:
-          platforms:
-            - browser_wasm
-            - browser_wasm_win
-          condition: or(eq(variables.isRollingBuild, true), eq(variables.wasmSingleThreadedBuildOnlyNeededOnDefaultPipeline, true))
-          nameSuffix: MultiThreaded
-          extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:WasmEnableThreads=true /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          publishArtifactsForWorkload: true
-          publishWBT: false
+      # - template: /eng/pipelines/common/templates/wasm-build-only.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #       - browser_wasm_win
+      #     condition: or(eq(variables.isRollingBuild, true), eq(variables.wasmSingleThreadedBuildOnlyNeededOnDefaultPipeline, true))
+      #     nameSuffix: MultiThreaded
+      #     extraBuildArgs: /p:MonoWasmBuildVariant=multithread /p:WasmEnableThreads=true /p:_WasmPThreadPoolSize=8 /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      #     publishArtifactsForWorkload: true
+      #     publishWBT: false
 
-      # Browser Wasm.Build.Tests
-      - template: /eng/pipelines/common/templates/browser-wasm-build-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-            - browser_wasm_win
-          alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      # # Browser Wasm.Build.Tests
+      # - template: /eng/pipelines/common/templates/browser-wasm-build-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #       - browser_wasm_win
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
-      # Wasm Debugger tests
-      - template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-            - browser_wasm_win
-          alwaysRun: ${{ variables.isRollingBuild }}
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      # # Wasm Debugger tests
+      # - template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - browser_wasm
+      #       - browser_wasm_win
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
 
       # Wasm runtime tests
       - template: /eng/pipelines/common/templates/wasm-runtime-tests.yml
@@ -532,238 +532,238 @@ extends:
           scenarios:
             - WasmTestOnBrowser
 
-      # WASI/WASM
+      # # WASI/WASM
 
-      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-        parameters:
-          platforms:
-            - wasi_wasm
-            - wasi_wasm_win
-          nameSuffix: '_Smoke'
-          extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          shouldContinueOnError: true
-          shouldRunSmokeOnly: true
-          alwaysRun: ${{ variables.isRollingBuild }}
-          scenarios:
-            - normal
+      # - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - wasi_wasm
+      #       - wasi_wasm_win
+      #     nameSuffix: '_Smoke'
+      #     extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      #     shouldContinueOnError: true
+      #     shouldRunSmokeOnly: true
+      #     alwaysRun: ${{ variables.isRollingBuild }}
+      #     scenarios:
+      #       - normal
 
-      - template: /eng/pipelines/common/templates/simple-wasm-build-tests.yml
-        parameters:
-          platforms:
-            - wasi_wasm
-            - wasi_wasm_win
-          extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          alwaysRun: ${{ variables.isRollingBuild }}
+      # - template: /eng/pipelines/common/templates/simple-wasm-build-tests.yml
+      #   parameters:
+      #     platforms:
+      #       - wasi_wasm
+      #       - wasi_wasm_win
+      #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      #     alwaysRun: ${{ variables.isRollingBuild }}
 
-      #
-      # iOS/tvOS devices - Full AOT + AggressiveTrimming to reduce size
-      # Build the whole product using Mono and run libraries tests
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-            - ios_arm64
-            - tvos_arm64
-          variables:
-            # map dependencies variables to local variables
-            - name: librariesContainsChange
-              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-            - name: monoContainsChange
-              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono
-            buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=true /p:BuildDarwinFrameworks=true
-            timeoutInMinutes: 480
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-            # extra steps, run tests
-            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-              extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
-              condition: >-
-                or(
-                eq(variables['librariesContainsChange'], true),
-                eq(variables['monoContainsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # iOS/tvOS devices - Full AOT + AggressiveTrimming to reduce size
+      # # Build the whole product using Mono and run libraries tests
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #       - ios_arm64
+      #       - tvos_arm64
+      #     variables:
+      #       # map dependencies variables to local variables
+      #       - name: librariesContainsChange
+      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+      #       - name: monoContainsChange
+      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono
+      #       buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=true /p:BuildDarwinFrameworks=true
+      #       timeoutInMinutes: 480
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+      #       # extra steps, run tests
+      #       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+      #         extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+      #         condition: >-
+      #           or(
+      #           eq(variables['librariesContainsChange'], true),
+      #           eq(variables['monoContainsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # iOS/tvOS devices
-      # Build the whole product using Native AOT and run libraries tests
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          buildConfig: Release
-          runtimeFlavor: coreclr
-          platforms:
-            - ios_arm64
-            - tvos_arm64
-          variables:
-            # map dependencies variables to local variables
-            - name: librariesContainsChange
-              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-            - name: coreclrContainsChange
-              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_NativeAOT
-            buildArgs: --cross -s clr.alljits+clr.tools+clr.nativeaotruntime+clr.nativeaotlibs+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=- /p:BuildTestsOnHelix=true /p:UseNativeAOTRuntime=true /p:RunAOTCompilation=false /p:ContinuousIntegrationBuild=true
-            timeoutInMinutes: 180
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-            # extra steps, run tests
-            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-              extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
-              condition: >-
-                or(
-                eq(variables['librariesContainsChange'], true),
-                eq(variables['coreclrContainsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # iOS/tvOS devices
+      # # Build the whole product using Native AOT and run libraries tests
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: coreclr
+      #     platforms:
+      #       - ios_arm64
+      #       - tvos_arm64
+      #     variables:
+      #       # map dependencies variables to local variables
+      #       - name: librariesContainsChange
+      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+      #       - name: coreclrContainsChange
+      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_NativeAOT
+      #       buildArgs: --cross -s clr.alljits+clr.tools+clr.nativeaotruntime+clr.nativeaotlibs+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=- /p:BuildTestsOnHelix=true /p:UseNativeAOTRuntime=true /p:RunAOTCompilation=false /p:ContinuousIntegrationBuild=true
+      #       timeoutInMinutes: 180
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+      #       # extra steps, run tests
+      #       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+      #         extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+      #         condition: >-
+      #           or(
+      #           eq(variables['librariesContainsChange'], true),
+      #           eq(variables['coreclrContainsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # MacCatalyst interp - requires AOT Compilation and Interp flags
-      # Build the whole product using Mono and run libraries tests
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-          - maccatalyst_x64
-          - ${{ if eq(variables['isRollingBuild'], true) }}:
-            - maccatalyst_arm64
-          variables:
-            # map dependencies variables to local variables
-            - name: librariesContainsChange
-              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-            - name: monoContainsChange
-              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono
-            buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true
-            timeoutInMinutes: 180
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-            # extra steps, run tests
-            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-              condition: >-
-                or(
-                  eq(variables['librariesContainsChange'], true),
-                  eq(variables['monoContainsChange'], true),
-                  eq(variables['isRollingBuild'], true))
+      # #
+      # # MacCatalyst interp - requires AOT Compilation and Interp flags
+      # # Build the whole product using Mono and run libraries tests
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - maccatalyst_x64
+      #     - ${{ if eq(variables['isRollingBuild'], true) }}:
+      #       - maccatalyst_arm64
+      #     variables:
+      #       # map dependencies variables to local variables
+      #       - name: librariesContainsChange
+      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+      #       - name: monoContainsChange
+      #         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono
+      #       buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true /p:BuildDarwinFrameworks=true
+      #       timeoutInMinutes: 180
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
+      #       # extra steps, run tests
+      #       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+      #       extraStepsParameters:
+      #         creator: dotnet-bot
+      #         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+      #         condition: >-
+      #           or(
+      #             eq(variables['librariesContainsChange'], true),
+      #             eq(variables['monoContainsChange'], true),
+      #             eq(variables['isRollingBuild'], true))
 
-      #
-      # Build Mono and Installer on LLVMJIT mode
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-          - osx_x64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_LLVMJIT
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Build Mono and Installer on LLVMJIT mode
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - osx_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono_LLVMJIT
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          runtimeFlavor: mono
-          platforms:
-          - linux_x64
-          - linux_arm64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_LLVMJIT
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - linux_x64
+      #     - linux_arm64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono_LLVMJIT
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # Build Mono and Installer on LLVMAOT mode
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-          - linux_x64
-          - linux_arm64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_LLVMAOT
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Build Mono and Installer on LLVMAOT mode
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: Release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - linux_x64
+      #     - linux_arm64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono_LLVMAOT
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          runtimeFlavor: mono
-          platforms:
-          - osx_x64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_LLVMAOT
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - osx_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       nameSuffix: AllSubsets_Mono_LLVMAOT
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #                 /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
       #
       # Build Mono debug
@@ -1023,127 +1023,127 @@ extends:
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
-      #
-      # Installer Build and Test
-      # These are always built since they only take like 15 minutes
-      # we expect these to be done before we finish libraries or coreclr testing.
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-            - linux_musl_arm
-            - linux_musl_arm64
-            - windows_x86
-            - windows_arm64
-            - linux_arm
-          jobParameters:
-            liveRuntimeBuildConfig: release
-            liveLibrariesBuildConfig: Release
-            runOnlyIfDependenciesSucceeded: true
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # Installer Build and Test
+      # # These are always built since they only take like 15 minutes
+      # # we expect these to be done before we finish libraries or coreclr testing.
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
+      #     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #     platforms:
+      #       - linux_musl_arm
+      #       - linux_musl_arm64
+      #       - windows_x86
+      #       - windows_arm64
+      #       - linux_arm
+      #     jobParameters:
+      #       liveRuntimeBuildConfig: release
+      #       liveLibrariesBuildConfig: Release
+      #       runOnlyIfDependenciesSucceeded: true
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
-          buildConfig: Release
-          platforms:
-            - osx_arm64
-            - osx_x64
-            - linux_x64
-            - linux_arm64
-            - linux_musl_x64
-            - windows_x64
-            - freebsd_x64
-          jobParameters:
-            liveRuntimeBuildConfig: release
-            liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-            runOnlyIfDependenciesSucceeded: true
-            condition:
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
+      #     buildConfig: Release
+      #     platforms:
+      #       - osx_arm64
+      #       - osx_x64
+      #       - linux_x64
+      #       - linux_arm64
+      #       - linux_musl_x64
+      #       - windows_x64
+      #       - freebsd_x64
+      #     jobParameters:
+      #       liveRuntimeBuildConfig: release
+      #       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #       runOnlyIfDependenciesSucceeded: true
+      #       condition:
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # CoreCLR Test builds using live libraries release build
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-          buildConfig: checked
-          platforms:
-          - CoreClrTestBuildHost # Either osx_x64 or linux_x64
-          jobParameters:
-            testGroup: innerloop
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # CoreCLR Test builds using live libraries release build
+      # # Only when CoreCLR is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - CoreClrTestBuildHost # Either osx_x64 or linux_x64
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      #
-      # CoreCLR Test executions using live libraries
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-          buildConfig: checked
-          platforms:
-          - linux_arm
-          - windows_x86
-          - windows_arm64
-          helixQueueGroup: pr
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testGroup: innerloop
-            liveLibrariesBuildConfig: Release
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # #
+      # # CoreCLR Test executions using live libraries
+      # # Only when CoreCLR is changed
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - linux_arm
+      #     - windows_x86
+      #     - windows_arm64
+      #     helixQueueGroup: pr
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       liveLibrariesBuildConfig: Release
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-          buildConfig: checked
-          platforms:
-          - osx_x64
-          - linux_x64
-          - linux_arm64
-          - windows_x64
-          helixQueueGroup: pr
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testGroup: innerloop
-            liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - osx_x64
+      #     - linux_x64
+      #     - linux_arm64
+      #     - windows_x64
+      #     helixQueueGroup: pr
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-          buildConfig: checked
-          platforms:
-          - osx_arm64
-          helixQueueGroup: pr
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testGroup: innerloop
-            liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_AppleSilicon.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - osx_arm64
+      #     helixQueueGroup: pr
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testGroup: innerloop
+      #       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      #       condition: >-
+      #         or(
+      #           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_AppleSilicon.containsChange'], true),
+      #           eq(variables['isRollingBuild'], true))
 
       #
       # Mono Test builds with CoreCLR runtime tests using live libraries debug build

--- a/src/libraries/Common/tests/System/TimeProviderTests.cs
+++ b/src/libraries/Common/tests/System/TimeProviderTests.cs
@@ -109,6 +109,7 @@ namespace Tests.System
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(TimersProvidersData))]
         public void TestProviderTimer(TimeProvider provider, int MaxMilliseconds)
         {
@@ -215,6 +216,7 @@ namespace Tests.System
 #endif // NETFRAMEWORK
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(TimersProvidersListData))]
         public static void CancellationTokenSourceWithTimer(TimeProvider provider)
         {

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -284,6 +284,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void BindingDoesNotThrowIfReloadedDuringBinding()
         {
             var dic = new Dictionary<string, string>

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -286,6 +286,7 @@ CommonKey3:CommonKey4=IniValue6";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void CanOverrideValuesWithNewConfigurationProvider()
         {
             WriteTestFiles();
@@ -940,6 +941,7 @@ IniKey1=IniValue2");
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void BindingDoesNotThrowIfReloadedDuringBinding()
         {
             WriteTestFiles();

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
@@ -285,6 +285,7 @@ namespace Microsoft.Extensions.Hosting.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPattern.Program))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/73420", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void NoSpecialEntryPointPatternCanRunInParallel()
         {
             var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPattern.Program).Assembly, s_WaitTimeout);

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
@@ -1204,6 +1204,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddHttpClient_GetAwaiterAndResult_InSingleThreadedSynchronizationContext_ShouldNotHangs()
         {
             // Arrange
@@ -1367,6 +1368,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91673", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddHttpClient_ConfigurePrimaryHttpMessageHandler_ApplyChangesPrimaryHandler()
         {
             // Arrange

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ConsoleLoggerOptions_TimeStampFormat_IsReloaded()
         {
             // Arrange
@@ -87,6 +88,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(FormatterNames))]
         public void InvalidLogLevel_Throws(string formatterName)
         {
@@ -101,6 +103,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(FormatterNamesAndLevels))]
         public void NoMessageOrException_Noop(string formatterName, LogLevel level)
         {
@@ -120,6 +123,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(FormatterNamesAndLevels))]
         public void Log_LogsCorrectTimestamp(string formatterName, LogLevel level)
         {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(FormatterNames))]
         public void AddConsole_ConsoleLoggerOptionsFromConfigFile_IsReadFromLoggingConfiguration(string formatterName)
         {
@@ -155,6 +156,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddSimpleConsole_ChangeProperties_IsReadFromLoggingConfiguration()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] {
@@ -185,6 +187,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddSimpleConsole_OutsideConfig_TakesProperty()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] {
@@ -215,6 +218,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddSystemdConsole_ChangeProperties_IsReadFromLoggingConfiguration()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] {
@@ -241,6 +245,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddSystemdConsole_OutsideConfig_TakesProperty()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] {
@@ -271,6 +276,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddJsonConsole_ChangeProperties_IsReadFromLoggingConfiguration()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] {
@@ -299,6 +305,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddJsonConsole_OutsideConfig_TakesProperty()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] {
@@ -333,6 +340,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddConsole_NullFormatterNameUsingSystemdFormat_AnyDeprecatedPropertiesOverwriteFormatterOptions()
         {
             var configs = new[] {
@@ -378,6 +386,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddConsole_MaxQueueLengthLargerThanZero_ConfiguredProperly()
         {
             var configs = new[] {
@@ -399,6 +408,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddConsole_NullFormatterName_UsingSystemdFormat_IgnoreFormatterOptionsAndUseDeprecatedInstead()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] {
@@ -431,6 +441,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddConsole_NullFormatterName_UsingDefaultFormat_IgnoreFormatterOptionsAndUseDeprecatedInstead()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] {
@@ -470,6 +481,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData("missingFormatter")]
         [InlineData("simple")]
         [InlineData("Simple")]
@@ -513,6 +525,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData("missingFormatter")]
         [InlineData("systemd")]
         [InlineData("Systemd")]

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         private const string _loggerName = "test";
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void LogAfterDisposeWritesLog()
         {
             // Arrange
@@ -63,6 +64,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(-1)]
         [InlineData(0)]
         public static void MaxQueueLength_SetInvalid_Throws(int invalidMaxQueueLength)

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -174,6 +174,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void LogsWhenMessageIsNotProvided()
         {
             // Arrange
@@ -206,6 +207,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void DoesNotLog_NewLine_WhenNoExceptionIsProvided()
         {
             // Arrange
@@ -234,6 +236,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(null, 0)]
         [InlineData(null, 1)]
         [InlineData("missingFormatter", 0)]
@@ -276,6 +279,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData("Route with name 'Simple' was not found.")]
         public void Writes_NewLine_WhenExceptionIsProvided(string message)
         {
@@ -300,6 +304,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ThrowsException_WhenNoFormatterIsProvided()
         {
             // Arrange
@@ -311,6 +316,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void LogsWhenNullFilterGiven()
         {
             // Arrange
@@ -332,6 +338,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void WriteCritical_LogsCorrectColors()
         {
             // Arrange
@@ -353,6 +360,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void WriteError_LogsCorrectColors()
         {
             // Arrange
@@ -374,6 +382,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void WriteWarning_LogsCorrectColors()
         {
             // Arrange
@@ -395,6 +404,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void WriteInformation_LogsCorrectColors()
         {
             // Arrange
@@ -446,6 +456,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void WriteDebug_LogsCorrectColors()
         {
             // Arrange
@@ -467,6 +478,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void WriteTrace_LogsCorrectColors()
         {
             // Arrange
@@ -488,6 +500,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void WriteAllLevelsDisabledColors_LogsNoColors()
         {
             // Arrange
@@ -512,6 +525,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(FormatsAndLevels))]
         public void Log_LogsCorrectTimestamp(ConsoleLoggerFormat format, LogLevel level)
         {
@@ -553,6 +567,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(FormatsAndLevels))]
         public void WriteCore_LogsCorrectTimestampInUtc(ConsoleLoggerFormat format, LogLevel level)
         {
@@ -594,6 +609,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(FormatsAndLevels))]
         public void WriteCore_LogsCorrectMessages(ConsoleLoggerFormat format, LogLevel level)
         {
@@ -638,6 +654,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void NoLogScope_DoesNotWriteAnyScopeContentToOutput()
         {
             // Arrange
@@ -659,6 +676,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void WritingScopes_LogsWithCorrectColors()
         {
             // Arrange
@@ -685,6 +703,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(Formats))]
         public void WritingScopes_LogsExpectedMessage(ConsoleLoggerFormat format)
         {
@@ -736,6 +755,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(Formats))]
         public void WritingNestedScope_LogsNullScopeName(ConsoleLoggerFormat format)
         {
@@ -785,6 +805,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(Formats))]
         public void WritingNestedScopes_LogsExpectedMessage(ConsoleLoggerFormat format)
         {
@@ -843,6 +864,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(Formats))]
         public void WritingMultipleScopes_LogsExpectedMessage(ConsoleLoggerFormat format)
         {
@@ -912,6 +934,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void CallingBeginScopeOnLogger_AlwaysReturnsNewDisposableInstance()
         {
             // Arrange
@@ -930,6 +953,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void CallingBeginScopeOnLogger_ReturnsNonNullableInstance()
         {
             // Arrange
@@ -945,6 +969,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(Formats))]
         public void ConsoleLoggerLogsToError_WhenOverErrorLevel(ConsoleLoggerFormat format)
         {
@@ -995,6 +1020,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(FormatsAndLevels))]
         public void WriteCore_NullMessageWithException(ConsoleLoggerFormat format, LogLevel level)
         {
@@ -1039,6 +1065,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(FormatsAndLevels))]
         public void WriteCore_EmptyMessageWithException(ConsoleLoggerFormat format, LogLevel level)
         {
@@ -1082,6 +1109,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(FormatsAndLevels))]
         public void WriteCore_MessageWithNullException(ConsoleLoggerFormat format, LogLevel level)
         {
@@ -1122,6 +1150,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(Levels))]
         public void WriteCore_NullMessageWithNullException(LogLevel level)
         {
@@ -1140,6 +1169,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void IsEnabledReturnsCorrectValue()
         {
             var logger = SetUp().Logger;
@@ -1154,6 +1184,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ConsoleLoggerOptions_DisableColors_IsAppliedToLoggers()
         {
             // Arrange
@@ -1188,6 +1219,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ConsoleLoggerOptions_DisableColors_IsReadFromLoggingConfiguration()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] { new KeyValuePair<string, string>("Console:DisableColors", "true") }).Build();
@@ -1205,6 +1237,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ConsoleLoggerOptions_TimeStampFormat_IsReloaded()
         {
             // Arrange
@@ -1219,6 +1252,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ConsoleLoggerOptions_TimeStampFormat_IsReadFromLoggingConfiguration()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] { new KeyValuePair<string, string>("Console:TimeStampFormat", "yyyyMMddHHmmss") }).Build();
@@ -1236,6 +1270,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ConsoleLoggerOptions_TimeStampFormat_MultipleReloads()
         {
             var monitor = new TestOptionsMonitor(new ConsoleLoggerOptions());
@@ -1250,6 +1285,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ConsoleLoggerOptions_IncludeScopes_IsAppliedToLoggers()
         {
             // Arrange
@@ -1264,6 +1300,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ConsoleLoggerOptions_LogAsErrorLevel_IsReadFromLoggingConfiguration()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] { new KeyValuePair<string, string>("Console:LogToStandardErrorThreshold", "Warning") }).Build();
@@ -1281,6 +1318,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ConsoleLoggerOptions_LogAsErrorLevel_IsAppliedToLoggers()
         {
             // Arrange
@@ -1295,6 +1333,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ConsoleLoggerOptions_UpdateQueueOptions_UpdatesConsoleLoggerProcessorProperties()
         {
             // Arrange
@@ -1314,6 +1353,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ConsoleLoggerOptions_UseUtcTimestamp_IsAppliedToLoggers()
         {
             // Arrange
@@ -1328,6 +1368,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ConsoleLoggerOptions_IncludeScopes_IsReadFromLoggingConfiguration()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] { new KeyValuePair<string, string>("Console:IncludeScopes", "true") }).Build();

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
     public class JsonConsoleFormatterTests : ConsoleFormatterTests
     {
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void NoLogScope_DoesNotWriteAnyScopeContentToOutput_Json()
         {
             // Arrange
@@ -79,6 +80,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Log_NullMessage_LogsWhenMessageIsNotProvided()
         {
             // Arrange
@@ -123,6 +125,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Log_ExceptionWithMessage_ExtractsInfo()
         {
             // Arrange
@@ -177,6 +180,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Log_IncludeScopes_ContainsDuplicateNamedPropertiesInScope_AcceptableJson()
         {
             // Arrange
@@ -210,6 +214,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Log_StateAndScopeAreCollections_IncludesMessageAndCollectionValues()
         {
             // Arrange
@@ -245,6 +250,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(SpecialCaseValues))]
         public void Log_StateAndScopeContainsSpecialCaseValue_SerializesValueAsExpected(object value, string expectedJsonValue)
         {
@@ -275,6 +281,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(FloatingPointValues))]
         public void Log_StateAndScopeContainsFloatingPointType_SerializesValue(object value)
         {
@@ -314,6 +321,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Log_StateAndScopeContainsNullValue_SerializesNull()
         {
             // Arrange
@@ -343,6 +351,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Log_ScopeIsIEnumerable_SerializesKeyValuePair()
         {
             // Arrange

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
     public class SimpleConsoleFormatterTests : ConsoleFormatterTests
     {
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(LoggerColorBehavior.Default)]
         [InlineData(LoggerColorBehavior.Enabled)]
         [InlineData(LoggerColorBehavior.Disabled)]
@@ -54,6 +55,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Log_NoLogScope_DoesNotWriteAnyScopeContentToOutput()
         {
             // Arrange
@@ -109,6 +111,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Log_SingleLine_LogsWhenBothMessageAndExceptionProvided()
         {
             // Arrange

--- a/src/libraries/System.Collections.NonGeneric/tests/QueueTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/QueueTests.cs
@@ -913,6 +913,7 @@ namespace System.Collections.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void SynchronizedEnqueue()
         {
             // Enqueue

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/TimerTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/TimerTests.cs
@@ -36,6 +36,7 @@ namespace System.Timers.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void TestTimerStartAutoReset()
         {
             using (var timer = new TestTimer(1))

--- a/src/libraries/System.Composition/tests/ConcurrencyTests.cs
+++ b/src/libraries/System.Composition/tests/ConcurrencyTests.cs
@@ -28,6 +28,7 @@ namespace System.Composition.UnitTests
         // This does not test the desired behaviour deterministically,
         // but is close enough to be repeatable at least on my machine :)
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void SharedInstancesAreNotVisibleUntilActivationCompletes()
         {
             var c = CreateContainer(typeof(PausesDuringActivation));

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoAsync.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoAsync.cs
@@ -30,6 +30,7 @@ namespace System.Globalization.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void TestCurrentCulturesWithAwait()
         {
             var newCurrentCulture = new CultureInfo(CultureInfo.CurrentCulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "en-US" : "ja-JP");

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -294,6 +294,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91547", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task CompleteWithLargeWriteThrows()
         {
             var completeDelay = TimeSpan.FromMilliseconds(10);

--- a/src/libraries/System.IO.Pipelines/tests/SchedulerFacts.cs
+++ b/src/libraries/System.IO.Pipelines/tests/SchedulerFacts.cs
@@ -181,6 +181,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task DefaultReaderSchedulerRunsOnThreadPool()
         {
             var pipe = new Pipe(new PipeOptions(useSynchronizationContext: false));
@@ -210,6 +211,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task DefaultWriterSchedulerRunsOnThreadPool()
         {
             using (var pool = new TestMemoryPool())
@@ -411,6 +413,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task FlushCallbackRunsOnWriterScheduler()
         {
             using (var pool = new TestMemoryPool())
@@ -456,6 +459,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task ReadAsyncCallbackRunsOnReaderScheduler()
         {
             using (var pool = new TestMemoryPool())
@@ -489,6 +493,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task ThreadPoolScheduler_SchedulesOnThreadPool()
         {
             var pipe = new Pipe(new PipeOptions(readerScheduler: PipeScheduler.ThreadPool, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false));

--- a/src/libraries/System.Linq.Parallel/tests/ExchangeTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/ExchangeTests.cs
@@ -89,6 +89,7 @@ namespace System.Linq.Parallel.Tests
         // or WithMergeOptions
 
         [ConditionalTheory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(PartitioningData), new[] { 0, 1, 2, 16, 1024 })]
         public static void Partitioning_Default(Labeled<ParallelQuery<int>> labeled, int count, int partitions)
         {
@@ -158,6 +159,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(ThrowOnCount_AllMergeOptions_MemberData), new[] { 4, 8 })]
         // FailingMergeData has enumerables that throw errors when attempting to perform the nth enumeration.
         // This test checks whether the query runs in a pipelined or buffered fashion.
@@ -167,6 +169,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(MergeData), new[] { 4, 8 })]
         // This test checks whether the query runs in a pipelined or buffered fashion.
         public static void Merge_Ordered_Pipelining_Select(Labeled<ParallelQuery<int>> labeled, int count, ParallelMergeOptions options)

--- a/src/libraries/System.Linq.Parallel/tests/PlinqModesTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/PlinqModesTests.cs
@@ -136,6 +136,7 @@ namespace System.Linq.Parallel.Tests
 
         // Check that some queries run in parallel by default, and some require forcing.
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91661", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(WithExecutionModeQueryData), new[] { 1, 4 })] // DOP of 1 to verify sequential and 4 to verify parallel
         public static void WithExecutionMode(
             Labeled<ParallelQuery<int>> labeled,

--- a/src/libraries/System.Linq.Parallel/tests/QueryOperators/GetEnumeratorTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/QueryOperators/GetEnumeratorTests.cs
@@ -165,6 +165,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void GetEnumerator_LargeQuery_PauseAfterOpening()
         {
             using (IEnumerator<int> e = Enumerable.Range(0, 8192).AsParallel().SkipWhile(i => true).GetEnumerator())

--- a/src/libraries/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
@@ -517,6 +517,7 @@ namespace System.Linq.Parallel.Tests
         // Heavily exercises OrderBy, but only throws one user delegate exception to simulate an occasional failure.
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(OrderByThreadedData), new[] { 1, 2, 16, 128, 1024 }, new[] { 1, 2, 4, 7, 8, 31, 32 })]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void OrderBy_ThreadedDeadlock_SingleException(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {
             int countdown = Math.Min(count / 2, degree) + 1;

--- a/src/libraries/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
@@ -69,6 +69,7 @@ namespace System.Xml.XmlReaderTests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void ReadAsyncAfterInitializationWithUriThrows()
         {
             using (XmlReader reader = XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = true }))
@@ -78,6 +79,7 @@ namespace System.Xml.XmlReaderTests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void ReadAfterInitializationWithUriOnAsyncReaderTrows()
         {
             using (XmlReader reader = XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = true }))
@@ -87,6 +89,7 @@ namespace System.Xml.XmlReaderTests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void InitializationWithUriOnNonAsyncReaderThrows()
         {
             Assert.Throws<System.Net.Http.HttpRequestException>(() => XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = false }));

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslTransformMultith.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslTransformMultith.cs
@@ -78,6 +78,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): Reader - Basic Test")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc1()
         {
             Load("xslt_multithreading_test.xsl", "foo.xml");
@@ -98,6 +99,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): Reader - QFE 505 Repro")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc2()
         {
             using (new AllowDefaultResolverContext())
@@ -119,6 +121,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): Reader - AVTs")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc3()
         {
             Load("xslt_multith_AVTs.xsl", "xslt_multith_AVTs.xml");
@@ -139,6 +142,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): Reader - xsl:key")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc4()
         {
             Load("xslt_multith_keytest.xsl", "xslt_multith_keytest.xml");
@@ -159,6 +163,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): Reader - xsl:sort")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc5()
         {
             Load("xslt_multith_sorting.xsl", "xslt_multith_sorting.xml");
@@ -179,6 +184,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): Reader - Attribute Sets")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc6()
         {
             Load("xslt_mutith_attribute_sets.xsl", "xslt_mutith_attribute_sets.xml");
@@ -199,6 +205,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): Reader - Boolean Expression AND")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc7()
         {
             Load("xslt_mutith_boolean_expr_and.xsl", "xslt_mutith_boolean_expr_and.xml");
@@ -219,6 +226,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): Reader - Boolean Expression OR")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc8()
         {
             Load("xslt_mutith_boolean_expr_or.xsl", "xslt_mutith_boolean_expr_or.xml");
@@ -239,6 +247,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): Reader - FormatNumber function")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc9()
         {
             Load("xslt_mutith_format_number.xsl", "xslt_mutith_format_number.xml");
@@ -259,6 +268,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): Reader - Position() function")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc10()
         {
             Load("xslt_mutith_position_func.xsl", "xslt_mutith_position_func.xml");
@@ -279,6 +289,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): Reader - preserve space")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc11()
         {
             Load("xslt_mutith_preserve_space.xsl", "xslt_mutith_preserve_space.xml");
@@ -299,6 +310,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): Reader - Variable nodeset")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc12()
         {
             Load("xslt_mutith_variable_nodeset.xsl", "xslt_mutith_variable_nodeset.xml");
@@ -365,6 +377,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): TextWriter - Basic Test")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc1()
         {
             Load("xslt_multithreading_test.xsl", "foo.xml");
@@ -385,6 +398,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): TextWriter - QFE 505 Repro")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc2()
         {
             using (new AllowDefaultResolverContext())
@@ -406,6 +420,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): TextWriter - AVTs")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc3()
         {
             Load("xslt_multith_AVTs.xsl", "xslt_multith_AVTs.xml");
@@ -426,6 +441,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): TextWriter - xsl:key")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc4()
         {
             Load("xslt_multith_keytest.xsl", "xslt_multith_keytest.xml");
@@ -446,6 +462,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): TextWriter - xsl:sort")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc5()
         {
             Load("xslt_multith_sorting.xsl", "xslt_multith_sorting.xml");
@@ -466,6 +483,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): TextWriter - Attribute Sets")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc6()
         {
             Load("xslt_mutith_attribute_sets.xsl", "xslt_mutith_attribute_sets.xml");
@@ -486,6 +504,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): TextWriter - Boolean Expression AND")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc7()
         {
             Load("xslt_mutith_boolean_expr_and.xsl", "xslt_mutith_boolean_expr_and.xml");
@@ -506,6 +525,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): TextWriter - Boolean Expression OR")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc8()
         {
             Load("xslt_mutith_boolean_expr_or.xsl", "xslt_mutith_boolean_expr_or.xml");
@@ -526,6 +546,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): TextWriter - FormatNumber function")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc9()
         {
             Load("xslt_mutith_format_number.xsl", "xslt_mutith_format_number.xml");
@@ -546,6 +567,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): TextWriter - Position() function")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc10()
         {
             Load("xslt_mutith_position_func.xsl", "xslt_mutith_position_func.xml");
@@ -566,6 +588,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): TextWriter - preserve space")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc11()
         {
             Load("xslt_mutith_preserve_space.xsl", "xslt_mutith_preserve_space.xml");
@@ -586,6 +609,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple Transform(): TextWriter - Variable nodeset")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc12()
         {
             Load("xslt_mutith_variable_nodeset.xsl", "xslt_mutith_variable_nodeset.xml");

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentListMultith.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentListMultith.cs
@@ -105,6 +105,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple GetParam for same parameter name")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc1()
         {
             CThreads rThreads = new CThreads(_output);
@@ -123,6 +124,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple GetParam for different parameter name")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc2()
         {
             CThreads rThreads = new CThreads(_output);
@@ -190,6 +192,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple GetExtensionObject for same namespace System.Xml.Tests")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc1()
         {
             CThreads rThreads = new CThreads(_output);
@@ -208,6 +211,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
         //[Variation("Multiple GetExtensionObject for different namespace System.Xml.Tests")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc2()
         {
             CThreads rThreads = new CThreads(_output);
@@ -276,6 +280,7 @@ namespace System.Xml.XslCompiledTransformApiTests
         ////////////////////////////////////////////////////////////////
         //[Variation("Multiple transforms using shared ArgumentList")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc1()
         {
             CThreads rThreads = new CThreads(_output);

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransformMultith.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransformMultith.cs
@@ -76,6 +76,7 @@ namespace System.Xml.XslTransformApiTests
         [InlineData("xslt_mutith_variable_global_forward_ref_deep.xsl", "xslt_mutith_variable_nodeset.xml")]
         //[Variation("Local and global variables", Params = new object[] { "xslt_mutith_variable_local_and_global.xsl", "xslt_mutith_variable_local_and_global.xsl" })]
         [InlineData("xslt_mutith_variable_local_and_global.xsl", "xslt_mutith_variable_local_and_global.xsl")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Variations(object param0, object param1)
         {

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXsltArgumentListMultith.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXsltArgumentListMultith.cs
@@ -105,6 +105,7 @@ namespace System.Xml.XslTransformApiTests
 
         //[Variation("Multiple GetParam for same parameter name")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc1()
         {
             CThreads rThreads = new CThreads(_output);
@@ -123,6 +124,7 @@ namespace System.Xml.XslTransformApiTests
 
         //[Variation("Multiple GetParam for different parameter name")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc2()
         {
             CThreads rThreads = new CThreads(_output);
@@ -189,6 +191,7 @@ namespace System.Xml.XslTransformApiTests
 
         //[Variation("Multiple GetExtensionObject for same namespace System.Xml.Tests")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc1()
         {
             CThreads rThreads = new CThreads(_output);
@@ -207,6 +210,7 @@ namespace System.Xml.XslTransformApiTests
 
         //[Variation("Multiple GetExtensionObject for different namespace System.Xml.Tests")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc2()
         {
             CThreads rThreads = new CThreads(_output);
@@ -275,6 +279,7 @@ namespace System.Xml.XslTransformApiTests
         ////////////////////////////////////////////////////////////////
         //[Variation("Multiple transforms using shared ArgumentList")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void proc1()
         {
             CThreads rThreads = new CThreads(_output);

--- a/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -59,6 +59,7 @@ namespace System.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void CurrentManagedThreadId_DifferentForActiveThreads()
         {
             var ids = new HashSet<int>();

--- a/src/libraries/System.Runtime.Extensions/tests/System/Progress.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Progress.cs
@@ -18,6 +18,7 @@ namespace System.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void NoWorkQueuedIfNoHandlers()
         {
             RunWithoutSyncCtx(() =>

--- a/src/libraries/System.Runtime.Extensions/tests/System/Random.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Random.cs
@@ -516,6 +516,7 @@ namespace System.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Shared_ParallelUsage()
         {
             using var barrier = new Barrier(2);

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -16,6 +16,7 @@ using Xunit;
 public static class XmlDictionaryWriterTest
 {
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
     public static void XmlBaseWriter_WriteBase64Async()
     {
         string actual;
@@ -63,6 +64,7 @@ public static class XmlDictionaryWriterTest
     }
 
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
     public static void XmlBaseWriter_FlushAsync()
     {
         string actual = null;
@@ -143,6 +145,7 @@ public static class XmlDictionaryWriterTest
     }
 
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
     public static void XmlBaseWriter_CheckAsync_ThrowInvalidOperationException()
     {
         int byteSize = 1024;
@@ -518,7 +521,7 @@ public static class XmlDictionaryWriterTest
             {
                 for (int i = 0; i < chars.Length; ++i)
                     chars[i] = (char)(i % 128);
-                chars[^1] = '\u00E4'; // 'ä' - Latin Small Letter a with Diaeresis. Latin-1 Supplement.
+                chars[^1] = '\u00E4'; // 'ï¿½' - Latin Small Letter a with Diaeresis. Latin-1 Supplement.
             });
 
             int numBytes = Encoding.UTF8.GetBytes(allAscii, buffer);

--- a/src/libraries/System.Runtime/tests/System/Attributes.cs
+++ b/src/libraries/System.Runtime/tests/System/Attributes.cs
@@ -327,6 +327,7 @@ namespace System.Tests
     {
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91597", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void customAttributeCount()
         {
             List<CustomAttributeData> customAttributes = typeof(GetCustomAttribute).Module.CustomAttributes.ToList();

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForEachAsyncTests.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForEachAsyncTests.cs
@@ -293,6 +293,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Dop_NegativeTaskSchedulerLimitTreatedAsDefault_Async()
         {
             static async IAsyncEnumerable<int> IterateUntilSet(StrongBox<bool> box)
@@ -327,6 +328,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task RunsAsynchronously_For()
         {
             var cts = new CancellationTokenSource();
@@ -340,6 +342,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task RunsAsynchronously_EvenForEntirelySynchronousWork_Sync()
         {
             static IEnumerable<int> Iterate()
@@ -358,6 +361,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task RunsAsynchronously_EvenForEntirelySynchronousWork_Async()
         {
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
@@ -378,6 +382,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(-1)]
         [InlineData(1)]
         [InlineData(2)]
@@ -417,6 +422,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void EmptyRange_For()
         {
             int counter = 0;
@@ -431,6 +437,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task EmptySource_Sync()
         {
             int counter = 0;
@@ -444,6 +451,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task EmptySource_Async()
         {
             int counter = 0;
@@ -457,6 +465,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task AllItemsEnumeratedOnce_For(bool yield)
@@ -502,6 +511,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task AllItemsEnumeratedOnce_Sync(bool yield)
@@ -532,6 +542,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task AllItemsEnumeratedOnce_Async(bool yield)
@@ -562,6 +573,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task TaskScheduler_AllCodeExecutedOnCorrectScheduler_For(bool defaultScheduler)
@@ -590,6 +602,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task TaskScheduler_AllCodeExecutedOnCorrectScheduler_Sync(bool defaultScheduler)
@@ -628,6 +641,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task TaskScheduler_AllCodeExecutedOnCorrectScheduler_Async(bool defaultScheduler)
@@ -667,6 +681,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Cancellation_CancelsIterationAndReturnsCanceledTask_For()
         {
             using var cts = new CancellationTokenSource(10);
@@ -699,6 +714,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Cancellation_CancelsIterationAndReturnsCanceledTask_Async()
         {
             static async IAsyncEnumerable<int> InfiniteAsync()
@@ -720,6 +736,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Cancellation_CorrectTokenPassedToAsyncEnumerator()
         {
             static async IAsyncEnumerable<CancellationToken> YieldTokenAsync([EnumeratorCancellation] CancellationToken cancellationToken)
@@ -736,6 +753,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Cancellation_SameTokenPassedToEveryInvocation_For()
         {
             var cq = new ConcurrentQueue<CancellationToken>();
@@ -751,6 +769,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Cancellation_SameTokenPassedToEveryInvocation_Sync()
         {
             var cq = new ConcurrentQueue<CancellationToken>();
@@ -766,6 +785,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Cancellation_SameTokenPassedToEveryInvocation_Async()
         {
             var cq = new ConcurrentQueue<CancellationToken>();
@@ -781,6 +801,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Cancellation_HasPriorityOverExceptions_For()
         {
             var tcs = new TaskCompletionSource();
@@ -807,6 +828,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Cancellation_HasPriorityOverExceptions_Sync()
         {
             static IEnumerable<int> Iterate()
@@ -839,6 +861,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Cancellation_HasPriorityOverExceptions_Async()
         {
             static async IAsyncEnumerable<int> Iterate()
@@ -875,6 +898,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task Cancellation_FaultsForOceForNonCancellation_For(bool internalToken)
@@ -891,6 +915,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task Cancellation_FaultsForOceForNonCancellation(bool internalToken)
@@ -917,6 +942,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(0, 4)]
         [InlineData(1, 4)]
         [InlineData(2, 4)]
@@ -949,6 +975,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(0, 4)]
         [InlineData(1, 4)]
         [InlineData(2, 4)]
@@ -981,6 +1008,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Exception_FromGetEnumerator_Sync()
         {
             Task t = Parallel.ForEachAsync((IEnumerable<int>)new ThrowsFromGetEnumerator(), (item, cancellationToken) => default);
@@ -990,6 +1018,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Exception_FromGetEnumerator_Async()
         {
             Task t = Parallel.ForEachAsync((IAsyncEnumerable<int>)new ThrowsFromGetEnumerator(), (item, cancellationToken) => default);
@@ -999,6 +1028,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Exception_NullFromGetEnumerator_Sync()
         {
             Task t = Parallel.ForEachAsync((IEnumerable<int>)new ReturnsNullFromGetEnumerator(), (item, cancellationToken) => default);
@@ -1008,6 +1038,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Exception_NullFromGetEnumerator_Async()
         {
             Task t = Parallel.ForEachAsync((IAsyncEnumerable<int>)new ReturnsNullFromGetEnumerator(), (item, cancellationToken) => default);
@@ -1017,6 +1048,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Exception_FromMoveNext_Sync()
         {
             static IEnumerable<int> Iterate()
@@ -1037,6 +1069,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Exception_FromMoveNext_Async()
         {
             static async IAsyncEnumerable<int> Iterate()
@@ -1058,6 +1091,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Exception_FromLoopBody_For()
         {
             var barrier = new Barrier(2);
@@ -1079,6 +1113,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Exception_FromLoopBody_Sync()
         {
             static IEnumerable<int> Iterate()
@@ -1106,6 +1141,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Exception_FromLoopBody_Async()
         {
             static async IAsyncEnumerable<int> Iterate()
@@ -1147,6 +1183,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Exception_FromDispose_Sync()
         {
             Task t = Parallel.ForEachAsync((IEnumerable<int>)new ThrowsExceptionFromDispose(), (item, cancellationToken) => default);
@@ -1155,6 +1192,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Exception_FromDispose_Async()
         {
             Task t = Parallel.ForEachAsync((IAsyncEnumerable<int>)new ThrowsExceptionFromDispose(), (item, cancellationToken) => default);
@@ -1163,6 +1201,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Exception_FromDisposeAndCancellationCallback_Sync()
         {
             Task t = Parallel.ForEachAsync((IEnumerable<int>)new ThrowsExceptionFromDisposeAndCancellationCallback(), (item, cancellationToken) => default);
@@ -1172,6 +1211,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Exception_FromDisposeAndCancellationCallback_Async()
         {
             Task t = Parallel.ForEachAsync((IAsyncEnumerable<int>)new ThrowsExceptionFromDisposeAndCancellationCallback(), (item, cancellationToken) => default);
@@ -1181,6 +1221,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Exception_ImplicitlyCancelsOtherWorkers_For()
         {
             await Assert.ThrowsAsync<Exception>(() => Parallel.ForAsync(0, long.MaxValue, async (item, cancellationToken) =>
@@ -1209,6 +1250,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task Exception_ImplicitlyCancelsOtherWorkers_Sync()
         {
             static IEnumerable<int> Iterate()
@@ -1314,6 +1356,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ExecutionContext_FlowsToWorkerBodies_For(bool defaultScheduler)
@@ -1332,6 +1375,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ExecutionContext_FlowsToWorkerBodies_Sync(bool defaultScheduler)

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
@@ -289,6 +289,7 @@ namespace System.Threading.Tasks.Tests
         [InlineData(1024)]
         [InlineData(1024 * 1024)]
         [InlineData(1024 * 1024 * 16)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void RunSimpleParallelForIncrementTest(int increms)
         {
             // Just increments a shared counter in a loop.
@@ -319,6 +320,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(-1)]
         [InlineData(0)]
         [InlineData(1)]
@@ -452,6 +454,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(1024)]
@@ -481,6 +484,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(1024)]
@@ -511,6 +515,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(1024)]
@@ -541,6 +546,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(1024)]
@@ -572,6 +578,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(1024)]
@@ -711,6 +718,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void TestParallelForPaths()
         {
             int loopsize = 1000;
@@ -872,6 +880,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void TestParallelForPaths_Exceptions()
         {
             int loopsize = 1000;
@@ -885,6 +894,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91582", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void TestParallelScheduler()
         {
             ParallelOptions parallelOptions = new ParallelOptions();
@@ -992,6 +1002,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void TestInvokeDOPAndCancel()
         {
             ParallelOptions parallelOptions = null;
@@ -1109,6 +1120,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void RunParallelLoopCancellationTests()
         {
             int counter = 0; // Counts the actual number of iterations
@@ -1211,6 +1223,7 @@ namespace System.Threading.Tasks.Tests
         /// Test to ensure that the task ID can be accessed from inside the task
         /// </summary>
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91583", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void TaskIDFromExternalContextTest()
         {
             int? withinTaskId = int.MinValue;
@@ -1242,6 +1255,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void CancelForIntTest()
         {
             for (int i = 0; i < 100; ++i)
@@ -1276,6 +1290,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void CancelForLongTest()
         {
             for (int i = 0; i < 100; ++i)
@@ -1317,6 +1332,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(CancelForEachTest_MemberData))]
         public static void CancelForEachTest(IEnumerable<int> enumerable)
         {

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelLoopResultTests.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelLoopResultTests.cs
@@ -373,6 +373,7 @@ Parallel.For(1L, 0L, delegate (long i, ParallelLoopState ps)
 
         // Perform tests on various combinations of Stop()/Break()
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91579", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void SimultaneousStopBreakTests()
         {
             //

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/RangePartitioner1Chunk.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/RangePartitioner1Chunk.cs
@@ -101,6 +101,7 @@ namespace System.Threading.Tasks.Tests
         /// </summary>
         /// <param name="length"></param>
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void IterationsWithDependency()
         {
             static void iterationsWithDependency(int length, int dependencyIndex)
@@ -166,6 +167,7 @@ namespace System.Threading.Tasks.Tests
         /// Exception is expected and the enumerators are disposed
         /// </summary>
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91581", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void ExceptionOnMoveNext()
         {
             static void exceptionOnMoveNext(int length, int indexToThrow, bool isOrderable)

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/RangePartitionerTests.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/RangePartitionerTests.cs
@@ -10,6 +10,7 @@ namespace System.Threading.Tasks.Tests
     public static class RangePartitionerTests
     {
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void RunPartitionerStaticTest_SingleChunking()
         {
             CountdownEvent cde = new CountdownEvent(2);

--- a/src/libraries/System.Threading.Timer/tests/TimerChangeTests.cs
+++ b/src/libraries/System.Threading.Timer/tests/TimerChangeTests.cs
@@ -50,6 +50,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]

--- a/src/libraries/System.Threading.Timer/tests/TimerDisposeTests.cs
+++ b/src/libraries/System.Threading.Timer/tests/TimerDisposeTests.cs
@@ -50,6 +50,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task DisposeAsync_DisposeDelayedUntilCallbacksComplete()
         {
             using (var b = new Barrier(2))
@@ -72,6 +73,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task DisposeAsync_MultipleDisposesBeforeCompletionReturnSameTask()
         {
             using (var b = new Barrier(2))
@@ -97,6 +99,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task DisposeAsync_AfterDisposeWorks()
         {
             using (var b = new Barrier(2))
@@ -120,6 +123,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task DisposeAsync_AfterDisposeWaitHandleThrows()
         {
             using (var b = new Barrier(2))
@@ -142,6 +146,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task DisposeAsync_ThenDisposeWaitHandleReturnsFalse()
         {
             using (var b = new Barrier(2))

--- a/src/libraries/System.Threading.Timer/tests/TimerFiringTests.cs
+++ b/src/libraries/System.Threading.Timer/tests/TimerFiringTests.cs
@@ -17,6 +17,7 @@ namespace System.Threading.Tests
         internal const int MaxPositiveTimeoutInMs = 30000;
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Timer_Fires_After_DueTime_Ellapses()
         {
             AutoResetEvent are = new AutoResetEvent(false);
@@ -31,6 +32,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Timer_Fires_AndPassesStateThroughCallback()
         {
             AutoResetEvent are = new AutoResetEvent(false);
@@ -47,6 +49,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Timer_Fires_AndPassesNullStateThroughCallback()
         {
             AutoResetEvent are = new AutoResetEvent(false);
@@ -122,6 +125,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Timer_CanDisposeSelfInCallback()
         {
             Timer t = null;
@@ -149,6 +153,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void NonRepeatingTimer_ThatHasAlreadyFired_CanChangeAndFireAgain()
         {
             AutoResetEvent are = new AutoResetEvent(false);
@@ -163,6 +168,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void MultpleTimers_PeriodicTimerIsntBlockedByBlockedCallback()
         {
             int callbacks = 2;
@@ -183,6 +189,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ManyTimers_EachTimerDoesFire()
         {
             int maxTimers = 10000;
@@ -200,6 +207,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Timer_Constructor_CallbackOnly_Change()
         {
             var e = new ManualResetEvent(false);
@@ -217,6 +225,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Timer_Dispose_WaitHandle()
         {
             int tickCount = 0;
@@ -362,6 +371,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void TimersCreatedConcurrentlyOnDifferentThreadsAllFire()
         {
             int processorCount = Environment.ProcessorCount;

--- a/src/libraries/System.Threading/tests/AutoResetEventTests.cs
+++ b/src/libraries/System.Threading/tests/AutoResetEventTests.cs
@@ -205,6 +205,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void PingPong()
         {
             using (AutoResetEvent are1 = new AutoResetEvent(true), are2 = new AutoResetEvent(false))

--- a/src/libraries/System.Threading/tests/BarrierTests.cs
+++ b/src/libraries/System.Threading/tests/BarrierTests.cs
@@ -292,6 +292,7 @@ namespace System.Threading.Tests
         /// </summary>
         /// <returns>True if the test succeeded, false otherwise</returns>
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void RunBarrierTest8_PostPhaseException()
         {
             bool shouldThrow = true;

--- a/src/libraries/System.Threading/tests/ExecutionContextTests.cs
+++ b/src/libraries/System.Threading/tests/ExecutionContextTests.cs
@@ -11,6 +11,7 @@ namespace System.Threading.Tests
     public static class ExecutionContextTests
     {
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void CreateCopyTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>
@@ -62,6 +63,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void FlowTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>
@@ -179,6 +181,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void CaptureThenSuppressThenRunFlowTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>
@@ -265,6 +268,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void AsyncFlowControlTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>

--- a/src/libraries/System.Threading/tests/HostExecutionContextManagerTests.cs
+++ b/src/libraries/System.Threading/tests/HostExecutionContextManagerTests.cs
@@ -8,6 +8,7 @@ namespace System.Threading.Tests
     public static class HostExecutionContextManagerTests
     {
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void BasicTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>

--- a/src/libraries/System.Threading/tests/InterlockedTests.cs
+++ b/src/libraries/System.Threading/tests/InterlockedTests.cs
@@ -461,6 +461,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void InterlockedIncrement_Multithreaded_Int32()
         {
             const int ThreadCount = 10;
@@ -498,6 +499,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void InterlockedCompareExchange_Multithreaded_Double()
         {
             const int ThreadCount = 10;
@@ -546,6 +548,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void InterlockedAddAndRead_Multithreaded_Int64()
         {
             const int ThreadCount = 10;
@@ -621,6 +624,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void MemoryBarrierProcessWide()
         {
             // Stress MemoryBarrierProcessWide correctness using a simple AsymmetricLock

--- a/src/libraries/System.Threading/tests/ManualResetEventTests.cs
+++ b/src/libraries/System.Threading/tests/ManualResetEventTests.cs
@@ -148,6 +148,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void PingPong()
         {
             using (ManualResetEvent mre1 = new ManualResetEvent(true), mre2 = new ManualResetEvent(false))

--- a/src/libraries/System.Threading/tests/MonitorTests.cs
+++ b/src/libraries/System.Threading/tests/MonitorTests.cs
@@ -65,6 +65,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void IsEntered_WhenHeldBySomeoneElse_ThrowsSynchronizationLockException()
         {
             var obj = new object();
@@ -216,6 +217,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void Enter_HasToWait()
         {
             var thinLock = new object();
@@ -414,6 +416,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void WaitTest()
         {
             var obj = new object();
@@ -450,6 +453,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void Enter_HasToWait_LockContentionCountTest()
         {
             long initialLockContentionCount = Monitor.LockContentionCount;
@@ -458,6 +462,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void ObjectHeaderSyncBlockTransitionTryEnterRaceTest()
         {
             var threadStarted = new AutoResetEvent(false);

--- a/src/libraries/System.Threading/tests/MutexTests.cs
+++ b/src/libraries/System.Threading/tests/MutexTests.cs
@@ -202,6 +202,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void MutualExclusionTest()
         {
             var threadLocked = new AutoResetEvent(false);
@@ -286,6 +287,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(GetValidNames))]
         public void OpenExisting(string name)
         {
@@ -421,6 +423,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91547", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(AbandonExisting_MemberData))]
         public void AbandonExisting(
             string name,
@@ -661,6 +664,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void NamedMutex_ThreadExitDisposeRaceTest()
         {
             var mutexName = Guid.NewGuid().ToString("N");
@@ -721,6 +725,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void NamedMutex_DisposeWhenLockedRaceTest()
         {
             var mutexName = Guid.NewGuid().ToString("N");

--- a/src/libraries/System.Threading/tests/ReaderWriterLockSlimTests.cs
+++ b/src/libraries/System.Threading/tests/ReaderWriterLockSlimTests.cs
@@ -177,6 +177,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(LockRecursionPolicy.NoRecursion)]
         [InlineData(LockRecursionPolicy.SupportsRecursion)]
         public static void InvalidExits(LockRecursionPolicy policy)
@@ -321,6 +322,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void WriterToWriterChain()
         {
             using (AutoResetEvent are = new AutoResetEvent(false))
@@ -341,6 +343,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void WriterToReaderChain()
         {
             using (AutoResetEvent are = new AutoResetEvent(false))
@@ -361,6 +364,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void WriterToUpgradeableReaderChain()
         {
             using (AutoResetEvent are = new AutoResetEvent(false))

--- a/src/libraries/System.Threading/tests/ReaderWriterLockTests.cs
+++ b/src/libraries/System.Threading/tests/ReaderWriterLockTests.cs
@@ -87,6 +87,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void InvalidLockCookieTest()
         {
             // Invalid lock cookie created by using one up with Upgrade/Downgrade
@@ -122,6 +123,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void BasicLockTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -499,6 +501,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void WaitingReadersTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -529,6 +532,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void WaitingWritersTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -560,6 +564,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void ReadersWaitingOnWaitingWriterTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -610,6 +615,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void ReadersWaitingOnWaitingUpgraderTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -663,6 +669,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void WaitingUpgradersTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -708,6 +715,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void AtomicRecursiveReaderTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -734,6 +742,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void AtomicDowngradeTest()
         {
             var trwl = new TestReaderWriterLock();

--- a/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
@@ -72,6 +72,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void RunSemaphoreSlimTest1_WaitAsync()
         {
             // Infinite timeout
@@ -90,6 +91,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void RunSemaphoreSlimTest1_WaitAsync_NegativeCases()
         {
             // Invalid timeout
@@ -462,6 +464,7 @@ namespace System.Threading.Tests
         /// <param name="finalCount">The final semaphore count</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(5, 1000, 50, 50, 50, 0, 5, 1000)]
         [InlineData(0, 1000, 50, 25, 25, 25, 0, 500)]
         [InlineData(0, 1000, 50, 0, 0, 50, 0, 100)]
@@ -528,6 +531,7 @@ namespace System.Threading.Tests
         /// <param name="finalCount">The final semaphore count</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(5, 1000, 50, 50, 50, 0, 5, 500)]
         [InlineData(0, 1000, 50, 25, 25, 25, 0, 500)]
         [InlineData(0, 1000, 50, 0, 0, 50, 0, 100)]

--- a/src/libraries/System.Threading/tests/SemaphoreTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreTests.cs
@@ -278,6 +278,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49890", TestPlatforms.Android)]
         public void AnonymousProducerConsumer()
         {

--- a/src/libraries/System.Threading/tests/SpinLockTests.cs
+++ b/src/libraries/System.Threading/tests/SpinLockTests.cs
@@ -13,6 +13,7 @@ namespace System.Threading.Tests
     public class SpinLockTests
     {
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void EnterExit()
         {
             var sl = new SpinLock();

--- a/src/libraries/System.Threading/tests/ThreadLocalTests.cs
+++ b/src/libraries/System.Threading/tests/ThreadLocalTests.cs
@@ -60,6 +60,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void RunThreadLocalTest4_Value()
         {
             ThreadLocal<string> tlocal = null;
@@ -356,6 +357,7 @@ namespace System.Threading.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void RunThreadLocalTest9_Uninitialized()
         {
             for (int iter = 0; iter < 10; iter++)
@@ -438,6 +440,7 @@ namespace System.Threading.Tests
         private enum UniqueEnumUsedOnlyWithNonInterferenceTest { True, False }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void TestUnrelatedThreadLocalDoesNotInterfereWithTrackAllValues()
         {
             ThreadLocal<UniqueEnumUsedOnlyWithNonInterferenceTest> localThatDoesNotTrackValues = new ThreadLocal<UniqueEnumUsedOnlyWithNonInterferenceTest>(false);

--- a/src/libraries/System.Transactions.Local/tests/AsyncTransactionScopeTests.cs
+++ b/src/libraries/System.Transactions.Local/tests/AsyncTransactionScopeTests.cs
@@ -437,6 +437,7 @@ namespace System.Transactions.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(true, false, null)]
         [InlineData(true, true, null)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AsyncTSAndDependantClone(bool requiresNew, bool synchronizeScope, string txId)
         {
             string txId1 = null;
@@ -527,6 +528,7 @@ namespace System.Transactions.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(true, false, null)]
         [InlineData(true, true, null)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91541", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void NestedAsyncTSAndDependantClone(bool parentrequiresNew, bool childRequiresNew, string txId)
         {
             string txId1;
@@ -1107,6 +1109,7 @@ namespace System.Transactions.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void VerifyBYOTOpenConnSimulationTest()
         {
             // Create threads to do work

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -374,6 +374,8 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.X509Certificates\tests\System.Security.Cryptography.X509Certificates.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Cose\tests\System.Security.Cryptography.Cose.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks\tests\System.Threading.Tasks.Tests.csproj" />
+    <!-- https://github.com/dotnet/runtime/issues/91593 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Dataflow\tests\System.Threading.Tasks.Dataflow.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread' and '$(RunDisabledWasmTests)' != 'true'">

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -373,7 +373,9 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Xml\tests\System.Security.Cryptography.Xml.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.X509Certificates\tests\System.Security.Cryptography.X509Certificates.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Cose\tests\System.Security.Cryptography.Cose.Tests.csproj" />
+    <!-- https://github.com/dotnet/runtime/issues/91538 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks\tests\System.Threading.Tasks.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections.Concurrent\tests\System.Collections.Concurrent.Tests.csproj" />
     <!-- https://github.com/dotnet/runtime/issues/91593 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Dataflow\tests\System.Threading.Tasks.Dataflow.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Channels\tests\System.Threading.Channels.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -52,7 +52,12 @@
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' != 'multithread'" >
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-threads\Wasm.Browser.Threads.Sample.csproj" />
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
+    <!-- <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-eventpipe\Wasm.Browser.EventPipe.Sample.csproj" /> -->
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'" >
+    <!-- https://github.com/dotnet/runtime/issues/91676 -->
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-eventpipe\Wasm.Browser.EventPipe.Sample.csproj" />
+    <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-eventpipe\Wasm.Browser.Config.Sample.csproj" />
   </ItemGroup>
 
   <!-- wasm EAT/AOT -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -376,6 +376,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks\tests\System.Threading.Tasks.Tests.csproj" />
     <!-- https://github.com/dotnet/runtime/issues/91593 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Dataflow\tests\System.Threading.Tasks.Dataflow.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Channels\tests\System.Threading.Channels.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread' and '$(RunDisabledWasmTests)' != 'true'">

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -57,7 +57,7 @@
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'" >
     <!-- https://github.com/dotnet/runtime/issues/91676 -->
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-eventpipe\Wasm.Browser.EventPipe.Sample.csproj" />
-    <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-eventpipe\Wasm.Browser.Config.Sample.csproj" />
+    <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-minimal-config\Wasm.Browser.Config.Sample.csproj" />
   </ItemGroup>
 
   <!-- wasm EAT/AOT -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -52,7 +52,7 @@
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' != 'multithread'" >
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-threads\Wasm.Browser.Threads.Sample.csproj" />
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
-    <!-- <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-eventpipe\Wasm.Browser.EventPipe.Sample.csproj" /> -->
+    <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-eventpipe\Wasm.Browser.EventPipe.Sample.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'" >
     <!-- https://github.com/dotnet/runtime/issues/91676 -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -373,6 +373,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Xml\tests\System.Security.Cryptography.Xml.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.X509Certificates\tests\System.Security.Cryptography.X509Certificates.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Cose\tests\System.Security.Cryptography.Cose.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks\tests\System.Threading.Tasks.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread' and '$(RunDisabledWasmTests)' != 'true'">


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/88765. This PR is testing how many failures we have after changing the MT smoke tests to full tests.
The libs that got disabled in `tests.csproj` - I was not able to define which single test is responsible for the failure, mostly because the failures are indeterministic.

- [x] When the following will pass, do `/azp run runtime-wasm` to check extra-platforms failures.

Projects containing failing/timeouting tests:

- [x] Wasm.Browser.Config.Sample
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/Wasm.Browser.Config.Sample/console
- [x] Wasm.Browser.EventPipe.Sample
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/Wasm.Browser.EventPipe.Sample/console
- [x] Microsoft.Extensions.Configuration.EnvironmentVariables.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-Microsoft.Extensions.Configuration.EnvironmentVariables.Tests/console
- [x] Microsoft.Extensions.Configuration.Functional.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-Microsoft.Extensions.Configuration.Functional.Tests/console
- [x] Microsoft.Extensions.HostFactoryResolver.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-Microsoft.Extensions.HostFactoryResolver.Tests/console
- [x] Microsoft.Extensions.Http.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-Microsoft.Extensions.Http.Tests/console
- [x] Microsoft.Extensions.Logging.Console.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-Microsoft.Extensions.Logging.Console.Tests/console
- [x] System.Collections.Concurrent.Tests (blocked the whole lib)
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-System.Collections.Concurrent.Tests/console
- [x] System.Collections.NonGeneric.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-System.Collections.NonGeneric.Tests/console
- [x] System.ComponentModel.TypeConverter.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-System.ComponentModel.TypeConverter.Tests/console
- [x] System.Composition.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-System.Composition.Tests/console
- [x] System.Globalization.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-System.Globalization.Tests/console
- [x] System.IO.Pipelines.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-System.IO.Pipelines.Tests/console
- [x] System.Linq.Parallel.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-System.Linq.Parallel.Tests/console
- [x] System.Private.Xml.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/27d806f8-8aa9-4799-80eb-3e6f6ef2f753/workitems/WasmTestOnBrowser-System.Private.Xml.Tests/console
- [x] System.Runtime.Extensions.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/fd364e36-1e6e-4969-a94a-ccc2c2059358/workitems/WasmTestOnBrowser-System.Runtime.Extensions.Tests/console
- [x] System.Runtime.Serialization.Xml.ReflectionOnly.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/fd364e36-1e6e-4969-a94a-ccc2c2059358/workitems/WasmTestOnBrowser-System.Runtime.Serialization.Xml.ReflectionOnly.Tests/console
- [x] System.Runtime.Serialization.Xml.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/fd364e36-1e6e-4969-a94a-ccc2c2059358/workitems/WasmTestOnBrowser-System.Runtime.Serialization.Xml.Tests/console
- [x] System.Runtime.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/fd364e36-1e6e-4969-a94a-ccc2c2059358/workitems/WasmTestOnBrowser-System.Runtime.Tests/console
- [x] System.Threading.Channels.Tests (blocked the whole lib)
Failure log: https://helix.dot.net/api/2019-06-17/jobs/fd364e36-1e6e-4969-a94a-ccc2c2059358/workitems/WasmTestOnBrowser-System.Threading.Channels.Tests/console
- [x] System.Threading.Tasks.Dataflow.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/fd364e36-1e6e-4969-a94a-ccc2c2059358/workitems/WasmTestOnBrowser-System.Threading.Tasks.Dataflow.Tests/console (blocked the whole lib)
- [x] System.Threading.Tasks.Parallel.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/fd364e36-1e6e-4969-a94a-ccc2c2059358/workitems/WasmTestOnBrowser-System.Threading.Tasks.Parallel.Tests/console
- [x] System.Threading.Tasks.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/fd364e36-1e6e-4969-a94a-ccc2c2059358/workitems/WasmTestOnBrowser-System.Threading.Tasks.Tests/console (blocked the whole lib)
- [x] System.Threading.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/fd364e36-1e6e-4969-a94a-ccc2c2059358/workitems/WasmTestOnBrowser-System.Threading.Tests/console
- [x] System.Threading.Timer.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/fd364e36-1e6e-4969-a94a-ccc2c2059358/workitems/WasmTestOnBrowser-System.Threading.Timer.Tests/console
- [x] System.Transactions.Local.Tests
Failure log: https://helix.dot.net/api/2019-06-17/jobs/fd364e36-1e6e-4969-a94a-ccc2c2059358/workitems/WasmTestOnBrowser-System.Transactions.Local.Tests/console
