### PR TITLE
fixed problems with how sampling is done and how we suspend to change heap count in DATAS

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -7086,12 +7086,12 @@ void gc_heap::gc_thread_function ()
             }
 #endif //DYNAMIC_HEAP_COUNT
             uint32_t wait_result = gc_heap::ee_suspend_event.Wait(wait_on_time_out_p ? wait_time : INFINITE, FALSE);
-            dprintf (6666, ("waiting for ee_suspend_event done res %d (timeout %d, %I64d ms since last suspend end)(should_change_heap_count is %d) (gradual_decommit_in_progress_p %d)",
+            dprintf (9999, ("waiting for ee_suspend_event done res %d (timeout %d, %I64d ms since last suspend end)(should_change_heap_count is %d) (gradual_decommit_in_progress_p %d)",
                 wait_result, wait_time, ((GetHighPrecisionTimeStamp() - last_suspended_end_time) / 1000),
                 dynamic_heap_count_data.should_change_heap_count, gradual_decommit_in_progress_p));
             if (wait_result == WAIT_TIMEOUT)
             {
-                dprintf (6666, ("timeout!"));
+                dprintf (9999, ("timeout!"));
 #ifdef DYNAMIC_HEAP_COUNT
                 if (dynamic_heap_count_data.should_change_heap_count)
                 {
@@ -7129,7 +7129,7 @@ void gc_heap::gc_thread_function ()
                 //gc_heap::ee_suspend_event.Set ();
             }
 
-            dprintf (6666, ("now checking if we need to wait for idle"));
+            dprintf (9999, ("now checking if we need to wait for idle"));
 
             // wait till the threads that should have gone idle at least reached the place where they are about to wait on the idle event.
             if ((gc_heap::dynamic_adaptation_mode == dynamic_adaptation_to_application_sizes) && 
@@ -7183,16 +7183,16 @@ void gc_heap::gc_thread_function ()
         }
         else
         {
-            dprintf (6666, ("GC thread %d waiting_for_gc_start(%d)(gc%Id)", heap_number, n_heaps, VolatileLoadWithoutBarrier(&settings.gc_index)));
+            dprintf (9999, ("GC thread %d waiting_for_gc_start(%d)(gc%Id)", heap_number, n_heaps, VolatileLoadWithoutBarrier(&settings.gc_index)));
             gc_start_event.Wait(INFINITE, FALSE);
 #ifdef DYNAMIC_HEAP_COUNT
-            dprintf (6666, ("GC thread %d waiting_done_gc_start(%d-%d)(i: %d)(gc%Id)",
+            dprintf (9999, ("GC thread %d waiting_done_gc_start(%d-%d)(i: %d)(gc%Id)",
                 heap_number, n_heaps, dynamic_heap_count_data.new_n_heaps, dynamic_heap_count_data.init_only_p, VolatileLoadWithoutBarrier (&settings.gc_index)));
 
             if ((gc_heap::dynamic_adaptation_mode == dynamic_adaptation_to_application_sizes) &&
                 (dynamic_heap_count_data.new_n_heaps != n_heaps))
             {
-                dprintf (6666, ("changing heap count on non h0 thread!"));
+                dprintf (9999, ("changing heap count on non h0 thread!"));
                 // The reason why we need to do this is -
                 // + for threads that were participating, we need them to do work for change_heap_count
                 // + for threads that were not participating but will need to participate, we need to make sure they are woken now instead of
@@ -7219,7 +7219,7 @@ void gc_heap::gc_thread_function ()
                             dprintf (9999, ("GC thread %d wait_on_idle(%d < %d)(gc%Id), total idle %d", heap_number, old_n_heaps, new_n_heaps,
                                 VolatileLoadWithoutBarrier (&settings.gc_index), VolatileLoadWithoutBarrier (&dynamic_heap_count_data.idle_thread_count)));
                             gc_idle_thread_event.Wait (INFINITE, FALSE);
-                            dprintf (6666, ("GC thread %d waking_from_idle(%d)(gc%Id) after doing change", heap_number, n_heaps, VolatileLoadWithoutBarrier (&settings.gc_index)));
+                            dprintf (9999, ("GC thread %d waking_from_idle(%d)(gc%Id) after doing change", heap_number, n_heaps, VolatileLoadWithoutBarrier (&settings.gc_index)));
                         }
                     }
                     else
@@ -25746,7 +25746,7 @@ bool gc_heap::prepare_to_change_heap_count (int new_n_heaps)
 
 bool gc_heap::change_heap_count (int new_n_heaps)
 {
-    dprintf (6666, ("BEG heap%d changing %d->%d", heap_number, n_heaps, new_n_heaps));
+    dprintf (9999, ("BEG heap%d changing %d->%d", heap_number, n_heaps, new_n_heaps));
 
     // use this variable for clarity - n_heaps will change during the transition
     int old_n_heaps = n_heaps;
@@ -25762,7 +25762,7 @@ bool gc_heap::change_heap_count (int new_n_heaps)
 #endif //BACKGROUND_GC
 
             dynamic_heap_count_data.init_only_p = false;
-            dprintf (6666, ("in change h%d resetting gc_start, update bgc join to %d heaps", heap_number, new_n_heaps));
+            dprintf (9999, ("in change h%d resetting gc_start, update bgc join to %d heaps", heap_number, new_n_heaps));
             gc_start_event.Reset();
             gc_t_join.restart ();
         }
@@ -26069,7 +26069,7 @@ bool gc_heap::change_heap_count (int new_n_heaps)
         }
     }
 
-    dprintf (6666, ("END heap%d changed %d->%d", heap_number, n_heaps, new_n_heaps));
+    dprintf (9999, ("END heap%d changed %d->%d", heap_number, n_heaps, new_n_heaps));
     return true;
 }
 
@@ -50162,7 +50162,7 @@ void gc_heap::do_post_gc()
 #endif //DYNAMIC_HEAP_COUNT
 
 #if defined(TRACE_GC) && defined(SIMPLE_DPRINTF)
-    //flush_gc_log (false);
+    flush_gc_log (false);
 #endif //TRACE_GC && SIMPLE_DPRINTF
 
     // Now record the gc info.

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -1511,7 +1511,7 @@ enter_msl_status gc_heap::enter_spin_lock_msl_helper (GCSpinLock* msl)
 #ifdef DYNAMIC_HEAP_COUNT
         uint64_t end = GetHighPrecisionTimeStamp();
         Interlocked::ExchangeAdd64 (&msl->msl_wait_time, end - start);
-        dprintf (6666, ("wait for msl lock total time: %zd, total count: %zd, this time: %zd, this count: %u", msl->msl_wait_time, msl->msl_wait_count, end - start, i));
+        dprintf (3, ("wait for msl lock total time: %zd, total count: %zd, this time: %zd, this count: %u", msl->msl_wait_time, msl->msl_wait_count, end - start, i));
 #endif //DYNAMIC_HEAP_COUNT
     }
     while (Interlocked::CompareExchange (&msl->lock, lock_taken, lock_free) != lock_free);
@@ -4364,14 +4364,14 @@ size_t size_seg_mapping_table_of (uint8_t* from, uint8_t* end)
 {
     from = align_lower_segment (from);
     end = align_on_segment (end);
-    dprintf (1, ("from: %p, end: %p, size: %zx", from, end,
+    dprintf (2, ("from: %p, end: %p, size: %zx", from, end,
         sizeof (seg_mapping)*(((size_t)(end - from) >> gc_heap::min_segment_size_shr))));
     return (sizeof (seg_mapping)*((size_t)(end - from) >> gc_heap::min_segment_size_shr));
 }
 
 size_t size_region_to_generation_table_of (uint8_t* from, uint8_t* end)
 {
-    dprintf (1, ("from: %p, end: %p, size: %zx", from, end,
+    dprintf (2, ("from: %p, end: %p, size: %zx", from, end,
         sizeof (uint8_t)*(((size_t)(end - from) >> gc_heap::min_segment_size_shr))));
     return sizeof (uint8_t)*((size_t)(end - from) >> gc_heap::min_segment_size_shr);
 }
@@ -7044,10 +7044,6 @@ bool gc_heap::create_gc_thread ()
     dprintf (3, ("Creating gc thread\n"));
     return GCToEEInterface::CreateThread(gc_thread_stub, this, false, ".NET Server GC");
 }
-
-#ifdef DYNAMIC_HEAP_COUNT
-static size_t prev_change_heap_count_gc_index;
-#endif //DYNAMIC_HEAP_COUNT
 
 #ifdef _MSC_VER
 #pragma warning(disable:4715) //IA64 xcompiler recognizes that without the 'break;' the while(1) will never end and therefore not return a value for that code path
@@ -12526,6 +12522,7 @@ void gc_heap::clear_gen0_bricks()
 {
     if (!gen0_bricks_cleared)
     {
+        dprintf (6666, ("clearing gen0 bricks for h%d", heap_number));
         gen0_bricks_cleared = TRUE;
         //initialize brick table for gen 0
 #ifdef USE_REGIONS
@@ -13372,7 +13369,7 @@ void gc_heap::distribute_free_regions()
         }
     }
 
-    dprintf (1, ("moved %2zd regions (%8zd) to decommit based on time", num_decommit_regions_by_time, size_decommit_regions_by_time));
+    dprintf (REGIONS_LOG, ("moved %2zd regions (%8zd) to decommit based on time", num_decommit_regions_by_time, size_decommit_regions_by_time));
 
     global_free_huge_regions.transfer_regions (&global_regions_to_decommit[huge_free_region]);
 
@@ -22105,6 +22102,11 @@ void gc_heap::update_end_gc_time_per_heap()
     {
         dynamic_data* dd = dynamic_data_of (gen_number);
         dd_gc_elapsed_time (dd) = (size_t)(end_gc_time - dd_time_clock (dd));
+
+        if (heap_number == 0)
+        {
+            dprintf (6666, ("updating NGC%d %Id elapsed time to %I64d - %I64d = %I64d", gen_number, dd_gc_clock (dd), end_gc_time, dd_time_clock (dd), dd_gc_elapsed_time (dd)));
+        }
     }
 }
 
@@ -22253,7 +22255,10 @@ void gc_heap::gc1()
         dynamic_data* dd = dynamic_data_of (n);
         end_gc_time = GetHighPrecisionTimeStamp();
         dd_gc_elapsed_time (dd) = (size_t)(end_gc_time - dd_time_clock (dd));
-
+        if (heap_number == 0)
+        {
+            dprintf (6666, ("updating BGC %Id elapsed time to %I64d - %I64d = %I64d", dd_gc_clock (dd), end_gc_time, dd_time_clock (dd), dd_gc_elapsed_time (dd)));
+        }
 #ifdef HEAP_BALANCE_INSTRUMENTATION
         if (heap_number == 0)
         {
@@ -23437,6 +23442,14 @@ void gc_heap::update_collection_counts ()
         dd_gc_clock (dd) = dd_gc_clock (dd0);
         dd_previous_time_clock (dd) = dd_time_clock (dd);
         dd_time_clock (dd) = now;
+
+        if (heap_number == 0)
+        {
+            dprintf (6666, ("updating gen%d collection count to %Id, clock to %Id, prev time %I64d, time %I64d, elapsed between gcs %I64d",
+                i,
+                dd_collection_count (dd), dd_gc_clock (dd), dd_previous_time_clock (dd), dd_time_clock (dd),
+                (dd_time_clock (dd) - dd_previous_time_clock (dd))));
+        }
     }
 }
 
@@ -25152,6 +25165,42 @@ void gc_heap::recommission_heap()
 #endif //RECORD_LOH_STATE
 }
 
+uint64_t median_of_3 (uint64_t a, uint64_t b, uint64_t c)
+{
+#define compare_and_swap(i, j)      \
+    {                               \
+        if (i < j)                  \
+        {                           \
+            uint64_t t = i;         \
+                         i = j;     \
+                             j = t; \
+        }                           \
+    }
+    compare_and_swap (b, a);
+    compare_and_swap (c, a);
+    compare_and_swap (c, b);
+#undef compare_and_swap
+    return b;
+}
+
+float median_of_3 (float a, float b, float c)
+{
+#define compare_and_swap(i, j)      \
+    {                               \
+        if (i < j)                  \
+        {                           \
+            float t = i;         \
+                         i = j;     \
+                             j = t; \
+        }                           \
+    }
+    compare_and_swap (b, a);
+    compare_and_swap (c, a);
+    compare_and_swap (c, b);
+#undef compare_and_swap
+    return b;
+}
+
 void gc_heap::check_heap_count ()
 {
     dynamic_heap_count_data.new_n_heaps = n_heaps;
@@ -25188,8 +25237,8 @@ void gc_heap::check_heap_count ()
             dynamic_data* dd = hp->dynamic_data_of (gen_idx);
 
             // estimate the size of each generation as the live data size plus the budget
-            heap_size += dd_promoted_size (dd) + dd_desired_allocation (dd);
-            dprintf (6666, ("h%d g%d promoted: %zd desired allocation: %zd", i, gen_idx, dd_promoted_size (dd), dd_desired_allocation (dd)));
+            heap_size += dd_current_size (dd) + dd_desired_allocation (dd);
+            dprintf (3, ("h%d g%d current: %zd desired allocation: %zd", i, gen_idx, dd_promoted_size (dd), dd_desired_allocation (dd)));
         }
     }
 
@@ -25198,10 +25247,15 @@ void gc_heap::check_heap_count ()
     // persist data for the current sample
     dynamic_heap_count_data_t::sample& sample = dynamic_heap_count_data.samples[dynamic_heap_count_data.sample_index];
 
+    uint64_t now = GetHighPrecisionTimeStamp();
+    uint64_t saved_last_sample_time = dynamic_heap_count_data.sample_time;
+
     sample.soh_msl_wait_time = soh_msl_wait_time / n_heaps;
     sample.uoh_msl_wait_time = uoh_msl_wait_time / n_heaps;
-    sample.elapsed_between_gcs = dd_time_clock (hp0_dd0) - dd_previous_time_clock (hp0_dd0);
+    sample.elapsed_between_gcs = now - dynamic_heap_count_data.sample_time;
+    dynamic_heap_count_data.sample_time = now;
     sample.gc_elapsed_time = dd_gc_elapsed_time (hp0_dd0);
+    sample.overhead_time = sample.soh_msl_wait_time + sample.uoh_msl_wait_time + sample.gc_elapsed_time;
     sample.allocating_thread_count = allocating_thread_count;
     sample.heap_size = heap_size;
 
@@ -25209,11 +25263,11 @@ void gc_heap::check_heap_count ()
         dynamic_heap_count_data.sample_index,
         sample.soh_msl_wait_time,
         sample.uoh_msl_wait_time,
+        now, saved_last_sample_time, 
         sample.elapsed_between_gcs,
         sample.gc_elapsed_time,
+        sample.overhead_time,
         sample.heap_size/(1024*1024)));
-
-    dynamic_heap_count_data.sample_index = (dynamic_heap_count_data.sample_index + 1) % dynamic_heap_count_data_t::sample_size;
 
     GCEventFireHeapCountSample_V1(
         sample.gc_elapsed_time,
@@ -25222,9 +25276,53 @@ void gc_heap::check_heap_count ()
         sample.elapsed_between_gcs
     );
 
+    dynamic_heap_count_data.sample_index = (dynamic_heap_count_data.sample_index + 1) % dynamic_heap_count_data_t::sample_size;
+
     dprintf (9999, ("current GC %Id, prev %Id", VolatileLoadWithoutBarrier (&settings.gc_index), prev_change_heap_count_gc_index));
 
-    if (settings.gc_index < (prev_change_heap_count_gc_index + 3))
+    float median_gen2_overhead_percent = 0.0f;
+    dynamic_data* hp0_dd2 = g_heaps[0]->dynamic_data_of (2);
+    if (dynamic_heap_count_data.gen2_gc_clock != dd_gc_clock (hp0_dd2))
+    {
+        size_t last_gc_clock = dynamic_heap_count_data.gen2_gc_clock;
+        dynamic_heap_count_data.gen2_gc_clock = dd_gc_clock (hp0_dd2);
+        uint64_t elapsed_between_gcs = dd_time_clock (hp0_dd2) - dd_previous_time_clock (hp0_dd2);
+
+        dprintf (6666, ("gen 2 elapsed between gc %Id - %Id: since last gen2 %zd gen 2 elapsed time: %zd",
+            last_gc_clock, dynamic_heap_count_data.gen2_gc_clock, elapsed_between_gcs, dd_gc_elapsed_time (hp0_dd2)));
+
+        // persist data for the current sample
+        dynamic_heap_count_data_t::gen2_sample& gen2_sample = dynamic_heap_count_data.gen2_samples[dynamic_heap_count_data.gen2_sample_index];
+
+        gen2_sample.elapsed_between_gcs = elapsed_between_gcs;
+        gen2_sample.gc_elapsed_time = dd_gc_elapsed_time (hp0_dd2);
+
+        dynamic_heap_count_data.gen2_sample_index += 1;
+
+        if (dynamic_heap_count_data.gen2_sample_index == dynamic_heap_count_data_t::sample_size)
+        {
+            dynamic_heap_count_data.gen2_sample_index = 0;
+
+            float percent_overhead[dynamic_heap_count_data_t::sample_size];
+            for (int i = 0; i < dynamic_heap_count_data_t::sample_size; i++)
+            {
+                dynamic_heap_count_data_t::gen2_sample& sample = dynamic_heap_count_data.gen2_samples[i];
+                percent_overhead[i] = (float)sample.gc_elapsed_time * 100.0f / sample.elapsed_between_gcs;
+                if (percent_overhead[i] < 0)
+                    percent_overhead[i] = 0;
+                else if (percent_overhead[i] > 100)
+                    percent_overhead[i] = 100;
+                dprintf (6666, ("gen2 sample %d: percent_overhead: %.3fms / %.3fms = %d%%",
+                    i, (float)sample.gc_elapsed_time / 1000.0, (float)sample.elapsed_between_gcs / 1000.0, (int)percent_overhead[i]));
+            }
+
+            median_gen2_overhead_percent = median_of_3 (percent_overhead[0], percent_overhead[1], percent_overhead[2]);
+
+            dprintf (6666, ("gen2 median gen2 overhead: %.3f", median_gen2_overhead_percent));
+        }
+    }
+
+    if (settings.gc_index < dynamic_heap_count_data.prev_gc_index + 3)
     {
         // reconsider the decision every few gcs
         return;
@@ -25240,36 +25338,22 @@ void gc_heap::check_heap_count ()
     else
 #endif //BACKGROUND_GC
     {
-        // compute the % overhead from msl waiting time and gc time for each of the samples
+        // If there was a blocking gen2 GC, the overhead would be very large and most likely we would not pick it. So we
+        // rely on the gen2 sample's overhead calculated above.
         float percent_overhead[dynamic_heap_count_data_t::sample_size];
         for (int i = 0; i < dynamic_heap_count_data_t::sample_size; i++)
         {
             dynamic_heap_count_data_t::sample& sample = dynamic_heap_count_data.samples[i];
-            uint64_t overhead_time = sample.soh_msl_wait_time + sample.uoh_msl_wait_time + sample.gc_elapsed_time;
-            percent_overhead[i] = overhead_time * 100.0f / sample.elapsed_between_gcs;
+            percent_overhead[i] = (float)sample.overhead_time * 100.0f / sample.elapsed_between_gcs;
             if (percent_overhead[i] < 0)
                 percent_overhead[i] = 0;
             else if (percent_overhead[i] > 100)
                 percent_overhead[i] = 100;
-            dprintf (9999, ("sample %d: percent_overhead: %.3f%%", i, percent_overhead[i]));
+            dprintf (6666, ("sample %d: percent_overhead: %.3fms / %.3fms = %d%%",
+                i, (float)sample.overhead_time / 1000.0, (float)sample.elapsed_between_gcs / 1000.0, (int)percent_overhead[i]));
         }
-        // compute the median of the percent overhead samples
-    #define compare_and_swap(i, j)                                       \
-        {                                                                \
-            if (percent_overhead[i] < percent_overhead[j])               \
-            {                                                            \
-                float t = percent_overhead[i];                           \
-                            percent_overhead[i] = percent_overhead[j];   \
-                                                percent_overhead[j] = t; \
-            }                                                            \
-        }
-        compare_and_swap (1, 0);
-        compare_and_swap (2, 0);
-        compare_and_swap (2, 1);
-    #undef compare_and_swap
 
-        // the middle element is the median overhead percentage
-        float median_percent_overhead = percent_overhead[1];
+        float median_percent_overhead = median_of_3 (percent_overhead[0], percent_overhead[1], percent_overhead[2]);
 
         // apply exponential smoothing and use 1/3 for the smoothing factor
         const float smoothing = 3;
@@ -25285,7 +25369,8 @@ void gc_heap::check_heap_count ()
             smoothed_median_percent_overhead = median_percent_overhead;
         }
 
-        dprintf (9999, ("median overhead: %.3f%% smoothed median overhead: %.3f%%", median_percent_overhead, smoothed_median_percent_overhead));
+        dprintf (6666, ("other median overhead: %.3f, smoothed median overhead: %.3f, gen2 overhead %.3f",
+            median_percent_overhead, smoothed_median_percent_overhead, median_gen2_overhead_percent));
 
         // estimate the space cost of adding a heap as the min gen0 size
         size_t heap_space_cost_per_heap = dd_min_size (hp0_dd0);
@@ -25316,8 +25401,13 @@ void gc_heap::check_heap_count ()
         // estimate the potential space saving of going down a step
         float space_cost_decrease_per_step_down = percent_heap_space_cost_per_heap * step_down;
 
-        dprintf (9999, ("up: %d down: %d, ou %.3f, od %.3f, su %.3f, sd %.3f", step_up, step_down,
-            overhead_reduction_per_step_up, overhead_increase_per_step_down, space_cost_increase_per_step_up, space_cost_decrease_per_step_down));
+        dprintf (6666, ("[CHP] u %d, d %d | space/hp %Id / %Id(%.2fmb) = %.3f (u: %.3f, d: %.3f) | so %.3f, u * %.1f = %.3f, d * %.1f = %.3f",
+            step_up, step_down,
+            heap_space_cost_per_heap, heap_size, ((float)heap_size / (float)1000 / (float)1000), percent_heap_space_cost_per_heap,
+            space_cost_increase_per_step_up, space_cost_decrease_per_step_down,
+            smoothed_median_percent_overhead,
+            ((float)step_up / (float)(n_heaps + step_up)), overhead_reduction_per_step_up,
+            ((float)step_down / (float)(n_heaps - step_down)), overhead_increase_per_step_down));
 
 #ifdef STRESS_DYNAMIC_HEAP_COUNT
         // quick hack for initial testing
@@ -25339,31 +25429,41 @@ void gc_heap::check_heap_count ()
             // ramp up more agressively - use as many heaps as it would take to bring
             // the overhead down to 5%
             new_n_heaps = (int)(n_heaps * (median_percent_overhead / 5.0));
+            dprintf (6666, ("[CHP0] o %.3f -> %d * %.3f = %d", median_percent_overhead, n_heaps, (median_percent_overhead / 5.0), new_n_heaps));
             new_n_heaps = min (new_n_heaps, n_max_heaps - extra_heaps);
         }
         // if the median overhead is 10% or less, react slower
-        else if (smoothed_median_percent_overhead > 5.0f)
+        else if ((smoothed_median_percent_overhead > 5.0f) || (median_gen2_overhead_percent > 10.0f))
         {
+            if (smoothed_median_percent_overhead > 5.0f)
+            {
+                dprintf (6666, ("[CHP1] so %.3f > 5, %d + %d = %d", smoothed_median_percent_overhead, n_heaps, step_up, (n_heaps + step_up)));
+            }
+            else
+            {
+                dprintf (6666, ("[CHP2] o2 %.3f > 10, %d + %d = %d", median_gen2_overhead_percent, n_heaps, step_up, (n_heaps + step_up)));
+            }
             new_n_heaps += step_up;
         }
         // if we can save at least 1% more in time than we spend in space, increase number of heaps
         else if ((overhead_reduction_per_step_up - space_cost_increase_per_step_up) >= 1.0f)
         {
+            dprintf (6666, ("[CHP3] % .3f - % .3f = % .3f, % d + % d = % d",
+                overhead_reduction_per_step_up, space_cost_increase_per_step_up, (overhead_reduction_per_step_up - space_cost_increase_per_step_up),
+                n_heaps, step_up, (n_heaps + step_up)));
             new_n_heaps += step_up;
         }
         // if we can save at least 1% more in space than we spend in time, decrease number of heaps
-        else if ((smoothed_median_percent_overhead < 1.0f) && ((space_cost_decrease_per_step_down - overhead_increase_per_step_down) >= 1.0f))
+        else if ((smoothed_median_percent_overhead < 1.0f) &&
+                 (median_gen2_overhead_percent < 5.0f) &&
+                 ((space_cost_decrease_per_step_down - overhead_increase_per_step_down) >= 1.0f))
         {
+            dprintf (6666, ("[CHP4] so %.3f o2 %.3f, %.3f - %.3f = %.3f, %d + %d = %d",
+                smoothed_median_percent_overhead, median_gen2_overhead_percent,
+                space_cost_decrease_per_step_down, overhead_increase_per_step_down, (space_cost_decrease_per_step_down - overhead_increase_per_step_down),
+                n_heaps, step_up, (n_heaps + step_up)));
             new_n_heaps -= step_down;
         }
-
-        dprintf (9999, ("or: %d, si: %d,  sd: %d, oi: %d => %d -> %d",
-            (int)overhead_reduction_per_step_up,
-            (int)space_cost_increase_per_step_up,
-            (int)space_cost_decrease_per_step_down,
-            (int)overhead_increase_per_step_down,
-            n_heaps,
-            new_n_heaps));
 
         assert (1 <= new_n_heaps);
         assert (new_n_heaps <= n_max_heaps);
@@ -25425,7 +25525,7 @@ void gc_heap::check_heap_count ()
         dprintf (9999, ("heap count stays the same, no work to do %d == %d", dynamic_heap_count_data.new_n_heaps, n_heaps));
 
         // come back after 3 GCs to reconsider
-        prev_change_heap_count_gc_index = settings.gc_index;
+        dynamic_heap_count_data.prev_gc_index = settings.gc_index;
 
         return;
     }
@@ -25468,11 +25568,11 @@ void gc_heap::check_heap_count ()
 
     GCToEEInterface::RestartEE(TRUE);
     dprintf (9999, ("h0 restarted EE"));
-    prev_change_heap_count_gc_index = settings.gc_index;
+    dynamic_heap_count_data.prev_gc_index = settings.gc_index;
 
     // we made changes to the heap count that will change the overhead,
     // so change the smoothed overhead to reflect that
-    dynamic_heap_count_data.smoothed_median_percent_overhead  = dynamic_heap_count_data.smoothed_median_percent_overhead/n_heaps*old_n_heaps;
+    dynamic_heap_count_data.smoothed_median_percent_overhead  = dynamic_heap_count_data.smoothed_median_percent_overhead / n_heaps * old_n_heaps;
 }
 
 bool gc_heap::prepare_to_change_heap_count (int new_n_heaps)
@@ -25894,7 +25994,7 @@ bool gc_heap::change_heap_count (int new_n_heaps)
                 assert (gen_size >= dd_fragmentation (dd));
                 dd_current_size (dd) = gen_size - dd_fragmentation (dd);
 
-                dprintf (6666, ("h%d g%d: new allocation: %zd generation_size: %zd fragmentation: %zd current_size: %zd",
+                dprintf (2, ("h%d g%d: new allocation: %zd generation_size: %zd fragmentation: %zd current_size: %zd",
                     i,
                     gen_idx,
                     dd_new_allocation (dd),
@@ -31573,7 +31673,7 @@ void gc_heap::process_remaining_regions (int current_plan_gen_num, generation* c
         }
     }
 
-    dprintf (1, ("we still need %d regions, %d will be empty", plan_regions_needed, to_be_empty_regions));
+    dprintf (REGIONS_LOG, ("we still need %d regions, %d will be empty", plan_regions_needed, to_be_empty_regions));
     if (plan_regions_needed > to_be_empty_regions)
     {
         dprintf (REGIONS_LOG, ("h%d %d regions will be empty but we still need %d regions!!", heap_number, to_be_empty_regions, plan_regions_needed));
@@ -32929,7 +33029,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
 #else
                 0;
 #endif //SHORT_PLUGS
-            dprintf (1, ("gen%d: NON PIN alloc: %zd, pin com: %zd, sweep: %zd, surv: %zd, pinsurv: %zd(%d%% added, %d%% art), np surv: %zd, pad: %zd",
+            dprintf (2, ("gen%d: NON PIN alloc: %zd, pin com: %zd, sweep: %zd, surv: %zd, pinsurv: %zd(%d%% added, %d%% art), np surv: %zd, pad: %zd",
                 gen_idx,
                 generation_allocation_size (temp_gen),
                 generation_pinned_allocation_compact_size (temp_gen),
@@ -32964,7 +33064,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
         if (growth > 0)
         {
-            dprintf (1, ("gen2 grew %zd (end seg alloc: %zd, condemned alloc: %zd",
+            dprintf (2, ("gen2 grew %zd (end seg alloc: %zd, condemned alloc: %zd",
                          growth, end_seg_allocated, condemned_allocated));
 
             maxgen_size_inc_p = true;
@@ -32976,12 +33076,12 @@ void gc_heap::plan_phase (int condemned_gen_number)
                          generation_condemned_allocated (generation_of (max_generation - 1))));
         }
 
-        dprintf (1, ("older gen's free alloc: %zd->%zd, seg alloc: %zd->%zd, condemned alloc: %zd->%zd",
+        dprintf (2, ("older gen's free alloc: %zd->%zd, seg alloc: %zd->%zd, condemned alloc: %zd->%zd",
                     r_older_gen_free_list_allocated, generation_free_list_allocated (older_gen),
                     r_older_gen_end_seg_allocated, generation_end_seg_allocated (older_gen),
                     r_older_gen_condemned_allocated, generation_condemned_allocated (older_gen)));
 
-        dprintf (1, ("this GC did %zd free list alloc(%zd bytes free space rejected)",
+        dprintf (2, ("this GC did %zd free list alloc(%zd bytes free space rejected)",
             free_list_allocated, rejected_free_space));
 
         maxgen_size_increase* maxgen_size_info = &(get_gc_data_per_heap()->maxgen_size_info);
@@ -43241,7 +43341,7 @@ size_t gc_heap::desired_new_allocation (dynamic_data* dd,
 
         dd_surv (dd) = cst;
 
-        dprintf (1, (ThreadStressLog::gcDesiredNewAllocationMsg(),
+        dprintf (2, (ThreadStressLog::gcDesiredNewAllocationMsg(),
                     heap_number, gen_number, out, current_size, (dd_desired_allocation (dd) - dd_gc_new_allocation (dd)),
                     (int)(cst*100), (int)(f*100), current_size + new_allocation, new_allocation));
 
@@ -49521,13 +49621,14 @@ void gc_heap::do_pre_gc()
 #ifdef TRACE_GC
     size_t total_allocated_since_last_gc = get_total_allocated_since_last_gc();
 #ifdef BACKGROUND_GC
-    dprintf (1, (ThreadStressLog::gcDetailedStartMsg(),
+    //dprintf (1, (ThreadStressLog::gcDetailedStartMsg(),
+    dprintf (1, ("*GC* %d(gen0:%d)(%d)(alloc: %zd)(%s)(%d)(%d)",
         VolatileLoad(&settings.gc_index),
         dd_collection_count (hp->dynamic_data_of (0)),
         settings.condemned_generation,
         total_allocated_since_last_gc,
         (settings.concurrent ? "BGC" : (gc_heap::background_running_p() ? "FGC" : "NGC")),
-        settings.b_state));
+        settings.b_state, n_heaps));
 #else
     dprintf (1, ("*GC* %d(gen0:%d)(%d)(alloc: %zd)",
         VolatileLoad(&settings.gc_index),

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -147,7 +147,7 @@ inline void FATAL_GC_ERROR()
 // This means any empty regions can be freely used for any generation. For
 // Server GC we will balance regions between heaps.
 // For now disable regions for StandAlone GC, NativeAOT and MacOS builds
-#if defined (HOST_64BIT) && !defined (BUILD_AS_STANDALONE) && !defined(__APPLE__)
+#if defined (HOST_64BIT) && defined (BUILD_AS_STANDALONE) && !defined(__APPLE__)
 #define USE_REGIONS
 #endif //HOST_64BIT && BUILD_AS_STANDALONE
 
@@ -157,7 +157,7 @@ inline void FATAL_GC_ERROR()
 #if defined(USE_REGIONS) && defined(MULTIPLE_HEAPS)
 // can only change heap count with regions
 #define DYNAMIC_HEAP_COUNT
-//#define STRESS_DYNAMIC_HEAP_COUNT
+#define STRESS_DYNAMIC_HEAP_COUNT
 #endif //USE_REGIONS && MULTIPLE_HEAPS
 
 #ifdef USE_REGIONS
@@ -363,7 +363,8 @@ const int policy_expand  = 2;
 #ifdef SIMPLE_DPRINTF
 
 void GCLog (const char *fmt, ... );
-#define dprintf(l,x) {if ((l == 1) || (l == GTC_LOG)) {GCLog x;}}
+//#define dprintf(l,x) {if ((l == 1) || (l == GTC_LOG)) {GCLog x;}}
+#define dprintf(l,x) {if ((l == 1) || (l == 6666)) {GCLog x;}}
 #else //SIMPLE_DPRINTF
 #ifdef HOST_64BIT
 #define dprintf(l,x) STRESS_LOG_VA(l,x);
@@ -4283,12 +4284,25 @@ private:
             uint64_t    gc_elapsed_time;        // time the gc took
             uint64_t    soh_msl_wait_time;      // time the allocator spent waiting for the soh msl lock
             uint64_t    uoh_msl_wait_time;      // time the allocator spent waiting for the uoh msl lock
+            uint64_t    overhead_time;          // sum of the above 3 overhead values
             size_t      allocating_thread_count;// number of allocating threads
             size_t      heap_size;
         };
 
         unsigned        sample_index;
         sample          samples[sample_size];
+        uint64_t        sample_time;
+        size_t          prev_gc_index;
+
+        struct gen2_sample
+        {
+            uint64_t    elapsed_between_gcs;    // time between gcs in microseconds
+            uint64_t    gc_elapsed_time;        // time the gc took
+        };
+
+        size_t          gen2_gc_clock;
+        unsigned        gen2_sample_index;
+        gen2_sample     gen2_samples[sample_size];
 
         float median_percent_overhead;          // estimated overhead of allocator + gc
         float smoothed_median_percent_overhead; // exponentially smoothed version

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -157,7 +157,7 @@ inline void FATAL_GC_ERROR()
 #if defined(USE_REGIONS) && defined(MULTIPLE_HEAPS)
 // can only change heap count with regions
 #define DYNAMIC_HEAP_COUNT
-#define STRESS_DYNAMIC_HEAP_COUNT
+//#define STRESS_DYNAMIC_HEAP_COUNT
 #endif //USE_REGIONS && MULTIPLE_HEAPS
 
 #ifdef USE_REGIONS


### PR DESCRIPTION
+ Moved the sample recording into when we are suspended. The way we were calculating the throughput cost was in `check_heap_count` (which is called right after we restart EE on heap0), we record the `msl_wait_time `(and reset it to 0 for soh/uoh). This is not synchronized with the allocating threads (which are already running at this point). So what can happen is the allocating threads are already accumulated more wait time which is attributed to this GC but it's not within the period we are counting for this GC (and we lose this part for the next GC). For BGC this is incorrect. If an ephemeral GC did happen before the BGC starts, we'd be adding a sample for that GC which is _basically_ correct for that eph GC. But if an eph GC did not happen, we are just adding a random sample which is calculating the tcp as (msl wait + whatever GC that was finished before this BGC) so obviously incorrect.

+ Added gen2 sampling - this was adapted from Peter's gen2 sampling changes. This serves as a backstop in case the existing sampling doesn't ever pick gen2 GC costs. I made the following fixes -
1) changed the way we calculated the median
2) moved where this is calculated to again avoid timing issues
3) made the gen2 samples actually count instead of losing that info if we happen to sample when a gen2 didn't just occur.

+ Changed when `check_heap_count` is called - the previous place is right after a suspension which does not help with spacing the suspension time out (it was "suspend for GC" then "immediately suspend to change heap count"). And it caused a problem with BGC which was it always tried to change heap count when it couldn't because BGC was in progress. I changed this to be on a timeout to intentionally space the suspensions out. Now most of the time, heap count changes happen due to this time out. If we are really in a situation where GCs are happening too quickly and we return from waiting on the `ee_suspend_event` due to a GC started, we change the heap count right before we do a GC. So this also helps with the BGC problem.