### PR TITLE
[MT][debugger] Block failing test `MiscTests.TestDebugUsingMultiThreadedRuntime`

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -1164,6 +1164,7 @@ namespace DebuggerTests
         }
 
         [ConditionalFact(nameof(WasmMultiThreaded))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/86496", typeof(DebuggerTests), nameof(DebuggerTests.WasmMultiThreaded))]
         public async Task TestDebugUsingMultiThreadedRuntime()
         {
             var bp = await SetBreakpointInMethod("debugger-test.dll", "MultiThreadedTest", "Write", 2);


### PR DESCRIPTION
Failing recently e.g. on https://github.com/dotnet/runtime/pull/91536.