### PR TITLE
Fix a potential shutdown hang with `Environment.Exit()` on Windows depending on timing with GCs

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1727,6 +1727,11 @@ struct TlsDestructionMonitor
         m_activated = true;
     }
 
+    void Deactivate()
+    {
+        m_activated = false;
+    }
+
     ~TlsDestructionMonitor()
     {
         if (m_activated)
@@ -1766,6 +1771,11 @@ thread_local TlsDestructionMonitor tls_destructionMonitor;
 void EnsureTlsDestructionMonitor()
 {
     tls_destructionMonitor.Activate();
+}
+
+void DeactivateTlsDestructionMonitor()
+{
+    tls_destructionMonitor.Deactivate();
 }
 
 #ifdef DEBUGGING_SUPPORTED

--- a/src/coreclr/vm/ceemain.h
+++ b/src/coreclr/vm/ceemain.h
@@ -46,6 +46,7 @@ void ForceEEShutdown(ShutdownCompleteAction sca = SCA_ExitProcessWhenShutdownCom
 void ThreadDetaching();
 
 void EnsureTlsDestructionMonitor();
+void DeactivateTlsDestructionMonitor();
 
 void SetLatchedExitCode (INT32 code);
 INT32 GetLatchedExitCode (void);

--- a/src/coreclr/vm/ceemain.h
+++ b/src/coreclr/vm/ceemain.h
@@ -17,6 +17,7 @@
 #include <windef.h> // for HFILE, HANDLE, HMODULE
 
 class EEDbgInterfaceImpl;
+class Thread;
 
 // Ensure the EE is started up.
 HRESULT EnsureEEStarted();
@@ -45,7 +46,7 @@ void ForceEEShutdown(ShutdownCompleteAction sca = SCA_ExitProcessWhenShutdownCom
 // Notification of a DLL_THREAD_DETACH or a Thread Terminate.
 void ThreadDetaching();
 
-void EnsureTlsDestructionMonitor();
+void EnsureTlsDestructionMonitor(Thread *thread);
 void DeactivateTlsDestructionMonitor();
 
 void SetLatchedExitCode (INT32 code);

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -369,7 +369,7 @@ void SetThread(Thread* t)
     gCurrentThreadInfo.m_pThread = t;
     if (t != NULL)
     {
-        EnsureTlsDestructionMonitor();
+        EnsureTlsDestructionMonitor(t);
     }
 }
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -30,6 +30,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/mono/runningmono/*">
             <Issue>This test is to verify we are running mono, and therefore only makes sense on mono.</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/regressions/2164/foreground-shutdown/*">
+            <Issue>https://github.com/dotnet/runtime/issues/83658</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/GC/Coverage/271010/**">
             <Issue>https://github.com/dotnet/runtime/issues/5933</Issue>
         </ExcludeList>
@@ -251,9 +254,6 @@
 
     <!-- Windows all architecture excludes -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' == 'true' and '$(RuntimeFlavor)' == 'coreclr'">
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/regressions/2164/foreground-shutdown/*">
-            <Issue>https://github.com/dotnet/runtime/issues/84006</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows x64 specific excludes -->


### PR DESCRIPTION
- On Windows when a thread calls `ExitProcess`, the `TlsDestructionMonitor` for the thread appears to be destructed after all other threads in the process are torn down. It's possible for a GC to be in progress during that time, and the thread cleanup code in `TlsDestructionMonitor` tries to enter cooperative GC mode to fix the frame pointer, leading to a hang. Fixed by deactivating the `TlsDestructionMonitor` for the thread before calling `ExitProcess`.
  - I believe it wouldn't have been an issue prior to https://github.com/dotnet/runtime/pull/43423 and https://github.com/dotnet/runtime/pull/65358, since the thread cleanup code was done on `DLL_THREAD_DETACH`, which is not raised by `ExitProcess`.
  - On Linux, upon a call to `exit` the `TlsDestructionMonitor` for the thread appears to be destructed while other threads are still running, so it is eventually able to enter cooperative GC mode. It seems the cleanup is unnecessary in this case anyway, and the behavior is similar to before, so I didn't special-case the fix for Windows.
- Also disabled the relevant test due to a different issue (https://github.com/dotnet/runtime/issues/83658) occurring in the same test on multiple platforms/architectures, which is not understood yet.

Fixes https://github.com/dotnet/runtime/issues/84006