### PR TITLE
Try fixing the new unhandled exception test

### DIFF
--- a/src/tests/baseservices/exceptions/unhandled/unhandled.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandled.cs
@@ -22,6 +22,9 @@ namespace TestUnhandledException
 
             Process testProcess = new Process();
 
+            // We don't need to trigger createdump logic.
+            testProcess.StartInfo.Environment.Remove("DOTNET_DbgEnableMiniDump");
+
             testProcess.StartInfo.FileName = Environment.ProcessPath;
             testProcess.StartInfo.Arguments = Environment.CommandLine + " throw";
             testProcess.StartInfo.RedirectStandardError = true;


### PR DESCRIPTION
The test is failing under NativeAOT in runtime-extra-platforms legs. Our test infra insists on createdump usage. We don't have one for NativeAOT testing.

```
      BEGIN EXECUTION
      /datadisks/disk1/work/A57B093F/p/nativeaottest.sh /datadisks/disk1/work/A57B093F/w/AE63091E/e/baseservices/exceptions/unhandled/unhandled/ unhandled.dll ''
      "DOTNET_DbgEnableMiniDump is set and the createdump binary does not exist: /datadisks/disk1/work/A57B093F/w/AE63091E/e/baseservices/exceptions/unhandled/unhandled/native/createdump"
      "Unhandled exception. System.Exception: Test"
      "   at TestUnhandledException.Program.Main(String[] args) + 0xbb"
      ""
      Missing Unhandled exception header
      Expected: 100
      Actual: 102
      END EXECUTION - FAILED
```

Cc @dotnet/ilc-contrib 