### PR TITLE
Fix ldapur instruction

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -1778,12 +1778,12 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
                 ins               = INS_ldapurb;
                 handledWithLdapur = true;
             }
-            else if (ins == INS_ldrh)
+            else if ((ins == INS_ldrh) && addrIsAligned)
             {
                 ins               = INS_ldapurh;
                 handledWithLdapur = true;
             }
-            else if (ins == INS_ldr)
+            else if ((ins == INS_ldr) && addrIsAligned && genIsValidIntReg(targetReg))
             {
                 ins               = INS_ldapur;
                 handledWithLdapur = true;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/91648
Fixes https://github.com/dotnet/runtime/issues/91647

The issue is that LDAPUR doesn't support fp regs, I made a small clean up and now it should ignore those (just like for existing ldar)

PTAL @BruceForstall @TIHan @dotnet/jit-contrib 