### PR TITLE
JIT: Fix case where we illegally optimize away a memory barrier on ARM32

### DIFF
--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -4848,6 +4848,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
 
     dispIns(id);
     appendToCurIG(id);
+    emitLastMemBarrier = nullptr; // Cannot optimize away future memory barriers
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -8908,6 +8908,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
 
     dispIns(id);
     appendToCurIG(id);
+    emitLastMemBarrier = nullptr; // Cannot optimize away future memory barriers
 }
 
 /*****************************************************************************


### PR DESCRIPTION
The ARM32/ARM64 backends have an optimization where they optimize out the latter of two subsequent memory barriers if no memory store/load has been seen between them. This optimization did not take calls into account, allowing the removal of a memory barrier even if a call (with potential memory operations) had happened since the last one.

Fix #91732

The problem happened in `ConcurrentQueueSegment<LargeStruct>.TryEnqueue` in this code:

https://github.com/dotnet/runtime/blob/e0a81708fd4f7f57ad85c3d4cffcc3752e5d4046/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentQueueSegment.cs#L293-L300

The block copy was turned into a helper call to `CORINFO_HELP_MEMCPY`. Then the JIT effectively turned the `Volatile.Write` into a plain write without any memory barrier. The diff with this PR is:

```diff
@@ -1,42 +1,42 @@
 G_M50486_IG05:  ;; offset=0x0042
 ldr     r6, [r4+0x94]
 dmb     15
 ldr     r0, [r4+0x0C]
 and     r7, r0, r6
 ldr     r0, [r5+0x04]
 cmp     r7, r0
 bhs     SHORT G_M50486_IG07
 movs    r0, 72
 mul     r0, r7, r0
 adds    r0, 8
 ldr     r0, [r5+r0]
 dmb     15
 sub     r8, r0, r6
 cmp     r8, 0
 bne     SHORT G_M50486_IG06
 add     r0, r4, 148
 adds    r1, r6, 1
 mov     r2, r6
 movw    r3, 0x221
 movt    r3, 0xf732
 blx     r3		// System.Threading.Interlocked:CompareExchange(byref,int,int):int
 cmp     r0, r6
 bne     SHORT G_M50486_IG05
 movs    r2, 72
 mul     r2, r7, r2
 adds    r2, 8
 adds    r2, r5, r2
 add     r0, r2, 8
 add     r1, sp, 40
 movs    r2, 64
 movw    r12, 0x565f
 movt    r12, 0xf749
 blx     r12		// CORINFO_HELP_MEMCPY
 movs    r0, 72
 mul     r0, r7, r0
 adds    r0, 8
 adds    r3, r6, 1
+dmb     15
 str     r3, [r5+r0]
 movs    r0, 1
 b       SHORT G_M50486_IG03
```