### PR TITLE
[CI][Android] Build mono runtime for Android on PRs

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -418,23 +418,6 @@ extends:
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
-      # Build the Mono runtime
-      # Only mono has changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: Debug
-          runtimeFlavor: mono
-          platforms:
-          - android_arm64
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: MonoSubset
-            buildArgs: -s mono -c $(_BuildConfig)
-            condition: >-
-              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true)
-
       # Build the whole product using Mono runtime
       # Only when libraries, mono or installer are changed
       #
@@ -612,6 +595,40 @@ extends:
             - wasi_wasm_win
           extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
           alwaysRun: ${{ variables.isRollingBuild }}
+
+      #
+      # Android devices - Build the Mono runtime and run smoke tests
+      # Only mono has changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+          buildConfig: Release
+          runtimeFlavor: mono
+          platforms:
+          - android_arm
+          - android_arm64
+          variables:
+            # map dependencies variables to local variables
+            - name: librariesContainsChange
+              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+            - name: monoContainsChange
+              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: MonoLibsTests
+            buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:EnableAdditionalTimezoneChecks=true
+            timeoutInMinutes: 480
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true))
+            # extra steps, run tests
+            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+            extraStepsParameters:
+              creator: dotnet-bot
+              testRunNamePrefixSuffix: Mono_$(_BuildConfig)
 
       #
       # iOS/tvOS devices - Full AOT + AggressiveTrimming to reduce size

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -597,8 +597,8 @@ extends:
           alwaysRun: ${{ variables.isRollingBuild }}
 
       #
-      # Android devices - Build the Mono runtime and run smoke tests
-      # Only mono has changed
+      # Android devices
+      # Build the whole product using Mono and run libraries tests
       #
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -617,18 +617,25 @@ extends:
               value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
           jobParameters:
             testGroup: innerloop
-            nameSuffix: MonoLibsTests
-            buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:EnableAdditionalTimezoneChecks=true
+            nameSuffix: AllSubsets_Mono
+            buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:EnableAdditionalTimezoneChecks=true
             timeoutInMinutes: 480
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true))
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
             # extra steps, run tests
             extraStepsTemplate: /eng/pipelines/libraries/helix.yml
             extraStepsParameters:
               creator: dotnet-bot
               testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+              condition: >-
+                or(
+                eq(variables['librariesContainsChange'], true),
+                eq(variables['monoContainsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
       #
       # iOS/tvOS devices - Full AOT + AggressiveTrimming to reduce size

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -418,6 +418,23 @@ extends:
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
+      # Build the Mono runtime
+      # Only mono has changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: Debug
+          runtimeFlavor: mono
+          platforms:
+          - android_arm64
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: MonoSubset
+            buildArgs: -s mono -c $(_BuildConfig)
+            condition: >-
+              eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true)
+
       # Build the whole product using Mono runtime
       # Only when libraries, mono or installer are changed
       #


### PR DESCRIPTION
This PR looks to readd a CI lane to test the Android devices runtime build and test smoke tests. The lane was originally removed to a separate pipeline that eventually became optional, and therefore not ran on PRs with relevant changes.