### PR TITLE
Make it possible to remove DotNetRuntimeDebugHeader

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -328,6 +328,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-o &quot;$(NativeBinary)&quot;" Condition="'$(_targetOS)' != 'win'" />
       <CustomLinkerArg Include="/OUT:&quot;$(NativeBinary)&quot;" Condition="'$(_targetOS)' == 'win'" />
       <CustomLinkerArg Include="/DEF:&quot;$(ExportsFile)&quot;" Condition="'$(_targetOS)' == 'win' and $(ExportsFile) != ''" />
+      <CustomLinkerArg Include="/EXPORT:DotNetRuntimeDebugHeader,DATA" Condition="'$(_targetOS)' == 'win' and '$(DebuggerSupport)' != 'false'" />
       <CustomLinkerArg Include="/LIBPATH:&quot;%(AdditionalNativeLibraryDirectories.Identity)&quot;" Condition="'$(_targetOS)' == 'win' and '@(AdditionalNativeLibraryDirectories->Count())' &gt; 0" />
       <CustomLinkerArg Include="-exported_symbols_list &quot;$(ExportsFile)&quot;" Condition="'$(_IsApplePlatform)' == 'true' and '$(ExportsFile)' != ''" />
       <CustomLinkerArg Include="-exported_symbols_list /dev/null" Condition="'$(OutputType)' == 'exe' and '$(_IsApplePlatform)' == 'true' and '$(ExportsFile)' == ''" />

--- a/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+++ b/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
@@ -107,9 +107,6 @@ struct DotNetRuntimeDebugHeader
     GlobalValueEntry (* volatile GlobalEntries)[GlobalEntriesArraySize] = nullptr;
 };
 
-#ifdef TARGET_WINDOWS
-#pragma comment (linker, "/EXPORT:DotNetRuntimeDebugHeader,DATA")
-#endif
 extern "C" struct DotNetRuntimeDebugHeader DotNetRuntimeDebugHeader;
 struct DotNetRuntimeDebugHeader DotNetRuntimeDebugHeader = {};
 


### PR DESCRIPTION
There's popular demand to be able to remove this export, see these in the past: #79197, dotnet/runtimelab#739

Fixes #90838 by lumping it together with `DebuggerSupport`. It feels like the most natural switch. I didn't go as far as completely removing the data structures because the savings would likely be miniscule (4 kB contribution from the object file per SizeBench).

Cc @dotnet/ilc-contrib 