### PR TITLE
Fix binder gen compile issues due to inaccessible members and identifier name clashes

### DIFF
--- a/src/libraries/Common/src/SourceGenerators/TypeModelHelper.cs
+++ b/src/libraries/Common/src/SourceGenerators/TypeModelHelper.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
@@ -74,7 +73,7 @@ namespace SourceGenerators
         /// </summary>
         public static string ToMinimalDisplayString(this ITypeSymbol type) => type.ToDisplayString(s_minimalDisplayFormat);
 
-        private static List<ITypeSymbol>? GetAllTypeArgumentsInScope(this INamedTypeSymbol type)
+        public static List<ITypeSymbol>? GetAllTypeArgumentsInScope(this INamedTypeSymbol type)
         {
             if (!type.IsGenericType)
             {

--- a/src/libraries/Common/src/SourceGenerators/TypeModelHelper.cs
+++ b/src/libraries/Common/src/SourceGenerators/TypeModelHelper.cs
@@ -9,7 +9,7 @@ using System.Diagnostics;
 
 namespace SourceGenerators
 {
-    internal static class TypeModelHelpers
+    internal static class TypeModelHelper
     {
         private static readonly SymbolDisplayFormat s_minimalDisplayFormat = new SymbolDisplayFormat(
             globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,

--- a/src/libraries/Common/src/SourceGenerators/TypeModelHelpers.cs
+++ b/src/libraries/Common/src/SourceGenerators/TypeModelHelpers.cs
@@ -17,13 +17,13 @@ namespace SourceGenerators
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
-        public static string ToIdentifierCompatibleSubstring(this ITypeSymbol type, bool useUniqueName = false)
+        public static string ToIdentifierCompatibleSubstring(this ITypeSymbol type, bool useUniqueName)
         {
             if (type is IArrayTypeSymbol arrayType)
             {
                 int rank = arrayType.Rank;
                 string suffix = rank == 1 ? "Array" : $"Array{rank}D"; // Array, Array2D, Array3D, ...
-                return ToIdentifierCompatibleSubstring(arrayType.ElementType) + suffix;
+                return ToIdentifierCompatibleSubstring(arrayType.ElementType, useUniqueName) + suffix;
             }
 
             StringBuilder? sb = null;
@@ -62,7 +62,7 @@ namespace SourceGenerators
             {
                 foreach (ITypeSymbol genericArg in typeArgsInScope)
                 {
-                    sb.Append(ToIdentifierCompatibleSubstring(genericArg));
+                    sb.Append(ToIdentifierCompatibleSubstring(genericArg, useUniqueName));
                 }
             }
 
@@ -94,7 +94,7 @@ namespace SourceGenerators
 
                 if (!current.TypeArguments.IsEmpty)
                 {
-                    (args ?? new()).AddRange(current.TypeArguments);
+                    (args ??= new()).AddRange(current.TypeArguments);
                 }
             }
         }

--- a/src/libraries/Common/src/SourceGenerators/TypeModelHelpers.cs
+++ b/src/libraries/Common/src/SourceGenerators/TypeModelHelpers.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
+
+namespace SourceGenerators
+{
+    internal static class TypeModelHelpers
+    {
+        private static readonly SymbolDisplayFormat s_minimalDisplayFormat = new SymbolDisplayFormat(
+            globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
+            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
+            genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+        public static string ToIdentifierCompatibleSubstring(this ITypeSymbol type, bool useUniqueName = false)
+        {
+            if (type is IArrayTypeSymbol arrayType)
+            {
+                int rank = arrayType.Rank;
+                string suffix = rank == 1 ? "Array" : $"Array{rank}D"; // Array, Array2D, Array3D, ...
+                return ToIdentifierCompatibleSubstring(arrayType.ElementType) + suffix;
+            }
+
+            string name = GetName(type);
+
+            if (type is not INamedTypeSymbol namedType || !namedType.IsGenericType)
+            {
+                return name;
+            }
+
+            StringBuilder sb = new();
+
+            sb.Append(name);
+
+            foreach (ITypeSymbol genericArg in namedType.GetAllTypeArgumentsInScope())
+            {
+                sb.Append(ToIdentifierCompatibleSubstring(genericArg));
+            }
+
+            return sb.ToString();
+
+            string GetName(ITypeSymbol type) => useUniqueName
+                ? ToIdentifierCompatibleSubstring(type.ToMinimalDisplayString())
+                : type.Name;
+        }
+
+        /// <summary>
+        /// Type name, prefixed with containing type names if it is nested (e.g. ContainingType.NestedType).
+        /// </summary>
+        /// <returns></returns>
+        public static string ToMinimalDisplayString(this ITypeSymbol type) => type.ToDisplayString(s_minimalDisplayFormat);
+
+        private static ITypeSymbol[] GetAllTypeArgumentsInScope(this INamedTypeSymbol type)
+        {
+            if (!type.IsGenericType)
+            {
+                return Array.Empty<ITypeSymbol>();
+            }
+
+            var args = new List<ITypeSymbol>();
+            TraverseContainingTypes(type);
+            return args.ToArray();
+
+            void TraverseContainingTypes(INamedTypeSymbol current)
+            {
+                if (current.ContainingType is INamedTypeSymbol parent)
+                {
+                    TraverseContainingTypes(parent);
+                }
+
+                args.AddRange(current.TypeArguments);
+            }
+        }
+
+        private static string ToIdentifierCompatibleSubstring(string input)
+        {
+            StringBuilder sb = new();
+
+            foreach (char c in input)
+            {
+                if (c is '[')
+                {
+                    sb.Append("Arr");
+                }
+                else if (c is ']')
+                {
+                    sb.Append("ay");
+                }
+                else if (c is not (',' or ' ' or '.' or '<' or '>' or '_'))
+                {
+                    sb.Append(c);
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 if (type is null ||
                     type.SpecialType is SpecialType.System_Object or SpecialType.System_Void ||
+                    !IsAccessibleFromGenBinders(type) ||
                     type.TypeKind is TypeKind.TypeParameter or TypeKind.Pointer or TypeKind.Error ||
                     type.IsRefLikeType ||
                     ContainsGenericParameters(type))
@@ -78,6 +79,16 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 }
 
                 return true;
+
+                static bool IsAccessibleFromGenBinders(ITypeSymbol type)
+                {
+                    if (type is IArrayTypeSymbol array)
+                    {
+                        return IsAccessibleFromGenBinders(array.ElementType);
+                    }
+
+                    return type.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal or Accessibility.Friend;
+                }
             }
 
             private TypeSpec? GetTargetTypeForRootInvocation(ITypeSymbol? type, Location? invocationLocation)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
+using SourceGenerators;
 
 namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 {
@@ -85,6 +86,17 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     if (type is IArrayTypeSymbol array)
                     {
                         return IsAccessibleFromGenBinders(array.ElementType);
+                    }
+
+                    if (type is INamedTypeSymbol namedType && namedType.GetAllTypeArgumentsInScope() is List<ITypeSymbol> typeArgsInScope)
+                    {
+                        foreach (ITypeSymbol genericArg in typeArgsInScope)
+                        {
+                            if (!IsAccessibleFromGenBinders(genericArg))
+                            {
+                                return false;
+                            }
+                        }
                     }
 
                     return type.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal or Accessibility.Friend;

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/ConfigurationBinder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using SourceGenerators;
 
 namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 {
@@ -138,7 +139,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         EmitBlankLineIfRequired();
                         _writer.WriteLine($"/// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>");
                         EmitInterceptsLocationAnnotations(interceptorInfoList);
-                        EmitStartBlock($"public static void {Identifier.Bind}_{type.DisplayString.ToIdentifierSubstring()}(this {Identifier.IConfiguration} {Identifier.configuration}, {additionalParams})");
+                        EmitStartBlock($"public static void {Identifier.Bind}_{type.IdentifierCompatibleSubstring}(this {Identifier.IConfiguration} {Identifier.configuration}, {additionalParams})");
 
                         if (type.NeedsMemberBinding)
                         {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/CoreBindingHelpers.cs
@@ -923,7 +923,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             private static string GetConfigKeyCacheFieldName(ObjectSpec type) =>
-                $"s_configKeys_{type.DisplayString.ToIdentifierSubstring()}";
+                $"s_configKeys_{type.IdentifierCompatibleSubstring}";
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Helpers/Emitter/Helpers.cs
@@ -245,18 +245,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             private string GetIncrementalIdentifier(string prefix) => $"{prefix}{_valueSuffixIndex++}";
 
             private static string GetInitalizeMethodDisplayString(ObjectSpec type) =>
-                $"{nameof(MethodsToGen_CoreBindingHelper.Initialize)}{type.DisplayString.ToIdentifierSubstring()}";
+                $"{nameof(MethodsToGen_CoreBindingHelper.Initialize)}{type.IdentifierCompatibleSubstring}";
         }
-    }
-
-    internal static class EmitterExtensions
-    {
-        public static string ToIdentifierSubstring(this string typeDisplayName) =>
-            typeDisplayName
-                .Replace("[]", nameof(Array))
-                .Replace(", ", string.Empty)
-                .Replace(".", string.Empty)
-                .Replace("<", string.Empty)
-                .Replace(">", string.Empty);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj
@@ -23,6 +23,7 @@
     <Compile Include="$(CommonPath)\Roslyn\DiagnosticDescriptorHelper.cs" Link="Common\Roslyn\DiagnosticDescriptorHelper.cs" />
     <Compile Include="$(CommonPath)\Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
     <Compile Include="$(CommonPath)\SourceGenerators\SourceWriter.cs" Link="Common\SourceGenerators\SourceWriter.cs" />
+    <Compile Include="$(CommonPath)\SourceGenerators\TypeModelHelpers.cs" Link="Common\SourceGenerators\TypeModelHelpers.cs" />
     <Compile Include="ConfigurationBindingGenerator.cs" />
     <Compile Include="ConfigurationBindingGenerator.Emitter.cs" />
     <Compile Include="ConfigurationBindingGenerator.Parser.cs" />

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj
@@ -23,7 +23,7 @@
     <Compile Include="$(CommonPath)\Roslyn\DiagnosticDescriptorHelper.cs" Link="Common\Roslyn\DiagnosticDescriptorHelper.cs" />
     <Compile Include="$(CommonPath)\Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
     <Compile Include="$(CommonPath)\SourceGenerators\SourceWriter.cs" Link="Common\SourceGenerators\SourceWriter.cs" />
-    <Compile Include="$(CommonPath)\SourceGenerators\TypeModelHelpers.cs" Link="Common\SourceGenerators\TypeModelHelpers.cs" />
+    <Compile Include="$(CommonPath)\SourceGenerators\TypeModelHelper.cs" Link="Common\SourceGenerators\TypeModelHelper.cs" />
     <Compile Include="ConfigurationBindingGenerator.cs" />
     <Compile Include="ConfigurationBindingGenerator.Emitter.cs" />
     <Compile Include="ConfigurationBindingGenerator.Parser.cs" />

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Model/TypeSpec.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Model/TypeSpec.cs
@@ -2,22 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.CodeAnalysis;
+using SourceGenerators;
 
 namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 {
     internal abstract record TypeSpec
     {
-        private static readonly SymbolDisplayFormat s_minimalDisplayFormat = new SymbolDisplayFormat(
-            globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
-            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
-            genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
-            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
-
         public TypeSpec(ITypeSymbol type)
         {
             IsValueType = type.IsValueType;
             Namespace = type.ContainingNamespace?.ToDisplayString();
-            DisplayString = type.ToDisplayString(s_minimalDisplayFormat);
+            DisplayString = type.ToMinimalDisplayString();
+            IdentifierCompatibleSubstring = type.ToIdentifierCompatibleSubstring(useUniqueName: true);
             Name = Namespace + "." + DisplayString.Replace(".", "+");
             IsInterface = type.TypeKind is TypeKind.Interface;
         }
@@ -25,6 +21,8 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         public string Name { get; }
 
         public string DisplayString { get; }
+
+        public string IdentifierCompatibleSubstring { get; }
 
         public string? Namespace { get; }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/Strings.resx
@@ -121,7 +121,7 @@
     <value>The collection type is not supported: '{0}'.</value>
   </data>
   <data name="CouldNotDetermineTypeInfoMessageFormat" xml:space="preserve">
-    <value>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</value>
+    <value>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</value>
   </data>
   <data name="CouldNotDetermineTypeInfoTitle" xml:space="preserve">
     <value>The target type for a binder call could not be determined</value>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">Pro volání vazače se nevygenerovala logika vazby. Nepodporované vstupní vzory zahrnují obecná volání a předávání zabalených objektů.</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">Pro volání vazače se nevygenerovala logika vazby. Nepodporované vstupní vzory zahrnují obecná volání a předávání zabalených objektů.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">Für einen Binderaufruf wurde keine Bindungslogik generiert. Nicht unterstützte Eingabemuster umfassen generische Aufrufe und übergeben geschachtelte Objekte.</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">Für einen Binderaufruf wurde keine Bindungslogik generiert. Nicht unterstützte Eingabemuster umfassen generische Aufrufe und übergeben geschachtelte Objekte.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">No se generó la lógica de enlace para una llamada de enlazador. Los patrones de entrada no admitidos incluyen llamadas genéricas y pasar objetos en cuadros.</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">No se generó la lógica de enlace para una llamada de enlazador. Los patrones de entrada no admitidos incluyen llamadas genéricas y pasar objetos en cuadros.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">La logique de liaison n’a pas été générée pour un appel de classeur. Les modèles d’entrée non pris en charge incluent les appels génériques et les objets boxed de passage.</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">La logique de liaison n’a pas été générée pour un appel de classeur. Les modèles d’entrée non pris en charge incluent les appels génériques et les objets boxed de passage.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">La logica di binding non è stata generata per una chiamata binder. I modelli di input non supportati includono chiamate generiche e il passaggio di oggetti in caselle.</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">La logica di binding non è stata generata per una chiamata binder. I modelli di input non supportati includono chiamate generiche e il passaggio di oggetti in caselle.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">バインダー呼び出しのバインド ロジックが生成されませんでした。サポートされていない入力パターンとしては、ジェネリック呼び出し、ボックス化されたオブジェクトの受け渡しなどがあります。</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">バインダー呼び出しのバインド ロジックが生成されませんでした。サポートされていない入力パターンとしては、ジェネリック呼び出し、ボックス化されたオブジェクトの受け渡しなどがあります。</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">바인더 호출에 대한 바인딩 논리가 생성되지 않았습니다. 지원되지 않는 입력 패턴에는 제네릭 호출 및 boxed 개체 전달이 포함됩니다.</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">바인더 호출에 대한 바인딩 논리가 생성되지 않았습니다. 지원되지 않는 입력 패턴에는 제네릭 호출 및 boxed 개체 전달이 포함됩니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">Nie wygenerowano logiki powiązania dla wywołania integratora. Nieobsługiwane wzorce wejściowe obejmują wywołania ogólne i przekazywanie obiektów w ramce.</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">Nie wygenerowano logiki powiązania dla wywołania integratora. Nieobsługiwane wzorce wejściowe obejmują wywołania ogólne i przekazywanie obiektów w ramce.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">A lógica de associação não foi gerada para uma chamada de associador. Os padrões de entrada sem suporte incluem chamadas genéricas e passagem de objetos em caixa.</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">A lógica de associação não foi gerada para uma chamada de associador. Os padrões de entrada sem suporte incluem chamadas genéricas e passagem de objetos em caixa.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">Логика привязки не была создана для вызова модуля привязки. К неподдерживаемым шаблонам ввода относятся универсальные вызовы и передача упакованных объектов.</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">Логика привязки не была создана для вызова модуля привязки. К неподдерживаемым шаблонам ввода относятся универсальные вызовы и передача упакованных объектов.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">Bir bağlayıcı çağrısı için bağlama mantığı oluşturulmadı. Desteklenmeyen giriş desenleri genel çağrılar ve geçici kutulu nesneler içeriyor.</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">Bir bağlayıcı çağrısı için bağlama mantığı oluşturulmadı. Desteklenmeyen giriş desenleri genel çağrılar ve geçici kutulu nesneler içeriyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">未为联编程序调用生成绑定逻辑。不支持的输入模式包括泛型调用和传递装箱对象。</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">未为联编程序调用生成绑定逻辑。不支持的输入模式包括泛型调用和传递装箱对象。</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoMessageFormat">
-        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls and passing boxed objects.</source>
-        <target state="translated">未產生文件夾呼叫的繫結邏輯。不支援的輸入模式包括一般呼叫和傳遞方塊物件。</target>
+        <source>Binding logic was not generated for a binder call. Unsupported input patterns include generic calls, passing boxed objects, and passing types that are not 'public' or 'internal'.</source>
+        <target state="needs-review-translation">未產生文件夾呼叫的繫結邏輯。不支援的輸入模式包括一般呼叫和傳遞方塊物件。</target>
         <note />
       </trans-unit>
       <trans-unit id="CouldNotDetermineTypeInfoTitle">

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -30,7 +30,7 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         }
     }
 
-    public sealed partial class ConfigurationBinderTests : ConfigurationBinderTestsBase
+    public partial class ConfigurationBinderTests : ConfigurationBinderTestsBase
     {
         [Fact]
         public void BindWithNestedTypesWithReadOnlyProperties()

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/ConfigurationBinderTests.Generator.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/ConfigurationBinderTests.Generator.cs
@@ -249,5 +249,118 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
         {
             Assert.Equal((longitude, latitude), (record.Longitude, record.Latitude));
         }
+
+        // These are regression tests for https://github.com/dotnet/runtime/issues/90976
+        // Ensure that every emitted identifier name is unique, otherwise name clashes
+        // will occur and cause compilation to fail.
+
+        [Fact]
+        public void NameClashTests_NamingPatternsThatCouldCauseClashes()
+        {
+            // Potential class between type with closed generic & non generic type.
+            // Both types start with same substring. The generic arg type's name is
+            // the same as the suffix of the non generic type's name.
+            // Manifested in https://github.com/dotnet/runtime/issues/90976.
+
+            IConfiguration configuration = TestHelpers.GetConfigurationFromJsonString(@"{""Value"":1}");
+
+            var c1 = new Cint();
+            var c2 = new C<int>();
+
+            configuration.Bind(c1);
+            configuration.Bind(c2);
+            Assert.Equal(1, c1.Value);
+            Assert.Equal(1, c2.Value);
+        }
+
+        internal class C<T>
+        {
+            public int Value { get; set; }
+        }
+
+        internal class Cint
+        {
+            public int Value { get; set; }
+        }
+
+        [Fact]
+        public void NameClashTests_SameTypeName()
+        {
+            // Both types have the same name, but one is a nested type.
+
+            IConfiguration configuration = TestHelpers.GetConfigurationFromJsonString(@"{""Value"":1}");
+
+            var c1 = new ClassWithThisIdentifier();
+            var c2 = new ClassWithThisIdentifier_Wrapper.ClassWithThisIdentifier();
+
+            configuration.Bind(c1);
+            configuration.Bind(c2);
+            Assert.Equal(1, c1.Value);
+            Assert.Equal(1, c2.Value);
+        }
+
+        internal class ClassWithThisIdentifier
+        {
+            public int Value { get; set; }
+        }
+
+        internal class ClassWithThisIdentifier_Wrapper
+        {
+            internal class ClassWithThisIdentifier
+            {
+                public int Value { get; set; }
+            }
+        }
+
+        /// <summary>
+        /// These are regression tests for https://github.com/dotnet/runtime/issues/90909.
+        /// Ensure that we don't emit root interceptors to handle types/members that
+        /// are inaccessible to the generated helpers. Tests for inaccessbile transitive members
+        /// are covered in the shared (reflection/src-gen) <see cref="ConfigurationBinderTests"/>,
+        /// e.g. <see cref="NonPublicModeGetStillIgnoresReadonly"/>.
+        /// </summary>
+        /// <remarks>
+        /// In these cases, binding calls will fallback to reflection, as with all cases where
+        /// we can't correctly resolve the type, such as generic call patterns and boxed objects.
+        /// </remarks>
+        [Fact]
+        public void MemberAccessibility_InaccessibleNestedTypeAsRootConfig()
+        {
+            IConfiguration configuration = TestHelpers.GetConfigurationFromJsonString(@"{""Value"":1}");
+
+            // Ensure no compilation errors; types are skipped.
+
+#pragma warning disable SYSLIB1104 // Binding logic was not generated for a binder call.
+            var c1 = new InaccessibleClass_1();
+            configuration.Bind(c1);
+            var c2 = configuration.Get<InaccessibleClass_2>();
+            var c3 = configuration.Get<InaccessibleClass_3>();
+
+            configuration = TestHelpers
+                .GetConfigurationFromJsonString(@"{""Array"": [{""Value"":1}]}")
+                .GetSection("Array");
+            var c4 = configuration.Get<InaccessibleClass_1[]>();
+#pragma warning disable SYSLIB1104
+
+            // Instead, there is a reflection fallback.
+            Assert.Equal(1, c1.Value);
+            Assert.Equal(1, c2.Value);
+            Assert.Equal(1, c3.Value);
+            Assert.Equal(1, c4[0].Value);
+        }
+
+        private class InaccessibleClass_1()
+        {
+            public int Value { get; set; }
+        }
+
+        protected record InaccessibleClass_2(int Value);
+
+        protected internal class InaccessibleClass_3
+        {
+            public InaccessibleClass_3(int value) => Value = value;
+
+            public int Value { get; }
+        }
     }
 }

--- a/src/libraries/System.Text.Json/gen/Helpers/RoslynExtensions.cs
+++ b/src/libraries/System.Text.Json/gen/Helpers/RoslynExtensions.cs
@@ -209,28 +209,6 @@ namespace System.Text.Json.SourceGeneration
             return false;
         }
 
-        public static ITypeSymbol[] GetAllTypeArgumentsInScope(this INamedTypeSymbol type)
-        {
-            if (!type.IsGenericType)
-            {
-                return Array.Empty<ITypeSymbol>();
-            }
-
-            var args = new List<ITypeSymbol>();
-            TraverseContainingTypes(type);
-            return args.ToArray();
-
-            void TraverseContainingTypes(INamedTypeSymbol current)
-            {
-                if (current.ContainingType is INamedTypeSymbol parent)
-                {
-                    TraverseContainingTypes(parent);
-                }
-
-                args.AddRange(current.TypeArguments);
-            }
-        }
-
         public static ITypeSymbol GetMemberType(this ISymbol member)
         {
             Debug.Assert(member is IFieldSymbol or IPropertySymbol);

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -590,17 +590,19 @@ namespace System.Text.Json.SourceGeneration
                 }
 
                 var typeRef = new TypeRef(type);
-                string typeInfoPropertyName = typeToGenerate.TypeInfoPropertyName ?? type.ToIdentifierCompatibleSubstring();
+                string typeInfoPropertyName = typeToGenerate.TypeInfoPropertyName ??
+                    type.ToIdentifierCompatibleSubstring(useUniqueName: false /* We leave identifier name conflicts to users, as codified below. */);
 
                 if (classType is ClassType.TypeUnsupportedBySourceGen)
                 {
                     ReportDiagnostic(DiagnosticDescriptors.TypeNotSupported, typeToGenerate.AttributeLocation ?? typeToGenerate.Location, type.ToDisplayString());
                 }
 
+                // Workaround for https://github.com/dotnet/roslyn/issues/54185 by keeping track of the file names we've used.
                 if (!_generatedContextAndTypeNames.Add((contextType.Name, typeInfoPropertyName)))
                 {
                     // The context name/property name combination will result in a conflict in generated types.
-                    // Workaround for https://github.com/dotnet/roslyn/issues/54185 by keeping track of the file names we've used.
+                    // This is by design; we leave conflict resolution to the user.
                     ReportDiagnostic(DiagnosticDescriptors.DuplicateTypeName, typeToGenerate.AttributeLocation ?? _contextClassLocation, typeInfoPropertyName);
                     classType = ClassType.TypeUnsupportedBySourceGen;
                 }

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SourceGenerators;
 
 namespace System.Text.Json.SourceGeneration
 {
@@ -589,7 +590,7 @@ namespace System.Text.Json.SourceGeneration
                 }
 
                 var typeRef = new TypeRef(type);
-                string typeInfoPropertyName = typeToGenerate.TypeInfoPropertyName ?? GetTypeInfoPropertyName(type);
+                string typeInfoPropertyName = typeToGenerate.TypeInfoPropertyName ?? type.ToIdentifierCompatibleSubstring();
 
                 if (classType is ClassType.TypeUnsupportedBySourceGen)
                 {
@@ -1587,34 +1588,6 @@ namespace System.Text.Json.SourceGeneration
                 }
 
                 return null;
-            }
-
-            private static string GetTypeInfoPropertyName(ITypeSymbol type)
-            {
-                if (type is IArrayTypeSymbol arrayType)
-                {
-                    int rank = arrayType.Rank;
-                    string suffix = rank == 1 ? "Array" : $"Array{rank}D"; // Array, Array2D, Array3D, ...
-                    return GetTypeInfoPropertyName(arrayType.ElementType) + suffix;
-                }
-
-                if (type is not INamedTypeSymbol namedType || !namedType.IsGenericType)
-                {
-                    return type.Name;
-                }
-
-                StringBuilder sb = new();
-
-                string name = namedType.Name;
-
-                sb.Append(name);
-
-                foreach (ITypeSymbol genericArg in namedType.GetAllTypeArgumentsInScope())
-                {
-                    sb.Append(GetTypeInfoPropertyName(genericArg));
-                }
-
-                return sb.ToString();
             }
 
             private bool TryGetDeserializationConstructor(

--- a/src/libraries/System.Text.Json/gen/System.Text.Json.SourceGeneration.targets
+++ b/src/libraries/System.Text.Json/gen/System.Text.Json.SourceGeneration.targets
@@ -31,6 +31,7 @@
     <Compile Include="$(CommonPath)\Roslyn\DiagnosticDescriptorHelper.cs" Link="Common\Roslyn\DiagnosticDescriptorHelper.cs" />
     <Compile Include="$(CommonPath)\Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
     <Compile Include="$(CommonPath)\SourceGenerators\SourceWriter.cs" Link="Common\SourceGenerators\SourceWriter.cs" />
+    <Compile Include="$(CommonPath)\SourceGenerators\TypeModelHelpers.cs" Link="Common\SourceGenerators\TypeModelHelpers.cs" />
     <Compile Include="..\Common\JsonCamelCaseNamingPolicy.cs" Link="Common\System\Text\Json\JsonCamelCaseNamingPolicy.cs" />
     <Compile Include="..\Common\JsonNamingPolicy.cs" Link="Common\System\Text\Json\JsonNamingPolicy.cs" />
     <Compile Include="..\Common\JsonAttribute.cs" Link="Common\System\Text\Json\Serialization\JsonAttribute.cs" />

--- a/src/libraries/System.Text.Json/gen/System.Text.Json.SourceGeneration.targets
+++ b/src/libraries/System.Text.Json/gen/System.Text.Json.SourceGeneration.targets
@@ -31,7 +31,7 @@
     <Compile Include="$(CommonPath)\Roslyn\DiagnosticDescriptorHelper.cs" Link="Common\Roslyn\DiagnosticDescriptorHelper.cs" />
     <Compile Include="$(CommonPath)\Roslyn\GetBestTypeByMetadataName.cs" Link="Common\Roslyn\GetBestTypeByMetadataName.cs" />
     <Compile Include="$(CommonPath)\SourceGenerators\SourceWriter.cs" Link="Common\SourceGenerators\SourceWriter.cs" />
-    <Compile Include="$(CommonPath)\SourceGenerators\TypeModelHelpers.cs" Link="Common\SourceGenerators\TypeModelHelpers.cs" />
+    <Compile Include="$(CommonPath)\SourceGenerators\TypeModelHelper.cs" Link="Common\SourceGenerators\TypeModelHelper.cs" />
     <Compile Include="..\Common\JsonCamelCaseNamingPolicy.cs" Link="Common\System\Text\Json\JsonCamelCaseNamingPolicy.cs" />
     <Compile Include="..\Common\JsonNamingPolicy.cs" Link="Common\System\Text\Json\JsonNamingPolicy.cs" />
     <Compile Include="..\Common\JsonAttribute.cs" Link="Common\System\Text\Json\Serialization\JsonAttribute.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/90909 and https://github.com/dotnet/runtime/issues/90976. RC-2 candidate.

cc @ericstj.