### PR TITLE
Remove unnecessary use of UseCompilerGeneratedDocXmlFile

### DIFF
--- a/src/libraries/Microsoft.Bcl.AsyncInterfaces/src/Microsoft.Bcl.AsyncInterfaces.csproj
+++ b/src/libraries/Microsoft.Bcl.AsyncInterfaces/src/Microsoft.Bcl.AsyncInterfaces.csproj
@@ -10,8 +10,6 @@ Commonly Used Types:
 System.IAsyncDisposable
 System.Collections.Generic.IAsyncEnumerable
 System.Collections.Generic.IAsyncEnumerator</PackageDescription>
-    <!-- This library uses IsPartialFacadeAssembly for which the compiler doesn't produce any XML documentation. -->
-    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/libraries/Microsoft.Bcl.TimeProvider/src/Microsoft.Bcl.TimeProvider.csproj
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/src/Microsoft.Bcl.TimeProvider.csproj
@@ -8,8 +8,6 @@
 Commonly Used Types:
 System.TimeProvider
 System.ITimer</PackageDescription>
-    <!-- This library uses IsPartialFacadeAssembly for which the compiler doesn't produce any XML documentation. -->
-    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->


### PR DESCRIPTION
These projects don't need to set that property as there doc XML file isn't included in the docs transport package and it's better to have the compiler generated XML files for the other TFMs than no XML file at all.