### PR TITLE
Respect StackTraceHiddenAttribute

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/DeveloperExperience/DeveloperExperience.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/DeveloperExperience/DeveloperExperience.cs
@@ -32,9 +32,9 @@ namespace Internal.DeveloperExperience
             return disableMetadata;
         }
 
-        public virtual string CreateStackTraceString(IntPtr ip, bool includeFileInfo)
+        public virtual string CreateStackTraceString(IntPtr ip, bool includeFileInfo, out bool isStackTraceHidden)
         {
-            string methodName = GetMethodName(ip, out IntPtr methodStart);
+            string methodName = GetMethodName(ip, out IntPtr methodStart, out isStackTraceHidden);
             if (methodName != null)
             {
                 if (ip != methodStart)
@@ -58,7 +58,7 @@ namespace Internal.DeveloperExperience
             return $"{fileNameWithoutExtension}!<BaseAddress>+0x{rva:x}";
         }
 
-        internal static string GetMethodName(IntPtr ip, out IntPtr methodStart)
+        internal static string GetMethodName(IntPtr ip, out IntPtr methodStart, out bool isStackTraceHidden)
         {
             methodStart = IntPtr.Zero;
             if (!IsMetadataStackTraceResolutionDisabled())
@@ -69,10 +69,11 @@ namespace Internal.DeveloperExperience
                     methodStart = RuntimeImports.RhFindMethodStartAddress(ip);
                     if (methodStart != IntPtr.Zero)
                     {
-                        return stackTraceCallbacks.TryGetMethodNameFromStartAddress(methodStart);
+                        return stackTraceCallbacks.TryGetMethodNameFromStartAddress(methodStart, out isStackTraceHidden);
                     }
                 }
             }
+            isStackTraceHidden = false;
             return null;
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -811,7 +811,7 @@ namespace Internal.Runtime.Augments
             if (ip == IntPtr.Zero)
                 return null;
 
-            return callbacks.TryGetMethodNameFromStartAddress(ip);
+            return callbacks.TryGetMethodNameFromStartAddress(ip, out _);
         }
 
         private static volatile ReflectionExecutionDomainCallbacks s_reflectionExecutionDomainCallbacks;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/StackTraceMetadataCallbacks.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/StackTraceMetadataCallbacks.cs
@@ -22,7 +22,8 @@ namespace Internal.Runtime.Augments
         /// Return null if stack trace information is not available.
         /// </summary>
         /// <param name="methodStartAddress">Memory address representing the start of a method</param>
+        /// <param name="isStackTraceHidden">Returns a value indicating whether the method should be hidden in stack traces</param>
         /// <returns>Formatted method name or null if metadata for the method is not available</returns>
-        public abstract string TryGetMethodNameFromStartAddress(IntPtr methodStartAddress);
+        public abstract string TryGetMethodNameFromStartAddress(IntPtr methodStartAddress, out bool isStackTraceHidden);
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/CrashInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/CrashInfo.cs
@@ -249,7 +249,7 @@ namespace System
             if (!WriteHexValue("offset"u8, frame.GetNativeOffset()))
                 return false;
 
-            string method = DeveloperExperience.GetMethodName(ip, out IntPtr _);
+            string method = DeveloperExperience.GetMethodName(ip, out _, out _);
             if (method != null)
             {
                 if (!WriteStringValue("name"u8, method, maxNameSize))

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
@@ -142,7 +142,7 @@ namespace System.Diagnostics
         /// </summary>
         private bool AppendStackFrameWithoutMethodBase(StringBuilder builder)
         {
-            builder.Append(DeveloperExperience.Default.CreateStackTraceString(_ipAddress, includeFileInfo: false));
+            builder.Append(DeveloperExperience.Default.CreateStackTraceString(_ipAddress, includeFileInfo: false, out _));
             return true;
         }
 
@@ -161,11 +161,15 @@ namespace System.Diagnostics
         {
             if (_ipAddress != Exception.EdiSeparator)
             {
-                // Passing a default string for "at" in case SR.UsingResourceKeys() is true
-                // as this is a special case and we don't want to have "Word_At" on stack traces.
-                string word_At = SR.UsingResourceKeys() ? "at" : SR.Word_At;
-                builder.Append("   ").Append(word_At).Append(' ');
-                builder.AppendLine(DeveloperExperience.Default.CreateStackTraceString(_ipAddress, _needFileInfo));
+                string s = DeveloperExperience.Default.CreateStackTraceString(_ipAddress, _needFileInfo, out bool isStackTraceHidden);
+                if (!isStackTraceHidden)
+                {
+                    // Passing a default string for "at" in case SR.UsingResourceKeys() is true
+                    // as this is a special case and we don't want to have "Word_At" on stack traces.
+                    string word_At = SR.UsingResourceKeys() ? "at" : SR.Word_At;
+                    builder.Append("   ").Append(word_At).Append(' ');
+                    builder.AppendLine(s);
+                }
             }
             if (_isLastFrameFromForeignExceptionStackTrace)
             {

--- a/src/coreclr/nativeaot/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
+++ b/src/coreclr/nativeaot/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
@@ -329,7 +329,7 @@ namespace Internal.StackTraceMetadata
 
             private struct StackTraceData : IComparable<StackTraceData>
             {
-                private const int IsHiddenFlag = 0x1;
+                private const int IsHiddenFlag = 0x2;
 
                 private readonly int _rvaAndIsHiddenBit;
 

--- a/src/coreclr/nativeaot/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
+++ b/src/coreclr/nativeaot/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection.Runtime.General;
 
 using Internal.Metadata.NativeFormat;
 using Internal.NativeFormat;
@@ -42,7 +43,7 @@ namespace Internal.StackTraceMetadata
         /// <summary>
         /// Locate the containing module for a method and try to resolve its name based on start address.
         /// </summary>
-        public static unsafe string GetMethodNameFromStartAddressIfAvailable(IntPtr methodStartAddress)
+        public static unsafe string GetMethodNameFromStartAddressIfAvailable(IntPtr methodStartAddress, out bool isStackTraceHidden)
         {
             IntPtr moduleStartAddress = RuntimeAugments.GetOSModuleFromPointer(methodStartAddress);
             int rva = (int)((byte*)methodStartAddress - (byte*)moduleStartAddress);
@@ -50,11 +51,13 @@ namespace Internal.StackTraceMetadata
             {
                 if (moduleInfo.Handle.OsModuleBase == moduleStartAddress)
                 {
-                    string name = _perModuleMethodNameResolverHashtable.GetOrCreateValue(moduleInfo.Handle.GetIntPtrUNSAFE()).GetMethodNameFromRvaIfAvailable(rva);
-                    if (name != null)
+                    string name = _perModuleMethodNameResolverHashtable.GetOrCreateValue(moduleInfo.Handle.GetIntPtrUNSAFE()).GetMethodNameFromRvaIfAvailable(rva, out isStackTraceHidden);
+                    if (name != null || isStackTraceHidden)
                         return name;
                 }
             }
+
+            isStackTraceHidden = false;
 
             // We haven't found information in the stack trace metadata tables, but maybe reflection will have this
             if (IsReflectionExecutionAvailable() && ReflectionExecution.TryGetMethodMetadataFromStartAddress(methodStartAddress,
@@ -62,6 +65,24 @@ namespace Internal.StackTraceMetadata
                 out TypeDefinitionHandle typeHandle,
                 out MethodHandle methodHandle))
             {
+                foreach (CustomAttributeHandle cah in reader.GetTypeDefinition(typeHandle).CustomAttributes)
+                {
+                    if (cah.IsCustomAttributeOfType(reader, "System.Diagnostics", "StackTraceHiddenAttribute"))
+                    {
+                        isStackTraceHidden = true;
+                        break;
+                    }
+                }
+
+                foreach (CustomAttributeHandle cah in reader.GetMethod(methodHandle).CustomAttributes)
+                {
+                    if (cah.IsCustomAttributeOfType(reader, "System.Diagnostics", "StackTraceHiddenAttribute"))
+                    {
+                        isStackTraceHidden = true;
+                        break;
+                    }
+                }
+
                 return MethodNameFormatter.FormatMethodName(reader, typeHandle, methodHandle);
             }
 
@@ -127,9 +148,9 @@ namespace Internal.StackTraceMetadata
         /// </summary>
         private sealed class StackTraceMetadataCallbacksImpl : StackTraceMetadataCallbacks
         {
-            public override string TryGetMethodNameFromStartAddress(IntPtr methodStartAddress)
+            public override string TryGetMethodNameFromStartAddress(IntPtr methodStartAddress, out bool isStackTraceHidden)
             {
-                return GetMethodNameFromStartAddressIfAvailable(methodStartAddress);
+                return GetMethodNameFromStartAddressIfAvailable(methodStartAddress, out isStackTraceHidden);
             }
         }
 
@@ -256,6 +277,7 @@ namespace Internal.StackTraceMetadata
                     _stacktraceDatas[current++] = new StackTraceData
                     {
                         Rva = methodRva,
+                        IsHidden = (command & StackTraceDataCommand.IsStackTraceHidden) != 0,
                         OwningType = currentOwningType,
                         Name = currentName,
                         Signature = currentSignature,
@@ -274,8 +296,10 @@ namespace Internal.StackTraceMetadata
             /// <summary>
             /// Try to resolve method name based on its address using the stack trace metadata
             /// </summary>
-            public string GetMethodNameFromRvaIfAvailable(int rva)
+            public string GetMethodNameFromRvaIfAvailable(int rva, out bool isStackTraceHidden)
             {
+                isStackTraceHidden = false;
+
                 if (_stacktraceDatas == null)
                 {
                     // No stack trace metadata for this module
@@ -290,12 +314,43 @@ namespace Internal.StackTraceMetadata
                 }
 
                 StackTraceData data = _stacktraceDatas[index];
+
+                isStackTraceHidden = data.IsHidden;
+
+                if (data.OwningType.IsNull(_metadataReader))
+                {
+                    Debug.Assert(data.Name.IsNull(_metadataReader) && data.Signature.IsNull(_metadataReader));
+                    Debug.Assert(isStackTraceHidden);
+                    return null;
+                }
+
                 return MethodNameFormatter.FormatMethodName(_metadataReader, data.OwningType, data.Name, data.Signature, data.GenericArguments);
             }
 
             private struct StackTraceData : IComparable<StackTraceData>
             {
-                public int Rva { get; init; }
+                private const int IsHiddenFlag = 0x1;
+
+                private readonly int _rvaAndIsHiddenBit;
+
+                public int Rva
+                {
+                    get => _rvaAndIsHiddenBit & ~IsHiddenFlag;
+                    init
+                    {
+                        Debug.Assert((value & IsHiddenFlag) == 0);
+                        _rvaAndIsHiddenBit = value | (_rvaAndIsHiddenBit & IsHiddenFlag);
+                    }
+                }
+                public bool IsHidden
+                {
+                    get => (_rvaAndIsHiddenBit & IsHiddenFlag) != 0;
+                    init
+                    {
+                        if (value)
+                            _rvaAndIsHiddenBit |= IsHiddenFlag;
+                    }
+                }
                 public Handle OwningType { get; init; }
                 public ConstantStringValueHandle Name { get; init; }
                 public MethodSignatureHandle Signature { get; init; }

--- a/src/coreclr/tools/Common/Internal/Runtime/StackTraceData.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/StackTraceData.cs
@@ -9,5 +9,7 @@ namespace Internal.Runtime
         public const byte UpdateName = 0x02;
         public const byte UpdateSignature = 0x04;
         public const byte UpdateGenericSignature = 0x08; // Just a shortcut - sig metadata has the info
+
+        public const byte IsStackTraceHidden = 0x10;
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/StackTraceMethodMappingNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/StackTraceMethodMappingNode.cs
@@ -121,6 +121,12 @@ namespace ILCompiler.DependencyAnalysis
                         command |= StackTraceDataCommand.UpdateSignature;
                     }
                 }
+
+                if (entry.IsHidden)
+                {
+                    command |= StackTraceDataCommand.IsStackTraceHidden;
+                }
+
                 objData.EmitByte(commandReservation, command);
                 objData.EmitReloc(factory.MethodEntrypoint(entry.Method), RelocType.IMAGE_REL_BASED_RELPTR32);
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -619,7 +619,7 @@ namespace ILCompiler
                                                 out List<MetadataMapping<FieldDesc>> fieldMappings,
                                                 out List<StackTraceMapping> stackTraceMapping);
 
-        protected StackTraceRecordData CreateStackTraceRecord(Metadata.MetadataTransform transform, MethodDesc method)
+        protected StackTraceRecordData CreateStackTraceRecord(Metadata.MetadataTransform transform, MethodDesc method, bool isHidden)
         {
             // In the metadata, we only represent the generic definition
             MethodDesc methodToGenerateMetadataFor = method.GetTypicalMethodDefinition();
@@ -668,7 +668,7 @@ namespace ILCompiler
                 methodInst = null;
             }
 
-            return new StackTraceRecordData(method, owningType, signature, name, methodInst);
+            return new StackTraceRecordData(method, owningType, signature, name, methodInst, isHidden);
         }
 
         /// <summary>
@@ -950,10 +950,11 @@ namespace ILCompiler
         public readonly int MethodSignatureHandle;
         public readonly int MethodNameHandle;
         public readonly int MethodInstantiationArgumentCollectionHandle;
+        public readonly bool IsHidden;
 
-        public StackTraceMapping(MethodDesc method, int owningTypeHandle, int methodSignatureHandle, int methodNameHandle, int methodInstantiationArgumentCollectionHandle)
-            => (Method, OwningTypeHandle, MethodSignatureHandle, MethodNameHandle, MethodInstantiationArgumentCollectionHandle)
-            = (method, owningTypeHandle, methodSignatureHandle, methodNameHandle, methodInstantiationArgumentCollectionHandle);
+        public StackTraceMapping(MethodDesc method, int owningTypeHandle, int methodSignatureHandle, int methodNameHandle, int methodInstantiationArgumentCollectionHandle, bool isHidden)
+            => (Method, OwningTypeHandle, MethodSignatureHandle, MethodNameHandle, MethodInstantiationArgumentCollectionHandle, IsHidden)
+            = (method, owningTypeHandle, methodSignatureHandle, methodNameHandle, methodInstantiationArgumentCollectionHandle, isHidden);
     }
 
     public readonly struct StackTraceRecordData
@@ -963,10 +964,11 @@ namespace ILCompiler
         public readonly MetadataRecord MethodSignature;
         public readonly MetadataRecord MethodName;
         public readonly MetadataRecord MethodInstantiationArgumentCollection;
+        public readonly bool IsHidden;
 
-        public StackTraceRecordData(MethodDesc method, MetadataRecord owningType, MetadataRecord methodSignature, MetadataRecord methodName, MetadataRecord methodInstantiationArgumentCollection)
-            => (Method, OwningType, MethodSignature, MethodName, MethodInstantiationArgumentCollection)
-            = (method, owningType, methodSignature, methodName, methodInstantiationArgumentCollection);
+        public StackTraceRecordData(MethodDesc method, MetadataRecord owningType, MetadataRecord methodSignature, MetadataRecord methodName, MetadataRecord methodInstantiationArgumentCollection, bool isHidden)
+            => (Method, OwningType, MethodSignature, MethodName, MethodInstantiationArgumentCollection, IsHidden)
+            = (method, owningType, methodSignature, methodName, methodInstantiationArgumentCollection, isHidden);
     }
 
     [Flags]

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -193,6 +193,9 @@ namespace Internal.IL.Stubs.StartupCode
             }
         }
 
+        public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
+            => attributeNamespace == "System.Diagnostics" && attributeName == "StackTraceHiddenAttribute";
+
         /// <summary>
         /// Wraps the main method in a layer of indirection. This is necessary to protect the startup code
         /// infrastructure from situations when the owning type of the main method cannot be loaded, and codegen
@@ -271,6 +274,9 @@ namespace Internal.IL.Stubs.StartupCode
 
                 return emit.Link(this);
             }
+
+            public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
+                => attributeNamespace == "System.Diagnostics" && attributeName == "StackTraceHiddenAttribute";
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/Diagnostics/StackTraceHiddenAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Diagnostics/StackTraceHiddenAttributeTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 namespace System.Tests
 {
     [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/91309", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
     public class StackTraceHiddenAttributeTests
     {
         [Fact]

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Main.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Main.cs
@@ -10,6 +10,7 @@ success &= RunTest(Generics.Run);
 success &= RunTest(Interfaces.Run);
 success &= RunTest(Threading.Run);
 success &= RunTest(Devirtualization.Run);
+success &= RunTest(StackTraces.Run);
 
 return success ? 100 : 1;
 

--- a/src/tests/nativeaot/SmokeTests/UnitTests/StackTraces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/StackTraces.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+class StackTraces
+{
+    internal static int Run()
+    {
+        TestStackTraceHidden.Run();
+
+        return 100;
+    }
+
+    class TestStackTraceHidden
+    {
+        [DynamicDependency(nameof(HiddenMethodWithMetadata))]
+        internal static void Run()
+        {
+            string s = null;
+            StackTrace t = null;
+            try
+            {
+                HiddenMethod(ref t);
+            }
+            catch (Exception ex)
+            {
+                s = ex.StackTrace;
+            }
+
+            Verify(s, false);
+            Verify(t.ToString(), false);
+
+            StringBuilder sb = new StringBuilder();
+            foreach (StackFrame f in t.GetFrames())
+                sb.AppendLine(f.ToString());
+
+            Verify(sb.ToString(), true);
+
+            if (GetSecretMethod(typeof(TestStackTraceHidden), nameof(HiddenMethodWithMetadata)) == null)
+                throw new Exception();
+
+            if (GetSecretMethod(typeof(TestStackTraceHidden), nameof(HiddenMethod)) != null)
+                throw new Exception();
+
+            static MethodInfo GetSecretMethod(Type t, string name) => t.GetMethod(name);
+
+            static void Verify(string s, bool expected)
+            {
+                if (s.Contains(nameof(HiddenMethod)) != expected
+                    || s.Contains(nameof(HiddenMethodWithMetadata)) != expected)
+                    throw new Exception(s);
+                if (!s.Contains(nameof(Collector)))
+                    throw new Exception(s);
+            }
+        }
+
+        [StackTraceHidden]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void HiddenMethod(ref StackTrace t) => HiddenMethodWithMetadata(ref t);
+
+        [StackTraceHidden]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void HiddenMethodWithMetadata(ref StackTrace t) => Collector(ref t);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Collector(ref StackTrace t)
+        {
+            t = new StackTrace();
+            throw new Exception();
+        }
+    }
+
+}

--- a/src/tests/nativeaot/SmokeTests/UnitTests/UnitTests.csproj
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/UnitTests.csproj
@@ -16,6 +16,7 @@
     <Compile Include="Generics.cs" />
     <Compile Include="Interfaces.cs" />
     <Compile Include="Threading.cs" />
+    <Compile Include="StackTraces.cs" />
     <Compile Include="Main.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #91309.

NativeAOT sources stack trace data from two places: reflection metadata (if the method was reflection-visible), or specialized stack trace metadata. Finding out if a method should be hidden from stack traces in the former case is easy: just look for the attribute. The latter case requires compiler work.

In this PR, I'm extending the specialized stack trace metadata format to contain a bit that says if the frame should be hidden or not. I'm doing it in a way that we can also do this for compiler-generated methods (that otherwise don't show up in stack trace metadata).

The runtime behavior is similar to CoreCLR - the methods show up in individual stack frames, but if we stringify the stack trace, they'll be skipped. I'm adding a specialized test that tests the two sources of metadata.

I'm also marking the methods involved in the startup path as stack trace hidden.

There is one thing I skipped - CoreCLR has logic to force generate the stack trace metadata for the first frame. If we do that, the compiler-generated startup code starts showing up in stack traces again. Marking `Main` as stack trace hidden might lead to an empty stack trace.

Cc @dotnet/ilc-contrib 