### PR TITLE
Don't generate Attribute comparison helpers when classlib doesn't hav…

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.ValueTypeMethods.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.ValueTypeMethods.cs
@@ -113,8 +113,14 @@ namespace ILCompiler
                 && Array.IndexOf(type.RuntimeInterfaces, _iAsyncStateMachineType) >= 0;
         }
 
-        private static bool RequiresAttributeGetFieldHelperMethod(TypeDesc attributeTypeDef)
+        private bool RequiresAttributeGetFieldHelperMethod(TypeDesc attributeTypeDef)
         {
+            _objectEqualsMethod ??= GetWellKnownType(WellKnownType.Object).GetMethod("Equals", null);
+
+            // If the classlib doesn't have Object.Equals, we don't need this.
+            if (_objectEqualsMethod == null)
+                return false;
+
             foreach (FieldDesc field in attributeTypeDef.GetFields())
             {
                 if (field.IsStatic)


### PR DESCRIPTION
…e Equals

I had things configured wrong for the hackathon, but this seems like an improvement. We gate ValueType Equals on the same thing.

Cc @dotnet/ilc-contrib 