### PR TITLE
Fix fgDebugCheckFlags checks for FTN_ADDR

### DIFF
--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3152,6 +3152,7 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
                 // Some of these aren't handles to invariant data...
                 if ((handleKind == GTF_ICON_STATIC_HDL) || // Pointer to a mutable class Static variable
                     (handleKind == GTF_ICON_BBC_PTR) ||    // Pointer to a mutable basic block count value
+                    (handleKind == GTF_ICON_FTN_ADDR) ||   // Pointer to a potentially mutable VM slot
                     (handleKind == GTF_ICON_GLOBAL_PTR))   // Pointer to mutable data from the VM state
                 {
                     // For statics, we expect the GTF_GLOB_REF to be set. However, we currently

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3331,6 +3331,12 @@ void Compiler::fgDebugCheckFlagsHelper(GenTree* tree, GenTreeFlags actualFlags, 
         //
         GenTreeFlags flagsToCheck = ~GTF_GLOB_REF & ~GTF_ORDER_SIDEEFF;
 
+        if (tree->isIndir() && tree->AsIndir()->Addr()->IsIconHandle(GTF_ICON_FTN_ADDR))
+        {
+            // IND(ICON_FTN_ADDR) may or may not have GTF_IND_INVARIANT flag.
+            flagsToCheck &= ~GTF_IND_INVARIANT;
+        }
+
         if ((actualFlags & ~expectedFlags & flagsToCheck) != 0)
         {
             // Print the tree so we can see it in the log.

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91505/Runtime_91505.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91505/Runtime_91505.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_91505
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Test();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static unsafe long Test()
+    {
+        delegate*<void> ptr = &Foo;
+        return *(long*)ptr;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Foo() {}
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91505/Runtime_91505.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91505/Runtime_91505.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Optimize>True</Optimize>
-	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91505/Runtime_91505.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91505/Runtime_91505.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/91505

the check used to complain that `IND(ICON)` should have `GTF_IND_INVARIANT` flag, but it's not true - `IND(FTNPTR)` is never invariant because it points to a potentially mutable data (e.g. tiering)