### PR TITLE
Don't log warnings for certain RemoveAttributeInstances

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -1093,7 +1093,7 @@ namespace ILCompiler
                 string internalValue = GetAttribute(nav, "internal");
                 if (!string.IsNullOrEmpty(internalValue))
                 {
-                    if (!IsRemoveAttributeInstances(internalValue) || !nav.IsEmptyElement)
+                    if (!IsRemoveAttributeInstances(internalValue))
                     {
                         LogWarning(nav, DiagnosticId.UnrecognizedInternalAttribute, internalValue);
                     }


### PR DESCRIPTION
Fixes #88994.

ILLinker attribute XML format has a way to express "only remove these attributes when parameter X has value of Y". We currently generate a warning and don't trim the attribute at all.

The savings from trimming these attributes are going to be miniscule. Even in IL, this is scraping the bottom of the barrel. In Native AOT these attributes are pretty effectively deduplicated across assemblies. We'll likely never need this.

This keeps the existing behavior (don't trim the attribute), but removes the warning.

Cc @dotnet/ilc-contrib 