### PR TITLE
[wasm] Use specific version of v8 for tests

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -273,6 +273,10 @@ jobs:
       - src/mono/nuget/Microsoft.NETCore.BrowserDebugHost.Transport/*
       - ${{ parameters._const_paths._always_exclude }}
 
+    - subset: wasm_chrome
+      include:
+      - ${{ parameters._const_paths._wasm_chrome }}
+
     # anything other than mono, or wasm specific paths
     - subset: non_mono_and_wasm
       exclude:

--- a/eng/pipelines/common/templates/wasm-library-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-tests.yml
@@ -36,6 +36,7 @@ jobs:
             eq(variables['wasmDarcDependenciesChanged'], true),
             eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
             eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_chrome.containsChange'], true),
             eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_specific_except_wbt_dbg.containsChange'], true))
          ]
       - name: _wasmRunSmokeTestsOnlyArg

--- a/eng/pipelines/common/templates/wasm-library-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-tests.yml
@@ -45,12 +45,17 @@ jobs:
           value: /p:InstallChromeForTests=true
         ${{ else }}:
           value: ''
+      - name: v8InstallArg
+        ${{ if containsValue(parameters.scenarios, 'normal') }}:
+          value: /p:InstallV8ForTests=true
+        ${{ else }}:
+          value: ''
 
     jobParameters:
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       testGroup: innerloop
       nameSuffix: LibraryTests${{ parameters.nameSuffix }}
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=$(_hostedOs) $(_wasmRunSmokeTestsOnlyArg) $(chromeInstallArg) ${{ parameters.extraBuildArgs }}
+      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=$(_hostedOs) $(_wasmRunSmokeTestsOnlyArg) $(chromeInstallArg) $(v8InstallArg) ${{ parameters.extraBuildArgs }}
       timeoutInMinutes: 240
       # if !alwaysRun, then:
       #   if this is runtime-wasm (isWasmOnlyBuild):

--- a/eng/pipelines/common/templates/wasm-runtime-tests.yml
+++ b/eng/pipelines/common/templates/wasm-runtime-tests.yml
@@ -36,7 +36,7 @@ jobs:
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       nameSuffix: AllSubsets_Mono_RuntimeTests
       runtimeVariant: monointerpreter
-      buildArgs: -s mono+libs -c $(_BuildConfig) ${{ parameters.extraBuildArgs }}
+      buildArgs: -s mono+libs -c $(_BuildConfig) /p:InstallV8ForTests=false ${{ parameters.extraBuildArgs }}
       timeoutInMinutes: 180
       condition: >-
         or(

--- a/eng/pipelines/common/templates/wasm-runtime-tests.yml
+++ b/eng/pipelines/common/templates/wasm-runtime-tests.yml
@@ -42,9 +42,10 @@ jobs:
         or(
           eq(variables['alwaysRunVar'], true),
           eq(variables['isDefaultPipeline'], variables['shouldRunOnDefaultPipelines']))
-      extraStepsTemplate: //eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+      extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
       extraStepsParameters:
         creator: dotnet-bot
         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+        testBuildArgs: /p:InstallV8ForTests=false
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml

--- a/eng/testing/WasmRunnerAOTTemplate.sh
+++ b/eng/testing/WasmRunnerAOTTemplate.sh
@@ -34,14 +34,6 @@ if [[ -z "$XHARNESS_COMMAND" ]]; then
 fi
 
 if [[ "$XHARNESS_COMMAND" == "test" ]]; then
-	if [[ -z "$JS_ENGINE" ]]; then
-		if [[ "$SCENARIO" == "WasmTestOnNodeJS" || "$SCENARIO" == "wasmtestonnodejs" ]]; then
-			JS_ENGINE="--engine=NodeJS"
-		else
-			JS_ENGINE="--engine=V8"
-		fi
-	fi
-
 	if [[ -z "$JS_ENGINE_ARGS" ]]; then
 		JS_ENGINE_ARGS="--engine-arg=--stack-trace-limit=1000"
 		if [[ "$SCENARIO" != "WasmTestOnNodeJS" && "$SCENARIO" != "wasmtestonnodejs" ]]; then
@@ -54,6 +46,17 @@ if [[ "$XHARNESS_COMMAND" == "test" ]]; then
 
 	if [[ -z "$MAIN_JS" ]]; then
 		MAIN_JS="--js-file=test-main.js"
+	fi
+
+	if [[ -z "$JS_ENGINE" ]]; then
+		if [[ "$SCENARIO" == "WasmTestOnNodeJS" || "$SCENARIO" == "wasmtestonnodejs" ]]; then
+			JS_ENGINE="--engine=NodeJS"
+		else
+			JS_ENGINE="--engine=V8"
+			if [[ -n "$V8_PATH_FOR_TESTS" ]]; then
+				JS_ENGINE_ARGS="$JS_ENGINE_ARGS --js-engine-path=$V8_PATH_FOR_TESTS"
+			fi
+		fi
 	fi
 fi
 

--- a/eng/testing/WasmRunnerTemplate.sh
+++ b/eng/testing/WasmRunnerTemplate.sh
@@ -34,14 +34,6 @@ if [[ -z "$XHARNESS_COMMAND" ]]; then
 fi
 
 if [[ "$XHARNESS_COMMAND" == "test" ]]; then
-	if [[ -z "$JS_ENGINE" ]]; then
-		if [[ "$SCENARIO" == "WasmTestOnNodeJS" || "$SCENARIO" == "wasmtestonnodejs" ]]; then
-			JS_ENGINE="--engine=NodeJS"
-		else
-			JS_ENGINE="--engine=V8"
-		fi
-	fi
-
 	if [[ -z "$MAIN_JS" ]]; then
 		MAIN_JS="--js-file=test-main.js"
 	fi
@@ -53,6 +45,17 @@ if [[ "$XHARNESS_COMMAND" == "test" ]]; then
 		fi
 		if [[ "$SCENARIO" == "WasmTestOnNodeJS" || "$SCENARIO" == "wasmtestonnodejs" ]]; then
 			JS_ENGINE_ARGS="$JS_ENGINE_ARGS --engine-arg=--experimental-wasm-eh"
+		fi
+	fi
+
+	if [[ -z "$JS_ENGINE" ]]; then
+		if [[ "$SCENARIO" == "WasmTestOnNodeJS" || "$SCENARIO" == "wasmtestonnodejs" ]]; then
+			JS_ENGINE="--engine=NodeJS"
+		else
+			JS_ENGINE="--engine=V8"
+			if [[ -n "$V8_PATH_FOR_TESTS" ]]; then
+				JS_ENGINE_ARGS="$JS_ENGINE_ARGS --js-engine-path=$V8_PATH_FOR_TESTS"
+			fi
 		fi
 	fi
 fi

--- a/eng/testing/tests.browser.targets
+++ b/eng/testing/tests.browser.targets
@@ -24,6 +24,7 @@
     <WasmIgnoreNet6WorkloadInstallErrors Condition="'$(WasmIgnoreNet6WorkloadInstallErrors)' != 'true'">false</WasmIgnoreNet6WorkloadInstallErrors>
     <!--<InstallWorkloadUsingArtifactsDependsOn>_GetWorkloadsToInstall;$(InstallWorkloadUsingArtifactsDependsOn)</InstallWorkloadUsingArtifactsDependsOn>-->
     <GetWorkloadInputsDependsOn>_GetWorkloadsToInstall;$(GetWorkloadInputsDependsOn)</GetWorkloadInputsDependsOn>
+    <!-- '/.dockerenv' - is to check if this is running in a codespace -->
     <InstallChromeForTests Condition="'$(InstallChromeForTests)' == '' and
                                         ('$(ContinuousIntegrationBuild)' != 'true' or Exists('/.dockerenv')) and
                                         '$(Scenario)' == 'WasmTestOnBrowser'">true</InstallChromeForTests>

--- a/eng/testing/tests.browser.targets
+++ b/eng/testing/tests.browser.targets
@@ -27,6 +27,9 @@
     <InstallChromeForTests Condition="'$(InstallChromeForTests)' == '' and
                                         ('$(ContinuousIntegrationBuild)' != 'true' or Exists('/.dockerenv')) and
                                         '$(Scenario)' == 'WasmTestOnBrowser'">true</InstallChromeForTests>
+    <InstallV8ForTests Condition="'$(InstallV8ForTests)' == '' and
+                                        ('$(ContinuousIntegrationBuild)' != 'true' or Exists('/.dockerenv')) and
+                                        ('$(Scenario)' == 'normal' or '$(Scenario)' == '')">true</InstallV8ForTests>
 
     <GetNuGetsToBuildForWorkloadTestingDependsOn>_GetRuntimePackNuGetsToBuild;_GetNugetsForAOT;$(GetNuGetsToBuildForWorkloadTestingDependsOn)</GetNuGetsToBuildForWorkloadTestingDependsOn>
     <_BundleAOTTestWasmAppForHelixDependsOn>$(_BundleAOTTestWasmAppForHelixDependsOn);PrepareForWasmBuildApp;_PrepareForAOTOnHelix</_BundleAOTTestWasmAppForHelixDependsOn>
@@ -59,11 +62,14 @@
   <!-- On CI this is installed as part of pretest, but it should still be installed
        for WBT, and debugger tests -->
   <Import Project="$(MSBuildThisFileDirectory)wasm-provisioning.targets"
-          Condition="'$(InstallChromeForTests)' == 'true' and ('$(ContinuousIntegrationBuild)' != 'true' or '$(IsBrowserWasmProject)' != 'true')" />
+          Condition="'$(ContinuousIntegrationBuild)' != 'true' or '$(IsBrowserWasmProject)' != 'true'" />
 
   <PropertyGroup>
     <_WasmBrowserPathForTests Condition="'$(BROWSER_PATH_FOR_TESTS)' != ''">$(BROWSER_PATH_FOR_TESTS)</_WasmBrowserPathForTests>
     <_WasmBrowserPathForTests Condition="'$(_WasmBrowserPathForTests)' == '' and '$(InstallChromeForTests)' == 'true'">$(ChromeBinaryPath)</_WasmBrowserPathForTests>
+
+    <_WasmJSEnginePathForTests Condition="'$(V8_PATH_FOR_TESTS)' != ''">$(V8_PATH_FOR_TESTS)</_WasmJSEnginePathForTests>
+    <_WasmJSEnginePathForTests Condition="'$(_WasmJSEnginePathForTests)' == '' and '$(InstallV8ForTests)' == 'true'">$(V8BinaryPath)</_WasmJSEnginePathForTests>
   </PropertyGroup>
 
   <!--
@@ -75,6 +81,7 @@
     <SetScriptCommands Condition="'$(Scenario)' != '' and '$(ContinuousIntegrationBuild)' != 'true'" Include="export SCENARIO=$(Scenario)" />
     <SetScriptCommands Condition="'$(JSEngine)' != ''" Include="export JS_ENGINE=--engine=$(JSEngine)" />
     <SetScriptCommands Condition="'$(JSEngineArgs)' != ''" Include="export JS_ENGINE_ARGS=$(JSEngineArgs)" />
+    <SetScriptCommands Condition="'$(_WasmJSEnginePathForTests)' != ''" Include="export V8_PATH_FOR_TESTS=${V8_PATH_FOR_TESTS:=$(_WasmJSEnginePathForTests)}" />
     <SetScriptCommands Condition="'$(_WasmMainJSFileName)' != ''" Include="export MAIN_JS=--js-file=$(_WasmMainJSFileName)" />
     <!-- Workaround for https://github.com/dotnet/runtime/issues/74328 -->
     <SetScriptCommands Condition="'$(BuildAOTTestsOnHelix)' == 'true'" Include="export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1" />

--- a/eng/testing/wasm-provisioning.targets
+++ b/eng/testing/wasm-provisioning.targets
@@ -11,10 +11,13 @@
 
     <!-- disable by default on unsupported platforms -->
     <InstallChromeForTests Condition="'$(InstallChromeForTests)' == '' and '$(ChromeOSIdentifier)' == ''">false</InstallChromeForTests>
+    <InstallV8ForTests Condition="'$(InstallV8ForTests)' == ''">false</InstallV8ForTests>
 
     <FirefoxDir>$(ArtifactsBinDir)firefox\</FirefoxDir>
     <FirefoxStampFile>$([MSBuild]::NormalizePath($(FirefoxDir), '.install-firefox-$(FirefoxRevision).stamp'))</FirefoxStampFile>
     <_BrowserStampDir>$(ArtifactsBinDir)\</_BrowserStampDir>
+
+    <WasmProvisionAfterTarget Condition="'$(WasmProvisionAfterTarget)' == ''">Build</WasmProvisionAfterTarget>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)ChromeVersions.props" />
@@ -38,6 +41,11 @@
 
     <ChromeUrl>$(linux_ChromeBaseSnapshotUrl)/chrome-linux.zip</ChromeUrl>
     <ChromeDriverUrl>$(linux_ChromeBaseSnapshotUrl)/chromedriver_linux64.zip</ChromeDriverUrl>
+
+    <V8Version>$(linux_V8Version)</V8Version>
+    <V8DirName>v8-$(linux_V8Version)</V8DirName>
+    <V8BinaryName>$(V8DirName).sh</V8BinaryName>
+    <_V8PlatformId>linux64</_V8PlatformId>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
@@ -53,6 +61,11 @@
 
     <ChromeUrl>$(win_ChromeBaseSnapshotUrl)/chrome-win.zip</ChromeUrl>
     <ChromeDriverUrl>$(win_ChromeBaseSnapshotUrl)/chromedriver_win32.zip</ChromeDriverUrl>
+
+    <V8Version>$(win_V8Version)</V8Version>
+    <V8DirName>v8-$(win_V8Version)</V8DirName>
+    <V8BinaryName>$(V8DirName).cmd</V8BinaryName>
+    <_V8PlatformId>win32</_V8PlatformId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ChromeVersion)' != ''">
@@ -65,6 +78,12 @@
     <ChromeDriverBinaryPath>$([MSBuild]::NormalizePath($(ChromeDriverDir), $(ChromeDriverDirName), $(ChromeDriverBinaryName)))</ChromeDriverBinaryPath>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(V8Version)' != ''">
+    <V8Dir>$(ArtifactsBinDir)$(V8DirName)\</V8Dir>
+    <V8StampFile>$([MSBuild]::NormalizePath('$(V8Dir)', '.install-$(V8Version).stamp'))</V8StampFile>
+    <V8BinaryPath>$([MSBuild]::NormalizePath($(V8Dir), $(V8BinaryName)))</V8BinaryPath>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(BrowserHost)' != 'windows'">
     <FirefoxRevision>108.0.1</FirefoxRevision>
     <FirefoxUrl>https://ftp.mozilla.org/pub/firefox/releases/$(FirefoxRevision)/linux-x86_64/en-US/firefox-$(FirefoxRevision).tar.bz2</FirefoxUrl>
@@ -72,9 +91,11 @@
   </PropertyGroup>
 
   <Target Name="DownloadAndInstallChrome"
-          AfterTargets="Build"
+          AfterTargets="$(WasmProvisionAfterTarget)"
           Condition="(!Exists($(ChromeStampFile)) or !Exists($(ChromeBinaryPath))) and '$(InstallChromeForTests)' == 'true'">
 
+    <Error Condition="!$([MSBuild]::IsOSPlatform('linux')) and !$([MSBuild]::IsOSPlatform('windows'))"
+           Text="Chrome provisioning only supported on Linux, and windows." />
     <Error Condition="'$(ChromeVersion)' == ''"
            Text="No %24(ChromeVersion) set. This can be set in eng/testing/ChromeVersions.props" />
 
@@ -87,6 +108,7 @@
       <Output TaskParameter="DownloadedFile" PropertyName="_DownloadedFile" />
     </DownloadFile>
     <Unzip SourceFiles="$(_DownloadedFile)" DestinationFolder="$(ChromeDir)" />
+    <Delete Files="$(_DownloadedFile)" />
 
     <Error Text="Cannot find chrome at $(ChromeBinaryPath) in the downloaded copy"
            Condition="!Exists($(ChromeBinaryPath))" />
@@ -97,9 +119,11 @@
   </Target>
 
   <Target Name="DownloadAndInstallChromeDriver"
-          AfterTargets="Build"
+          AfterTargets="$(WasmProvisionAfterTarget)"
           Condition="(!Exists($(ChromeDriverStampFile)) or !Exists($(ChromeDriverBinaryPath))) and '$(InstallChromeForTests)' == 'true'">
 
+    <Error Condition="!$([MSBuild]::IsOSPlatform('linux')) and !$([MSBuild]::IsOSPlatform('windows'))"
+           Text="ChromeDriver provisioning only supported on Linux, and windows." />
     <Error Condition="'$(ChromeVersion)' == ''"
            Text="No %24(ChromeVersion) set. This can be set in eng/testing/ChromeVersions.props" />
 
@@ -121,8 +145,39 @@
     <Touch Files="$(ChromeDriverStampFile)" AlwaysCreate="true" />
   </Target>
 
+  <Target Name="DownloadAndInstallV8"
+          AfterTargets="$(WasmProvisionAfterTarget)"
+          Condition="(!Exists($(V8StampFile)) or !Exists($(V8BinaryPath))) and '$(InstallV8ForTests)' == 'true'">
+
+    <Error Condition="!$([MSBuild]::IsOSPlatform('linux')) and !$([MSBuild]::IsOSPlatform('windows'))"
+           Text="V8 provisioning only supported on Linux, and windows." />
+    <Error Condition="'$(V8Version)' == ''" Text="%24(V8Version) not set" />
+    <Error Condition="'$(_V8PlatformId)' == ''" Text="%24(_V8PlatformId) not set, needed for constructing the snapshot url." />
+
+    <PropertyGroup>
+      <_V8SnapshotUrl>https://storage.googleapis.com/chromium-v8/official/canary/v8-$(_V8PlatformId)-rel-$(V8Version).zip</_V8SnapshotUrl>
+
+      <_V8Script Condition="$([MSBuild]::IsOSPlatform('linux'))">#!/usr/bin/env bash
+export __SCRIPT_DIR=%24( cd -- "%24( dirname -- "%24{BASH_SOURCE[0]}" )" &amp;> /dev/null &amp;&amp; pwd )
+"$__SCRIPT_DIR/d8" --snapshot_blob="$__SCRIPT_DIR/snapshot_blob.bin" "$@"
+      </_V8Script>
+      <_V8Script Condition="$([MSBuild]::IsOSPlatform('windows'))">@echo off
+"%~dp0\d8.exe --snapshot_blob="%~dp0\snapshot_blob.bin" %*
+      </_V8Script>
+    </PropertyGroup>
+
+    <DownloadFile SourceUrl="$(_V8SnapshotUrl)" DestinationFolder="$(V8Dir)" SkipUnchangedFiles="true">
+      <Output TaskParameter="DownloadedFile" PropertyName="_DownloadedFile" />
+    </DownloadFile>
+
+    <Unzip SourceFiles="$(_DownloadedFile)" DestinationFolder="$(V8Dir)" />
+
+    <WriteLinesToFile Lines="$(_V8Script)" File="$(V8BinaryPath)" Overwrite="true" />
+    <Exec Command="chmod +x $(V8BinaryPath) $(V8Dir)/d8" Condition="$([MSBuild]::IsOSPlatform('linux'))" />
+  </Target>
+
   <Target Name="DownloadAndInstallFirefox"
-          AfterTargets="Build"
+          AfterTargets="$(WasmProvisionAfterTarget)"
           Condition="!Exists($(FirefoxStampFile)) and '$(InstallFirefoxForTests)' == 'true' and !$([MSBuild]::IsOSPlatform('windows'))">
     <ItemGroup>
       <_StampFile Include="$(_BrowserStampDir).install-firefox*.stamp" />

--- a/eng/testing/wasm-provisioning.targets
+++ b/eng/testing/wasm-provisioning.targets
@@ -174,6 +174,8 @@ export __SCRIPT_DIR=%24( cd -- "%24( dirname -- "%24{BASH_SOURCE[0]}" )" &amp;> 
 
     <WriteLinesToFile Lines="$(_V8Script)" File="$(V8BinaryPath)" Overwrite="true" />
     <Exec Command="chmod +x $(V8BinaryPath) $(V8Dir)/d8" Condition="$([MSBuild]::IsOSPlatform('linux'))" />
+
+    <Touch Files="$(V8StampFile)" AlwaysCreate="true" />
   </Target>
 
   <Target Name="DownloadAndInstallFirefox"

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -428,6 +428,7 @@ namespace System
                 return Registry.GetValue(key, "ContainerType", defaultValue: null) != null;
             }
 
+            // '/.dockerenv' - is to check if this is running in a codespace
             return (IsLinux && File.Exists("/.dockerenv"));
         }
 

--- a/src/libraries/sendtohelix-wasm.targets
+++ b/src/libraries/sendtohelix-wasm.targets
@@ -59,6 +59,7 @@
     <NeedsEMSDK Condition="'$(NeedsToBuildWasmAppsOnHelix)' == 'true'">true</NeedsEMSDK>
     <NeedsEMSDKNode Condition="'$(Scenario)' == 'WasmTestOnNodeJS' or '$(Scenario)' == 'BuildWasmApps'">false</NeedsEMSDKNode>
     <NeedsToRunOnBrowser Condition="'$(Scenario)' == 'WasmTestOnBrowser' or '$(Scenario)' == 'BuildWasmApps'">true</NeedsToRunOnBrowser>
+    <NeedsToRunOnV8 Condition="'$(Scenario)' == '' or '$(Scenario)' == 'normal' or '$(Scenario)' == 'BuildWasmApps'">true</NeedsToRunOnV8>
     <NeedsBuiltNugets Condition="'$(Scenario)' == 'BuildWasmApps'">true</NeedsBuiltNugets>
 
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
@@ -101,6 +102,8 @@
 
     <HelixPreCommand Condition="'$(NeedsToRunOnBrowser)' == 'true' and '$(DebuggerHost)' == 'chrome'" Include="export PATH=$HELIX_CORRELATION_PAYLOAD/$(ChromeDriverDirName):$PATH" />
     <HelixPreCommand Condition="'$(NeedsToRunOnBrowser)' == 'true' and '$(DebuggerHost)' == 'chrome'" Include="export PATH=$HELIX_CORRELATION_PAYLOAD/$(ChromeDirName):$PATH" />
+
+    <HelixPreCommand Condition="'$(NeedsToRunOnV8)' == 'true'" Include="export V8_PATH_FOR_TESTS=$HELIX_CORRELATION_PAYLOAD/$(V8DirName)/$(V8BinaryName)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(WindowsShell)' == 'true'">
@@ -114,6 +117,8 @@
 
     <HelixPreCommand Condition="'$(NeedsToRunOnBrowser)' == 'true' and '$(DebuggerHost)' == 'chrome'" Include="set PATH=%HELIX_CORRELATION_PAYLOAD%\$(ChromeDriverDirName)%3B%PATH%" />
     <HelixPreCommand Condition="'$(NeedsToRunOnBrowser)' == 'true' and '$(DebuggerHost)' == 'chrome'" Include="set PATH=%HELIX_CORRELATION_PAYLOAD%\$(ChromeDirName)%3B%PATH%" />
+
+    <HelixPreCommand Condition="'$(NeedsToRunOnV8)' == 'true'" Include="set V8_PATH_FOR_TESTS=%HELIX_CORRELATION_PAYLOAD%\$(V8DirName)\$(V8BinaryName)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(NeedsEMSDKNode)' == 'true' and '$(WindowsShell)' != 'true'">
@@ -187,6 +192,8 @@
            Text="Could not find chrome at $(ChromeDir)" />
     <Error Condition="'$(NeedsToRunOnBrowser)' == 'true' and '$(DebuggerHost)' == 'chrome' and !Exists($(ChromeDriverDir))"
            Text="Could not find chromedriver at $(ChromeDriverDir)" />
+    <Error Condition="'$(NeedsToRunOnV8)' == 'true' and !Exists($(V8BinaryPath))"
+           Text="Could not find v8 at $(V8BinaryPath)" />
     <Error Condition="'$(NeedsToRunOnBrowser)' == 'true' and '$(DebuggerHost)' == 'firefox' and !Exists($(FirefoxDir))"
            Text="Could not find firefox at $(FirefoxDir)" />
 
@@ -195,6 +202,10 @@
       <HelixCorrelationPayload Condition="'$(DebuggerHost)' == 'chrome'" Include="$(ChromeDriverDir)" />
 
       <HelixCorrelationPayload Condition="'$(WindowsShell)' != 'true' and '$(DebuggerHost)' == 'firefox'" Include="$(FirefoxDir)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <HelixCorrelationPayload Condition="'$(NeedsToRunOnV8)' == 'true'" Include="$(V8Dir)" Destination="$(V8DirName)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(NeedsEMSDK)' == 'true'">

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -111,7 +111,7 @@ run-browser-tests-%:
 	PATH="$(GECKODRIVER):$(CHROMEDRIVER):$(PATH)" XHARNESS_COMMAND="test-browser --browser=$(XHARNESS_BROWSER)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
 
 build-runtime-tests:
-	$(TOP)/src/tests/build.sh -mono os browser wasm $(CONFIG)
+	$(TOP)/src/tests/build.sh -mono os browser wasm $(CONFIG) $(MSBUILD_ARGS)
 
 build-debugger-tests-helix:
 	$(DOTNET) build -restore -bl:$(LOG_PATH)/Wasm.Debugger.Tests.binlog \

--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -323,7 +323,6 @@ npm update --lockfile-version=1
 | Wasm.Build.Tests  | linux+windows              | none                  | linux+windows             |
 | Debugger tests    | linux+windows              | none                  | linux+windows             |
 | Runtime tests     | linux                      | none                  | linux                     |
-| Perftrace         | linux: all tests           | linux: all tests      | none                      |
 | Multi-thread      | linux: all tests           | linux: all tests      | none                      |
 
 * `runtime-extra-platforms` does not run any wasm jobs on PRs
@@ -346,13 +345,27 @@ npm update --lockfile-version=1
 | Wasm.Build.Tests  | linux+windows              | none                                 |
 | Debugger tests    | linux+windows              | none                                 |
 | Runtime tests     | linux                      | none                                 |
-| Perftrace         | linux: build only          | none                                 |
 | Multi-thread      | linux: build only          | none                                 |
 
 * `high resource aot` runs a few specific library tests with AOT, that require more memory to AOT.
 
 
+## Test setup on CI
+
+Tests are run with V8, Chrome, node, and wasmtime for the various jobs.
+
+- V8: the version used is from `eng/testing/ChromeVersions.props`. This is used for all the library tests, and WBT, but *not* runtime tests.
+- Chrome: Same as V8.
+- Node: fixed version from emsdk
+- wasmtime - fixed version in `src/mono/wasi/wasi-sdk-version.txt`.
+
+### `eng/testing/ChromeVersions.props`
+
+This file is updated once a week by a github action `.github/workflows/bump-chrome-version.yml`, and the version is obtained by `src/tasks/WasmBuildTasks/GetChromeVersions.cs` task.
+
 # Perf pipeline
+
+- V8 version used to run the microbenchmarks is from `eng/testing/ChromeVersions.props`
 
 TBD
 

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -265,13 +265,6 @@ namespace Wasm.Build.Tests
             if (File.Exists("/.dockerenv"))
                 args.Append(" --browser-arg=--no-sandbox");
 
-            if (!string.IsNullOrEmpty(EnvironmentVariables.BrowserPathForTests))
-            {
-                if (!File.Exists(EnvironmentVariables.BrowserPathForTests))
-                    throw new Exception($"Cannot find BROWSER_PATH_FOR_TESTS={EnvironmentVariables.BrowserPathForTests}");
-                args.Append($" --browser-path=\"{EnvironmentVariables.BrowserPathForTests}\"");
-            }
-
             args.Append(" -- ");
             if (extraXHarnessMonoArgs != null)
             {

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -262,6 +262,7 @@ namespace Wasm.Build.Tests
             args.Append($" --expected-exit-code={expectedAppExitCode}");
             args.Append($" {extraXHarnessArgs ?? string.Empty}");
 
+            // `/.dockerenv` - is to check if this is running in a codespace
             if (File.Exists("/.dockerenv"))
                 args.Append(" --browser-arg=--no-sandbox");
 

--- a/src/mono/wasm/Wasm.Build.Tests/Common/EnvironmentVariables.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Common/EnvironmentVariables.cs
@@ -17,6 +17,7 @@ namespace Wasm.Build.Tests
         internal static readonly string? XHarnessCliPath           = Environment.GetEnvironmentVariable("XHARNESS_CLI_PATH");
         internal static readonly string? BuiltNuGetsPath           = Environment.GetEnvironmentVariable("BUILT_NUGETS_PATH");
         internal static readonly string? BrowserPathForTests       = Environment.GetEnvironmentVariable("BROWSER_PATH_FOR_TESTS");
+        internal static readonly string? V8PathForTests            = Environment.GetEnvironmentVariable("V8_PATH_FOR_TESTS");
         internal static readonly bool    ShowBuildOutput           = Environment.GetEnvironmentVariable("SHOW_BUILD_OUTPUT") is not null;
         internal static readonly bool UseWebcil                    = Environment.GetEnvironmentVariable("USE_WEBCIL_FOR_TESTS") is "true";
         internal static readonly string? SdkDirName                = Environment.GetEnvironmentVariable("SDK_DIR_NAME");

--- a/src/mono/wasm/Wasm.Build.Tests/HostRunner/BrowserHostRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/HostRunner/BrowserHostRunner.cs
@@ -5,11 +5,37 @@
 
 namespace Wasm.Build.Tests;
 
+using System;
+using System.IO;
+
 public class BrowserHostRunner : IHostRunner
 {
+    private static string? s_binaryPathArg;
+    private static string BinaryPathArg
+    {
+        get
+        {
+            if (s_binaryPathArg is null)
+            {
+                if (!string.IsNullOrEmpty(EnvironmentVariables.BrowserPathForTests))
+                {
+                    if (!File.Exists(EnvironmentVariables.BrowserPathForTests))
+                        throw new Exception($"Cannot find BROWSER_PATH_FOR_TESTS={EnvironmentVariables.BrowserPathForTests}");
+                    s_binaryPathArg = $" --browser-path=\"{EnvironmentVariables.BrowserPathForTests}\"";
+                }
+                else
+                {
+                    s_binaryPathArg = "";
+                }
+            }
+            return s_binaryPathArg;
+        }
+    }
+
+
     public string GetTestCommand() => "wasm test-browser";
-    public string GetXharnessArgsWindowsOS(XHarnessArgsOptions options) => $"-v trace -b {options.host} --browser-arg=--lang={options.environmentLocale} --web-server-use-cop";  // Windows: chrome.exe --lang=locale
-    public string GetXharnessArgsOtherOS(XHarnessArgsOptions options) => $"-v trace -b {options.host} --locale={options.environmentLocale} --web-server-use-cop";                // Linux: LANGUAGE=locale ./chrome
+    public string GetXharnessArgsWindowsOS(XHarnessArgsOptions options) => $"-v trace -b {options.host} --browser-arg=--lang={options.environmentLocale} --web-server-use-cop {BinaryPathArg}";  // Windows: chrome.exe --lang=locale
+    public string GetXharnessArgsOtherOS(XHarnessArgsOptions options) => $"-v trace -b {options.host} --locale={options.environmentLocale} --web-server-use-cop {BinaryPathArg}";                // Linux: LANGUAGE=locale ./chrome
     public bool UseWasmConsoleOutput() => false;
     public bool CanRunWBT() => true;
 }

--- a/src/mono/wasm/Wasm.Build.Tests/HostRunner/V8HostRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/HostRunner/V8HostRunner.cs
@@ -5,11 +5,35 @@
 
 namespace Wasm.Build.Tests;
 
+using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 public class V8HostRunner : IHostRunner
 {
-    private string GetXharnessArgs(string jsRelativePath) => $"--js-file={jsRelativePath} --engine=V8 -v trace --engine-arg=--experimental-wasm-simd --engine-arg=--module";
+    private static string? s_binaryPathArg;
+    private static string BinaryPathArg
+    {
+        get
+        {
+            if (s_binaryPathArg is null)
+            {
+                if (!string.IsNullOrEmpty(EnvironmentVariables.V8PathForTests))
+                {
+                    if (!File.Exists(EnvironmentVariables.V8PathForTests))
+                        throw new Exception($"Cannot find V8_PATH_FOR_TESTS={EnvironmentVariables.V8PathForTests}");
+                    s_binaryPathArg += $" --js-engine-path=\"{EnvironmentVariables.V8PathForTests}\"";
+                }
+                else
+                {
+                    s_binaryPathArg = "";
+                }
+            }
+            return s_binaryPathArg;
+        }
+    }
+
+    private string GetXharnessArgs(string jsRelativePath) => $"--js-file={jsRelativePath} --engine=V8 -v trace --engine-arg=--experimental-wasm-simd --engine-arg=--module {BinaryPathArg}";
 
     public string GetTestCommand() => "wasm test";
     public string GetXharnessArgsWindowsOS(XHarnessArgsOptions options) => GetXharnessArgs(options.jsRelativePath);

--- a/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
+++ b/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
@@ -15,6 +15,7 @@
     <!-- these are imported in this project instead -->
     <SkipWorkloadsTestingTargetsImport>false</SkipWorkloadsTestingTargetsImport>
     <InstallWorkloadForTesting>true</InstallWorkloadForTesting>
+    <!-- '/.dockerenv' - is to check if this is running in a codespace -->
     <InstallChromeForTests Condition="'$(InstallChromeForTests)' == '' and ('$(ContinuousIntegrationBuild)' == 'true' or Exists('/.dockerenv'))">true</InstallChromeForTests>
     <InstallV8ForTests Condition="'$(InstallV8ForTests)' == '' and ('$(ContinuousIntegrationBuild)' == 'true' or Exists('/.dockerenv'))">true</InstallV8ForTests>
 

--- a/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
+++ b/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
@@ -16,6 +16,7 @@
     <SkipWorkloadsTestingTargetsImport>false</SkipWorkloadsTestingTargetsImport>
     <InstallWorkloadForTesting>true</InstallWorkloadForTesting>
     <InstallChromeForTests Condition="'$(InstallChromeForTests)' == '' and ('$(ContinuousIntegrationBuild)' == 'true' or Exists('/.dockerenv'))">true</InstallChromeForTests>
+    <InstallV8ForTests Condition="'$(InstallV8ForTests)' == '' and ('$(ContinuousIntegrationBuild)' == 'true' or Exists('/.dockerenv'))">true</InstallV8ForTests>
 
     <!-- don't run any wasm build steps -->
     <IsBrowserWasmProject>false</IsBrowserWasmProject>
@@ -93,6 +94,9 @@
 
       <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export BROWSER_PATH_FOR_TESTS=$(_WasmBrowserPathForTests)" />
       <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set BROWSER_PATH_FOR_TESTS=$(_WasmBrowserPathForTests)" />
+
+      <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export V8_PATH_FOR_TESTS=$(_WasmJSEnginePathForTests)" />
+      <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set V8_PATH_FOR_TESTS=$(_WasmJSEnginePathForTests)" />
 
       <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export BUILT_NUGETS_PATH=$(LibrariesShippingPackagesDir)/" />
       <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set BUILT_NUGETS_PATH=$(LibrariesShippingPackagesDir)" />

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -475,7 +475,7 @@
     </PropertyGroup>
 
     <Error Condition="'$(WasmMainAssemblyFileName)' == ''" Text="%24(WasmMainAssemblyFileName) property needs to be set for generating $(WasmRunV8ScriptPath)." />
-    
+
     <WriteLinesToFile
       File="$(WasmRunV8ScriptPath)"
       Lines="$(V8ScriptShebang);v8 --expose_wasm --module $(_WasmMainJSFileName) -- ${RUNTIME_ARGS} --run $(WasmMainAssemblyFileName) $*"

--- a/src/mono/wasm/debugger/DebuggerTestSuite/ChromeProvider.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/ChromeProvider.cs
@@ -170,6 +170,7 @@ internal class ChromeProvider : WasmHostProvider
     private static string GetInitParms(int port, string lang="en-US")
     {
         string str = $"--headless --disable-gpu --lang={lang} --incognito --remote-debugging-port={port}";
+        // `/.dockerenv` - is to check if this is running in a codespace
         if (File.Exists("/.dockerenv"))
         {
             Console.WriteLine ("Detected a container, disabling sandboxing for debugger tests.");

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
@@ -8,6 +8,7 @@
     <DefineConstants Condition="'$(DebuggerHost)' == 'chrome'">$(DefineConstants);RUN_IN_CHROME</DefineConstants>
     <DefineConstants Condition="'$(RuntimeConfiguration)' == 'release'">$(DefineConstants);RELEASE_RUNTIME</DefineConstants>
     <BrowserHost Condition="$([MSBuild]::IsOSPlatform('windows'))">windows</BrowserHost>
+    <!-- '/.dockerenv' - is to check if this is running in a codespace -->
     <_ProvisionBrowser Condition="'$(ContinuousIntegrationBuild)' == 'true' or Exists('/.dockerenv')">true</_ProvisionBrowser>
     <InstallChromeForTests Condition="'$(InstallChromeForTests)' == '' and '$(DebuggerHost)' == 'chrome' and '$(_ProvisionBrowser)' == 'true'">true</InstallChromeForTests>
     <InstallFirefoxForTests Condition="'$(InstallFirefoxForTests)' == '' and '$(DebuggerHost)' == 'firefox' and '$(_ProvisionBrowser)' == 'true'">true</InstallFirefoxForTests>

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -4,6 +4,7 @@
     <LibrariesConfiguration>Release</LibrariesConfiguration>
     <!-- NativeAot tests rely on presence of ILLink targets, but don't actually run ILLink. -->
     <UsingToolMicrosoftNetILLinkTasks Condition="'$(UsingToolMicrosoftNetILLinkTasks)' == ''">true</UsingToolMicrosoftNetILLinkTasks>
+    <InstallV8ForTests>false</InstallV8ForTests>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\Common\dir.sdkbuild.props" Condition="'$(UsingMicrosoftNETSdk)' == 'true'"  />


### PR DESCRIPTION
On CI, provision `v8` using version from `eng/testing/ChromeVersions.props` and use that for running library tests, and Wasm.Build.Tests .

The only remaining build which will be using system `v8` after this would be the runtime tests.