### PR TITLE
Disable Http3 LargeSingleHeader_ThrowsException Test

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -68,6 +68,7 @@ namespace System.Net.Http.Functional.Tests
             server => server.AcceptConnectionSendResponseAndCloseAsync());
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/74896")]
         [Theory]
         [InlineData(1)]
         [InlineData(15)]

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -68,7 +68,6 @@ namespace System.Net.Http.Functional.Tests
             server => server.AcceptConnectionSendResponseAndCloseAsync());
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/74896")]
         [Theory]
         [InlineData(1)]
         [InlineData(15)]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1633,6 +1633,7 @@ namespace System.Net.Http.Functional.Tests
         protected override Version UseVersion => HttpVersion.Version20;
     }
 
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/74896")]
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsQuicSupported))]
     public sealed class SocketsHttpHandler_HttpClientHandler_MaxResponseHeadersLength_Http3 : SocketsHttpHandler_HttpClientHandler_MaxResponseHeadersLength
     {


### PR DESCRIPTION
Disabling HTTP/3 test `LargeSingleHeader_ThrowsException` against #74896 because it's happening quite often until we're back to investigate it.

Related to #91757