### PR TITLE
[System.HashCode] Adjust nullable annotation on generic Add method which accepts IEqualityComparer

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
@@ -304,7 +304,7 @@ namespace System
             Add(value?.GetHashCode() ?? 0);
         }
 
-        public void Add<T>(T value, IEqualityComparer<T>? comparer)
+        public void Add<T>(T? value, IEqualityComparer<T>? comparer)
         {
             Add(value is null ? 0 : (comparer?.GetHashCode(value) ?? value.GetHashCode()));
         }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -3064,7 +3064,7 @@ namespace System
         private int _dummyPrimitive;
         public void AddBytes(System.ReadOnlySpan<byte> value) { }
         public void Add<T>(T value) { }
-        public void Add<T>(T value, System.Collections.Generic.IEqualityComparer<T>? comparer) { }
+        public void Add<T>(T? value, System.Collections.Generic.IEqualityComparer<T>? comparer) { }
         public static int Combine<T1>(T1 value1) { throw null; }
         public static int Combine<T1, T2>(T1 value1, T2 value2) { throw null; }
         public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3) { throw null; }


### PR DESCRIPTION
## Changes

* Changes the signature of the `Add<T>` method which accepts `IEqualityComparer` from `T value` to `T? value` on `System.HashCode`

## Reason

I just ran into this:

```csharp
    private class MyLogic
    {
        private static readonly MyComparer MyComparer = new();

        public MyClass? Instance { get; set; }

        public override int GetHashCode()
        {
            HashCode hashCode = default;

            // Error CS8620 Argument of type 'MyComparer'
            // cannot be used for parameter 'comparer' of type
            // 'IEqualityComparer<MyClass?>' in 'void
            // HashCode.Add<MyClass?>(MyClass? value,
            // IEqualityComparer<MyClass?>? comparer)' due to differences in the
            // nullability of reference types.
            hashCode.Add(this.Instance, MyComparer);

            return hashCode.GetHashCode();
        }
    }

    private class MyClass
    {
    }

    private class MyComparer : IEqualityComparer<MyClass>
    {
        public bool Equals(MyClass? x, MyClass? y)
        {
            // Not important for the issue at hand
            throw new NotImplementedException();
        }

        public int GetHashCode([DisallowNull] MyClass obj)
        {
            // Not important for the issue at hand
            throw new NotImplementedException();
        }
    }
```

If I change my code to do...

```csharp
hashCode.Add(this.Instance!, MyComparer);
```

...it will work fine, but I think the annotation tweak smooths it out nicely?