### PR TITLE
Fix handling of `--help` in the build-commons.sh

### DIFF
--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -311,7 +311,7 @@ while :; do
 
     lowerI="$(echo "${1/--/-}" | tr "[:upper:]" "[:lower:]")"
     case "$lowerI" in
-        -\?|-h|--help)
+        -\?|-h|-help)
             usage
             exit 1
             ;;


### PR DESCRIPTION
The `--help` was not recognized in that script because double dashes were converted to single ones before processing the options. That causes e.g. the src/test/build.sh to not to recognize the `--help` option, so it instead starts building the tests.

This change fixes it.