### PR TITLE
Remove RCPC and RCPC2 from optimisticInstructionSet

### DIFF
--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -186,8 +186,6 @@ namespace System.CommandLine
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("lse");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("dotprod");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("rdma");
-                optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("rcpc");
-                optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("rcpc2");
             }
 
             // Vector<T> can always be part of the optimistic set, we only want to optionally exclude it from the supported set


### PR DESCRIPTION
Not all HW supports these (especially RCPC2 which is arm64 8.4+) so many methods with volatile loads/stores end up thrown away (their R2R'd versions) and we don't get static pgo for them.

Also, on Windows we don't support recognizing RCPC2 at all (there is no official way currently).

PTAL @dotnet/jit-contrib 