### PR TITLE
[mono][ios] Call mono_gc_init_finalizer_thread to allow gc thread creation

### DIFF
--- a/src/tasks/AppleAppBuilder/Templates/runtime.m
+++ b/src/tasks/AppleAppBuilder/Templates/runtime.m
@@ -382,10 +382,7 @@ mono_ios_runtime_init (void)
     MonoDomain *domain = mono_jit_init_version ("dotnet.ios", "mobile");
     assert (domain);
 
-#if !FORCE_INTERPRETER && (!TARGET_OS_SIMULATOR || FORCE_AOT)
-    // device runtimes are configured to use lazy gc thread creation
     mono_gc_init_finalizer_thread ();
-#endif
 
     MonoAssembly *assembly = load_assembly (executable, NULL);
     assert (assembly);

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3699,9 +3699,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/Regressions/v2.0-beta1/149926/149926/*">
             <Issue>needs triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/gcdump/**">
-            <Issue>https://github.com/dotnet/runtime/issues/90012</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/CustomAttributes/**">
             <Issue>Dynamic code generation is not supported on this platform</Issue>
         </ExcludeList>


### PR DESCRIPTION
This PR modifies the `runtime.m` Apple template to call the `mono_gc_init_finalizer_thread`. This function enables the creation of the finalizer thread. If the runtime is compiled with the lazy gc thread creation flag, embedders must call this function to initiate the finalizer. Otherwise, the function does nothing and the runtime creates the finalizer thread automatically.

Fixes https://github.com/dotnet/runtime/issues/90012