### PR TITLE
[browser] ENVIRONMENT_IS_WEB is also true on WebWorker

### DIFF
--- a/src/mono/wasm/runtime/globals.ts
+++ b/src/mono/wasm/runtime/globals.ts
@@ -15,8 +15,8 @@ export let Module: DotnetModuleInternal;
 export let INTERNAL: any;
 
 export const ENVIRONMENT_IS_NODE = typeof process == "object" && typeof process.versions == "object" && typeof process.versions.node == "string";
-export const ENVIRONMENT_IS_WEB = typeof window == "object";
 export const ENVIRONMENT_IS_WORKER = typeof importScripts == "function";
+export const ENVIRONMENT_IS_WEB = typeof window == "object" || (ENVIRONMENT_IS_WORKER && !ENVIRONMENT_IS_NODE);
 export const ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
 // these are imported and re-exported from emscripten internals
 export let ENVIRONMENT_IS_PTHREAD: boolean;

--- a/src/mono/wasm/runtime/loader/globals.ts
+++ b/src/mono/wasm/runtime/loader/globals.ts
@@ -16,8 +16,8 @@ import { hasDebuggingEnabled } from "./config";
 import { logDownloadStatsToConsole, purgeUnusedCacheEntriesAsync } from "./assetsCache";
 
 export const ENVIRONMENT_IS_NODE = typeof process == "object" && typeof process.versions == "object" && typeof process.versions.node == "string";
-export const ENVIRONMENT_IS_WEB = typeof window == "object";
 export const ENVIRONMENT_IS_WORKER = typeof importScripts == "function";
+export const ENVIRONMENT_IS_WEB = typeof window == "object" || (ENVIRONMENT_IS_WORKER && !ENVIRONMENT_IS_NODE);
 export const ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
 
 export let runtimeHelpers: RuntimeHelpers = {} as any;

--- a/src/mono/wasm/runtime/polyfills.ts
+++ b/src/mono/wasm/runtime/polyfills.ts
@@ -4,7 +4,7 @@
 import MonoWasmThreads from "consts:monoWasmThreads";
 import type { EmscriptenReplacements } from "./types/internal";
 import type { TypedArray } from "./types/emscripten";
-import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_WEB, INTERNAL, Module, loaderHelpers, runtimeHelpers } from "./globals";
+import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_PTHREAD, ENVIRONMENT_IS_WEB, INTERNAL, Module, loaderHelpers, runtimeHelpers } from "./globals";
 import { replaceEmscriptenPThreadLibrary } from "./pthreads/shared/emscripten-replacements";
 
 const dummyPerformance = {
@@ -30,7 +30,7 @@ export function initializeReplacements(replacements: EmscriptenReplacements): vo
     replacements.fetch = loaderHelpers.fetch_like;
 
     // misc
-    replacements.noExitRuntime = ENVIRONMENT_IS_WEB;
+    replacements.noExitRuntime = ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_PTHREAD;
 
     // threads
     if (MonoWasmThreads) {


### PR DESCRIPTION
`ENVIRONMENT_IS_WEB` impacts `noExitRuntime` among other things.

Fixes https://github.com/dotnet/runtime/issues/91528

This may need Net8 backport