### PR TITLE
[mono][ios] Disable exceptions unhandled runtime test on apple mobile platforms

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3705,6 +3705,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/CustomAttributes/**">
             <Issue>Dynamic code generation is not supported on this platform</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/baseservices/exceptions/unhandled/unhandled/**">
+            <Issue>System.Diagnostics.Process is not supported</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetArchitecture)' == 'wasm' or '$(TargetsMobile)' == 'true'">

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3705,7 +3705,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/CustomAttributes/**">
             <Issue>Dynamic code generation is not supported on this platform</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/baseservices/exceptions/unhandled/unhandled/**">
+        <ExcludeList Include = "$(XunitTestBinBase)/baseservices/exceptions/unhandled/**">
             <Issue>System.Diagnostics.Process is not supported</Issue>
         </ExcludeList>
     </ItemGroup>


### PR DESCRIPTION
This PR disables unsupported runtime test on apple mobile platforms. More details at https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.start?view=net-7.0.

Fixes https://github.com/dotnet/runtime/issues/91669