### PR TITLE
ARM64: Enable jumptable to BT optimization

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1150,6 +1150,10 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
 bool Lowering::TryLowerSwitchToBitTest(
     BasicBlock* jumpTable[], unsigned jumpCount, unsigned targetCount, BasicBlock* bbSwitch, GenTree* switchValue)
 {
+#if !defined(TARGET_XARCH) && !defined(TARGET_ARM64)
+    // Other architectures may use this if they support either GT_BT or GT_TEST
+    return false;
+#else
     assert(jumpCount >= 2);
     assert(targetCount >= 2);
     assert(bbSwitch->bbJumpKind == BBJ_SWITCH);
@@ -1291,6 +1295,7 @@ bool Lowering::TryLowerSwitchToBitTest(
 #endif // !TARGET_XARCH
 
     return true;
+#endif // !TARGET_XARCH && !TARGET_ARM64
 }
 
 void Lowering::ReplaceArgWithPutArgOrBitcast(GenTree** argSlot, GenTree* putArgOrBitcast)


### PR DESCRIPTION
"jump-table to BT" optimization is currently limited to XARCH only, this PR enables it for ARM64
```cs
int Test(int x)
{
    switch (x)
    {
        case 11:
        case 13:
        case 15:
        case 17:
        case 18:
        case 20:
            return 1;
    }
    return 2;
}
```
```diff
; Method Prog:Test(int):int:this (FullOpts)	
            stp     fp, lr, [sp, #-0x10]!	
            mov     fp, sp	
            sub     w0, w1, #11	
            cmp     w0, #9	
            bhi     G_M9307_IG05	
-           mov     w0, w0	
-           adr     x1, [@RWD00]	
-           ldr     w1, [x1, x0, LSL #2]	
-           adr     x2, [G_M9307_IG02]	
-           add     x1, x1, x2	
-           br      x1	
-G_M9307_IG03:	
+           mov     w1, #725
+           lsr     w0, w1, w0
+           tbz     w0, #0, G_M9307_IG05
            mov     w0, #1	
            ldp     fp, lr, [sp], #0x10	
            ret     lr	
G_M9307_IG05:	
            mov     w0, #2	
            ldp     fp, lr, [sp], #0x10	
            ret     lr	
-RWD00  dd 00000024h ; case G_M9307_IG03	
-       dd 00000030h ; case G_M9307_IG05	
-       dd 00000024h ; case G_M9307_IG03	
-       dd 00000030h ; case G_M9307_IG05	
-       dd 00000024h ; case G_M9307_IG03	
-       dd 00000030h ; case G_M9307_IG05	
-       dd 00000024h ; case G_M9307_IG03	
-       dd 00000024h ; case G_M9307_IG03	
-       dd 00000030h ; case G_M9307_IG05	
-       dd 00000024h ; case G_M9307_IG03	
-; Total bytes of code: 68
+; Total bytes of code: 56
```