### PR TITLE
Remove all uses of non `Ex` version of `LoadLibrary` API from PAL

### DIFF
--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -181,9 +181,9 @@ STDAPI DLLEXPORT OpenVirtualProcessImpl2(
     CLR_DEBUGGING_PROCESS_FLAGS* pFlagsOut)
 {
 #ifdef TARGET_WINDOWS
-    HMODULE hDac = LoadLibraryExW(pDacModulePath, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+    HMODULE hDac = WszLoadLibrary(pDacModulePath, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
 #else
-    HMODULE hDac = LoadLibraryW(pDacModulePath);
+    HMODULE hDac = WszLoadLibrary(pDacModulePath);
 #endif // !TARGET_WINDOWS
     if (hDac == NULL)
     {

--- a/src/coreclr/debug/di/shimprocess.cpp
+++ b/src/coreclr/debug/di/shimprocess.cpp
@@ -1609,11 +1609,7 @@ HMODULE ShimProcess::GetDacModule(PathString& dacModulePath)
             ThrowLastError();
         }
 
-        // Dac Dll is named:
-        //   mscordaccore.dll  <-- coreclr
-        //   mscordacwks.dll   <-- desktop
         PCWSTR eeFlavor = MAKEDLLNAME_W(W("mscordaccore"));
-
         wszAccessDllPath.Append(eeFlavor);
     }
     hDacDll = WszLoadLibrary(wszAccessDllPath);

--- a/src/coreclr/dlls/mscordac/mscordac_unixexports.src
+++ b/src/coreclr/dlls/mscordac/mscordac_unixexports.src
@@ -128,8 +128,7 @@ nativeStringResourceTable_mscorrc
 #GetTempPathW
 #InitializeCriticalSection
 #LeaveCriticalSection
-#LoadLibraryA
-#LoadLibraryW
+#LoadLibraryExA
 #LoadLibraryExW
 #MapViewOfFile
 #MapViewOfFileEx

--- a/src/coreclr/inc/winwrap.h
+++ b/src/coreclr/inc/winwrap.h
@@ -71,8 +71,6 @@
 #undef OpenSemaphore
 #undef CreateWaitableTimer
 #undef CreateFileMapping
-#undef LoadLibrary
-#undef LoadLibraryEx
 #undef GetModuleFileName
 #undef GetModuleHandle
 #undef GetModuleHandleEx

--- a/src/coreclr/inc/winwrap.h
+++ b/src/coreclr/inc/winwrap.h
@@ -191,12 +191,10 @@
 //Note only the functions which are currently used are defined
 #ifdef HOST_WINDOWS
 #define WszLoadLibrary         LoadLibraryExWrapper
-#define WszLoadLibraryEx       LoadLibraryExWrapper
 #define WszCreateFile          CreateFileWrapper
 #define WszGetFileAttributesEx GetFileAttributesExWrapper
 #else // HOST_WINDOWS
-#define WszLoadLibrary         LoadLibraryW
-#define WszLoadLibraryEx       LoadLibraryExW
+#define WszLoadLibrary         LoadLibraryExW
 #define WszCreateFile          CreateFileW
 #define WszGetFileAttributesEx GetFileAttributesExW
 #endif // HOST_WINDOWS

--- a/src/coreclr/md/enc/stgio.cpp
+++ b/src/coreclr/md/enc/stgio.cpp
@@ -232,7 +232,7 @@ HRESULT StgIO::Open(                    // Return code.
             // most of the security risk anyway).
             if ((fFlags & DBPROP_TMODEF_TRYLOADLIBRARY) != 0)
             {
-                m_hModule = WszLoadLibraryEx(szName, NULL, LOAD_LIBRARY_AS_IMAGE_RESOURCE);
+                m_hModule = WszLoadLibrary(szName, NULL, LOAD_LIBRARY_AS_IMAGE_RESOURCE);
                 if (m_hModule != NULL)
                 {
                     m_iType = STGIO_HMODULE;

--- a/src/coreclr/nativeaot/BuildIntegration/WindowsAPIs.txt
+++ b/src/coreclr/nativeaot/BuildIntegration/WindowsAPIs.txt
@@ -1263,7 +1263,6 @@ kernel32!LCMapStringEx
 kernel32!LCMapStringW
 kernel32!LeaveCriticalSection
 kernel32!LeaveCriticalSectionWhenCallbackReturns
-kernel32!LoadLibraryA
 kernel32!LoadLibraryExA
 kernel32!LoadLibraryExW
 kernel32!LoadLibraryW

--- a/src/coreclr/nativeaot/BuildIntegration/WindowsAPIs.txt
+++ b/src/coreclr/nativeaot/BuildIntegration/WindowsAPIs.txt
@@ -1263,6 +1263,7 @@ kernel32!LCMapStringEx
 kernel32!LCMapStringW
 kernel32!LeaveCriticalSection
 kernel32!LeaveCriticalSectionWhenCallbackReturns
+kernel32!LoadLibraryA
 kernel32!LoadLibraryExA
 kernel32!LoadLibraryExW
 kernel32!LoadLibraryW

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -2826,13 +2826,6 @@ PALAPI
 UnmapViewOfFile(
         IN LPCVOID lpBaseAddress);
 
-
-PALIMPORT
-HMODULE
-PALAPI
-LoadLibraryW(
-        IN LPCWSTR lpLibFileName);
-
 PALIMPORT
 HMODULE
 PALAPI

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -2838,8 +2838,8 @@ HMODULE
 PALAPI
 LoadLibraryExW(
         IN LPCWSTR lpLibFileName,
-        IN /*Reserved*/ HANDLE hFile,
-        IN DWORD dwFlags);
+        IN /*Reserved*/ HANDLE hFile = NULL,
+        IN DWORD dwFlags = 0);
 
 PALIMPORT
 NATIVE_LIBRARY_HANDLE

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -2919,14 +2919,6 @@ BOOL
 PALAPI
 PAL_LOADMarkSectionAsNotNeeded(void * ptr);
 
-#ifdef UNICODE
-#define LoadLibrary LoadLibraryW
-#define LoadLibraryEx LoadLibraryExW
-#else
-#define LoadLibrary LoadLibraryA
-#define LoadLibraryEx LoadLibraryExA
-#endif
-
 PALIMPORT
 FARPROC
 PALAPI

--- a/src/coreclr/pal/inc/palprivate.h
+++ b/src/coreclr/pal/inc/palprivate.h
@@ -131,12 +131,6 @@ OpenMutexA(
 PALIMPORT
 HMODULE
 PALAPI
-LoadLibraryA(
-        IN LPCSTR lpLibFileName);
-
-PALIMPORT
-HMODULE
-PALAPI
 LoadLibraryExA(
         IN LPCSTR lpLibFileName,
         IN /*Reserved*/ HANDLE hFile,

--- a/src/coreclr/pal/src/loader/module.cpp
+++ b/src/coreclr/pal/src/loader/module.cpp
@@ -106,34 +106,6 @@ static BOOL LOADCallDllMainSafe(MODSTRUCT *module, DWORD dwReason, LPVOID lpRese
 
 /*++
 Function:
-  LoadLibraryA
-
-See MSDN doc.
---*/
-HMODULE
-PALAPI
-LoadLibraryA(
-    IN LPCSTR lpLibFileName)
-{
-    return LoadLibraryExA(lpLibFileName, nullptr, 0);
-}
-
-/*++
-Function:
-  LoadLibraryW
-
-See MSDN doc.
---*/
-HMODULE
-PALAPI
-LoadLibraryW(
-    IN LPCWSTR lpLibFileName)
-{
-    return LoadLibraryExW(lpLibFileName, nullptr, 0);
-}
-
-/*++
-Function:
 LoadLibraryExA
 
 See MSDN doc.

--- a/src/coreclr/pal/src/loader/module.cpp
+++ b/src/coreclr/pal/src/loader/module.cpp
@@ -126,7 +126,7 @@ LoadLibraryExA(
 
     HMODULE hModule = nullptr;
 
-    PERF_ENTRY(LoadLibraryA);
+    PERF_ENTRY(LoadLibraryExA);
     ENTRY("LoadLibraryExA (lpLibFileName=%p (%s)) \n",
           (lpLibFileName) ? lpLibFileName : "NULL",
           (lpLibFileName) ? lpLibFileName : "NULL");

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/FreeLibrary/test1/FreeLibrary.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/FreeLibrary/test1/FreeLibrary.cpp
@@ -34,14 +34,14 @@ PALTEST(filemapping_memmgt_FreeLibrary_test1_paltest_freelibrary_test1, "filemap
     {
         return (FAIL);
     }
-    
+
     /*Load library (DLL). */
-    hLib = LoadLibrary(LibraryName);
+    hLib = LoadLibraryExA(LibraryName, NULL, 0);
 
     if(hLib == NULL)
     {
-        Fail("ERROR:%u:Unable to load library %s\n", 
-             GetLastError(), 
+        Fail("ERROR:%u:Unable to load library %s\n",
+             GetLastError(),
              LibraryName);
     }
 
@@ -54,10 +54,10 @@ PALTEST(filemapping_memmgt_FreeLibrary_test1_paltest_freelibrary_test1, "filemap
         Fail("");
     }
 
-    /* Call the FreeLibrary API. */ 
+    /* Call the FreeLibrary API. */
     if (!FreeLibrary(hLib))
     {
-        Fail("ERROR:%u: Unable to free library \"%s\"\n", 
+        Fail("ERROR:%u: Unable to free library \"%s\"\n",
              GetLastError(),
              LibraryName);
     }
@@ -83,7 +83,7 @@ BOOL PALAPI TestDll(HMODULE hLib, int testResult)
 #else
     char    FunctName[] = "DllTest";
 #endif
-    FARPROC DllAddr;    
+    FARPROC DllAddr;
 
     /* Attempt to grab the proc address of the dll function.
      * This one should succeed.*/
@@ -92,12 +92,12 @@ BOOL PALAPI TestDll(HMODULE hLib, int testResult)
         DllAddr = GetProcAddress(hLib, FunctName);
         if(DllAddr == NULL)
         {
-            Trace("ERROR: Unable to load function \"%s\" library \"%s\"\n", 
+            Trace("ERROR: Unable to load function \"%s\" library \"%s\"\n",
                     FunctName,
                     LibraryName);
             return (FALSE);
         }
-        /* Run the function in the DLL, 
+        /* Run the function in the DLL,
          * to ensure that the DLL was loaded properly.*/
         RetVal = DllAddr();
         if (RetVal != 1)
@@ -117,8 +117,8 @@ BOOL PALAPI TestDll(HMODULE hLib, int testResult)
         if(DllAddr != NULL)
         {
             Trace("ERROR: Able to load function \"%s\" from free'd"
-                " library \"%s\"\n", 
-                FunctName, 
+                " library \"%s\"\n",
+                FunctName,
                 LibraryName);
             return (FALSE);
         }

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/GetModuleFileNameA/test1/GetModuleFileNameA.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/GetModuleFileNameA/test1/GetModuleFileNameA.cpp
@@ -44,7 +44,7 @@ PALTEST(filemapping_memmgt_GetModuleFileNameA_test1_paltest_getmodulefilenamea_t
 
 
     //load a module
-    ModuleHandle = LoadLibrary(ModuleName);
+    ModuleHandle = LoadLibraryExA(ModuleName, NULL, 0);
     if(!ModuleHandle)
     {
         Fail("Failed to call LoadLibrary API!\n");

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/GetModuleFileNameW/test1/GetModuleFileNameW.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/GetModuleFileNameW/test1/GetModuleFileNameW.cpp
@@ -50,7 +50,7 @@ PALTEST(filemapping_memmgt_GetModuleFileNameW_test1_paltest_getmodulefilenamew_t
     lpModuleName = convert(ModuleName);
 
     //load a module
-        ModuleHandle = LoadLibrary(lpModuleName);
+        ModuleHandle = LoadLibraryExW(lpModuleName, NULL, 0);
 
     //free the memory
     free(lpModuleName);

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/GetProcAddress/test1/test1.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/GetProcAddress/test1/test1.cpp
@@ -6,9 +6,9 @@
 ** Source: test1.c (filemapping_memmgt\getprocaddress\test1)
 **
 ** Purpose: Positive test the GetProcAddress API.
-**          The first test calls GetProcAddress to retrieve the 
-**          address of SimpleFunction inside testlib by its name, 
-**          then calls the function and checks that it worked. 
+**          The first test calls GetProcAddress to retrieve the
+**          address of SimpleFunction inside testlib by its name,
+**          then calls the function and checks that it worked.
 **
 **
 **===========================================================================*/
@@ -43,7 +43,7 @@ PALTEST(filemapping_memmgt_GetProcAddress_test1_paltest_getprocaddress_test1, "f
 
 
     /* load a module */
-    hModule = LoadLibrary(lpModuleName);
+    hModule = LoadLibraryExA(lpModuleName, NULL, 0);
     if(!hModule)
     {
         Fail("Unexpected error: "
@@ -54,7 +54,7 @@ PALTEST(filemapping_memmgt_GetProcAddress_test1_paltest_getprocaddress_test1, "f
     /*
      * Test 1
      *
-     * Get the address of a function 
+     * Get the address of a function
      */
     procAddressByName = (SIMPLEFUNCTION) GetProcAddress(hModule,FunctionName);
     if(!procAddressByName)
@@ -67,7 +67,7 @@ PALTEST(filemapping_memmgt_GetProcAddress_test1_paltest_getprocaddress_test1, "f
         err = FreeLibrary(hModule);
         if(0 == err)
 	    {
-            Fail("Unexpected error: Failed to FreeLibrary %s\n", 
+            Fail("Unexpected error: Failed to FreeLibrary %s\n",
                  lpModuleName);
 	    }
         Fail("");
@@ -76,14 +76,14 @@ PALTEST(filemapping_memmgt_GetProcAddress_test1_paltest_getprocaddress_test1, "f
     /* Call the function to see that it really worked */
     /* Simple function adds 1 to the argument passed */
     if( 2 != ((procAddressByName)(1)))
-    { 
+    {
         Trace("ERROR: Problem calling the function by its address.\n");
-         
+
         /* Cleanup */
         err = FreeLibrary(hModule);
         if(0 == err)
 	    {
-            Fail("Unexpected error: Failed to FreeLibrary %s\n", 
+            Fail("Unexpected error: Failed to FreeLibrary %s\n",
                  lpModuleName);
 	    }
         Fail("");
@@ -93,7 +93,7 @@ PALTEST(filemapping_memmgt_GetProcAddress_test1_paltest_getprocaddress_test1, "f
     err = FreeLibrary(hModule);
     if(0 == err)
 	{
-        Fail("Unexpected error: Failed to FreeLibrary %s\n", 
+        Fail("Unexpected error: Failed to FreeLibrary %s\n",
              lpModuleName);
 	}
 

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/GetProcAddress/test2/test2.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/GetProcAddress/test2/test2.cpp
@@ -6,8 +6,8 @@
 ** Source: test2.c (filemapping_memmgt\getprocaddress\test2)
 **
 ** Purpose: This test tries to call GetProcAddress with
-**          a NULL handle, with a NULL function name, with an empty 
-**          function name, with an invalid name and with an 
+**          a NULL handle, with a NULL function name, with an empty
+**          function name, with an invalid name and with an
 **          invalid ordinal value.
 **
 **
@@ -39,7 +39,7 @@ PALTEST(filemapping_memmgt_GetProcAddress_test2_paltest_getprocaddress_test2, "f
     }
 
     /* load a module */
-    hModule = LoadLibrary(lpModuleName);
+    hModule = LoadLibraryExA(lpModuleName, NULL, 0);
     if(!hModule)
     {
         Fail("Unexpected error: "
@@ -63,7 +63,7 @@ PALTEST(filemapping_memmgt_GetProcAddress_test2_paltest_getprocaddress_test2, "f
         err = FreeLibrary(hModule);
         if(0 == err)
 	    {
-            Fail("Unexpected error: Failed to FreeLibrary %s\n", 
+            Fail("Unexpected error: Failed to FreeLibrary %s\n",
                  lpModuleName);
 	    }
         Fail("");
@@ -86,7 +86,7 @@ PALTEST(filemapping_memmgt_GetProcAddress_test2_paltest_getprocaddress_test2, "f
         err = FreeLibrary(hModule);
         if(0 == err)
 	    {
-            Fail("Unexpected error: Failed to FreeLibrary %s\n", 
+            Fail("Unexpected error: Failed to FreeLibrary %s\n",
                  lpModuleName);
 	    }
         Fail("");
@@ -109,7 +109,7 @@ PALTEST(filemapping_memmgt_GetProcAddress_test2_paltest_getprocaddress_test2, "f
         err = FreeLibrary(hModule);
         if(0 == err)
 	    {
-            Fail("Unexpected error: Failed to FreeLibrary %s\n", 
+            Fail("Unexpected error: Failed to FreeLibrary %s\n",
                  lpModuleName);
 	    }
         Fail("");
@@ -132,7 +132,7 @@ PALTEST(filemapping_memmgt_GetProcAddress_test2_paltest_getprocaddress_test2, "f
         err = FreeLibrary(hModule);
         if(0 == err)
 	    {
-            Fail("Unexpected error: Failed to FreeLibrary %s\n", 
+            Fail("Unexpected error: Failed to FreeLibrary %s\n",
                  lpModuleName);
 	    }
         Fail("");
@@ -142,7 +142,7 @@ PALTEST(filemapping_memmgt_GetProcAddress_test2_paltest_getprocaddress_test2, "f
     err = FreeLibrary(hModule);
     if(0 == err)
 	{
-        Fail("Unexpected error: Failed to FreeLibrary %s\n", 
+        Fail("Unexpected error: Failed to FreeLibrary %s\n",
               lpModuleName);
 	}
 

--- a/src/coreclr/pal/tests/palsuite/loader/LoadLibraryA/test1/LoadLibraryA.cpp
+++ b/src/coreclr/pal/tests/palsuite/loader/LoadLibraryA/test1/LoadLibraryA.cpp
@@ -6,7 +6,7 @@
 ** Source:  loadlibrarya.c
 **
 ** Purpose: Positive test the LoadLibrary API.
-**          Call LoadLibrary to map a module into the calling 
+**          Call LoadLibrary to map a module into the calling
 **          process address space(DLL file)
 **
 **
@@ -34,7 +34,7 @@ PALTEST(loader_LoadLibraryA_test1_paltest_loadlibrarya_test1, "loader/LoadLibrar
     }
 
     /* load a module */
-    ModuleHandle = LoadLibrary(ModuleName);
+    ModuleHandle = LoadLibraryExA(ModuleName, NULL, 0);
     if(!ModuleHandle)
     {
         Fail("Failed to call LoadLibrary API!\n");

--- a/src/coreclr/pal/tests/palsuite/loader/LoadLibraryA/test2/LoadLibraryA.cpp
+++ b/src/coreclr/pal/tests/palsuite/loader/LoadLibraryA/test2/LoadLibraryA.cpp
@@ -6,7 +6,7 @@
 ** Source: loadlibrarya.c
 **
 ** Purpose: Negative test the LoadLibraryA API.
-**          Call LoadLibraryA with a not exist module Name 
+**          Call LoadLibraryA with a not exist module Name
 **
 **
 **============================================================*/
@@ -24,12 +24,12 @@ PALTEST(loader_LoadLibraryA_test2_paltest_loadlibrarya_test2, "loader/LoadLibrar
     {
         return FAIL;
     }
-    
+
     /*try to load a not exist module */
-    ModuleHandle = LoadLibraryA(pModuleName);
+    ModuleHandle = LoadLibraryExA(pModuleName, NULL, 0);
     if(NULL != ModuleHandle)
     {
-        Trace("Failed to call LoadLibraryA with a not exist mudule name, "
+        Trace("Failed to call LoadLibraryExA with a not exist mudule name, "
             "a NULL module handle is expected, but no NULL module handle "
             "is returned, error code=%u\n", GetLastError());
 

--- a/src/coreclr/pal/tests/palsuite/loader/LoadLibraryA/test3/loadlibrarya.cpp
+++ b/src/coreclr/pal/tests/palsuite/loader/LoadLibraryA/test3/loadlibrarya.cpp
@@ -25,15 +25,15 @@ PALTEST(loader_LoadLibraryA_test3_paltest_loadlibrarya_test3, "loader/LoadLibrar
     }
 
     /*load a module by passing a NULL module name*/
-    ModuleHandle = LoadLibraryA(NULL);
+    ModuleHandle = LoadLibraryExA(NULL, NULL, 0);
     if(NULL != ModuleHandle)
     {
-        Fail("\nFailed to call loadlibrarya API for a negative test, "
-            "call loadibrarya with NULL moudle name, a NULL module "
+        Fail("\nFailed to call LoadLibraryExA API for a negative test, "
+            "call LoadLibraryExA with NULL moudle name, a NULL module "
             "handle is expected, but no NULL module handle is returned, "
-            "error code =%u\n", GetLastError());   
+            "error code =%u\n", GetLastError());
     }
-  
+
     PAL_Terminate();
     return PASS;
 }

--- a/src/coreclr/pal/tests/palsuite/loader/LoadLibraryA/test5/loadlibrarya.cpp
+++ b/src/coreclr/pal/tests/palsuite/loader/LoadLibraryA/test5/loadlibrarya.cpp
@@ -39,11 +39,11 @@ PALTEST(loader_LoadLibraryA_test5_paltest_loadlibrarya_test5, "loader/LoadLibrar
     /* load a module which does not have the file extension,
      * but has a trailing dot
     */
-    ModuleHandle = LoadLibraryA(ModuleName);
+    ModuleHandle = LoadLibraryExA(ModuleName, NULL, 0);
     if(NULL != ModuleHandle)
     {
-        Trace("Failed to call LoadLibraryA API for a negative test "
-            "call LoadLibraryA with module name which does not have "
+        Trace("Failed to call LoadLibraryExA API for a negative test "
+            "call LoadLibraryExA with module name which does not have "
             "extension except a trailing dot, a NULL module handle is"
             "expected, but no NULL module handle is returned, "
              "error code = %u\n", GetLastError());

--- a/src/coreclr/pal/tests/palsuite/loader/LoadLibraryA/test7/LoadLibraryA.cpp
+++ b/src/coreclr/pal/tests/palsuite/loader/LoadLibraryA/test7/LoadLibraryA.cpp
@@ -6,7 +6,7 @@
 ** Source:  loadlibrarya.c
 **
 ** Purpose: Positive test the LoadLibrary API by calling it multiple times.
-**          Call LoadLibrary to map a module into the calling 
+**          Call LoadLibrary to map a module into the calling
 **          process address space(DLL file)
 **
 **
@@ -24,7 +24,7 @@
 PALTEST(loader_LoadLibraryA_test7_paltest_loadlibrarya_test7, "loader/LoadLibraryA/test7/paltest_loadlibrarya_test7")
 {
     HMODULE ModuleHandle;
-	HMODULE ReturnHandle;
+    HMODULE ReturnHandle;
     int err;
 
     /* Initialize the PAL environment */
@@ -35,36 +35,36 @@ PALTEST(loader_LoadLibraryA_test7_paltest_loadlibrarya_test7, "loader/LoadLibrar
     }
 
     /* load a module */
-    ModuleHandle = LoadLibrary(ModuleName);
+    ModuleHandle = LoadLibraryExA(ModuleName, NULL, 0);
     if(!ModuleHandle)
     {
-		Fail("Error[%u]:Failed to call LoadLibrary API!\n", GetLastError());
+        Fail("Error[%u]:Failed to call LoadLibrary API!\n", GetLastError());
     }
 
-	/* Call LoadLibrary again, should return same handle as returned for first time */
-	ReturnHandle = LoadLibrary(ModuleName);
-	if(!ReturnHandle)
+    /* Call LoadLibrary again, should return same handle as returned for first time */
+    ReturnHandle = LoadLibraryExA(ModuleName, NULL, 0);
+    if(!ReturnHandle)
     {
-		Fail("Error[%u]:Failed to call LoadLibrary API second time!\n", GetLastError());
+        Fail("Error[%u]:Failed to call LoadLibrary API second time!\n", GetLastError());
     }
-   
+
     if(ModuleHandle != ReturnHandle)
     {
-		Fail("Error[%u]:Failed to return the same handle while calling LoadLibrary API twice!\n", GetLastError());
+        Fail("Error[%u]:Failed to return the same handle while calling LoadLibrary API twice!\n", GetLastError());
     }
- 
+
     Trace("Value of handle ModuleHandle[%x], ReturnHandle[%x]\n", ModuleHandle, ReturnHandle);
 	/* decrement the reference count of the loaded dll */
     err = FreeLibrary(ModuleHandle);
-	
+
     if(0 == err)
     {
 		Fail("Error[%u]:Failed to FreeLibrary API!\n", GetLastError());
     }
-	
+
 	/* Try Freeing a library again, should not fail */
 	err = FreeLibrary(ReturnHandle);
-	
+
     if(0 == err)
     {
 		Fail("Error[%u][%d]: Was not successful in freeing a Library twice using FreeLibrary!\n", GetLastError(), err);
@@ -72,7 +72,7 @@ PALTEST(loader_LoadLibraryA_test7_paltest_loadlibrarya_test7, "loader/LoadLibrar
 
 	/* Try Freeing a library again, should fail */
 	err = FreeLibrary(ReturnHandle);
-	
+
     if(1 != err)
     {
 		Fail("Error[%u][%d]: Was successful in freeing a Library thrice using FreeLibrary!\n", GetLastError(), err);

--- a/src/coreclr/pal/tests/palsuite/loader/LoadLibraryW/test1/LoadLibraryW.cpp
+++ b/src/coreclr/pal/tests/palsuite/loader/LoadLibraryW/test1/LoadLibraryW.cpp
@@ -38,7 +38,7 @@ PALTEST(loader_LoadLibraryW_test1_paltest_loadlibraryw_test1, "loader/LoadLibrar
     lpModuleName = convert(ModuleName);
 
     /* load a module */
-    ModuleHandle = LoadLibrary(lpModuleName);
+    ModuleHandle = LoadLibraryExW(lpModuleName, NULL, 0);
 
     /* free the memory */
     free(lpModuleName);

--- a/src/coreclr/pal/tests/palsuite/loader/LoadLibraryW/test2/loadlibraryw.cpp
+++ b/src/coreclr/pal/tests/palsuite/loader/LoadLibraryW/test2/loadlibraryw.cpp
@@ -6,7 +6,7 @@
 ** Source: loadlibraryw.c
 **
 ** Purpose: Negative test the LoadLibraryW API.
-**          Call LoadLibraryW with a not exist module Name 
+**          Call LoadLibraryW with a not exist module Name
 **
 **
 **============================================================*/
@@ -26,20 +26,20 @@ PALTEST(loader_LoadLibraryW_test2_paltest_loadlibraryw_test2, "loader/LoadLibrar
     {
         return FAIL;
     }
-    
+
     /* convert a normal string to a wide one */
     pwModuleName = convert((char *)pModuleName);
 
 
     /*try to load a not exist module */
-    ModuleHandle = LoadLibraryW(pwModuleName);
-    
+    ModuleHandle = LoadLibraryExW(pwModuleName);
+
     /* free the memory */
     free(pwModuleName);
-    
+
     if(NULL != ModuleHandle)
     {
-        Trace("Failed to call LoadLibraryW with a not exist mudule name, "
+        Trace("Failed to call LoadLibraryExW with a not exist mudule name, "
             "a NULL module handle is expected, but no NULL module handle "
             "is returned, error code=%u\n", GetLastError());
 

--- a/src/coreclr/pal/tests/palsuite/loader/LoadLibraryW/test3/loadlibraryw.cpp
+++ b/src/coreclr/pal/tests/palsuite/loader/LoadLibraryW/test3/loadlibraryw.cpp
@@ -26,15 +26,15 @@ PALTEST(loader_LoadLibraryW_test3_paltest_loadlibraryw_test3, "loader/LoadLibrar
     }
 
     /* load a module with a NULL module name */
-    ModuleHandle = LoadLibraryW(NULL);
+    ModuleHandle = LoadLibraryExW(NULL);
     if(NULL != ModuleHandle)
     {
         Fail("\nFailed to call loadlibraryw API for a negative test, "
             "call loadibraryw with NULL moudle name, a NULL module "
             "handle is expected, but no NULL module handle is returned, "
-            "error code =%u\n", GetLastError());   
+            "error code =%u\n", GetLastError());
     }
-  
+
     PAL_Terminate();
     return PASS;
 }

--- a/src/coreclr/pal/tests/palsuite/loader/LoadLibraryW/test5/loadlibraryw.cpp
+++ b/src/coreclr/pal/tests/palsuite/loader/LoadLibraryW/test5/loadlibraryw.cpp
@@ -41,15 +41,15 @@ PALTEST(loader_LoadLibraryW_test5_paltest_loadlibraryw_test5, "loader/LoadLibrar
     lpModuleName = convert(ModuleName);
 
     /* load a module */
-    ModuleHandle = LoadLibraryW(lpModuleName);
+    ModuleHandle = LoadLibraryExW(lpModuleName);
 
     /* free the memory */
     free(lpModuleName);
 
     if(NULL != ModuleHandle)
     {
-        Trace("Failed to call LoadLibraryW API for a negative test "
-            "call LoadLibraryW with module name which does not have "
+        Trace("Failed to call LoadLibraryExW API for a negative test "
+            "call LoadLibraryExW with module name which does not have "
             "extension except a trailing dot, a NULL module handle is"
             "expected, but no NULL module handle is returned, "
             "error code = %u\n", GetLastError());

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
@@ -138,7 +138,7 @@ bool LoadRealJitLib(HMODULE& jitLib, WCHAR* jitLibPath)
             LogError("LoadRealJitLib - No real jit path");
             return false;
         }
-        jitLib = ::LoadLibraryW(jitLibPath);
+        jitLib = ::LoadLibraryExW(jitLibPath, NULL, 0);
         if (jitLib == NULL)
         {
             LogError("LoadRealJitLib - LoadLibrary failed to load '%ws' (0x%08x)", jitLibPath, ::GetLastError());

--- a/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jitinstance.cpp
@@ -177,7 +177,7 @@ HRESULT JitInstance::StartUp(char* PathToJit, bool copyJit, bool breakOnDebugBre
 #endif // !TARGET_UNIX
 
     // Load Library
-    hLib = ::LoadLibraryA(PathToTempJit);
+    hLib = ::LoadLibraryExA(PathToTempJit, NULL, 0);
     if (hLib == 0)
     {
         LogError("LoadLibrary failed (0x%08x)", ::GetLastError());
@@ -237,7 +237,7 @@ bool JitInstance::reLoad(MethodContext* firstContext)
     FreeLibrary(hLib);
 
     // Load Library
-    hLib = ::LoadLibraryA(PathToTempJit);
+    hLib = ::LoadLibraryExA(PathToTempJit, NULL, 0);
     if (hLib == 0)
     {
         LogError("LoadLibrary failed (0x%08x)", ::GetLastError());

--- a/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
@@ -91,7 +91,7 @@ bool NearDiffer::InitAsmDiff()
         coreDisToolsLibrary = coreCLRLoadedPath;
 #endif // TARGET_UNIX
 
-        HMODULE hCoreDisToolsLib = ::LoadLibraryW(coreDisToolsLibrary);
+        HMODULE hCoreDisToolsLib = ::LoadLibraryExW(coreDisToolsLibrary, NULL, 0);
         if (hCoreDisToolsLib == 0)
         {
             LogError("LoadLibrary(%s) failed (0x%08x)", MAKEDLLNAME_A("coredistools"), ::GetLastError());

--- a/src/coreclr/utilcode/ccomprc.cpp
+++ b/src/coreclr/utilcode/ccomprc.cpp
@@ -555,7 +555,7 @@ HRESULT CCompRC::LoadResourceFile(HRESOURCEDLL * pHInst, LPCWSTR lpFileName)
         dwLoadLibraryFlags = 0;
     }
 
-    if((*pHInst = WszLoadLibraryEx(lpFileName, NULL, dwLoadLibraryFlags)) == NULL)
+    if((*pHInst = WszLoadLibrary(lpFileName, NULL, dwLoadLibraryFlags)) == NULL)
     {
         return HRESULT_FROM_GetLastError();
     }

--- a/src/coreclr/utilcode/clrhost.cpp
+++ b/src/coreclr/utilcode/clrhost.cpp
@@ -66,7 +66,7 @@ static void SetupHashStack ()
 
         PAL_TRY(void *, unused, NULL) {
             FHashStack func;
-            HMODULE hmod = LoadLibraryExA ("mscorrfs.dll", NULL, 0);
+            HMODULE hmod = WszLoadLibrary(W("mscorrfs.dll"), NULL, 0);
             if (hmod) {
                 func = (FHashStack)GetProcAddress (hmod, "HashStack");
                 if (func == 0) {
@@ -132,7 +132,7 @@ HMODULE CLRLoadLibrary(LPCWSTR lpLibFileName)
 HMODULE CLRLoadLibraryEx(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
 {
     WRAPPER_NO_CONTRACT;
-    return WszLoadLibraryEx(lpLibFileName, hFile, dwFlags);
+    return WszLoadLibrary(lpLibFileName, hFile, dwFlags);
 }
 
 BOOL CLRFreeLibrary(HMODULE hModule)

--- a/src/coreclr/utilcode/stacktrace.cpp
+++ b/src/coreclr/utilcode/stacktrace.cpp
@@ -32,7 +32,7 @@ HINSTANCE LoadImageHlp()
     STATIC_CONTRACT_CANNOT_TAKE_LOCK;
     SCAN_IGNORE_FAULT; // Faults from Wsz funcs are handled.
 
-    return LoadLibraryExA("imagehlp.dll", NULL, 0);
+    return WszLoadLibrary(W("imagehlp.dll"), NULL, 0);
 }
 
 HINSTANCE LoadDbgHelp()
@@ -41,7 +41,7 @@ HINSTANCE LoadDbgHelp()
     STATIC_CONTRACT_GC_NOTRIGGER;
     SCAN_IGNORE_FAULT; // Faults from Wsz funcs are handled.
 
-    return LoadLibraryExA("dbghelp.dll", NULL, 0);
+    return WszLoadLibrary(W("dbghelp.dll"), NULL, 0);
 }
 
 /****************************************************************************

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -216,7 +216,7 @@ namespace
         _ASSERTE(wszDllPath != nullptr);
 
         // We've got the name of the DLL to load, so load it.
-        HModuleHolder hDll = WszLoadLibraryEx(wszDllPath, nullptr, GetLoadWithAlteredSearchPathFlag());
+        HModuleHolder hDll = WszLoadLibrary(wszDllPath, nullptr, GetLoadWithAlteredSearchPathFlag());
         if (hDll == nullptr)
             return HRESULT_FROM_GetLastError();
 

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -871,7 +871,7 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
     return base;
 }
 
-#if TARGET_WINDOWS
+#ifdef TARGET_WINDOWS
 
 // VirtualAlloc2
 typedef PVOID(WINAPI* VirtualAlloc2Fn)(
@@ -907,7 +907,6 @@ static bool HavePlaceholderAPI()
         return false;
     }
 
-#ifdef TARGET_WINDOWS
     if (pMapViewOfFile3 == NULL)
     {
         HMODULE hm = WszLoadLibrary(W("kernelbase.dll"), NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
@@ -924,7 +923,6 @@ static bool HavePlaceholderAPI()
             return true;
         }
     }
-#endif // TARGET_WINDOWS
 
     pMapViewOfFile3 = INVALID_ADDRESS_SENTINEL;
     return false;

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -918,14 +918,14 @@ static bool HavePlaceholderAPI()
             FreeLibrary(hm);
         }
 
-        if (pMapViewOfFile3 != NULL && pVirtualAlloc2 != NULL)
+        if (pMapViewOfFile3 == NULL || pVirtualAlloc2 == NULL)
         {
-            return true;
+            pMapViewOfFile3 = INVALID_ADDRESS_SENTINEL;
+            return false;
         }
     }
 
-    pMapViewOfFile3 = INVALID_ADDRESS_SENTINEL;
-    return false;
+    return true;
 }
 
 static PVOID AllocPlaceholder(PVOID BaseAddress, SIZE_T Size)

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -907,9 +907,10 @@ static bool HavePlaceholderAPI()
         return false;
     }
 
+#ifdef TARGET_WINDOWS
     if (pMapViewOfFile3 == NULL)
     {
-        HMODULE hm = LoadLibraryW(_T("kernelbase.dll"));
+        HMODULE hm = WszLoadLibrary(W("kernelbase.dll"), NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
         if (hm != NULL)
         {
             pVirtualAlloc2 = (VirtualAlloc2Fn)GetProcAddress(hm, "VirtualAlloc2");
@@ -918,14 +919,15 @@ static bool HavePlaceholderAPI()
             FreeLibrary(hm);
         }
 
-        if (pMapViewOfFile3 == NULL || pVirtualAlloc2 == NULL)
+        if (pMapViewOfFile3 != NULL && pVirtualAlloc2 != NULL)
         {
-            pMapViewOfFile3 = INVALID_ADDRESS_SENTINEL;
-            return false;
+            return true;
         }
     }
+#endif // TARGET_WINDOWS
 
-    return true;
+    pMapViewOfFile3 = INVALID_ADDRESS_SENTINEL;
+    return false;
 }
 
 static PVOID AllocPlaceholder(PVOID BaseAddress, SIZE_T Size)

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -8206,7 +8206,7 @@ void Thread::InitializeSpecialUserModeApc()
     WRAPPER_NO_CONTRACT;
     static_assert_no_msg(OFFSETOF__APC_CALLBACK_DATA__ContextRecord == offsetof(CLONE_APC_CALLBACK_DATA, ContextRecord));
 
-    HMODULE hKernel32 = WszLoadLibraryEx(WINDOWS_KERNEL32_DLLNAME_W, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    HMODULE hKernel32 = WszLoadLibrary(WINDOWS_KERNEL32_DLLNAME_W, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
 
     // See if QueueUserAPC2 exists
     QueueUserAPC2Proc pfnQueueUserAPC2Proc = (QueueUserAPC2Proc)GetProcAddress(hKernel32, "QueueUserAPC2");

--- a/src/coreclr/vm/util.cpp
+++ b/src/coreclr/vm/util.cpp
@@ -951,7 +951,7 @@ static HMODULE CLRLoadLibraryExWorker(LPCWSTR lpLibFileName, HANDLE hFile, DWORD
     ErrorModeHolder errorMode{};
     {
         INDEBUG(PEDecoder::ForceRelocForDLL(lpLibFileName));
-        hMod = WszLoadLibraryEx(lpLibFileName, hFile, dwFlags);
+        hMod = WszLoadLibrary(lpLibFileName, hFile, dwFlags);
         *pLastError = GetLastError();
     }
     return hMod;


### PR DESCRIPTION
The `LoadLibraryExA` is only used in some JIT scenarios, but is being left here for now.