### PR TITLE
[mono][mini] Fix gshared crash when calling svm and constrained class is interface

### DIFF
--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -2272,22 +2272,28 @@ instantiate_info (MonoMemoryManager *mem_manager, MonoRuntimeGenericContextInfoT
 
 		mono_class_setup_vtable (info->klass);
 		// FIXME: Check type load
-		if (mono_class_is_interface (iface_class)) {
-			gboolean variance_used;
-			ioffset = mono_class_interface_offset_with_variance (info->klass, iface_class, &variance_used);
-			g_assert (ioffset != -1);
+
+		if (mono_class_is_interface (info->klass)) {
+			// If constrained class is interface, we don't learn anything new by constraining
+			method = info->method;
 		} else {
-			ioffset = 0;
+			if (mono_class_is_interface (iface_class)) {
+				gboolean variance_used;
+				ioffset = mono_class_interface_offset_with_variance (info->klass, iface_class, &variance_used);
+				g_assert (ioffset != -1);
+			} else {
+				ioffset = 0;
+			}
+
+			if (info->method->is_generic == 0 && mono_class_is_ginst (info->method->klass)) {
+				slot = mono_method_get_vtable_slot (((MonoMethodInflated*)(info->method))->declaring);
+			} else {
+				slot = mono_method_get_vtable_slot (info->method);
+			}
+			g_assert (slot != -1);
+			g_assert (m_class_get_vtable (info->klass));
+			method = m_class_get_vtable (info->klass) [ioffset + slot];
 		}
-		
-		if (info->method->is_generic == 0 && mono_class_is_ginst (info->method->klass)) {
-			slot = mono_method_get_vtable_slot (((MonoMethodInflated*)(info->method))->declaring);
-		} else {
-			slot = mono_method_get_vtable_slot (info->method);
-		}
-		g_assert (slot != -1);
-		g_assert (m_class_get_vtable (info->klass));
-		method = m_class_get_vtable (info->klass) [ioffset + slot];
 
 		if (info->method->is_inflated) {
 			MonoGenericContext *method_ctx = mono_method_get_context (info->method);


### PR DESCRIPTION
If constrained class is interface, then we don't need to do any vtable lookup, call interface method directly.

Fixes https://github.com/dotnet/runtime/issues/90139