### PR TITLE
Remove ObjRefInitBlk (has a GC hole)

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/GitHub_21761/GitHub_21761.il
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_21761/GitHub_21761.il
@@ -217,32 +217,6 @@ FAIL:
     ret
 }
 
-// Non-zero initialization of a GC reference is not exactly a valid scenario.
-// Still, the JIT shouldn't end up generating invalid IR (non-zero GC typed
-// constant nodes).
-
-.class sequential sealed Pair extends [System.Runtime]System.ValueType
-{
-    .field public int64 Key
-    .field public class [System.Runtime]System.Object Value
-}
-
-.method static bool ObjRefInitBlk() cil managed noinlining
-{
-    .locals init (valuetype Pair a)
-
-    ldloca a
-    ldc.i4 1
-    sizeof Pair
-    initblk
-
-    ldloca a
-    ldind.i8
-    ldc.i8 0x0101010101010101
-    ceq
-    ret
-}
-
 // Non-zero SIMD constants are not supported so field by field initialization
 // should not be attempted.
 
@@ -308,9 +282,6 @@ FAIL:
     brfalse FAIL
 
     call bool Float32NaNInitBlk()
-    brfalse FAIL
-
-    call bool ObjRefInitBlk()
     brfalse FAIL
 
     call bool SimdInitBlk()


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/91894

The test seems to be filling a struct `struct { long key; object Value; }` with all ones (1).

Judging by the comment it was intentional to test a different issue but I guess there is no point in making GC-hole code more robust in jit so I am removing it.


I was able to repro the GC assert locally, it happend on:
```asm
; Assembly listing for method <Module>:ObjRefInitBlk():ubyte (MinOpts)
; Emitting BLENDED_CODE for X64 with AVX512 - Windows
; MinOpts code
; rbp based frame
; fully interruptible
; Final local variable assignments
;
;  V00 loc0         [V00    ] (  1,  1   )  struct (16) [rbp-0x18]  do-not-enreg[SF] must-init ld-addr-op unsafe-buffer <Pair>
;  V01 tmp0         [V01    ] (  1,  1   )     int  ->  [rbp-0x1C]  do-not-enreg[V] "GSCookie dummy"
;  V02 OutArgs      [V02    ] (  1,  1   )  struct (32) [rsp+0x00]  do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
;  V03 GsCookie     [V03    ] (  1,  1   )    long  ->  [rbp-0x08]  do-not-enreg[X] addr-exposed "GSSecurityCookie"
;  V04 tmp3         [V04    ] (  1,  1   )    long  ->  [rbp-0x28]  do-not-enreg[] "Spilling to split statement for tree"
;
; Lcl frame size = 80

G_M46709_IG01:        ; bbWeight=1, gcrefRegs=0000 {}, byrefRegs=0000 {}, byref, nogc <-- Prolog IG
       push     rbp
       sub      rsp, 80
       vzeroupper
       lea      rbp, [rsp+0x50]
       xor      eax, eax
       mov      qword ptr [rbp-0x18], rax
       mov      qword ptr [rbp-0x10], rax
       mov      rax, 0x9ABCDEF012345678
       mov      qword ptr [rbp-0x08], rax
                                                ;; size=37 bbWeight=1 PerfScore 6.25
G_M46709_IG02:        ; bbWeight=1, gcrefRegs=0000 {}, byrefRegs=0000 {}, byref, isz
       vmovups  xmm0, xmmword ptr [reloc @RWD00]
       vmovdqu  xmmword ptr [rbp-0x18], xmm0
       mov      rax, qword ptr [rbp-0x18]
       mov      qword ptr [rbp-0x28], rax
       mov      rax, 0x101010101010101
       cmp      qword ptr [rbp-0x28], rax
       sete     al
       movzx    rax, al
       mov      rcx, 0x9ABCDEF012345678
       cmp      qword ptr [rbp-0x08], rcx
       je       SHORT G_M46709_IG03
       call     CORINFO_HELP_FAIL_FAST
                            ; gcr arg pop 0
                                                ;; size=62 bbWeight=1 PerfScore 13.75
G_M46709_IG03:        ; bbWeight=1, gcrefRegs=0000 {}, byrefRegs=0000 {}, byref
       nop
                                                ;; size=1 bbWeight=1 PerfScore 0.25
G_M46709_IG04:        ; bbWeight=1, epilog, nogc, extend
       add      rsp, 80
       pop      rbp
       ret
                                                ;; size=6 bbWeight=1 PerfScore 1.75
RWD00   dq      0101010101010101h, 0101010101010101h


; Total bytes of code 106
```
on `rbp-0x18` GC slot (`object Value` field since layout of the struct was re-ordered to make `Value` first)