### PR TITLE
Remove uses of IlcTrimMetadata from the test tree

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/DeflateTests.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/DeflateTests.cs
@@ -61,8 +61,8 @@ namespace System.Net.WebSockets.Client.Tests
 
                 await ConnectAsync(client, uri, cancellation.Token);
 
-                object webSocketHandle = client.GetType().GetField("_innerWebSocket", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(client);
-                WebSocketDeflateOptions negotiatedDeflateOptions = (WebSocketDeflateOptions)webSocketHandle.GetType()
+                object webSocketHandle = typeof(ClientWebSocket).GetField("_innerWebSocket", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(client);
+                WebSocketDeflateOptions negotiatedDeflateOptions = (WebSocketDeflateOptions)Type.GetType("System.Net.WebSockets.WebSocketHandle, System.Net.WebSockets.Client")
                     .GetField("_negotiatedDeflateOptions", BindingFlags.NonPublic | BindingFlags.Instance)
                     .GetValue(webSocketHandle);
 

--- a/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -5,8 +5,6 @@
     <StringResourcesPath>../src/Resources/Strings.resx</StringResourcesPath>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-browser</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
-    <!--Remove once this is fixed, https://github.com/dotnet/runtime/issues/71506 -->
-    <IlcTrimMetadata>false</IlcTrimMetadata>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'browser'">

--- a/src/libraries/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
+++ b/src/libraries/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
@@ -3,7 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <TestRuntime>true</TestRuntime>
-    <!-- Uses a lot of `dynamic` that IlcTrimMetadata=false happens for fix -->
+    <!-- Uses a lot of `dynamic` that IlcTrimMetadata=false happens to fix -->
     <IlcTrimMetadata>false</IlcTrimMetadata>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
+++ b/src/libraries/System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj
@@ -3,7 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <TestRuntime>true</TestRuntime>
-    <!--Remove once this is fixed, https://github.com/dotnet/runtime/issues/71506 -->
+    <!-- Uses a lot of `dynamic` that IlcTrimMetadata=false happens for fix -->
     <IlcTrimMetadata>false</IlcTrimMetadata>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Private.Xml/tests/AllowDefaultResolverContext.cs
+++ b/src/libraries/System.Private.Xml/tests/AllowDefaultResolverContext.cs
@@ -32,7 +32,7 @@ namespace System.Xml.Tests
             // the default, or alternatively separate all such tests into a separate test project
             // where that project contains only those tests that require the switch set.
 
-            Type t = typeof(XmlConvert).Assembly.GetType("System.Xml.LocalAppContextSwitches");
+            Type t = Type.GetType("System.Xml.LocalAppContextSwitches, System.Private.Xml");
             Assert.NotNull(t);
 
             FieldInfo fi = t.GetField("s_allowDefaultResolver", BindingFlags.NonPublic | BindingFlags.Static);

--- a/src/libraries/System.Private.Xml/tests/System.Private.Xml.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/System.Private.Xml.Tests.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <RootNamespace>System.Xml.Tests</RootNamespace>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    
-    <!--Remove once this is fixed, https://github.com/dotnet/runtime/issues/71506 -->
-    <IlcTrimMetadata>false</IlcTrimMetadata>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Misc.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Misc.cs
@@ -1023,10 +1023,12 @@ namespace System.Xml.XmlSchemaTests
             return;
         }
 
-        // Test failure on ILC: Test depends on Xml Serialization and requires reflection on a LOT of types under System.Xml.Schema namespace.
-        // Rd.xml with "<Namespace Name="System.Xml.Schema" Dynamic="Required Public" />" lets this test pass but we should probably be
-        // fixing up XmlSerializer's own rd.xml rather than the test here.
+#if !ReflectionOnly && !XMLSERIALIZERGENERATORTESTS
+        // Conditioned the same as XmlSerializer tests. This uses XmlSerializer to serialize the schema.
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
+#else
         [Fact]
+#endif
         public void GetBuiltinSimpleTypeWorksAsEcpected()
         {
             Initialize();

--- a/src/libraries/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-unix;$(NetCoreAppCurrent)-browser</TargetFrameworks>
     <!-- SYSLIB0021: Derived cryptographic types are obsolete -->
     <NoWarn>$(NoWarn);SYSLIB0021</NoWarn>
-    <!--Remove once this is fixed, https://github.com/dotnet/runtime/issues/71506 -->
+    <!-- These APIs are not trim safe but IlcTrimMetadata happens to make the tests using them work -->
     <IlcTrimMetadata>false</IlcTrimMetadata>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Threading.Tasks.Extensions/tests/System.Threading.Tasks.Extensions.Tests.csproj
+++ b/src/libraries/System.Threading.Tasks.Extensions/tests/System.Threading.Tasks.Extensions.Tests.csproj
@@ -3,8 +3,6 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TestRuntime>true</TestRuntime>
-    <!--Remove once this is fixed, https://github.com/dotnet/runtime/issues/71506 -->
-    <IlcTrimMetadata>false</IlcTrimMetadata>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AsyncMethodBuilderAttributeTests.cs" />

--- a/src/libraries/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
+++ b/src/libraries/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
@@ -1269,7 +1269,7 @@ namespace System.Threading.Tasks.Tests
 
             // _obj is null but other fields are from Task construction
             vtBoxed = new ValueTask(Task.CompletedTask);
-            vtBoxed.GetType().GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, null);
+            typeof(ValueTask).GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, null);
             Record.Exception(() =>
             {
                 bool completed = ((ValueTask)vtBoxed).IsCompleted;
@@ -1278,7 +1278,7 @@ namespace System.Threading.Tasks.Tests
 
             // _obj is a Task but other fields are from result construction
             vtBoxed = new ValueTask();
-            vtBoxed.GetType().GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, Task.CompletedTask);
+            typeof(ValueTask).GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, Task.CompletedTask);
             Record.Exception(() =>
             {
                 bool completed = ((ValueTask)vtBoxed).IsCompleted;
@@ -1287,7 +1287,7 @@ namespace System.Threading.Tasks.Tests
 
             // _obj is an IValueTaskSource but other fields are from Task construction
             vtBoxed = new ValueTask(Task.CompletedTask);
-            vtBoxed.GetType().GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, ManualResetValueTaskSourceFactory.Completed(42));
+            typeof(ValueTask).GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, ManualResetValueTaskSourceFactory.Completed(42));
             Record.Exception(() =>
             {
                 bool completed = ((ValueTask)vtBoxed).IsCompleted;
@@ -1304,7 +1304,7 @@ namespace System.Threading.Tasks.Tests
 
             // _obj is null but other fields are from Task construction
             vtBoxed = new ValueTask<int>(Task.FromResult(42));
-            vtBoxed.GetType().GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, null);
+            typeof(ValueTask<int>).GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, null);
             Record.Exception(() =>
             {
                 bool completed = ((ValueTask)vtBoxed).IsCompleted;
@@ -1313,7 +1313,7 @@ namespace System.Threading.Tasks.Tests
 
             // _obj is a Task but other fields are from result construction
             vtBoxed = new ValueTask<int>(42);
-            vtBoxed.GetType().GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, Task.FromResult(42));
+            typeof(ValueTask<int>).GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, Task.FromResult(42));
             Record.Exception(() =>
             {
                 bool completed = ((ValueTask)vtBoxed).IsCompleted;
@@ -1322,7 +1322,7 @@ namespace System.Threading.Tasks.Tests
 
             // _obj is an IValueTaskSource but other fields are from Task construction
             vtBoxed = new ValueTask<int>(Task.FromResult(42));
-            vtBoxed.GetType().GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, ManualResetValueTaskSourceFactory.Completed(42));
+            typeof(ValueTask<int>).GetField("_obj", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(vtBoxed, ManualResetValueTaskSourceFactory.Completed(42));
             Record.Exception(() =>
             {
                 bool completed = ((ValueTask)vtBoxed).IsCompleted;

--- a/src/libraries/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/libraries/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -3,8 +3,6 @@
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <!--Remove once this is fixed, https://github.com/dotnet/runtime/issues/71506 -->
-    <IlcTrimMetadata>false</IlcTrimMetadata>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Helpers.cs" />

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests.cs
@@ -538,13 +538,13 @@ namespace System.Threading.Tasks.Tests
                 var contingentProperties = contingentPropertiesField.GetValue(faultedTask);
                 if (contingentProperties != null)
                 {
-                    var exceptionsHolderField = contingentProperties.GetType().GetField("m_exceptionsHolder", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                    var exceptionsHolderField = typeof(Task).GetNestedType("ContingentProperties", BindingFlags.NonPublic).GetField("m_exceptionsHolder", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
                     if (exceptionsHolderField != null)
                     {
                         holderObject = exceptionsHolderField.GetValue(contingentProperties);
                         if (holderObject != null)
                         {
-                            isHandledField = holderObject.GetType().GetField("m_isHandled", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                            isHandledField = Type.GetType("System.Threading.Tasks.TaskExceptionHolder").GetField("m_isHandled", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
                         }
                     }
                 }


### PR DESCRIPTION
This is basically just making tests trimmable. We want to be testing the shipping configuration without weird switches.

I left IlcTrimMetadata in two test projects because the uses there were too annoying to fix up. For System.Security, the problem is in non-trimmability of the APIs and would need RD.XML/whatever. For Vectors, the problem is in the use of `dynamic` in the tests due to laziness and I'm equally lazy to rewrite all of it.

Fixes #71506.

Cc @dotnet/ilc-contrib 