### PR TITLE
JIT: Handle mistyped commas in morph in pre-order too

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8915,6 +8915,8 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac, bool* optA
                 typ = tree->gtType = TYP_VOID;
             }
 
+            break;
+
         default:
             break;
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8909,6 +8909,12 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac, bool* optA
             break;
 #endif
 
+        case GT_COMMA:
+            if (op2->OperIsStore() || (op2->OperGet() == GT_COMMA && op2->TypeGet() == TYP_VOID) || fgIsThrow(op2))
+            {
+                typ = tree->gtType = TYP_VOID;
+            }
+
         default:
             break;
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91443/Runtime_91443.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91443/Runtime_91443.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_91443
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        new Runtime_91443().Method0();
+    }
+    
+    static Vector3 s;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Method0()
+    {
+        Vector3.Cross(s, s);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91443/Runtime_91443.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91443/Runtime_91443.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Morph has post-order logic to compensate for mistyped commas produced by impStoreStruct. However, block morphing can optimize unused stores into INDs; this interacts with the mistyped commas to produce illegal IR shapes (e.g. `COMMA<simd12>(..., IND<ubyte>(...))`).

The ideal solution is to fix impStoreStruct (#91586 tracks this), but this change has a more surgical fix that can be backported to .NET 8. It duplicates the compensation logic to run in pre-order too.

Fix #91443