### PR TITLE
Added missing *Async overrides to TlsStream

### DIFF
--- a/src/libraries/Common/src/System/Net/TlsStream.cs
+++ b/src/libraries/Common/src/System/Net/TlsStream.cs
@@ -5,6 +5,8 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net
 {
@@ -46,6 +48,11 @@ namespace System.Net
             _sslStream.EndAuthenticateAsClient(asyncResult);
         }
 
+        public override void Write(byte[] buffer, int offset, int size)
+        {
+            _sslStream.Write(buffer, offset, size);
+        }
+
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int size, AsyncCallback? callback, object? state)
         {
             return _sslStream.BeginWrite(buffer, offset, size, callback, state);
@@ -56,14 +63,19 @@ namespace System.Net
             _sslStream.EndWrite(result);
         }
 
-        public override void Write(byte[] buffer, int offset, int size)
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            _sslStream.Write(buffer, offset, size);
+            return _sslStream.WriteAsync(buffer, offset, count, cancellationToken);
         }
 
         public override int Read(byte[] buffer, int offset, int size)
         {
             return _sslStream.Read(buffer, offset, size);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _sslStream.ReadAsync(buffer, offset, count, cancellationToken);
         }
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)


### PR DESCRIPTION
#82644 replaced custom IAsyncResult with call to `ReadAsync` on `BufferedReadStream`. But `TlsStream` doesn't have `ReadAsync` and the call went to the base class `NetworkStream.ReadAsync` effectively bypassing `SslStream.Decrypt` of the data.

I added `Read/WriteAsync` overrides to call into `_sslStream` as is expected.

Note that we do not have any coverage for SSL enabled SMTP. So in order to add tests for this, I'll need add support for SSL into `LoopbackSmtpServer`. @karelz this might take some time, so let me know, if you want to move forward with this fix with just local validation and do the test afterwards.

Fixes #91377