### PR TITLE
Merge CoreMangLib, Exceptions and Interop folders

### DIFF
--- a/src/tests/CoreMangLib/CoreMangLib.csproj
+++ b/src/tests/CoreMangLib/CoreMangLib.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <MergedWrapperProjectReference Include="*/**/*.??proj" />
+  </ItemGroup>
+
+  <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
+</Project>

--- a/src/tests/CoreMangLib/Directory.Build.props
+++ b/src/tests/CoreMangLib/Directory.Build.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Merged.props', $(MSBuildThisFileDirectory)..))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <RunAnalyzers>true</RunAnalyzers>
+    <NoWarn>$(NoWarn);xUnit1013</NoWarn>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+  </PropertyGroup>
+</Project>

--- a/src/tests/CoreMangLib/system/buffer/ASURT_99893.csproj
+++ b/src/tests/CoreMangLib/system/buffer/ASURT_99893.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/buffer/asurt_99893.cs
+++ b/src/tests/CoreMangLib/system/buffer/asurt_99893.cs
@@ -5,12 +5,14 @@
 // and thus one could define a new System.Int32 (as below) and use that instead.
 
 using System;
+using Xunit;
 
 namespace System
 {
     public class ASURT_99893
     {
-	public static int Main()
+	[Fact]
+	public static int TestEntryPoint()
 	{
 	    Boolean pass=true;
 #pragma warning disable 0436

--- a/src/tests/CoreMangLib/system/buffer/asurt_99893.cs
+++ b/src/tests/CoreMangLib/system/buffer/asurt_99893.cs
@@ -8,9 +8,9 @@ using System;
 
 namespace System
 {
-    class ASURT_99893
+    public class ASURT_99893
     {
-	static int Main()
+	public static int Main()
 	{
 	    Boolean pass=true;
 #pragma warning disable 0436

--- a/src/tests/CoreMangLib/system/delegate/VSD/OpenDelegate.cs
+++ b/src/tests/CoreMangLib/system/delegate/VSD/OpenDelegate.cs
@@ -3,8 +3,9 @@
 using System;
 using System.Reflection;
 using System.Collections.Generic;
+using Xunit;
 
-class Program
+public class Program
 {
     public class ClassA
     {
@@ -28,7 +29,8 @@ class Program
         }
         return result;
     }
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         Type typeTestClass = typeof(ClassA);
         ClassA TestClass = (ClassA)Activator.CreateInstance(typeTestClass);

--- a/src/tests/CoreMangLib/system/delegate/VSD/OpenDelegate.csproj
+++ b/src/tests/CoreMangLib/system/delegate/VSD/OpenDelegate.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/CoreMangLib/system/delegate/VSD/OpenDelegate.csproj
+++ b/src/tests/CoreMangLib/system/delegate/VSD/OpenDelegate.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/delegate/DelegateCombine1.csproj
+++ b/src/tests/CoreMangLib/system/delegate/delegate/DelegateCombine1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/delegate/DelegateCombineImpl.csproj
+++ b/src/tests/CoreMangLib/system/delegate/delegate/DelegateCombineImpl.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/delegate/DelegateEquals1.csproj
+++ b/src/tests/CoreMangLib/system/delegate/delegate/DelegateEquals1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/delegate/DelegateGetHashCode1.csproj
+++ b/src/tests/CoreMangLib/system/delegate/delegate/DelegateGetHashCode1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/delegate/DelegateGetInvocationList1.csproj
+++ b/src/tests/CoreMangLib/system/delegate/delegate/DelegateGetInvocationList1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/delegate/DelegateRemove.csproj
+++ b/src/tests/CoreMangLib/system/delegate/delegate/DelegateRemove.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/delegate/delegateRemoveImpl.csproj
+++ b/src/tests/CoreMangLib/system/delegate/delegate/delegateRemoveImpl.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/delegate/delegatecombine1.cs
+++ b/src/tests/CoreMangLib/system/delegate/delegate/delegatecombine1.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Collections;
+using Xunit;
 //create for delegate combine(delegate a,delegate b) testing
 namespace DelegateTest
 {
@@ -26,7 +27,8 @@ namespace DelegateTest
         booldelegate starkWork;
         booldelegate working;
         voiddelegate completeWork;
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             DelegateCombine1 delegateCombine1 = new DelegateCombine1();
 

--- a/src/tests/CoreMangLib/system/delegate/delegate/delegatecombineimpl.cs
+++ b/src/tests/CoreMangLib/system/delegate/delegate/delegatecombineimpl.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Collections;
+using Xunit;
 //create for delegate combine(delegate a,delegate b) testing
 namespace DelegateTest
 {
@@ -25,7 +26,8 @@ namespace DelegateTest
         }
         booldelegate starkWork;
         booldelegate working;
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             DelegateCombineImpl delegateCombineImpl = new DelegateCombineImpl();
 

--- a/src/tests/CoreMangLib/system/delegate/delegate/delegateequals1.cs
+++ b/src/tests/CoreMangLib/system/delegate/delegate/delegateequals1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using Xunit;
 //test case for delegate Equals method.
 namespace DelegateTest
 {
@@ -12,7 +13,8 @@ namespace DelegateTest
 
         object starkWork;
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             DelegateEquals DelegateEquals = new DelegateEquals();
 

--- a/src/tests/CoreMangLib/system/delegate/delegate/delegategethashcode1.cs
+++ b/src/tests/CoreMangLib/system/delegate/delegate/delegategethashcode1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using Xunit;
 //test case for delegate GetHashCode method.
 namespace DelegateTest
 {
@@ -14,7 +15,8 @@ namespace DelegateTest
     {
 
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             DelegateGetHashCode DelegateGetHashCode = new DelegateGetHashCode();
 

--- a/src/tests/CoreMangLib/system/delegate/delegate/delegategetinvocationlist1.cs
+++ b/src/tests/CoreMangLib/system/delegate/delegate/delegategetinvocationlist1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using Xunit;
 //test case for delegate GetInvocationList method.
 namespace DelegateTest
 {
@@ -12,7 +13,8 @@ namespace DelegateTest
 
         booldelegate starkWork;
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             DelegateGetInvocationList delegateGetInvocationList = new DelegateGetInvocationList();
 

--- a/src/tests/CoreMangLib/system/delegate/delegate/delegateremove.cs
+++ b/src/tests/CoreMangLib/system/delegate/delegate/delegateremove.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using Xunit;
 //test case for delegate Remove(System.Delegate,System.Delegate) method.
 namespace DelegateTest
 {
@@ -13,7 +14,8 @@ namespace DelegateTest
 
         booldelegate starkWork;
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             DelegateRemove delegateRemoveImpl = new DelegateRemove();
 

--- a/src/tests/CoreMangLib/system/delegate/delegate/delegateremoveimpl.cs
+++ b/src/tests/CoreMangLib/system/delegate/delegate/delegateremoveimpl.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using Xunit;
 //test case for delegate RemoveImpl(System.Delegate) method.
 namespace DelegateTest
 {
@@ -12,7 +13,8 @@ namespace DelegateTest
 
         booldelegate starkWork;
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             DelegateRemoveImpl delegateRemoveImpl = new DelegateRemoveImpl();
 

--- a/src/tests/CoreMangLib/system/delegate/generics/NG_Standard.csproj
+++ b/src/tests/CoreMangLib/system/delegate/generics/NG_Standard.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/generics/NegativeGenerics.csproj
+++ b/src/tests/CoreMangLib/system/delegate/generics/NegativeGenerics.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/generics/negativegenerics.cs
+++ b/src/tests/CoreMangLib/system/delegate/generics/negativegenerics.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 //Covers various negative binding cases for delegates and generics...
 using System;
+using Xunit;
 
 
 //Define some classes and method for use in our scenarios...
@@ -18,10 +19,11 @@ delegate void Closed();
 delegate void Open(B<int> b);
 delegate void GClosed<T>();
 
-class Test_negativegenerics{
+public class Test_negativegenerics{
 	public static int retVal=100;
 
-	public static int Main(){
+	[Fact]
+	public static int TestEntryPoint(){
 		//Try to create an open-instance delegate to a virtual generic method (@TODO - Need early bound case here too)
 		//Try to create a generic delegate of a non-instantiated type
 		//Try to create a delegate over a non-instantiated target type

--- a/src/tests/CoreMangLib/system/delegate/generics/ng_standard.cs
+++ b/src/tests/CoreMangLib/system/delegate/generics/ng_standard.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 
-class Test_ng_standard{
-	public static int Main(){
+public class Test_ng_standard{
+	public static void Main(){
 		Console.WriteLine("Test creation/invocation of non-generic closed instance or open static delegates over various generic methods");
 
 		GenericClass<EQStruct<long>> refr = new GenericClass<EQStruct<long>>();
@@ -102,8 +102,5 @@ class Test_ng_standard{
 		d9(50,new EQClass<long>(50));
 		d9 = new dc7(GenericStruct<EQStruct<long>>.SM9<EQClass<long>>);
 		d9(50,new EQClass<long>(50));		
-
-		Console.WriteLine("Done - Passed");
-		return 100;
 	}
 }

--- a/src/tests/CoreMangLib/system/delegate/generics/ng_standard.cs
+++ b/src/tests/CoreMangLib/system/delegate/generics/ng_standard.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using Xunit;
 
 public class Test_ng_standard{
-	public static void Main(){
+	[Fact]
+	public static void TestEntryPoint(){
 		Console.WriteLine("Test creation/invocation of non-generic closed instance or open static delegates over various generic methods");
 
 		GenericClass<EQStruct<long>> refr = new GenericClass<EQStruct<long>>();

--- a/src/tests/CoreMangLib/system/delegate/miscellaneous/ClosedStatic.cs
+++ b/src/tests/CoreMangLib/system/delegate/miscellaneous/ClosedStatic.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Reflection;
 
-class Program
+public class Program
 {
     public int scale;
 
@@ -15,7 +15,8 @@ class Program
     {
         return new decimal(constituent/prog.scale);
     }
-    static int Main()
+
+    public static int Main()
     {
         int result = -1;
         

--- a/src/tests/CoreMangLib/system/delegate/miscellaneous/ClosedStatic.cs
+++ b/src/tests/CoreMangLib/system/delegate/miscellaneous/ClosedStatic.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Reflection;
+using Xunit;
 
 public class Program
 {
@@ -16,7 +17,8 @@ public class Program
         return new decimal(constituent/prog.scale);
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int result = -1;
         

--- a/src/tests/CoreMangLib/system/delegate/miscellaneous/ClosedStatic.csproj
+++ b/src/tests/CoreMangLib/system/delegate/miscellaneous/ClosedStatic.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/miscellaneous/Co6010DelegateEqualsTwo.csproj
+++ b/src/tests/CoreMangLib/system/delegate/miscellaneous/Co6010DelegateEqualsTwo.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/miscellaneous/Co6031GetHashCode.csproj
+++ b/src/tests/CoreMangLib/system/delegate/miscellaneous/Co6031GetHashCode.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/miscellaneous/co6010delegateequalstwo.cs
+++ b/src/tests/CoreMangLib/system/delegate/miscellaneous/co6010delegateequalstwo.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using Xunit;
 
 delegate void Void_VoidDelegate();
 public class TestClass
@@ -20,7 +21,8 @@ public class TestClass
 		return a;
 	}
 
-	public static int Main() {
+	[Fact]
+	public static int TestEntryPoint() {
 		int iErrorCount = 0;
 		int iTestCount = 0;
 		{

--- a/src/tests/CoreMangLib/system/delegate/miscellaneous/co6031gethashcode.cs
+++ b/src/tests/CoreMangLib/system/delegate/miscellaneous/co6031gethashcode.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using Xunit;
 
 delegate int Int32_VoidDelegate();
 public class TestClass
 {
-	public static int Main() 
+	[Fact]
+	public static int TestEntryPoint() 
 	{
 		int iTestCount= 0;
 		int iErrorCount= 0;

--- a/src/tests/CoreMangLib/system/delegate/regressions/Github_13160/Github_13160.cs
+++ b/src/tests/CoreMangLib/system/delegate/regressions/Github_13160/Github_13160.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using Xunit;
 
 public class Program
 {
@@ -12,7 +13,8 @@ public class Program
     {
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         Program p = new Program();
 

--- a/src/tests/CoreMangLib/system/delegate/regressions/Github_13160/Github_13160.cs
+++ b/src/tests/CoreMangLib/system/delegate/regressions/Github_13160/Github_13160.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 
-class Program
+public class Program
 {
     public virtual void VirtualMethod()
     {
@@ -12,7 +12,7 @@ class Program
     {
     }
 
-    static int Main()
+    public static int Main()
     {
         Program p = new Program();
 

--- a/src/tests/CoreMangLib/system/delegate/regressions/Github_13160/Github_13160.csproj
+++ b/src/tests/CoreMangLib/system/delegate/regressions/Github_13160/Github_13160.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/regressions/devdivbugs/113347/DDB113347.csproj
+++ b/src/tests/CoreMangLib/system/delegate/regressions/devdivbugs/113347/DDB113347.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/delegate/regressions/devdivbugs/113347/ddb113347.cs
+++ b/src/tests/CoreMangLib/system/delegate/regressions/devdivbugs/113347/ddb113347.cs
@@ -3,10 +3,12 @@
 using System;
 using System.Reflection;
 using System.Security;
+using Xunit;
 
 [SecuritySafeCritical]
 public class Program {
-    public static int Main() {
+    [Fact]
+    public static int TestEntryPoint() {
         Console.WriteLine("Attempting delegate construction with null method pointer.");
         Console.WriteLine("Expecting: ArgumentNullException wrapped in TargetInvocationException.");
         try {

--- a/src/tests/CoreMangLib/system/delegate/regressions/devdivbugs/113347/ddb113347.cs
+++ b/src/tests/CoreMangLib/system/delegate/regressions/devdivbugs/113347/ddb113347.cs
@@ -5,8 +5,8 @@ using System.Reflection;
 using System.Security;
 
 [SecuritySafeCritical]
-class Program {
-    static int Main() {
+public class Program {
+    public static int Main() {
         Console.WriteLine("Attempting delegate construction with null method pointer.");
         Console.WriteLine("Expecting: ArgumentNullException wrapped in TargetInvocationException.");
         try {

--- a/src/tests/CoreMangLib/system/enum/EnumIConvertibleToInt64.csproj
+++ b/src/tests/CoreMangLib/system/enum/EnumIConvertibleToInt64.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/enum/EnumIConvertibleToSingle.csproj
+++ b/src/tests/CoreMangLib/system/enum/EnumIConvertibleToSingle.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/enum/EnumIConvertibleToType.csproj
+++ b/src/tests/CoreMangLib/system/enum/EnumIConvertibleToType.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/enum/EnumIConvertibleToUint16.csproj
+++ b/src/tests/CoreMangLib/system/enum/EnumIConvertibleToUint16.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/enum/EnumIConvertibleToUint32.csproj
+++ b/src/tests/CoreMangLib/system/enum/EnumIConvertibleToUint32.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/enum/EnumIConvertibleToUint64.csproj
+++ b/src/tests/CoreMangLib/system/enum/EnumIConvertibleToUint64.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/enum/enumiconvertibletoint64.cs
+++ b/src/tests/CoreMangLib/system/enum/enumiconvertibletoint64.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using Xunit;
 
 /// <summary>
 /// System.Enum.IConvertibleToInt64(System.IFormatProvider)
@@ -159,7 +160,8 @@ public class EnumIConvertibleToInt64
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         EnumIConvertibleToInt64 test = new EnumIConvertibleToInt64();
 

--- a/src/tests/CoreMangLib/system/enum/enumiconvertibletosingle.cs
+++ b/src/tests/CoreMangLib/system/enum/enumiconvertibletosingle.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using Xunit;
 
 /// <summary>
 /// System.Enum.IConvertibleToSingle(provider)
@@ -186,7 +187,8 @@ public class EnumIConvertibleToSingle
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         EnumIConvertibleToSingle test = new EnumIConvertibleToSingle();
 

--- a/src/tests/CoreMangLib/system/enum/enumiconvertibletotype.cs
+++ b/src/tests/CoreMangLib/system/enum/enumiconvertibletotype.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using Xunit;
 
 /// <summary>
 /// System.Enum.IConvertibleToType(System.Type,IFormatProvider )
@@ -215,7 +216,8 @@ public class EnumIConvertibleToType
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         EnumIConvertibleToType test = new EnumIConvertibleToType();
 

--- a/src/tests/CoreMangLib/system/enum/enumiconvertibletouint16.cs
+++ b/src/tests/CoreMangLib/system/enum/enumiconvertibletouint16.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using Xunit;
 
 /// <summary>
 /// System.Enum.IConvertibleToUint16(System.Type,IFormatProvider )
@@ -188,7 +189,8 @@ public class EnumIConvertibleToUint16
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         EnumIConvertibleToUint16 test = new EnumIConvertibleToUint16();
 

--- a/src/tests/CoreMangLib/system/enum/enumiconvertibletouint32.cs
+++ b/src/tests/CoreMangLib/system/enum/enumiconvertibletouint32.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using Xunit;
 
 /// <summary>
 /// System.Enum.IConvertibleToUint32(System.Type,IFormatProvider )
@@ -187,7 +188,8 @@ public class EnumIConvertibleToUint32
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         EnumIConvertibleToUint32 test = new EnumIConvertibleToUint32();
 

--- a/src/tests/CoreMangLib/system/enum/enumiconvertibletouint64.cs
+++ b/src/tests/CoreMangLib/system/enum/enumiconvertibletouint64.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using Xunit;
 
 /// <summary>
 /// System.Enum.IConvertibleToUint64(System.Type,IFormatProvider )
@@ -159,7 +160,8 @@ public class EnumIConvertibleToUint64
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         EnumIConvertibleToUint64 test = new EnumIConvertibleToUint64();
 

--- a/src/tests/CoreMangLib/system/environment/environment_version.cs
+++ b/src/tests/CoreMangLib/system/environment/environment_version.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Xunit;
 
 public class environment_version
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         Version ver = Environment.Version;
         Console.WriteLine($"Environment.Version = {ver}");

--- a/src/tests/CoreMangLib/system/environment/environment_version.cs
+++ b/src/tests/CoreMangLib/system/environment/environment_version.cs
@@ -3,9 +3,9 @@
 
 using System;
 
-class environment_version
+public class environment_version
 {
-    static int Main()
+    public static int Main()
     {
         Version ver = Environment.Version;
         Console.WriteLine($"Environment.Version = {ver}");

--- a/src/tests/CoreMangLib/system/environment/environment_version.csproj
+++ b/src/tests/CoreMangLib/system/environment/environment_version.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/CoreMangLib/system/multicastdelegate/MulticastDelegateCombineImpl.csproj
+++ b/src/tests/CoreMangLib/system/multicastdelegate/MulticastDelegateCombineImpl.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/multicastdelegate/MulticastDelegateEquals.csproj
+++ b/src/tests/CoreMangLib/system/multicastdelegate/MulticastDelegateEquals.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/multicastdelegate/MulticastDelegateGetHashCode.csproj
+++ b/src/tests/CoreMangLib/system/multicastdelegate/MulticastDelegateGetHashCode.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/multicastdelegate/MulticastDelegateGetInvocationList.csproj
+++ b/src/tests/CoreMangLib/system/multicastdelegate/MulticastDelegateGetInvocationList.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/multicastdelegate/multicastdelegatecombineimpl.cs
+++ b/src/tests/CoreMangLib/system/multicastdelegate/multicastdelegatecombineimpl.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using Xunit;
 
 public class MulticastDelegateCombineImpl
 {
@@ -422,7 +423,8 @@ public class MulticastDelegateCombineImpl
     }
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         MulticastDelegateCombineImpl mdci = new MulticastDelegateCombineImpl();
 

--- a/src/tests/CoreMangLib/system/multicastdelegate/multicastdelegateequals.cs
+++ b/src/tests/CoreMangLib/system/multicastdelegate/multicastdelegateequals.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Security;
+using Xunit;
 
 public class MulticastDelegateEquals
 {
@@ -405,7 +406,8 @@ public class MulticastDelegateEquals
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         MulticastDelegateEquals mde = new MulticastDelegateEquals();
 

--- a/src/tests/CoreMangLib/system/multicastdelegate/multicastdelegategethashcode.cs
+++ b/src/tests/CoreMangLib/system/multicastdelegate/multicastdelegategethashcode.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Security;
+using Xunit;
 
 public class MulticastDelegateGetHashCode
 {
@@ -85,7 +86,8 @@ public class MulticastDelegateGetHashCode
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         MulticastDelegateGetHashCode mdghc = new MulticastDelegateGetHashCode();
 

--- a/src/tests/CoreMangLib/system/multicastdelegate/multicastdelegategetinvocationlist.cs
+++ b/src/tests/CoreMangLib/system/multicastdelegate/multicastdelegategetinvocationlist.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Security;
+using Xunit;
 
 public class MulticastDelegateGetInvocationList
 {
@@ -142,7 +143,8 @@ public class MulticastDelegateGetInvocationList
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         MulticastDelegateGetInvocationList mdgil = new MulticastDelegateGetInvocationList();
 

--- a/src/tests/CoreMangLib/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests.cs
+++ b/src/tests/CoreMangLib/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests.cs
@@ -9,10 +9,9 @@ using System.Threading;
 
 public static class DynamicMethodJumpStubTests
 {
-    private static int Main()
+    public static void Main()
     {
         DynamicMethodJumpStubTest();
-        return 100;
     }
 
     public static void DynamicMethodJumpStubTest()

--- a/src/tests/CoreMangLib/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests.cs
+++ b/src/tests/CoreMangLib/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests.cs
@@ -6,10 +6,12 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Xunit;
 
 public static class DynamicMethodJumpStubTests
 {
-    public static void Main()
+    [Fact]
+    public static void TestEntryPoint()
     {
         DynamicMethodJumpStubTest();
     }

--- a/src/tests/CoreMangLib/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests.csproj
+++ b/src/tests/CoreMangLib/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/CoreMangLib/system/runtime/interopservices/marshal/MarshalSizeOf1_PSC.csproj
+++ b/src/tests/CoreMangLib/system/runtime/interopservices/marshal/MarshalSizeOf1_PSC.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/runtime/interopservices/marshal/MarshalSizeOf2_PSC.csproj
+++ b/src/tests/CoreMangLib/system/runtime/interopservices/marshal/MarshalSizeOf2_PSC.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/runtime/interopservices/marshal/marshalsizeof1.cs
+++ b/src/tests/CoreMangLib/system/runtime/interopservices/marshal/marshalsizeof1.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Security;
+using Xunit;
 
 
 [SecuritySafeCritical]
@@ -499,7 +500,8 @@ public class MarshalSizeOf1
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         MarshalSizeOf1 test = new MarshalSizeOf1();
 

--- a/src/tests/CoreMangLib/system/runtime/interopservices/marshal/marshalsizeof2.cs
+++ b/src/tests/CoreMangLib/system/runtime/interopservices/marshal/marshalsizeof2.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Security;
+using Xunit;
 
 
 [SecuritySafeCritical]
@@ -503,7 +504,8 @@ public class MarshalSizeOf2
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         MarshalSizeOf2 test = new MarshalSizeOf2();
 

--- a/src/tests/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDangerousAddRef_PSC.csproj
+++ b/src/tests/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDangerousAddRef_PSC.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDangerousRelease_PSC.csproj
+++ b/src/tests/CoreMangLib/system/runtime/interopservices/safehandle/SafeHandleDangerousRelease_PSC.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/runtime/interopservices/safehandle/safehandledangerousaddref.cs
+++ b/src/tests/CoreMangLib/system/runtime/interopservices/safehandle/safehandledangerousaddref.cs
@@ -3,6 +3,7 @@
 using System.Security;
 using System;
 using System.Runtime.InteropServices; // For SafeHandle
+using Xunit;
 
 
 [SecurityCritical]
@@ -206,7 +207,8 @@ public class SafeHandleDangerousAddRef
 
 
     [SecuritySafeCritical]
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         SafeHandleDangerousAddRef test = new SafeHandleDangerousAddRef();
 

--- a/src/tests/CoreMangLib/system/runtime/interopservices/safehandle/safehandledangerousrelease.cs
+++ b/src/tests/CoreMangLib/system/runtime/interopservices/safehandle/safehandledangerousrelease.cs
@@ -3,6 +3,7 @@
 using System.Security;
 using System;
 using System.Runtime.InteropServices; // For SafeHandle
+using Xunit;
 
 /// <summary>
 /// DangerousRelease
@@ -375,7 +376,8 @@ public class SafeHandleDangerousRelease
 
 
     [SecuritySafeCritical]
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         SafeHandleDangerousRelease test = new SafeHandleDangerousRelease();
 

--- a/src/tests/CoreMangLib/system/span/RefStructWithSpan.cs
+++ b/src/tests/CoreMangLib/system/span/RefStructWithSpan.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Xunit;
 
 ref struct MyStruct<A, B>
 {
@@ -44,7 +45,7 @@ ref struct MyStruct<A, B>
     }
 }
 
-class My
+public class My
 {
     static void Stress()
     {
@@ -68,7 +69,8 @@ class My
 
     public static int[][] g = new int[10000][];
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int[] empty = new int[] { 1 };
         for (int i = 0; i < g.Length; i++)

--- a/src/tests/CoreMangLib/system/span/RefStructWithSpan.cs
+++ b/src/tests/CoreMangLib/system/span/RefStructWithSpan.cs
@@ -68,7 +68,7 @@ class My
 
     public static int[][] g = new int[10000][];
 
-    static int Main()
+    public static int Main()
     {
         int[] empty = new int[] { 1 };
         for (int i = 0; i < g.Length; i++)

--- a/src/tests/CoreMangLib/system/span/RefStructWithSpan.csproj
+++ b/src/tests/CoreMangLib/system/span/RefStructWithSpan.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for GCStressIncompatible, UnloadabilityIncompatible -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>

--- a/src/tests/CoreMangLib/system/span/SlowTailCallArgs.cs
+++ b/src/tests/CoreMangLib/system/span/SlowTailCallArgs.cs
@@ -5,10 +5,12 @@ using System;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
+using Xunit;
 
 public static class Program
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool allPassed = true;
         bool passed;

--- a/src/tests/CoreMangLib/system/span/SlowTailCallArgs.cs
+++ b/src/tests/CoreMangLib/system/span/SlowTailCallArgs.cs
@@ -6,9 +6,9 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 
-internal static class Program
+public static class Program
 {
-    private static int Main()
+    public static int Main()
     {
         bool allPassed = true;
         bool passed;

--- a/src/tests/CoreMangLib/system/span/SlowTailCallArgs.csproj
+++ b/src/tests/CoreMangLib/system/span/SlowTailCallArgs.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for GCStressIncompatible -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedAdd1.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedAdd1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedAdd2.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedAdd2.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange1.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange5.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange5.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange6.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange6.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange7.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedCompareExchange7.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedDecrement1.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedDecrement1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedDecrement2.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedDecrement2.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedExchange1.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedExchange1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedExchange5.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedExchange5.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedExchange6.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedExchange6.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedExchange7.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedExchange7.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedIncrement1.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedIncrement1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/InterlockedIncrement2.csproj
+++ b/src/tests/CoreMangLib/system/threading/interlocked/InterlockedIncrement2.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockedadd1.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockedadd1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 // This tests Interlocked.Add.  
 // Interlocked.Add Adds two 32-bit integers and replaces the first 
@@ -14,7 +15,8 @@ public class InterlockedAdd1
 {
     private const int c_NUM_LOOPS = 100;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedAdd1 test = new InterlockedAdd1();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockedadd2.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockedadd2.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 // This tests Interlocked.Add.  
 // Interlocked.Add Adds two 64-bit integers and replaces the first 
@@ -14,7 +15,8 @@ public class InterlockedAdd2
 {
     private const int c_NUM_LOOPS = 100;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedAdd2 test = new InterlockedAdd2();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockedcompareexchange1.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockedcompareexchange1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 // This test makes sure that CompareExchange<T> works
 // where T is string
@@ -11,7 +12,8 @@ public class InterlockedCompareExchange1
     private const int c_MIN_STRING_LEN = 64;
     private const int c_MAX_STRING_LEN = 1024;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedCompareExchange1 test = new InterlockedCompareExchange1();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockedcompareexchange5.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockedcompareexchange5.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 // Tests that CompareExchange(Int64, Int64, Int64)
 // actually switches values when location = comparand and
@@ -10,7 +11,8 @@ public class InterlockedCompareExchange5
 {
     private const int c_NUM_LOOPS = 100;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedCompareExchange5 test = new InterlockedCompareExchange5();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockedcompareexchange6.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockedcompareexchange6.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 public class InterlockedCompareExchange6
 {
     private const int c_NUM_LOOPS = 100;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedCompareExchange6 test = new InterlockedCompareExchange6();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockedcompareexchange7.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockedcompareexchange7.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 // This tests CompareExchange<object>.
 // It just casts a bunch of different types to object,
@@ -12,7 +13,8 @@ public class InterlockedCompareExchange7
     private const int c_MIN_STRING_LEN = 5;
     private const int c_MAX_STRING_LEN = 128;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedCompareExchange7 test = new InterlockedCompareExchange7();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockeddecrement1.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockeddecrement1.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 public class InterlockedDecrement1
 {
     private const int c_NUM_LOOPS = 100;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedDecrement1 test = new InterlockedDecrement1();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockeddecrement2.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockeddecrement2.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 public class InterlockedDecrement2
 {
     private const int c_NUM_LOOPS = 100;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedDecrement2 test = new InterlockedDecrement2();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockedexchange1.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockedexchange1.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 public class InterlockedExchange1
 {
@@ -9,7 +10,8 @@ public class InterlockedExchange1
     private const int c_MIN_STRING_LEN = 64;
     private const int c_MAX_STRING_LEN = 1024;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedExchange1 test = new InterlockedExchange1();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockedexchange5.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockedexchange5.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 // Tests that Exchange(Int64, Int64)
 // actually switches values
@@ -9,7 +10,8 @@ public class InterlockedExchange5
 {
     private const int c_NUM_LOOPS = 100;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedExchange5 test = new InterlockedExchange5();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockedexchange6.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockedexchange6.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 public class InterlockedExchange6
 {
     private const int c_NUM_LOOPS = 100;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedExchange6 test = new InterlockedExchange6();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockedexchange7.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockedexchange7.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 // Tests that Exchange<object>(object, object) works on variety 
 // of casted types:  It just casts a bunch of different types to 
@@ -12,7 +13,8 @@ public class InterlockedExchange7
     private const int c_MIN_STRING_LEN = 5;
     private const int c_MAX_STRING_LEN = 128;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedExchange7 test = new InterlockedExchange7();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockedincrement1.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockedincrement1.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 public class InterlockedIncrement1
 {
     private const int c_NUM_LOOPS = 100;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedIncrement1 test = new InterlockedIncrement1();
 

--- a/src/tests/CoreMangLib/system/threading/interlocked/interlockedincrement2.cs
+++ b/src/tests/CoreMangLib/system/threading/interlocked/interlockedincrement2.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Threading;
+using Xunit;
 
 public class InterlockedIncrement2
 {
     private const int c_NUM_LOOPS = 100;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         InterlockedIncrement2 test = new InterlockedIncrement2();
 

--- a/src/tests/CoreMangLib/system/type/TypeEquals1.csproj
+++ b/src/tests/CoreMangLib/system/type/TypeEquals1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/type/TypeEquals2.csproj
+++ b/src/tests/CoreMangLib/system/type/TypeEquals2.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/type/TypeGetHashCode.csproj
+++ b/src/tests/CoreMangLib/system/type/TypeGetHashCode.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/type/TypeGetType1.csproj
+++ b/src/tests/CoreMangLib/system/type/TypeGetType1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/type/TypeGetType2.csproj
+++ b/src/tests/CoreMangLib/system/type/TypeGetType2.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/type/TypeGetTypeFromHandle.csproj
+++ b/src/tests/CoreMangLib/system/type/TypeGetTypeFromHandle.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/type/TypeToString.csproj
+++ b/src/tests/CoreMangLib/system/type/TypeToString.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/CoreMangLib/system/type/typeequals1.cs
+++ b/src/tests/CoreMangLib/system/type/typeequals1.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using Xunit;
 
 /// <summary>
 /// System.Type.Equals(System.Object)
@@ -188,7 +189,8 @@ public class TypeEquals1
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         TypeEquals1 test = new TypeEquals1();
 

--- a/src/tests/CoreMangLib/system/type/typeequals2.cs
+++ b/src/tests/CoreMangLib/system/type/typeequals2.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using Xunit;
 
 public class TypeEquals2
 {
@@ -100,7 +101,8 @@ public class TypeEquals2
     #endregion
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         TypeEquals2 test = new TypeEquals2();
 

--- a/src/tests/CoreMangLib/system/type/typegethashcode.cs
+++ b/src/tests/CoreMangLib/system/type/typegethashcode.cs
@@ -6,13 +6,15 @@ using System.Text;
 using System.Reflection;
 using System.Globalization;
 using System.Collections;
+using Xunit;
 
 /// <summary>
 /// Type.GetHashCode()
 /// </summary>
 public class TypeGetHashCode
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         TypeGetHashCode tghc = new TypeGetHashCode();
         TestLibrary.TestFramework.BeginTestCase("TypeGetHashCode");

--- a/src/tests/CoreMangLib/system/type/typegettype1.cs
+++ b/src/tests/CoreMangLib/system/type/typegettype1.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Reflection;
+using Xunit;
 
 
 class MyTypeClass
@@ -29,7 +30,8 @@ class MyTypeClass
 
 public class TypeGetType1
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         TypeGetType1 getType1 = new TypeGetType1();
         TestLibrary.TestFramework.BeginScenario("Testing System.Type.GetType()...");

--- a/src/tests/CoreMangLib/system/type/typegettype2.cs
+++ b/src/tests/CoreMangLib/system/type/typegettype2.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Collections.Generic;
+using Xunit;
 
 class MyClass
 {
@@ -17,7 +18,8 @@ class MyClass
 
 public class TypeGetType2
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         TypeGetType2 getType2 = new TypeGetType2();
         TestLibrary.TestFramework.BeginScenario("Testing System.Type.GetType(System.String)...");

--- a/src/tests/CoreMangLib/system/type/typegettypefromhandle.cs
+++ b/src/tests/CoreMangLib/system/type/typegettypefromhandle.cs
@@ -4,12 +4,14 @@ using System;
 using System.Globalization;
 using System.Reflection;
 using System.Collections;
+using Xunit;
 /// <summary>
 ///GetTypeCode
 /// </summary>
 public class TypeGetTypeFromHandle
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         TypeGetTypeFromHandle TypeGetTypeFromHandle = new TypeGetTypeFromHandle();
 

--- a/src/tests/CoreMangLib/system/type/typetostring.cs
+++ b/src/tests/CoreMangLib/system/type/typetostring.cs
@@ -3,14 +3,16 @@
 using System;
 using System.Collections.Generic;
 using TestHelper;
+using Xunit;
 
 /// <summary>
 /// Type.ToString()
 /// Returns a String representing the name of the current Type
 /// </summary>
-class TypeToString
+public class TypeToString
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         TypeToString tts = new TypeToString();
 

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -508,7 +508,7 @@
 
     <ItemGroup>
       <ProjectReference Remove="@(ReferencedProjectRequiringProcessIsolation->'%(OriginalItemSpec)')" />
-      <ProjectReference Include="@(ReferencedProjectRequiringProcessIsolation->'%(OriginalItemSpec)')" OutputItemType="OutOfProcessTests" BuildReference="true" ReferenceOutputAssembly="false" />
+      <ProjectReference Include="@(ReferencedProjectRequiringProcessIsolation->'%(OriginalItemSpec)')" OutputItemType="OutOfProcessTests" BuildReference="true" ReferenceOutputAssembly="false" Private="False" />
     </ItemGroup>
   </Target>
 

--- a/src/tests/Exceptions/Directory.Build.props
+++ b/src/tests/Exceptions/Directory.Build.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Merged.props', $(MSBuildThisFileDirectory)..))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <RunAnalyzers>true</RunAnalyzers>
+    <NoWarn>$(NoWarn);xUnit1013</NoWarn>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+  </PropertyGroup>
+</Project>

--- a/src/tests/Exceptions/Exceptions.csproj
+++ b/src/tests/Exceptions/Exceptions.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <MergedWrapperProjectReference Include="*/**/*.??proj" />
+  </ItemGroup>
+
+  <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
+</Project>

--- a/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.cs
+++ b/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.cs
@@ -3,10 +3,11 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 public delegate void MyCallback();
 
-class ForeignThreadExceptionsTest
+public class ForeignThreadExceptionsTest
 {
     [DllImport("ForeignThreadExceptionsNative")]
     public static extern void InvokeCallback(MyCallback callback);
@@ -57,7 +58,8 @@ class ForeignThreadExceptionsTest
         });
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.csproj
+++ b/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <MonoAotIncompatible>true</MonoAotIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Exceptions/UnwindFpBleedTest/UnwindFpBleedTest.cs
+++ b/src/tests/Exceptions/UnwindFpBleedTest/UnwindFpBleedTest.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
-class Program
+public class Program
 {
-    static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         double a0 = 1.0;
         double a1 = 2.0;

--- a/src/tests/Exceptions/UnwindFpBleedTest/UnwindFpBleedTest.csproj
+++ b/src/tests/Exceptions/UnwindFpBleedTest/UnwindFpBleedTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="UnwindFpBleedTest.cs" />

--- a/src/tests/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.cs
+++ b/src/tests/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Security;
 using System.Runtime.InteropServices;
 using TestLibrary;
+using Xunit;
 
 public class MarshalBoolArray
 {
@@ -217,7 +218,8 @@ public class MarshalBoolArray
     #endregion
 
     [System.Security.SecuritySafeCritical]
-    public static void Main()
+    [Fact]
+    public static void TestEntryPoint()
     {
         bool retVal = true;
         

--- a/src/tests/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.cs
+++ b/src/tests/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.cs
@@ -4,7 +4,7 @@
 //
 
 //
-//	Adding tests for BoolArrayMarshaler code coverage
+//  Adding tests for BoolArrayMarshaler code coverage
 //
 //Rule for Passing Value
 //        Reverse Pinvoke
@@ -128,7 +128,7 @@ public class MarshalBoolArray
         //Since now the sizeconst doesnt support on ref,so only check the first item instead.
         //Unhandled Exception: System.Runtime.InteropServices.MarshalDirectiveException: Cannot marshal 'parameter #2': Cannot use SizeParamIndex for ByRef array parameters.
         //for (int i = 0; i < size; ++i) //Reverse PInvoke, true,false,true false,true
-        //{	
+        //{ 
         //    if ((0 == i % 2) && !array[i])
         //    {
         //      ReportFailure("Failed on the Managed Side:TestMethod_CallBackRefIn. The " + (i + 1) + "st Item failed", true.ToString(), false.ToString());
@@ -217,7 +217,7 @@ public class MarshalBoolArray
     #endregion
 
     [System.Security.SecuritySafeCritical]
-    static int Main()
+    public static void Main()
     {
         bool retVal = true;
         
@@ -263,13 +263,9 @@ public class MarshalBoolArray
             //TestFramework.LogError("019","Error happens in Native side:DoCallBackRefInOut");
         }
 
-	if(retVal)
-	{
-       //Console.WriteLine("Succeeded!");
-	  return 100;
-	}
-
-      throw new Exception("Failed");
-      // return 101;
+        if(!retVal)
+        {
+          throw new Exception("Failed");
+        }
     }
 }

--- a/src/tests/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.csproj
+++ b/src/tests/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.csproj
+++ b/src/tests/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.csproj
@@ -7,7 +7,7 @@
     <Compile Include="MarshalBoolArrayTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.cs
+++ b/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.cs
@@ -11,7 +11,8 @@ using Xunit;
 
 public class Tester
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.csproj
+++ b/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.csproj
+++ b/src/tests/Interop/ArrayMarshalling/SafeArray/SafeArrayTest.csproj
@@ -8,7 +8,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/ArrayMarshalling/StructArray/MarshalStructArrayTest.csproj
+++ b/src/tests/Interop/ArrayMarshalling/StructArray/MarshalStructArrayTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/BestFitMapping/BestFitMapping.cs
+++ b/src/tests/Interop/BestFitMapping/BestFitMapping.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Security;
 using System.Runtime.InteropServices;
 using TestLibrary;
+using Xunit;
 
 public class BestFitMapping
 {
@@ -883,7 +884,8 @@ public class BestFitMapping
 
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
 
         ////Cdecl

--- a/src/tests/Interop/BestFitMapping/BestFitMapping.csproj
+++ b/src/tests/Interop/BestFitMapping/BestFitMapping.csproj
@@ -8,7 +8,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/BestFitMapping/BestFitMapping.csproj
+++ b/src/tests/Interop/BestFitMapping/BestFitMapping.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/Interop/BestFitMapping/BestFitMapping.csproj
+++ b/src/tests/Interop/BestFitMapping/BestFitMapping.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/Interop/COM/Activator/Activator.csproj
+++ b/src/tests/Interop/COM/Activator/Activator.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for UnloadabilityIncompatible, NativeAotIncompatible -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
     <!-- The test fails casting from ClassFromA from the default ALC to type IGetTypeFromC from a custom ALC -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/Interop/COM/Activator/ActivatorBuiltInComDisabled.csproj
+++ b/src/tests/Interop/COM/Activator/ActivatorBuiltInComDisabled.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for UnloadabilityIncompatible, NativeAotIncompatible -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
     <!-- The test fails casting from ClassFromA from the default ALC to type IGetTypeFromC from a custom ALC -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/Interop/COM/Activator/Program.cs
+++ b/src/tests/Interop/COM/Activator/Program.cs
@@ -328,7 +328,8 @@ namespace Activator
             }
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             try
             {

--- a/src/tests/Interop/COM/Activator/Program.cs
+++ b/src/tests/Interop/COM/Activator/Program.cs
@@ -50,7 +50,7 @@ sealed class ClassFactoryWrapper
 
 namespace Activator
 {
-    unsafe class Program
+    public unsafe class Program
     {
         private static delegate*<ComActivationContext, object> GetClassFactoryForTypeMethod = (delegate*<ComActivationContext, object>)typeof(object).Assembly.GetType("Internal.Runtime.InteropServices.ComActivator", throwOnError: true).GetMethod("GetClassFactoryForType", BindingFlags.NonPublic | BindingFlags.Static).MethodHandle.GetFunctionPointer();
         private static delegate*<ComActivationContext, bool, void> ClassRegistrationScenarioForType = (delegate*<ComActivationContext, bool, void>)typeof(object).Assembly.GetType("Internal.Runtime.InteropServices.ComActivator", throwOnError: true).GetMethod("ClassRegistrationScenarioForType", BindingFlags.NonPublic | BindingFlags.Static).MethodHandle.GetFunctionPointer();
@@ -328,7 +328,7 @@ namespace Activator
             }
         }
 
-        static int Main()
+        public static int Main()
         {
             try
             {

--- a/src/tests/Interop/COM/ComWrappers/API/ComWrappersTests.csproj
+++ b/src/tests/Interop/COM/ComWrappers/API/ComWrappersTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference, GC.WaitForPendingFinalizers -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/ComWrappers/API/ComWrappersTestsBuiltInComDisabled.csproj
+++ b/src/tests/Interop/COM/ComWrappers/API/ComWrappersTestsBuiltInComDisabled.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Uses custom runtime host configuration option -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -15,7 +15,7 @@ namespace ComWrappersTests
     using TestLibrary;
     using Xunit;
 
-    class Program : IDisposable
+    public class Program : IDisposable
     {
         class TestComWrappers : ComWrappers
         {
@@ -376,7 +376,7 @@ namespace ComWrappersTests
 
             unsafe static void CallSetValue(ComWrappers wrappers)
             {
-                Assert.NotEqual(null, Test.Resurrected);
+                Assert.NotNull(Test.Resurrected);
                 IntPtr nativeInstance = wrappers.GetOrCreateComInterfaceForObject(Test.Resurrected, CreateComInterfaceFlags.None);
                 Assert.NotEqual(IntPtr.Zero, nativeInstance);
 

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.Marshalling.cs
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.Marshalling.cs
@@ -9,7 +9,7 @@ namespace ComWrappersTests.GlobalInstance
     using TestLibrary;
     using Xunit;
 
-    partial class Program
+    public partial class Program
     {
         private static void ValidateNotRegisteredForTrackerSupport()
         {
@@ -19,7 +19,7 @@ namespace ComWrappersTests.GlobalInstance
             Assert.NotEqual(GlobalComWrappers.ReleaseObjectsCallAck, hr);
         }
 
-        static int Main()
+        public static int Main()
         {
             try
             {

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.Marshalling.cs
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.Marshalling.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace ComWrappersTests.GlobalInstance
 {
     using System;
@@ -19,7 +20,8 @@ namespace ComWrappersTests.GlobalInstance
             Assert.NotEqual(GlobalComWrappers.ReleaseObjectsCallAck, hr);
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             try
             {

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.TrackerSupport.cs
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.TrackerSupport.cs
@@ -10,7 +10,7 @@ namespace ComWrappersTests.GlobalInstance
     using TestLibrary;
     using Xunit;
 
-    partial class Program
+    public partial class Program
     {
         private static void ValidateNotRegisteredForMarshalling()
         {
@@ -25,7 +25,7 @@ namespace ComWrappersTests.GlobalInstance
             Assert.False(objWrapper is FakeWrapper, $"ComWrappers instance should not have been called");
         }
 
-        static int Main()
+        public static int Main()
         {
             try
             {

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.TrackerSupport.cs
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.TrackerSupport.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace ComWrappersTests.GlobalInstance
 {
     using System;
@@ -25,7 +26,8 @@ namespace ComWrappersTests.GlobalInstance
             Assert.False(objWrapper is FakeWrapper, $"ComWrappers instance should not have been called");
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             try
             {

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceMarshallingTests.csproj
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceMarshallingTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
     <UseManagedCOMServer>true</UseManagedCOMServer>
     <IsManagedCOMClient>true</IsManagedCOMClient>

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceMarshallingTestsBuiltInComDisabled.csproj
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceMarshallingTestsBuiltInComDisabled.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
     <UseManagedCOMServer>true</UseManagedCOMServer>
     <IsManagedCOMClient>true</IsManagedCOMClient>

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests_TargetUnix.csproj
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests_TargetUnix.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- There is a Windows and a non-Windows version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' == 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests_TargetWindows.csproj
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests_TargetWindows.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
     <UseManagedCOMServer>true</UseManagedCOMServer>
     <IsManagedCOMClient>true</IsManagedCOMClient>

--- a/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
+++ b/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
@@ -121,7 +121,7 @@ namespace ComWrappersTests
         public static readonly TestComWrappers MarshallingInstance = new TestComWrappers(WrapperRegistration.Marshalling);
     }
 
-    class Program
+    public class Program
     {
 
         private static void ValidateWeakReferenceState(WeakReference<WeakReferenceableWrapper> wr, bool expectedIsAlive, TestComWrappers sourceWrappers = null)
@@ -277,7 +277,7 @@ namespace ComWrappersTests
             Assert.False(weakRef.TryGetTarget(out _));
         }
 
-        static int Main()
+        public static int Main()
         {
             try
             {
@@ -305,4 +305,3 @@ namespace ComWrappersTests
         }
     }
 }
-

--- a/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
+++ b/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using Xunit;
 
 namespace ComWrappersTests
 {
@@ -277,7 +278,8 @@ namespace ComWrappersTests
             Assert.False(weakRef.TryGetTarget(out _));
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             try
             {

--- a/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.csproj
+++ b/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for UnloadabilityIncompatible, CMakeProjectReference, GC.WaitForPendingFinalizers -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Registers global instances of ComWrappers -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/tests/Interop/COM/Dynamic/Dynamic.csproj
+++ b/src/tests/Interop/COM/Dynamic/Dynamic.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for GCStressIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
     <IsManagedCOMClient>true</IsManagedCOMClient>
     <UseManagedCOMServer>true</UseManagedCOMServer>

--- a/src/tests/Interop/COM/Dynamic/Dynamic.csproj
+++ b/src/tests/Interop/COM/Dynamic/Dynamic.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="Server/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <ProjectReference Include="../NETServer/NETServer.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>

--- a/src/tests/Interop/COM/Dynamic/ParametersTest.cs
+++ b/src/tests/Interop/COM/Dynamic/ParametersTest.cs
@@ -141,11 +141,11 @@ namespace Dynamic
         private void VarArgs()
         {
             VarEnum[] ret = obj.VarArgs();
-            Assert.Equal(0, ret.Length);
+            Assert.Empty(ret);
 
             // COM server returns the type of each variant
             ret = obj.VarArgs(false);
-            Assert.Equal(1, ret.Length);
+            Assert.Single(ret);
             AssertExtensions.CollectionEqual(new [] { VarEnum.VT_BOOL }, ret);
 
             VarEnum[] expected = { VarEnum.VT_BSTR, VarEnum.VT_R8, VarEnum.VT_DATE, VarEnum.VT_I4 };

--- a/src/tests/Interop/COM/Dynamic/Program.cs
+++ b/src/tests/Interop/COM/Dynamic/Program.cs
@@ -7,9 +7,9 @@ namespace Dynamic
     using TestLibrary;
     using Xunit;
 
-    class Program
+    public class Program
     {
-        static int Main()
+        public static int Main()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/Dynamic/Program.cs
+++ b/src/tests/Interop/COM/Dynamic/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace Dynamic
 {
     using System;
@@ -9,7 +10,8 @@ namespace Dynamic
 
     public class Program
     {
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
+++ b/src/tests/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
+++ b/src/tests/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/Aggregation/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Aggregation/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace NetClient
 {
     using System;
@@ -33,7 +34,8 @@ namespace NetClient
             Assert.False(nativeOuter.AreAggregated(nativeOuter, new object()));
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/Aggregation/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Aggregation/Program.cs
@@ -11,7 +11,7 @@ namespace NetClient
     using Server.Contract;
     using Server.Contract.Servers;
 
-    class Program
+    public class Program
     {
         class ManagedInner : AggregationTestingClass
         {
@@ -33,7 +33,7 @@ namespace NetClient
             Assert.False(nativeOuter.AreAggregated(nativeOuter, new object()));
         }
 
-        static int Main()
+        public static int Main()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/ComDisabled/NETClientComDisabled.csproj
+++ b/src/tests/Interop/COM/NETClients/ComDisabled/NETClientComDisabled.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/NETClients/ComDisabled/NETClientComDisabled.csproj
+++ b/src/tests/Interop/COM/NETClients/ComDisabled/NETClientComDisabled.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.BuiltInComInterop.IsSupported" Value="false" />

--- a/src/tests/Interop/COM/NETClients/ComDisabled/Program.cs
+++ b/src/tests/Interop/COM/NETClients/ComDisabled/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace NetClient
 {
     using System;
@@ -10,7 +11,8 @@ namespace NetClient
 
     public class Program
     {
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // RegFree COM is not supported on Windows Nano
             if (TestLibrary.Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/ComDisabled/Program.cs
+++ b/src/tests/Interop/COM/NETClients/ComDisabled/Program.cs
@@ -8,9 +8,9 @@ namespace NetClient
     using System.Runtime.InteropServices;
     using System.Runtime.CompilerServices;
 
-    class Program
+    public class Program
     {
-        static int Main()
+        public static int Main()
         {
             // RegFree COM is not supported on Windows Nano
             if (TestLibrary.Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer.csproj
+++ b/src/tests/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../NETServer/NETServer.csproj" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
   <ItemGroup>
     <None Include="CoreShim.X.manifest">

--- a/src/tests/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer.csproj
+++ b/src/tests/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
     <UseManagedCOMServer>true</UseManagedCOMServer>
     <!--  Suppress warning about conflicting type names. This occurs because of the reference to NETServer.

--- a/src/tests/Interop/COM/NETClients/ConsumeNETServer/Program.cs
+++ b/src/tests/Interop/COM/NETClients/ConsumeNETServer/Program.cs
@@ -24,7 +24,7 @@ namespace NetClient
             test.ReleaseResources();
 
             // The CoClass should be the activated type, _not_ the activation interface.
-            Assert.Equal(test.GetType(), typeof(CoClass.ConsumeNETServerTestingClass));
+            Assert.Equal(typeof(CoClass.ConsumeNETServerTestingClass), test.GetType());
             Assert.True(typeof(CoClass.ConsumeNETServerTestingClass).IsCOMObject);
             Assert.False(typeof(CoClass.ConsumeNETServerTesting).IsCOMObject);
             Assert.True(Marshal.IsComObject(test));
@@ -62,7 +62,7 @@ namespace NetClient
             // The CoClass should be the activated type, _not_ the implementation class.
             // This indicates the real implementation class is wrapped in its CCW and exposed
             // to the runtime as an RCW.
-            Assert.NotEqual(test.GetType(), typeof(ConsumeNETServerTesting));
+            Assert.NotEqual(typeof(ConsumeNETServerTesting), test.GetType());
         }
 
         static void Validate_Client_CCW_RCW()

--- a/src/tests/Interop/COM/NETClients/ConsumeNETServer/Program.cs
+++ b/src/tests/Interop/COM/NETClients/ConsumeNETServer/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace NetClient
 {
     using System;
@@ -103,7 +104,8 @@ namespace NetClient
             }
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/ConsumeNETServer/Program.cs
+++ b/src/tests/Interop/COM/NETClients/ConsumeNETServer/Program.cs
@@ -14,7 +14,7 @@ namespace NetClient
 
     using CoClass = Server.Contract.Servers;
 
-    class Program
+    public class Program
     {
         static void Validate_Activation()
         {
@@ -103,7 +103,7 @@ namespace NetClient
             }
         }
 
-        static int Main()
+        public static int Main()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/Events/NETClientEvents.csproj
+++ b/src/tests/Interop/COM/NETClients/Events/NETClientEvents.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/NETClients/Events/NETClientEvents.csproj
+++ b/src/tests/Interop/COM/NETClients/Events/NETClientEvents.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/Events/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Events/Program.cs
@@ -13,7 +13,7 @@ namespace NetClient
     using Server.Contract.Servers;
     using Server.Contract.Events;
 
-    class Program
+    public class Program
     {
         static void Validate_BasicCOMEvent()
         {
@@ -88,7 +88,7 @@ namespace NetClient
             }
         }
 
-        static int Main()
+        public static int Main()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/Events/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Events/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace NetClient
 {
     using System;
@@ -88,7 +89,8 @@ namespace NetClient
             }
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
+++ b/src/tests/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
+++ b/src/tests/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
@@ -214,7 +214,7 @@ namespace NetClient
             }
         }
 
-        static int Main()
+        public static int Main()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace NetClient
 {
     using System;
@@ -13,7 +14,7 @@ namespace NetClient
     using Server.Contract;
     using Server.Contract.Servers;
 
-    class Program
+    public class Program
     {
         static void Validate_Numeric_In_ReturnByRef()
         {
@@ -214,7 +215,8 @@ namespace NetClient
             }
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/IInspectable/NETClientIInspectable.csproj
+++ b/src/tests/Interop/COM/NETClients/IInspectable/NETClientIInspectable.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/NETClients/IInspectable/NETClientIInspectable.csproj
+++ b/src/tests/Interop/COM/NETClients/IInspectable/NETClientIInspectable.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/IInspectable/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IInspectable/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace NetClient
 {
     using System;
@@ -21,7 +22,8 @@ namespace NetClient
             Assert.Throws<PlatformNotSupportedException>(() => _ = (IInspectableTesting2)server);
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/IInspectable/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IInspectable/Program.cs
@@ -13,7 +13,7 @@ namespace NetClient
     using Server.Contract;
     using Server.Contract.Servers;
 
-    class Program
+    public class Program
     {
         static void Validate_IInspectable()
         {
@@ -21,7 +21,7 @@ namespace NetClient
             Assert.Throws<PlatformNotSupportedException>(() => _ = (IInspectableTesting2)server);
         }
 
-        static int Main()
+        public static int Main()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
+++ b/src/tests/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
+++ b/src/tests/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/Licensing/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Licensing/Program.cs
@@ -88,7 +88,7 @@ namespace NetClient
                 var licenseTesting = (LicenseTesting)new LicenseTestingClass();
 
                 // During design time the IClassFactory::CreateInstance will be called - no license
-                Assert.Equal(null, licenseTesting.GetLicense());
+                Assert.Null(licenseTesting.GetLicense());
 
                 // Verify the value retrieved from the IClassFactory2::RequestLicKey was what was set
                 Assert.Equal(DefaultLicKey, LicenseManager.CurrentContext.GetSavedLicenseKey(typeof(LicenseTestingClass), resourceAssembly: null));

--- a/src/tests/Interop/COM/NETClients/Licensing/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Licensing/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace NetClient
 {
     using System;
@@ -121,7 +122,8 @@ namespace NetClient
             }
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/Licensing/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Licensing/Program.cs
@@ -14,7 +14,7 @@ namespace NetClient
     using Server.Contract;
     using Server.Contract.Servers;
 
-    class Program
+    public class Program
     {
         static readonly string DefaultLicKey = "__MOCK_LICENSE_KEY__";
         static void ActivateLicensedObject()
@@ -121,7 +121,7 @@ namespace NetClient
             }
         }
 
-        static int Main()
+        public static int Main()
         {
             // RegFree COM is not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/Lifetime/NETClientLifetime.csproj
+++ b/src/tests/Interop/COM/NETClients/Lifetime/NETClientLifetime.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/Lifetime/NETClientLifetime.csproj
+++ b/src/tests/Interop/COM/NETClients/Lifetime/NETClientLifetime.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference, GC.WaitForPendingFinalizers -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/Interop/COM/NETClients/Lifetime/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Lifetime/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace NetClient
 {
     using System;
@@ -12,7 +13,7 @@ namespace NetClient
     using Server.Contract;
     using Server.Contract.Servers;
 
-    unsafe class Program
+    public unsafe class Program
     {
         static delegate* unmanaged<int> GetAllocationCount;
 
@@ -82,7 +83,8 @@ namespace NetClient
             Assert.False(Marshal.AreComObjectsAvailableForCleanup());
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // RegFree COM and STA apartments are not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/Lifetime/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Lifetime/Program.cs
@@ -82,7 +82,7 @@ namespace NetClient
             Assert.False(Marshal.AreComObjectsAvailableForCleanup());
         }
 
-        static int Main()
+        public static int Main()
         {
             // RegFree COM and STA apartments are not supported on Windows Nano
             if (Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -16,6 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
+++ b/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Test needs explicit Main for interop purposes -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
+++ b/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <ProjectReference Include="NETClientPrimitives.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
+++ b/src/tests/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
@@ -3,7 +3,6 @@
     <!-- Test needs explicit Main for interop purposes -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
-    <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/NETClients/Primitives/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Primitives/Program.cs
@@ -8,9 +8,9 @@ namespace NetClient
     using System.Runtime.InteropServices;
     using Xunit;
 
-    class Program
+    public class Program
     {
-        static int Main()
+        public static int Main()
         {
             // RegFree COM is not supported on Windows Nano
             if (TestLibrary.Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NETClients/Primitives/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Primitives/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace NetClient
 {
     using System;
@@ -10,7 +11,8 @@ namespace NetClient
 
     public class Program
     {
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // RegFree COM is not supported on Windows Nano
             if (TestLibrary.Utilities.IsWindowsNanoServer)

--- a/src/tests/Interop/COM/NativeClients/DefaultInterfaces.csproj
+++ b/src/tests/Interop/COM/NativeClients/DefaultInterfaces.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <CMakeProjectReference Include="DefaultInterfaces/CMakeLists.txt" />

--- a/src/tests/Interop/COM/NativeClients/Dispatch.csproj
+++ b/src/tests/Interop/COM/NativeClients/Dispatch.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <CMakeProjectReference Include="Dispatch/CMakeLists.txt" />

--- a/src/tests/Interop/COM/NativeClients/Events.csproj
+++ b/src/tests/Interop/COM/NativeClients/Events.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <CMakeProjectReference Include="Events/CMakeLists.txt" />

--- a/src/tests/Interop/COM/NativeClients/Licensing.csproj
+++ b/src/tests/Interop/COM/NativeClients/Licensing.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <CMakeProjectReference Include="Licensing/CMakeLists.txt" />

--- a/src/tests/Interop/COM/NativeClients/Primitives.csproj
+++ b/src/tests/Interop/COM/NativeClients/Primitives.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <CMakeProjectReference Include="Primitives/CMakeLists.txt" />

--- a/src/tests/Interop/COM/Reflection/Reflection.cs
+++ b/src/tests/Interop/COM/Reflection/Reflection.cs
@@ -105,7 +105,8 @@ public class Reflection
     }
 
     [System.Security.SecuritySafeCritical]
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int failures = 0;
         if (!ReflectionLoad())

--- a/src/tests/Interop/COM/Reflection/Reflection.cs
+++ b/src/tests/Interop/COM/Reflection/Reflection.cs
@@ -105,7 +105,7 @@ public class Reflection
     }
 
     [System.Security.SecuritySafeCritical]
-    static int Main()
+    public static int Main()
     {
         int failures = 0;
         if (!ReflectionLoad())

--- a/src/tests/Interop/COM/Reflection/Reflection.csproj
+++ b/src/tests/Interop/COM/Reflection/Reflection.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for NativeAotIncompatible -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/COM/Reflection/Reflection.csproj
+++ b/src/tests/Interop/COM/Reflection/Reflection.csproj
@@ -7,7 +7,7 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <ProjectReference Include="..\NETServer\NETServer.csproj">
       <Project>{C04AB564-CC61-499D-9F4C-AA1A9FDE42C9}</Project>
       <Name>NETServer</Name>

--- a/src/tests/Interop/Directory.Build.props
+++ b/src/tests/Interop/Directory.Build.props
@@ -1,9 +1,12 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- SDK Style projects auto-magically include this file. -->
-  <Import Project="..\Directory.Build.props" />
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Merged.props', $(MSBuildThisFileDirectory)..))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', $(MSBuildThisFileDirectory)..))" />
 
-  <!-- Properties for all Interop managed test assets -->
   <PropertyGroup>
+    <RunAnalyzers>true</RunAnalyzers>
+    <NoWarn>$(NoWarn);xUnit1013</NoWarn>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <InteropCommonDir>$(MSBuildThisFileDirectory)common/</InteropCommonDir>
   </PropertyGroup>
 </Project>

--- a/src/tests/Interop/Directory.Build.targets
+++ b/src/tests/Interop/Directory.Build.targets
@@ -5,7 +5,7 @@
   <!-- Add the CoreCLRTestLibrary dependency -->
   <ItemGroup Condition="'$(IgnoreCoreCLRTestLibraryDependency)' != 'true'">
     <ProjectReference
-      Include="$(MSBuildThisFileDirectory)\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj" />
+      Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 
   <Target Name="CopyInteropNativeRuntimeDependencies"

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeAssemblyDisabled.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeAssemblyDisabled.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- ActiveIssue https://github.com/dotnet/runtime/issues/84402 -->

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeAssemblyEnabled.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeAssemblyEnabled.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MonoAotIncompatible>true</MonoAotIncompatible>
   </PropertyGroup>

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeTypeInAssembly.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeTypeInAssembly.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- ActiveIssue https://github.com/dotnet/runtime/issues/84402 -->

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeTypeInAssembly_ro.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeTypeInAssembly_ro.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Run the same test suite with optimizations on to validate that inlined IL stubs with the disabled marshalling behavior work correctly. -->
     <DebugType>None</DebugType>

--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_NativeAssemblyDisabled.csproj
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_NativeAssemblyDisabled.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- ActiveIssue https://github.com/dotnet/runtime/issues/84402 -->

--- a/src/tests/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.cs
+++ b/src/tests/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.cs
@@ -5,8 +5,9 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Xunit;
 
-class Test
+public class Test
 {
     private const string RelativeSubdirectoryName = "RelativeNative";
     private const string PathEnvSubdirectoryName = "Subdirectory";
@@ -168,7 +169,8 @@ class Test
         GetZero_Exe();
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.csproj
+++ b/src/tests/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for UnloadabilityIncompatible, CLRTestBashEnvironmentVariable, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- The test cannot be run twice in the same process since it moves a native dll that it uses for pinvoke later -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/src/tests/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.cs
+++ b/src/tests/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.cs
@@ -5,7 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
-class ExactSpellingTest
+public class ExactSpellingTest
 {
     class Ansi
     {
@@ -125,7 +125,8 @@ class ExactSpellingTest
         Assert.Throws<EntryPointNotFoundException>(() => Ansi.MarshalPointer_Int_InOut2(ref int8));
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.csproj
+++ b/src/tests/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.csproj
@@ -7,6 +7,6 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.csproj
+++ b/src/tests/Interop/DllImportAttribute/ExactSpelling/ExactSpellingTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExactSpellingTest.cs" />

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- This test needs process isolation because it creates a subdirectory structure -->
+    <!-- in its output folder for the purpose of testing assembly loading. -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/ExecInDefAppDom/ExecInDefAppDom.cs
+++ b/src/tests/Interop/ExecInDefAppDom/ExecInDefAppDom.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 public class FakeInjectedCode
 {
@@ -55,7 +56,8 @@ public class Program
         return passed ? 0 : 1;
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int result = 100;
         String myPath = System.Reflection.Assembly.GetExecutingAssembly().Location;

--- a/src/tests/Interop/ExecInDefAppDom/ExecInDefAppDom.csproj
+++ b/src/tests/Interop/ExecInDefAppDom/ExecInDefAppDom.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, NativeAotIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>

--- a/src/tests/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParam.csproj
+++ b/src/tests/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParam.csproj
@@ -8,7 +8,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParam.csproj
+++ b/src/tests/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParam.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParam.csproj
+++ b/src/tests/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParam.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParamManaged.cs
+++ b/src/tests/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParamManaged.cs
@@ -29,7 +29,7 @@ public class Test_FuncPtrAsDelegateParamManaged
     }
 
     [SecuritySafeCritical]
-    static int Main()
+    public static int Main()
     {
         bool breturn = true;
 

--- a/src/tests/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParamManaged.cs
+++ b/src/tests/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParamManaged.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Security;
 using System.Runtime.InteropServices;
 using TestLibrary;
+using Xunit;
 
 //Value Pass N-->M	M--->N
 //Cdecl		 -1		 678
@@ -29,7 +30,8 @@ public class Test_FuncPtrAsDelegateParamManaged
     }
 
     [SecuritySafeCritical]
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool breturn = true;
 

--- a/src/tests/Interop/ICastable/ICastable.CoreLib.csproj
+++ b/src/tests/Interop/ICastable/ICastable.CoreLib.csproj
@@ -6,7 +6,12 @@
     which enables us to avoid using Reflection.Emit to provide the implementations.
   -->
   <PropertyGroup>
+    <!-- Without process isolation, this support assembly gets copied to the merged wrapper folder -->
+    <!-- where it subsequently crashes with other custom System.Private.CoreLib assemblies.  -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
+
     <AssemblyName>System.Private.CoreLib</AssemblyName>
     <Nullable>disable</Nullable>
     <NoWarn>$(NoWarn);nullable</NoWarn>

--- a/src/tests/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs.csproj
+++ b/src/tests/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for GCStressIncompatible, UnloadabilityIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <GCStressIncompatible>true</GCStressIncompatible>

--- a/src/tests/Interop/ICustomMarshaler/ConflictingNames/RunInALC.cs
+++ b/src/tests/Interop/ICustomMarshaler/ConflictingNames/RunInALC.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 public class RunInALC
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/ICustomMarshaler/ConflictingNames/SameNameDifferentAssembly.cs
+++ b/src/tests/Interop/ICustomMarshaler/ConflictingNames/SameNameDifferentAssembly.cs
@@ -10,7 +10,8 @@ using Xunit;
 
 public class RunInALC
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/ICustomMarshaler/ConflictingNames/SameNameDifferentAssembly.csproj
+++ b/src/tests/Interop/ICustomMarshaler/ConflictingNames/SameNameDifferentAssembly.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for UnloadabilityIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.cs
+++ b/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.cs
@@ -686,7 +686,8 @@ namespace System.Runtime.InteropServices.Tests
         {
             Assert.Throws<MarshalDirectiveException>(() => CustomMarshallerWithDelegateRef(84664, (ref int x) => x.ToString()));
         }
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             try
             {

--- a/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler_TargetUnix.csproj
+++ b/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler_TargetUnix.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, UnloadabilityIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- There is a Windows and a non-Windows version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' == 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler_TargetWindows.csproj
+++ b/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler_TargetWindows.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, UnloadabilityIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);Windows</DefineConstants>
     <!-- There is a Windows and a non-Windows version of this test to allow it to be compiled for all targets -->

--- a/src/tests/Interop/IDynamicInterfaceCastable/IDynamicInterfaceCastable.csproj
+++ b/src/tests/Interop/IDynamicInterfaceCastable/IDynamicInterfaceCastable.csproj
@@ -7,6 +7,6 @@
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/IDynamicInterfaceCastable/IDynamicInterfaceCastable.csproj
+++ b/src/tests/Interop/IDynamicInterfaceCastable/IDynamicInterfaceCastable.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
+++ b/src/tests/Interop/IDynamicInterfaceCastable/Program.cs
@@ -558,7 +558,8 @@ namespace IDynamicInterfaceCastableTests
             Console.WriteLine($" ---- {ex.GetType().Name}: {ex.Message}");
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             try
             {

--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
@@ -9,9 +9,9 @@ using Xunit;
 
 namespace CopyConstructorMarshaler
 {
-    class CopyConstructorMarshaler
+    public class CopyConstructorMarshaler
     {
-        static int Main()
+        public static int Main()
         {
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)
             {

--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.cs
@@ -11,7 +11,8 @@ namespace CopyConstructorMarshaler
 {
     public class CopyConstructorMarshaler
     {
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)
             {

--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.csproj
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <CopyDebugCRTDllsToOutputDirectory>true</CopyDebugCRTDllsToOutputDirectory>

--- a/src/tests/Interop/IJW/FixupCallsHostWhenLoaded/FixupCallsHostWhenLoaded.cs
+++ b/src/tests/Interop/IJW/FixupCallsHostWhenLoaded/FixupCallsHostWhenLoaded.cs
@@ -11,7 +11,8 @@ namespace FixupCallsHostWhenLoaded
 {
     public class FixupCallsHostWhenLoaded
     {
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // Disable running on Windows 7 until IJW activation work is complete.
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)

--- a/src/tests/Interop/IJW/FixupCallsHostWhenLoaded/FixupCallsHostWhenLoaded.cs
+++ b/src/tests/Interop/IJW/FixupCallsHostWhenLoaded/FixupCallsHostWhenLoaded.cs
@@ -9,9 +9,9 @@ using Xunit;
 
 namespace FixupCallsHostWhenLoaded
 {
-    class FixupCallsHostWhenLoaded
+    public class FixupCallsHostWhenLoaded
     {
-        static int Main()
+        public static int Main()
         {
             // Disable running on Windows 7 until IJW activation work is complete.
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)

--- a/src/tests/Interop/IJW/FixupCallsHostWhenLoaded/FixupCallsHostWhenLoaded.csproj
+++ b/src/tests/Interop/IJW/FixupCallsHostWhenLoaded/FixupCallsHostWhenLoaded.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <CopyDebugCRTDllsToOutputDirectory>true</CopyDebugCRTDllsToOutputDirectory>

--- a/src/tests/Interop/IJW/ManagedCallingNative/ManagedCallingNative.cs
+++ b/src/tests/Interop/IJW/ManagedCallingNative/ManagedCallingNative.cs
@@ -6,12 +6,14 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using TestLibrary;
+using Xunit;
 
 namespace ManagedCallingNative
 {
     public class ManagedCallingNative
     {
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // Disable running on Windows 7 until IJW activation work is complete.
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)

--- a/src/tests/Interop/IJW/ManagedCallingNative/ManagedCallingNative.cs
+++ b/src/tests/Interop/IJW/ManagedCallingNative/ManagedCallingNative.cs
@@ -9,9 +9,9 @@ using TestLibrary;
 
 namespace ManagedCallingNative
 {
-    class ManagedCallingNative
+    public class ManagedCallingNative
     {
-        static int Main()
+        public static int Main()
         {
             // Disable running on Windows 7 until IJW activation work is complete.
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)

--- a/src/tests/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
+++ b/src/tests/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <CopyDebugCRTDllsToOutputDirectory>true</CopyDebugCRTDllsToOutputDirectory>

--- a/src/tests/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
+++ b/src/tests/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
@@ -11,6 +11,6 @@
   <ItemGroup>
     <CMakeProjectReference Include="../IjwNativeDll/CMakeLists.txt" />
     <CMakeProjectReference Include="../ijwhostmock/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/IJW/NativeCallingManaged/NativeCallingManaged.cs
+++ b/src/tests/Interop/IJW/NativeCallingManaged/NativeCallingManaged.cs
@@ -6,12 +6,14 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using TestLibrary;
+using Xunit;
 
 namespace NativeCallingManaged
 {
     public class NativeCallingManaged
     {
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             // Disable running on Windows 7 until IJW activation work is complete.
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)

--- a/src/tests/Interop/IJW/NativeCallingManaged/NativeCallingManaged.cs
+++ b/src/tests/Interop/IJW/NativeCallingManaged/NativeCallingManaged.cs
@@ -9,9 +9,9 @@ using TestLibrary;
 
 namespace NativeCallingManaged
 {
-    class NativeCallingManaged
+    public class NativeCallingManaged
     {
-        static int Main()
+        public static int Main()
         {
             // Disable running on Windows 7 until IJW activation work is complete.
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)

--- a/src/tests/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
+++ b/src/tests/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
     <CopyDebugCRTDllsToOutputDirectory>true</CopyDebugCRTDllsToOutputDirectory>

--- a/src/tests/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
+++ b/src/tests/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
@@ -11,6 +11,6 @@
   <ItemGroup>
     <CMakeProjectReference Include="../IjwNativeCallingManagedDll/CMakeLists.txt" />
     <CMakeProjectReference Include="../ijwhostmock/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.cs
+++ b/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.cs
@@ -12,9 +12,9 @@ using Xunit;
 
 namespace NativeVarargsTest
 {
-    class NativeVarargsTest
+    public NativeVarargsTest
     {
-        static int Main()
+        public static int Main()
         {
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7 || TestLibrary.Utilities.IsWindowsNanoServer)
             {

--- a/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.cs
+++ b/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.cs
@@ -14,7 +14,8 @@ namespace NativeVarargsTest
 {
     public class NativeVarargsTest
     {
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7 || TestLibrary.Utilities.IsWindowsNanoServer)
             {

--- a/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.cs
+++ b/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace NativeVarargsTest
 {
-    public NativeVarargsTest
+    public class NativeVarargsTest
     {
         public static int Main()
         {

--- a/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.csproj
+++ b/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Native varargs not supported on ARM -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'armel'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/Interop/Interop.csproj
+++ b/src/tests/Interop/Interop.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <MergedWrapperProjectReference Include="*/**/*.??proj" />
+  </ItemGroup>
+
+  <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
+</Project>

--- a/src/tests/Interop/LayoutClass/LayoutClassTest.cs
+++ b/src/tests/Interop/LayoutClass/LayoutClassTest.cs
@@ -137,7 +137,7 @@ namespace PInvokeTests
         public RecursiveTestClass c;
     }
 
-    class StructureTests
+    public class StructureTests
     {
         private const string SimpleBlittableSeqLayoutClass_UpdateField = nameof(SimpleBlittableSeqLayoutClass_UpdateField);
 
@@ -320,7 +320,8 @@ namespace PInvokeTests
             Assert.Throws<TypeLoadException>(() => RecursiveNativeLayoutInvalid(new RecursiveTestStruct()));
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             try
             {

--- a/src/tests/Interop/LayoutClass/LayoutClassTest.csproj
+++ b/src/tests/Interop/LayoutClass/LayoutClassTest.csproj
@@ -7,7 +7,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/LayoutClass/LayoutClassTest.csproj
+++ b/src/tests/Interop/LayoutClass/LayoutClassTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/Interop/LayoutClass/LayoutClassTest.csproj
+++ b/src/tests/Interop/LayoutClass/LayoutClassTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointer.cs
+++ b/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointer.cs
@@ -41,7 +41,7 @@ public partial class FunctionPtr
         {
             IntPtr fcnptr = FunctionPointerNative.GetVoidVoidFcnPtr();
             VoidDelegate del = (VoidDelegate)Marshal.GetDelegateForFunctionPointer(fcnptr, typeof(VoidDelegate));
-            Assert.Equal(null, del.Target);
+            Assert.Null(del.Target);
             Assert.Equal("Invoke", del.Method.Name);
 
             // Round trip of a native function pointer is never legal for a non-concrete Delegate type

--- a/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointer.cs
+++ b/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointer.cs
@@ -105,7 +105,8 @@ public partial class FunctionPtr
         Assert.Equal(expectedValue, outVar);
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest.csproj
+++ b/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest.csproj
+++ b/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest.csproj
@@ -7,7 +7,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTest.cs
+++ b/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTest.cs
@@ -213,7 +213,8 @@ public class IUnknownMarshalingTest
         return true;
     }
 
-    public static void Main()
+    [Fact]
+    public static void TestEntryPoint()
     {
         IUnknownMarshalingTest testObj = new IUnknownMarshalingTest(); 
         testObj.Initialize();

--- a/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTest.cs
+++ b/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTest.cs
@@ -213,12 +213,11 @@ public class IUnknownMarshalingTest
         return true;
     }
 
-    public static int Main()
+    public static void Main()
     {
         IUnknownMarshalingTest testObj = new IUnknownMarshalingTest(); 
         testObj.Initialize();
         testObj.RunTests();
-        return 100;
     }
 
 }

--- a/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTest.csproj
+++ b/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, GCStressIncompatible, NativeAotIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <NativeAotIncompatible>true</NativeAotIncompatible>

--- a/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTest.csproj
+++ b/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTest.csproj
@@ -11,7 +11,7 @@
     <Compile Include="IUnknownTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTestInALC.csproj
+++ b/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTestInALC.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needs explicit Main for interop purposes -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
     <OutputType>Exe</OutputType>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTestInALC.csproj
+++ b/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTestInALC.csproj
@@ -3,7 +3,6 @@
     <!-- Needs explicit Main for interop purposes -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
-    <OutputType>Exe</OutputType>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <NativeAotIncompatible>true</NativeAotIncompatible>

--- a/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTestInALC.csproj
+++ b/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTestInALC.csproj
@@ -12,7 +12,7 @@
     <Compile Include="TestInALC.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <ProjectReference Include="IUnknownTest.csproj" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>

--- a/src/tests/Interop/MonoAPI/MonoMono/InstallEHCallback.cs
+++ b/src/tests/Interop/MonoAPI/MonoMono/InstallEHCallback.cs
@@ -5,183 +5,183 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 
+using Xunit;
+
 namespace MonoAPI.Tests.MonoMono.InstallEHCallback;
 
 public class MonoPInvokeCallbackAttribute : Attribute {
-	public MonoPInvokeCallbackAttribute (Type delegateType) { }
+    public MonoPInvokeCallbackAttribute (Type delegateType) { }
 }
 
 public class InstallEHCallback {
 
-	[DllImport (MonoAPISupport.TestLibName)]
-	public static extern void mono_test_setjmp_and_call (VoidVoidDelegate del, out IntPtr handle);
+    [DllImport (MonoAPISupport.TestLibName)]
+    public static extern void mono_test_setjmp_and_call (VoidVoidDelegate del, out IntPtr handle);
 
-	[DllImport (MonoAPISupport.TestLibName)]
-	public static extern void mono_test_setup_ftnptr_eh_callback (VoidVoidDelegate del, VoidHandleHandleOutDelegate inside_eh_callback);
+    [DllImport (MonoAPISupport.TestLibName)]
+    public static extern void mono_test_setup_ftnptr_eh_callback (VoidVoidDelegate del, VoidHandleHandleOutDelegate inside_eh_callback);
 
-	[DllImport (MonoAPISupport.TestLibName)]
-	public static extern void mono_test_cleanup_ftptr_eh_callback ();
-	
-	public delegate void VoidVoidDelegate ();
-	public delegate void VoidHandleHandleOutDelegate (uint handle, out int exception_handle);
+    [DllImport (MonoAPISupport.TestLibName)]
+    public static extern void mono_test_cleanup_ftptr_eh_callback ();
+    
+    public delegate void VoidVoidDelegate ();
+    public delegate void VoidHandleHandleOutDelegate (uint handle, out int exception_handle);
 
-	public class SpecialExn : Exception {
-	}
+    public class SpecialExn : Exception {
+    }
 
-	public class SomeOtherExn : Exception {
-	}
+    public class SomeOtherExn : Exception {
+    }
 
-	[MethodImpl (MethodImplOptions.NoInlining)]
-	private static void callee (ref bool called) {
-		called = true;
-		throw new SpecialExn ();
-	}
+    [MethodImpl (MethodImplOptions.NoInlining)]
+    private static void callee (ref bool called) {
+        called = true;
+        throw new SpecialExn ();
+    }
 
-	public class Caller {
-		public static bool called;
-		public static bool finally_called;
-		
-		public static void Setup () {
-			called = false;
-			finally_called = false;
-		}
+    public class Caller {
+        public static bool called;
+        public static bool finally_called;
+        
+        public static void Setup () {
+            called = false;
+            finally_called = false;
+        }
 
-		[MonoPInvokeCallback (typeof (VoidVoidDelegate))]
-		public static void M1 () {
-			try {
-				callee (ref called);
-				throw new Exception ("unexpected return from callee");
-			} catch (SomeOtherExn) {
-			} finally {
-				finally_called = true;
-			}
-		}
+        [MonoPInvokeCallback (typeof (VoidVoidDelegate))]
+        public static void M1 () {
+            try {
+                callee (ref called);
+                throw new Exception ("unexpected return from callee");
+            } catch (SomeOtherExn) {
+            } finally {
+                finally_called = true;
+            }
+        }
 
-		[MonoPInvokeCallback (typeof (VoidVoidDelegate))]
-		public static void M2 () {
-			try {
-				callee (ref called);
-				throw new Exception ("unexpected return from callee");
-			} catch (SomeOtherExn) {
-			}
-		}
-	}
+        [MonoPInvokeCallback (typeof (VoidVoidDelegate))]
+        public static void M2 () {
+            try {
+                callee (ref called);
+                throw new Exception ("unexpected return from callee");
+            } catch (SomeOtherExn) {
+            }
+        }
+    }
 
-	public static int test_0_setjmp_exn_handler ()
-	{
-		IntPtr res;
-		Caller.Setup ();
-		VoidVoidDelegate f = new VoidVoidDelegate (Caller.M1);
-			
-		try {
-			mono_test_setjmp_and_call (f, out res);
-		} catch (SpecialExn) {
-			Console.Error.WriteLine ("should not have caught a SpecialExn");
-			return 1;
-		}
-		if (!Caller.called) {
-			Console.Error.WriteLine ("delegate not even called");
-			return 2;
-		}
-		if (!Caller.finally_called) {
-			Console.Error.WriteLine ("finally not reached");
-			return 3;
-		}
-		if (res == IntPtr.Zero) {
-			Console.Error.WriteLine ("res should be a GCHandle, was 0");
-			return 4;
-		}
-		GCHandle h = GCHandle.FromIntPtr (res);
-		object o = h.Target;
-		h.Free ();
-		if (o == null) {
-			Console.Error.WriteLine ("GCHandle target was null");
-			return 5;
-		}
-		else if (o is SpecialExn)
-			return 0;
-		else {
-			Console.Error.WriteLine ("o was not a SpecialExn, it is {0}", o);
-			return 6;
-		}
-	}
+    public static int test_0_setjmp_exn_handler ()
+    {
+        IntPtr res;
+        Caller.Setup ();
+        VoidVoidDelegate f = new VoidVoidDelegate (Caller.M1);
+            
+        try {
+            mono_test_setjmp_and_call (f, out res);
+        } catch (SpecialExn) {
+            Console.Error.WriteLine ("should not have caught a SpecialExn");
+            return 1;
+        }
+        if (!Caller.called) {
+            Console.Error.WriteLine ("delegate not even called");
+            return 2;
+        }
+        if (!Caller.finally_called) {
+            Console.Error.WriteLine ("finally not reached");
+            return 3;
+        }
+        if (res == IntPtr.Zero) {
+            Console.Error.WriteLine ("res should be a GCHandle, was 0");
+            return 4;
+        }
+        GCHandle h = GCHandle.FromIntPtr (res);
+        object o = h.Target;
+        h.Free ();
+        if (o == null) {
+            Console.Error.WriteLine ("GCHandle target was null");
+            return 5;
+        }
+        else if (o is SpecialExn)
+            return 0;
+        else {
+            Console.Error.WriteLine ("o was not a SpecialExn, it is {0}", o);
+            return 6;
+        }
+    }
 
-	public class Caller2 {
-		public static bool rethrow_called;
-		public static bool exception_caught;
-		public static bool return_from_inner_managed_callback;
+    public class Caller2 {
+        public static bool rethrow_called;
+        public static bool exception_caught;
+        public static bool return_from_inner_managed_callback;
 
-		public static void Setup () {
-			rethrow_called = false;
-			exception_caught = false;
-			return_from_inner_managed_callback = false;
-		}
+        public static void Setup () {
+            rethrow_called = false;
+            exception_caught = false;
+            return_from_inner_managed_callback = false;
+        }
 
-		public static void RethrowException (uint original_exception) {
-			var e = (Exception) GCHandle.FromIntPtr ((IntPtr) original_exception).Target;
-			rethrow_called = true;
-			System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture (e).Throw ();
-		}
+        public static void RethrowException (uint original_exception) {
+            var e = (Exception) GCHandle.FromIntPtr ((IntPtr) original_exception).Target;
+            rethrow_called = true;
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture (e).Throw ();
+        }
 
-		[MonoPInvokeCallback (typeof (VoidHandleHandleOutDelegate))]
-		public static void Del2 (uint original_exception, out int exception_handle) {
-			exception_handle = 0;
-			try {
-				RethrowException (original_exception);
-			} catch (Exception ex) {
-				var handle = GCHandle.Alloc (ex, GCHandleType.Normal);
-				exception_handle = GCHandle.ToIntPtr (handle).ToInt32 ();
-				exception_caught = true;
-			}
-			return_from_inner_managed_callback = true;
-		}
-	}
-		
-	public static int test_0_throw_and_raise_exception ()
-	{
-		Caller.Setup ();
-		Caller2.Setup ();
-		VoidVoidDelegate f = new VoidVoidDelegate (Caller.M2);
-		VoidHandleHandleOutDelegate del2 = new VoidHandleHandleOutDelegate (Caller2.Del2);
-		bool outer_managed_callback = false;
-		try {
-			mono_test_setup_ftnptr_eh_callback (f, del2);
-		} catch (Exception e) {
-			outer_managed_callback = true;
-		}
+        [MonoPInvokeCallback (typeof (VoidHandleHandleOutDelegate))]
+        public static void Del2 (uint original_exception, out int exception_handle) {
+            exception_handle = 0;
+            try {
+                RethrowException (original_exception);
+            } catch (Exception ex) {
+                var handle = GCHandle.Alloc (ex, GCHandleType.Normal);
+                exception_handle = GCHandle.ToIntPtr (handle).ToInt32 ();
+                exception_caught = true;
+            }
+            return_from_inner_managed_callback = true;
+        }
+    }
+        
+    public static int test_0_throw_and_raise_exception ()
+    {
+        Caller.Setup ();
+        Caller2.Setup ();
+        VoidVoidDelegate f = new VoidVoidDelegate (Caller.M2);
+        VoidHandleHandleOutDelegate del2 = new VoidHandleHandleOutDelegate (Caller2.Del2);
+        bool outer_managed_callback = false;
+        try {
+            mono_test_setup_ftnptr_eh_callback (f, del2);
+        } catch (Exception e) {
+            outer_managed_callback = true;
+        }
 
-		if (!outer_managed_callback) {
-			Console.Error.WriteLine ("outer managed callback did not throw exception");
-			return 1;
-		}
-		if (!Caller2.rethrow_called) {
-			Console.Error.WriteLine ("exception was not rethrown by eh callback");
-			return 2;
-		}
-		if (!Caller2.exception_caught) {
-			Console.Error.WriteLine ("rethrown exception was not caught");
-			return 3;
-		}
-		if (!Caller2.return_from_inner_managed_callback) {
-			Console.Error.WriteLine ("managed callback called from native eh callback did not return");
-			return 4;
-		}
+        if (!outer_managed_callback) {
+            Console.Error.WriteLine ("outer managed callback did not throw exception");
+            return 1;
+        }
+        if (!Caller2.rethrow_called) {
+            Console.Error.WriteLine ("exception was not rethrown by eh callback");
+            return 2;
+        }
+        if (!Caller2.exception_caught) {
+            Console.Error.WriteLine ("rethrown exception was not caught");
+            return 3;
+        }
+        if (!Caller2.return_from_inner_managed_callback) {
+            Console.Error.WriteLine ("managed callback called from native eh callback did not return");
+            return 4;
+        }
 
-		mono_test_cleanup_ftptr_eh_callback ();
-		return 0;
-	}
+        mono_test_cleanup_ftptr_eh_callback ();
+        return 0;
+    }
 
-	static int Main ()
-	{
-		MonoAPI.Tests.MonoAPISupport.Setup();
-		int result;
-		result = test_0_setjmp_exn_handler ();
-		if (result != 0)
-			return 100 + result;
-		result = test_0_throw_and_raise_exception ();
-		if (result != 0)
-			return 100 + result;
-		return 100;
-	}
+    [Fact]
+    public static void TestEntryPoint ()
+    {
+        MonoAPI.Tests.MonoAPISupport.Setup();
+        int result;
+        result = test_0_setjmp_exn_handler ();
+        Assert.Equal(0, result);
+        result = test_0_throw_and_raise_exception ();
+        Assert.Equal(0, result);
+    }
 }
 

--- a/src/tests/Interop/MonoAPI/MonoMono/InstallEHCallback.csproj
+++ b/src/tests/Interop/MonoAPI/MonoMono/InstallEHCallback.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/MonoAPI/MonoMono/PInvokeDetach.cs
+++ b/src/tests/Interop/MonoAPI/MonoMono/PInvokeDetach.cs
@@ -10,95 +10,93 @@ using System;
 using System.Threading;
 using System.Runtime.InteropServices;
 
+using Xunit;
+
 namespace MonoAPI.Tests.MonoMono.PInvokeDetach;
 
 public class MonoPInvokeCallbackAttribute : Attribute {
-	public MonoPInvokeCallbackAttribute (Type delegateType) { }
+    public MonoPInvokeCallbackAttribute (Type delegateType) { }
 }
 
 public class PInvokeDetach {
-	const string TestNamespace = "MonoAPI.Tests.MonoMono.PInvokeDetach";
-	const string TestName = nameof (PInvokeDetach);
+    const string TestNamespace = "MonoAPI.Tests.MonoMono.PInvokeDetach";
+    const string TestName = nameof (PInvokeDetach);
 
-	public static int Main ()
-	{
-		MonoAPI.Tests.MonoAPISupport.Setup();
-		int result;
-		result = test_0_attach_invoke_foreign_thread ();
-		if (result != 0)
-			return 100 + result;
-		result = test_0_attach_invoke_foreign_thread_delegate ();
-		if (result != 0)
-			return 100 + result;
-		result = test_0_attach_invoke_block_foreign_thread ();
-		if (result != 0)
-			return 100 + result;
-		result = test_0_attach_invoke_block_foreign_thread_delegate ();
-		if (result != 0)
-			return 100 + result;
-		return 100;
-	}
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        MonoAPI.Tests.MonoAPISupport.Setup();
+        int result;
+        result = test_0_attach_invoke_foreign_thread ();
+        Assert.Equal(0, result);
+        result = test_0_attach_invoke_foreign_thread_delegate ();
+        Assert.Equal(0, result);
+        result = test_0_attach_invoke_block_foreign_thread ();
+        Assert.Equal(0, result);
+        result = test_0_attach_invoke_block_foreign_thread_delegate ();
+        Assert.Equal(0, result);
+    }
 
-	public delegate void VoidVoidDelegate ();
+    public delegate void VoidVoidDelegate ();
 
-	static int was_called;
+    static int was_called;
 
-	[MonoPInvokeCallback (typeof (VoidVoidDelegate))]
-	private static void MethodInvokedFromNative ()
-	{
-		was_called++;
-	}
+    [MonoPInvokeCallback (typeof (VoidVoidDelegate))]
+    private static void MethodInvokedFromNative ()
+    {
+        was_called++;
+    }
 
-	[DllImport (MonoAPISupport.TestLibName, EntryPoint="mono_test_attach_invoke_foreign_thread")]
-	public static extern bool mono_test_attach_invoke_foreign_thread (string assm_name, string name_space, string class_name, string method_name, VoidVoidDelegate del);
+    [DllImport (MonoAPISupport.TestLibName, EntryPoint="mono_test_attach_invoke_foreign_thread")]
+    public static extern bool mono_test_attach_invoke_foreign_thread (string assm_name, string name_space, string class_name, string method_name, VoidVoidDelegate del);
 
-	public static int test_0_attach_invoke_foreign_thread ()
-	{
-		was_called = 0;
-		bool skipped = mono_test_attach_invoke_foreign_thread (typeof (PInvokeDetach).Assembly.Location, TestNamespace, TestName, nameof(MethodInvokedFromNative), null);
-		GC.Collect (); // should not hang waiting for the foreign thread
-		return skipped || was_called == 5 ? 0 : 1;
-	}
+    public static int test_0_attach_invoke_foreign_thread ()
+    {
+        was_called = 0;
+        bool skipped = mono_test_attach_invoke_foreign_thread (typeof (PInvokeDetach).Assembly.Location, TestNamespace, TestName, nameof(MethodInvokedFromNative), null);
+        GC.Collect (); // should not hang waiting for the foreign thread
+        return skipped || was_called == 5 ? 0 : 1;
+    }
 
-	static int was_called_del;
+    static int was_called_del;
 
-	[MonoPInvokeCallback (typeof (VoidVoidDelegate))]
-	private static void MethodInvokedFromNative_del ()
-	{
-		was_called_del++;
-	}
+    [MonoPInvokeCallback (typeof (VoidVoidDelegate))]
+    private static void MethodInvokedFromNative_del ()
+    {
+        was_called_del++;
+    }
 
-	public static int test_0_attach_invoke_foreign_thread_delegate ()
-	{
-		var del = new VoidVoidDelegate (MethodInvokedFromNative_del);
-		was_called_del = 0;
-		bool skipped = mono_test_attach_invoke_foreign_thread (null, null, null, null, del);
-		GC.Collect (); // should not hang waiting for the foreign thread
-		return skipped || was_called_del == 5 ? 0 : 1;
-	}
+    public static int test_0_attach_invoke_foreign_thread_delegate ()
+    {
+        var del = new VoidVoidDelegate (MethodInvokedFromNative_del);
+        was_called_del = 0;
+        bool skipped = mono_test_attach_invoke_foreign_thread (null, null, null, null, del);
+        GC.Collect (); // should not hang waiting for the foreign thread
+        return skipped || was_called_del == 5 ? 0 : 1;
+    }
 
-	[MonoPInvokeCallback (typeof (VoidVoidDelegate))]
-	private static void MethodInvokedFromNative2 ()
-	{
-	}
+    [MonoPInvokeCallback (typeof (VoidVoidDelegate))]
+    private static void MethodInvokedFromNative2 ()
+    {
+    }
 
-	[DllImport (MonoAPISupport.TestLibName, EntryPoint="mono_test_attach_invoke_block_foreign_thread")]
-	public static extern bool mono_test_attach_invoke_block_foreign_thread (string assm_name, string name_space, string class_name, string method_name, VoidVoidDelegate del);
+    [DllImport (MonoAPISupport.TestLibName, EntryPoint="mono_test_attach_invoke_block_foreign_thread")]
+    public static extern bool mono_test_attach_invoke_block_foreign_thread (string assm_name, string name_space, string class_name, string method_name, VoidVoidDelegate del);
 
-	public static int test_0_attach_invoke_block_foreign_thread ()
-	{
-		bool skipped = mono_test_attach_invoke_block_foreign_thread (typeof (PInvokeDetach).Assembly.Location, TestNamespace, TestName, nameof(MethodInvokedFromNative2), null);
-		GC.Collect (); // should not hang waiting for the foreign thread
-		return 0; // really we succeed if the app can shut down without hanging
-	}
+    public static int test_0_attach_invoke_block_foreign_thread ()
+    {
+        bool skipped = mono_test_attach_invoke_block_foreign_thread (typeof (PInvokeDetach).Assembly.Location, TestNamespace, TestName, nameof(MethodInvokedFromNative2), null);
+        GC.Collect (); // should not hang waiting for the foreign thread
+        return 0; // really we succeed if the app can shut down without hanging
+    }
 
-	// This one fails because we haven't fully detached, so shutdown is waiting for the thread
-	public static int test_0_attach_invoke_block_foreign_thread_delegate ()
-	{
-		var del = new VoidVoidDelegate (MethodInvokedFromNative2);
-		bool skipped = mono_test_attach_invoke_block_foreign_thread (null, null, null, null, del);
-		GC.Collect (); // should not hang waiting for the foreign thread
-		return 0; // really we succeed if the app can shut down without hanging
-	}
+    // This one fails because we haven't fully detached, so shutdown is waiting for the thread
+    public static int test_0_attach_invoke_block_foreign_thread_delegate ()
+    {
+        var del = new VoidVoidDelegate (MethodInvokedFromNative2);
+        bool skipped = mono_test_attach_invoke_block_foreign_thread (null, null, null, null, del);
+        GC.Collect (); // should not hang waiting for the foreign thread
+        return 0; // really we succeed if the app can shut down without hanging
+    }
 
 }

--- a/src/tests/Interop/MonoAPI/MonoMono/PInvokeDetach.csproj
+++ b/src/tests/Interop/MonoAPI/MonoMono/PInvokeDetach.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/MonoAPI/MonoMono/Thunks.cs
+++ b/src/tests/Interop/MonoAPI/MonoMono/Thunks.cs
@@ -36,8 +36,10 @@ public class Thunks
         }
     }
 
+    // By default the ILTransform tool renames Main to TestEntryPoint but that doesn't work
+    // in this case because it uses reflection to enumerate method with names starting with "Test".
     [Fact]
-    public static void TestEntryPoint()
+    public static void EntryPoint()
     {
         MonoAPI.Tests.MonoAPISupport.Setup();
         RunTests (0, typeof (Thunks));

--- a/src/tests/Interop/MonoAPI/MonoMono/Thunks.cs
+++ b/src/tests/Interop/MonoAPI/MonoMono/Thunks.cs
@@ -5,154 +5,156 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
+using Xunit;
+
 namespace MonoAPI.Tests.MonoMono.Thunks;
 
 public class Thunks
 {
-	[DllImport (MonoAPISupport.TestLibName)]
-		public static extern int test_method_thunk (int test_id, IntPtr testMethodHandle,
-		IntPtr createObjectHandle);
+    [DllImport (MonoAPISupport.TestLibName)]
+        public static extern int test_method_thunk (int test_id, IntPtr testMethodHandle,
+        IntPtr createObjectHandle);
 
-	static void RunTests(int series, Type type)
-	{
-		const string Prefix = "Test";
-		MethodInfo createObjectMethod = type.GetMethod ("CreateObject");
-		
-		foreach (MethodInfo mi in type.GetMethods ()) {
-			string name = mi.Name;
-			if (!name.StartsWith (Prefix))
-				continue;
+    static void RunTests(int series, Type type)
+    {
+        const string Prefix = "Test";
+        MethodInfo createObjectMethod = type.GetMethod ("CreateObject");
+        
+        foreach (MethodInfo mi in type.GetMethods ()) {
+            string name = mi.Name;
+            if (!name.StartsWith (Prefix))
+                continue;
 
-			int id = Convert.ToInt32 (name.Substring (Prefix.Length));
+            int id = Convert.ToInt32 (name.Substring (Prefix.Length));
 
-			int res = test_method_thunk (series + id, mi.MethodHandle.Value, createObjectMethod.MethodHandle.Value);
+            int res = test_method_thunk (series + id, mi.MethodHandle.Value, createObjectMethod.MethodHandle.Value);
 
-			if (res != 0) {
-				Console.WriteLine ("{0} returned {1}", mi, res);
-				Environment.Exit ((id << 3) + res);
-			}
-		}
-	}
+            if (res != 0) {
+                Console.WriteLine ("{0} returned {1}", mi, res);
+                Environment.Exit ((id << 3) + res);
+            }
+        }
+    }
 
-	public static int Main ()
-	{
-		MonoAPI.Tests.MonoAPISupport.Setup();
-		RunTests (0, typeof (Thunks));
-		RunTests (100, typeof (TestStruct));
-		return 100;
-	}
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        MonoAPI.Tests.MonoAPISupport.Setup();
+        RunTests (0, typeof (Thunks));
+        RunTests (100, typeof (TestStruct));
+    }
 
-	public static object CreateObject ()
-	{
-		return new Thunks ();
-	}
+    public static object CreateObject ()
+    {
+        return new Thunks ();
+    }
 
-	public static void Test0 ()
-	{
-	}
+    public static void Test0 ()
+    {
+    }
 
-	public static int Test1 ()
-	{
-		return 42;
-	}
+    public static int Test1 ()
+    {
+        return 42;
+    }
 
-	public static string Test2 (string s)
-	{
-		return s;
-	}
+    public static string Test2 (string s)
+    {
+        return s;
+    }
 
-	public string Test3 (string a)
-	{
-		return a;
-	}
+    public string Test3 (string a)
+    {
+        return a;
+    }
 
-	public int Test4 (string a, int i)
-	{
-		return i;
-	}
+    public int Test4 (string a, int i)
+    {
+        return i;
+    }
 
-	public int Test5 (string a, int i)
-	{
-		throw new NotImplementedException ();
-	}
+    public int Test5 (string a, int i)
+    {
+        throw new NotImplementedException ();
+    }
 
-	public bool Test6 (byte a1, short a2, int a3, long a4, float a5, double a6, string a7)
-	{
-		return  a1 == 254 &&
-			a2 == 32700 &&
-			a3 == -245378 &&
-			a4 == 6789600 &&
-			(Math.Abs (a5 - 3.1415) < 0.001) &&
-			(Math.Abs (a6 - 3.1415) < 0.001) &&
-			a7 == "Test6";
-	}
+    public bool Test6 (byte a1, short a2, int a3, long a4, float a5, double a6, string a7)
+    {
+        return  a1 == 254 &&
+            a2 == 32700 &&
+            a3 == -245378 &&
+            a4 == 6789600 &&
+            (Math.Abs (a5 - 3.1415) < 0.001) &&
+            (Math.Abs (a6 - 3.1415) < 0.001) &&
+            a7 == "Test6";
+    }
 
-	public static long Test7 ()
-	{
-		return Int64.MaxValue;
-	}
+    public static long Test7 ()
+    {
+        return Int64.MaxValue;
+    }
 
-	public static void Test8 (ref byte a1, ref short a2, ref int a3, ref long a4, ref float a5, ref double a6, ref string a7)
-	{
-		a1 = 254;
-		a2 = 32700;
-		a3 = -245378;
-		a4 = 6789600;
-		a5 = 3.1415f;
-		a6 = 3.1415;
-		a7 = "Test8";
-	}
+    public static void Test8 (ref byte a1, ref short a2, ref int a3, ref long a4, ref float a5, ref double a6, ref string a7)
+    {
+        a1 = 254;
+        a2 = 32700;
+        a3 = -245378;
+        a4 = 6789600;
+        a5 = 3.1415f;
+        a6 = 3.1415;
+        a7 = "Test8";
+    }
 
-	public static void Test9 (ref byte a1, ref short a2, ref int a3, ref long a4, ref float a5, ref double a6, ref string a7)
-	{
-		throw new NotImplementedException ();
-	}
+    public static void Test9 (ref byte a1, ref short a2, ref int a3, ref long a4, ref float a5, ref double a6, ref string a7)
+    {
+        throw new NotImplementedException ();
+    }
 
-	public static void Test10 (ref Thunks obj)
-	{
-		obj = new Thunks ();
-	}
+    public static void Test10 (ref Thunks obj)
+    {
+        obj = new Thunks ();
+    }
 }
 
 
 public struct TestStruct
 {
-	public int A;
-	public double B;
+    public int A;
+    public double B;
 
-	public static object CreateObject ()
-	{
-		return new TestStruct ();
-	}
+    public static object CreateObject ()
+    {
+        return new TestStruct ();
+    }
 
-	public static bool Test0 (TestStruct s)
-	{
-		bool res =  s.A == 42 && Math.Abs (s.B - 3.1415) < 0.001;
+    public static bool Test0 (TestStruct s)
+    {
+        bool res =  s.A == 42 && Math.Abs (s.B - 3.1415) < 0.001;
 
-		/* these changes must not be visible in unmanaged code */
-		s.A = 12;
-		s.B = 13;
+        /* these changes must not be visible in unmanaged code */
+        s.A = 12;
+        s.B = 13;
 
-		return res;
-	}
+        return res;
+    }
 
-	public static void Test1 (ref TestStruct s)
-	{
-		s.A = 42;
-		s.B = 3.1415;
-	}
+    public static void Test1 (ref TestStruct s)
+    {
+        s.A = 42;
+        s.B = 3.1415;
+    }
 
-	public static TestStruct Test2 ()
-	{
-		TestStruct s = new TestStruct ();
-		s.A = 42;
-		s.B = 3.1415;
-		return s;
-	}
+    public static TestStruct Test2 ()
+    {
+        TestStruct s = new TestStruct ();
+        s.A = 42;
+        s.B = 3.1415;
+        return s;
+    }
 
-	public void Test3 ()
-	{
-		A = 1;
-		B = 17;
-	}
+    public void Test3 ()
+    {
+        A = 1;
+        B = 17;
+    }
 }

--- a/src/tests/Interop/MonoAPI/MonoMono/Thunks.csproj
+++ b/src/tests/Interop/MonoAPI/MonoMono/Thunks.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference, Environment.Exit -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/NativeLibrary/API/GetLibraryExportTests.cs
+++ b/src/tests/Interop/NativeLibrary/API/GetLibraryExportTests.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 using Xunit;
 using static TestHelpers;
 
-class GetLibraryExportTests : IDisposable
+public class GetLibraryExportTests : IDisposable
 {
     private readonly IntPtr handle;
 

--- a/src/tests/Interop/NativeLibrary/API/GetMainProgramHandleTests.cs
+++ b/src/tests/Interop/NativeLibrary/API/GetMainProgramHandleTests.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 using Xunit;
 using static TestHelpers;
 
-class GetMainProgramHandleTests
+public class GetMainProgramHandleTests
 {
     // Mobile test runs aren't hosted by corerun, so we don't have a well-known export to test here
     [ConditionalFact(nameof(IsHostedByCoreRun))]

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
@@ -49,14 +49,16 @@ public class NativeLibraryTests : IDisposable
     [Fact]
     public void LoadLibraryRelativePaths_NameOnly()
     {
+        string appDir = Path.GetDirectoryName(assembly.Location);
+        
         {
-            string libName = Path.Combine("..", NativeLibraryToLoad.InvalidName, NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.InvalidName));
+            string libName = Path.Combine(appDir, NativeLibraryToLoad.InvalidName, NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.InvalidName));
             EXPECT(LoadLibrary_NameOnly(libName), TestResult.DllNotFound);
             EXPECT(TryLoadLibrary_NameOnly(libName), TestResult.ReturnFailure);
         }
 
         {
-            string libName = Path.Combine("..", nameof(NativeLibraryTests), NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.Name));
+            string libName = Path.Combine(appDir, nameof(NativeLibraryTests), NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.Name));
             EXPECT(LoadLibrary_NameOnly(libName), TestResult.Success);
             EXPECT(TryLoadLibrary_NameOnly(libName), TestResult.Success);
         }

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.cs
@@ -49,16 +49,15 @@ public class NativeLibraryTests : IDisposable
     [Fact]
     public void LoadLibraryRelativePaths_NameOnly()
     {
-        string appDir = Path.GetDirectoryName(assembly.Location);
         
         {
-            string libName = Path.Combine(appDir, NativeLibraryToLoad.InvalidName, NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.InvalidName));
+            string libName = Path.Combine("..", NativeLibraryToLoad.InvalidName, NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.InvalidName));
             EXPECT(LoadLibrary_NameOnly(libName), TestResult.DllNotFound);
             EXPECT(TryLoadLibrary_NameOnly(libName), TestResult.ReturnFailure);
         }
 
         {
-            string libName = Path.Combine(appDir, nameof(NativeLibraryTests), NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.Name));
+            string libName = Path.Combine("..", nameof(NativeLibraryTests), NativeLibraryToLoad.GetLibraryFileName(NativeLibraryToLoad.Name));
             EXPECT(LoadLibrary_NameOnly(libName), TestResult.Success);
             EXPECT(TryLoadLibrary_NameOnly(libName), TestResult.Success);
         }

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- This test needs process isolation because it tests native library loading -->
+    <!-- from explicitly specified paths. -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Finalize in different assembly from Dispose, tries to load the assembly with Dispose after the ALC unload started -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
@@ -3,7 +3,6 @@
     <!-- This test needs process isolation because it tests native library loading -->
     <!-- from explicitly specified paths. -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Finalize in different assembly from Dispose, tries to load the assembly with Dispose after the ALC unload started -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
@@ -14,7 +14,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/tests/Interop/NativeLibrary/AssemblyLoadContext/ResolveUnmanagedDllTests.cs
+++ b/src/tests/Interop/NativeLibrary/AssemblyLoadContext/ResolveUnmanagedDllTests.cs
@@ -59,7 +59,8 @@ public class ResolveUnmanagedDllTests
     private static readonly int seed = 123;
     internal static readonly Random rand = new Random(seed);
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/NativeLibrary/AssemblyLoadContext/ResolveUnmanagedDllTests.csproj
+++ b/src/tests/Interop/NativeLibrary/AssemblyLoadContext/ResolveUnmanagedDllTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for UnloadabilityIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- The test leaves AssemblyLoadContext.Default.ResolvingUnmanagedDll event registered to a method in the test at exit -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/Interop/NativeLibrary/AssemblyLoadContext/ResolveUnmanagedDllTests.csproj
+++ b/src/tests/Interop/NativeLibrary/AssemblyLoadContext/ResolveUnmanagedDllTests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <ProjectReference Include="TestAsm/TestAsm.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>

--- a/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest.cs
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Xunit;
 
 [assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
 public class CallbackStressTest
@@ -125,7 +126,8 @@ public class CallbackStressTest
 #endif
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         for(int i = 0; i < s_LoopCounter; i++)
         {

--- a/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest_TargetUnix.csproj
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest_TargetUnix.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- There is a Windows and a non-Windows version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' == 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest_TargetWindows.csproj
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest_TargetWindows.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest_TargetWindows.csproj
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest_TargetWindows.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants >WINDOWS</DefineConstants>
     <!-- There is a Windows and a non-Windows version of this test to allow it to be compiled for all targets -->

--- a/src/tests/Interop/NativeLibrary/Callback/CallbackTests.cs
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackTests.cs
@@ -14,7 +14,8 @@ public class CallbackTests
     private static readonly int seed = 123;
     private static readonly Random rand = new Random(seed);
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/NativeLibrary/Callback/CallbackTests.csproj
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/NativeLibrary/Callback/CallbackTests.csproj
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackTests.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.cs
+++ b/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.cs
@@ -26,7 +26,8 @@ public static class MainProgramHandleTests
             return IntPtr.Zero;
         });
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.csproj
+++ b/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.csproj
@@ -8,6 +8,6 @@
     <Compile Include="MainProgramHandleTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.csproj
+++ b/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' == 'true' or '$(RuntimeVariant)' == 'monointerpreter'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/Interop/ObjectiveC/AutoReleaseTest/AutoReleaseTest.cs
+++ b/src/tests/Interop/ObjectiveC/AutoReleaseTest/AutoReleaseTest.cs
@@ -18,7 +18,8 @@ internal static unsafe class ObjectiveC
 
 public class AutoReleaseTest
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/ObjectiveC/AutoReleaseTest/AutoReleaseTest.csproj
+++ b/src/tests/Interop/ObjectiveC/AutoReleaseTest/AutoReleaseTest.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="./CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/ObjectiveC/AutoReleaseTest/AutoReleaseTest.csproj
+++ b/src/tests/Interop/ObjectiveC/AutoReleaseTest/AutoReleaseTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference, GC.WaitForPendingFinalizers -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true' and '$(TargetsiOS)' != 'true' and '$(TargetstvOS)' != 'true'">true</CLRTestTargetUnsupported>
     <AutoreleasePoolSupport>true</AutoreleasePoolSupport>

--- a/src/tests/Interop/ObjectiveC/ObjectiveCMarshalAPI/ObjectiveCMarshalAPI.csproj
+++ b/src/tests/Interop/ObjectiveC/ObjectiveCMarshalAPI/ObjectiveCMarshalAPI.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference, GC.WaitForPendingFinalizers -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of OSX -->
     <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/tests/Interop/ObjectiveC/ObjectiveCMarshalAPI/Program.cs
+++ b/src/tests/Interop/ObjectiveC/ObjectiveCMarshalAPI/Program.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
 namespace ObjectiveCMarshalAPI
 {
     using System;
@@ -436,7 +437,8 @@ namespace ObjectiveCMarshalAPI
                 });
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             try
             {

--- a/src/tests/Interop/ObjectiveC/ObjectiveCMarshalAPI/Program.cs
+++ b/src/tests/Interop/ObjectiveC/ObjectiveCMarshalAPI/Program.cs
@@ -36,7 +36,7 @@ namespace ObjectiveCMarshalAPI
         public static extern IntPtr GetThrowException();
     }
 
-    unsafe class Program
+    public unsafe class Program
     {
         static void Validate_ReferenceTrackingAPIs_InvalidArgs()
         {
@@ -436,7 +436,7 @@ namespace ObjectiveCMarshalAPI
                 });
         }
 
-        static int Main()
+        public static int Main()
         {
             try
             {

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsByValArray/AsByValArrayTest.cs
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsByValArray/AsByValArrayTest.cs
@@ -1176,7 +1176,8 @@ public class Test
         Assert.True(TestStructEquals(InitStructArray(ARRAY_SIZE), retval13.arr));
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsByValArray/AsByValArrayTest.cs
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsByValArray/AsByValArrayTest.cs
@@ -508,7 +508,7 @@ public class C_BOOLArray_Exp
 
 #endregion
 
-class Test
+public class Test
 {
     //for RunTest1
     [DllImport("MarshalArrayByValArrayNative", CallingConvention = CallingConvention.Cdecl)]
@@ -1176,7 +1176,7 @@ class Test
         Assert.True(TestStructEquals(InitStructArray(ARRAY_SIZE), retval13.arr));
     }
 
-    static int Main()
+    public static int Main()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsByValArray/AsByValArrayTest.csproj
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsByValArray/AsByValArrayTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsLPArray/AsLPArrayTest.cs
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsLPArray/AsLPArrayTest.cs
@@ -5,7 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
-class Test
+public class Test
 {
     [DllImport("MarshalArrayByValArrayNative", CallingConvention = CallingConvention.Cdecl)]
     static extern bool TakeIntArraySeqStructByVal([In]S_INTArray_Seq s, [In]int size);
@@ -421,7 +421,7 @@ class Test
         Assert.Throws<TypeLoadException>(() => TakeStructArrayExpClassByVal(c14, ARRAY_SIZE));
     }
 
-    static int Main()
+    public static int Main()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsLPArray/AsLPArrayTest.cs
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsLPArray/AsLPArrayTest.cs
@@ -421,7 +421,8 @@ public class Test
         Assert.Throws<TypeLoadException>(() => TakeStructArrayExpClassByVal(c14, ARRAY_SIZE));
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsLPArray/AsLPArrayTest.csproj
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/AsLPArray/AsLPArrayTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs
@@ -395,7 +395,7 @@ public class ArrayMarshal
         Console.WriteLine("CStyle_Array_Int_InOut_ZeroLength");
         int[] iArrLength0 = InitArray<int>(0);
         Assert.True(CStyle_Array_Int_InOut_ZeroLength(iArrLength0));
-        Assert.Equal(0, iArrLength0.Length);
+        Assert.Empty(iArrLength0);
 
         Console.WriteLine("CStyle_Array_Uint_InOut");
         uint[] uiArr = InitArray<uint>(ARRAY_SIZE);
@@ -560,7 +560,7 @@ public class ArrayMarshal
         Console.WriteLine("CStyle_Array_Int_Out_ZeroLength");
         int[] iArrLength0 = new int[0];
         Assert.True(CStyle_Array_Int_Out_ZeroLength(iArrLength0));
-        Assert.Equal(0, iArrLength0.Length);
+        Assert.Empty(iArrLength0);
 
         Console.WriteLine("CStyle_Array_Uint_Out");
         uint[] uiArr = new uint[ARRAY_SIZE];

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs
@@ -652,7 +652,8 @@ public class ArrayMarshal
         Assert.Equal(sum, Get_Multidimensional_Array_Sum(array, ROWS, COLUMNS));
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.csproj
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest.cs
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest.cs
@@ -374,7 +374,7 @@ public class ArrayMarshal
 
         int[] iArrLength0 = InitArray<int>(0);
         Assert.True(CStyle_Array_Int_InOut_ZeroLength(iArrLength0));
-        Assert.Equal(0, iArrLength0.Length);
+        Assert.Empty(iArrLength0);
 
         uint[] uiArr = InitArray<uint>(ARRAY_SIZE);
         Assert.True(CStyle_Array_Uint_InOut(uiArr, ARRAY_SIZE));
@@ -503,7 +503,7 @@ public class ArrayMarshal
 
         int[] iArrLength0 = new int[0];
         Assert.True(CStyle_Array_Int_Out_ZeroLength(iArrLength0));
-        Assert.Equal(0, iArrLength0.Length);
+        Assert.Empty(iArrLength0);
 
         uint[] uiArr = new uint[ARRAY_SIZE];
         Assert.True(CStyle_Array_Uint_Out(uiArr, ARRAY_SIZE));

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest.cs
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest.cs
@@ -630,7 +630,8 @@ public class ArrayMarshal
     }
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try{
             TestMarshalByVal_NoAttributes();

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest.csproj
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/Interop/PInvoke/ArrayWithOffset/ArrayWithOffsetTest.cs
+++ b/src/tests/Interop/PInvoke/ArrayWithOffset/ArrayWithOffsetTest.cs
@@ -6,9 +6,10 @@ using System.Text;
 using System.Runtime.InteropServices;
 using Xunit;
 
-unsafe class ArrayWithOffsetTest
+public unsafe class ArrayWithOffsetTest
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/ArrayWithOffset/ArrayWithOffsetTest.csproj
+++ b/src/tests/Interop/PInvoke/ArrayWithOffset/ArrayWithOffsetTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/PInvoke/AsAny/AsAnyTest.cs
+++ b/src/tests/Interop/PInvoke/AsAny/AsAnyTest.cs
@@ -10,13 +10,13 @@ using Xunit;
 
 #pragma warning disable CS0612, CS0618
 
-struct A
+public struct A
 {
     public long a;
     public long b;
 }
 
-struct AsAnyField
+public struct AsAnyField
 {
     [MarshalAs(UnmanagedType.AsAny)]
     public object intArray;

--- a/src/tests/Interop/PInvoke/AsAny/AsAnyTest.cs
+++ b/src/tests/Interop/PInvoke/AsAny/AsAnyTest.cs
@@ -22,7 +22,7 @@ public struct AsAnyField
     public object intArray;
 }
 
-class AsAnyTests
+public class AsAnyTests
 {
     private const char mappableChar = (char)0x2075;
     private const char unmappableChar = (char)0x7777;
@@ -295,7 +295,8 @@ class AsAnyTests
     [DllImport("AsAnyNative", EntryPoint = "PassMixStruct")]
     public static extern bool PassMixStruct(AsAnyField mix);
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/AsAny/AsAnyTest.csproj
+++ b/src/tests/Interop/PInvoke/AsAny/AsAnyTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/Interop/PInvoke/Attributes/LCID/LCIDTest.cs
+++ b/src/tests/Interop/PInvoke/Attributes/LCID/LCIDTest.cs
@@ -19,7 +19,7 @@ class LCIDNative
     public static extern bool VerifyValidLCIDPassed(int lcid);
 }
 
-class LCIDTest
+public class LCIDTest
 {
     private static string Reverse(string s)
     {
@@ -28,7 +28,8 @@ class LCIDTest
         return new string(chars);
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/Attributes/LCID/LCIDTest.csproj
+++ b/src/tests/Interop/PInvoke/Attributes/LCID/LCIDTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/Interop/PInvoke/BestFitMapping/Assembly_Default/Assembly_Default.csproj
+++ b/src/tests/Interop/PInvoke/BestFitMapping/Assembly_Default/Assembly_Default.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/Interop/PInvoke/BestFitMapping/Assembly_False_False/Assembly_False_False.csproj
+++ b/src/tests/Interop/PInvoke/BestFitMapping/Assembly_False_False/Assembly_False_False.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/Interop/PInvoke/BestFitMapping/Assembly_False_True/Assembly_False_True.csproj
+++ b/src/tests/Interop/PInvoke/BestFitMapping/Assembly_False_True/Assembly_False_True.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/Interop/PInvoke/BestFitMapping/Assembly_True_False/Assembly_True_False.csproj
+++ b/src/tests/Interop/PInvoke/BestFitMapping/Assembly_True_False/Assembly_True_False.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/Interop/PInvoke/BestFitMapping/Assembly_True_True/Assembly_True_True.csproj
+++ b/src/tests/Interop/PInvoke/BestFitMapping/Assembly_True_True/Assembly_True_True.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>

--- a/src/tests/Interop/PInvoke/BestFitMapping/Program.cs
+++ b/src/tests/Interop/PInvoke/BestFitMapping/Program.cs
@@ -6,37 +6,33 @@ using System.Text;
 using System.Runtime.InteropServices;
 using TestLibrary;
 
+using Xunit;
+
 public class Program
 {
-    public static int Main()
+    [Fact]
+    public static void TestEntryPoint()
     {
         if (System.Globalization.CultureInfo.CurrentCulture.Name != "en-US")
         {
             Console.WriteLine("Non-US English platforms are not supported.\nPassing without running tests");
 
             Console.WriteLine("--- Success");
-            return 100;
+            return;
         }
 
-        try
-        {
-            Console.WriteLine("Validating char marshalling...");
-            Char.PInvoke_Default.RunTest();
-            Char.PInvoke_False_False.RunTest();
-            Char.PInvoke_False_True.RunTest();
-            Char.PInvoke_True_False.RunTest();
-            Char.PInvoke_True_True.RunTest();
+        Console.WriteLine("Validating char marshalling...");
+        Char.PInvoke_Default.RunTest();
+        Char.PInvoke_False_False.RunTest();
+        Char.PInvoke_False_True.RunTest();
+        Char.PInvoke_True_False.RunTest();
+        Char.PInvoke_True_True.RunTest();
 
-            Console.WriteLine("Validating LPStr marshalling...");
-            LPStr.PInvoke_Default.RunTest();
-            LPStr.PInvoke_False_False.RunTest();
-            LPStr.PInvoke_False_True.RunTest();
-            LPStr.PInvoke_True_False.RunTest();
-            LPStr.PInvoke_True_True.RunTest();
-            return 100;
-        } catch (Exception e){
-            Console.WriteLine($"Test Failure: {e}");
-            return 101;
-        }
+        Console.WriteLine("Validating LPStr marshalling...");
+        LPStr.PInvoke_Default.RunTest();
+        LPStr.PInvoke_False_False.RunTest();
+        LPStr.PInvoke_False_True.RunTest();
+        LPStr.PInvoke_True_False.RunTest();
+        LPStr.PInvoke_True_True.RunTest();
     }
 }

--- a/src/tests/Interop/PInvoke/CriticalHandles/ArrayTest/ArrayTest.cs
+++ b/src/tests/Interop/PInvoke/CriticalHandles/ArrayTest/ArrayTest.cs
@@ -134,7 +134,8 @@ public class CriticalHandleArrayTest
         Assert.Throws<MarshalDirectiveException>(() => Native.RefModify(handleValue2, ref myCriticalHandleArray));
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/CriticalHandles/ArrayTest/ArrayTest.csproj
+++ b/src/tests/Interop/PInvoke/CriticalHandles/ArrayTest/ArrayTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference, GC.WaitForPendingFinalizers -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Interop/PInvoke/CriticalHandles/ReverseTest/ReverseTest.cs
+++ b/src/tests/Interop/PInvoke/CriticalHandles/ReverseTest/ReverseTest.cs
@@ -131,7 +131,8 @@ public class Reverse
         internal static extern IntPtr InvokeRetCallback(RetCallback callback);
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/CriticalHandles/ReverseTest/ReverseTest.csproj
+++ b/src/tests/Interop/PInvoke/CriticalHandles/ReverseTest/ReverseTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Interop/PInvoke/CriticalHandles/StructTest/StructTest.cs
+++ b/src/tests/Interop/PInvoke/CriticalHandles/StructTest/StructTest.cs
@@ -178,7 +178,8 @@ public class CriticalHandleStructTest
         internal static extern MyCriticalHandleStruct Ret(IntPtr handleValue);
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/CriticalHandles/StructTest/StructTest.csproj
+++ b/src/tests/Interop/PInvoke/CriticalHandles/StructTest/StructTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference, GC.WaitForPendingFinalizers -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Interop/PInvoke/CriticalHandles/Test/Test.cs
+++ b/src/tests/Interop/PInvoke/CriticalHandles/Test/Test.cs
@@ -358,7 +358,8 @@ public class NoDefaultCtorCriticalHandleTest
 
 public class Test
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/CriticalHandles/Test/Test.csproj
+++ b/src/tests/Interop/PInvoke/CriticalHandles/Test/Test.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference, GC.WaitForPendingFinalizers -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Interop/PInvoke/CustomMarshalers/CustomMarshalersTest.cs
+++ b/src/tests/Interop/PInvoke/CustomMarshalers/CustomMarshalersTest.cs
@@ -26,7 +26,8 @@ namespace PInvokeTests
 
     public static class CustomMarshalersTests
     {
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             try
             {

--- a/src/tests/Interop/PInvoke/CustomMarshalers/CustomMarshalersTest.csproj
+++ b/src/tests/Interop/PInvoke/CustomMarshalers/CustomMarshalersTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CLRTestTargetUnsupported, NativeAotIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- CustomMarshalers unsupported outside of windows -->

--- a/src/tests/Interop/PInvoke/CustomMarshalers/CustomMarshalersTest.csproj
+++ b/src/tests/Interop/PInvoke/CustomMarshalers/CustomMarshalersTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported, NativeAotIncompatible, CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- CustomMarshalers unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/Interop/PInvoke/DateTime/DateTimeTest.cs
+++ b/src/tests/Interop/PInvoke/DateTime/DateTimeTest.cs
@@ -25,7 +25,8 @@ class NativeDateTime
 
 public class DateTimeTest
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/DateTime/DateTimeTest.cs
+++ b/src/tests/Interop/PInvoke/DateTime/DateTimeTest.cs
@@ -23,9 +23,9 @@ class NativeDateTime
     public static extern DateWrapper GetTomorrowWrapped(DateWrapper today);
 }
 
-class DateTimeTest
+public class DateTimeTest
 {
-    static int Main()
+    public static int Main()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/DateTime/DateTimeTest.csproj
+++ b/src/tests/Interop/PInvoke/DateTime/DateTimeTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DateTimeTest.cs" />

--- a/src/tests/Interop/PInvoke/Decimal/DecimalTest.csproj
+++ b/src/tests/Interop/PInvoke/Decimal/DecimalTest.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
   </ItemGroup>

--- a/src/tests/Interop/PInvoke/Delegate/DelegateTest.cs
+++ b/src/tests/Interop/PInvoke/Delegate/DelegateTest.cs
@@ -119,7 +119,8 @@ public class DelegateTest
         Assert.Throws<MarshalDirectiveException>(() => MarshalDelegateAsInterface(TestFunction));
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/Delegate/DelegateTest.cs
+++ b/src/tests/Interop/PInvoke/Delegate/DelegateTest.cs
@@ -70,7 +70,7 @@ public class DelegateTest
         {
             TestDelegate localDelegate = TestFunction;
             Assert.True(ValidateDelegateValueMatchesExpectedAndClear(expectedValue, ref localDelegate));
-            Assert.Equal(null, localDelegate);
+            Assert.Null(localDelegate);
         }
 
         {
@@ -102,7 +102,7 @@ public class DelegateTest
             };
 
             Assert.True(ValidateDelegateValueMatchesExpectedAndClearStruct(ref cb));
-            Assert.Equal(null, cb.del);
+            Assert.Null(cb.del);
         }
 
         {

--- a/src/tests/Interop/PInvoke/Delegate/DelegateTest.cs
+++ b/src/tests/Interop/PInvoke/Delegate/DelegateTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 using static DelegateTestNative;
 
-class DelegateTest
+public class DelegateTest
 {
     private static void TestFunctionPointer()
     {
@@ -119,7 +119,7 @@ class DelegateTest
         Assert.Throws<MarshalDirectiveException>(() => MarshalDelegateAsInterface(TestFunction));
     }
 
-    static int Main()
+    public static int Main()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/Delegate/DelegateTest.csproj
+++ b/src/tests/Interop/PInvoke/Delegate/DelegateTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 unsafe partial class GenericsNative
 {
@@ -44,9 +45,10 @@ unsafe partial class GenericsNative
     }
 }
 
-unsafe partial class GenericsTest
+public unsafe partial class GenericsTest
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.csproj
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);xUnit2000</NoWarn>
     <OutputType>exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.csproj
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.csproj
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);xUnit2000</NoWarn>
     <OutputType>exe</OutputType>

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.csproj
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.csproj
@@ -5,7 +5,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);xUnit2000</NoWarn>
-    <OutputType>exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.cs
+++ b/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.cs
@@ -64,7 +64,8 @@ namespace PInvokeTests
             Assert.Equal(managedEnumerator, IEnumeratorNative.PassThroughEnumerator(managedEnumerator));
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             try
             {

--- a/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.csproj
+++ b/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported, GCStressIncompatible, UnloadabilityIncompatible, CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/37237 -->
     <GCStressIncompatible>true</GCStressIncompatible>

--- a/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.csproj
+++ b/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CLRTestTargetUnsupported, GCStressIncompatible, UnloadabilityIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/37237 -->

--- a/src/tests/Interop/PInvoke/Int128/Int128Test.cs
+++ b/src/tests/Interop/PInvoke/Int128/Int128Test.cs
@@ -6,13 +6,13 @@ using System.Runtime.InteropServices;
 using Xunit;
 
 
-struct StructJustInt128
+public struct StructJustInt128
 {
     public StructJustInt128(Int128 val) { value = val; }
     public Int128 value;
 }
 
-struct StructWithInt128
+public struct StructWithInt128
 {
     public StructWithInt128(Int128 val) { value = val; messUpPadding = 0x10; }
     public byte messUpPadding;

--- a/src/tests/Interop/PInvoke/Int128/Int128Test.csproj
+++ b/src/tests/Interop/PInvoke/Int128/Int128Test.csproj
@@ -5,7 +5,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>embedded</DebugType>
-    <OutputType>exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Int128Test.cs" />

--- a/src/tests/Interop/PInvoke/Int128/Int128Test.csproj
+++ b/src/tests/Interop/PInvoke/Int128/Int128Test.csproj
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>embedded</DebugType>
     <OutputType>exe</OutputType>

--- a/src/tests/Interop/PInvoke/Int128/Int128TestFieldLayout.csproj
+++ b/src/tests/Interop/PInvoke/Int128/Int128TestFieldLayout.csproj
@@ -5,7 +5,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>embedded</DebugType>
-    <OutputType>exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Int128Test.cs" />

--- a/src/tests/Interop/PInvoke/Int128/Int128TestFieldLayout.csproj
+++ b/src/tests/Interop/PInvoke/Int128/Int128TestFieldLayout.csproj
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>embedded</DebugType>
     <OutputType>exe</OutputType>

--- a/src/tests/Interop/PInvoke/Int128/Program.cs
+++ b/src/tests/Interop/PInvoke/Int128/Program.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
-unsafe partial class Int128Native
+public unsafe partial class Int128Native
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/Int128/ProgramFieldLayout.cs
+++ b/src/tests/Interop/PInvoke/Int128/ProgramFieldLayout.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
-unsafe partial class Int128NativeFieldLayout
+public unsafe partial class Int128NativeFieldLayout
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/Miscellaneous/CopyCtor/CopyCtorTest.cs
+++ b/src/tests/Interop/PInvoke/Miscellaneous/CopyCtor/CopyCtorTest.cs
@@ -8,7 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;
 
-static unsafe class CopyCtor
+public static unsafe class CopyCtor
 {
     public static unsafe int StructWithCtorTest(StructWithCtor* ptrStruct, ref StructWithCtor refStruct)
     {
@@ -26,7 +26,8 @@ static unsafe class CopyCtor
         return 100;
     }
 
-    public static unsafe int Main()
+    [Fact]
+    public static unsafe int TestEntryPoint()
     {
         TestDelegate del = (TestDelegate)Delegate.CreateDelegate(typeof(TestDelegate), typeof(CopyCtor).GetMethod("StructWithCtorTest"));
         StructWithCtor s1 = new StructWithCtor();

--- a/src/tests/Interop/PInvoke/Miscellaneous/CopyCtor/CopyCtorTest.csproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/CopyCtor/CopyCtorTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/PInvoke/Miscellaneous/HandleRef/HandleRefTest.cs
+++ b/src/tests/Interop/PInvoke/Miscellaneous/HandleRef/HandleRefTest.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 using System.Text;
 using Xunit;
 
-class HandleRefTest
+public class HandleRefTest
 {
     [DllImport(@"HandleRefNative", CallingConvention = CallingConvention.Winapi)]
     private static extern int MarshalPointer_In(HandleRef pintValue, int stackGuard);
@@ -24,7 +24,8 @@ class HandleRefTest
     [DllImport(@"HandleRefNative")]
     private static extern HandleRef InvalidMarshalPointer_Return();
 
-    public unsafe static int Main()
+    [Fact]
+    public unsafe static int TestEntryPoint()
     {
         try{
             const int intManaged = 1000;

--- a/src/tests/Interop/PInvoke/Miscellaneous/HandleRef/HandleRefTest.csproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/HandleRef/HandleRefTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference, GC.WaitForPendingFinalizers -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/MAWSPITest.cs
+++ b/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/MAWSPITest.cs
@@ -5,12 +5,13 @@ using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
-class MultipleAssembliesWithSamePInvokeTest
+public class MultipleAssembliesWithSamePInvokeTest
 {
     [DllImport(@"MAWSPINative", CallingConvention = CallingConvention.StdCall)]
     private static extern int GetInt();
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try{
             Assert.Equal(24, GetInt());

--- a/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/MAWSPITest.csproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/MAWSPITest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MAWSPITest.cs" />

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyTrue/AssemblyTrueTest.cs
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyTrue/AssemblyTrueTest.cs
@@ -895,7 +895,8 @@ public class ComVisibleServer
         Assert.Equal(Helpers.E_NOINTERFACE, CCWTest_NestedInterfaceGenericVisibleTrue((object)nestedGenericServer, out fooSuccessVal));
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyTrue/AssemblyTrueTest.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyTrue/AssemblyTrueTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, NativeAotIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <NativeAotIncompatible>true</NativeAotIncompatible>

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyWithoutComVisible/AssemblyWithoutComVisibleTest.cs
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyWithoutComVisible/AssemblyWithoutComVisibleTest.cs
@@ -894,7 +894,8 @@ public class ComVisibleServer
         Assert.Equal(Helpers.E_NOINTERFACE, CCWTest_NestedInterfaceGenericVisibleTrue((object)nestedGenericServer, out fooSuccessVal));
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyWithoutComVisible/AssemblyWithoutComVisibleTest.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyWithoutComVisible/AssemblyWithoutComVisibleTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, NativeAotIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <NativeAotIncompatible>true</NativeAotIncompatible>

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTest.cs
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTest.cs
@@ -998,7 +998,8 @@ public class ComVisibleServer
         Assert.Equal<Guid>(new Guid("0ea2cb33-db9f-3655-9240-47ef1dea0f1e"), typeof(INestedInterfaceVisibleTrueNoGuid).GetTypeInfo().GUID);
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTest.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, NativeAotIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <NativeAotIncompatible>true</NativeAotIncompatible>

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTestInALC.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTestInALC.csproj
@@ -3,7 +3,6 @@
     <!-- Test needs explicit Main for interop purposes -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
-    <OutputType>Exe</OutputType>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <NativeAotIncompatible>true</NativeAotIncompatible>

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTestInALC.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTestInALC.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Test needs explicit Main for interop purposes -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
     <OutputType>Exe</OutputType>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/Interop/PInvoke/Primitives/Int/PInvokeIntTest.cs
+++ b/src/tests/Interop/PInvoke/Primitives/Int/PInvokeIntTest.cs
@@ -3,8 +3,9 @@
 
 using System.Runtime.InteropServices;
 using System;
+using Xunit;
 
-class ClientPInvokeIntNativeTest
+public class ClientPInvokeIntNativeTest
 {
     [DllImport("PInvokeIntNative")]
     private static extern int Marshal_In([In]int intValue);
@@ -31,7 +32,8 @@ class ClientPInvokeIntNativeTest
     private static extern int Marshal_InMany_InOutPointer([In]short i1, [In]short i2, [In]short i3, [In]short i4, [In]short i5, [In]short i6, [In]short i7, [In]short i8, [In]short i9, [In]short i10, [In]short i11, [In]byte i12, [In]byte i13, [In]int i14, [In]short i15, ref int pintValue);
 
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         int failures = 0;
         int intManaged = (int)1000;

--- a/src/tests/Interop/PInvoke/Primitives/Int/PInvokeIntTest.csproj
+++ b/src/tests/Interop/PInvoke/Primitives/Int/PInvokeIntTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PInvokeIntTest.cs" />

--- a/src/tests/Interop/PInvoke/Primitives/Pointer/NonBlittablePointer.csproj
+++ b/src/tests/Interop/PInvoke/Primitives/Pointer/NonBlittablePointer.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/tests/Interop/PInvoke/Primitives/Pointer/Program.cs
+++ b/src/tests/Interop/PInvoke/Primitives/Pointer/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace NonBlittablePointer
 {
@@ -14,7 +15,8 @@ namespace NonBlittablePointer
 
     public class Program
     {
-        public static unsafe int Main()
+        [Fact]
+        public static unsafe int TestEntryPoint()
         {
             bool value = true;
             NonBlittablePointerNative.Negate(&value);

--- a/src/tests/Interop/PInvoke/Primitives/Pointer/Program.cs
+++ b/src/tests/Interop/PInvoke/Primitives/Pointer/Program.cs
@@ -12,9 +12,9 @@ namespace NonBlittablePointer
         public static unsafe extern void Negate(bool* ptr);
     }
 
-    class Program
+    public class Program
     {
-        static unsafe int Main()
+        public static unsafe int Main()
         {
             bool value = true;
             NonBlittablePointerNative.Negate(&value);

--- a/src/tests/Interop/PInvoke/Primitives/RuntimeHandles/RuntimeHandlesTest.cs
+++ b/src/tests/Interop/PInvoke/Primitives/RuntimeHandles/RuntimeHandlesTest.cs
@@ -15,7 +15,7 @@ class TestClass
     }
 }
 
-class RuntimeHandlesTest
+public class RuntimeHandlesTest
 {
     [DllImport("RuntimeHandlesNative")]
     private static extern bool Marshal_In(RuntimeMethodHandle expected, IntPtr handle);
@@ -42,7 +42,8 @@ class RuntimeHandlesTest
         Assert.True(Marshal_In(handle, handle.Value));
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/Primitives/RuntimeHandles/RuntimeHandlesTest.csproj
+++ b/src/tests/Interop/PInvoke/Primitives/RuntimeHandles/RuntimeHandlesTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="RuntimeHandlesTest.cs" />

--- a/src/tests/Interop/PInvoke/SafeHandles/Program.cs
+++ b/src/tests/Interop/PInvoke/SafeHandles/Program.cs
@@ -5,12 +5,14 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Collections.Generic;
+using Xunit;
 
 namespace SafeHandleTests
 {
-    class Test
+    public class Test
     {
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             try
             {

--- a/src/tests/Interop/PInvoke/SafeHandles/SafeHandleTests.csproj
+++ b/src/tests/Interop/PInvoke/SafeHandles/SafeHandleTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/Interop/PInvoke/SetLastError/SetLastErrorTest.cs
+++ b/src/tests/Interop/PInvoke/SetLastError/SetLastErrorTest.cs
@@ -62,7 +62,8 @@ public class SetLastErrorTest
         Assert.Equal(0, actual);
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/SetLastError/SetLastErrorTest.cs
+++ b/src/tests/Interop/PInvoke/SetLastError/SetLastErrorTest.cs
@@ -5,7 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
-class SetLastErrorTest
+public class SetLastErrorTest
 {
     private static class SetLastErrorNative
     {
@@ -62,7 +62,7 @@ class SetLastErrorTest
         Assert.Equal(0, actual);
     }
 
-    static int Main()
+    public static int Main()
     {
         try
         {

--- a/src/tests/Interop/PInvoke/SetLastError/SetLastErrorTest.csproj
+++ b/src/tests/Interop/PInvoke/SetLastError/SetLastErrorTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SetLastErrorTest.cs" />

--- a/src/tests/Interop/PInvoke/SetLastError/SetLastErrorTest.csproj
+++ b/src/tests/Interop/PInvoke/SetLastError/SetLastErrorTest.csproj
@@ -6,7 +6,7 @@
     <Compile Include="SetLastErrorTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex.cs
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex.cs
@@ -15,7 +15,8 @@ public class Program
     public static extern void SizeParamIndexWrongType(
         out string arrSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] out byte[] arrByte);
 
-    public static void Main()
+    [Fact]
+    public static void TestEntryPoint()
     {
         Assert.Throws<MarshalDirectiveException>(() => SizeParamIndexTooBig(out var _, out var _));
         Assert.Throws<MarshalDirectiveException>(() => SizeParamIndexWrongType(out var _, out var _));

--- a/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex.cs
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex.cs
@@ -5,7 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
-class Program
+public class Program
 {
     [DllImport("Unused")]
     static extern void SizeParamIndexTooBig(
@@ -15,11 +15,9 @@ class Program
     public static extern void SizeParamIndexWrongType(
         out string arrSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] out byte[] arrByte);
 
-    static int Main()
+    public static void Main()
     {
         Assert.Throws<MarshalDirectiveException>(() => SizeParamIndexTooBig(out var _, out var _));
         Assert.Throws<MarshalDirectiveException>(() => SizeParamIndexWrongType(out var _, out var _));
-
-        return 100;
     }
 }

--- a/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex.csproj
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InvalidParamIndex.cs" />

--- a/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByOut/PassingByOutTest.cs
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByOut/PassingByOutTest.cs
@@ -229,7 +229,7 @@ public class ClientMarshalArrayAsSizeParamIndexByOutTest
         Console.WriteLine(strDescription + " Ends!");
     }
 
-    static int Main()
+    public static int Main()
     {
         try{
             SizeParamTypeIsByte();

--- a/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByOut/PassingByOutTest.cs
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByOut/PassingByOutTest.cs
@@ -229,7 +229,8 @@ public class ClientMarshalArrayAsSizeParamIndexByOutTest
         Console.WriteLine(strDescription + " Ends!");
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try{
             SizeParamTypeIsByte();

--- a/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByOut/PassingByOutTest.csproj
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByOut/PassingByOutTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PassingByOutTest.cs" />

--- a/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByRef/PassingByRefTest.cs
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByRef/PassingByRefTest.cs
@@ -237,7 +237,7 @@ public class ClientMarshalArrayAsSizeParamIndexByRefTest
         Console.WriteLine(strDescription + " Ends!");
     }
 
-    static int Main()
+    public static int Main()
     {
         try{
             SizeParamTypeIsByte();

--- a/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByRef/PassingByRefTest.cs
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByRef/PassingByRefTest.cs
@@ -237,7 +237,8 @@ public class ClientMarshalArrayAsSizeParamIndexByRefTest
         Console.WriteLine(strDescription + " Ends!");
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try{
             SizeParamTypeIsByte();

--- a/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByRef/PassingByRefTest.csproj
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/PInvoke/PassingByRef/PassingByRefTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PassingByRefTest.cs" />

--- a/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByOut/PassingByOutTest.cs
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByOut/PassingByOutTest.cs
@@ -192,7 +192,8 @@ public class ReversePInvoke_MashalArrayByOut_AsManagedTest
         }
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try{
             RunTestByOut();

--- a/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByOut/PassingByOutTest.csproj
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByOut/PassingByOutTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PassingByOutTest.cs" />

--- a/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.cs
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.cs
@@ -207,7 +207,8 @@ public class ReversePInvoke_MashalArrayByRef_AsManagedTest
         }
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try{
             RunTestByRef();

--- a/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.csproj
+++ b/src/tests/Interop/PInvoke/SizeParamIndex/ReversePInvoke/PassingByRef/PassingByRefTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PassingByRefTest.cs" />

--- a/src/tests/Interop/PInvoke/Varargs/VarargsTest.cs
+++ b/src/tests/Interop/PInvoke/Varargs/VarargsTest.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace PInvokeTests
 {
-    class VarargsTest
+    public class VarargsTest
     {
         [DllImport("VarargsNative", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
         private static extern void TestVarArgs(StringBuilder builder, IntPtr bufferSize, string formatString, __arglist);
@@ -33,7 +33,8 @@ namespace PInvokeTests
             return true;
         }
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             var passed = true;
             int arg1 = 10;

--- a/src/tests/Interop/PInvoke/Varargs/VarargsTest.csproj
+++ b/src/tests/Interop/PInvoke/Varargs/VarargsTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Varargs/ArgIterator marshalling unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/Interop/PInvoke/Varargs/VarargsTest.csproj
+++ b/src/tests/Interop/PInvoke/Varargs/VarargsTest.csproj
@@ -11,7 +11,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PInvoke/Varargs/VarargsTest.csproj
+++ b/src/tests/Interop/PInvoke/Varargs/VarargsTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Varargs/ArgIterator marshalling unsupported outside of windows -->

--- a/src/tests/Interop/PInvoke/Variant/VariantTest.BuiltInCom.cs
+++ b/src/tests/Interop/PInvoke/Variant/VariantTest.BuiltInCom.cs
@@ -7,9 +7,10 @@ using Xunit;
 using static VariantNative;
 
 #pragma warning disable CS0612, CS0618
-partial class Test_VariantTest
+public partial class Test_VariantTest
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool builtInComDisabled=false;
         var comConfig = AppContext.GetData("System.Runtime.InteropServices.BuiltInComInterop.IsSupported");

--- a/src/tests/Interop/PInvoke/Variant/VariantTest.ComWrappers.cs
+++ b/src/tests/Interop/PInvoke/Variant/VariantTest.ComWrappers.cs
@@ -10,9 +10,10 @@ using static VariantNative;
 using ComTypes = System.Runtime.InteropServices.ComTypes;
 
 #pragma warning disable CS0612, CS0618
-partial class Test_VariantTest
+public partial class Test_VariantTest
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool testComMarshal=true;
         ComWrappers.RegisterForMarshalling(new ComWrappersImpl());

--- a/src/tests/Interop/PInvoke/Variant/VariantTest.csproj
+++ b/src/tests/Interop/PInvoke/Variant/VariantTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/Interop/PInvoke/Variant/VariantTestBuiltInComDisabled.csproj
+++ b/src/tests/Interop/PInvoke/Variant/VariantTestBuiltInComDisabled.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/Interop/PInvoke/Variant/VariantTestComWrappers.csproj
+++ b/src/tests/Interop/PInvoke/Variant/VariantTestComWrappers.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, UnloadabilityIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Test creates non-collectible AssemblyLoadContext -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/Interop/PrimitiveMarshalling/Bool/BoolTest.cs
+++ b/src/tests/Interop/PrimitiveMarshalling/Bool/BoolTest.cs
@@ -5,8 +5,9 @@ using System.Runtime.InteropServices;
 using System;
 using System.Reflection;
 using System.Text;
+using Xunit;
 
-class Test
+public class Test
 {
     const bool boolManaged = true;
     const bool boolNative = false;
@@ -16,7 +17,8 @@ class Test
         throw new Exception(" === Fail: " + describe + "\n\tExpected:" + expect + "\n\tActual:" + actual);        
     }
     
-    public static void Main()
+    [Fact]
+    public static void TestEntryPoint()
     {
         //Test Method1
         bool boolValue1 = boolManaged;

--- a/src/tests/Interop/PrimitiveMarshalling/Bool/BoolTest.cs
+++ b/src/tests/Interop/PrimitiveMarshalling/Bool/BoolTest.cs
@@ -16,7 +16,7 @@ class Test
         throw new Exception(" === Fail: " + describe + "\n\tExpected:" + expect + "\n\tActual:" + actual);        
     }
     
-    public static int Main()
+    public static void Main()
     {
         //Test Method1
         bool boolValue1 = boolManaged;
@@ -122,8 +122,6 @@ class Test
         {
             TestVariantBool();
         }
-        
-        return 100;
     }
 
     private static void TestVariantBool()

--- a/src/tests/Interop/PrimitiveMarshalling/Bool/BoolTest.csproj
+++ b/src/tests/Interop/PrimitiveMarshalling/Bool/BoolTest.csproj
@@ -8,7 +8,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PrimitiveMarshalling/Bool/BoolTest.csproj
+++ b/src/tests/Interop/PrimitiveMarshalling/Bool/BoolTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/Interop/PrimitiveMarshalling/Bool/BoolTest.csproj
+++ b/src/tests/Interop/PrimitiveMarshalling/Bool/BoolTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/Interop/PrimitiveMarshalling/EnumMarshalling/EnumTest.csproj
+++ b/src/tests/Interop/PrimitiveMarshalling/EnumMarshalling/EnumTest.csproj
@@ -8,7 +8,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/PrimitiveMarshalling/EnumMarshalling/EnumTest.csproj
+++ b/src/tests/Interop/PrimitiveMarshalling/EnumMarshalling/EnumTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/Interop/PrimitiveMarshalling/EnumMarshalling/EnumTest.csproj
+++ b/src/tests/Interop/PrimitiveMarshalling/EnumMarshalling/EnumTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/Interop/PrimitiveMarshalling/EnumMarshalling/MarshalEnumManaged.cs
+++ b/src/tests/Interop/PrimitiveMarshalling/EnumMarshalling/MarshalEnumManaged.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using TestLibrary;
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace EnumRoundtrip
 {
@@ -36,7 +37,8 @@ namespace EnumRoundtrip
 
         #endregion
         [System.Security.SecuritySafeCritical]
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             bool result = true;
             int r = 0;

--- a/src/tests/Interop/PrimitiveMarshalling/EnumMarshalling/MarshalEnumManaged.cs
+++ b/src/tests/Interop/PrimitiveMarshalling/EnumMarshalling/MarshalEnumManaged.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace EnumRoundtrip
 {
-    class MarshalEnumManaged
+    public class MarshalEnumManaged
     {
         [Flags]
         public enum DialogResult
@@ -36,7 +36,7 @@ namespace EnumRoundtrip
 
         #endregion
         [System.Security.SecuritySafeCritical]
-        static int Main()
+        public static int Main()
         {
             bool result = true;
             int r = 0;
@@ -61,8 +61,7 @@ namespace EnumRoundtrip
                 TestFramework.LogError("04", "Main : Returned value of enum doesn't match with the value passed in to pinvoke call");
                 return 101;
             }
-
-            Console.WriteLine("PASS");
+            
             return 100;
         }
     }

--- a/src/tests/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.cs
+++ b/src/tests/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.cs
@@ -28,7 +28,7 @@ class Test
     private static extern UIntPtr MarshalPointer_Out(out UIntPtr puintPtr);
 
 
-    public static int Main()
+    public static void Main()
     {
         UIntPtr uintPtrManaged = (UIntPtr)1000;
         UIntPtr uintPtrNative = (UIntPtr)2000;
@@ -56,7 +56,5 @@ class Test
         UIntPtr uintPtr6 = uintPtrManaged;
         Assert.Equal(uintPtrReturn, MarshalPointer_Out(out uintPtr6));
         Assert.Equal(uintPtrNative, uintPtr6);
-
-        return 100;
     }
 }

--- a/src/tests/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.cs
+++ b/src/tests/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 using System.Text;
 using Xunit;
 
-class Test
+public class Test
 {
     [DllImport(@"UIntPtrNative", CallingConvention = CallingConvention.StdCall)]
     private static extern UIntPtr Marshal_In([In]UIntPtr uintPtr);
@@ -28,7 +28,8 @@ class Test
     private static extern UIntPtr MarshalPointer_Out(out UIntPtr puintPtr);
 
 
-    public static void Main()
+    [Fact]
+    public static void TestEntryPoint()
     {
         UIntPtr uintPtrManaged = (UIntPtr)1000;
         UIntPtr uintPtrNative = (UIntPtr)2000;

--- a/src/tests/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.csproj
+++ b/src/tests/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.csproj
+++ b/src/tests/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.csproj
+++ b/src/tests/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.csproj
@@ -8,7 +8,7 @@
     <Compile Include="PInvokeUIntPtrTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/RefCharArray/RefCharArrayTest.cs
+++ b/src/tests/Interop/RefCharArray/RefCharArrayTest.cs
@@ -247,7 +247,7 @@ public class Test_RefCharArrayTest
     #endregion
 
     
-    static int Main()
+    public static int Main()
     {
         bool bresult = true;
 

--- a/src/tests/Interop/RefCharArray/RefCharArrayTest.cs
+++ b/src/tests/Interop/RefCharArray/RefCharArrayTest.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Security;
 using System.Runtime.InteropServices;
 using TestLibrary;
+using Xunit;
 
 public class Test_RefCharArrayTest
 {
@@ -247,7 +248,8 @@ public class Test_RefCharArrayTest
     #endregion
 
     
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool bresult = true;
 

--- a/src/tests/Interop/RefCharArray/RefCharArrayTest.csproj
+++ b/src/tests/Interop/RefCharArray/RefCharArrayTest.csproj
@@ -8,7 +8,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/RefCharArray/RefCharArrayTest.csproj
+++ b/src/tests/Interop/RefCharArray/RefCharArrayTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/Interop/RefCharArray/RefCharArrayTest.csproj
+++ b/src/tests/Interop/RefCharArray/RefCharArrayTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/Interop/SimpleStruct/SimpleStruct.csproj
+++ b/src/tests/Interop/SimpleStruct/SimpleStruct.csproj
@@ -8,7 +8,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/SimpleStruct/SimpleStruct.csproj
+++ b/src/tests/Interop/SimpleStruct/SimpleStruct.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/Interop/SimpleStruct/SimpleStruct.csproj
+++ b/src/tests/Interop/SimpleStruct/SimpleStruct.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/Interop/SimpleStruct/SimpleStructManaged.cs
+++ b/src/tests/Interop/SimpleStruct/SimpleStructManaged.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Runtime.InteropServices;
 using TestLibrary;
+using Xunit;
 
 namespace PInvokeTests
 {
@@ -99,7 +100,7 @@ namespace PInvokeTests
     }
     #endregion
 
-    class StructureTests
+    public class StructureTests
     {
         #region direct Pinvoke declarartions
 
@@ -509,7 +510,8 @@ namespace PInvokeTests
 
         #endregion
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             bool retVal = true;
 

--- a/src/tests/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest.cs
+++ b/src/tests/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest.cs
@@ -7,9 +7,10 @@ using System.Reflection;
 using System.Text;
 using Xunit;
 
-class AnsiBStrTest
+public class AnsiBStrTest
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest.csproj
+++ b/src/tests/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);ANSIBSTR</DefineConstants>
   </PropertyGroup>

--- a/src/tests/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest.csproj
+++ b/src/tests/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);ANSIBSTR</DefineConstants>

--- a/src/tests/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest.csproj
+++ b/src/tests/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../Native/StringMarshalingTestNative.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StringMarshalling/BSTR/BSTRTest.cs
+++ b/src/tests/Interop/StringMarshalling/BSTR/BSTRTest.cs
@@ -7,9 +7,10 @@ using System.Reflection;
 using System.Text;
 using Xunit;
 
-class BStrTest
+public class BStrTest
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/StringMarshalling/BSTR/BSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/BSTR/BSTRTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);BSTR</DefineConstants>

--- a/src/tests/Interop/StringMarshalling/BSTR/BSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/BSTR/BSTRTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);BSTR</DefineConstants>
   </PropertyGroup>

--- a/src/tests/Interop/StringMarshalling/BSTR/BSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/BSTR/BSTRTest.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../Native/StringMarshalingTestNative.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StringMarshalling/LPSTR/LPSTRTest.cs
+++ b/src/tests/Interop/StringMarshalling/LPSTR/LPSTRTest.cs
@@ -7,9 +7,10 @@ using System.Reflection;
 using System.Text;
 using Xunit;
 
-class LPStrTest
+public class LPStrTest
 {
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LPSTR</DefineConstants>

--- a/src/tests/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LPSTR</DefineConstants>
   </PropertyGroup>

--- a/src/tests/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
@@ -10,7 +10,7 @@
     <Compile Include="../Native/StringMarshalingTestNative.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StringMarshalling/LPTSTR/LPTSTRTest.cs
+++ b/src/tests/Interop/StringMarshalling/LPTSTR/LPTSTRTest.cs
@@ -9,13 +9,14 @@ using Xunit;
 
 using static LPTStrTestNative;
 
-class LPTStrTest
+public class LPTStrTest
 {
     private static readonly string InitialString = "Hello World";
     private static readonly string LongString = "0123456789abcdefghi";
     private static readonly string LongUnicodeString = "\uD83D\uDC68\u200D\uD83D\uDC68\u200D\uD83D\uDC67\u200D\uD83D\uDC67\uD83D\uDC31\u200D\uD83D\uDC64";
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/StringMarshalling/LPTSTR/LPTSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/LPTSTR/LPTSTRTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LPTSTR</DefineConstants>

--- a/src/tests/Interop/StringMarshalling/LPTSTR/LPTSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/LPTSTR/LPTSTRTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LPTSTR</DefineConstants>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/Interop/StringMarshalling/LPTSTR/LPTSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/LPTSTR/LPTSTRTest.csproj
@@ -11,7 +11,7 @@
     <Compile Include="../Native/StringMarshalingTestNative.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.cs
+++ b/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.cs
@@ -5,6 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Collections.Generic;
+using Xunit;
 
 // UTF8
 class UTF8StringTests
@@ -235,7 +236,8 @@ public class Test
                                  null,
                                };
 
-    public static void Main()
+    [Fact]
+    public static void TestEntryPoint()
     {
         // Test string as [In,Out] parameter
         for (int i = 0; i < utf8Strings.Length; i++)

--- a/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.cs
+++ b/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.cs
@@ -222,7 +222,7 @@ class UTF8DelegateMarshalling
 }
 
 
-class Test
+public class Test
 {
     //test strings
     public static string[] utf8Strings = {
@@ -235,7 +235,7 @@ class Test
                                  null,
                                };
 
-    public static int Main()
+    public static void Main()
     {
         // Test string as [In,Out] parameter
         for (int i = 0; i < utf8Strings.Length; i++)
@@ -272,8 +272,5 @@ class Test
 
         // String.Empty tests
         UTF8StringTests.EmptyStringTest();
-
-
-        return 100;
     }
 }

--- a/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.csproj
+++ b/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.csproj
@@ -8,7 +8,7 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.csproj
+++ b/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.csproj
+++ b/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/Interop/StringMarshalling/VBByRefStr/VBByRefStrTest.cs
+++ b/src/tests/Interop/StringMarshalling/VBByRefStr/VBByRefStrTest.cs
@@ -9,10 +9,11 @@ using Xunit;
 
 #pragma warning disable CS0612, CS0618
 
-class Test
+public class Test
 {
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/StringMarshalling/VBByRefStr/VBByRefStrTest.csproj
+++ b/src/tests/Interop/StringMarshalling/VBByRefStr/VBByRefStrTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/Interop/StringMarshalling/VBByRefStr/VBByRefStrTest.csproj
+++ b/src/tests/Interop/StringMarshalling/VBByRefStr/VBByRefStrTest.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Test unsupported outside of windows -->

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp.cs
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Security;
+using Xunit;
 
 public class Managed
 {
@@ -22,7 +23,8 @@ public class Managed
     }
 
     [SecuritySafeCritical]
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         RunMarshalStructAsParamAsExpByVal();
         RunMarshalStructAsParamAsExpByRef();

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp.csproj
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp.csproj
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp.csproj
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp.csproj
@@ -10,7 +10,7 @@
     <Compile Include="Helper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.cs
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Security;
+using Xunit;
 
 public class Managed
 {
@@ -55,7 +56,8 @@ public class Managed
     }
 
     [SecuritySafeCritical]
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         RunMarshalSeqStructAsParamByVal();
         RunMarshalSeqStructAsParamByRef();

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.csproj
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.csproj
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.csproj
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.csproj
@@ -9,7 +9,7 @@
     <Compile Include="Helper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StructMarshalling/PInvoke/NestedStruct.cs
+++ b/src/tests/Interop/StructMarshalling/PInvoke/NestedStruct.cs
@@ -10,7 +10,8 @@ public class Managed
     [DllImport("MarshalStructAsParam")]
     static extern GameControllerBindType getBindType (GameControllerButtonBind button);
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         GameControllerButtonBind button = new GameControllerButtonBind(GameControllerBindType.ControllerBindtypeAxis, null);
         if (getBindType(button) == GameControllerBindType.ControllerBindtypeAxis)

--- a/src/tests/Interop/StructMarshalling/PInvoke/NestedStruct.csproj
+++ b/src/tests/Interop/StructMarshalling/PInvoke/NestedStruct.csproj
@@ -8,7 +8,7 @@
     <Compile Include="GameControllerButtonBind.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StructMarshalling/PInvoke/NestedStruct.csproj
+++ b/src/tests/Interop/StructMarshalling/PInvoke/NestedStruct.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/Interop/StructMarshalling/PInvoke/NestedStruct.csproj
+++ b/src/tests/Interop/StructMarshalling/PInvoke/NestedStruct.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/DelegatePInvoke/DelegatePInvokeTest.cs
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/DelegatePInvoke/DelegatePInvokeTest.cs
@@ -688,7 +688,7 @@ public class Test_DelegatePInvokeTest
 
     #endregion
 
-    static int Main()
+    public static int Main()
     {
         try
         {

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/DelegatePInvoke/DelegatePInvokeTest.cs
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/DelegatePInvoke/DelegatePInvokeTest.cs
@@ -688,7 +688,8 @@ public class Test_DelegatePInvokeTest
 
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/DelegatePInvoke/DelegatePInvokeTest.csproj
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/DelegatePInvoke/DelegatePInvokeTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/ReversePInvokeManaged/ReversePInvokeTest.cs
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/ReversePInvokeManaged/ReversePInvokeTest.cs
@@ -743,7 +743,8 @@ public class Test_ReversePInvokeTest
 
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try{
 

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/ReversePInvokeManaged/ReversePInvokeTest.cs
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/ReversePInvokeManaged/ReversePInvokeTest.cs
@@ -743,7 +743,7 @@ public class Test_ReversePInvokeTest
 
     #endregion
 
-    static int Main()
+    public static int Main()
     {
         try{
 

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/ReversePInvokeManaged/ReversePInvokeTest.csproj
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/ReversePInvokeManaged/ReversePInvokeTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest.cs
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest.cs
@@ -1413,7 +1413,7 @@ public class MarshalStructTest
 
     #endregion
 
-    static int Main()
+    public static int Main()
     {
         try{
             Console.WriteLine("\nRun the methods for marshaling structure Delegate P/Invoke ByRef");

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest.cs
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest.cs
@@ -1413,7 +1413,8 @@ public class MarshalStructTest
 
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try{
             Console.WriteLine("\nRun the methods for marshaling structure Delegate P/Invoke ByRef");

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest.csproj
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke/ReversePInvokeTest.csproj
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke/ReversePInvokeTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke/ReversePInvokeTest_.cs
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke/ReversePInvokeTest_.cs
@@ -1832,7 +1832,7 @@ public class MarshalStructTest
 
     #endregion
 
-    static int Main()
+    public static int Main()
     {
         try{
 

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke/ReversePInvokeTest_.cs
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke/ReversePInvokeTest_.cs
@@ -1832,7 +1832,8 @@ public class MarshalStructTest
 
     #endregion
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try{
 

--- a/src/tests/Interop/StructPacking/StructPacking.cs
+++ b/src/tests/Interop/StructPacking/StructPacking.cs
@@ -6,6 +6,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential, Pack = 8, Size = 8)]
 struct MyVector64<T> where T : struct { }
@@ -104,7 +105,8 @@ public unsafe class Program
     const int Pass = 100;
     const int Fail = 0;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         bool succeeded = true;
 

--- a/src/tests/Interop/StructPacking/StructPacking.cs
+++ b/src/tests/Interop/StructPacking/StructPacking.cs
@@ -99,12 +99,12 @@ struct AutoLayoutMaxPacking<T> : ITestStructure
     public int OffsetOfValue => Program.OffsetOf(ref this, ref _value);
 }
 
-unsafe class Program
+public unsafe class Program
 {
     const int Pass = 100;
     const int Fail = 0;
 
-    static int Main()
+    public static int Main()
     {
         bool succeeded = true;
 

--- a/src/tests/Interop/StructPacking/StructPacking.csproj
+++ b/src/tests/Interop/StructPacking/StructPacking.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionNegativeTest.cs
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionNegativeTest.cs
@@ -107,7 +107,7 @@ unsafe static class SuppressGCTransitionNative
     }
 }
 
-unsafe class SuppressGCTransitionTest
+public unsafe class SuppressGCTransitionTest
 {
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
     private static int ReturnInt(int value)
@@ -150,7 +150,8 @@ unsafe class SuppressGCTransitionTest
         return n + 1;
     }
 
-    public static void Main()
+    [Fact]
+    public static void TestEntryPoint()
     {
         CheckGCMode.Initialize(&SuppressGCTransitionNative.SetIsInCooperativeModeFunction);
 

--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionNegativeTest.cs
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionNegativeTest.cs
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Xunit;
+
+unsafe static class SuppressGCTransitionNative
+{
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl)]
+    public static extern unsafe void SetIsInCooperativeModeFunction(delegate* unmanaged<int> fn);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "NextUInt")]
+    [SuppressGCTransition]
+    public static extern unsafe int NextUInt_Inline_NoGCTransition(int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "NextUInt")]
+    public static extern unsafe int NextUInt_Inline_GCTransition(int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "NextUInt")]
+    [SuppressGCTransition]
+    public static extern unsafe bool NextUInt_NoInline_NoGCTransition(int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "NextUInt")]
+    public static extern unsafe bool NextUInt_NoInline_GCTransition(int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    [SuppressGCTransition]
+    public static extern unsafe int InvokeCallbackFuncPtr_Inline_NoGCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    public static extern unsafe int InvokeCallbackFuncPtr_Inline_GCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    [SuppressGCTransition]
+    public static extern unsafe bool InvokeCallbackFuncPtr_NoInline_NoGCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    public static extern unsafe bool InvokeCallbackFuncPtr_NoInline_GCTransition(delegate* unmanaged[Cdecl]<int, int> cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    [SuppressGCTransition]
+    public static extern unsafe int InvokeCallbackVoidPtr_Inline_NoGCTransition(void* cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    public static extern unsafe int InvokeCallbackVoidPtr_Inline_GCTransition(void* cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    [SuppressGCTransition]
+    public static extern unsafe bool InvokeCallbackVoidPtr_NoInline_NoGCTransition(void* cb, int* n);
+
+    [DllImport(nameof(SuppressGCTransitionNative), CallingConvention=CallingConvention.Cdecl, EntryPoint = "InvokeCallback")]
+    public static extern unsafe bool InvokeCallbackVoidPtr_NoInline_GCTransition(void* cb, int* n);
+
+    private static IntPtr nativeLibrary;
+
+    public static IntPtr GetNextUIntFunctionPointer()
+    {
+        if (nativeLibrary == IntPtr.Zero)
+        {
+            nativeLibrary = GetNativeLibrary();
+        }
+
+        IntPtr fptr;
+        if (NativeLibrary.TryGetExport(nativeLibrary, "NextUInt", out fptr))
+        {
+            return fptr;
+        }
+
+        throw new Exception($"Failed to find native export");
+    }
+
+    public static delegate* unmanaged[Cdecl]<int*, int> GetNextUIntFunctionPointer_Inline_GCTransition()
+        => (delegate* unmanaged[Cdecl]<int*, int>)GetNextUIntFunctionPointer();
+
+    public static delegate* unmanaged[Cdecl, SuppressGCTransition]<int*, int> GetNextUIntFunctionPointer_Inline_NoGCTransition()
+        => (delegate* unmanaged[Cdecl, SuppressGCTransition]<int*, int>)GetNextUIntFunctionPointer();
+
+    public static delegate* unmanaged[Cdecl]<int*, bool> GetNextUIntFunctionPointer_NoInline_GCTransition()
+        => (delegate* unmanaged[Cdecl]<int*, bool>)GetNextUIntFunctionPointer();
+
+    public static delegate* unmanaged[Cdecl, SuppressGCTransition]<int*, bool> GetNextUIntFunctionPointer_NoInline_NoGCTransition()
+        => (delegate* unmanaged[Cdecl, SuppressGCTransition]<int*, bool>)GetNextUIntFunctionPointer();
+
+    private static IntPtr GetNativeLibrary()
+    {
+        var libNames = new []
+        {
+            $"{nameof(SuppressGCTransitionNative)}.dll",
+            $"lib{nameof(SuppressGCTransitionNative)}.so",
+            $"lib{nameof(SuppressGCTransitionNative)}.dylib",
+        };
+
+        string binDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        foreach (var ln in libNames)
+        {
+            if (NativeLibrary.TryLoad(Path.Combine(binDir, ln), out IntPtr mod))
+            {
+                return mod;
+            }
+        }
+
+        throw new Exception($"Failed to find native library {nameof(SuppressGCTransitionNative)}");
+    }
+}
+
+unsafe class SuppressGCTransitionTest
+{
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    private static int ReturnInt(int value)
+    {
+        return value;
+    }
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int ILStubCache_GCTransition_NoGCTransition(int expected)
+    {
+        // This test uses a callback marked UnmanagedCallersOnly as a way to verify that
+        // SuppressGCTransition is taken into account when caching IL stubs.
+        // It calls functions with the same signature, differing only in SuppressGCTransition.
+        // When calling an UnmanagedCallersOnly method, the runtime validates that the GC is in
+        // pre-emptive mode. If not, it throws a fatal error that cannot be caught and crashes.
+        Console.WriteLine($"{nameof(ILStubCache_GCTransition_NoGCTransition)} ({expected}) ...");
+
+        int n;
+
+        void* cb = (delegate* unmanaged[Cdecl]<int, int>)&ReturnInt;
+
+        // Call function that does not have SuppressGCTransition
+        SuppressGCTransitionNative.InvokeCallbackVoidPtr_Inline_GCTransition(cb, &n);
+        Assert.Equal(expected++, n);
+
+        // Call function with same (blittable) signature, but with SuppressGCTransition.
+        // IL stub should not be re-used, GC transition not should occur, and callback invocation should fail.
+        SuppressGCTransitionNative.InvokeCallbackVoidPtr_Inline_NoGCTransition(cb, &n);
+        Assert.Equal(expected++, n);
+
+        // Call function that does not have SuppressGCTransition
+        SuppressGCTransitionNative.InvokeCallbackVoidPtr_NoInline_GCTransition(cb, &n);
+        Assert.Equal(expected++, n);
+
+        // Call function with same (non-blittable) signature, but with SuppressGCTransition
+        // IL stub should not be re-used, GC transition not should occur, and callback invocation should fail.
+        expected = n + 1;
+        SuppressGCTransitionNative.InvokeCallbackVoidPtr_NoInline_NoGCTransition(cb, &n);
+        Assert.Equal(expected++, n);
+
+        return n + 1;
+    }
+
+    public static void Main()
+    {
+        CheckGCMode.Initialize(&SuppressGCTransitionNative.SetIsInCooperativeModeFunction);
+
+        int n = 1;
+        // This test intentionally results in a fatal error, so only run when manually specified
+        n = ILStubCache_GCTransition_NoGCTransition(n);
+
+        throw new Exception("Failure - fatal error expected!");
+    }
+}

--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionNegativeTest.csproj
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionNegativeTest.csproj
@@ -1,8 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <MonoAotIncompatible>true</MonoAotIncompatible>
+    <!-- Expected COR_E_EXECUTIONENGINE -->
+    <CLRTestExitCode>-2146233082</CLRTestExitCode>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(InteropCommonDir)CheckGCMode.cs" />

--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionNegativeTest.csproj
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionNegativeTest.csproj
@@ -5,7 +5,9 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <!-- Expected COR_E_EXECUTIONENGINE -->
-    <CLRTestExitCode>-2146233082</CLRTestExitCode>
+    <CLRTestExitCode>134</CLRTestExitCode>
+    <CLRTestExitCode Condition="'$(TestWrapperTargetsWindows)' == 'true'">-2146233082</CLRTestExitCode>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(InteropCommonDir)CheckGCMode.cs" />

--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionNegativeTest.csproj
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionNegativeTest.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <MonoAotIncompatible>true</MonoAotIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(InteropCommonDir)CheckGCMode.cs" />
+    <Compile Include="SuppressGCTransitionNegativeTest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <CMakeProjectReference Include="CMakeLists.txt" />
+    <ProjectReference Include="SuppressGCTransitionUtil.ilproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionTest.cs
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionTest.cs
@@ -107,7 +107,7 @@ unsafe static class SuppressGCTransitionNative
     }
 }
 
-unsafe class SuppressGCTransitionTest
+public unsafe class SuppressGCTransitionTest
 {
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static int Inline_NoGCTransition(int expected)
@@ -286,7 +286,8 @@ unsafe class SuppressGCTransitionTest
         return n + 1;
     }
 
-    public static void Main()
+    [Fact]
+    public static void TestEntryPoint()
     {
         CheckGCMode.Initialize(&SuppressGCTransitionNative.SetIsInCooperativeModeFunction);
 

--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionTest.cs
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionTest.cs
@@ -285,72 +285,23 @@ unsafe class SuppressGCTransitionTest
 
         return n + 1;
     }
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static int ILStubCache_GCTransition_NoGCTransition(int expected)
+
+    public static void Main()
     {
-        // This test uses a callback marked UnmanagedCallersOnly as a way to verify that
-        // SuppressGCTransition is taken into account when caching IL stubs.
-        // It calls functions with the same signature, differing only in SuppressGCTransition.
-        // When calling an UnmanagedCallersOnly method, the runtime validates that the GC is in
-        // pre-emptive mode. If not, it throws a fatal error that cannot be caught and crashes.
-        Console.WriteLine($"{nameof(ILStubCache_GCTransition_NoGCTransition)} ({expected}) ...");
+        CheckGCMode.Initialize(&SuppressGCTransitionNative.SetIsInCooperativeModeFunction);
 
-        int n;
-
-        void* cb = (delegate* unmanaged[Cdecl]<int, int>)&ReturnInt;
-
-        // Call function that does not have SuppressGCTransition
-        SuppressGCTransitionNative.InvokeCallbackVoidPtr_Inline_GCTransition(cb, &n);
-        Assert.Equal(expected++, n);
-
-        // Call function with same (blittable) signature, but with SuppressGCTransition.
-        // IL stub should not be re-used, GC transition not should occur, and callback invocation should fail.
-        SuppressGCTransitionNative.InvokeCallbackVoidPtr_Inline_NoGCTransition(cb, &n);
-        Assert.Equal(expected++, n);
-
-        // Call function that does not have SuppressGCTransition
-        SuppressGCTransitionNative.InvokeCallbackVoidPtr_NoInline_GCTransition(cb, &n);
-        Assert.Equal(expected++, n);
-
-        // Call function with same (non-blittable) signature, but with SuppressGCTransition
-        // IL stub should not be re-used, GC transition not should occur, and callback invocation should fail.
-        expected = n + 1;
-        SuppressGCTransitionNative.InvokeCallbackVoidPtr_NoInline_NoGCTransition(cb, &n);
-        Assert.Equal(expected++, n);
-
-        return n + 1;
-    }
-    public static int Main(string[] args)
-    {
-        try
-        {
-            CheckGCMode.Initialize(&SuppressGCTransitionNative.SetIsInCooperativeModeFunction);
-
-            int n = 1;
-            n = Inline_NoGCTransition(n);
-            n = Inline_GCTransition(n);
-            n = NoInline_NoGCTransition(n);
-            n = NoInline_GCTransition(n);
-            n = Mixed(n);
-            n = Mixed_TightLoop(n);
-            n = Inline_NoGCTransition_FunctionPointer(n);
-            n = Inline_GCTransition_FunctionPointer(n);
-            n = NoInline_NoGCTransition_FunctionPointer(n);
-            n = NoInline_GCTransition_FunctionPointer(n);
-            n = CallAsFunctionPointer(n);
-            n = ILStubCache_NoGCTransition_GCTransition(n);
-
-            if (args.Length != 0 && args[0].Equals("ILStubCache", StringComparison.OrdinalIgnoreCase))
-            {
-                // This test intentionally results in a fatal error, so only run when manually specified
-                n = ILStubCache_GCTransition_NoGCTransition(n);
-            }
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e.ToString());
-            return 101;
-        }
-        return 100;
+        int n = 1;
+        n = Inline_NoGCTransition(n);
+        n = Inline_GCTransition(n);
+        n = NoInline_NoGCTransition(n);
+        n = NoInline_GCTransition(n);
+        n = Mixed(n);
+        n = Mixed_TightLoop(n);
+        n = Inline_NoGCTransition_FunctionPointer(n);
+        n = Inline_GCTransition_FunctionPointer(n);
+        n = NoInline_NoGCTransition_FunctionPointer(n);
+        n = NoInline_GCTransition_FunctionPointer(n);
+        n = CallAsFunctionPointer(n);
+        n = ILStubCache_NoGCTransition_GCTransition(n);
     }
 }

--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionTest.csproj
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <MonoAotIncompatible>true</MonoAotIncompatible>
   </PropertyGroup>

--- a/src/tests/Interop/UnmanagedCallConv/UnmanagedCallConvTest.cs
+++ b/src/tests/Interop/UnmanagedCallConv/UnmanagedCallConvTest.cs
@@ -384,7 +384,8 @@ public unsafe class Program
         }
     }
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/UnmanagedCallConv/UnmanagedCallConvTest.csproj
+++ b/src/tests/Interop/UnmanagedCallConv/UnmanagedCallConvTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/UnmanagedCallConv/UnmanagedCallConvTest.csproj
+++ b/src/tests/Interop/UnmanagedCallConv/UnmanagedCallConvTest.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <CMakeProjectReference Include="CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <ProjectReference Include="PInvokesIL.ilproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyNegativeTest.cs
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyNegativeTest.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Xunit;
+using InvalidCSharp;
+
+public unsafe class Program
+{
+    public static class UnmanagedCallersOnlyDll
+    {
+        [DllImport(nameof(UnmanagedCallersOnlyDll))]
+        public static extern int CallManagedProc(IntPtr callbackProc, int n);
+
+        [DllImport(nameof(UnmanagedCallersOnlyDll))]
+        // Returns -1 if exception was throw and caught.
+        public static extern int CallManagedProcCatchException(IntPtr callbackProc, int n);
+    }
+
+    private delegate int IntNativeMethodInvoker();
+    private delegate void NativeMethodInvoker();
+
+    public static void Main()
+    {
+        NegativeTest_ViaCalli();
+        throw new Exception("Fatal error - runtime crash expected!");
+    }
+
+    [UnmanagedCallersOnly]
+    public static void CallbackViaCalli(int val)
+    {
+        Assert.True(false, $"Functions with attribute {nameof(UnmanagedCallersOnlyAttribute)} cannot be called via calli");
+    }
+
+    public static void NegativeTest_ViaCalli()
+    {
+        Console.WriteLine($"{nameof(NegativeTest_ViaCalli)} function via calli instruction. The CLR _will_ crash.");
+
+        // It is not possible to catch the resulting ExecutionEngineException exception.
+        // To observe the crashing behavior set a breakpoint in the ReversePInvokeBadTransition() function
+        // located in src/vm/dllimportcallback.cpp.
+        TestNativeMethod();
+
+        static void TestNativeMethod()
+        {
+            ((delegate*<int, void>)(delegate* unmanaged<int, void>)&CallbackViaCalli)(1234);
+        }
+    }
+}

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyNegativeTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyNegativeTest.csproj
@@ -5,7 +5,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <NativeAotIncompatible>true</NativeAotIncompatible>
-    <CLRTestExitCode>-2146233082</CLRTestExitCode>
+    <CLRTestExitCode>134</CLRTestExitCode>
+    <CLRTestExitCode Condition="'$(TestWrapperTargetsWindows)' == 'true'">-2146233082</CLRTestExitCode>
+    <CLRTestPriority>1</CLRTestPriority>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyNegativeTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyNegativeTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Test needs explicit executable and isolation as it tests crashing the runtime. -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <NativeAotIncompatible>true</NativeAotIncompatible>

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyNegativeTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyNegativeTest.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Test needs explicit executable and isolation as it tests crashing the runtime. -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <MonoAotIncompatible>true</MonoAotIncompatible>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
+    <CLRTestExitCode>-2146233082</CLRTestExitCode>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="UnmanagedCallersOnlyNegativeTest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- This is needed to make sure native binary gets installed in the right location -->
+    <CMakeProjectReference Include="CMakeLists.txt" />
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="InvalidCSharp.ilproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.cs
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.cs
@@ -33,7 +33,6 @@ public unsafe class Program
         {
             NegativeTest_NonStaticMethod();
             NegativeTest_ViaDelegate();
-            NegativeTest_ViaCalli();
             NegativeTest_NonBlittable();
             NegativeTest_InstantiatedGenericArguments();
             NegativeTest_FromInstantiatedGenericClass();
@@ -137,27 +136,6 @@ public unsafe class Program
         int n = 12345;
         // Try invoking method
         Assert.Throws<InvalidProgramException>(() => { UnmanagedCallersOnlyDll.CallManagedProc((IntPtr)(delegate* unmanaged<int, int>)&GenericClass<int>.CallbackMethod, n); });
-    }
-
-    [UnmanagedCallersOnly]
-    public static void CallbackViaCalli(int val)
-    {
-        Assert.True(false, $"Functions with attribute {nameof(UnmanagedCallersOnlyAttribute)} cannot be called via calli");
-    }
-
-    public static void NegativeTest_ViaCalli()
-    {
-        Console.WriteLine($"{nameof(NegativeTest_ViaCalli)} function via calli instruction. The CLR _will_ crash.");
-
-        // It is not possible to catch the resulting ExecutionEngineException exception.
-        // To observe the crashing behavior set a breakpoint in the ReversePInvokeBadTransition() function
-        // located in src/vm/dllimportcallback.cpp.
-        TestNativeMethod();
-
-        static void TestNativeMethod()
-        {
-            ((delegate*<int, void>)(delegate* unmanaged<int, void>)&CallbackViaCalli)(1234);
-        }
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.cs
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.cs
@@ -26,7 +26,8 @@ public unsafe class Program
     private delegate int IntNativeMethodInvoker();
     private delegate void NativeMethodInvoker();
 
-    public static int Main()
+    [Fact]
+    public static int TestEntryPoint()
     {
         try
         {

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.cs
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.cs
@@ -26,12 +26,13 @@ public unsafe class Program
     private delegate int IntNativeMethodInvoker();
     private delegate void NativeMethodInvoker();
 
-    public static int Main(string[] args)
+    public static int Main()
     {
         try
         {
             NegativeTest_NonStaticMethod();
             NegativeTest_ViaDelegate();
+            NegativeTest_ViaCalli();
             NegativeTest_NonBlittable();
             NegativeTest_InstantiatedGenericArguments();
             NegativeTest_FromInstantiatedGenericClass();
@@ -44,11 +45,6 @@ public unsafe class Program
             {
                 TestUnmanagedCallersOnlyValid_ThrowException();
                 TestUnmanagedCallersOnlyViaUnmanagedCalli_ThrowException();
-            }
-
-            if (args.Length != 0 && args[0].Equals("calli"))
-            {
-                NegativeTest_ViaCalli();
             }
         }
         catch (Exception e)

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for NativeAotIncompatible, CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <NativeAotIncompatible>true</NativeAotIncompatible>

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <!-- This is needed to make sure native binary gets installed in the right location -->
     <CMakeProjectReference Include="CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
     <ProjectReference Include="InvalidCSharp.ilproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/UnmanagedCallersOnlyBasic/UnmanagedCallersOnlyBasicTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnlyBasic/UnmanagedCallersOnlyBasicTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/UnmanagedCallersOnlyBasic/UnmanagedCallersOnlyBasicTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnlyBasic/UnmanagedCallersOnlyBasicTest.csproj
@@ -9,6 +9,6 @@
   <ItemGroup>
     <!-- This is needed to make sure native binary gets installed in the right location -->
     <CMakeProjectReference Include="../UnmanagedCallersOnly/CMakeLists.txt" />
-    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/WinRT/Program.cs
+++ b/src/tests/Interop/WinRT/Program.cs
@@ -11,12 +11,13 @@ namespace WinRT
     [WindowsRuntimeImport]
     interface I {}
 
-    class Program
+    public class Program
     {
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool ObjectIsI(object o) => o is I;
 
-        public static int Main()
+        [Fact]
+        public static int TestEntryPoint()
         {
             try
             {

--- a/src/tests/Interop/WinRT/WinRT.csproj
+++ b/src/tests/Interop/WinRT/WinRT.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <!-- Needed for CLRTestTargetUnsupported -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>


### PR DESCRIPTION
This change converts tests in the CoreMangLib, Exceptions and Interop to the merged model. As next step I plan to work on review feedback to my previous PR merging baseservices and on merging the remaining tests.

Thanks

Tomas