### PR TITLE
Converge Representations between NativeAOT and CoreCLR

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -491,7 +491,7 @@ namespace System.Runtime.CompilerServices
         private const uint enum_flag_NonTrivialInterfaceCast = 0x00080000 // enum_flag_Category_Array
                                                              | 0x40000000 // enum_flag_ComObject
                                                              | 0x00400000 // enum_flag_ICastable;
-                                                             | 0x00200000 // enum_flag_IDynamicInterfaceCastable;
+                                                             | 0x10000000 // enum_flag_IDynamicInterfaceCastable;
                                                              | 0x00040000; // enum_flag_Category_ValueType
 
         private const int DebugClassNamePtr = // adjust for debug_m_szClassName

--- a/src/coreclr/gc/env/gcenv.object.h
+++ b/src/coreclr/gc/env/gcenv.object.h
@@ -46,15 +46,15 @@ public:
 
 static_assert(sizeof(ObjHeader) == sizeof(uintptr_t), "this assumption is made by the VM!");
 
-#define MTFlag_RequireAlign8            0x00001000
-#define MTFlag_Category_ValueType       0x00040000
-#define MTFlag_Category_ValueType_Mask  0x000C0000
-#define MTFlag_ContainsPointers         0x01000000
-#define MTFlag_HasCriticalFinalizer     0x00000002
-#define MTFlag_HasFinalizer             0x00100000
-#define MTFlag_IsArray                  0x00080000
-#define MTFlag_Collectible              0x00200000
-#define MTFlag_HasComponentSize         0x80000000
+#define MTFlag_RequiresAlign8           0x00001000 // enum_flag_RequiresAlign8
+#define MTFlag_Category_ValueType       0x00040000 // enum_flag_Category_ValueType
+#define MTFlag_Category_ValueType_Mask  0x000C0000 // enum_flag_Category_ValueType_Mask
+#define MTFlag_ContainsPointers         0x01000000 // enum_flag_ContainsPointers
+#define MTFlag_HasCriticalFinalizer     0x00000002 // enum_flag_HasCriticalFinalizer
+#define MTFlag_HasFinalizer             0x00100000 // enum_flag_HasFinalizer
+#define MTFlag_IsArray                  0x00080000 // enum_flag_Category_Array
+#define MTFlag_Collectible              0x00200000 // enum_flag_Collectible
+#define MTFlag_HasComponentSize         0x80000000 // enum_flag_HasComponentSize
 
 class MethodTable
 {
@@ -112,7 +112,7 @@ public:
 
     bool RequiresAlign8()
     {
-        return (m_flags & MTFlag_RequireAlign8) != 0;
+        return (m_flags & MTFlag_RequiresAlign8) != 0;
     }
 
     bool IsValueType()
@@ -147,7 +147,7 @@ public:
             return (m_flags & Old_MTFlag_HasCriticalFinalizer) != 0;
         }
 #endif
-        return (m_flags & MTFlag_HasCriticalFinalizer) && !HasComponentSize();
+        return !HasComponentSize() && (m_flags & MTFlag_HasCriticalFinalizer);
     }
 
     bool SanityCheck()

--- a/src/coreclr/gc/env/gcenv.object.h
+++ b/src/coreclr/gc/env/gcenv.object.h
@@ -127,7 +127,12 @@ public:
 
     bool HasCriticalFinalizer()
     {
+#ifdef FEATURE_NATIVEAOT
+        const int HasCriticalFinalizerFlag = 0x0002;
+        return (m_flags & HasCriticalFinalizerFlag) && !HasComponentSize();
+#else
         return (m_flags & MTFlag_HasCriticalFinalizer) != 0;
+#endif
     }
 
     bool IsArray()

--- a/src/coreclr/gc/gccommon.cpp
+++ b/src/coreclr/gc/gccommon.cpp
@@ -19,6 +19,7 @@ IGCHandleManager* g_theGCHandleManager;
 #ifdef BUILD_AS_STANDALONE
 IGCToCLR* g_theGCToCLR;
 VersionInfo g_runtimeSupportedVersion;
+bool g_oldMethodTableFlags;
 #endif // BUILD_AS_STANDALONE
 
 #ifdef GC_CONFIG_DRIVEN

--- a/src/coreclr/gc/gcenv.ee.standalone.inl
+++ b/src/coreclr/gc/gcenv.ee.standalone.inl
@@ -14,7 +14,7 @@ extern IGCToCLR* g_theGCToCLR;
 // GC version that the current runtime supports
 extern VersionInfo g_runtimeSupportedVersion;
 
-// Does the runtime use the new method table flags
+// Does the runtime use the old method table flags
 extern bool g_oldMethodTableFlags;
 
 struct StressLogMsg;

--- a/src/coreclr/gc/gcenv.ee.standalone.inl
+++ b/src/coreclr/gc/gcenv.ee.standalone.inl
@@ -14,6 +14,9 @@ extern IGCToCLR* g_theGCToCLR;
 // GC version that the current runtime supports
 extern VersionInfo g_runtimeSupportedVersion;
 
+// Does the runtime use the new method table flags
+extern bool g_oldMethodTableFlags;
+
 struct StressLogMsg;
 
 // When we are building the GC in a standalone environment, we

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -15,7 +15,7 @@
 
 // The major version of the IGCToCLR interface. Breaking changes to this interface
 // require bumps in the major version number.
-#define EE_INTERFACE_MAJOR_VERSION 1
+#define EE_INTERFACE_MAJOR_VERSION 2
 
 struct ScanContext;
 struct gc_alloc_context;

--- a/src/coreclr/gc/gcload.cpp
+++ b/src/coreclr/gc/gcload.cpp
@@ -51,6 +51,7 @@ GC_VersionInfo(/* InOut */ VersionInfo* info)
     // For example, GC would only call functions on g_theGCToCLR interface that the runtime
     // supports.
     g_runtimeSupportedVersion = *info;
+    g_oldMethodTableFlags = g_runtimeSupportedVersion.MajorVersion < 2;
 #endif
     info->MajorVersion = GC_INTERFACE_MAJOR_VERSION;
     info->MinorVersion = GC_INTERFACE_MINOR_VERSION;

--- a/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+++ b/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
@@ -77,7 +77,7 @@ struct DotNetRuntimeDebugHeader
     // This counter can be incremented to indicate breaking changes
     // This field must be encoded little endian, regardless of the typical endianness of
     // the machine
-    const uint16_t MajorVersion = 3;
+    const uint16_t MajorVersion = 4;
 
     // This counter can be incremented to indicate back-compatible changes
     // This field must be encoded little endian, regardless of the typical endianness of
@@ -269,7 +269,6 @@ extern "C" void PopulateDebugHeaders()
 
     static_assert(MethodTable::Flags::EETypeKindMask         == 0x00030000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
     static_assert(MethodTable::Flags::HasFinalizerFlag       == 0x00100000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
-    // TODO, andrewau, bump version number, testing
     static_assert(MethodTable::Flags::HasPointersFlag        == 0x01000000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
     static_assert(MethodTable::Flags::GenericVarianceFlag    == 0x00800000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
     static_assert(MethodTable::Flags::IsGenericFlag          == 0x02000000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");

--- a/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+++ b/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
@@ -269,7 +269,8 @@ extern "C" void PopulateDebugHeaders()
 
     static_assert(MethodTable::Flags::EETypeKindMask         == 0x00030000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
     static_assert(MethodTable::Flags::HasFinalizerFlag       == 0x00100000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
-    static_assert(MethodTable::Flags::HasPointersFlag        == 0x00200000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
+    // TODO, andrewau, bump version number, testing
+    static_assert(MethodTable::Flags::HasPointersFlag        == 0x01000000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
     static_assert(MethodTable::Flags::GenericVarianceFlag    == 0x00800000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
     static_assert(MethodTable::Flags::IsGenericFlag          == 0x02000000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");
     static_assert(MethodTable::Flags::ElementTypeMask        == 0x7C000000, "The debugging data contract has a hard coded dependency on this value of MethodTable::Flags. If you change this value you must bump major_version_number.");

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -131,6 +131,9 @@ private:
         // simplified version of MethodTable. See LimitedEEType definition below.
         EETypeKindMask = 0x00030000,
 
+        // This type has optional fields present.
+        OptionalFieldsFlag      = 0x00040000,
+
         // GC depends on this bit, this bit must be zero
         CollectibleFlag         = 0x00200000,
 
@@ -145,9 +148,6 @@ private:
         // This type is generic and one or more of it's type parameters is co- or contra-variant. This only
         // applies to interface and delegate types.
         GenericVarianceFlag     = 0x00800000,
-
-        // This type has optional fields present.
-        OptionalFieldsFlag      = 0x00040000,
 
         // This type is generic.
         IsGenericFlag           = 0x02000000,

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -131,14 +131,15 @@ private:
         // simplified version of MethodTable. See LimitedEEType definition below.
         EETypeKindMask = 0x00030000,
 
-        // Unused = 0x00040000,
+        // GC depends on this bit, this bit must be zero
+        CollectibleFlag         = 0x00200000,
 
         IsDynamicTypeFlag       = 0x00080000,
 
-        // This MethodTable represents a type which requires finalization
+        // GC depends on this bit, this type requires finalization
         HasFinalizerFlag        = 0x00100000,
 
-        // This type contain gc pointers
+        // GC depends on this bit, this type contain gc pointers
         HasPointersFlag         = 0x01000000,
 
         // This type is generic and one or more of it's type parameters is co- or contra-variant. This only
@@ -146,7 +147,7 @@ private:
         GenericVarianceFlag     = 0x00800000,
 
         // This type has optional fields present.
-        OptionalFieldsFlag      = 0x00200000,
+        OptionalFieldsFlag      = 0x00040000,
 
         // This type is generic.
         IsGenericFlag           = 0x02000000,
@@ -162,6 +163,7 @@ private:
     enum ExtendedFlags
     {
         HasEagerFinalizerFlag = 0x0001,
+        // GC depends on this bit, this type has a critical finalizer
         HasCriticalFinalizerFlag = 0x0002,
         IsTrackedReferenceWithFinalizerFlag = 0x0004,
     };

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -139,14 +139,14 @@ private:
         HasFinalizerFlag        = 0x00100000,
 
         // This type contain gc pointers
-        HasPointersFlag         = 0x00200000,
+        HasPointersFlag         = 0x01000000,
 
         // This type is generic and one or more of it's type parameters is co- or contra-variant. This only
         // applies to interface and delegate types.
         GenericVarianceFlag     = 0x00800000,
 
         // This type has optional fields present.
-        OptionalFieldsFlag      = 0x01000000,
+        OptionalFieldsFlag      = 0x00200000,
 
         // This type is generic.
         IsGenericFlag           = 0x02000000,

--- a/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
@@ -32,9 +32,9 @@ namespace Internal.Runtime
         HasFinalizerFlag = 0x00100000,
 
         /// <summary>
-        /// This type contain GC pointers.
+        /// This type has optional fields present.
         /// </summary>
-        HasPointersFlag = 0x01000000,
+        OptionalFieldsFlag = 0x00200000,
 
         /// <summary>
         /// This MethodTable has sealed vtable entries
@@ -48,9 +48,9 @@ namespace Internal.Runtime
         GenericVarianceFlag = 0x00800000,
 
         /// <summary>
-        /// This type has optional fields present.
+        /// This type contain GC pointers.
         /// </summary>
-        OptionalFieldsFlag = 0x00200000,
+        HasPointersFlag = 0x01000000,
 
         /// <summary>
         /// This type is generic.

--- a/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
@@ -34,7 +34,7 @@ namespace Internal.Runtime
         /// <summary>
         /// This type contain GC pointers.
         /// </summary>
-        HasPointersFlag = 0x00200000,
+        HasPointersFlag = 0x01000000,
 
         /// <summary>
         /// This MethodTable has sealed vtable entries
@@ -50,7 +50,7 @@ namespace Internal.Runtime
         /// <summary>
         /// This type has optional fields present.
         /// </summary>
-        OptionalFieldsFlag = 0x01000000,
+        OptionalFieldsFlag = 0x00200000,
 
         /// <summary>
         /// This type is generic.

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -3292,15 +3292,15 @@ private:
         // apply to Strings / Arrays.
 
         enum_flag_UNUSED_ComponentSize_1    = 0x00000001,
-
-        enum_flag_StaticsMask               = 0x00002004,
+        // GC depends on this bit
+        enum_flag_HasCriticalFinalizer      = 0x00000002, // finalizer must be run on Appdomain Unload
+        enum_flag_StaticsMask               = 0x0000000C,
         enum_flag_StaticsMask_NonDynamic    = 0x00000000,
-        enum_flag_StaticsMask_Dynamic       = 0x00002000,   // dynamic statics (EnC, reflection.emit)
+        enum_flag_StaticsMask_Dynamic       = 0x00000008,   // dynamic statics (EnC, reflection.emit)
         enum_flag_StaticsMask_Generics      = 0x00000004,   // generics statics
-        enum_flag_StaticsMask_CrossModuleGenerics       = 0x00002004, // cross module generics statics (NGen)
-        enum_flag_StaticsMask_IfGenericsThenCrossModule = 0x00002000, // helper constant to get rid of unnecessary check
+        enum_flag_StaticsMask_CrossModuleGenerics       = 0x0000000C, // cross module generics statics (NGen)
+        enum_flag_StaticsMask_IfGenericsThenCrossModule = 0x00000008, // helper constant to get rid of unnecessary check
 
-        enum_flag_NotInPZM                  = 0x00000008,   // True if this type is not in its PreferredZapModule
 
         enum_flag_GenericsMask              = 0x00000030,
         enum_flag_GenericsMask_NonGeneric   = 0x00000000,   // no instantiation
@@ -3329,6 +3329,8 @@ private:
 
         enum_flag_IsByRefLike               = 0x00001000,
 
+        enum_flag_NotInPZM                  = 0x00002000,   // True if this type is not in its PreferredZapModule
+
         // In a perfect world we would fill these flags using other flags that we already have
         // which have a constant value for something which has a component size.
         enum_flag_UNUSED_ComponentSize_6    = 0x00004000,
@@ -3342,8 +3344,8 @@ private:
         // As you change the flags in WFLAGS_LOW_ENUM you also need to change this
         // to be up to date to reflect the default values of those flags for the
         // case where this MethodTable is for a String or Array
-        // TODO, AndrewAu, this looks important, do it!
-        enum_flag_StringArrayValues = SET_TRUE(enum_flag_StaticsMask_NonDynamic) |
+        enum_flag_StringArrayValues = SET_FALSE(enum_flag_HasCriticalFinalizer) |
+                                      SET_TRUE(enum_flag_StaticsMask_NonDynamic) |
                                       SET_FALSE(enum_flag_NotInPZM) |
                                       SET_TRUE(enum_flag_GenericsMask_NonGeneric) |
                                       SET_FALSE(enum_flag_HasVariance) |
@@ -3403,9 +3405,6 @@ private:
 
         enum_flag_IsTrackedReferenceWithFinalizer   = 0x04000000,
 
-        // TODO, andrewau, move fields to reflect value changes
-        // GC depends on this bit
-        enum_flag_HasCriticalFinalizer        = 0x00000002, // finalizer must be run on Appdomain Unload
         // GC depends on this bit
         enum_flag_Collectible                 = 0x00200000,
         enum_flag_ContainsGenericVariables    = 0x20000000,   // we cache this flag to help detect these efficiently and

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -3342,6 +3342,7 @@ private:
         // As you change the flags in WFLAGS_LOW_ENUM you also need to change this
         // to be up to date to reflect the default values of those flags for the
         // case where this MethodTable is for a String or Array
+        // TODO, AndrewAu, this looks important, do it!
         enum_flag_StringArrayValues = SET_TRUE(enum_flag_StaticsMask_NonDynamic) |
                                       SET_FALSE(enum_flag_NotInPZM) |
                                       SET_TRUE(enum_flag_GenericsMask_NonGeneric) |
@@ -3387,9 +3388,10 @@ private:
         enum_flag_Category_ElementTypeMask  = 0x000E0000, // bits that matter for element type mask
 
 
+        // GC depends on this bit
         enum_flag_HasFinalizer                = 0x00100000, // instances require finalization
 
-        enum_flag_IDynamicInterfaceCastable   = 0x00200000, // class implements IDynamicInterfaceCastable interface
+        enum_flag_IDynamicInterfaceCastable   = 0x10000000, // class implements IDynamicInterfaceCastable interface
 
         enum_flag_ICastable                   = 0x00400000, // class implements ICastable interface
 
@@ -3401,8 +3403,11 @@ private:
 
         enum_flag_IsTrackedReferenceWithFinalizer   = 0x04000000,
 
+        // TODO, andrewau, move fields to reflect value changes
+        // GC depends on this bit
         enum_flag_HasCriticalFinalizer        = 0x00000002, // finalizer must be run on Appdomain Unload
-        enum_flag_Collectible                 = 0x10000000,
+        // GC depends on this bit
+        enum_flag_Collectible                 = 0x00200000,
         enum_flag_ContainsGenericVariables    = 0x20000000,   // we cache this flag to help detect these efficiently and
                                                               // to detect this condition when restoring
 

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -2246,6 +2246,7 @@ public:
     void SetHasCriticalFinalizer()
     {
         LIMITED_METHOD_CONTRACT;
+        _ASSERTE(!HasComponentSize());
         SetFlag(enum_flag_HasCriticalFinalizer);
     }
     // Does this class have non-trivial finalization requirements?
@@ -2259,7 +2260,7 @@ public:
     DWORD HasCriticalFinalizer() const
     {
         LIMITED_METHOD_CONTRACT;
-        return GetFlag(enum_flag_HasCriticalFinalizer);
+        return !HasComponentSize() && GetFlag(enum_flag_HasCriticalFinalizer);
     }
 
     //-------------------------------------------------------------------
@@ -3292,12 +3293,12 @@ private:
 
         enum_flag_UNUSED_ComponentSize_1    = 0x00000001,
 
-        enum_flag_StaticsMask               = 0x00000006,
+        enum_flag_StaticsMask               = 0x00002004,
         enum_flag_StaticsMask_NonDynamic    = 0x00000000,
-        enum_flag_StaticsMask_Dynamic       = 0x00000002,   // dynamic statics (EnC, reflection.emit)
+        enum_flag_StaticsMask_Dynamic       = 0x00002000,   // dynamic statics (EnC, reflection.emit)
         enum_flag_StaticsMask_Generics      = 0x00000004,   // generics statics
-        enum_flag_StaticsMask_CrossModuleGenerics       = 0x00000006, // cross module generics statics (NGen)
-        enum_flag_StaticsMask_IfGenericsThenCrossModule = 0x00000002, // helper constant to get rid of unnecessary check
+        enum_flag_StaticsMask_CrossModuleGenerics       = 0x00002004, // cross module generics statics (NGen)
+        enum_flag_StaticsMask_IfGenericsThenCrossModule = 0x00002000, // helper constant to get rid of unnecessary check
 
         enum_flag_NotInPZM                  = 0x00000008,   // True if this type is not in its PreferredZapModule
 
@@ -3330,7 +3331,6 @@ private:
 
         // In a perfect world we would fill these flags using other flags that we already have
         // which have a constant value for something which has a component size.
-        enum_flag_UNUSED_ComponentSize_5    = 0x00002000,
         enum_flag_UNUSED_ComponentSize_6    = 0x00004000,
         enum_flag_UNUSED_ComponentSize_7    = 0x00008000,
 
@@ -3401,7 +3401,7 @@ private:
 
         enum_flag_IsTrackedReferenceWithFinalizer   = 0x04000000,
 
-        enum_flag_HasCriticalFinalizer        = 0x08000000, // finalizer must be run on Appdomain Unload
+        enum_flag_HasCriticalFinalizer        = 0x00000002, // finalizer must be run on Appdomain Unload
         enum_flag_Collectible                 = 0x10000000,
         enum_flag_ContainsGenericVariables    = 0x20000000,   // we cache this flag to help detect these efficiently and
                                                               // to detect this condition when restoring


### PR DESCRIPTION
To facilitate the work to produce a standalone GC for NativeAOT as in https://github.com/dotnet/runtime/pull/91038, I am making this PR to make the GC view of the runtime look more closely to each other. The eventual goal is to avoid special casing in the GC for NativeAOT as much as possible.

This is a work in progress - checked in the list below means either there is no difference, or the difference is understood and handled so that it is okay.

> With this change, I am able to use a standard release mode clrgc on NativeAOT and it appears to work for BasicMinimalApi

Here is an analysis of how NativeAOT and CoreCLR differ based on analyzing `gcenv.object.h` [here](https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/env/gcenv.object.h):

> Caveat: This analysis is based on reading code only, it maybe not be complete and extra differences might be found by more testing.

- [x] Both NativeAOT and CoreCLR use the `ObjHeader` to represent `BIT_SBLK_GC_RESERVE` and `BIT_SBLK_FINALIZER_RUN` in the same way.

The method table bits:
- [x] NativeAOT never use the `MTFlag_RequireAlign8`, `MTFlag_Category_ValueType_Mask`, `MTFlag_Category_ValueType` flag in the GC (*)
- [x] NativeAOT and CoreCLR use a different bit for `MTFlag_ContainsPointers`, and this change fixed it by moving the NativeAOT bit so that it is the same as the CoreCLR one. 
- [x] NativeAOT and CoreCLR use a different bit for `MTFlag_HasCriticalFinalizer`, and this change fixed it by moving the CoreCLR bit so that it is the same as the NativeAOT one. Care is taken to make sure `clrgc` is still backward compatible with older `coreclr` before the move.  
- [x] NativeAOT and CoreCLR use the same bit for `MTFlag_HasFinalizer` and `MTFlag_HasComponentSize`
- [ ] NativeAOT does not use a bit to determine if it is an array or value type.
- [x] NativeAOT doesn't have collectible types, and this change fixed it by having a reserved bit that is always zero for NativeAOT, also changed CoreCLR so they use the same bit for Collectible.

The method table methods:
- [x] InitializeFreeObject, incorrectly used the `MTFlag_IsArray` flag for NativeAOT, only used for GCSample, okay.
- [x] GetBaseSize, okay
- [x] RawGetComponentSize, okay
- [x] Collectible, fixed by changing bits, okay.
- [x] ContainsPointers, okay
- [x] ContainsPointersOrCollectible, okay
- [x] RequiresAlign8, not called for NativeAOT, okay
- [x] IsValueType, not called for NativeAOT, okay
- [x] HasComponentSize, okay
- [x] HasFinalizer, okay
- [x] HasCriticalFinalizer, okay
- [x] IsArray, deleted, okay
- [x] GetParent, deleted, okay
- [x] SanityCheck, okay

(*) As of the current code, `pMT->RequiresAlign8()` and `pMT->IsValueType()` is used only in validation, and it is ifdef out by NativeAOT. 