### PR TITLE
[Release/8.0] Fix x64 crossbuild on macOS arm64

### DIFF
--- a/src/native/minipal/cpufeatures.c
+++ b/src/native/minipal/cpufeatures.c
@@ -8,11 +8,11 @@
 #include "cpufeatures.h"
 #include "cpuid.h"
 
-#if TARGET_WINDOWS
+#if HOST_WINDOWS
 
 #include <Windows.h>
 
-#else // TARGET_WINDOWS
+#else // HOST_WINDOWS
 
 #include "minipalconfig.h"
 
@@ -38,10 +38,10 @@
 #include <sys/sysctl.h>
 #endif
 
-#endif // !TARGET_WINDOWS
+#endif // !HOST_WINDOWS
 
-#if defined(TARGET_UNIX)
-#if defined(TARGET_X86) || defined(TARGET_AMD64)
+#if defined(HOST_UNIX)
+#if defined(HOST_X86) || defined(HOST_AMD64)
 
 static uint32_t xmmYmmStateSupport()
 {
@@ -61,7 +61,7 @@ static uint32_t xmmYmmStateSupport()
 
 static uint32_t avx512StateSupport()
 {
-#if defined(TARGET_APPLE)
+#if defined(HOST_APPLE)
     // MacOS has specialized behavior where it reports AVX512 support but doesnt
     // actually enable AVX512 until the first instruction is executed and does so
     // on a per thread basis. It does this by catching the faulting instruction and
@@ -95,11 +95,11 @@ static bool IsAvx512Enabled()
 {
     return true;
 }
-#endif // defined(TARGET_X86) || defined(TARGET_AMD64)
-#endif // TARGET_UNIX
+#endif // defined(HOST_X86) || defined(HOST_AMD64)
+#endif // HOST_UNIX
 
-#if defined(TARGET_WINDOWS)
-#if defined(TARGET_X86) || defined(TARGET_AMD64)
+#if defined(HOST_WINDOWS)
+#if defined(HOST_X86) || defined(HOST_AMD64)
 static uint32_t xmmYmmStateSupport()
 {
     // check OS has enabled both XMM and YMM state support
@@ -124,14 +124,14 @@ static bool IsAvx512Enabled()
     return ((FeatureMask & XSTATE_MASK_AVX512) != 0);
 }
 
-#endif // defined(TARGET_X86) || defined(TARGET_AMD64)
-#endif // TARGET_WINDOWS
+#endif // defined(HOST_X86) || defined(HOST_AMD64)
+#endif // HOST_WINDOWS
 
 int minipal_getcpufeatures(void)
 {
     int result = 0;
 
-#if defined(TARGET_X86) || defined(TARGET_AMD64)
+#if defined(HOST_X86) || defined(HOST_AMD64)
 
     int cpuidInfo[4];
 
@@ -315,10 +315,10 @@ int minipal_getcpufeatures(void)
         }
 
     }
-#endif // TARGET_X86 || TARGET_AMD64
+#endif // HOST_X86 || HOST_AMD64
 
-#if defined(TARGET_ARM64)
-#if defined(TARGET_UNIX)
+#if defined(HOST_ARM64)
+#if defined(HOST_UNIX)
 
 #if HAVE_AUXV_HWCAP_H
     unsigned long hwCap = getauxval(AT_HWCAP);
@@ -386,9 +386,9 @@ int minipal_getcpufeatures(void)
 
     result |= ARM64IntrinsicConstants_AdvSimd | ARM64IntrinsicConstants_VectorT128;
 #endif // HAVE_AUXV_HWCAP_H
-#endif // TARGET_UNIX
+#endif // HOST_UNIX
 
-#if defined(TARGET_WINDOWS)
+#if defined(HOST_WINDOWS)
     // FP and SIMD support are enabled by default
     result |= ARM64IntrinsicConstants_AdvSimd | ARM64IntrinsicConstants_VectorT128;
 
@@ -418,9 +418,12 @@ int minipal_getcpufeatures(void)
     {
         result |= ARM64IntrinsicConstants_Rcpc;
     }
-#endif // TARGET_WINDOWS
 
-#endif // TARGET_ARM64
+    // TODO: IsProcessorFeaturePresent doesn't support LRCPC2 yet.
+
+#endif // HOST_WINDOWS
+
+#endif // HOST_ARM64
 
     return result;
 }

--- a/src/native/minipal/cpufeatures.h
+++ b/src/native/minipal/cpufeatures.h
@@ -8,7 +8,7 @@
 // Should match the constants defined in the compiler in HardwareIntrinsicHelpers.cs
 //
 
-#if defined(TARGET_X86) || defined(TARGET_AMD64)
+#if defined(HOST_X86) || defined(HOST_AMD64)
 enum XArchIntrinsicConstants
 {
     XArchIntrinsicConstants_Aes = 0x0001,
@@ -41,9 +41,9 @@ enum XArchIntrinsicConstants
     XArchIntrinsicConstants_VectorT256 = 0x8000000,
     XArchIntrinsicConstants_VectorT512 = 0x10000000,
 };
-#endif // TARGET_X86 || TARGET_AMD64
+#endif // HOST_X86 || HOST_AMD64
 
-#if defined(TARGET_ARM64)
+#if defined(HOST_ARM64)
 enum ARM64IntrinsicConstants
 {
     ARM64IntrinsicConstants_AdvSimd = 0x0001,
@@ -64,7 +64,7 @@ enum ARM64IntrinsicConstants
 #define ARM64_ATOMICS_FEATURE_FLAG_BIT 7
 static_assert((1 << ARM64_ATOMICS_FEATURE_FLAG_BIT) == ARM64IntrinsicConstants_Atomics, "ARM64_ATOMICS_FEATURE_FLAG_BIT must match with ARM64IntrinsicConstants_Atomics");
 
-#endif // TARGET_ARM64
+#endif // HOST_ARM64
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
Backport of #91413 to release/8.0

## Customer Impact
When a customer attempts to do a cross build of .NET runtime for macOS x64 on macOS arm64, the build fails during cross tools build phase. It happens due to the cpufeatures.c/h using `TARGET_XXX` ifdefs instead of `HOST_XXX` ones.

## Testing
Local cross build of the runtime on macOS arm64, local build on macOS x64 and local build on linux arm64.

## Risk
Low, the change does not cause different CPU features being detected.
