### PR TITLE
Split the informational version on both SemVer2 separators when calculating TFM

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/AnalyzerConfigOptionsExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/AnalyzerConfigOptionsExtensions.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Interop
         // Parse from the informational version as that is the only version that always matches the TFM version
         // even in debug builds.
         private static readonly Version ThisAssemblyVersion = Version.Parse(
-            typeof(IncrementalGeneratorInitializationContextExtensions).Assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('-')[0]);
+            typeof(AnalyzerConfigOptionsExtensions).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('-', '+')[0]);
 
         public static TargetFrameworkSettings GetTargetFrameworkSettings(this AnalyzerConfigOptions options)
         {


### PR DESCRIPTION
This fixes a build break found when we stabilize the package version (and the only separator in the informational version is '+' before the commit id)