### PR TITLE
[mono] Unaligned read/write only when NO_UNALIGNED_ACCESS is set

### DIFF
--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -556,7 +556,10 @@ MONO_RESTORE_WARNING
 		t = mini_get_underlying_type (t);
 		if (cfg->gshared && t != ctx->method_inst->type_argv [0] && MONO_TYPE_ISSTRUCT (t) && mono_class_check_context_used (mono_class_from_mono_type_internal (t)))
 			cfg->prefer_instances = TRUE;
-		return mini_emit_memory_load (cfg, t, args [0], 0, MONO_INST_UNALIGNED);
+			
+		int align;
+		int esize = mono_type_size (t, &align);
+		return mini_emit_memory_load (cfg, t, args [0], 0, ((guintptr)&(args [0]->dreg) % align == 0) ? 0 : MONO_INST_UNALIGNED);
 	} else if (!strcmp (cmethod->name, "WriteUnaligned")) {
 		g_assert (ctx);
 		g_assert (ctx->method_inst);

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -556,10 +556,7 @@ MONO_RESTORE_WARNING
 		t = mini_get_underlying_type (t);
 		if (cfg->gshared && t != ctx->method_inst->type_argv [0] && MONO_TYPE_ISSTRUCT (t) && mono_class_check_context_used (mono_class_from_mono_type_internal (t)))
 			cfg->prefer_instances = TRUE;
-			
-		int align;
-		int esize = mono_type_size (t, &align);
-		return mini_emit_memory_load (cfg, t, args [0], 0, ((guintptr)&(args [0]->dreg) % align == 0) ? 0 : MONO_INST_UNALIGNED);
+		return mini_emit_memory_load (cfg, t, args [0], 0, MONO_INST_UNALIGNED);
 	} else if (!strcmp (cmethod->name, "WriteUnaligned")) {
 		g_assert (ctx);
 		g_assert (ctx->method_inst);

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -558,7 +558,7 @@ MONO_RESTORE_WARNING
 			cfg->prefer_instances = TRUE;
 			
 		int align;
-		int esize = mono_type_size (t, &align);
+		mono_type_size (t, &align);
 		return mini_emit_memory_load (cfg, t, args [0], 0, ((guintptr)&(args [0]->dreg) % align == 0) ? 0 : MONO_INST_UNALIGNED);
 	} else if (!strcmp (cmethod->name, "WriteUnaligned")) {
 		g_assert (ctx);

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -556,12 +556,7 @@ MONO_RESTORE_WARNING
 		t = mini_get_underlying_type (t);
 		if (cfg->gshared && t != ctx->method_inst->type_argv [0] && MONO_TYPE_ISSTRUCT (t) && mono_class_check_context_used (mono_class_from_mono_type_internal (t)))
 			cfg->prefer_instances = TRUE;
-
-		#ifdef NO_UNALIGNED_ACCESS
-			return mini_emit_memory_load (cfg, t, args [0], 0, MONO_INST_UNALIGNED);
-		#else
-			return mini_emit_memory_load (cfg, t, args [0], 0, 0);
-		#endif
+		return mini_emit_memory_load (cfg, t, args [0], 0, MONO_INST_UNALIGNED);
 	} else if (!strcmp (cmethod->name, "WriteUnaligned")) {
 		g_assert (ctx);
 		g_assert (ctx->method_inst);

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -558,7 +558,7 @@ MONO_RESTORE_WARNING
 			cfg->prefer_instances = TRUE;
 			
 		int align;
-		mono_type_size (t, &align);
+		int esize = mono_type_size (t, &align);
 		return mini_emit_memory_load (cfg, t, args [0], 0, ((guintptr)&(args [0]->dreg) % align == 0) ? 0 : MONO_INST_UNALIGNED);
 	} else if (!strcmp (cmethod->name, "WriteUnaligned")) {
 		g_assert (ctx);

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -556,7 +556,12 @@ MONO_RESTORE_WARNING
 		t = mini_get_underlying_type (t);
 		if (cfg->gshared && t != ctx->method_inst->type_argv [0] && MONO_TYPE_ISSTRUCT (t) && mono_class_check_context_used (mono_class_from_mono_type_internal (t)))
 			cfg->prefer_instances = TRUE;
-		return mini_emit_memory_load (cfg, t, args [0], 0, MONO_INST_UNALIGNED);
+
+		#ifdef NO_UNALIGNED_ACCESS
+			return mini_emit_memory_load (cfg, t, args [0], 0, MONO_INST_UNALIGNED);
+		#else
+			return mini_emit_memory_load (cfg, t, args [0], 0, 0);
+		#endif
 	} else if (!strcmp (cmethod->name, "WriteUnaligned")) {
 		g_assert (ctx);
 		g_assert (ctx->method_inst);


### PR DESCRIPTION
Using unaligned read code path only when `NO_UNALIGNED_ACCESS` is set. Otherwise emit regular memory load (`EMIT_NEW_LOAD_MEMBASE_TYPE`) without using `memcpy`.


Edit: Increased the scope of the change to both load/store operations. When CPU supports unaligned memory access (`NO_UNALIGNED_ACCESS` is not set) we let CPU handle the unaligned load/store operation rather than handling it ourselves.

---

Locally confirmed that it fixes `Perf_Matrix3x2.CreateRotation*` benchmarks (https://github.com/dotnet/runtime/issues/91361)