### PR TITLE
[mono] add nullable annotation to InternalInvoke

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.Mono.cs
@@ -808,7 +808,7 @@ namespace System.Reflection
          * to match the types of the method signature.
          */
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal extern object InternalInvoke(object? obj, IntPtr *args, out Exception exc);
+        internal extern object InternalInvoke(object? obj, IntPtr *args, out Exception? exc);
 
         public override RuntimeMethodHandle MethodHandle
         {


### PR DESCRIPTION
We had two of these icalls with different signatures in RuntimeMethodInfo and RuntimeConstructorInfo.

They both end up calling `ves_icall_InternalInvoke` which sometimes returns null