### PR TITLE
Support for easy lazy with implicit operator

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Lazy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Lazy.cs
@@ -505,6 +505,17 @@ namespace System
         /// </remarks>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public T Value => _state == null ? _value! : CreateValue();
+
+        /// <summary>
+        /// Gets the lazily initialized value of the current without using lazystuff.value
+        /// </summary>
+        /// <param name="lazy">The lazily initialized value of the current</param>
+        public static implicit operator T(Lazy<T> lazy) => lazy.Value;
+        /// <summary>
+        /// Gets the lazily instance of the current function without using new Lazy<typeparamref name="T"/>()
+        /// </summary>
+        /// <param name="valueFactory"></param>
+        public static implicit operator Lazy<T>(Func<T>? valueFactory) => new Lazy<T>(valueFactory);
     }
 
     /// <summary>A debugger view of the Lazy&lt;T&gt; to surface additional debugging properties and

--- a/src/libraries/System.Runtime/tests/System/LazyTests.cs
+++ b/src/libraries/System.Runtime/tests/System/LazyTests.cs
@@ -549,6 +549,17 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void Implicit_Operator_LazyTest()
+        {
+            string value  = "Compiler Test";
+            Lazy<string> lazyString = () => value;
+            VerifyLazy(lazyString, value, hasValue: false, isValueCreated: false);
+
+            string result = lazyString;
+            Assert.Equal(result, value);
+        }
+
+        [Fact]
         public static void EnsureInitialized_FuncInitializationWithoutTrackingBool_Uninitialized()
         {
             string template = "foo";


### PR DESCRIPTION
Hi,
These changes let you use Lazy<T> in an easy way.

In the past we have to use Lazy<T> this way:

```CSharp
var lazy = new Lazy<string>(() => "data");
var value = lazy.Value;
```

with this feature, you can use it more easily:

```CSharp
Lazy<string> lazy = () => "data";
string value = lazy;
```

