### PR TITLE
Fix SearchValues<string>.Contains issue if one value is a prefix of all the others

### DIFF
--- a/src/libraries/System.Memory/tests/Span/StringSearchValues.cs
+++ b/src/libraries/System.Memory/tests/Span/StringSearchValues.cs
@@ -27,6 +27,7 @@ namespace System.Memory.Tests.Span
         [InlineData(StringComparison.OrdinalIgnoreCase, "a")]
         [InlineData(StringComparison.OrdinalIgnoreCase, "A")]
         [InlineData(StringComparison.OrdinalIgnoreCase, "A", "a")]
+        [InlineData(StringComparison.OrdinalIgnoreCase, "Ab", "Abc")]
         [InlineData(StringComparison.OrdinalIgnoreCase, "a", "Ab", "abc", "bC")]
         public static void Values_ImplementsSearchValuesBase(StringComparison comparisonType, params string[] values)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/StringSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/StringSearchValues.cs
@@ -311,23 +311,23 @@ namespace System.Buffers
             {
                 if (!ignoreCase)
                 {
-                    return new SingleStringSearchValuesThreeChars<CaseSensitive>(value);
+                    return new SingleStringSearchValuesThreeChars<CaseSensitive>(uniqueValues, value);
                 }
 
                 if (asciiLettersOnly)
                 {
-                    return new SingleStringSearchValuesThreeChars<CaseInsensitiveAsciiLetters>(value);
+                    return new SingleStringSearchValuesThreeChars<CaseInsensitiveAsciiLetters>(uniqueValues, value);
                 }
 
                 if (allAscii)
                 {
-                    return new SingleStringSearchValuesThreeChars<CaseInsensitiveAscii>(value);
+                    return new SingleStringSearchValuesThreeChars<CaseInsensitiveAscii>(uniqueValues, value);
                 }
 
                 // When ignoring casing, all anchor chars we search for must be ASCII.
                 if (char.IsAscii(value[0]) && value.AsSpan().LastIndexOfAnyInRange((char)0, (char)127) > 0)
                 {
-                    return new SingleStringSearchValuesThreeChars<CaseInsensitiveUnicode>(value);
+                    return new SingleStringSearchValuesThreeChars<CaseInsensitiveUnicode>(uniqueValues, value);
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/StringSearchValuesBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/StringSearchValuesBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Buffers
 {
@@ -14,16 +15,25 @@ namespace System.Buffers
     /// </summary>
     internal abstract class StringSearchValuesBase : SearchValues<string>
     {
-        private readonly HashSet<string> _uniqueValues;
+        private readonly HashSet<string>? _uniqueValues;
 
-        public StringSearchValuesBase(HashSet<string> uniqueValues) =>
+        /// <summary>
+        /// This exists to allow <see cref="SingleStringSearchValuesThreeChars{TCaseSensitivity}"/> to avoid the HashSet allocation.
+        /// </summary>
+        protected bool HasUniqueValues => _uniqueValues is not null;
+
+        public StringSearchValuesBase(HashSet<string>? uniqueValues) =>
             _uniqueValues = uniqueValues;
 
-        internal sealed override bool ContainsCore(string value) =>
-            _uniqueValues.Contains(value);
-
-        internal sealed override string[] GetValues()
+        internal override bool ContainsCore(string value)
         {
+            Debug.Assert(_uniqueValues is not null, "ContainsCore should be overridden if uniqueValues weren't provided.");
+            return _uniqueValues.Contains(value);
+        }
+
+        internal override string[] GetValues()
+        {
+            Debug.Assert(_uniqueValues is not null, "GetValues should be overridden if uniqueValues weren't provided.");
             string[] values = new string[_uniqueValues.Count];
             _uniqueValues.CopyTo(values);
             return values;
@@ -46,7 +56,7 @@ namespace System.Buffers
         {
             for (int i = 0; i < span.Length; i++)
             {
-                if (TNegator.NegateIfNeeded(_uniqueValues.Contains(span[i])))
+                if (TNegator.NegateIfNeeded(ContainsCore(span[i])))
                 {
                     return i;
                 }
@@ -60,7 +70,7 @@ namespace System.Buffers
         {
             for (int i = span.Length - 1; i >= 0; i--)
             {
-                if (TNegator.NegateIfNeeded(_uniqueValues.Contains(span[i])))
+                if (TNegator.NegateIfNeeded(ContainsCore(span[i])))
                 {
                     return i;
                 }


### PR DESCRIPTION
We remove values that are suffixes of other values when constructing a `SearchValues<string>` instance.
If we're left with just one value, we'll use the single-value implementation, but we weren't accounting for values that may have been removed, and `ContainsCore` would return a false negative for such values.