### PR TITLE
Enable analyzer analyzers

### DIFF
--- a/eng/Analyzers.targets
+++ b/eng/Analyzers.targets
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">

--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -475,7 +475,7 @@ dotnet_diagnostic.CA1860.severity = warning
 dotnet_diagnostic.CA1861.severity = warning
 
 # CA1862: Prefer using 'StringComparer'/'StringComparison' to perform case-insensitive string comparisons
-dotnet_diagnostic.CA1862.severity = info
+dotnet_diagnostic.CA1862.severity = suggestion
 
 # CA1863: Use 'CompositeFormat'
 dotnet_diagnostic.CA1863.severity = suggestion
@@ -954,6 +954,147 @@ dotnet_diagnostic.IL3001.severity = warning
 
 # IL3002: Using member with RequiresAssemblyFilesAttribute can break functionality when embedded in a single-file app
 dotnet_diagnostic.IL3002.severity = warning
+
+# RS1001: Missing diagnostic analyzer attribute
+dotnet_diagnostic.RS1001.severity = warning
+
+# RS1002: Missing kind argument when registering an analyzer action
+dotnet_diagnostic.RS1002.severity = warning
+
+# RS1003: Unsupported SymbolKind argument when registering a symbol analyzer action
+dotnet_diagnostic.RS1003.severity = warning
+
+# RS1004: Recommend adding language support to diagnostic analyzer
+dotnet_diagnostic.RS1004.severity = warning
+
+# RS1005: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor
+dotnet_diagnostic.RS1005.severity = warning
+
+# RS1006: Invalid type argument for DiagnosticAnalyzer's Register method
+dotnet_diagnostic.RS1006.severity = warning
+
+# RS1007: Provide localizable arguments to diagnostic descriptor constructor
+dotnet_diagnostic.RS1007.severity = none
+
+# RS1008: Avoid storing per-compilation data into the fields of a diagnostic analyzer
+dotnet_diagnostic.RS1008.severity = warning
+
+# RS1009: Only internal implementations of this interface are allowed
+dotnet_diagnostic.RS1009.severity = error
+
+# RS1010: Create code actions should have a unique EquivalenceKey for FixAll occurrences support
+dotnet_diagnostic.RS1010.severity = warning
+
+# RS1011: Use code actions that have a unique EquivalenceKey for FixAll occurrences support
+dotnet_diagnostic.RS1011.severity = warning
+
+# RS1012: Start action has no registered actions
+dotnet_diagnostic.RS1012.severity = warning
+
+# RS1013: Start action has no registered non-end actions
+dotnet_diagnostic.RS1013.severity = warning
+
+# RS1014: Do not ignore values returned by methods on immutable objects
+dotnet_diagnostic.RS1014.severity = warning
+
+# RS1015: Provide non-null 'helpLinkUri' value to diagnostic descriptor constructor
+dotnet_diagnostic.RS1015.severity = none
+
+# RS1016: Code fix providers should provide FixAll support
+dotnet_diagnostic.RS1016.severity = suggestion
+
+# RS1017: DiagnosticId for analyzers must be a non-null constant
+dotnet_diagnostic.RS1017.severity = warning
+
+# RS1018: DiagnosticId for analyzers must be in specified format
+dotnet_diagnostic.RS1018.severity = warning
+
+# RS1019: DiagnosticId must be unique across analyzers
+dotnet_diagnostic.RS1019.severity = warning
+
+# RS1020: Category for analyzers must be from the specified values
+dotnet_diagnostic.RS1020.severity = none
+
+# RS1021: Invalid entry in analyzer category and diagnostic ID range specification file
+dotnet_diagnostic.RS1021.severity = warning
+
+# RS1022: Do not use types from Workspaces assembly in an analyzer
+dotnet_diagnostic.RS1022.severity = warning
+
+# RS1023: Upgrade MSBuildWorkspace
+dotnet_diagnostic.RS1023.severity = warning
+
+# RS1024: Symbols should be compared for equality
+dotnet_diagnostic.RS1024.severity = warning
+
+# RS1025: Configure generated code analysis
+dotnet_diagnostic.RS1025.severity = warning
+
+# RS1026: Enable concurrent execution
+dotnet_diagnostic.RS1026.severity = warning
+
+# RS1027: Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer
+dotnet_diagnostic.RS1027.severity = warning
+
+# RS1028: Provide non-null 'customTags' value to diagnostic descriptor constructor
+dotnet_diagnostic.RS1028.severity = none
+
+# RS1029: Do not use reserved diagnostic IDs
+dotnet_diagnostic.RS1029.severity = warning
+
+# RS1030: Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
+dotnet_diagnostic.RS1030.severity = warning
+
+# RS1031: Define diagnostic title correctly
+dotnet_diagnostic.RS1031.severity = warning
+
+# RS1032: Define diagnostic message correctly
+dotnet_diagnostic.RS1032.severity = warning
+
+# RS1033: Define diagnostic description correctly
+dotnet_diagnostic.RS1033.severity = warning
+
+# RS1034: Prefer 'IsKind' for checking syntax kinds
+dotnet_diagnostic.RS1034.severity = warning
+
+# RS1035: Do not use APIs banned for analyzers
+dotnet_diagnostic.RS1035.severity = error
+
+# RS1036: Specify analyzer banned API enforcement setting
+dotnet_diagnostic.RS1036.severity = warning
+
+# RS1037: Add "CompilationEnd" custom tag to compilation end diagnostic descriptor
+dotnet_diagnostic.RS1037.severity = warning
+
+# RS1038: Compiler extensions should be implemented in assemblies with compiler-provided references
+dotnet_diagnostic.RS1038.severity = suggestion
+
+# RS2000: Add analyzer diagnostic IDs to analyzer release
+dotnet_diagnostic.RS2000.severity = warning
+
+# RS2001: Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release
+dotnet_diagnostic.RS2001.severity = warning
+
+# RS2002: Do not add removed analyzer diagnostic IDs to unshipped analyzer release
+dotnet_diagnostic.RS2002.severity = warning
+
+# RS2003: Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file
+dotnet_diagnostic.RS2003.severity = warning
+
+# RS2004: Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers
+dotnet_diagnostic.RS2004.severity = warning
+
+# RS2005: Remove duplicate entries for diagnostic ID in the same analyzer release
+dotnet_diagnostic.RS2005.severity = warning
+
+# RS2006: Remove duplicate entries for diagnostic ID between analyzer releases
+dotnet_diagnostic.RS2006.severity = warning
+
+# RS2007: Invalid entry in analyzer release file
+dotnet_diagnostic.RS2007.severity = warning
+
+# RS2008: Enable analyzer release tracking
+dotnet_diagnostic.RS2008.severity = warning
 
 # SA0001: XML comments
 dotnet_diagnostic.SA0001.severity = none

--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -951,6 +951,147 @@ dotnet_diagnostic.IL3001.severity = none
 # IL3002: Using member with RequiresAssemblyFilesAttribute can break functionality when embedded in a single-file app
 dotnet_diagnostic.IL3002.severity = none
 
+# RS1001: Missing diagnostic analyzer attribute
+dotnet_diagnostic.RS1001.severity = none
+
+# RS1002: Missing kind argument when registering an analyzer action
+dotnet_diagnostic.RS1002.severity = none
+
+# RS1003: Unsupported SymbolKind argument when registering a symbol analyzer action
+dotnet_diagnostic.RS1003.severity = none
+
+# RS1004: Recommend adding language support to diagnostic analyzer
+dotnet_diagnostic.RS1004.severity = none
+
+# RS1005: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor
+dotnet_diagnostic.RS1005.severity = none
+
+# RS1006: Invalid type argument for DiagnosticAnalyzer's Register method
+dotnet_diagnostic.RS1006.severity = none
+
+# RS1007: Provide localizable arguments to diagnostic descriptor constructor
+dotnet_diagnostic.RS1007.severity = none
+
+# RS1008: Avoid storing per-compilation data into the fields of a diagnostic analyzer
+dotnet_diagnostic.RS1008.severity = none
+
+# RS1009: Only internal implementations of this interface are allowed
+dotnet_diagnostic.RS1009.severity = none
+
+# RS1010: Create code actions should have a unique EquivalenceKey for FixAll occurrences support
+dotnet_diagnostic.RS1010.severity = none
+
+# RS1011: Use code actions that have a unique EquivalenceKey for FixAll occurrences support
+dotnet_diagnostic.RS1011.severity = none
+
+# RS1012: Start action has no registered actions
+dotnet_diagnostic.RS1012.severity = none
+
+# RS1013: Start action has no registered non-end actions
+dotnet_diagnostic.RS1013.severity = none
+
+# RS1014: Do not ignore values returned by methods on immutable objects
+dotnet_diagnostic.RS1014.severity = none
+
+# RS1015: Provide non-null 'helpLinkUri' value to diagnostic descriptor constructor
+dotnet_diagnostic.RS1015.severity = none
+
+# RS1016: Code fix providers should provide FixAll support
+dotnet_diagnostic.RS1016.severity = suggestion
+
+# RS1017: DiagnosticId for analyzers must be a non-null constant
+dotnet_diagnostic.RS1017.severity = none
+
+# RS1018: DiagnosticId for analyzers must be in specified format
+dotnet_diagnostic.RS1018.severity = none
+
+# RS1019: DiagnosticId must be unique across analyzers
+dotnet_diagnostic.RS1019.severity = none
+
+# RS1020: Category for analyzers must be from the specified values
+dotnet_diagnostic.RS1020.severity = none
+
+# RS1021: Invalid entry in analyzer category and diagnostic ID range specification file
+dotnet_diagnostic.RS1021.severity = none
+
+# RS1022: Do not use types from Workspaces assembly in an analyzer
+dotnet_diagnostic.RS1022.severity = none
+
+# RS1023: Upgrade MSBuildWorkspace
+dotnet_diagnostic.RS1023.severity = none
+
+# RS1024: Symbols should be compared for equality
+dotnet_diagnostic.RS1024.severity = none
+
+# RS1025: Configure generated code analysis
+dotnet_diagnostic.RS1025.severity = none
+
+# RS1026: Enable concurrent execution
+dotnet_diagnostic.RS1026.severity = none
+
+# RS1027: Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer
+dotnet_diagnostic.RS1027.severity = none
+
+# RS1028: Provide non-null 'customTags' value to diagnostic descriptor constructor
+dotnet_diagnostic.RS1028.severity = none
+
+# RS1029: Do not use reserved diagnostic IDs
+dotnet_diagnostic.RS1029.severity = none
+
+# RS1030: Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
+dotnet_diagnostic.RS1030.severity = none
+
+# RS1031: Define diagnostic title correctly
+dotnet_diagnostic.RS1031.severity = none
+
+# RS1032: Define diagnostic message correctly
+dotnet_diagnostic.RS1032.severity = none
+
+# RS1033: Define diagnostic description correctly
+dotnet_diagnostic.RS1033.severity = none
+
+# RS1034: Prefer 'IsKind' for checking syntax kinds
+dotnet_diagnostic.RS1034.severity = none
+
+# RS1035: Do not use APIs banned for analyzers
+dotnet_diagnostic.RS1035.severity = none
+
+# RS1036: Specify analyzer banned API enforcement setting
+dotnet_diagnostic.RS1036.severity = none
+
+# RS1037: Add "CompilationEnd" custom tag to compilation end diagnostic descriptor
+dotnet_diagnostic.RS1037.severity = none
+
+# RS1038: Compiler extensions should be implemented in assemblies with compiler-provided references
+dotnet_diagnostic.RS1038.severity = suggestion
+
+# RS2000: Add analyzer diagnostic IDs to analyzer release
+dotnet_diagnostic.RS2000.severity = none
+
+# RS2001: Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release
+dotnet_diagnostic.RS2001.severity = none
+
+# RS2002: Do not add removed analyzer diagnostic IDs to unshipped analyzer release
+dotnet_diagnostic.RS2002.severity = none
+
+# RS2003: Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file
+dotnet_diagnostic.RS2003.severity = none
+
+# RS2004: Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers
+dotnet_diagnostic.RS2004.severity = none
+
+# RS2005: Remove duplicate entries for diagnostic ID in the same analyzer release
+dotnet_diagnostic.RS2005.severity = none
+
+# RS2006: Remove duplicate entries for diagnostic ID between analyzer releases
+dotnet_diagnostic.RS2006.severity = none
+
+# RS2007: Invalid entry in analyzer release file
+dotnet_diagnostic.RS2007.severity = none
+
+# RS2008: Enable analyzer release tracking
+dotnet_diagnostic.RS2008.severity = none
+
 # SA0001: XML comments
 dotnet_diagnostic.SA0001.severity = none
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Roslyn3.11.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Roslyn3.11.cs
@@ -7,6 +7,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
+#pragma warning disable RS1035 // IIncrementalGenerator isn't available for the target configuration
+
 [assembly: System.Resources.NeutralResourcesLanguage("en-us")]
 
 namespace Microsoft.Extensions.Logging.Generators

--- a/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Extensions.Options.Generators
                 attrInstantiationStatementLines.Add("}");
             }
 
-            var instantiationStatement = string.Join(Environment.NewLine, attrInstantiationStatementLines);
+            var instantiationStatement = string.Join("\n", attrInstantiationStatementLines);
 
             if (!staticValidationAttributesDict.TryGetValue(instantiationStatement, out var staticValidationAttributeInstance))
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj
@@ -26,7 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Roslyn3.11.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Roslyn3.11.cs
@@ -9,6 +9,8 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
+#pragma warning disable RS1035 // IIncrementalGenerator isn't available for the target configuration
+
 namespace System.Text.Json.SourceGeneration
 {
     /// <summary>

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.csproj
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimDataFlowAnalysis.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimDataFlowAnalysis.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using ILLink.RoslynAnalyzer.DataFlow;
 using ILLink.Shared.DataFlow;
@@ -125,12 +126,15 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 		static void WriteIndented (string? s, int level)
 		{
-			string[]? lines = s?.Trim ().Split (new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-			if (lines == null)
-				return;
-			foreach (var line in lines) {
-				TraceWrite (new string ('\t', level));
-				TraceWriteLine (line);
+			if (s is not null) {
+				var reader = new StringReader (s);
+				string? line;
+				while ((line = reader.ReadLine ()) != null) {
+					if (line.Length != 0) {
+						TraceWrite (new string ('\t', level));
+						TraceWriteLine (line);
+					}
+				}
 			}
 		}
 

--- a/src/tools/illink/src/ILLink.Shared/DataFlow/DefaultValueDictionary.cs
+++ b/src/tools/illink/src/ILLink.Shared/DataFlow/DefaultValueDictionary.cs
@@ -83,10 +83,10 @@ namespace ILLink.Shared.DataFlow
 			sb.Append ('{');
 			if (Dictionary != null) {
 				foreach (var kvp in Dictionary)
-					sb.Append (Environment.NewLine).Append ('\t').Append (kvp.Key.ToString ()).Append (" -> ").Append (kvp.Value.ToString ());
+					sb.AppendLine().Append ('\t').Append (kvp.Key.ToString ()).Append (" -> ").Append (kvp.Value.ToString ());
 			}
-			sb.Append (Environment.NewLine).Append ("\t_ -> ").Append (DefaultValue.ToString ());
-			sb.Append (Environment.NewLine).Append ('}');
+			sb.AppendLine().Append ("\t_ -> ").Append (DefaultValue.ToString ());
+			sb.AppendLine().Append ('}');
 			return sb.ToString ();
 		}
 


### PR DESCRIPTION
Use Microsoft.CodeAnalysis.Analyzer in our builds, to help validate our analyzers and source generators. A few projects were doing this explicitly; this does it for all.

Note that for Environment.NewLine, there's a debate happening about it in https://github.com/dotnet/roslyn-analyzers/issues/6467. I chose to silence the warnings by making tweaks to the code that don't actually impact what's generated but that make the use of the banned symbol go away.