### PR TITLE
Make src gen for property setters consistent with reflection

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/ConfigurationBinder.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                             EmitCheckForNullArgument_WithBlankLine(Identifier.instance, voidReturn: true);
                             _writer.WriteLine($$"""
                                 var {{Identifier.typedObj}} = ({{type.EffectiveType.DisplayString}}){{Identifier.instance}};
-                                {{nameof(MethodsToGen_CoreBindingHelper.BindCore)}}({{configExpression}}, ref {{Identifier.typedObj}}, false, {{binderOptionsArg}});
+                                {{nameof(MethodsToGen_CoreBindingHelper.BindCore)}}({{configExpression}}, ref {{Identifier.typedObj}}, defaultValueIfNotFound: false, {{binderOptionsArg}});
                                 """);
                         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/ConfigurationBinder.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                             EmitCheckForNullArgument_WithBlankLine(Identifier.instance, voidReturn: true);
                             _writer.WriteLine($$"""
                                 var {{Identifier.typedObj}} = ({{type.EffectiveType.DisplayString}}){{Identifier.instance}};
-                                {{nameof(MethodsToGen_CoreBindingHelper.BindCore)}}({{configExpression}}, ref {{Identifier.typedObj}}, {{binderOptionsArg}});
+                                {{nameof(MethodsToGen_CoreBindingHelper.BindCore)}}({{configExpression}}, ref {{Identifier.typedObj}}, false, {{binderOptionsArg}});
                                 """);
                         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 }
                 else
                 {
-                    EmitBindCoreImplForObject((ObjectSpec)effectiveType, ValueDefaulting.None);
+                    EmitBindCoreImplForObject((ObjectSpec)effectiveType);
                 }
 
                 EmitEndBlock();
@@ -384,8 +384,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         parsedMemberAssignmentLhsExpr,
                         sectionPathExpr: GetSectionPathFromConfigurationExpression(configKeyName),
                         canSet: true,
-                        firstTimeInitialization: true,
-                        ValueDefaulting.None);
+                        firstTimeInitialization: true);
 
                     if (canBindToMember)
                     {
@@ -767,7 +766,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 EmitEndBlock();
             }
 
-            private void EmitBindCoreImplForObject(ObjectSpec type, ValueDefaulting valueDefaulting)
+            private void EmitBindCoreImplForObject(ObjectSpec type)
             {
                 Debug.Assert(type.HasBindableMembers);
 
@@ -786,8 +785,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                             memberAccessExpr: $"{containingTypeRef}.{property.Name}",
                             GetSectionPathFromConfigurationExpression(property.ConfigurationKeyName),
                             canSet: property.CanSet,
-                            firstTimeInitialization: false,
-                            valueDefaulting);
+                            firstTimeInitialization: false);
                     }
                 }
             }
@@ -797,8 +795,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 string memberAccessExpr,
                 string sectionPathExpr,
                 bool canSet,
-                bool firstTimeInitialization,
-                ValueDefaulting valueDefaulting)
+                bool firstTimeInitialization)
             {
                 TypeSpec effectiveMemberType = member.Type.EffectiveType;
 
@@ -845,7 +842,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
                             EmitBlankLineIfRequired();
                             EmitStartBlock($"if ({sectionValidationCall} is {Identifier.IConfigurationSection} {sectionIdentifier})");
-                            EmitBindingLogicForComplexMember(member, memberAccessExpr, sectionIdentifier, canSet, valueDefaulting);
+                            EmitBindingLogicForComplexMember(member, memberAccessExpr, sectionIdentifier, canSet);
                             EmitEndBlock();
 
                             return complexType.CanInstantiate;
@@ -859,8 +856,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 MemberSpec member,
                 string memberAccessExpr,
                 string configArgExpr,
-                bool canSet,
-                ValueDefaulting valueDefaulting)
+                bool canSet)
             {
 
                 TypeSpec memberType = member.Type;
@@ -923,7 +919,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     targetObjAccessExpr,
                     configArgExpr,
                     initKind,
-                    valueDefaulting,
+                    ValueDefaulting.None,
                     writeOnSuccess
                     );
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
@@ -807,7 +807,6 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         {
                             if (canSet)
                             {
-                                string nullBangExpr = member.Type.IsValueType ? string.Empty : "!";
                                 bool useDefaultValueIfSectionValueIsNull = !firstTimeInitialization &&
                                     member is PropertySpec &&
                                     member.Type.IsValueType &&
@@ -818,7 +817,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                                     stringParsableType,
                                     $@"{Identifier.configuration}[""{member.ConfigurationKeyName}""]",
                                     sectionPathExpr,
-                                    writeOnSuccess: parsedValueExpr => _writer.WriteLine($"{memberAccessExpr} = {parsedValueExpr}{nullBangExpr};"),
+                                    writeOnSuccess: parsedValueExpr => _writer.WriteLine($"{memberAccessExpr} = {parsedValueExpr};"),
                                     checkForNullSectionValue: true,
                                     useDefaultValueIfSectionValueIsNull,
                                     useIncrementalStringValueIdentifier: true);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/Helpers.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             /// The type of defaulting for a property if it does not have a config entry.
             /// This should only be applied for "Get" cases, not "Bind" and is also conditioned
             /// on the source generated for a particular property as to whether it uses this value.
+            /// Note this is different than "InitializationKind.Declaration" since it only applied to
+            /// complex types and not arrays\enumerables.
             /// </summary>
             private enum ValueDefaulting
             {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/Helpers.cs
@@ -24,6 +24,21 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 Declaration = 3,
             }
 
+            /// <summary>
+            /// The type of defaulting for a property if it does not have a config entry.
+            /// This should only be applied for "Get" cases, not "Bind" and is also conditioned
+            /// on the source generated for a particular property as to whether it uses this value.
+            /// </summary>
+            private enum ValueDefaulting
+            {
+                None = 0,
+
+                /// <summary>
+                /// Call the setter with the default value for the property's Type.
+                /// </summary>
+                CallSetter = 1,
+            }
+
             private static class Expression
             {
                 public const string configurationGetSection = "configuration.GetSection";

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Members/MemberSpec.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Members/MemberSpec.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         }
 
         public string Name { get; }
-        public bool ErrorOnFailedBinding { get; protected set; }
         public string DefaultValueExpr { get; protected set; }
 
         public required TypeSpec Type { get; init; }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Members/ParameterSpec.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Members/ParameterSpec.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
+        public bool ErrorOnFailedBinding { get; private set; }
+
         public RefKind RefKind { get; }
 
         public override bool CanGet => false;

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Types/SimpleTypeSpec.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Types/SimpleTypeSpec.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         None = 0,
 
         /// <summary>
-        /// Declared types that can be assigned directly from IConfigurationSection.Value, i.e. string and tyepof(object).
+        /// Declared types that can be assigned directly from IConfigurationSection.Value, i.e. string and typeof(object).
         /// </summary>
         AssignFromSectionValue = 1,
         Enum = 2,

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -444,6 +444,7 @@ namespace Microsoft.Extensions
         {
             private int _otherCode;
             private int _otherCodeNullable;
+            private string _otherCodeString = "default";
             private object _otherCodeNull;
             private Uri _otherCodeUri;
             private ICollection<string> blacklist = new HashSet<string>();
@@ -475,6 +476,12 @@ namespace Microsoft.Extensions
             {
                 get => _otherCodeNullable;
                 set => _otherCodeNullable = !value.HasValue ? 3 : value.Value;
+            }
+
+            public string OtherCodeString
+            {
+                get => _otherCodeString;
+                set => _otherCodeString = value;
             }
 
             public object? OtherCodeNull

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -443,6 +443,9 @@ namespace Microsoft.Extensions
         public class OptionWithCollectionProperties
         {
             private int _otherCode;
+            private int _otherCodeNullable;
+            private object _otherCodeNull;
+            private Uri _otherCodeUri;
             private ICollection<string> blacklist = new HashSet<string>();
 
             public ICollection<string> Blacklist
@@ -460,11 +463,30 @@ namespace Microsoft.Extensions
             // ParsedBlacklist initialized using the setter of Blacklist.
             public ICollection<string> ParsedBlacklist { get; private set; } = new HashSet<string>();
 
-            // This property not having any match in the configuration. Still the setter need to be called during the binding.
+            // This does not have a match in the configuration, however the setter should be called during the binding:
             public int OtherCode
             {
                 get => _otherCode;
                 set => _otherCode = value == 0 ? 2 : value;
+            }
+
+            // These do not have any match in the configuration, and the setters should not be called  during the binding:
+            public int? OtherCodeNullable
+            {
+                get => _otherCodeNullable;
+                set => _otherCodeNullable = !value.HasValue ? 3 : value.Value;
+            }
+
+            public object? OtherCodeNull
+            {
+                get => _otherCodeNull;
+                set => _otherCodeNull = value is null ? 4 : value;
+            }
+
+            public Uri OtherCodeUri
+            {
+                get => _otherCodeUri;
+                set => _otherCodeUri = value is null ? new Uri("hello") : value;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -567,6 +567,47 @@ namespace Microsoft.Extensions
             }
         }
 
+        public struct StructWithNestedStructAndSetterLogic
+        {
+            private string _string;
+            private int _int32;
+
+            public string String
+            {
+                get => _string;
+                // Setter should not be called for missing values.
+                set { _string = string.IsNullOrEmpty(value) ? "Hello" : value; }
+            }
+
+            public int Int32
+            {
+                get => _int32;
+                set { _int32 = value == 0 ? 42 : value; }
+            }
+
+            public Nested NestedStruct;
+            public Nested[] NestedStructs;
+
+            public struct Nested
+            {
+                private string _string;
+                private int _int32;
+
+                public string String
+                {
+                    get => _string;
+                    // Setter should not be called for missing values.
+                    set { _string = string.IsNullOrEmpty(value) ? "Hello2" : value; }
+                }
+
+                public int Int32
+                {
+                    get => _int32;
+                    set { _int32 = value == 0 ? 43 : value; }
+                }
+            }
+        }
+
         public class BaseClassWithVirtualProperty
         {
             private string? PrivateProperty { get; set; }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Extensions
                 set => _otherCode = value == 0 ? 2 : value;
             }
 
-            // These do not have any match in the configuration, and the setters should not be called  during the binding:
+            // These do not have any match in the configuration, and the setters should not be called during the binding:
             public int? OtherCodeNullable
             {
                 get => _otherCodeNullable;
@@ -818,5 +818,27 @@ namespace Microsoft.Extensions
             public ClassWith_DirectlyAssignable_CtorParams(IConfigurationSection mySection, object myObject, string myString) =>
                 (MySection, MyObject, MyString) = (mySection, myObject, myString);
         }
+
+        public class SharedChildInstance_Class
+        {
+            public string? ConnectionString { get; set; }
+        }
+
+        public class ClassThatThrowsOnSetters
+        {
+            private int _myIntProperty;
+
+            public ClassThatThrowsOnSetters()
+            {
+                _myIntProperty = 42;
+            }
+
+            public int MyIntProperty
+            {
+                get => _myIntProperty;
+                set => throw new InvalidOperationException("Not expected");
+            }
+        }
+
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -1723,7 +1723,7 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         }
 
         [Fact]
-        public void EnsureNotCallingThePropertySetterOnBindWhenNoOwningConfig()
+        public void EnsureNotCallingSettersWhenGivenExistingInstanceNotInConfig()
         {
             var builder = new ConfigurationBuilder();
             builder.AddInMemoryCollection(new KeyValuePair<string, string?>[] { });
@@ -1731,7 +1731,7 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
 
             ClassThatThrowsOnSetters instance = new();
 
-            // The setter for MyIntProperty throws.
+            // The setter for MyIntProperty throws, so this verifies that the setter is not called.
             config.GetSection("Dmy").Bind(instance);
             Assert.Equal(42, instance.MyIntProperty);
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -1712,13 +1712,12 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             Assert.Equal(2, options.ParsedBlacklist.Count); // should be initialized when calling the options.Blacklist setter.
 
             Assert.Equal(401, options.HttpStatusCode); // exists in configuration and properly sets the property
-#if BUILDING_SOURCE_GENERATOR_TESTS
-            // Setter not called if there's no matching configuration value.
-            Assert.Equal(0, options.OtherCode);
-#else
-            // doesn't exist in configuration. the setter sets default value '2'
-            Assert.Equal(2, options.OtherCode);
-#endif
+            Assert.Equal(2, options.OtherCode); // doesn't exist in configuration. the setter sets default value '2'
+
+            // These don't exist in configuration and setters are not called.
+            Assert.Equal(0, options.OtherCodeNullable);
+            Assert.Null(options.OtherCodeNull);
+            Assert.Null(options.OtherCodeUri);            
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -1581,6 +1581,52 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         }
 
         [Fact]
+        public void CanBindNestedStructProperties_SetterCalledWithMissingConfigEntry()
+        {
+            ConfigurationBuilder configurationBuilder = new();
+            configurationBuilder.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "dmy", "dmy" },
+            });
+
+            IConfiguration config = configurationBuilder.Build();
+
+            var bound = config.Get<StructWithNestedStructAndSetterLogic>();
+            Assert.Null(bound.String);
+            Assert.Null(bound.NestedStruct.String);
+            Assert.Equal(42, bound.Int32);
+            Assert.Equal(0, bound.NestedStruct.Int32);
+        }
+
+        [Fact]
+        public void CanBindNestedStructProperties_SetterNotCalledWithMissingConfigSection()
+        {
+            ConfigurationBuilder configurationBuilder = new();
+            configurationBuilder.AddInMemoryCollection(new Dictionary<string, string>
+            {
+            });
+
+            IConfiguration config = configurationBuilder.Build();
+
+            var bound = config.Get<StructWithNestedStructAndSetterLogic>();
+            Assert.Null(bound.String);
+            Assert.Null(bound.NestedStruct.String);
+            Assert.Equal(0, bound.Int32);
+            Assert.Equal(0, bound.NestedStruct.Int32);
+        }
+
+        [Fact]
+        public void CanBindNestedStructProperties_SetterCalledWithMissingConfig_Array()
+        {
+            var config = TestHelpers.GetConfigurationFromJsonString(
+                """{"value": [{ }]}""");
+
+            var bound = config.GetSection("value").Get<StructWithNestedStructAndSetterLogic[]>();
+            Assert.Null(bound[0].String);
+            Assert.Equal(0, bound[0].Int32);
+        }
+
+        [Fact]
         public void IgnoresReadOnlyNestedStructProperties()
         {
             ConfigurationBuilder configurationBuilder = new();

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -1604,6 +1604,7 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             ConfigurationBuilder configurationBuilder = new();
             configurationBuilder.AddInMemoryCollection(new Dictionary<string, string>
             {
+                // An empty value will not trigger defaulting.
             });
 
             IConfiguration config = configurationBuilder.Build();
@@ -1764,6 +1765,7 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
 
             // These don't exist in configuration and setters are not called since they are nullable.
             Assert.Equal(0, options.OtherCodeNullable);
+            Assert.Equal("default", options.OtherCodeString);
             Assert.Null(options.OtherCodeNull);
             Assert.Null(options.OtherCodeUri);            
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Collections.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Collections.generated.txt
@@ -169,7 +169,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Program.CustomDictionary<string, int>? temp3 = instance.CustomDictionary;
                 temp3 ??= new Program.CustomDictionary<string, int>();
-                BindCore(section1, ref temp3, true, binderOptions);
+                BindCore(section1, ref temp3, false, binderOptions);
                 instance.CustomDictionary = temp3;
             }
 
@@ -177,7 +177,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Program.CustomList? temp6 = instance.CustomList;
                 temp6 ??= new Program.CustomList();
-                BindCore(section4, ref temp6, true, binderOptions);
+                BindCore(section4, ref temp6, false, binderOptions);
                 instance.CustomList = temp6;
             }
 
@@ -185,7 +185,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 IReadOnlyList<int>? temp9 = instance.IReadOnlyList;
                 temp9 = temp9 is null ? new List<int>() : new List<int>(temp9);
-                BindCore(section7, ref temp9, true, binderOptions);
+                BindCore(section7, ref temp9, false, binderOptions);
                 instance.IReadOnlyList = temp9;
             }
 
@@ -193,7 +193,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 IReadOnlyDictionary<string, int>? temp12 = instance.IReadOnlyDictionary;
                 temp12 = temp12 is null ? new Dictionary<string, int>() : temp12.ToDictionary(pair => pair.Key, pair => pair.Value);
-                BindCore(section10, ref temp12, true, binderOptions);
+                BindCore(section10, ref temp12, false, binderOptions);
                 instance.IReadOnlyDictionary = temp12;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Collections.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Collections.generated.txt
@@ -56,14 +56,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClassWithCustomCollections))
             {
                 var instance = new Program.MyClassWithCustomCollections();
-                BindCore(configuration, ref instance, binderOptions);
+                BindCore(configuration, ref instance, true, binderOptions);
                 return instance;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.CustomDictionary<string, int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.CustomDictionary<string, int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.CustomList instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.CustomList instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -85,7 +85,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -96,7 +96,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref ICollection<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref ICollection<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -107,7 +107,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref IReadOnlyList<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref IReadOnlyList<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             if (instance is not ICollection<int> temp)
             {
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -134,7 +134,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref IDictionary<string, int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref IDictionary<string, int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -145,7 +145,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref IReadOnlyDictionary<string, int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref IReadOnlyDictionary<string, int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             if (instance is not IDictionary<string, int> temp)
             {
@@ -161,7 +161,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClassWithCustomCollections instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClassWithCustomCollections instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClassWithCustomCollections), s_configKeys_ProgramMyClassWithCustomCollections, configuration, binderOptions);
 
@@ -169,7 +169,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Program.CustomDictionary<string, int>? temp3 = instance.CustomDictionary;
                 temp3 ??= new Program.CustomDictionary<string, int>();
-                BindCore(section1, ref temp3, binderOptions);
+                BindCore(section1, ref temp3, true, binderOptions);
                 instance.CustomDictionary = temp3;
             }
 
@@ -177,7 +177,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Program.CustomList? temp6 = instance.CustomList;
                 temp6 ??= new Program.CustomList();
-                BindCore(section4, ref temp6, binderOptions);
+                BindCore(section4, ref temp6, true, binderOptions);
                 instance.CustomList = temp6;
             }
 
@@ -185,7 +185,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 IReadOnlyList<int>? temp9 = instance.IReadOnlyList;
                 temp9 = temp9 is null ? new List<int>() : new List<int>(temp9);
-                BindCore(section7, ref temp9, binderOptions);
+                BindCore(section7, ref temp9, true, binderOptions);
                 instance.IReadOnlyList = temp9;
             }
 
@@ -193,7 +193,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 IReadOnlyDictionary<string, int>? temp12 = instance.IReadOnlyDictionary;
                 temp12 = temp12 is null ? new Dictionary<string, int>() : temp12.ToDictionary(pair => pair.Key, pair => pair.Value);
-                BindCore(section10, ref temp12, binderOptions);
+                BindCore(section10, ref temp12, true, binderOptions);
                 instance.IReadOnlyDictionary = temp12;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Collections.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Collections.generated.txt
@@ -56,7 +56,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClassWithCustomCollections))
             {
                 var instance = new Program.MyClassWithCustomCollections();
-                BindCore(configuration, ref instance, true, binderOptions);
+                BindCore(configuration, ref instance, defaultValueIfNotFound: true, binderOptions);
                 return instance;
             }
 
@@ -169,7 +169,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Program.CustomDictionary<string, int>? temp3 = instance.CustomDictionary;
                 temp3 ??= new Program.CustomDictionary<string, int>();
-                BindCore(section1, ref temp3, false, binderOptions);
+                BindCore(section1, ref temp3, defaultValueIfNotFound: false, binderOptions);
                 instance.CustomDictionary = temp3;
             }
 
@@ -177,7 +177,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Program.CustomList? temp6 = instance.CustomList;
                 temp6 ??= new Program.CustomList();
-                BindCore(section4, ref temp6, false, binderOptions);
+                BindCore(section4, ref temp6, defaultValueIfNotFound: false, binderOptions);
                 instance.CustomList = temp6;
             }
 
@@ -185,7 +185,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 IReadOnlyList<int>? temp9 = instance.IReadOnlyList;
                 temp9 = temp9 is null ? new List<int>() : new List<int>(temp9);
-                BindCore(section7, ref temp9, false, binderOptions);
+                BindCore(section7, ref temp9, defaultValueIfNotFound: false, binderOptions);
                 instance.IReadOnlyList = temp9;
             }
 
@@ -193,7 +193,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 IReadOnlyDictionary<string, int>? temp12 = instance.IReadOnlyDictionary;
                 temp12 = temp12 is null ? new Dictionary<string, int>() : temp12.ToDictionary(pair => pair.Key, pair => pair.Value);
-                BindCore(section10, ref temp12, false, binderOptions);
+                BindCore(section10, ref temp12, defaultValueIfNotFound: false, binderOptions);
                 instance.IReadOnlyDictionary = temp12;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind.generated.txt
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration, ref typedObj, false, binderOptions: null);
+            BindCore(configuration, ref typedObj, defaultValueIfNotFound: false, binderOptions: null);
         }
 
         /// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration, ref typedObj, false, GetBinderOptions(configureOptions));
+            BindCore(configuration, ref typedObj, defaultValueIfNotFound: false, GetBinderOptions(configureOptions));
         }
 
         /// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>
@@ -81,7 +81,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration.GetSection(key), ref typedObj, false, binderOptions: null);
+            BindCore(configuration.GetSection(key), ref typedObj, defaultValueIfNotFound: false, binderOptions: null);
         }
         #endregion IConfiguration extensions.
 
@@ -144,7 +144,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
-                BindCore(section2, ref temp4, false, binderOptions);
+                BindCore(section2, ref temp4, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp4;
             }
 
@@ -152,7 +152,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
-                BindCore(section5, ref temp7, false, binderOptions);
+                BindCore(section5, ref temp7, defaultValueIfNotFound: false, binderOptions);
                 instance.MyDictionary = temp7;
             }
 
@@ -160,7 +160,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
-                BindCore(section8, ref temp10, false, binderOptions);
+                BindCore(section8, ref temp10, defaultValueIfNotFound: false, binderOptions);
                 instance.MyComplexDictionary = temp10;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind.generated.txt
@@ -128,7 +128,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value0)
             {
-                instance.MyString = value0!;
+                instance.MyString = value0;
             }
 
             if (configuration["MyInt"] is string value1)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind.generated.txt
@@ -126,11 +126,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value0)
+            {
+                instance.MyString = value0!;
+            }
 
             if (configuration["MyInt"] is string value1)
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section2)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind.generated.txt
@@ -144,7 +144,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
-                BindCore(section2, ref temp4, true, binderOptions);
+                BindCore(section2, ref temp4, false, binderOptions);
                 instance.MyList = temp4;
             }
 
@@ -152,7 +152,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
-                BindCore(section5, ref temp7, true, binderOptions);
+                BindCore(section5, ref temp7, false, binderOptions);
                 instance.MyDictionary = temp7;
             }
 
@@ -160,7 +160,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
-                BindCore(section8, ref temp10, true, binderOptions);
+                BindCore(section8, ref temp10, false, binderOptions);
                 instance.MyComplexDictionary = temp10;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind.generated.txt
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration, ref typedObj, binderOptions: null);
+            BindCore(configuration, ref typedObj, false, binderOptions: null);
         }
 
         /// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration, ref typedObj, GetBinderOptions(configureOptions));
+            BindCore(configuration, ref typedObj, false, GetBinderOptions(configureOptions));
         }
 
         /// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>
@@ -81,14 +81,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration.GetSection(key), ref typedObj, binderOptions: null);
+            BindCore(configuration.GetSection(key), ref typedObj, false, binderOptions: null);
         }
         #endregion IConfiguration extensions.
 
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList", "MyDictionary", "MyComplexDictionary" });
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -110,7 +110,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -122,7 +122,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -135,7 +135,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -144,7 +144,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
-                BindCore(section2, ref temp4, binderOptions);
+                BindCore(section2, ref temp4, true, binderOptions);
                 instance.MyList = temp4;
             }
 
@@ -152,7 +152,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
-                BindCore(section5, ref temp7, binderOptions);
+                BindCore(section5, ref temp7, true, binderOptions);
                 instance.MyDictionary = temp7;
             }
 
@@ -160,7 +160,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
-                BindCore(section8, ref temp10, binderOptions);
+                BindCore(section8, ref temp10, true, binderOptions);
                 instance.MyComplexDictionary = temp10;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance.generated.txt
@@ -92,7 +92,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value0)
             {
-                instance.MyString = value0!;
+                instance.MyString = value0;
             }
 
             if (configuration["MyInt"] is string value1)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance.generated.txt
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration, ref typedObj, false, binderOptions: null);
+            BindCore(configuration, ref typedObj, defaultValueIfNotFound: false, binderOptions: null);
         }
         #endregion IConfiguration extensions.
 
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
-                BindCore(section2, ref temp4, false, binderOptions);
+                BindCore(section2, ref temp4, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp4;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
-                BindCore(section5, ref temp7, false, binderOptions);
+                BindCore(section5, ref temp7, defaultValueIfNotFound: false, binderOptions);
                 instance.MyDictionary = temp7;
             }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
-                BindCore(section8, ref temp10, false, binderOptions);
+                BindCore(section8, ref temp10, defaultValueIfNotFound: false, binderOptions);
                 instance.MyComplexDictionary = temp10;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance.generated.txt
@@ -45,14 +45,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration, ref typedObj, binderOptions: null);
+            BindCore(configuration, ref typedObj, false, binderOptions: null);
         }
         #endregion IConfiguration extensions.
 
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList", "MyDictionary", "MyComplexDictionary" });
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
-                BindCore(section2, ref temp4, binderOptions);
+                BindCore(section2, ref temp4, true, binderOptions);
                 instance.MyList = temp4;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
-                BindCore(section5, ref temp7, binderOptions);
+                BindCore(section5, ref temp7, true, binderOptions);
                 instance.MyDictionary = temp7;
             }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
-                BindCore(section8, ref temp10, binderOptions);
+                BindCore(section8, ref temp10, true, binderOptions);
                 instance.MyComplexDictionary = temp10;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance.generated.txt
@@ -90,11 +90,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value0)
+            {
+                instance.MyString = value0!;
+            }
 
             if (configuration["MyInt"] is string value1)
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section2)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance.generated.txt
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
-                BindCore(section2, ref temp4, true, binderOptions);
+                BindCore(section2, ref temp4, false, binderOptions);
                 instance.MyList = temp4;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
-                BindCore(section5, ref temp7, true, binderOptions);
+                BindCore(section5, ref temp7, false, binderOptions);
                 instance.MyDictionary = temp7;
             }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
-                BindCore(section8, ref temp10, true, binderOptions);
+                BindCore(section8, ref temp10, false, binderOptions);
                 instance.MyComplexDictionary = temp10;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance_BinderOptions.generated.txt
@@ -92,7 +92,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value0)
             {
-                instance.MyString = value0!;
+                instance.MyString = value0;
             }
 
             if (configuration["MyInt"] is string value1)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance_BinderOptions.generated.txt
@@ -45,14 +45,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration, ref typedObj, GetBinderOptions(configureOptions));
+            BindCore(configuration, ref typedObj, false, GetBinderOptions(configureOptions));
         }
         #endregion IConfiguration extensions.
 
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList", "MyDictionary", "MyComplexDictionary" });
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
-                BindCore(section2, ref temp4, binderOptions);
+                BindCore(section2, ref temp4, true, binderOptions);
                 instance.MyList = temp4;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
-                BindCore(section5, ref temp7, binderOptions);
+                BindCore(section5, ref temp7, true, binderOptions);
                 instance.MyDictionary = temp7;
             }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
-                BindCore(section8, ref temp10, binderOptions);
+                BindCore(section8, ref temp10, true, binderOptions);
                 instance.MyComplexDictionary = temp10;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance_BinderOptions.generated.txt
@@ -90,11 +90,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value0)
+            {
+                instance.MyString = value0!;
+            }
 
             if (configuration["MyInt"] is string value1)
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section2)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance_BinderOptions.generated.txt
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
-                BindCore(section2, ref temp4, true, binderOptions);
+                BindCore(section2, ref temp4, false, binderOptions);
                 instance.MyList = temp4;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
-                BindCore(section5, ref temp7, true, binderOptions);
+                BindCore(section5, ref temp7, false, binderOptions);
                 instance.MyDictionary = temp7;
             }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
-                BindCore(section8, ref temp10, true, binderOptions);
+                BindCore(section8, ref temp10, false, binderOptions);
                 instance.MyComplexDictionary = temp10;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Instance_BinderOptions.generated.txt
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration, ref typedObj, false, GetBinderOptions(configureOptions));
+            BindCore(configuration, ref typedObj, defaultValueIfNotFound: false, GetBinderOptions(configureOptions));
         }
         #endregion IConfiguration extensions.
 
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
-                BindCore(section2, ref temp4, false, binderOptions);
+                BindCore(section2, ref temp4, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp4;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
-                BindCore(section5, ref temp7, false, binderOptions);
+                BindCore(section5, ref temp7, defaultValueIfNotFound: false, binderOptions);
                 instance.MyDictionary = temp7;
             }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
-                BindCore(section8, ref temp10, false, binderOptions);
+                BindCore(section8, ref temp10, defaultValueIfNotFound: false, binderOptions);
                 instance.MyComplexDictionary = temp10;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Key_Instance.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Key_Instance.generated.txt
@@ -92,7 +92,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value0)
             {
-                instance.MyString = value0!;
+                instance.MyString = value0;
             }
 
             if (configuration["MyInt"] is string value1)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Key_Instance.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Key_Instance.generated.txt
@@ -45,14 +45,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration.GetSection(key), ref typedObj, binderOptions: null);
+            BindCore(configuration.GetSection(key), ref typedObj, false, binderOptions: null);
         }
         #endregion IConfiguration extensions.
 
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MyString", "MyInt", "MyList", "MyDictionary", "MyComplexDictionary" });
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, Program.MyClass2> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
-                BindCore(section2, ref temp4, binderOptions);
+                BindCore(section2, ref temp4, true, binderOptions);
                 instance.MyList = temp4;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
-                BindCore(section5, ref temp7, binderOptions);
+                BindCore(section5, ref temp7, true, binderOptions);
                 instance.MyDictionary = temp7;
             }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
-                BindCore(section8, ref temp10, binderOptions);
+                BindCore(section8, ref temp10, true, binderOptions);
                 instance.MyComplexDictionary = temp10;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Key_Instance.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Key_Instance.generated.txt
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration.GetSection(key), ref typedObj, false, binderOptions: null);
+            BindCore(configuration.GetSection(key), ref typedObj, defaultValueIfNotFound: false, binderOptions: null);
         }
         #endregion IConfiguration extensions.
 
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
-                BindCore(section2, ref temp4, false, binderOptions);
+                BindCore(section2, ref temp4, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp4;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
-                BindCore(section5, ref temp7, false, binderOptions);
+                BindCore(section5, ref temp7, defaultValueIfNotFound: false, binderOptions);
                 instance.MyDictionary = temp7;
             }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
-                BindCore(section8, ref temp10, false, binderOptions);
+                BindCore(section8, ref temp10, defaultValueIfNotFound: false, binderOptions);
                 instance.MyComplexDictionary = temp10;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Key_Instance.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Key_Instance.generated.txt
@@ -90,11 +90,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value0)
+            {
+                instance.MyString = value0!;
+            }
 
             if (configuration["MyInt"] is string value1)
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section2)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Key_Instance.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Bind_Key_Instance.generated.txt
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp4 = instance.MyList;
                 temp4 ??= new List<int>();
-                BindCore(section2, ref temp4, true, binderOptions);
+                BindCore(section2, ref temp4, false, binderOptions);
                 instance.MyList = temp4;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp7 = instance.MyDictionary;
                 temp7 ??= new Dictionary<string, string>();
-                BindCore(section5, ref temp7, true, binderOptions);
+                BindCore(section5, ref temp7, false, binderOptions);
                 instance.MyDictionary = temp7;
             }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, Program.MyClass2>? temp10 = instance.MyComplexDictionary;
                 temp10 ??= new Dictionary<string, Program.MyClass2>();
-                BindCore(section8, ref temp10, true, binderOptions);
+                BindCore(section8, ref temp10, false, binderOptions);
                 instance.MyComplexDictionary = temp10;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get.generated.txt
@@ -68,13 +68,13 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var instance = new Program.MyClass();
-                BindCore(configuration, ref instance, true, binderOptions);
+                BindCore(configuration, ref instance, defaultValueIfNotFound: true, binderOptions);
                 return instance;
             }
             else if (type == typeof(Program.MyClass2))
             {
                 var instance = new Program.MyClass2();
-                BindCore(configuration, ref instance, true, binderOptions);
+                BindCore(configuration, ref instance, defaultValueIfNotFound: true, binderOptions);
                 return instance;
             }
 
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         public static void BindCore(IConfiguration configuration, ref int[] instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             var temp2 = new List<int>();
-            BindCore(configuration, ref temp2, false, binderOptions);
+            BindCore(configuration, ref temp2, defaultValueIfNotFound: false, binderOptions);
             int originalCount = instance.Length;
             Array.Resize(ref instance, originalCount + temp2.Count);
             temp2.CopyTo(instance, originalCount);
@@ -134,7 +134,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp8 = instance.MyList;
                 temp8 ??= new List<int>();
-                BindCore(section6, ref temp8, false, binderOptions);
+                BindCore(section6, ref temp8, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp8;
             }
 
@@ -142,7 +142,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 int[]? temp11 = instance.MyArray;
                 temp11 ??= new int[0];
-                BindCore(section9, ref temp11, false, binderOptions);
+                BindCore(section9, ref temp11, defaultValueIfNotFound: false, binderOptions);
                 instance.MyArray = temp11;
             }
 
@@ -150,7 +150,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp14 = instance.MyDictionary;
                 temp14 ??= new Dictionary<string, string>();
-                BindCore(section12, ref temp14, false, binderOptions);
+                BindCore(section12, ref temp14, defaultValueIfNotFound: false, binderOptions);
                 instance.MyDictionary = temp14;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get.generated.txt
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         public static void BindCore(IConfiguration configuration, ref int[] instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             var temp2 = new List<int>();
-            BindCore(configuration, ref temp2, true, binderOptions);
+            BindCore(configuration, ref temp2, false, binderOptions);
             int originalCount = instance.Length;
             Array.Resize(ref instance, originalCount + temp2.Count);
             temp2.CopyTo(instance, originalCount);
@@ -134,7 +134,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp8 = instance.MyList;
                 temp8 ??= new List<int>();
-                BindCore(section6, ref temp8, true, binderOptions);
+                BindCore(section6, ref temp8, false, binderOptions);
                 instance.MyList = temp8;
             }
 
@@ -142,7 +142,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 int[]? temp11 = instance.MyArray;
                 temp11 ??= new int[0];
-                BindCore(section9, ref temp11, true, binderOptions);
+                BindCore(section9, ref temp11, false, binderOptions);
                 instance.MyArray = temp11;
             }
 
@@ -150,7 +150,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp14 = instance.MyDictionary;
                 temp14 ??= new Dictionary<string, string>();
-                BindCore(section12, ref temp14, true, binderOptions);
+                BindCore(section12, ref temp14, false, binderOptions);
                 instance.MyDictionary = temp14;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get.generated.txt
@@ -118,7 +118,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value4)
             {
-                instance.MyString = value4!;
+                instance.MyString = value4;
             }
 
             if (configuration["MyInt"] is string value5)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get.generated.txt
@@ -116,11 +116,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value4)
+            {
+                instance.MyString = value4!;
+            }
 
             if (configuration["MyInt"] is string value5)
             {
                 instance.MyInt = ParseInt(value5, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section6)
@@ -155,6 +162,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (configuration["MyInt"] is string value15)
             {
                 instance.MyInt = ParseInt(value15, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get.generated.txt
@@ -68,20 +68,20 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var instance = new Program.MyClass();
-                BindCore(configuration, ref instance, binderOptions);
+                BindCore(configuration, ref instance, true, binderOptions);
                 return instance;
             }
             else if (type == typeof(Program.MyClass2))
             {
                 var instance = new Program.MyClass2();
-                BindCore(configuration, ref instance, binderOptions);
+                BindCore(configuration, ref instance, true, binderOptions);
                 return instance;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -92,16 +92,16 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref int[] instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref int[] instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             var temp2 = new List<int>();
-            BindCore(configuration, ref temp2, binderOptions);
+            BindCore(configuration, ref temp2, true, binderOptions);
             int originalCount = instance.Length;
             Array.Resize(ref instance, originalCount + temp2.Count);
             temp2.CopyTo(instance, originalCount);
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -112,7 +112,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -125,7 +125,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value5, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -134,7 +134,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp8 = instance.MyList;
                 temp8 ??= new List<int>();
-                BindCore(section6, ref temp8, binderOptions);
+                BindCore(section6, ref temp8, true, binderOptions);
                 instance.MyList = temp8;
             }
 
@@ -142,7 +142,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 int[]? temp11 = instance.MyArray;
                 temp11 ??= new int[0];
-                BindCore(section9, ref temp11, binderOptions);
+                BindCore(section9, ref temp11, true, binderOptions);
                 instance.MyArray = temp11;
             }
 
@@ -150,12 +150,12 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp14 = instance.MyDictionary;
                 temp14 ??= new Dictionary<string, string>();
-                BindCore(section12, ref temp14, binderOptions);
+                BindCore(section12, ref temp14, true, binderOptions);
                 instance.MyDictionary = temp14;
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
@@ -163,7 +163,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value15, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T.generated.txt
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value3)
             {
-                instance.MyString = value3!;
+                instance.MyString = value3;
             }
 
             if (configuration["MyInt"] is string value4)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T.generated.txt
@@ -97,11 +97,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value3)
+            {
+                instance.MyString = value3!;
+            }
 
             if (configuration["MyInt"] is string value4)
             {
                 instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section5)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T.generated.txt
@@ -76,7 +76,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         public static void BindCore(IConfiguration configuration, ref int[] instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             var temp1 = new List<int>();
-            BindCore(configuration, ref temp1, true, binderOptions);
+            BindCore(configuration, ref temp1, false, binderOptions);
             int originalCount = instance.Length;
             Array.Resize(ref instance, originalCount + temp1.Count);
             temp1.CopyTo(instance, originalCount);
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, true, binderOptions);
+                BindCore(section5, ref temp7, false, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 int[]? temp10 = instance.MyArray;
                 temp10 ??= new int[0];
-                BindCore(section8, ref temp10, true, binderOptions);
+                BindCore(section8, ref temp10, false, binderOptions);
                 instance.MyArray = temp10;
             }
 
@@ -131,7 +131,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, true, binderOptions);
+                BindCore(section11, ref temp13, false, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T.generated.txt
@@ -55,14 +55,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var instance = new Program.MyClass();
-                BindCore(configuration, ref instance, binderOptions);
+                BindCore(configuration, ref instance, true, binderOptions);
                 return instance;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -73,16 +73,16 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref int[] instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref int[] instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             var temp1 = new List<int>();
-            BindCore(configuration, ref temp1, binderOptions);
+            BindCore(configuration, ref temp1, true, binderOptions);
             int originalCount = instance.Length;
             Array.Resize(ref instance, originalCount + temp1.Count);
             temp1.CopyTo(instance, originalCount);
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -93,7 +93,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, binderOptions);
+                BindCore(section5, ref temp7, true, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 int[]? temp10 = instance.MyArray;
                 temp10 ??= new int[0];
-                BindCore(section8, ref temp10, binderOptions);
+                BindCore(section8, ref temp10, true, binderOptions);
                 instance.MyArray = temp10;
             }
 
@@ -131,7 +131,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, binderOptions);
+                BindCore(section11, ref temp13, true, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T.generated.txt
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var instance = new Program.MyClass();
-                BindCore(configuration, ref instance, true, binderOptions);
+                BindCore(configuration, ref instance, defaultValueIfNotFound: true, binderOptions);
                 return instance;
             }
 
@@ -76,7 +76,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         public static void BindCore(IConfiguration configuration, ref int[] instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             var temp1 = new List<int>();
-            BindCore(configuration, ref temp1, false, binderOptions);
+            BindCore(configuration, ref temp1, defaultValueIfNotFound: false, binderOptions);
             int originalCount = instance.Length;
             Array.Resize(ref instance, originalCount + temp1.Count);
             temp1.CopyTo(instance, originalCount);
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, false, binderOptions);
+                BindCore(section5, ref temp7, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 int[]? temp10 = instance.MyArray;
                 temp10 ??= new int[0];
-                BindCore(section8, ref temp10, false, binderOptions);
+                BindCore(section8, ref temp10, defaultValueIfNotFound: false, binderOptions);
                 instance.MyArray = temp10;
             }
 
@@ -131,7 +131,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, false, binderOptions);
+                BindCore(section11, ref temp13, defaultValueIfNotFound: false, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T_BinderOptions.generated.txt
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value3)
             {
-                instance.MyString = value3!;
+                instance.MyString = value3;
             }
 
             if (configuration["MyInt"] is string value4)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T_BinderOptions.generated.txt
@@ -97,11 +97,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value3)
+            {
+                instance.MyString = value3!;
+            }
 
             if (configuration["MyInt"] is string value4)
             {
                 instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section5)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T_BinderOptions.generated.txt
@@ -76,7 +76,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         public static void BindCore(IConfiguration configuration, ref int[] instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             var temp1 = new List<int>();
-            BindCore(configuration, ref temp1, true, binderOptions);
+            BindCore(configuration, ref temp1, false, binderOptions);
             int originalCount = instance.Length;
             Array.Resize(ref instance, originalCount + temp1.Count);
             temp1.CopyTo(instance, originalCount);
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, true, binderOptions);
+                BindCore(section5, ref temp7, false, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 int[]? temp10 = instance.MyArray;
                 temp10 ??= new int[0];
-                BindCore(section8, ref temp10, true, binderOptions);
+                BindCore(section8, ref temp10, false, binderOptions);
                 instance.MyArray = temp10;
             }
 
@@ -131,7 +131,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, true, binderOptions);
+                BindCore(section11, ref temp13, false, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T_BinderOptions.generated.txt
@@ -55,14 +55,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var instance = new Program.MyClass();
-                BindCore(configuration, ref instance, binderOptions);
+                BindCore(configuration, ref instance, true, binderOptions);
                 return instance;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -73,16 +73,16 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref int[] instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref int[] instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             var temp1 = new List<int>();
-            BindCore(configuration, ref temp1, binderOptions);
+            BindCore(configuration, ref temp1, true, binderOptions);
             int originalCount = instance.Length;
             Array.Resize(ref instance, originalCount + temp1.Count);
             temp1.CopyTo(instance, originalCount);
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -93,7 +93,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, binderOptions);
+                BindCore(section5, ref temp7, true, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 int[]? temp10 = instance.MyArray;
                 temp10 ??= new int[0];
-                BindCore(section8, ref temp10, binderOptions);
+                BindCore(section8, ref temp10, true, binderOptions);
                 instance.MyArray = temp10;
             }
 
@@ -131,7 +131,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, binderOptions);
+                BindCore(section11, ref temp13, true, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_T_BinderOptions.generated.txt
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var instance = new Program.MyClass();
-                BindCore(configuration, ref instance, true, binderOptions);
+                BindCore(configuration, ref instance, defaultValueIfNotFound: true, binderOptions);
                 return instance;
             }
 
@@ -76,7 +76,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         public static void BindCore(IConfiguration configuration, ref int[] instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             var temp1 = new List<int>();
-            BindCore(configuration, ref temp1, false, binderOptions);
+            BindCore(configuration, ref temp1, defaultValueIfNotFound: false, binderOptions);
             int originalCount = instance.Length;
             Array.Resize(ref instance, originalCount + temp1.Count);
             temp1.CopyTo(instance, originalCount);
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, false, binderOptions);
+                BindCore(section5, ref temp7, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 int[]? temp10 = instance.MyArray;
                 temp10 ??= new int[0];
-                BindCore(section8, ref temp10, false, binderOptions);
+                BindCore(section8, ref temp10, defaultValueIfNotFound: false, binderOptions);
                 instance.MyArray = temp10;
             }
 
@@ -131,7 +131,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, false, binderOptions);
+                BindCore(section11, ref temp13, defaultValueIfNotFound: false, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf.generated.txt
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass2))
             {
                 var instance = new Program.MyClass2();
-                BindCore(configuration, ref instance, true, binderOptions);
+                BindCore(configuration, ref instance, defaultValueIfNotFound: true, binderOptions);
                 return instance;
             }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf.generated.txt
@@ -55,14 +55,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass2))
             {
                 var instance = new Program.MyClass2();
-                BindCore(configuration, ref instance, binderOptions);
+                BindCore(configuration, ref instance, true, binderOptions);
                 return instance;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
@@ -70,7 +70,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf.generated.txt
@@ -70,6 +70,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
+            else
+            {
+                instance.MyInt = default;
+            }
         }
 
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf_BinderOptions.generated.txt
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass2))
             {
                 var instance = new Program.MyClass2();
-                BindCore(configuration, ref instance, true, binderOptions);
+                BindCore(configuration, ref instance, defaultValueIfNotFound: true, binderOptions);
                 return instance;
             }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf_BinderOptions.generated.txt
@@ -55,14 +55,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass2))
             {
                 var instance = new Program.MyClass2();
-                BindCore(configuration, ref instance, binderOptions);
+                BindCore(configuration, ref instance, true, binderOptions);
                 return instance;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
@@ -70,7 +70,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ConfigurationBinder/Get_TypeOf_BinderOptions.generated.txt
@@ -70,6 +70,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
+            else
+            {
+                instance.MyInt = default;
+            }
         }
 
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/EmptyConfigType.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/EmptyConfigType.generated.txt
@@ -51,14 +51,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (TypeWithNoMembers_Wrapper)instance;
-            BindCore(configuration, ref typedObj, binderOptions: null);
+            BindCore(configuration, ref typedObj, false, binderOptions: null);
         }
         #endregion IConfiguration extensions.
 
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_TypeWithNoMembersWrapper = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Member" });
 
-        public static void BindCore(IConfiguration configuration, ref TypeWithNoMembers_Wrapper instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref TypeWithNoMembers_Wrapper instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(TypeWithNoMembers_Wrapper), s_configKeys_TypeWithNoMembersWrapper, configuration, binderOptions);
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/EmptyConfigType.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/EmptyConfigType.generated.txt
@@ -51,7 +51,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (TypeWithNoMembers_Wrapper)instance;
-            BindCore(configuration, ref typedObj, false, binderOptions: null);
+            BindCore(configuration, ref typedObj, defaultValueIfNotFound: false, binderOptions: null);
         }
         #endregion IConfiguration extensions.
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/BindConfiguration.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/BindConfiguration.generated.txt
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, true, binderOptions);
+                BindCore(configuration, ref temp, false, binderOptions);
                 return;
             }
 
@@ -122,7 +122,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp5 = instance.MyList;
                 temp5 ??= new List<int>();
-                BindCore(section3, ref temp5, true, binderOptions);
+                BindCore(section3, ref temp5, false, binderOptions);
                 instance.MyList = temp5;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/BindConfiguration.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/BindConfiguration.generated.txt
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, false, binderOptions);
+                BindCore(configuration, ref temp, defaultValueIfNotFound: false, binderOptions);
                 return;
             }
 
@@ -122,7 +122,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp5 = instance.MyList;
                 temp5 ??= new List<int>();
-                BindCore(section3, ref temp5, false, binderOptions);
+                BindCore(section3, ref temp5, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp5;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/BindConfiguration.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/BindConfiguration.generated.txt
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value1)
             {
-                instance.MyString = value1!;
+                instance.MyString = value1;
             }
 
             if (configuration["MyInt"] is string value2)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/BindConfiguration.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/BindConfiguration.generated.txt
@@ -82,14 +82,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, binderOptions);
+                BindCore(configuration, ref temp, true, binderOptions);
                 return;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -113,7 +113,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value2, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -122,7 +122,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp5 = instance.MyList;
                 temp5 ??= new List<int>();
-                BindCore(section3, ref temp5, binderOptions);
+                BindCore(section3, ref temp5, true, binderOptions);
                 instance.MyList = temp5;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/BindConfiguration.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/BindConfiguration.generated.txt
@@ -104,11 +104,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value1)
+            {
+                instance.MyString = value1!;
+            }
 
             if (configuration["MyInt"] is string value2)
             {
                 instance.MyInt = ParseInt(value2, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section3)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T.generated.txt
@@ -92,7 +92,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, true, binderOptions);
+                BindCore(configuration, ref temp, false, binderOptions);
                 return;
             }
 
@@ -132,7 +132,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp5 = instance.MyList;
                 temp5 ??= new List<int>();
-                BindCore(section3, ref temp5, true, binderOptions);
+                BindCore(section3, ref temp5, false, binderOptions);
                 instance.MyList = temp5;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T.generated.txt
@@ -92,14 +92,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, binderOptions);
+                BindCore(configuration, ref temp, true, binderOptions);
                 return;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -110,7 +110,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value2, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -132,7 +132,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp5 = instance.MyList;
                 temp5 ??= new List<int>();
-                BindCore(section3, ref temp5, binderOptions);
+                BindCore(section3, ref temp5, true, binderOptions);
                 instance.MyList = temp5;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T.generated.txt
@@ -114,11 +114,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value1)
+            {
+                instance.MyString = value1!;
+            }
 
             if (configuration["MyInt"] is string value2)
             {
                 instance.MyInt = ParseInt(value2, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section3)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T.generated.txt
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value1)
             {
-                instance.MyString = value1!;
+                instance.MyString = value1;
             }
 
             if (configuration["MyInt"] is string value2)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T.generated.txt
@@ -92,7 +92,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, false, binderOptions);
+                BindCore(configuration, ref temp, defaultValueIfNotFound: false, binderOptions);
                 return;
             }
 
@@ -132,7 +132,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp5 = instance.MyList;
                 temp5 ??= new List<int>();
-                BindCore(section3, ref temp5, false, binderOptions);
+                BindCore(section3, ref temp5, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp5;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T_BinderOptions.generated.txt
@@ -110,7 +110,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value1)
             {
-                instance.MyString = value1!;
+                instance.MyString = value1;
             }
 
             if (configuration["MyInt"] is string value2)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T_BinderOptions.generated.txt
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, false, binderOptions);
+                BindCore(configuration, ref temp, defaultValueIfNotFound: false, binderOptions);
                 return;
             }
 
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp5 = instance.MyList;
                 temp5 ??= new List<int>();
-                BindCore(section3, ref temp5, false, binderOptions);
+                BindCore(section3, ref temp5, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp5;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T_BinderOptions.generated.txt
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, true, binderOptions);
+                BindCore(configuration, ref temp, false, binderOptions);
                 return;
             }
 
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp5 = instance.MyList;
                 temp5 ??= new List<int>();
-                BindCore(section3, ref temp5, true, binderOptions);
+                BindCore(section3, ref temp5, false, binderOptions);
                 instance.MyList = temp5;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T_BinderOptions.generated.txt
@@ -108,11 +108,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value1)
+            {
+                instance.MyString = value1!;
+            }
 
             if (configuration["MyInt"] is string value2)
             {
                 instance.MyInt = ParseInt(value2, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section3)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/OptionsBuilder/Bind_T_BinderOptions.generated.txt
@@ -86,14 +86,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, binderOptions);
+                BindCore(configuration, ref temp, true, binderOptions);
                 return;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -104,7 +104,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -117,7 +117,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value2, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp5 = instance.MyList;
                 temp5 ??= new List<int>();
-                BindCore(section3, ref temp5, binderOptions);
+                BindCore(section3, ref temp5, true, binderOptions);
                 instance.MyList = temp5;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Primitives.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Primitives.generated.txt
@@ -45,14 +45,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration, ref typedObj, binderOptions: null);
+            BindCore(configuration, ref typedObj, false, binderOptions: null);
         }
         #endregion IConfiguration extensions.
 
         #region Core binding extensions.
         private readonly static Lazy<HashSet<string>> s_configKeys_ProgramMyClass = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Prop0", "Prop1", "Prop2", "Prop3", "Prop4", "Prop5", "Prop6", "Prop8", "Prop9", "Prop10", "Prop13", "Prop14", "Prop15", "Prop16", "Prop17", "Prop19", "Prop20", "Prop21", "Prop23", "Prop24", "Prop25", "Prop26", "Prop27", "Prop7", "Prop11", "Prop12", "Prop18", "Prop22", "Prop28", "Prop29", "Prop30" });
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop0 = ParseBool(value0, () => configuration.GetSection("Prop0").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop0 = default;
             }
@@ -69,7 +69,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop1 = ParseByte(value1, () => configuration.GetSection("Prop1").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop1 = default;
             }
@@ -78,7 +78,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop2 = ParseSbyte(value2, () => configuration.GetSection("Prop2").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop2 = default;
             }
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop3 = ParseChar(value3, () => configuration.GetSection("Prop3").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop3 = default;
             }
@@ -96,7 +96,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop4 = ParseDouble(value4, () => configuration.GetSection("Prop4").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop4 = default;
             }
@@ -110,7 +110,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop6 = ParseInt(value6, () => configuration.GetSection("Prop6").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop6 = default;
             }
@@ -119,7 +119,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop8 = ParseShort(value7, () => configuration.GetSection("Prop8").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop8 = default;
             }
@@ -128,7 +128,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop9 = ParseLong(value8, () => configuration.GetSection("Prop9").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop9 = default;
             }
@@ -137,7 +137,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop10 = ParseFloat(value9, () => configuration.GetSection("Prop10").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop10 = default;
             }
@@ -146,7 +146,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop13 = ParseUshort(value10, () => configuration.GetSection("Prop13").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop13 = default;
             }
@@ -155,7 +155,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop14 = ParseUint(value11, () => configuration.GetSection("Prop14").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop14 = default;
             }
@@ -164,7 +164,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop15 = ParseUlong(value12, () => configuration.GetSection("Prop15").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop15 = default;
             }
@@ -183,7 +183,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop19 = ParseDateTime(value15, () => configuration.GetSection("Prop19").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop19 = default;
             }
@@ -192,7 +192,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop20 = ParseDateTimeOffset(value16, () => configuration.GetSection("Prop20").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop20 = default;
             }
@@ -201,7 +201,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop21 = ParseDecimal(value17, () => configuration.GetSection("Prop21").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop21 = default;
             }
@@ -210,7 +210,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop23 = ParseTimeSpan(value18, () => configuration.GetSection("Prop23").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop23 = default;
             }
@@ -219,7 +219,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop24 = ParseGuid(value19, () => configuration.GetSection("Prop24").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop24 = default;
             }
@@ -238,7 +238,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop27 = ParseEnum<DayOfWeek>(value22, () => configuration.GetSection("Prop27").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop27 = default;
             }
@@ -247,7 +247,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop7 = ParseInt128(value23, () => configuration.GetSection("Prop7").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop7 = default;
             }
@@ -256,7 +256,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop11 = ParseHalf(value24, () => configuration.GetSection("Prop11").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop11 = default;
             }
@@ -265,7 +265,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop12 = ParseUInt128(value25, () => configuration.GetSection("Prop12").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop12 = default;
             }
@@ -274,7 +274,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop18 = ParseDateOnly(value26, () => configuration.GetSection("Prop18").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop18 = default;
             }
@@ -283,7 +283,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop22 = ParseTimeOnly(value27, () => configuration.GetSection("Prop22").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop22 = default;
             }
@@ -297,7 +297,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop29 = ParseInt(value29, () => configuration.GetSection("Prop29").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop29 = default;
             }
@@ -306,7 +306,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop30 = ParseDateTime(value30, () => configuration.GetSection("Prop30").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.Prop30 = default;
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Primitives.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Primitives.generated.txt
@@ -60,149 +60,255 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.Prop0 = ParseBool(value0, () => configuration.GetSection("Prop0").Path);
             }
+            else
+            {
+                instance.Prop0 = default;
+            }
 
             if (configuration["Prop1"] is string value1)
             {
                 instance.Prop1 = ParseByte(value1, () => configuration.GetSection("Prop1").Path);
+            }
+            else
+            {
+                instance.Prop1 = default;
             }
 
             if (configuration["Prop2"] is string value2)
             {
                 instance.Prop2 = ParseSbyte(value2, () => configuration.GetSection("Prop2").Path);
             }
+            else
+            {
+                instance.Prop2 = default;
+            }
 
             if (configuration["Prop3"] is string value3)
             {
                 instance.Prop3 = ParseChar(value3, () => configuration.GetSection("Prop3").Path);
+            }
+            else
+            {
+                instance.Prop3 = default;
             }
 
             if (configuration["Prop4"] is string value4)
             {
                 instance.Prop4 = ParseDouble(value4, () => configuration.GetSection("Prop4").Path);
             }
+            else
+            {
+                instance.Prop4 = default;
+            }
 
-            instance.Prop5 = configuration["Prop5"]!;
+            if (configuration["Prop5"] is string value5)
+            {
+                instance.Prop5 = value5!;
+            }
 
             if (configuration["Prop6"] is string value6)
             {
                 instance.Prop6 = ParseInt(value6, () => configuration.GetSection("Prop6").Path);
+            }
+            else
+            {
+                instance.Prop6 = default;
             }
 
             if (configuration["Prop8"] is string value7)
             {
                 instance.Prop8 = ParseShort(value7, () => configuration.GetSection("Prop8").Path);
             }
+            else
+            {
+                instance.Prop8 = default;
+            }
 
             if (configuration["Prop9"] is string value8)
             {
                 instance.Prop9 = ParseLong(value8, () => configuration.GetSection("Prop9").Path);
+            }
+            else
+            {
+                instance.Prop9 = default;
             }
 
             if (configuration["Prop10"] is string value9)
             {
                 instance.Prop10 = ParseFloat(value9, () => configuration.GetSection("Prop10").Path);
             }
+            else
+            {
+                instance.Prop10 = default;
+            }
 
             if (configuration["Prop13"] is string value10)
             {
                 instance.Prop13 = ParseUshort(value10, () => configuration.GetSection("Prop13").Path);
+            }
+            else
+            {
+                instance.Prop13 = default;
             }
 
             if (configuration["Prop14"] is string value11)
             {
                 instance.Prop14 = ParseUint(value11, () => configuration.GetSection("Prop14").Path);
             }
+            else
+            {
+                instance.Prop14 = default;
+            }
 
             if (configuration["Prop15"] is string value12)
             {
                 instance.Prop15 = ParseUlong(value12, () => configuration.GetSection("Prop15").Path);
             }
+            else
+            {
+                instance.Prop15 = default;
+            }
 
-            instance.Prop16 = configuration["Prop16"]!;
+            if (configuration["Prop16"] is string value13)
+            {
+                instance.Prop16 = value13!;
+            }
 
             if (configuration["Prop17"] is string value14)
             {
-                instance.Prop17 = ParseCultureInfo(value14, () => configuration.GetSection("Prop17").Path);
+                instance.Prop17 = ParseCultureInfo(value14, () => configuration.GetSection("Prop17").Path)!;
             }
 
             if (configuration["Prop19"] is string value15)
             {
                 instance.Prop19 = ParseDateTime(value15, () => configuration.GetSection("Prop19").Path);
             }
+            else
+            {
+                instance.Prop19 = default;
+            }
 
             if (configuration["Prop20"] is string value16)
             {
                 instance.Prop20 = ParseDateTimeOffset(value16, () => configuration.GetSection("Prop20").Path);
+            }
+            else
+            {
+                instance.Prop20 = default;
             }
 
             if (configuration["Prop21"] is string value17)
             {
                 instance.Prop21 = ParseDecimal(value17, () => configuration.GetSection("Prop21").Path);
             }
+            else
+            {
+                instance.Prop21 = default;
+            }
 
             if (configuration["Prop23"] is string value18)
             {
                 instance.Prop23 = ParseTimeSpan(value18, () => configuration.GetSection("Prop23").Path);
+            }
+            else
+            {
+                instance.Prop23 = default;
             }
 
             if (configuration["Prop24"] is string value19)
             {
                 instance.Prop24 = ParseGuid(value19, () => configuration.GetSection("Prop24").Path);
             }
+            else
+            {
+                instance.Prop24 = default;
+            }
 
             if (configuration["Prop25"] is string value20)
             {
-                instance.Prop25 = ParseUri(value20, () => configuration.GetSection("Prop25").Path);
+                instance.Prop25 = ParseUri(value20, () => configuration.GetSection("Prop25").Path)!;
             }
 
             if (configuration["Prop26"] is string value21)
             {
-                instance.Prop26 = ParseVersion(value21, () => configuration.GetSection("Prop26").Path);
+                instance.Prop26 = ParseVersion(value21, () => configuration.GetSection("Prop26").Path)!;
             }
 
             if (configuration["Prop27"] is string value22)
             {
                 instance.Prop27 = ParseEnum<DayOfWeek>(value22, () => configuration.GetSection("Prop27").Path);
             }
+            else
+            {
+                instance.Prop27 = default;
+            }
 
             if (configuration["Prop7"] is string value23)
             {
                 instance.Prop7 = ParseInt128(value23, () => configuration.GetSection("Prop7").Path);
+            }
+            else
+            {
+                instance.Prop7 = default;
             }
 
             if (configuration["Prop11"] is string value24)
             {
                 instance.Prop11 = ParseHalf(value24, () => configuration.GetSection("Prop11").Path);
             }
+            else
+            {
+                instance.Prop11 = default;
+            }
 
             if (configuration["Prop12"] is string value25)
             {
                 instance.Prop12 = ParseUInt128(value25, () => configuration.GetSection("Prop12").Path);
+            }
+            else
+            {
+                instance.Prop12 = default;
             }
 
             if (configuration["Prop18"] is string value26)
             {
                 instance.Prop18 = ParseDateOnly(value26, () => configuration.GetSection("Prop18").Path);
             }
+            else
+            {
+                instance.Prop18 = default;
+            }
 
             if (configuration["Prop22"] is string value27)
             {
                 instance.Prop22 = ParseTimeOnly(value27, () => configuration.GetSection("Prop22").Path);
             }
+            else
+            {
+                instance.Prop22 = default;
+            }
 
             if (configuration["Prop28"] is string value28)
             {
-                instance.Prop28 = ParseByteArray(value28, () => configuration.GetSection("Prop28").Path);
+                instance.Prop28 = ParseByteArray(value28, () => configuration.GetSection("Prop28").Path)!;
             }
 
             if (configuration["Prop29"] is string value29)
             {
                 instance.Prop29 = ParseInt(value29, () => configuration.GetSection("Prop29").Path);
             }
+            else
+            {
+                instance.Prop29 = default;
+            }
 
             if (configuration["Prop30"] is string value30)
             {
                 instance.Prop30 = ParseDateTime(value30, () => configuration.GetSection("Prop30").Path);
+            }
+            else
+            {
+                instance.Prop30 = default;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Primitives.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Primitives.generated.txt
@@ -103,7 +103,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["Prop5"] is string value5)
             {
-                instance.Prop5 = value5!;
+                instance.Prop5 = value5;
             }
 
             if (configuration["Prop6"] is string value6)
@@ -171,12 +171,12 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["Prop16"] is string value13)
             {
-                instance.Prop16 = value13!;
+                instance.Prop16 = value13;
             }
 
             if (configuration["Prop17"] is string value14)
             {
-                instance.Prop17 = ParseCultureInfo(value14, () => configuration.GetSection("Prop17").Path)!;
+                instance.Prop17 = ParseCultureInfo(value14, () => configuration.GetSection("Prop17").Path);
             }
 
             if (configuration["Prop19"] is string value15)
@@ -226,12 +226,12 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["Prop25"] is string value20)
             {
-                instance.Prop25 = ParseUri(value20, () => configuration.GetSection("Prop25").Path)!;
+                instance.Prop25 = ParseUri(value20, () => configuration.GetSection("Prop25").Path);
             }
 
             if (configuration["Prop26"] is string value21)
             {
-                instance.Prop26 = ParseVersion(value21, () => configuration.GetSection("Prop26").Path)!;
+                instance.Prop26 = ParseVersion(value21, () => configuration.GetSection("Prop26").Path);
             }
 
             if (configuration["Prop27"] is string value22)
@@ -290,7 +290,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["Prop28"] is string value28)
             {
-                instance.Prop28 = ParseByteArray(value28, () => configuration.GetSection("Prop28").Path)!;
+                instance.Prop28 = ParseByteArray(value28, () => configuration.GetSection("Prop28").Path);
             }
 
             if (configuration["Prop29"] is string value29)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Primitives.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/Primitives.generated.txt
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
 
             var typedObj = (Program.MyClass)instance;
-            BindCore(configuration, ref typedObj, false, binderOptions: null);
+            BindCore(configuration, ref typedObj, defaultValueIfNotFound: false, binderOptions: null);
         }
         #endregion IConfiguration extensions.
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T.generated.txt
@@ -79,7 +79,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, false, binderOptions);
+                BindCore(configuration, ref temp, defaultValueIfNotFound: false, binderOptions);
                 return;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
-                BindCore(section, ref value, false, binderOptions);
+                BindCore(section, ref value, defaultValueIfNotFound: false, binderOptions);
                 instance.Add(value);
             }
         }
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, false, binderOptions);
+                BindCore(section5, ref temp7, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
-                BindCore(section8, ref temp10, false, binderOptions);
+                BindCore(section8, ref temp10, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList2 = temp10;
             }
 
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, false, binderOptions);
+                BindCore(section11, ref temp13, defaultValueIfNotFound: false, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T.generated.txt
@@ -79,14 +79,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, binderOptions);
+                BindCore(configuration, ref temp, true, binderOptions);
                 return;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -97,7 +97,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
@@ -105,23 +105,23 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
-                BindCore(section, ref value, binderOptions);
+                BindCore(section, ref value, true, binderOptions);
                 instance.Add(value);
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -132,7 +132,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -145,7 +145,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, binderOptions);
+                BindCore(section5, ref temp7, true, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
-                BindCore(section8, ref temp10, binderOptions);
+                BindCore(section8, ref temp10, true, binderOptions);
                 instance.MyList2 = temp10;
             }
 
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, binderOptions);
+                BindCore(section11, ref temp13, true, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T.generated.txt
@@ -138,7 +138,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value3)
             {
-                instance.MyString = value3!;
+                instance.MyString = value3;
             }
 
             if (configuration["MyInt"] is string value4)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T.generated.txt
@@ -79,7 +79,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, true, binderOptions);
+                BindCore(configuration, ref temp, false, binderOptions);
                 return;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
-                BindCore(section, ref value, true, binderOptions);
+                BindCore(section, ref value, false, binderOptions);
                 instance.Add(value);
             }
         }
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, true, binderOptions);
+                BindCore(section5, ref temp7, false, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
-                BindCore(section8, ref temp10, true, binderOptions);
+                BindCore(section8, ref temp10, false, binderOptions);
                 instance.MyList2 = temp10;
             }
 
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, true, binderOptions);
+                BindCore(section11, ref temp13, false, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T.generated.txt
@@ -105,6 +105,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
+            else
+            {
+                instance.MyInt = default;
+            }
         }
 
         public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, BinderOptions? binderOptions)
@@ -132,11 +136,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value3)
+            {
+                instance.MyString = value3!;
+            }
 
             if (configuration["MyInt"] is string value4)
             {
                 instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section5)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_BinderOptions.generated.txt
@@ -79,7 +79,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, false, binderOptions);
+                BindCore(configuration, ref temp, defaultValueIfNotFound: false, binderOptions);
                 return;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
-                BindCore(section, ref value, false, binderOptions);
+                BindCore(section, ref value, defaultValueIfNotFound: false, binderOptions);
                 instance.Add(value);
             }
         }
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, false, binderOptions);
+                BindCore(section5, ref temp7, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
-                BindCore(section8, ref temp10, false, binderOptions);
+                BindCore(section8, ref temp10, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList2 = temp10;
             }
 
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, false, binderOptions);
+                BindCore(section11, ref temp13, defaultValueIfNotFound: false, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_BinderOptions.generated.txt
@@ -79,14 +79,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, binderOptions);
+                BindCore(configuration, ref temp, true, binderOptions);
                 return;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -97,7 +97,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
@@ -105,23 +105,23 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
-                BindCore(section, ref value, binderOptions);
+                BindCore(section, ref value, true, binderOptions);
                 instance.Add(value);
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -132,7 +132,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -145,7 +145,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, binderOptions);
+                BindCore(section5, ref temp7, true, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
-                BindCore(section8, ref temp10, binderOptions);
+                BindCore(section8, ref temp10, true, binderOptions);
                 instance.MyList2 = temp10;
             }
 
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, binderOptions);
+                BindCore(section11, ref temp13, true, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_BinderOptions.generated.txt
@@ -138,7 +138,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value3)
             {
-                instance.MyString = value3!;
+                instance.MyString = value3;
             }
 
             if (configuration["MyInt"] is string value4)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_BinderOptions.generated.txt
@@ -79,7 +79,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, true, binderOptions);
+                BindCore(configuration, ref temp, false, binderOptions);
                 return;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
-                BindCore(section, ref value, true, binderOptions);
+                BindCore(section, ref value, false, binderOptions);
                 instance.Add(value);
             }
         }
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, true, binderOptions);
+                BindCore(section5, ref temp7, false, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
-                BindCore(section8, ref temp10, true, binderOptions);
+                BindCore(section8, ref temp10, false, binderOptions);
                 instance.MyList2 = temp10;
             }
 
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, true, binderOptions);
+                BindCore(section11, ref temp13, false, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_BinderOptions.generated.txt
@@ -105,6 +105,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
+            else
+            {
+                instance.MyInt = default;
+            }
         }
 
         public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, BinderOptions? binderOptions)
@@ -132,11 +136,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value3)
+            {
+                instance.MyString = value3!;
+            }
 
             if (configuration["MyInt"] is string value4)
             {
                 instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section5)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name.generated.txt
@@ -79,7 +79,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, false, binderOptions);
+                BindCore(configuration, ref temp, defaultValueIfNotFound: false, binderOptions);
                 return;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
-                BindCore(section, ref value, false, binderOptions);
+                BindCore(section, ref value, defaultValueIfNotFound: false, binderOptions);
                 instance.Add(value);
             }
         }
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, false, binderOptions);
+                BindCore(section5, ref temp7, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
-                BindCore(section8, ref temp10, false, binderOptions);
+                BindCore(section8, ref temp10, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList2 = temp10;
             }
 
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, false, binderOptions);
+                BindCore(section11, ref temp13, defaultValueIfNotFound: false, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name.generated.txt
@@ -79,14 +79,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, binderOptions);
+                BindCore(configuration, ref temp, true, binderOptions);
                 return;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -97,7 +97,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
@@ -105,23 +105,23 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
-                BindCore(section, ref value, binderOptions);
+                BindCore(section, ref value, true, binderOptions);
                 instance.Add(value);
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -132,7 +132,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -145,7 +145,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, binderOptions);
+                BindCore(section5, ref temp7, true, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
-                BindCore(section8, ref temp10, binderOptions);
+                BindCore(section8, ref temp10, true, binderOptions);
                 instance.MyList2 = temp10;
             }
 
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, binderOptions);
+                BindCore(section11, ref temp13, true, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name.generated.txt
@@ -138,7 +138,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value3)
             {
-                instance.MyString = value3!;
+                instance.MyString = value3;
             }
 
             if (configuration["MyInt"] is string value4)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name.generated.txt
@@ -79,7 +79,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, true, binderOptions);
+                BindCore(configuration, ref temp, false, binderOptions);
                 return;
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
-                BindCore(section, ref value, true, binderOptions);
+                BindCore(section, ref value, false, binderOptions);
                 instance.Add(value);
             }
         }
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, true, binderOptions);
+                BindCore(section5, ref temp7, false, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -162,7 +162,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
-                BindCore(section8, ref temp10, true, binderOptions);
+                BindCore(section8, ref temp10, false, binderOptions);
                 instance.MyList2 = temp10;
             }
 
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, true, binderOptions);
+                BindCore(section11, ref temp13, false, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name.generated.txt
@@ -105,6 +105,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
+            else
+            {
+                instance.MyInt = default;
+            }
         }
 
         public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, BinderOptions? binderOptions)
@@ -132,11 +136,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value3)
+            {
+                instance.MyString = value3!;
+            }
 
             if (configuration["MyInt"] is string value4)
             {
                 instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section5)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
@@ -132,7 +132,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             if (configuration["MyString"] is string value3)
             {
-                instance.MyString = value3!;
+                instance.MyString = value3;
             }
 
             if (configuration["MyInt"] is string value4)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
@@ -73,14 +73,14 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, binderOptions);
+                BindCore(configuration, ref temp, true, binderOptions);
                 return;
             }
 
             throw new NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<int> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<int> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -91,7 +91,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass2 instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass2), s_configKeys_ProgramMyClass2, configuration, binderOptions);
 
@@ -99,23 +99,23 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
-                BindCore(section, ref value, binderOptions);
+                BindCore(section, ref value, true, binderOptions);
                 instance.Add(value);
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Dictionary<string, string> instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
 
-        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, BinderOptions? binderOptions)
+        public static void BindCore(IConfiguration configuration, ref Program.MyClass instance, bool defaultValueIfNotFound, BinderOptions? binderOptions)
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
@@ -139,7 +139,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
             }
-            else
+            else if (defaultValueIfNotFound)
             {
                 instance.MyInt = default;
             }
@@ -148,7 +148,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, binderOptions);
+                BindCore(section5, ref temp7, true, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -156,7 +156,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
-                BindCore(section8, ref temp10, binderOptions);
+                BindCore(section8, ref temp10, true, binderOptions);
                 instance.MyList2 = temp10;
             }
 
@@ -164,7 +164,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, binderOptions);
+                BindCore(section11, ref temp13, true, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
@@ -99,6 +99,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 instance.MyInt = ParseInt(value1, () => configuration.GetSection("MyInt").Path);
             }
+            else
+            {
+                instance.MyInt = default;
+            }
         }
 
         public static void BindCore(IConfiguration configuration, ref List<Program.MyClass2> instance, BinderOptions? binderOptions)
@@ -126,11 +130,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             ValidateConfigurationKeys(typeof(Program.MyClass), s_configKeys_ProgramMyClass, configuration, binderOptions);
 
-            instance.MyString = configuration["MyString"]!;
+            if (configuration["MyString"] is string value3)
+            {
+                instance.MyString = value3!;
+            }
 
             if (configuration["MyInt"] is string value4)
             {
                 instance.MyInt = ParseInt(value4, () => configuration.GetSection("MyInt").Path);
+            }
+            else
+            {
+                instance.MyInt = default;
             }
 
             if (AsConfigWithChildren(configuration.GetSection("MyList")) is IConfigurationSection section5)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, true, binderOptions);
+                BindCore(configuration, ref temp, false, binderOptions);
                 return;
             }
 
@@ -110,7 +110,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
-                BindCore(section, ref value, true, binderOptions);
+                BindCore(section, ref value, false, binderOptions);
                 instance.Add(value);
             }
         }
@@ -148,7 +148,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, true, binderOptions);
+                BindCore(section5, ref temp7, false, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -156,7 +156,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
-                BindCore(section8, ref temp10, true, binderOptions);
+                BindCore(section8, ref temp10, false, binderOptions);
                 instance.MyList2 = temp10;
             }
 
@@ -164,7 +164,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, true, binderOptions);
+                BindCore(section11, ref temp13, false, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             if (type == typeof(Program.MyClass))
             {
                 var temp = (Program.MyClass)instance;
-                BindCore(configuration, ref temp, false, binderOptions);
+                BindCore(configuration, ref temp, defaultValueIfNotFound: false, binderOptions);
                 return;
             }
 
@@ -110,7 +110,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
                 var value = new Program.MyClass2();
-                BindCore(section, ref value, false, binderOptions);
+                BindCore(section, ref value, defaultValueIfNotFound: false, binderOptions);
                 instance.Add(value);
             }
         }
@@ -148,7 +148,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<int>? temp7 = instance.MyList;
                 temp7 ??= new List<int>();
-                BindCore(section5, ref temp7, false, binderOptions);
+                BindCore(section5, ref temp7, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList = temp7;
             }
 
@@ -156,7 +156,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 List<Program.MyClass2>? temp10 = instance.MyList2;
                 temp10 ??= new List<Program.MyClass2>();
-                BindCore(section8, ref temp10, false, binderOptions);
+                BindCore(section8, ref temp10, defaultValueIfNotFound: false, binderOptions);
                 instance.MyList2 = temp10;
             }
 
@@ -164,7 +164,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Dictionary<string, string>? temp13 = instance.MyDictionary;
                 temp13 ??= new Dictionary<string, string>();
-                BindCore(section11, ref temp13, false, binderOptions);
+                BindCore(section11, ref temp13, defaultValueIfNotFound: false, binderOptions);
                 instance.MyDictionary = temp13;
             }
         }


### PR DESCRIPTION
Address https://github.com/dotnet/runtime/issues/86333 (RC2 candidate as well)
- Call the setter for value type properties (with the default value for the property type) if the value is not in the config, unless it is during a Bind (not "Get"). This requires a adding a `bool` arg to the `BindCore()` method.
- Always check for a `null` value or missing section for properties and if null\missing (this was not done in all cases previously) then don't call the setter with the `null`. This addresses https://github.com/dotnet/runtime/issues/91380.

Note that this PR matches known semantics regarding the above with the goal of maintaining compat with reflection; this is the case even for non-intuitive cases including:
- Only value type properties get their setter called; not reference types or `Nullable<T>`.
- Also, properties on objects that are nested objects or those added to a collection are also not defaulted through the setter (only properties on root objects are).

We could create an issue for these non-intuitive cases, but would need to consider the benefit:risk including breaking changes.