### PR TITLE
Add an option to set maximum processes to run tests

### DIFF
--- a/src/tests/Common/scripts/bringup_runtest.sh
+++ b/src/tests/Common/scripts/bringup_runtest.sh
@@ -36,6 +36,7 @@ function print_usage {
     echo '                                     Failing tests are listed in coreclr/tests/failingTestsOutsideWindows.txt, one per'
     echo '                                     line, as paths to .sh files relative to the directory specified by --testRootDir.'
     echo '  --disableEventLogging            : Disable the events logged by both VM and Managed Code'
+    echo '  --jobs=<n>                       : Set the maximum number of processes the scheduler can create.'
     echo '  --sequential                     : Run tests sequentially (default is to run in parallel).'
     echo '  --playlist=<path>                : Run only the tests that are specified in the file at <path>, in the same format as'
     echo '                                     runFailingTestsOnly'
@@ -1114,6 +1115,9 @@ do
             ;;
         --runcrossgentests)
             export RunCrossGen2=1
+            ;;
+        --jobs=*)
+            maxProcesses=${i#*=}
             ;;
         --sequential)
             ((maxProcesses = 1))


### PR DESCRIPTION
While testing RISC-V we've encountered a problem that didn't show up, when we limited the number of processes created for the task scheduler.

This PR contains a small modification, that adds an option to set number of processes manually.

Part of https://github.com/dotnet/runtime/issues/84834
cc @jkotas @tomeksowi @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov @clamp03 