### PR TITLE
Log disk space available and consumed by SPMI download

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -3198,7 +3198,21 @@ def process_mch_files_arg(coreclr_args):
         logging.info("Found download cache directory \"%s\" and --force_download not set; skipping download", mch_cache_dir)
         return [ mch_cache_dir ]
 
+    # MCH files can be large. Log the disk space before and after the download.
+    if os.path.isdir(coreclr_args.spmi_location):
+        before_total, _, before_free = shutil.disk_usage(coreclr_args.spmi_location)
+        before_total_gb = int(before_total / 1024 / 1024 / 1024)
+        before_free_gb = int(before_free / 1024 / 1024 / 1024)
+        logging.debug("Disk usage (%s): total %s GB; free %s GB", coreclr_args.spmi_location, format(before_total_gb, ','), format(before_free_gb, ','))
+
     local_mch_paths = download_mch_from_azure(coreclr_args, mch_cache_dir)
+
+    if os.path.isdir(coreclr_args.spmi_location): # This should always be true here; just being defensive.
+        after_total, _, after_free = shutil.disk_usage(coreclr_args.spmi_location)
+        after_total_gb = int(after_total / 1024 / 1024 / 1024)
+        after_free_gb = int(after_free / 1024 / 1024 / 1024)
+        consumed_gb = before_free_gb - after_free_gb
+        logging.debug("Disk usage (%s): total %s GB; free %s GB; consumed by download %s GB", coreclr_args.spmi_location, format(after_total_gb, ','), format(after_free_gb, ','), format(consumed_gb, ','))
 
     # Add the private store files
     if coreclr_args.private_store is not None:


### PR DESCRIPTION
Example output in the DEBUG log:
```
[10:39:04] Disk usage (c:\spmi): total 2,047 GB; free 1,411 GB
[10:42:45] Disk usage (c:\spmi): total 2,047 GB; free 1,378 GB; consumed by download 33 GB
```