### PR TITLE
The IConfiguration.GetSection method will not return null, call the IConfigurationSection.Exists extension method to determine.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Configuration/src/LoggerFilterConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Configuration/src/LoggerFilterConfigureOptions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.Logging
                 else
                 {
                     IConfigurationSection logLevelSection = configurationSection.GetSection(LogLevelKey);
-                    if (logLevelSection?.Exists())
+                    if (logLevelSection != null && logLevelSection.Exists())
                     {
                         // Load logger specific rules
                         string logger = configurationSection.Key;

--- a/src/libraries/Microsoft.Extensions.Logging.Configuration/src/LoggerFilterConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Configuration/src/LoggerFilterConfigureOptions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.Logging
                 else
                 {
                     IConfigurationSection logLevelSection = configurationSection.GetSection(LogLevelKey);
-                    if (logLevelSection != null)
+                    if (logLevelSection?.Exists())
                     {
                         // Load logger specific rules
                         string logger = configurationSection.Key;


### PR DESCRIPTION
The implementation type of IConfiguration always returns a ConfigurationSection instance in the implementation of the GetSection method, regardless of whether the configuration section exists or not.

Should the IConfigurationSection.Exists extension method be called here to determine whether the configuration section exists？