### PR TITLE
[release/8.0] Delete the RequiresPreviewFeaturesAttribute from RefreshMemoryLimit

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -899,13 +899,10 @@ namespace System
         ///
         /// This API will only handle configs that could be handled when the runtime is loaded, for example, for configs that don't have any effects on 32-bit systems (like the GCHeapHardLimit* ones), this API will not handle it.
         ///
-        /// As of now, this API is feature preview only and subject to changes as necessary.
-        ///
         /// <exception cref="InvalidOperationException">If the hard limit is too low. This can happen if the heap hard limit that the refresh will set, either because of new AppData settings or implied by the container memory limit changes, is lower than what is already committed.</exception>
         /// <exception cref="InvalidOperationException">If the hard limit is invalid. This can happen, for example, with negative heap hard limit percentages.</exception>
         ///
         /// </summary>
-        [RequiresPreviewFeatures("RefreshMemoryLimit is in preview.")]
         public static void RefreshMemoryLimit()
         {
             ulong heapHardLimit = (AppContext.GetData("GCHeapHardLimit") as ulong?) ?? ulong.MaxValue;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
@@ -869,7 +869,6 @@ namespace System
             return new TimeSpan(RuntimeImports.RhGetTotalPauseDuration());
         }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("RefreshMemoryLimit is in preview.")]
         public static void RefreshMemoryLimit()
         {
             ulong heapHardLimit = (AppContext.GetData("GCHeapHardLimit") as ulong?) ?? ulong.MaxValue;

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2722,7 +2722,6 @@ namespace System
         public static void WaitForPendingFinalizers() { }
         public static TimeSpan GetTotalPauseDuration() { throw null; }
         public static System.Collections.Generic.IReadOnlyDictionary<string, object> GetConfigurationVariables() { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("RefreshMemoryLimit is in preview.")]
         public static void RefreshMemoryLimit() { throw null; }
     }
 

--- a/src/mono/System.Private.CoreLib/src/System/GC.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/GC.Mono.cs
@@ -320,7 +320,6 @@ namespace System
             return new System.Collections.Generic.Dictionary<string, object>();
         }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("RefreshMemoryLimit is in preview.")]
         public static void RefreshMemoryLimit()
         {
             throw new PlatformNotSupportedException();


### PR DESCRIPTION
Backport of #91622 to release/8.0

### Customer Impact
This is to enable the RefreshMemoryLimit feature so that it won't require the `RequiresPreviewFeaturesAttribute`. This is going to be used by Amazon Lambda [here](https://github.com/aws/aws-lambda-dotnet/pull/1578).

### Testing
The internal working is tested by enabling the `COMMITTED_BYTES_SHADOW` feature switch - the switch will trigger a call to `RefreshMemoryLimit` for each GC, and it was run as part of the GC exit criteria run.

The managed part of the method is not currently tested, work is in progress to provide some coverage through https://github.com/dotnet/runtime/pull/91833.

### Risk
The API is already public, this change does not add any more risk for customers who will call it regardless of the existence of a warning or not.