### PR TITLE
Replace http.error.reason with OTel standard error.type

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using System.Net.Http.HPack;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
@@ -142,7 +142,7 @@ namespace System.Net.Http.Metrics
                 // https://github.com/open-telemetry/semantic-conventions/blob/2bad9afad58fbd6b33cc683d1ad1f006e35e4a5d/docs/http/http-spans.md
                 if (statusCode >= 400 && statusCode <= 599)
                 {
-                    errorType = GetStatusCodeString(statusCode);
+                    errorType = GetErrorStatusCodeString(statusCode);
                     return true;
                 }
             }
@@ -221,11 +221,14 @@ namespace System.Net.Http.Metrics
                 : statusCode;
         }
 
-        private static string GetStatusCodeString(int statusCode)
+        private static string GetErrorStatusCodeString(int statusCode)
         {
-            string[] strings = LazyInitializer.EnsureInitialized(ref s_statusCodeStrings, static () => new string[512]);
-            return (uint)statusCode < (uint)strings.Length
-                ? strings[statusCode] ??= statusCode.ToString()
+            Debug.Assert(statusCode >= 400 && statusCode <= 599);
+
+            string[] strings = LazyInitializer.EnsureInitialized(ref s_statusCodeStrings, static () => new string[200]);
+            int index = statusCode - 400;
+            return (uint)index < (uint)strings.Length
+                ? strings[index] ??= statusCode.ToString()
                 : statusCode.ToString();
         }
 


### PR DESCRIPTION
Fixes #91909

Align attribute name and semantics with the OpenTelemetry spec (which was finalized yesterday 2023/9/11 - see https://github.com/open-telemetry/semantic-conventions/pull/205) -- `http.error.reason` attribute has been standardized under name `error.type`. We need to:
- Rename `http.error.reason` to `error.type`.
- Report `error.type` also for valid responses where the HTTP status code indicates an error (4xx or 5xx) -- in such case, the value should be the string representation of the HTTP status code.
    - Note: Currently we report `http.error.reason` only when the underlying handler fails to fetch a response.

See `error.type` in [the spec](https://github.com/open-telemetry/semantic-conventions/blob/2bad9afad58fbd6b33cc683d1ad1f006e35e4a5d/docs/http/http-spans.md#common-attributes) for more details.

For context: We introduced the attribute `http.error.reason` in PR #89809 (on 2023/8/3) based on the in-progress draft of the OTel spec (https://github.com/open-telemetry/semantic-conventions/pull/205).

Given that this is new 8.0 feature, we should adapt to the spec in 8.0 to avoid breaking changes with 9.0.