### PR TITLE
#ifdef out code that requires FEATURE_EVENT_TRACE

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -10056,7 +10056,9 @@ void gc_heap::update_ro_segment (heap_segment* seg, uint8_t* allocated, uint8_t*
 {
     enter_spin_lock (&gc_heap::gc_lock);
 
+#ifdef FEATURE_EVENT_TRACE
     assert (use_frozen_segments_p);
+#endif // FEATURE_EVENT_TRACE
     assert (heap_segment_read_only_p (seg));
     assert (allocated <= committed);
     assert (committed <= heap_segment_reserved (seg));

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -10056,9 +10056,6 @@ void gc_heap::update_ro_segment (heap_segment* seg, uint8_t* allocated, uint8_t*
 {
     enter_spin_lock (&gc_heap::gc_lock);
 
-#ifdef FEATURE_EVENT_TRACE
-    assert (use_frozen_segments_p);
-#endif // FEATURE_EVENT_TRACE
     assert (heap_segment_read_only_p (seg));
     assert (allocated <= committed);
     assert (committed <= heap_segment_reserved (seg));

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -749,10 +749,12 @@ void GCToEEInterface::DiagGCEnd(size_t index, int gen, int reason, bool fConcurr
     UNREFERENCED_PARAMETER(gen);
     UNREFERENCED_PARAMETER(reason);
 
+#ifdef FEATURE_EVENT_TRACE
     if (!fConcurrent)
     {
         ETW::GCLog::WalkHeap();
     }
+#endif // FEATURE_EVENT_TRACE
 }
 
 // Note on last parameter: when calling this for bgc, only ETW


### PR DESCRIPTION
This PR follows #90847 and removes some more code when FEATURE_EVENT_TRACE is not defined.  Surfaced as part of https://github.com/dotnet/runtimelab/pull/2396

Not sure about the `gcrhenv.cpp` change.  Maybe I should be removing all the `DiagGC*` methods and `#ifdef`ing their usages ?

cc @EgorBo 

Thanks