### PR TITLE
[browser] [wasm] Refactor Request Streaming to use HttpContent.CopyToAsync

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -302,6 +302,7 @@ namespace System.Net.Http.Functional.Tests
             var content = new MultipartFormDataContent();
             content.Add(new StreamContent(new DelegateStream(
                 canReadFunc: () => true,
+                readFunc: (buffer, offset, count) => throw new FormatException(),
                 readAsyncFunc: (buffer, offset, count, cancellationToken) =>
                 {
                     if (remaining > 0)

--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -296,6 +296,7 @@ namespace System.Net.Http.Functional.Tests
             req.Options.Set(WebAssemblyEnableStreamingRequestKey, true);
 
             int size = 1500 * 1024 * 1024;
+            int multipartOverhead = 125 + 4 /* "test" */;
             int remaining = size;
             var content = new MultipartFormDataContent();
             content.Add(new StreamContent(new DelegateStream(
@@ -319,7 +320,7 @@ namespace System.Net.Http.Functional.Tests
             using (HttpResponseMessage response = await client.SendAsync(req))
             {
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                Assert.Equal((size + 129).ToString(), Assert.Single(response.Headers.GetValues("X-HttpRequest-Body-Length")));
+                Assert.Equal((size + multipartOverhead).ToString(), Assert.Single(response.Headers.GetValues("X-HttpRequest-Body-Length")));
                 // Streaming requests can't set Content-Length
                 Assert.False(response.Headers.Contains("X-HttpRequest-Headers-ContentLength"));
             }

--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -534,6 +534,9 @@
   <data name="net_http_synchronous_reads_not_supported" xml:space="preserve">
     <value>Synchronous reads are not supported, use ReadAsync instead.</value>
   </data>
+  <data name="net_http_synchronous_writes_not_supported" xml:space="preserve">
+    <value>Synchronous writes are not supported, use WriteAsync instead.</value>
+  </data>
   <data name="net_socks_auth_failed" xml:space="preserve">
     <value>Failed to authenticate with the SOCKS server.</value>
   </data>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -223,8 +223,8 @@ namespace System.Net.Http
                         JSObject transformStream = BrowserHttpInterop.CreateTransformStream();
                         try
                         {
-                            promise = BrowserHttpInterop.Fetch(uri, headerNames.ToArray(), headerValues.ToArray(), optionNames, optionValues, abortController, transformStream);
-                            promise = WasmHttpWriteStream.CopyToAsync(promise, transformStream, request.Content, cancellationToken);
+                            Task<JSObject> fetchPromise = BrowserHttpInterop.Fetch(uri, headerNames.ToArray(), headerValues.ToArray(), optionNames, optionValues, abortController, transformStream);
+                            promise = WasmHttpWriteStream.CopyToAsync(fetchPromise, transformStream, request.Content, cancellationToken);
                         }
                         catch
                         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -133,9 +133,9 @@ namespace System.Net.Http
             List<string> headerNames = new List<string>(headerCount);
             List<string> headerValues = new List<string>(headerCount);
             JSObject abortController = BrowserHttpInterop.CreateAbortController();
-            CancellationTokenRegistration? abortRegistration = cancellationToken.Register(static (object? state) =>
+            CancellationTokenRegistration? abortRegistration = cancellationToken.Register(static s =>
             {
-                JSObject _abortController = (JSObject)state!;
+                JSObject _abortController = (JSObject)s!;
 #if FEATURE_WASM_THREADS
                 if (!_abortController.IsDisposed)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -343,17 +343,13 @@ namespace System.Net.Http
             {
                 try
                 {
-                    Task copyTask = content.CopyToAsync(stream, cancellationToken);
-                    if (await Task.WhenAny(copyTask, fetchResponsePromise).ConfigureAwait(true) == copyTask)
-                    {
-                        await copyTask.ConfigureAwait(true);
-                    }
+                    await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(true);
                     await BrowserHttpInterop.TransformStreamClose(transformStream).ConfigureAwait(true);
                     return await fetchResponsePromise.ConfigureAwait(true);
                 }
                 catch (Exception ex)
                 {
-                    await BrowserHttpInterop.TransformStreamClose(transformStream, ex).ConfigureAwait(true);
+                    BrowserHttpInterop.TransformStreamAbort(transformStream, ex);
                     throw;
                 }
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -347,8 +347,8 @@ namespace System.Net.Http
                     if (await Task.WhenAny(copyTask, fetchResponsePromise).ConfigureAwait(true) == copyTask)
                     {
                         await copyTask.ConfigureAwait(true);
-                        await BrowserHttpInterop.TransformStreamClose(transformStream).ConfigureAwait(true);
                     }
+                    await BrowserHttpInterop.TransformStreamClose(transformStream).ConfigureAwait(true);
                     return await fetchResponsePromise.ConfigureAwait(true);
                 }
                 catch (Exception ex)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -39,8 +39,12 @@ namespace System.Net.Http
 
         [JSImport("INTERNAL.http_wasm_transform_stream_close")]
         public static partial Task TransformStreamClose(
+            JSObject transformStream);
+
+        [JSImport("INTERNAL.http_wasm_transform_stream_abort")]
+        public static partial void TransformStreamAbort(
             JSObject transformStream,
-            Exception? error = null);
+            Exception error);
 
         [JSImport("INTERNAL.http_wasm_get_response_header_names")]
         private static partial string[] _GetResponseHeaderNames(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -28,16 +28,16 @@ namespace System.Net.Http
         public static partial void AbortResponse(
             JSObject fetchResponse);
 
-        [JSImport("INTERNAL.http_wasm_readable_stream_controller_enqueue")]
-        public static partial void ReadableStreamControllerEnqueue(
-            [JSMarshalAs<JSType.Any>] object pullState,
+        [JSImport("INTERNAL.http_wasm_request_stream_write")]
+        public static partial Task RequestStreamWrite(
+            JSObject requestStream,
             IntPtr bufferPtr,
             int bufferLength);
 
-        [JSImport("INTERNAL.http_wasm_readable_stream_controller_error")]
-        public static partial void ReadableStreamControllerError(
-            [JSMarshalAs<JSType.Any>] object pullState,
-            Exception error);
+        [JSImport("INTERNAL.http_wasm_request_stream_close")]
+        public static partial Task<JSObject> RequestStreamClose(
+            JSObject requestStream,
+            Exception? error = null);
 
         [JSImport("INTERNAL.http_wasm_get_response_header_names")]
         private static partial string[] _GetResponseHeaderNames(
@@ -72,15 +72,13 @@ namespace System.Net.Http
             JSObject abortControler);
 
         [JSImport("INTERNAL.http_wasm_fetch_stream")]
-        public static partial Task<JSObject> Fetch(
+        public static partial JSObject FetchStream(
             string uri,
             string[] headerNames,
             string[] headerValues,
             string[] optionNames,
             [JSMarshalAs<JSType.Array<JSType.Any>>] object?[] optionValues,
-            JSObject abortControler,
-            [JSMarshalAs<JSType.Function<JSType.Any>>] Action<object> pull,
-            [JSMarshalAs<JSType.Any>] object pullState);
+            JSObject abortControler);
 
         [JSImport("INTERNAL.http_wasm_fetch_bytes")]
         private static partial Task<JSObject> FetchBytes(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -131,9 +131,9 @@ namespace System.Net.Http
             }
             try
             {
-                using (var operationRegistration = cancellationToken.Register(static (object? state) =>
+                using (var operationRegistration = cancellationToken.Register(static s =>
                 {
-                    (Task _promise, JSObject? _fetchResponse) = ((Task, JSObject?))state!;
+                    (Task _promise, JSObject? _fetchResponse) = ((Task, JSObject?))s!;
                     CancelablePromise.CancelPromise(_promise, static (JSObject? __fetchResponse) =>
                     {
                         if (__fetchResponse != null)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -43,8 +43,7 @@ namespace System.Net.Http
 
         [JSImport("INTERNAL.http_wasm_transform_stream_abort")]
         public static partial void TransformStreamAbort(
-            JSObject transformStream,
-            Exception error);
+            JSObject transformStream);
 
         [JSImport("INTERNAL.http_wasm_get_response_header_names")]
         private static partial string[] _GetResponseHeaderNames(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -28,15 +28,18 @@ namespace System.Net.Http
         public static partial void AbortResponse(
             JSObject fetchResponse);
 
-        [JSImport("INTERNAL.http_wasm_request_stream_write")]
-        public static partial Task RequestStreamWrite(
-            JSObject requestStream,
+        [JSImport("INTERNAL.http_wasm_create_transform_stream")]
+        public static partial JSObject CreateTransformStream();
+
+        [JSImport("INTERNAL.http_wasm_transform_stream_write")]
+        public static partial Task TransformStreamWrite(
+            JSObject transformStream,
             IntPtr bufferPtr,
             int bufferLength);
 
-        [JSImport("INTERNAL.http_wasm_request_stream_close")]
-        public static partial Task<JSObject> RequestStreamClose(
-            JSObject requestStream,
+        [JSImport("INTERNAL.http_wasm_transform_stream_close")]
+        public static partial Task TransformStreamClose(
+            JSObject transformStream,
             Exception? error = null);
 
         [JSImport("INTERNAL.http_wasm_get_response_header_names")]
@@ -72,13 +75,14 @@ namespace System.Net.Http
             JSObject abortControler);
 
         [JSImport("INTERNAL.http_wasm_fetch_stream")]
-        public static partial JSObject FetchStream(
+        public static partial Task<JSObject> Fetch(
             string uri,
             string[] headerNames,
             string[] headerValues,
             string[] optionNames,
             [JSMarshalAs<JSType.Array<JSType.Any>>] object?[] optionValues,
-            JSObject abortControler);
+            JSObject abortControler,
+            JSObject transformStream);
 
         [JSImport("INTERNAL.http_wasm_fetch_bytes")]
         private static partial Task<JSObject> FetchBytes(

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
@@ -274,7 +274,7 @@ namespace System.Net.Http.Functional.Tests
                 await LoopbackServer.CreateServerAsync(async (server, uri) =>
                 {
                     var request = new HttpRequestMessage(HttpMethod.Post, uri);
-                    request.Content = new StringContent("Hello World", null, ((MediaTypeHeaderValue)null)!);
+                    request.Content = new StringContent("", null, ((MediaTypeHeaderValue)null)!);
 
                     Task<HttpResponseMessage> requestTask = client.SendAsync(request);
                     await server.AcceptConnectionAsync(async connection =>

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -580,10 +580,10 @@ namespace System.Net.WebSockets
             }
             try
             {
-                using (var receiveRegistration = cancellationToken.Register(() =>
+                using (var receiveRegistration = cancellationToken.Register(static (object? state) =>
                 {
-                    CancelablePromise.CancelPromise(jsTask);
-                }))
+                    CancelablePromise.CancelPromise((Task)state!);
+                }, jsTask))
                 {
                     await jsTask.ConfigureAwait(true);
                     return;

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -580,9 +580,9 @@ namespace System.Net.WebSockets
             }
             try
             {
-                using (var receiveRegistration = cancellationToken.Register(static (object? state) =>
+                using (var receiveRegistration = cancellationToken.Register(static s =>
                 {
-                    CancelablePromise.CancelPromise((Task)state!);
+                    CancelablePromise.CancelPromise((Task)s!);
                 }, jsTask))
                 {
                     await jsTask.ConfigureAwait(true);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CancelablePromise.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CancelablePromise.cs
@@ -32,7 +32,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #endif
         }
 
-        public static void CancelPromise<T1, T2>(Task promise, Action<T1, T2> callback, T1 state1, T2 state2)
+        public static void CancelPromise<T>(Task promise, Action<T> callback, T state)
         {
             // this check makes sure that promiseGCHandle is still valid handle
             if (promise.IsCompleted)
@@ -48,7 +48,7 @@ namespace System.Runtime.InteropServices.JavaScript
             {
 #endif
                 _CancelPromise(holder.GCHandle);
-                callback.Invoke(state1, state2);
+                callback.Invoke(state);
 #if FEATURE_WASM_THREADS
             }, holder);
 #endif

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
@@ -159,10 +159,10 @@ namespace System.Runtime.InteropServices.JavaScript
             {
                 return jsTask.Result;
             }
-            using (var receiveRegistration = cancellationToken.Register(() =>
+            using (var receiveRegistration = cancellationToken.Register(static (object? state) =>
             {
-                CancelablePromise.CancelPromise(jsTask);
-            }))
+                CancelablePromise.CancelPromise((Task<JSObject>)state!);
+            }, jsTask))
             {
                 return await jsTask.ConfigureAwait(true);
             }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
@@ -159,9 +159,9 @@ namespace System.Runtime.InteropServices.JavaScript
             {
                 return jsTask.Result;
             }
-            using (var receiveRegistration = cancellationToken.Register(static (object? state) =>
+            using (var receiveRegistration = cancellationToken.Register(static s =>
             {
-                CancelablePromise.CancelPromise((Task<JSObject>)state!);
+                CancelablePromise.CancelPromise((Task<JSObject>)s!);
             }, jsTask))
             {
                 return await jsTask.ConfigureAwait(true);

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -4,7 +4,7 @@
 import { mono_wasm_cancel_promise } from "./cancelable-promise";
 import cwraps, { profiler_c_functions } from "./cwraps";
 import { mono_wasm_send_dbg_command_with_parms, mono_wasm_send_dbg_command, mono_wasm_get_dbg_command_info, mono_wasm_get_details, mono_wasm_release_object, mono_wasm_call_function_on, mono_wasm_debugger_resume, mono_wasm_detach_debugger, mono_wasm_raise_debug_event, mono_wasm_change_debugger_log_level, mono_wasm_debugger_attached } from "./debug";
-import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_request_stream_write, http_wasm_request_stream_close, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
+import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_create_transform_stream, http_wasm_transform_stream_write, http_wasm_transform_stream_close, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
 import { exportedRuntimeAPI, Module, runtimeHelpers } from "./globals";
 import { get_property, set_property, has_property, get_typeof_property, get_global_this, dynamic_import } from "./invoke-js";
 import { mono_wasm_stringify_as_error_with_stack } from "./logging";
@@ -69,8 +69,9 @@ export function export_internal(): any {
         http_wasm_create_abort_controler,
         http_wasm_abort_request,
         http_wasm_abort_response,
-        http_wasm_request_stream_write,
-        http_wasm_request_stream_close,
+        http_wasm_create_transform_stream,
+        http_wasm_transform_stream_write,
+        http_wasm_transform_stream_close,
         http_wasm_fetch,
         http_wasm_fetch_stream,
         http_wasm_fetch_bytes,

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -4,7 +4,7 @@
 import { mono_wasm_cancel_promise } from "./cancelable-promise";
 import cwraps, { profiler_c_functions } from "./cwraps";
 import { mono_wasm_send_dbg_command_with_parms, mono_wasm_send_dbg_command, mono_wasm_get_dbg_command_info, mono_wasm_get_details, mono_wasm_release_object, mono_wasm_call_function_on, mono_wasm_debugger_resume, mono_wasm_detach_debugger, mono_wasm_raise_debug_event, mono_wasm_change_debugger_log_level, mono_wasm_debugger_attached } from "./debug";
-import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_readable_stream_controller_enqueue, http_wasm_readable_stream_controller_error, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
+import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_request_stream_write, http_wasm_request_stream_close, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
 import { exportedRuntimeAPI, Module, runtimeHelpers } from "./globals";
 import { get_property, set_property, has_property, get_typeof_property, get_global_this, dynamic_import } from "./invoke-js";
 import { mono_wasm_stringify_as_error_with_stack } from "./logging";
@@ -69,8 +69,8 @@ export function export_internal(): any {
         http_wasm_create_abort_controler,
         http_wasm_abort_request,
         http_wasm_abort_response,
-        http_wasm_readable_stream_controller_enqueue,
-        http_wasm_readable_stream_controller_error,
+        http_wasm_request_stream_write,
+        http_wasm_request_stream_close,
         http_wasm_fetch,
         http_wasm_fetch_stream,
         http_wasm_fetch_bytes,

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -4,7 +4,7 @@
 import { mono_wasm_cancel_promise } from "./cancelable-promise";
 import cwraps, { profiler_c_functions } from "./cwraps";
 import { mono_wasm_send_dbg_command_with_parms, mono_wasm_send_dbg_command, mono_wasm_get_dbg_command_info, mono_wasm_get_details, mono_wasm_release_object, mono_wasm_call_function_on, mono_wasm_debugger_resume, mono_wasm_detach_debugger, mono_wasm_raise_debug_event, mono_wasm_change_debugger_log_level, mono_wasm_debugger_attached } from "./debug";
-import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_create_transform_stream, http_wasm_transform_stream_write, http_wasm_transform_stream_close, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
+import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_abort_controler, http_wasm_abort_request, http_wasm_abort_response, http_wasm_create_transform_stream, http_wasm_transform_stream_write, http_wasm_transform_stream_close, http_wasm_transform_stream_abort, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes } from "./http";
 import { exportedRuntimeAPI, Module, runtimeHelpers } from "./globals";
 import { get_property, set_property, has_property, get_typeof_property, get_global_this, dynamic_import } from "./invoke-js";
 import { mono_wasm_stringify_as_error_with_stack } from "./logging";
@@ -72,6 +72,7 @@ export function export_internal(): any {
         http_wasm_create_transform_stream,
         http_wasm_transform_stream_write,
         http_wasm_transform_stream_close,
+        http_wasm_transform_stream_abort,
         http_wasm_fetch,
         http_wasm_fetch_stream,
         http_wasm_fetch_bytes,

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -81,15 +81,16 @@ export async function http_wasm_transform_stream_write(ts: TransformStreamExtens
     await Promise.race([ts.__writer.write(copy), ts.__fetch_promise_control.promise]);
 }
 
-export async function http_wasm_transform_stream_close(ts: TransformStreamExtension, error: Error | undefined): Promise<void> {
+export async function http_wasm_transform_stream_close(ts: TransformStreamExtension): Promise<void> {
     mono_assert(ts.__fetch_promise_control, "expected fetch promise control");
-    if (error) {
-        ts.__fetch_promise_control.reject(error);
-        ts.__writer.abort(error);
-    } else {
-        await Promise.race([ts.__writer.ready, ts.__fetch_promise_control.promise]);
-        ts.__writer.close();
-    }
+    await Promise.race([ts.__writer.ready, ts.__fetch_promise_control.promise]);
+    ts.__writer.close();
+}
+
+export function http_wasm_transform_stream_abort(ts: TransformStreamExtension, error: Error): void {
+    mono_assert(ts.__fetch_promise_control, "expected fetch promise control");
+    ts.__fetch_promise_control.reject(error);
+    ts.__writer.abort(error);
 }
 
 export function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, body: TransformStreamExtension): Promise<ResponseExtension> {

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { wrap_as_cancelable_promise } from "./cancelable-promise";
-import { ENVIRONMENT_IS_NODE, Module, createPromiseController, loaderHelpers, mono_assert } from "./globals";
-import { ManagedObject, MemoryViewType, Span } from "./marshal";
+import { ENVIRONMENT_IS_NODE, Module, loaderHelpers, mono_assert } from "./globals";
+import { MemoryViewType, Span } from "./marshal";
 import type { VoidPtr } from "./types/emscripten";
 import { ControllablePromise, PromiseController } from "./types/internal";
 
@@ -25,7 +25,7 @@ export function http_wasm_supports_streaming_request(): boolean {
     // So, if that header is set, then we know the browser doesn't support streams in request objects, and we can exit early.
     // Safari does support streams in request objects, but doesn't allow them to be used with fetch, so the duplex option is tested, which Safari doesn't currently support.
     // See https://developer.chrome.com/articles/fetch-streaming-requests/
-    if (typeof Request !== "undefined" && "body" in Request.prototype && typeof ReadableStream === "function") {
+    if (typeof Request !== "undefined" && "body" in Request.prototype && typeof ReadableStream === "function" && typeof TransformStream === "function") {
         let duplexAccessed = false;
         const hasContentType = new Request("", {
             body: new ReadableStream(),
@@ -65,80 +65,32 @@ export function http_wasm_abort_response(res: ResponseExtension): void {
     }
 }
 
-export function http_wasm_readable_stream_controller_enqueue(pull_state: PullStateExtension, bufferPtr: VoidPtr, bufferLength: number): void {
-    const controller = pull_state.__controller;
-    const pull_promise_control = pull_state.__pull_promise_control;
-    mono_assert(controller, "expected controller");
-    mono_assert(pull_promise_control, "expected pull_promise_control");
-    try {
-        if (bufferLength === 0) {
-            controller.close();
-            pull_state.dispose();
-            pull_state.__pull_promise_control = null;
-            pull_state.__controller = null;
-        } else {
-            // the bufferPtr is pinned by the caller
-            const view = new Span(bufferPtr, bufferLength, MemoryViewType.Byte);
-            // because https://github.com/WebAssembly/design/issues/1162 we need to copy the buffer
-            // also it doesn't make much sense to use byob
-            const copy = view.slice() as Uint8Array;
-            controller.enqueue(copy);
-        }
-        pull_promise_control.resolve();
-    }
-    catch (err) {
-        pull_state.dispose();
-        pull_promise_control.reject(err);
-    }
-    finally {
-        pull_state.__pull_promise_control = null;
-    }
+export async function http_wasm_request_stream_write(ts: TransformStreamExtension, bufferPtr: VoidPtr, bufferLength: number): Promise<void> {
+    mono_assert(bufferLength > 0, "expected bufferLength > 0");
+    await ts.__writer.ready;
+    // the bufferPtr is pinned by the caller
+    const view = new Span(bufferPtr, bufferLength, MemoryViewType.Byte);
+    const copy = view.slice() as Uint8Array;
+    await ts.__writer.write(copy);
 }
 
-export function http_wasm_readable_stream_controller_error(pull_state: PullStateExtension, error: Error): void {
-    const controller = pull_state.__controller;
-    mono_assert(controller, "expected controller");
-    pull_state.__pull_promise_control?.reject(error);
-    pull_state.__fetch_promise_control?.reject(error);
-    pull_state.dispose();
-    controller.error(error);
-    pull_state.__pull_promise_control = null;
+export async function http_wasm_request_stream_close(ts: TransformStreamExtension, error: Error | undefined): Promise<ResponseExtension> {
+    if (error) {
+        ts.__fetch_promise_control.reject(error);
+        await ts.__writer.abort(error);
+    } else {
+        await ts.__writer.ready;
+        await ts.__writer.close();
+    }
+    return await ts.__fetch_promise_control.promise;
 }
 
-export function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController,
-    pull_delegate: (pull_state: PullStateExtension) => void,
-    pull_state: PullStateExtension): Promise<ResponseExtension> {
-    function pull(controller: ReadableByteStreamController): Promise<void> {
-        const { promise, promise_control } = createPromiseController<void>();
-        try {
-            mono_assert(!pull_state.__pull_promise_control, "expected pull_promise_control to be null");
-            pull_state.__controller = controller;
-            pull_state.__pull_promise_control = promise_control;
-            pull_delegate(pull_state);
-            return promise;
-        }
-        catch (error) {
-            pull_state.dispose();
-            pull_state.__controller = null;
-            pull_state.__pull_promise_control = null;
-            pull_state.__fetch_promise_control?.reject(error);
-            return Promise.reject(error);
-        }
-    }
-
-    function cancel(error: any) {
-        pull_state.__fetch_promise_control?.reject(error);
-    }
-
-    const body = new ReadableStream({
-        type: "bytes",
-        pull,
-        cancel
-    });
-
-    const cancelable_promise = http_wasm_fetch(url, header_names, header_values, option_names, option_values, abort_controller, body);
-    pull_state.__fetch_promise_control = loaderHelpers.getPromiseController(cancelable_promise);
-    return cancelable_promise;
+export function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController): TransformStreamExtension {
+    const transform_stream = new TransformStream<Uint8Array, Uint8Array>() as TransformStreamExtension;
+    transform_stream.__writer = transform_stream.writable.getWriter();
+    const cancelable_promise = http_wasm_fetch(url, header_names, header_values, option_names, option_values, abort_controller, transform_stream.readable);
+    transform_stream.__fetch_promise_control = loaderHelpers.getPromiseController(cancelable_promise);
+    return transform_stream;
 }
 
 export function http_wasm_fetch_bytes(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, bodyPtr: VoidPtr, bodyLength: number): Promise<ResponseExtension> {
@@ -252,10 +204,9 @@ export function http_wasm_get_streamed_response_bytes(res: ResponseExtension, bu
     });
 }
 
-interface PullStateExtension extends ManagedObject {
-    __pull_promise_control: PromiseController<void> | null
-    __fetch_promise_control: PromiseController<ResponseExtension> | null
-    __controller: ReadableByteStreamController | null
+interface TransformStreamExtension extends TransformStream<Uint8Array, Uint8Array> {
+    __fetch_promise_control: PromiseController<ResponseExtension>
+    __writer: WritableStreamDefaultWriter<Uint8Array>
 }
 
 interface ResponseExtension extends Response {

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -5,6 +5,7 @@ import { wrap_as_cancelable_promise } from "./cancelable-promise";
 import { ENVIRONMENT_IS_NODE, Module, loaderHelpers, mono_assert } from "./globals";
 import { MemoryViewType, Span } from "./marshal";
 import type { VoidPtr } from "./types/emscripten";
+import { ControllablePromise } from "./types/internal";
 
 
 function verifyEnvironment() {
@@ -70,7 +71,7 @@ export function http_wasm_create_transform_stream(): TransformStreamExtension {
     return transform_stream;
 }
 
-export function http_wasm_transform_stream_write(ts: TransformStreamExtension, bufferPtr: VoidPtr, bufferLength: number): Promise<void> {
+export function http_wasm_transform_stream_write(ts: TransformStreamExtension, bufferPtr: VoidPtr, bufferLength: number): ControllablePromise<void> {
     mono_assert(bufferLength > 0, "expected bufferLength > 0");
     // the bufferPtr is pinned by the caller
     const view = new Span(bufferPtr, bufferLength, MemoryViewType.Byte);
@@ -83,7 +84,7 @@ export function http_wasm_transform_stream_write(ts: TransformStreamExtension, b
     });
 }
 
-export function http_wasm_transform_stream_close(ts: TransformStreamExtension): Promise<void> {
+export function http_wasm_transform_stream_close(ts: TransformStreamExtension): ControllablePromise<void> {
     return wrap_as_cancelable_promise(async () => {
         mono_assert(ts.__fetch_promise, "expected fetch promise");
         // race with fetch because fetch does not cancel the ReadableStream see https://bugs.chromium.org/p/chromium/issues/detail?id=1480250
@@ -96,20 +97,20 @@ export function http_wasm_transform_stream_abort(ts: TransformStreamExtension): 
     ts.__writer.abort();
 }
 
-export function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, body: TransformStreamExtension): Promise<ResponseExtension> {
+export function http_wasm_fetch_stream(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, body: TransformStreamExtension): ControllablePromise<ResponseExtension> {
     const fetch_promise = http_wasm_fetch(url, header_names, header_values, option_names, option_values, abort_controller, body.readable);
     body.__fetch_promise = fetch_promise;
     return fetch_promise;
 }
 
-export function http_wasm_fetch_bytes(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, bodyPtr: VoidPtr, bodyLength: number): Promise<ResponseExtension> {
+export function http_wasm_fetch_bytes(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, bodyPtr: VoidPtr, bodyLength: number): ControllablePromise<ResponseExtension> {
     // the bodyPtr is pinned by the caller
     const view = new Span(bodyPtr, bodyLength, MemoryViewType.Byte);
     const copy = view.slice() as Uint8Array;
     return http_wasm_fetch(url, header_names, header_values, option_names, option_values, abort_controller, copy);
 }
 
-export function http_wasm_fetch(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, body: Uint8Array | ReadableStream | null): Promise<ResponseExtension> {
+export function http_wasm_fetch(url: string, header_names: string[], header_values: string[], option_names: string[], option_values: any[], abort_controller: AbortController, body: Uint8Array | ReadableStream | null): ControllablePromise<ResponseExtension> {
     verifyEnvironment();
     mono_assert(url && typeof url === "string", "expected url string");
     mono_assert(header_names && header_values && Array.isArray(header_names) && Array.isArray(header_values) && header_names.length === header_values.length, "expected headerNames and headerValues arrays");
@@ -162,7 +163,7 @@ export function http_wasm_get_response_header_values(res: ResponseExtension): st
     return res.__headerValues;
 }
 
-export function http_wasm_get_response_length(res: ResponseExtension): Promise<number> {
+export function http_wasm_get_response_length(res: ResponseExtension): ControllablePromise<number> {
     return wrap_as_cancelable_promise(async () => {
         const buffer = await res.arrayBuffer();
         res.__buffer = buffer;
@@ -183,7 +184,7 @@ export function http_wasm_get_response_bytes(res: ResponseExtension, view: Span)
     return bytes_read;
 }
 
-export function http_wasm_get_streamed_response_bytes(res: ResponseExtension, bufferPtr: VoidPtr, bufferLength: number): Promise<number> {
+export function http_wasm_get_streamed_response_bytes(res: ResponseExtension, bufferPtr: VoidPtr, bufferLength: number): ControllablePromise<number> {
     // the bufferPtr is pinned by the caller
     const view = new Span(bufferPtr, bufferLength, MemoryViewType.Byte);
     return wrap_as_cancelable_promise(async () => {


### PR DESCRIPTION
Uses a [`TransformStream`](https://developer.mozilla.org/en-US/docs/Web/API/TransformStream) into which the `HttpContent` gets [copied into](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter). Sync writes are not allowed like sync reads in response streaming.

Ref: https://github.com/dotnet/runtime/pull/91295#issuecomment-1706919710