### PR TITLE
[release/8.0] JIT: DNER multiregs with SIMD12

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7484,6 +7484,28 @@ bool Lowering::CheckMultiRegLclVar(GenTreeLclVar* lclNode, int registerCount)
             if (registerCount == varDsc->lvFieldCnt)
             {
                 canEnregisterAsMultiReg = true;
+
+#ifdef FEATURE_SIMD
+                // TYP_SIMD12 breaks the above invariant that "we won't have
+                // matching reg and field counts"; for example, consider
+                //
+                // * STORE_LCL_VAR<struct{Vector3, int}>(CALL)
+                // * RETURN(LCL_VAR<struct{Vector3, int}>)
+                //
+                // These return in two GPR registers, while the fields of the
+                // local are stored in SIMD and GPR register, so registerCount
+                // == varDsc->lvFieldCnt == 2. But the backend cannot handle
+                // this.
+
+                for (int i = 0; i < varDsc->lvFieldCnt; i++)
+                {
+                    if (comp->lvaGetDesc(varDsc->lvFieldLclStart + i)->TypeGet() == TYP_SIMD12)
+                    {
+                        canEnregisterAsMultiReg = false;
+                        break;
+                    }
+                }
+#endif
             }
         }
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91062/Runtime_91062.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91062/Runtime_91062.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.aa
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91170/Runtime_91170.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91170/Runtime_91170.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.aa
+// The .NET Foundation licenses this file to you under the MIT license.
 
 // Found by Antigen
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91214/Runtime_91214.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91214/Runtime_91214.cs
@@ -16,25 +16,25 @@ public class Runtime_91214
         Method0();
     }
 
-    public struct S
+    struct S
     {
         public Vector3 v3;
         public bool b;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static S Method2()
+    static S Method2()
     {
         return default;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void Method0()
+    static void Method0()
     {
         S s = Method2();
         Log(null, s.v3);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void Log(object a, object b) { }
+    static void Log(object a, object b) { }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91214/Runtime_91214.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91214/Runtime_91214.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Found by Antigen
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Numerics;
+using Xunit;
+
+public class Runtime_91214
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Method0();
+    }
+
+    public struct S
+    {
+        public Vector3 v3;
+        public bool b;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static S Method2()
+    {
+        return default;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Method0()
+    {
+        S s = Method2();
+        Log(null, s.v3);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Log(object a, object b) { }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91214/Runtime_91214.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91214/Runtime_91214.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #91674 to release/8.0

## Customer Impact
The JIT will incorrectly handle structs of size 16 that contain `Vector3` on Unix x64 ABIs and on ARM64. Bad codegen or JIT crashes can happen when these structs are returned from functions or are passed to them.

## Testing
Regression test included.

## Risk
Low. Fall back to more conservative treatment in the affected cases.