### PR TITLE
[browser] [wasm] Remove manual ThrowIfCancellationRequested from ReadAsync response streaming

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -550,8 +550,6 @@ namespace System.Net.Http
         {
             ArgumentNullException.ThrowIfNull(buffer, nameof(buffer));
             _fetchResponse.ThrowIfDisposed();
-            cancellationToken.ThrowIfCancellationRequested();
-
 #if FEATURE_WASM_THREADS
             return await _fetchResponse.FetchResponse!.SynchronizationContext.Send(() => Impl(this, buffer, cancellationToken)).ConfigureAwait(true);
 #else


### PR DESCRIPTION
While working on #91699 I noticed that there was one manual call to `ThrowIfCancellationRequested` in `ReadAsync` when doing response streaming, which means that this cancellation token does not go through the `CancelationHelper` which means that this won't abort the actual fetch request.

It normally shouldn't be an issue because developers are supposed to dispose the `HttpResponseMessage` / `Stream` which both would abort the fetch request.

With this PR `ReadAsync` would also abort the fetch request:
```c#
var request = new HttpRequestMessage(HttpMethod.Get, "https://someurl");
request.SetBrowserResponseStreamingEnabled(true);

var response = await new HttpClient().SendAsync(request, HttpCompletionOption.ResponseHeadersRead); // no using / dispose
var stream = await response.Content.ReadAsStreamAsync(); // no using / dispose
await stream.ReadAsync(Array.Emtpy<byte>(), new CancellationToken(true)); // now aborts fetch!
```

---

All other methods which could have called `ThrowIfCancellationRequested` also didn't and correctly go through `CancelationHelper`.

https://github.com/dotnet/runtime/blob/d859279d1c43ab9e0a8907e181d1037d5ba47f67/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs#L455
https://github.com/dotnet/runtime/blob/d859279d1c43ab9e0a8907e181d1037d5ba47f67/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs#L504

