### PR TITLE
JIT: Fix illegal operand swapping in VectorXYZ.AndNot transformation

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11028,7 +11028,16 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
                 }
             }
 
-            if (lhs == nullptr || rhs == nullptr)
+            if ((lhs == nullptr) || (rhs == nullptr))
+            {
+                break;
+            }
+
+            // Filter out side effecting cases for several reasons:
+            // 1. gtNewSimdBinOpNode may swap operand order.
+            // 2. The code above will swap operand order.
+            // 3. The code above does not handle GTF_REVERSE_OPS.
+            if (((lhs->gtFlags | rhs->gtFlags) & GTF_ALL_EFFECT) != 0)
             {
                 break;
             }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91855/Runtime_91855.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91855/Runtime_91855.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.aa
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Runitme_91855
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Throws<DivideByZeroException>(() => Foo(null, 0));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<uint> Foo(C c, uint val)
+    {
+        return Vector128.Create<uint>(100u / val) & (c.V ^ Vector128<uint>.AllBitsSet);
+    }
+
+    private class C
+    {
+        public Vector128<uint> V;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91855/Runtime_91855.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91855/Runtime_91855.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The new logic introduced in #81993 would swap the LHS and RHS of the
operands without any additional checks for side effects.

Fix #91855