### PR TITLE
JIT: Optimize JitStressOnly

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9352,7 +9352,7 @@ public:
     // State information - which phases have completed?
     // These are kept together for easy discoverability
 
-    bool    bRangeAllowStress;
+    bool    compAllowStress;
     bool    compCodeGenDone;
     int64_t compNumStatementLinksTraversed; // # of links traversed while doing debug checks
     bool    fgNormalizeEHDone;              // Has the flowgraph EH normalization phase been done?


### PR DESCRIPTION
Calling `MethodSet::contains` on every invocation to `compStressCompile` is very expensive since it requires multiple JIT-EE calls to print the full method name. This merges the logic with the existing cached bool.

I was seeing 5 second tests running in 50+ seconds with a moderately long `JitStressOnly` method set before this change.