### PR TITLE
SPMI: Optimize collection download, increase diffs timeout

### DIFF
--- a/eng/pipelines/coreclr/templates/run-superpmi-diffs-job.yml
+++ b/eng/pipelines/coreclr/templates/run-superpmi-diffs-job.yml
@@ -11,7 +11,7 @@ parameters:
   osSubgroup: ''                  # optional -- operating system subgroup
   continueOnError: 'false'        # optional -- determines whether to continue the build if the step errors
   dependsOn: ''                   # optional -- dependencies of the job
-  timeoutInMinutes: 120           # optional -- timeout for the job
+  timeoutInMinutes: 180           # optional -- timeout for the job
   enableTelemetry: false          # optional -- enable for telemetry
   liveLibrariesBuildConfig: ''    # optional -- live-live libraries configuration to use for the run
   helixQueues: ''                 # required -- Helix queues
@@ -119,7 +119,7 @@ jobs:
         helixType: 'build/tests/'
         helixQueues: ${{ join(',', parameters.helixQueues) }}
         creator: dotnet-bot
-        WorkItemTimeout: 2:00 # 2 hours
+        WorkItemTimeout: 3:00 # 3 hours
         WorkItemDirectory: '$(WorkItemDirectory)'
         CorrelationPayloadDirectory: '$(CorrelationPayloadDirectory)'
         helixProjectArguments: '$(Build.SourcesDirectory)/src/coreclr/scripts/superpmi-diffs.proj'

--- a/eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
@@ -5,7 +5,7 @@ parameters:
   osSubgroup: ''                  # optional -- operating system subgroup
   condition: true
   pool: ''
-  timeoutInMinutes: 180           # build timeout
+  timeoutInMinutes: 240           # build timeout
   variables: {}
   helixQueues: ''
   dependOnEvaluatePaths: false

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -116,8 +116,8 @@ void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolv
 {
     pResolvedToken->tokenContext = impTokenLookupContextHandle;
     pResolvedToken->tokenScope   = info.compScopeHnd;
-    pResolvedToken->token        = getU4LittleEndian(addr);
     pResolvedToken->tokenType    = kind;
+    pResolvedToken->token        = getU4LittleEndian(addr);
 
     info.compCompHnd->resolveToken(pResolvedToken);
 }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -116,8 +116,8 @@ void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolv
 {
     pResolvedToken->tokenContext = impTokenLookupContextHandle;
     pResolvedToken->tokenScope   = info.compScopeHnd;
-    pResolvedToken->tokenType    = kind;
     pResolvedToken->token        = getU4LittleEndian(addr);
+    pResolvedToken->tokenType    = kind;
 
     info.compCompHnd->resolveToken(pResolvedToken);
 }

--- a/src/coreclr/scripts/superpmi-diffs.proj
+++ b/src/coreclr/scripts/superpmi-diffs.proj
@@ -57,7 +57,7 @@
 
   <PropertyGroup>
     <WorkItemCommand>$(Python) $(ProductDirectory)/superpmi_diffs.py -type $(SuperPmiDiffType) -base_jit_directory $(ProductDirectory)/base -diff_jit_directory $(ProductDirectory)/diff $(SuperPmiBaseJitOptionsArg) $(SuperPmiDiffJitOptionsArg) -log_directory $(SuperpmiLogsLocation)</WorkItemCommand>
-    <WorkItemTimeout>2:00</WorkItemTimeout>
+    <WorkItemTimeout>3:00</WorkItemTimeout>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With the latest collections we are frequently hitting timeouts during
linux tpdiff runs. This PR applies two changes to improve the
situation:
- Optimize the download/extraction of collections by extracting directly
  to the target location. The Helix machines actually seem to spend many
  times longer to extract and copy the collections than they do
  downloading them.
- Increase the timeout of superpmi-diffs by one hour.