### PR TITLE
[wasm] Add blazor First UI measurement

### DIFF
--- a/src/mono/sample/wasm/blazor-frame/Pages/Index.razor
+++ b/src/mono/sample/wasm/blazor-frame/Pages/Index.razor
@@ -1,7 +1,15 @@
 ﻿@page "/"
+@inject IJSRuntime JSRuntime
 
 <PageTitle>Index</PageTitle>
 
 <h1>Hello, world!</h1>
 
 Welcome to your new app.
+
+@code {
+    protected override void OnAfterRender(bool firstRender)
+    {
+        BenchmarkEvent.Send(JSRuntime, "Rendered Index.razor");
+    }
+}

--- a/src/mono/sample/wasm/blazor-frame/wwwroot/frame.js
+++ b/src/mono/sample/wasm/blazor-frame/wwwroot/frame.js
@@ -19,6 +19,13 @@ try {
         window.addEventListener("pageshow", event => { window.parent.resolveAppStartEvent("pageshow"); })
     }
 
+    // receive blazor benchmark event and forward it to resolveAppStartEvent
+    window.receiveBenchmarkEvent = function (name) {
+        if (window !== window.parent) {
+            window.parent.resolveAppStartEvent("blazor: " + name);
+        }
+    };
+
     window.muteErrors = () => {
         mute = true;
     }

--- a/src/mono/sample/wasm/blazor-frame/wwwroot/index.html
+++ b/src/mono/sample/wasm/blazor-frame/wwwroot/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>blazor</title>
-    <!-- <base href="/blazor-template/" /> -->
+    <base href="/blazor-template/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="css/bootstrap-icons/bootstrap-icons.min.css" />
     <link rel="stylesheet" href="css/app.css" />
@@ -26,7 +26,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="/blazor-template/_framework/blazor.webassembly.js"></script>
     <script type="module" src="frame.js"></script>
 </body>
 

--- a/src/mono/sample/wasm/browser-bench/AppStart.cs
+++ b/src/mono/sample/wasm/browser-bench/AppStart.cs
@@ -26,6 +26,7 @@ namespace Sample
                 new ReachManagedCold(),
                 new BlazorPageShow(),
                 new BlazorReachManaged(),
+                new BlazorFirstUI(),
                 new BlazorReachManagedCold(),
             };
         }
@@ -73,7 +74,7 @@ namespace Sample
         abstract class BlazorAppStartMeasurement : BenchTask.Measurement
         {
             protected readonly string urlBase = "blazor-template/";
-            protected readonly string framePage = "index.html";
+            protected readonly string framePage = "";
 
             public override async Task<bool> IsEnabled()
             {
@@ -123,6 +124,18 @@ namespace Sample
             }
         }
 
+        class BlazorFirstUI : BlazorAppStartMeasurement
+        {
+            public override string Name => "Blazor First UI";
+            public override int InitialSamples => 3;
+            public override bool HasRunStepAsync => true;
+
+            public override async Task RunStepAsync()
+            {
+                await MainApp.FrameBlazorFirstUI(null, urlBase);
+            }
+        }
+
         class BlazorReachManagedCold : BlazorAppStartMeasurement
         {
             public override string Name => "Blazor Reach managed cold";
@@ -138,6 +151,8 @@ namespace Sample
 
         public partial class MainApp
         {
+            [JSImport("globalThis.mainApp.FrameBlazorFirstUI")]
+            public static partial Task FrameBlazorFirstUI(string guid, string urlBase);
             [JSImport("globalThis.mainApp.PageShow")]
             public static partial Task PageShow(string guid, string urlBase);
             [JSImport("globalThis.mainApp.FrameReachedManaged")]

--- a/src/mono/sample/wasm/browser-bench/main.js
+++ b/src/mono/sample/wasm/browser-bench/main.js
@@ -149,6 +149,14 @@ class MainApp {
         }
     }
 
+    async frameBlazorFirstUI(guid, base) {
+        try {
+            await this.waitFor('blazor: Rendered Index.razor', guid, base);
+        } finally {
+            this.removeFrame();
+        }
+    }
+
     framePage = 'appstart-frame.html';
 
     async setFramePage(page) {
@@ -187,6 +195,7 @@ class MainApp {
 
 try {
     globalThis.mainApp = new MainApp();
+    globalThis.mainApp.FrameBlazorFirstUI = globalThis.mainApp.frameBlazorFirstUI.bind(globalThis.mainApp);
     globalThis.mainApp.FrameReachedManaged = globalThis.mainApp.frameReachedManaged.bind(globalThis.mainApp);
     globalThis.mainApp.PageShow = globalThis.mainApp.pageShow.bind(globalThis.mainApp);
     globalThis.mainApp.Origin = globalThis.mainApp.origin.bind(globalThis.mainApp);

--- a/src/mono/sample/wasm/simple-server/HttpServer.csproj
+++ b/src/mono/sample/wasm/simple-server/HttpServer.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <RollForward>major</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/mono/sample/wasm/simple-server/Program.cs
+++ b/src/mono/sample/wasm/simple-server/Program.cs
@@ -177,7 +177,7 @@ namespace HttpServer
             if (url == null)
                 return;
 
-            string path = url.LocalPath == "/" ? "index.html" : url.LocalPath;
+            string path = url.LocalPath.EndsWith("/") ? url.LocalPath + "index.html" : url.LocalPath;
             if (Verbose)
                 Console.WriteLine($"  serving: {path}");
 


### PR DESCRIPTION
This measures the time of `OnAfterRender` event on index page, to mimic the blazor benchmark's `First UI` measurement.

Also

 * fix blazor frame url base

 * let simple-server handle non-root urls with trailing '/'