### PR TITLE
Remove unnecessary imports

### DIFF
--- a/src/tests/tracing/eventcounter/runtimecounters.csproj
+++ b/src/tests/tracing/eventcounter/runtimecounters.csproj
@@ -16,7 +16,6 @@
   <!-- Hack to get NativeAOT assemblies into IlcReference
        In CoreCLR tests, these assemblies get copied to CORE_ROOT, which NativeAOT doesn't use
   -->
-  <Import Project="$(RepoRoot)eng/liveBuilds.targets" Condition="'$(TestBuildMode)' == 'nativeaot'" />
   <!-- Get all the *.dll files that has IsNative != "true"-->
   <Target Name="GetRequiredNativeAOTAssemblies"
       DependsOnTargets="ResolveLibrariesRuntimeFilesFromLocalBuild"

--- a/src/tests/tracing/eventpipe/Directory.Build.targets
+++ b/src/tests/tracing/eventpipe/Directory.Build.targets
@@ -5,7 +5,6 @@
 
   <!-- EventPipe tests use Microsoft.Extensions.Logging and getting its dependencies require this workaround for NativeAOT
   -->
-  <Import Project="$(RepoRoot)eng/liveBuilds.targets" Condition="'$(TestBuildMode)' == 'nativeaot'" />
   <!-- Get all the *.dll files that has IsNative != "true"-->
   <Target Name="GetRequiredNativeAOTAssemblies" 
       DependsOnTargets="ResolveLibrariesRuntimeFilesFromLocalBuild"


### PR DESCRIPTION
I think these are unnecessary. I noticed the eventpipe test build produces a warning about a duplicate import of liveBuilds.targets, which is already imported by src/tests/Directory.Build.targets.