### PR TITLE
Arm64: Pass the small size accurately to emitIns_valid_imm_for_ldst_offset

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -335,10 +335,14 @@ bool CodeGen::genInstrWithConstant(instruction ins,
             break;
 
         case INS_ldrsb:
-        case INS_ldrsh:
-        case INS_ldrsw:
         case INS_ldrb:
+            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_1BYTE);
+            break;
+        case INS_ldrsh:
         case INS_ldrh:
+            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_2BYTE);
+            break;
+        case INS_ldrsw:
         case INS_ldr:
             immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, size);
             break;

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -334,11 +334,19 @@ bool CodeGen::genInstrWithConstant(instruction ins,
             immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, size);
             break;
 
-        case INS_ldrsb:
-        case INS_ldrsh:
-        case INS_ldrsw:
         case INS_ldrb:
+        case INS_ldrsb:
+            assert(size == EA_1BYTE);
+            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, size);
+            break;
+
         case INS_ldrh:
+        case INS_ldrsh:
+            assert(size == EA_2BYTE);
+            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, size);
+            break;
+
+        case INS_ldrsw:
         case INS_ldr:
             immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, size);
             break;

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -327,7 +327,15 @@ bool CodeGen::genInstrWithConstant(instruction ins,
             break;
 
         case INS_strb:
+            assert(size == EA_1BYTE);
+            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_1BYTE);
+            break;
+
         case INS_strh:
+            assert(size == EA_2BYTE);
+            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_2BYTE);
+            break;
+
         case INS_str:
             // reg1 is a source register for store instructions
             assert(tmpReg != reg1); // regTmp can not match any source register
@@ -336,18 +344,21 @@ bool CodeGen::genInstrWithConstant(instruction ins,
 
         case INS_ldrb:
         case INS_ldrsb:
-            assert(size == EA_1BYTE);
-            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, size);
+            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_1BYTE);
             break;
 
         case INS_ldrh:
         case INS_ldrsh:
-            assert(size == EA_2BYTE);
-            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, size);
+            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_2BYTE);
             break;
 
         case INS_ldrsw:
+            assert(size == EA_4BYTE);
+            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_4BYTE);
+            break;
+
         case INS_ldr:
+            assert((size == EA_4BYTE) || (size == EA_8BYTE));
             immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, size);
             break;
 

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -358,7 +358,7 @@ bool CodeGen::genInstrWithConstant(instruction ins,
             break;
 
         case INS_ldr:
-            assert((size == EA_4BYTE) || (size == EA_8BYTE));
+            assert((size == EA_4BYTE) || (size == EA_8BYTE) || (size == EA_16BYTE));
             immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, size);
             break;
 

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -335,14 +335,10 @@ bool CodeGen::genInstrWithConstant(instruction ins,
             break;
 
         case INS_ldrsb:
-        case INS_ldrb:
-            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_1BYTE);
-            break;
         case INS_ldrsh:
-        case INS_ldrh:
-            immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, EA_2BYTE);
-            break;
         case INS_ldrsw:
+        case INS_ldrb:
+        case INS_ldrh:
         case INS_ldr:
             immFitsInIns = emitter::emitIns_valid_imm_for_ldst_offset(imm, size);
             break;

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4735,7 +4735,7 @@ void CodeGen::genEnregisterOSRArgsAndLocals()
         // Note we are always reading from the tier0 frame here
         //
         const var_types lclTyp  = varDsc->GetStackSlotHomeType();
-        const emitAttr  size    = emitActualTypeSize(lclTyp);
+        const emitAttr  size    = emitTypeSize(lclTyp);
         const int       stkOffs = patchpointInfo->Offset(lclNum) + fieldOffset;
 
 #if defined(TARGET_AMD64)

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4735,7 +4735,7 @@ void CodeGen::genEnregisterOSRArgsAndLocals()
         // Note we are always reading from the tier0 frame here
         //
         const var_types lclTyp  = varDsc->GetStackSlotHomeType();
-        const emitAttr  size    = emitTypeSize(lclTyp);
+        const emitAttr  size    = emitActualTypeSize(lclTyp);
         const int       stkOffs = patchpointInfo->Offset(lclNum) + fieldOffset;
 
 #if defined(TARGET_AMD64)


### PR DESCRIPTION
Pass the correct size of instruction to determine if the immediate will fit in the instruction or not.

Fixes: https://github.com/dotnet/runtime/issues/68536