### PR TITLE
Use `Unsafe.WriteUnaligned` in `BitConverter.GetBytes`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -29,6 +29,7 @@ namespace System
         /// </summary>
         /// <param name="value">A Boolean value.</param>
         /// <returns>A byte array with length 1.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte[] GetBytes(bool value)
         {
             byte[] r = new byte[1];

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -56,6 +56,7 @@ namespace System
         /// </summary>
         /// <param name="value">A Char value.</param>
         /// <returns>An array of bytes with length 2.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte[] GetBytes(char value)
         {
             byte[] bytes = new byte[sizeof(char)];
@@ -83,6 +84,7 @@ namespace System
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 2.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte[] GetBytes(short value)
         {
             byte[] bytes = new byte[sizeof(short)];
@@ -110,6 +112,7 @@ namespace System
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 4.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte[] GetBytes(int value)
         {
             byte[] bytes = new byte[sizeof(int)];
@@ -137,6 +140,7 @@ namespace System
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 8.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte[] GetBytes(long value)
         {
             byte[] bytes = new byte[sizeof(long)];
@@ -165,6 +169,7 @@ namespace System
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 2.</returns>
         [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte[] GetBytes(ushort value)
         {
             byte[] bytes = new byte[sizeof(ushort)];
@@ -194,6 +199,7 @@ namespace System
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 4.</returns>
         [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte[] GetBytes(uint value)
         {
             byte[] bytes = new byte[sizeof(uint)];
@@ -223,6 +229,7 @@ namespace System
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 8.</returns>
         [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte[] GetBytes(ulong value)
         {
             byte[] bytes = new byte[sizeof(ulong)];

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -251,12 +251,7 @@ namespace System
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 2.</returns>
-        public static unsafe byte[] GetBytes(Half value)
-        {
-            byte[] bytes = new byte[sizeof(Half)];
-            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
-            return bytes;
-        }
+        public static unsafe byte[] GetBytes(Half value) => GetBytes(HalfToInt16Bits(value));
 
         /// <summary>
         /// Converts a half-precision floating-point value into a span of bytes.
@@ -278,12 +273,7 @@ namespace System
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 4.</returns>
-        public static byte[] GetBytes(float value)
-        {
-            byte[] bytes = new byte[sizeof(float)];
-            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
-            return bytes;
-        }
+        public static byte[] GetBytes(float value) => GetBytes(SingleToInt32Bits(value));
 
         /// <summary>
         /// Converts a single-precision floating-point value into a span of bytes.
@@ -305,12 +295,7 @@ namespace System
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 8.</returns>
-        public static byte[] GetBytes(double value)
-        {
-            byte[] bytes = new byte[sizeof(double)];
-            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
-            return bytes;
-        }
+        public static byte[] GetBytes(double value) => GetBytes(DoubleToInt64Bits(value));
 
         /// <summary>
         /// Converts a double-precision floating-point value into a span of bytes.

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -59,7 +59,7 @@ namespace System
         public static byte[] GetBytes(char value)
         {
             byte[] bytes = new byte[sizeof(char)];
-            Unsafe.As<byte, char>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
             return bytes;
         }
 
@@ -86,7 +86,7 @@ namespace System
         public static byte[] GetBytes(short value)
         {
             byte[] bytes = new byte[sizeof(short)];
-            Unsafe.As<byte, short>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
             return bytes;
         }
 
@@ -113,7 +113,7 @@ namespace System
         public static byte[] GetBytes(int value)
         {
             byte[] bytes = new byte[sizeof(int)];
-            Unsafe.As<byte, int>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
             return bytes;
         }
 
@@ -140,7 +140,7 @@ namespace System
         public static byte[] GetBytes(long value)
         {
             byte[] bytes = new byte[sizeof(long)];
-            Unsafe.As<byte, long>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
             return bytes;
         }
 
@@ -168,7 +168,7 @@ namespace System
         public static byte[] GetBytes(ushort value)
         {
             byte[] bytes = new byte[sizeof(ushort)];
-            Unsafe.As<byte, ushort>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
             return bytes;
         }
 
@@ -197,7 +197,7 @@ namespace System
         public static byte[] GetBytes(uint value)
         {
             byte[] bytes = new byte[sizeof(uint)];
-            Unsafe.As<byte, uint>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
             return bytes;
         }
 
@@ -226,7 +226,7 @@ namespace System
         public static byte[] GetBytes(ulong value)
         {
             byte[] bytes = new byte[sizeof(ulong)];
-            Unsafe.As<byte, ulong>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
             return bytes;
         }
 
@@ -254,7 +254,7 @@ namespace System
         public static unsafe byte[] GetBytes(Half value)
         {
             byte[] bytes = new byte[sizeof(Half)];
-            Unsafe.As<byte, Half>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
             return bytes;
         }
 
@@ -281,7 +281,7 @@ namespace System
         public static byte[] GetBytes(float value)
         {
             byte[] bytes = new byte[sizeof(float)];
-            Unsafe.As<byte, float>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
             return bytes;
         }
 
@@ -308,7 +308,7 @@ namespace System
         public static byte[] GetBytes(double value)
         {
             byte[] bytes = new byte[sizeof(double)];
-            Unsafe.As<byte, double>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
             return bytes;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -258,7 +258,13 @@ namespace System
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 2.</returns>
-        public static unsafe byte[] GetBytes(Half value) => GetBytes(HalfToUInt16Bits(value));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe byte[] GetBytes(Half value)
+        {
+            byte[] bytes = new byte[sizeof(Half)];
+            Unsafe.As<byte, Half>(ref bytes[0]) = value;
+            return bytes;
+        }
 
         /// <summary>
         /// Converts a half-precision floating-point value into a span of bytes.
@@ -280,7 +286,13 @@ namespace System
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 4.</returns>
-        public static byte[] GetBytes(float value) => GetBytes(SingleToUInt32Bits(value));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte[] GetBytes(float value)
+        {
+            byte[] bytes = new byte[sizeof(float)];
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
+            return bytes;
+        }
 
         /// <summary>
         /// Converts a single-precision floating-point value into a span of bytes.
@@ -302,7 +314,13 @@ namespace System
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 8.</returns>
-        public static byte[] GetBytes(double value) => GetBytes(DoubleToUInt64Bits(value));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte[] GetBytes(double value)
+        {
+            byte[] bytes = new byte[sizeof(double)];
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
+            return bytes;
+        }
 
         /// <summary>
         /// Converts a double-precision floating-point value into a span of bytes.

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -251,7 +251,7 @@ namespace System
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 2.</returns>
-        public static unsafe byte[] GetBytes(Half value) => GetBytes(HalfToInt16Bits(value));
+        public static unsafe byte[] GetBytes(Half value) => GetBytes(HalfToUInt16Bits(value));
 
         /// <summary>
         /// Converts a half-precision floating-point value into a span of bytes.
@@ -273,7 +273,7 @@ namespace System
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 4.</returns>
-        public static byte[] GetBytes(float value) => GetBytes(SingleToInt32Bits(value));
+        public static byte[] GetBytes(float value) => GetBytes(SingleToUInt32Bits(value));
 
         /// <summary>
         /// Converts a single-precision floating-point value into a span of bytes.
@@ -295,7 +295,7 @@ namespace System
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 8.</returns>
-        public static byte[] GetBytes(double value) => GetBytes(DoubleToInt64Bits(value));
+        public static byte[] GetBytes(double value) => GetBytes(DoubleToUInt64Bits(value));
 
         /// <summary>
         /// Converts a double-precision floating-point value into a span of bytes.

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -262,7 +262,7 @@ namespace System
         public static unsafe byte[] GetBytes(Half value)
         {
             byte[] bytes = new byte[sizeof(Half)];
-            Unsafe.As<byte, Half>(ref bytes[0]) = value;
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(bytes), value);
             return bytes;
         }
 


### PR DESCRIPTION
[sharplab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBLANgHwAEAmARgFgAoQgBgAJDSA6AJQFcA7DbAWxiYDCEHgAc8MKAGUJAN2xgYAZwDcVWg2bsuvfgEkuEiCOlQ5ClVTUBmBsToC6Abyp1XDG4yR1gATwwwAbQBdOgBxGAwAIT8lAH0AEWwAMySACiTcCABDDDoZLNw2GABKFzdnSjcq7xjgmv9FOgBeOg4YAHd6wMVsAC8YCDSM7IxioNVK6tcAVQ5FLKT+AHUobH9ZguwAczaAE1TYJLoAWRgeaB9jrKhFAAsCpnCMAEEoKCyfeJyslhhF2A4ClSvgaxTQeQKRWKEymrkIAHYuhZJq4AL5lOEeUheEGBEJPaINWJPV7vT7fX7/GCAmDpTI5CGFEoYpwsqq4uq4xotNqdDk9fqDOkjMYw2GzeaLJjPRQAHlx4OGOQAfAc/iczhcrjd7rhHhFSR8vhgfn8JNSgVzisVmoyimKpgikQ66KjqizCFicbV8RFCXFIllFLSlbl8kzSijWVH2T6kbbeV0AgKBkN6aNxmy3BKFvwZfKYor06rDkiAjQgjaWuH7Vm4YiuS70ZRUUA==)

Added `AggressiveInlining` to prevent regressions from from failure to inline.
