### PR TITLE
[Mono][WASM][Test] Unblock JIT/SIMD/Vector3Interop_r/Vector3Interop_r.sh

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1216,12 +1216,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/Convert/out_of_range_fp_to_int_conversions/*">
             <Issue>Mono does not define out of range fp to int conversions</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/Vector3Interop_r/*">
-            <Issue>https://github.com/dotnet/runtime/issues/46174</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/Vector3Interop_ro/*">
-            <Issue>https://github.com/dotnet/runtime/issues/46174</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/ShiftOperations/*">
           <Issue>There is a known undefined behavior with shifts and 0xFFFFFFFF overflows, so skip the test for mono.</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/46174.
The test should be passing currently:
```
artifacts/tests/coreclr/linux.x64.Debug/Tests/Core_Root/corerun -p System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=true Vector3Interop_r.dll
...
All RPInvoke testcases passed
Expected: 100
Actual: 100
END EXECUTION - PASSED
```