### PR TITLE
Don't shut down event pipe in DLLs on Windows

### DIFF
--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -93,7 +93,7 @@ static char& __unbox_z = __stop___unbox;
 
 #endif // _MSC_VER
 
-extern "C" bool RhInitialize();
+extern "C" bool RhInitialize(bool isDll);
 extern "C" void RhSetRuntimeInitializationCallback(int (*fPtr)());
 
 extern "C" bool RhRegisterOSModule(void * pModule,
@@ -164,7 +164,13 @@ extern "C" void __managed__Startup();
 
 static int InitializeRuntime()
 {
-    if (!RhInitialize())
+    if (!RhInitialize(
+#ifdef NATIVEAOT_DLL
+        /* isDll */ true
+#else
+        /* isDll */ false
+#endif
+        ))
         return -1;
 
     void * osModule = PalGetModuleHandleFromPointer((void*)&NATIVEAOT_ENTRYPOINT);

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -50,6 +50,8 @@
       Text="RuntimeIdentifier is required for native compilation. Try running dotnet publish with the -r option value specified." />
     <Error Condition="'$(GeneratePackageOnBuild)' == 'true'" Text="GeneratePackageOnBuild is not supported for native compilation." />
     <Error Condition="'$(OutputType)' != 'Library' and '$(NativeLib)' != '' and '$(CustomNativeMain)' != 'true'" Text="NativeLib requires OutputType=Library." />
+    <!-- See https://github.com/dotnet/runtime/issues/89346 for details -->
+    <Error Condition="'$(NativeLib)' != '' and '$(EventSourceSupport)' == 'true' and '$(_SuppressNativeLibEventSourceError)' != 'true'" Text="EventSource is not supported when compiling to a native library. Set EventSourceSupport to false." />
 
     <Error Condition="'$(PublishTrimmed)' == 'false'" Text="PublishTrimmed is implied by native compilation and cannot be disabled." />
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -50,7 +50,7 @@
       Text="RuntimeIdentifier is required for native compilation. Try running dotnet publish with the -r option value specified." />
     <Error Condition="'$(GeneratePackageOnBuild)' == 'true'" Text="GeneratePackageOnBuild is not supported for native compilation." />
     <Error Condition="'$(OutputType)' != 'Library' and '$(NativeLib)' != '' and '$(CustomNativeMain)' != 'true'" Text="NativeLib requires OutputType=Library." />
-    <Warning Condition="'$(NativeLib)' != '' and '$(EventSourceSupport)' == 'true' and '$(_SuppressNativeLibEventSourceWarning)' != 'true'" Text="Multiple components (including CoreCLR) with EventSource enabled can't be loaded into the same process: see https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/diagnostics for details and workarounds. EventSource should only be enabled in libraries if you are certain it will be the only component with EventSource loaded into the process. To suppress this warning you can set  the _SuppressNativeLibEventSourceWarning MSBuild property to true." />
+    <Warning Condition="'$(NativeLib)' != '' and '$(EventSourceSupport)' == 'true' and '$(_SuppressNativeLibEventSourceWarning)' != 'true'" Text="EventSource is not supported or recommended when compiling to a native library. Please go to https://github.com/dotnet/runtime/issues/91762 for more details." />
 
     <Error Condition="'$(PublishTrimmed)' == 'false'" Text="PublishTrimmed is implied by native compilation and cannot be disabled." />
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -50,7 +50,7 @@
       Text="RuntimeIdentifier is required for native compilation. Try running dotnet publish with the -r option value specified." />
     <Error Condition="'$(GeneratePackageOnBuild)' == 'true'" Text="GeneratePackageOnBuild is not supported for native compilation." />
     <Error Condition="'$(OutputType)' != 'Library' and '$(NativeLib)' != '' and '$(CustomNativeMain)' != 'true'" Text="NativeLib requires OutputType=Library." />
-    <Warning Condition="'$(NativeLib)' != '' and '$(EventSourceSupport)' == 'true' and '$(_SuppressNativeLibEventSourceWarning)' != 'true'" Text="EventSource has known issues when compiling to a native library: see https://github.com/dotnet/runtime/issues/91762 for details and workarounds. It is recommended to leave EventSourceSupport MSBuild property at the default value of false. If you wish to leave EventSourceSupport at true and remove this warning instead, set _SuppressNativeLibEventSourceWarning MSBuild property to true." />
+    <Warning Condition="'$(NativeLib)' != '' and '$(EventSourceSupport)' == 'true' and '$(_SuppressNativeLibEventSourceWarning)' != 'true'" Text="Multiple components (including CoreCLR) with EventSource enabled can't be loaded into the same process: see https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/diagnostics for details and workarounds. EventSource should only be enabled in libraries if you are certain it will be the only component with EventSource loaded into the process. To suppress this warning you can set  the _SuppressNativeLibEventSourceWarning MSBuild property to true." />
 
     <Error Condition="'$(PublishTrimmed)' == 'false'" Text="PublishTrimmed is implied by native compilation and cannot be disabled." />
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -50,8 +50,7 @@
       Text="RuntimeIdentifier is required for native compilation. Try running dotnet publish with the -r option value specified." />
     <Error Condition="'$(GeneratePackageOnBuild)' == 'true'" Text="GeneratePackageOnBuild is not supported for native compilation." />
     <Error Condition="'$(OutputType)' != 'Library' and '$(NativeLib)' != '' and '$(CustomNativeMain)' != 'true'" Text="NativeLib requires OutputType=Library." />
-    <!-- See https://github.com/dotnet/runtime/issues/89346 for details -->
-    <Error Condition="'$(NativeLib)' != '' and '$(EventSourceSupport)' == 'true' and '$(_SuppressNativeLibEventSourceError)' != 'true'" Text="EventSource is not supported when compiling to a native library. Set EventSourceSupport to false." />
+    <Warning Condition="'$(NativeLib)' != '' and '$(EventSourceSupport)' == 'true' and '$(_SuppressNativeLibEventSourceWarning)' != 'true'" Text="EventSource has known issues when compiling to a native library: see https://github.com/dotnet/runtime/issues/91762 for details and workarounds. It is recommended to leave EventSourceSupport MSBuild property at the default value of false. If you wish to leave EventSourceSupport at true and remove this warning instead, set _SuppressNativeLibEventSourceWarning MSBuild property to true." />
 
     <Error Condition="'$(PublishTrimmed)' == 'false'" Text="PublishTrimmed is implied by native compilation and cannot be disabled." />
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -50,8 +50,6 @@
       Text="RuntimeIdentifier is required for native compilation. Try running dotnet publish with the -r option value specified." />
     <Error Condition="'$(GeneratePackageOnBuild)' == 'true'" Text="GeneratePackageOnBuild is not supported for native compilation." />
     <Error Condition="'$(OutputType)' != 'Library' and '$(NativeLib)' != '' and '$(CustomNativeMain)' != 'true'" Text="NativeLib requires OutputType=Library." />
-    <!-- See https://github.com/dotnet/runtime/issues/89346 for details -->
-    <Error Condition="'$(NativeLib)' != '' and '$(EventSourceSupport)' == 'true'" Text="EventSource is not supported when compiling to a native library. Set EventSourceSupport to false." />
 
     <Error Condition="'$(PublishTrimmed)' == 'false'" Text="PublishTrimmed is implied by native compilation and cannot be disabled." />
 

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -292,6 +292,10 @@ static void UninitDLL()
 Thread* g_threadPerformingShutdown = NULL;
 #endif
 
+#if defined(_WIN32) && defined(FEATURE_PERFTRACING)
+bool g_safeToShutdownTracing;
+#endif
+
 static void __cdecl OnProcessExit()
 {
 #ifdef _WIN32
@@ -304,8 +308,16 @@ static void __cdecl OnProcessExit()
 #endif
 
 #ifdef FEATURE_PERFTRACING
-    EventPipe_Shutdown();
-    DiagnosticServer_Shutdown();
+#ifdef _WIN32
+    // We forgo shutting down event pipe if it wouldn't be safe and could lead to a hang.
+    // If there was an active trace session, the trace will likely be corrupted without
+    // orderly shutdown. See https://github.com/dotnet/runtime/issues/89346.
+    if (g_safeToShutdownTracing)
+#endif
+    {
+        EventPipe_Shutdown();
+        DiagnosticServer_Shutdown();
+    }
 #endif
 }
 
@@ -343,13 +355,17 @@ void RuntimeThreadShutdown(void* thread)
 #endif
 }
 
-extern "C" bool RhInitialize()
+extern "C" bool RhInitialize(bool isDll)
 {
     if (!PalInit())
         return false;
 
 #if defined(_WIN32) || defined(FEATURE_PERFTRACING)
     atexit(&OnProcessExit);
+#endif
+
+#if defined(_WIN32) && defined(FEATURE_PERFTRACING)
+    g_safeToShutdownTracing = !isDll;
 #endif
 
     if (!InitDLL(PalGetModuleHandleFromPointer((void*)&RhInitialize)))


### PR DESCRIPTION
Works around #89346.

We blocked event pipe completely in shared libraries in #90811 but:

* Elinor found out the shutdown problem is actually Windows specific, so blocking Linux (our most important target) is unnecessary.
* We can avoid the hang at the cost of corrupting the ongoing event pipe session by just not doing the shutdown. This can be worked around by simply stopping the event pipe session at dotnet-trace side manually.

I validated the shared library scenario no longer hangs at shutdown with this.

#89346 still tracks if we can do better here.

Cc @dotnet/ilc-contrib 