### PR TITLE
Disable CodeQL for jitrollingbuild pipeline

### DIFF
--- a/eng/pipelines/coreclr/jitrollingbuild.yml
+++ b/eng/pipelines/coreclr/jitrollingbuild.yml
@@ -13,6 +13,11 @@ trigger:
 # and should not be triggerable from a PR.
 pr: none
 
+variables:
+# disable CodeQL here, we have a separate pipeline for it
+- name: Codeql.Enabled
+  value: False
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:


### PR DESCRIPTION
It appears to cause osx builds to fail due to timeout or crash.

I followed the pattern of #90329

Verified this worked on internal pipeline.