### PR TITLE
Move SearchValues scalar loops into IndexOfAnyAsciiSearcher

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/AnyByteSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/AnyByteSearchValues.cs
@@ -3,94 +3,56 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
+using System.Runtime.Intrinsics.X86;
 
 namespace System.Buffers
 {
     internal sealed class AnyByteSearchValues : SearchValues<byte>
     {
-        private Vector512<byte> _bitmaps;
-        private readonly BitVector256 _lookup;
+        private IndexOfAnyAsciiSearcher.AnyByteState _state;
 
-        public AnyByteSearchValues(ReadOnlySpan<byte> values)
-        {
-            IndexOfAnyAsciiSearcher.ComputeBitmap256(values, out Vector256<byte> bitmap0, out Vector256<byte> bitmap1, out _lookup);
-            _bitmaps = Vector512.Create(bitmap0, bitmap1);
-        }
+        public AnyByteSearchValues(ReadOnlySpan<byte> values) =>
+            IndexOfAnyAsciiSearcher.ComputeAnyByteState(values, out _state);
 
-        internal override byte[] GetValues() => _lookup.GetByteValues();
+        internal override byte[] GetValues() =>
+            _state.Lookup.GetByteValues();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override bool ContainsCore(byte value) =>
-            _lookup.Contains(value);
+            _state.Lookup.Contains(value);
 
+        [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int IndexOfAny(ReadOnlySpan<byte> span) =>
-            IndexOfAny<IndexOfAnyAsciiSearcher.DontNegate>(ref MemoryMarshal.GetReference(span), span.Length);
+            IndexOfAnyAsciiSearcher.IndexOfAnyVectorizedAnyByte<IndexOfAnyAsciiSearcher.DontNegate>(
+                ref MemoryMarshal.GetReference(span), span.Length, ref _state);
 
+        [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int IndexOfAnyExcept(ReadOnlySpan<byte> span) =>
-            IndexOfAny<IndexOfAnyAsciiSearcher.Negate>(ref MemoryMarshal.GetReference(span), span.Length);
+            IndexOfAnyAsciiSearcher.IndexOfAnyVectorizedAnyByte<IndexOfAnyAsciiSearcher.Negate>(
+                ref MemoryMarshal.GetReference(span), span.Length, ref _state);
 
+        [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int LastIndexOfAny(ReadOnlySpan<byte> span) =>
-            LastIndexOfAny<IndexOfAnyAsciiSearcher.DontNegate>(ref MemoryMarshal.GetReference(span), span.Length);
+            IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorizedAnyByte<IndexOfAnyAsciiSearcher.DontNegate>(
+                ref MemoryMarshal.GetReference(span), span.Length, ref _state);
 
+        [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int LastIndexOfAnyExcept(ReadOnlySpan<byte> span) =>
-            LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate>(ref MemoryMarshal.GetReference(span), span.Length);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int IndexOfAny<TNegator>(ref byte searchSpace, int searchSpaceLength)
-            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
-        {
-            return IndexOfAnyAsciiSearcher.IsVectorizationSupported && searchSpaceLength >= sizeof(ulong)
-                ? IndexOfAnyAsciiSearcher.IndexOfAnyVectorizedAnyByte<TNegator>(ref searchSpace, searchSpaceLength, ref _bitmaps)
-                : IndexOfAnyScalar<TNegator>(ref searchSpace, searchSpaceLength);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int LastIndexOfAny<TNegator>(ref byte searchSpace, int searchSpaceLength)
-            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
-        {
-            return IndexOfAnyAsciiSearcher.IsVectorizationSupported && searchSpaceLength >= sizeof(ulong)
-                ? IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorizedAnyByte<TNegator>(ref searchSpace, searchSpaceLength, ref _bitmaps)
-                : LastIndexOfAnyScalar<TNegator>(ref searchSpace, searchSpaceLength);
-        }
-
-        private int IndexOfAnyScalar<TNegator>(ref byte searchSpace, int searchSpaceLength)
-            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
-        {
-            ref byte searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
-            ref byte cur = ref searchSpace;
-
-            while (!Unsafe.AreSame(ref cur, ref searchSpaceEnd))
-            {
-                byte b = cur;
-                if (TNegator.NegateIfNeeded(_lookup.Contains(b)))
-                {
-                    return (int)Unsafe.ByteOffset(ref searchSpace, ref cur);
-                }
-
-                cur = ref Unsafe.Add(ref cur, 1);
-            }
-
-            return -1;
-        }
-
-        private int LastIndexOfAnyScalar<TNegator>(ref byte searchSpace, int searchSpaceLength)
-            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
-        {
-            for (int i = searchSpaceLength - 1; i >= 0; i--)
-            {
-                byte b = Unsafe.Add(ref searchSpace, i);
-                if (TNegator.NegateIfNeeded(_lookup.Contains(b)))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
+            IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorizedAnyByte<IndexOfAnyAsciiSearcher.Negate>(
+                ref MemoryMarshal.GetReference(span), span.Length, ref _state);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/AsciiByteSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/AsciiByteSearchValues.cs
@@ -3,91 +3,56 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
+using System.Runtime.Intrinsics.X86;
 
 namespace System.Buffers
 {
     internal sealed class AsciiByteSearchValues : SearchValues<byte>
     {
-        private Vector256<byte> _bitmap;
-        private readonly BitVector256 _lookup;
+        private IndexOfAnyAsciiSearcher.AsciiState _state;
 
         public AsciiByteSearchValues(ReadOnlySpan<byte> values) =>
-            IndexOfAnyAsciiSearcher.ComputeBitmap(values, out _bitmap, out _lookup);
+            IndexOfAnyAsciiSearcher.ComputeAsciiState(values, out _state);
 
-        internal override byte[] GetValues() => _lookup.GetByteValues();
+        internal override byte[] GetValues() =>
+            _state.Lookup.GetByteValues();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override bool ContainsCore(byte value) =>
-            _lookup.Contains(value);
+            _state.Lookup.Contains(value);
 
+        [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int IndexOfAny(ReadOnlySpan<byte> span) =>
-            IndexOfAny<IndexOfAnyAsciiSearcher.DontNegate>(ref MemoryMarshal.GetReference(span), span.Length);
+            IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.DontNegate>(
+                ref MemoryMarshal.GetReference(span), span.Length, ref _state);
 
+        [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int IndexOfAnyExcept(ReadOnlySpan<byte> span) =>
-            IndexOfAny<IndexOfAnyAsciiSearcher.Negate>(ref MemoryMarshal.GetReference(span), span.Length);
+            IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate>(
+                ref MemoryMarshal.GetReference(span), span.Length, ref _state);
 
+        [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int LastIndexOfAny(ReadOnlySpan<byte> span) =>
-            LastIndexOfAny<IndexOfAnyAsciiSearcher.DontNegate>(ref MemoryMarshal.GetReference(span), span.Length);
+            IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<IndexOfAnyAsciiSearcher.DontNegate>(
+                ref MemoryMarshal.GetReference(span), span.Length, ref _state);
 
+        [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int LastIndexOfAnyExcept(ReadOnlySpan<byte> span) =>
-            LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate>(ref MemoryMarshal.GetReference(span), span.Length);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int IndexOfAny<TNegator>(ref byte searchSpace, int searchSpaceLength)
-            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
-        {
-            return IndexOfAnyAsciiSearcher.IsVectorizationSupported && searchSpaceLength >= sizeof(ulong)
-                ? IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<TNegator>(ref searchSpace, searchSpaceLength, ref _bitmap)
-                : IndexOfAnyScalar<TNegator>(ref searchSpace, searchSpaceLength);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int LastIndexOfAny<TNegator>(ref byte searchSpace, int searchSpaceLength)
-            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
-        {
-            return IndexOfAnyAsciiSearcher.IsVectorizationSupported && searchSpaceLength >= sizeof(ulong)
-                ? IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<TNegator>(ref searchSpace, searchSpaceLength, ref _bitmap)
-                : LastIndexOfAnyScalar<TNegator>(ref searchSpace, searchSpaceLength);
-        }
-
-        private int IndexOfAnyScalar<TNegator>(ref byte searchSpace, int searchSpaceLength)
-            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
-        {
-            ref byte searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
-            ref byte cur = ref searchSpace;
-
-            while (!Unsafe.AreSame(ref cur, ref searchSpaceEnd))
-            {
-                byte b = cur;
-                if (TNegator.NegateIfNeeded(_lookup.Contains(b)))
-                {
-                    return (int)Unsafe.ByteOffset(ref searchSpace, ref cur);
-                }
-
-                cur = ref Unsafe.Add(ref cur, 1);
-            }
-
-            return -1;
-        }
-
-        private int LastIndexOfAnyScalar<TNegator>(ref byte searchSpace, int searchSpaceLength)
-            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
-        {
-            for (int i = searchSpaceLength - 1; i >= 0; i--)
-            {
-                byte b = Unsafe.Add(ref searchSpace, i);
-                if (TNegator.NegateIfNeeded(_lookup.Contains(b)))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
+            IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate>(
+                ref MemoryMarshal.GetReference(span), span.Length, ref _state);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/AsciiCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/AsciiCharSearchValues.cs
@@ -3,95 +3,57 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.Wasm;
+using System.Runtime.Intrinsics.X86;
 
 namespace System.Buffers
 {
     internal sealed class AsciiCharSearchValues<TOptimizations> : SearchValues<char>
         where TOptimizations : struct, IndexOfAnyAsciiSearcher.IOptimizations
     {
-        private Vector256<byte> _bitmap;
-        private readonly BitVector256 _lookup;
+        private IndexOfAnyAsciiSearcher.AsciiState _state;
 
-        public AsciiCharSearchValues(Vector256<byte> bitmap, BitVector256 lookup)
-        {
-            _bitmap = bitmap;
-            _lookup = lookup;
-        }
+        public AsciiCharSearchValues(ReadOnlySpan<char> values) =>
+            IndexOfAnyAsciiSearcher.ComputeAsciiState(values, out _state);
 
-        internal override char[] GetValues() => _lookup.GetCharValues();
+        internal override char[] GetValues() =>
+            _state.Lookup.GetCharValues();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override bool ContainsCore(char value) =>
-            _lookup.Contains128(value);
+            _state.Lookup.Contains128(value);
 
+        [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int IndexOfAny(ReadOnlySpan<char> span) =>
-            IndexOfAny<IndexOfAnyAsciiSearcher.DontNegate>(ref MemoryMarshal.GetReference(span), span.Length);
+            IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.DontNegate, TOptimizations>(
+                ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)), span.Length, ref _state);
 
+        [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int IndexOfAnyExcept(ReadOnlySpan<char> span) =>
-            IndexOfAny<IndexOfAnyAsciiSearcher.Negate>(ref MemoryMarshal.GetReference(span), span.Length);
+            IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, TOptimizations>(
+                ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)), span.Length, ref _state);
 
+        [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int LastIndexOfAny(ReadOnlySpan<char> span) =>
-            LastIndexOfAny<IndexOfAnyAsciiSearcher.DontNegate>(ref MemoryMarshal.GetReference(span), span.Length);
+            IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<IndexOfAnyAsciiSearcher.DontNegate, TOptimizations>(
+                ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)), span.Length, ref _state);
 
+        [CompExactlyDependsOn(typeof(Ssse3))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int LastIndexOfAnyExcept(ReadOnlySpan<char> span) =>
-            LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate>(ref MemoryMarshal.GetReference(span), span.Length);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int IndexOfAny<TNegator>(ref char searchSpace, int searchSpaceLength)
-            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
-        {
-            return IndexOfAnyAsciiSearcher.IsVectorizationSupported && searchSpaceLength >= Vector128<short>.Count
-                ? IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<TNegator, TOptimizations>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, ref _bitmap)
-                : IndexOfAnyScalar<TNegator>(ref searchSpace, searchSpaceLength);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int LastIndexOfAny<TNegator>(ref char searchSpace, int searchSpaceLength)
-            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
-        {
-            return IndexOfAnyAsciiSearcher.IsVectorizationSupported && searchSpaceLength >= Vector128<short>.Count
-                ? IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<TNegator, TOptimizations>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, ref _bitmap)
-                : LastIndexOfAnyScalar<TNegator>(ref searchSpace, searchSpaceLength);
-        }
-
-        private int IndexOfAnyScalar<TNegator>(ref char searchSpace, int searchSpaceLength)
-            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
-        {
-            ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
-            ref char cur = ref searchSpace;
-
-            while (!Unsafe.AreSame(ref cur, ref searchSpaceEnd))
-            {
-                char c = cur;
-                if (TNegator.NegateIfNeeded(_lookup.Contains128(c)))
-                {
-                    return (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
-                }
-
-                cur = ref Unsafe.Add(ref cur, 1);
-            }
-
-            return -1;
-        }
-
-        private int LastIndexOfAnyScalar<TNegator>(ref char searchSpace, int searchSpaceLength)
-            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
-        {
-            for (int i = searchSpaceLength - 1; i >= 0; i--)
-            {
-                char c = Unsafe.Add(ref searchSpace, i);
-                if (TNegator.NegateIfNeeded(_lookup.Contains128(c)))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
+            IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, TOptimizations>(
+                ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)), span.Length, ref _state);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/BitVector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/BitVector256.cs
@@ -11,6 +11,18 @@ namespace System.Buffers
     {
         private fixed uint _values[8];
 
+        public readonly BitVector256 CreateInverse()
+        {
+            BitVector256 inverse = default;
+
+            for (int i = 0; i < 8; i++)
+            {
+                inverse._values[i] = ~_values[i];
+            }
+
+            return inverse;
+        }
+
         public void Set(int c)
         {
             Debug.Assert(c < 256);

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Numerics;
-using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
@@ -17,14 +16,25 @@ namespace System.Buffers
 {
     internal static class IndexOfAnyAsciiSearcher
     {
+        public struct AsciiState(Vector128<byte> bitmap, BitVector256 lookup)
+        {
+            public Vector256<byte> Bitmap = Vector256.Create(bitmap, bitmap);
+            public BitVector256 Lookup = lookup;
+
+            public readonly AsciiState CreateInverse() =>
+                new AsciiState(~Bitmap._lower, Lookup.CreateInverse());
+        }
+
+        public struct AnyByteState(Vector128<byte> bitmap0, Vector128<byte> bitmap1, BitVector256 lookup)
+        {
+            public Vector256<byte> Bitmap0 = Vector256.Create(bitmap0, bitmap0);
+            public Vector256<byte> Bitmap1 = Vector256.Create(bitmap1, bitmap1);
+            public BitVector256 Lookup = lookup;
+        }
+
         internal static bool IsVectorizationSupported => Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool BitmapContains(ref Vector256<byte> bitmap, char c) =>
-            c <= 127 &&
-            (bitmap.GetElementUnsafe(c & 0xF) & (1 << (c >> 4))) != 0;
-
-        internal static unsafe void ComputeBitmap256(ReadOnlySpan<byte> values, out Vector256<byte> bitmap0, out Vector256<byte> bitmap1, out BitVector256 lookup)
+        internal static unsafe void ComputeAnyByteState(ReadOnlySpan<byte> values, out AnyByteState state)
         {
             // The exact format of these bitmaps differs from the other ComputeBitmap overloads as it's meant for the full [0, 255] range algorithm.
             // See http://0x80.pl/articles/simd-byte-lookup.html#universal-algorithm
@@ -52,12 +62,10 @@ namespace System.Buffers
                 }
             }
 
-            bitmap0 = Vector256.Create(bitmapSpace0, bitmapSpace0);
-            bitmap1 = Vector256.Create(bitmapSpace1, bitmapSpace1);
-            lookup = lookupLocal;
+            state = new AnyByteState(bitmapSpace0, bitmapSpace1, lookupLocal);
         }
 
-        internal static unsafe void ComputeBitmap<T>(ReadOnlySpan<T> values, out Vector256<byte> bitmap, out BitVector256 lookup)
+        internal static unsafe void ComputeAsciiState<T>(ReadOnlySpan<T> values, out AsciiState state)
             where T : struct, IUnsignedNumber<T>
         {
             Debug.Assert(typeof(T) == typeof(byte) || typeof(T) == typeof(char));
@@ -83,8 +91,7 @@ namespace System.Buffers
                 bitmapLocal[(uint)lowNibble] |= (byte)(1 << highNibble);
             }
 
-            bitmap = Vector256.Create(bitmapSpace, bitmapSpace);
-            lookup = lookupLocal;
+            state = new AsciiState(bitmapSpace, lookupLocal);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -134,14 +141,17 @@ namespace System.Buffers
 
             if (IsVectorizationSupported)
             {
-                Vector128<byte> bitmap = default;
-                if (TryComputeBitmap(asciiValues, (byte*)&bitmap, out bool needleContainsZero))
+                AsciiState state = default;
+
+                if (TryComputeBitmap(asciiValues, (byte*)&state.Bitmap._lower, out bool needleContainsZero))
                 {
-                    Vector256<byte> bitmap256 = Vector256.Create(bitmap, bitmap);
+                    // Only initializing the bitmap here is okay as we can only get here if the search space is long enough
+                    // and we support vectorization, so the IndexOfAnyVectorized implementation will never touch state.Lookup.
+                    state.Bitmap = Vector256.Create(state.Bitmap._lower, state.Bitmap._lower);
 
                     index = (Ssse3.IsSupported || PackedSimd.IsSupported) && needleContainsZero
-                        ? IndexOfAnyVectorized<TNegator, Ssse3AndWasmHandleZeroInNeedle>(ref searchSpace, searchSpaceLength, ref bitmap256)
-                        : IndexOfAnyVectorized<TNegator, Default>(ref searchSpace, searchSpaceLength, ref bitmap256);
+                        ? IndexOfAnyVectorized<TNegator, Ssse3AndWasmHandleZeroInNeedle>(ref searchSpace, searchSpaceLength, ref state)
+                        : IndexOfAnyVectorized<TNegator, Default>(ref searchSpace, searchSpaceLength, ref state);
                     return true;
                 }
             }
@@ -158,14 +168,17 @@ namespace System.Buffers
 
             if (IsVectorizationSupported)
             {
-                Vector128<byte> bitmap = default;
-                if (TryComputeBitmap(asciiValues, (byte*)&bitmap, out bool needleContainsZero))
+                AsciiState state = default;
+
+                if (TryComputeBitmap(asciiValues, (byte*)&state.Bitmap._lower, out bool needleContainsZero))
                 {
-                    Vector256<byte> bitmap256 = Vector256.Create(bitmap, bitmap);
+                    // Only initializing the bitmap here is okay as we can only get here if the search space is long enough
+                    // and we support vectorization, so the LastIndexOfAnyVectorized implementation will never touch state.Lookup.
+                    state.Bitmap = Vector256.Create(state.Bitmap._lower, state.Bitmap._lower);
 
                     index = (Ssse3.IsSupported || PackedSimd.IsSupported) && needleContainsZero
-                        ? LastIndexOfAnyVectorized<TNegator, Ssse3AndWasmHandleZeroInNeedle>(ref searchSpace, searchSpaceLength, ref bitmap256)
-                        : LastIndexOfAnyVectorized<TNegator, Default>(ref searchSpace, searchSpaceLength, ref bitmap256);
+                        ? LastIndexOfAnyVectorized<TNegator, Ssse3AndWasmHandleZeroInNeedle>(ref searchSpace, searchSpaceLength, ref state)
+                        : LastIndexOfAnyVectorized<TNegator, Default>(ref searchSpace, searchSpaceLength, ref state);
                     return true;
                 }
             }
@@ -177,17 +190,35 @@ namespace System.Buffers
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
-        internal static int IndexOfAnyVectorized<TNegator, TOptimizations>(ref short searchSpace, int searchSpaceLength, ref Vector256<byte> bitmapRef)
+        internal static int IndexOfAnyVectorized<TNegator, TOptimizations>(ref short searchSpace, int searchSpaceLength, ref AsciiState state)
             where TNegator : struct, INegator
             where TOptimizations : struct, IOptimizations
         {
             ref short currentSearchSpace = ref searchSpace;
 
+            if (searchSpaceLength < Vector128<ushort>.Count)
+            {
+                ref short searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
+
+                while (!Unsafe.AreSame(ref currentSearchSpace, ref searchSpaceEnd))
+                {
+                    char c = (char)currentSearchSpace;
+                    if (TNegator.NegateIfNeeded(state.Lookup.Contains128(c)))
+                    {
+                        return (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref currentSearchSpace) / sizeof(char));
+                    }
+
+                    currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, 1);
+                }
+
+                return -1;
+            }
+
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough // The behavior of the rest of the function remains the same if Avx2.IsSupported is false
             if (Avx2.IsSupported && searchSpaceLength > 2 * Vector128<short>.Count)
 #pragma warning restore IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough
             {
-                Vector256<byte> bitmap256 = bitmapRef;
+                Vector256<byte> bitmap256 = state.Bitmap;
 
                 if (searchSpaceLength > 2 * Vector256<short>.Count)
                 {
@@ -238,7 +269,7 @@ namespace System.Buffers
                 return -1;
             }
 
-            Vector128<byte> bitmap = bitmapRef._lower;
+            Vector128<byte> bitmap = state.Bitmap._lower;
 
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough // The behavior of the rest of the function remains the same if Avx2.IsSupported is false
             if (!Avx2.IsSupported && searchSpaceLength > 2 * Vector128<short>.Count)
@@ -294,17 +325,31 @@ namespace System.Buffers
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
-        internal static int LastIndexOfAnyVectorized<TNegator, TOptimizations>(ref short searchSpace, int searchSpaceLength, ref Vector256<byte> bitmapRef)
+        internal static int LastIndexOfAnyVectorized<TNegator, TOptimizations>(ref short searchSpace, int searchSpaceLength, ref AsciiState state)
             where TNegator : struct, INegator
             where TOptimizations : struct, IOptimizations
         {
+            if (searchSpaceLength < Vector128<ushort>.Count)
+            {
+                for (int i = searchSpaceLength - 1; i >= 0; i--)
+                {
+                    char c = (char)Unsafe.Add(ref searchSpace, i);
+                    if (TNegator.NegateIfNeeded(state.Lookup.Contains128(c)))
+                    {
+                        return i;
+                    }
+                }
+
+                return -1;
+            }
+
             ref short currentSearchSpace = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
 
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough // The else clause is semantically equivalent
             if (Avx2.IsSupported && searchSpaceLength > 2 * Vector128<short>.Count)
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough
             {
-                Vector256<byte> bitmap256 = bitmapRef;
+                Vector256<byte> bitmap256 = state.Bitmap;
 
                 if (searchSpaceLength > 2 * Vector256<short>.Count)
                 {
@@ -355,7 +400,7 @@ namespace System.Buffers
                 return -1;
             }
 
-            Vector128<byte> bitmap = bitmapRef._lower;
+            Vector128<byte> bitmap = state.Bitmap._lower;
 
             if (!Avx2.IsSupported && searchSpaceLength > 2 * Vector128<short>.Count)
             {
@@ -409,16 +454,34 @@ namespace System.Buffers
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
-        internal static int IndexOfAnyVectorized<TNegator>(ref byte searchSpace, int searchSpaceLength, ref Vector256<byte> bitmapRef)
+        internal static int IndexOfAnyVectorized<TNegator>(ref byte searchSpace, int searchSpaceLength, ref AsciiState state)
             where TNegator : struct, INegator
         {
             ref byte currentSearchSpace = ref searchSpace;
+
+            if (searchSpaceLength < sizeof(ulong))
+            {
+                ref byte searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
+
+                while (!Unsafe.AreSame(ref currentSearchSpace, ref searchSpaceEnd))
+                {
+                    byte b = currentSearchSpace;
+                    if (TNegator.NegateIfNeeded(state.Lookup.Contains(b)))
+                    {
+                        return (int)Unsafe.ByteOffset(ref searchSpace, ref currentSearchSpace);
+                    }
+
+                    currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, 1);
+                }
+
+                return -1;
+            }
 
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough // The behavior of the rest of the function remains the same if Avx2.IsSupported is false
             if (Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough
             {
-                Vector256<byte> bitmap256 = bitmapRef;
+                Vector256<byte> bitmap256 = state.Bitmap;
 
                 if (searchSpaceLength > Vector256<byte>.Count)
                 {
@@ -467,7 +530,7 @@ namespace System.Buffers
                 return -1;
             }
 
-            Vector128<byte> bitmap = bitmapRef._lower;
+            Vector128<byte> bitmap = state.Bitmap._lower;
 
             if (!Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
             {
@@ -519,16 +582,30 @@ namespace System.Buffers
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
-        internal static int LastIndexOfAnyVectorized<TNegator>(ref byte searchSpace, int searchSpaceLength, ref Vector256<byte> bitmapRef)
+        internal static int LastIndexOfAnyVectorized<TNegator>(ref byte searchSpace, int searchSpaceLength, ref AsciiState state)
             where TNegator : struct, INegator
         {
+            if (searchSpaceLength < sizeof(ulong))
+            {
+                for (int i = searchSpaceLength - 1; i >= 0; i--)
+                {
+                    byte b = Unsafe.Add(ref searchSpace, i);
+                    if (TNegator.NegateIfNeeded(state.Lookup.Contains(b)))
+                    {
+                        return i;
+                    }
+                }
+
+                return -1;
+            }
+
             ref byte currentSearchSpace = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
 
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough // The behavior of the rest of the function remains the same if Avx2.IsSupported is false
             if (Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough
             {
-                Vector256<byte> bitmap256 = bitmapRef;
+                Vector256<byte> bitmap256 = state.Bitmap;
 
                 if (searchSpaceLength > Vector256<byte>.Count)
                 {
@@ -577,7 +654,7 @@ namespace System.Buffers
                 return -1;
             }
 
-            Vector128<byte> bitmap = bitmapRef._lower;
+            Vector128<byte> bitmap = state.Bitmap._lower;
 
             if (!Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
             {
@@ -629,17 +706,35 @@ namespace System.Buffers
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
-        internal static int IndexOfAnyVectorizedAnyByte<TNegator>(ref byte searchSpace, int searchSpaceLength, ref Vector512<byte> bitmapsRef)
+        internal static int IndexOfAnyVectorizedAnyByte<TNegator>(ref byte searchSpace, int searchSpaceLength, ref AnyByteState state)
             where TNegator : struct, INegator
         {
             ref byte currentSearchSpace = ref searchSpace;
+
+            if (!IsVectorizationSupported || searchSpaceLength < sizeof(ulong))
+            {
+                ref byte searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
+
+                while (!Unsafe.AreSame(ref currentSearchSpace, ref searchSpaceEnd))
+                {
+                    byte b = currentSearchSpace;
+                    if (TNegator.NegateIfNeeded(state.Lookup.Contains(b)))
+                    {
+                        return (int)Unsafe.ByteOffset(ref searchSpace, ref currentSearchSpace);
+                    }
+
+                    currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, 1);
+                }
+
+                return -1;
+            }
 
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough // The behavior of the rest of the function remains the same if Avx2.IsSupported is false
             if (Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
 #pragma warning restore IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough
             {
-                Vector256<byte> bitmap256_0 = bitmapsRef._lower;
-                Vector256<byte> bitmap256_1 = bitmapsRef._upper;
+                Vector256<byte> bitmap256_0 = state.Bitmap0;
+                Vector256<byte> bitmap256_1 = state.Bitmap1;
 
                 if (searchSpaceLength > Vector256<byte>.Count)
                 {
@@ -688,8 +783,8 @@ namespace System.Buffers
                 return -1;
             }
 
-            Vector128<byte> bitmap0 = bitmapsRef._lower._lower;
-            Vector128<byte> bitmap1 = bitmapsRef._upper._lower;
+            Vector128<byte> bitmap0 = state.Bitmap0._lower;
+            Vector128<byte> bitmap1 = state.Bitmap1._lower;
 
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough // The behavior of the rest of the function remains the same if Avx2.IsSupported is false
             if (!Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
@@ -743,17 +838,31 @@ namespace System.Buffers
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
-        internal static int LastIndexOfAnyVectorizedAnyByte<TNegator>(ref byte searchSpace, int searchSpaceLength, ref Vector512<byte> bitmapsRef)
+        internal static int LastIndexOfAnyVectorizedAnyByte<TNegator>(ref byte searchSpace, int searchSpaceLength, ref AnyByteState state)
             where TNegator : struct, INegator
         {
+            if (!IsVectorizationSupported || searchSpaceLength < sizeof(ulong))
+            {
+                for (int i = searchSpaceLength - 1; i >= 0; i--)
+                {
+                    byte b = Unsafe.Add(ref searchSpace, i);
+                    if (TNegator.NegateIfNeeded(state.Lookup.Contains(b)))
+                    {
+                        return i;
+                    }
+                }
+
+                return -1;
+            }
+
             ref byte currentSearchSpace = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
 
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough // The behavior of the rest of the function remains the same if Avx2.IsSupported is false
             if (Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)
             {
 #pragma warning restore IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough
-                Vector256<byte> bitmap256_0 = bitmapsRef._lower;
-                Vector256<byte> bitmap256_1 = bitmapsRef._upper;
+                Vector256<byte> bitmap256_0 = state.Bitmap0;
+                Vector256<byte> bitmap256_1 = state.Bitmap1;
 
                 if (searchSpaceLength > Vector256<byte>.Count)
                 {
@@ -802,8 +911,8 @@ namespace System.Buffers
                 return -1;
             }
 
-            Vector128<byte> bitmap0 = bitmapsRef._lower._lower;
-            Vector128<byte> bitmap1 = bitmapsRef._upper._lower;
+            Vector128<byte> bitmap0 = state.Bitmap0._lower;
+            Vector128<byte> bitmap1 = state.Bitmap1._lower;
 
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough // The behavior of the rest of the function remains the same if Avx2.IsSupported is false
             if (!Avx2.IsSupported && searchSpaceLength > Vector128<byte>.Count)

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
@@ -13,8 +13,8 @@ namespace System.Buffers
     internal sealed class ProbabilisticWithAsciiCharSearchValues<TOptimizations> : SearchValues<char>
         where TOptimizations : struct, IndexOfAnyAsciiSearcher.IOptimizations
     {
-        private Vector256<byte> _asciiBitmap;
-        private Vector256<byte> _inverseAsciiBitmap;
+        private IndexOfAnyAsciiSearcher.AsciiState _asciiState;
+        private IndexOfAnyAsciiSearcher.AsciiState _inverseAsciiState;
         private ProbabilisticMap _map;
         private readonly string _values;
 
@@ -23,8 +23,8 @@ namespace System.Buffers
             Debug.Assert(IndexOfAnyAsciiSearcher.IsVectorizationSupported);
             Debug.Assert(values.ContainsAnyInRange((char)0, (char)127));
 
-            IndexOfAnyAsciiSearcher.ComputeBitmap(values, out _asciiBitmap, out _);
-            _inverseAsciiBitmap = ~_asciiBitmap;
+            IndexOfAnyAsciiSearcher.ComputeAsciiState(values, out _asciiState);
+            _inverseAsciiState = _asciiState.CreateInverse();
 
             _values = new string(values);
             _map = new ProbabilisticMap(_values);
@@ -48,29 +48,29 @@ namespace System.Buffers
                 // We do this by inverting the bitmap and using the opposite search function (Negate instead of DontNegate).
 
                 // If the bitmap we're using contains a 0, we have to use 'Ssse3AndWasmHandleZeroInNeedle' when running on X86 and WASM.
-                // Everything else should use 'Default'. 'TOptimizations' specifies whether '_asciiBitmap' contains a 0.
+                // Everything else should use 'Default'. 'TOptimizations' specifies whether '_asciiState' contains a 0.
                 // Since we're using the inverse bitmap in this case, we have to use 'Ssse3AndWasmHandleZeroInNeedle' iff we're
                 // running on X86/WASM and 'TOptimizations' is 'Default' (as that means that the inverse bitmap definitely has a 0).
-                Debug.Assert((_asciiBitmap[0] & 1) != (_inverseAsciiBitmap[0] & 1));
+                Debug.Assert(_asciiState.Lookup.Contains(0) != _inverseAsciiState.Lookup.Contains(0));
 
                 if ((Ssse3.IsSupported || PackedSimd.IsSupported) && typeof(TOptimizations) == typeof(IndexOfAnyAsciiSearcher.Default))
                 {
-                    Debug.Assert((_inverseAsciiBitmap[0] & 1) == 1, "The inverse bitmap did not contain a 0.");
+                    Debug.Assert(_inverseAsciiState.Lookup.Contains(0), "The inverse bitmap did not contain a 0.");
 
                     offset = IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle>(
                         ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
                         span.Length,
-                        ref _inverseAsciiBitmap);
+                        ref _inverseAsciiState);
                 }
                 else
                 {
-                    Debug.Assert(!(Ssse3.IsSupported || PackedSimd.IsSupported) || (_inverseAsciiBitmap[0] & 1) == 0,
+                    Debug.Assert(!(Ssse3.IsSupported || PackedSimd.IsSupported) || !_inverseAsciiState.Lookup.Contains(0),
                         "The inverse bitmap contained a 0, but we're not using Ssse3AndWasmHandleZeroInNeedle.");
 
                     offset = IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Default>(
                         ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
                         span.Length,
-                        ref _inverseAsciiBitmap);
+                        ref _inverseAsciiState);
                 }
 
                 // If we've reached the end of the span or stopped at an ASCII character, we've found the result.
@@ -110,7 +110,7 @@ namespace System.Buffers
                 offset = IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, TOptimizations>(
                     ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
                     span.Length,
-                    ref _asciiBitmap);
+                    ref _asciiState);
 
                 // If we've reached the end of the span or stopped at an ASCII character, we've found the result.
                 if ((uint)offset >= (uint)span.Length || char.IsAscii(span[offset]))
@@ -146,31 +146,31 @@ namespace System.Buffers
                 // We do this by inverting the bitmap and using the opposite search function (Negate instead of DontNegate).
 
                 // If the bitmap we're using contains a 0, we have to use 'Ssse3AndWasmHandleZeroInNeedle' when running on X86 and WASM.
-                // Everything else should use 'Default'. 'TOptimizations' specifies whether '_asciiBitmap' contains a 0.
+                // Everything else should use 'Default'. 'TOptimizations' specifies whether '_asciiState' contains a 0.
                 // Since we're using the inverse bitmap in this case, we have to use 'Ssse3AndWasmHandleZeroInNeedle' iff we're
                 // running on X86/WASM and 'TOptimizations' is 'Default' (as that means that the inverse bitmap definitely has a 0).
-                Debug.Assert((_asciiBitmap[0] & 1) != (_inverseAsciiBitmap[0] & 1));
+                Debug.Assert(_asciiState.Lookup.Contains(0) != _inverseAsciiState.Lookup.Contains(0));
 
                 int offset;
 
                 if ((Ssse3.IsSupported || PackedSimd.IsSupported) && typeof(TOptimizations) == typeof(IndexOfAnyAsciiSearcher.Default))
                 {
-                    Debug.Assert((_inverseAsciiBitmap[0] & 1) == 1, "The inverse bitmap did not contain a 0.");
+                    Debug.Assert(_inverseAsciiState.Lookup.Contains(0), "The inverse bitmap did not contain a 0.");
 
                     offset = IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle>(
                         ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
                         span.Length,
-                        ref _inverseAsciiBitmap);
+                        ref _inverseAsciiState);
                 }
                 else
                 {
-                    Debug.Assert(!(Ssse3.IsSupported || PackedSimd.IsSupported) || (_inverseAsciiBitmap[0] & 1) == 0,
+                    Debug.Assert(!(Ssse3.IsSupported || PackedSimd.IsSupported) ||!_inverseAsciiState.Lookup.Contains(0),
                         "The inverse bitmap contained a 0, but we're not using Ssse3AndWasmHandleZeroInNeedle.");
 
                     offset = IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Default>(
                         ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
                         span.Length,
-                        ref _inverseAsciiBitmap);
+                        ref _inverseAsciiState);
                 }
 
                 // If we've reached the end of the span or stopped at an ASCII character, we've found the result.
@@ -200,7 +200,7 @@ namespace System.Buffers
                 int offset = IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, TOptimizations>(
                     ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
                     span.Length,
-                    ref _asciiBitmap);
+                    ref _asciiState);
 
                 // If we've reached the end of the span or stopped at an ASCII character, we've found the result.
                 if ((uint)offset >= (uint)span.Length || char.IsAscii(span[offset]))

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
@@ -113,11 +113,9 @@ namespace System.Buffers
             // IndexOfAnyAsciiSearcher for chars is slower than Any3CharSearchValues, but faster than Any4SearchValues
             if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && maxInclusive < 128)
             {
-                IndexOfAnyAsciiSearcher.ComputeBitmap(values, out Vector256<byte> bitmap, out BitVector256 lookup);
-
-                return (Ssse3.IsSupported || PackedSimd.IsSupported) && lookup.Contains(0)
-                    ? new AsciiCharSearchValues<IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle>(bitmap, lookup)
-                    : new AsciiCharSearchValues<IndexOfAnyAsciiSearcher.Default>(bitmap, lookup);
+                return (Ssse3.IsSupported || PackedSimd.IsSupported) && minInclusive == 0
+                    ? new AsciiCharSearchValues<IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle>(values)
+                    : new AsciiCharSearchValues<IndexOfAnyAsciiSearcher.Default>(values);
             }
 
             // Vector128<char> isn't valid. Treat the values as shorts instead.

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasick.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasick.cs
@@ -18,21 +18,19 @@ namespace System.Buffers
     internal readonly struct AhoCorasick
     {
         private readonly AhoCorasickNode[] _nodes;
-        private readonly Vector256<byte> _startingCharsAsciiBitmap;
+        private readonly IndexOfAnyAsciiSearcher.AsciiState _startingAsciiChars;
 
-        public AhoCorasick(AhoCorasickNode[] nodes, Vector256<byte> startingAsciiBitmap)
+        public AhoCorasick(AhoCorasickNode[] nodes, IndexOfAnyAsciiSearcher.AsciiState startingAsciiChars)
         {
             _nodes = nodes;
-            _startingCharsAsciiBitmap = startingAsciiBitmap;
+            _startingAsciiChars = startingAsciiChars;
         }
 
         public readonly bool ShouldUseAsciiFastScan
         {
             get
             {
-                Vector256<byte> bitmap = _startingCharsAsciiBitmap;
-
-                if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && bitmap != default)
+                if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && _startingAsciiChars.Bitmap != default)
                 {
                     // If there are a lot of starting characters such that we often find one early,
                     // the ASCII fast scan may end up performing worse than checking one character at a time.
@@ -51,7 +49,7 @@ namespace System.Buffers
 
                     for (int i = 0; i < 128; i++)
                     {
-                        if (IndexOfAnyAsciiSearcher.BitmapContains(ref bitmap, (char)i))
+                        if (_startingAsciiChars.Lookup.Contains128((char)i))
                         {
                             frequency += CharacterFrequencyHelper.AsciiFrequency[i];
                         }
@@ -101,7 +99,7 @@ namespace System.Buffers
                     int offset = IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.DontNegate, IndexOfAnyAsciiSearcher.Default>(
                         ref Unsafe.As<char, short>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), i)),
                         remainingLength,
-                        ref Unsafe.AsRef(in _startingCharsAsciiBitmap));
+                        ref Unsafe.AsRef(in _startingAsciiChars));
 
                     if (offset < 0)
                     {
@@ -210,7 +208,7 @@ namespace System.Buffers
                     int offset = IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.DontNegate, IndexOfAnyAsciiSearcher.Default>(
                         ref Unsafe.As<char, short>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), i)),
                         remainingLength,
-                        ref Unsafe.AsRef(in _startingCharsAsciiBitmap));
+                        ref Unsafe.AsRef(in _startingAsciiChars));
 
                     if (offset < 0)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasickBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasickBuilder.cs
@@ -17,7 +17,7 @@ namespace System.Buffers
         private readonly bool _ignoreCase;
         private ValueListBuilder<AhoCorasickNode> _nodes;
         private ValueListBuilder<int> _parents;
-        private Vector256<byte> _startingCharsAsciiBitmap;
+        private IndexOfAnyAsciiSearcher.AsciiState _startingAsciiChars;
 
         public AhoCorasickBuilder(ReadOnlySpan<string> values, bool ignoreCase, ref HashSet<string>? unreachableValues)
         {
@@ -53,7 +53,7 @@ namespace System.Buffers
                 GenerateStartingAsciiCharsBitmap();
             }
 
-            return new AhoCorasick(_nodes.AsSpan().ToArray(), _startingCharsAsciiBitmap);
+            return new AhoCorasick(_nodes.AsSpan().ToArray(), _startingAsciiChars);
         }
 
         public void Dispose()
@@ -215,7 +215,7 @@ namespace System.Buffers
 
             if (Ascii.IsValid(startingChars.AsSpan()))
             {
-                IndexOfAnyAsciiSearcher.ComputeBitmap(startingChars.AsSpan(), out _startingCharsAsciiBitmap, out _);
+                IndexOfAnyAsciiSearcher.ComputeAsciiState(startingChars.AsSpan(), out _startingAsciiChars);
             }
 
             startingChars.Dispose();


### PR DESCRIPTION
This PR moves the scalar loops into the core worker methods. This reduces the amount of code on each call site and makes it easier for us to make further changes like adding Avx512 support.

The code that's inlined into `IndexOfAny` callers is now just a call to the worker method instead of `length < 8 ? call scalar : call vectorized`.

<details>
<summary>Example call site diff</summary>

```diff
 ; Assembly listing for method System.Buffers.Text.Base64+Base64CharValidatable:IndexOfAnyExcept(System.ReadOnlySpan`1[ushort]):int (FullOpts)
 ; Emitting BLENDED_CODE for X64 with AVX512 - Unix
 ; FullOpts code
 
 G_M48088_IG01:
        push     rbp
-       sub      rsp, 16
-       lea      rbp, [rsp+0x10]
-						;; size=10 bbWeight=1 PerfScore 1.75
+       mov      rbp, rsp
+						;; size=4 bbWeight=1 PerfScore 1.25
 G_M48088_IG02:
        mov      rdx, 0xD1FFAB1E      ; const ptr
-       mov      rax, gword ptr [rdx]
-       mov      rdx, rax
-       mov      bword ptr [rbp-0x10], rdi
-       mov      dword ptr [rbp-0x04], esi
-       cmp      esi, 8
-       jge      SHORT G_M48088_IG04
-						;; size=28 bbWeight=1 PerfScore 5.75
-G_M48088_IG03:
-       mov      rdi, rdx
-       mov      rsi, bword ptr [rbp-0x10]
-       mov      edx, dword ptr [rbp-0x04]
-       mov      rax, 0xD1FFAB1E      ; code for System.Buffers.AsciiCharSearchValues`1[System.Buffers.IndexOfAnyAsciiSearcher+Default]:IndexOfAnyScalar[System.Buffers.IndexOfAnyAsciiSearcher+Negate](byref,int):int:this
-       call     [rax]System.Buffers.AsciiCharSearchValues`1[System.Buffers.IndexOfAnyAsciiSearcher+Default]:IndexOfAnyScalar[System.Buffers.IndexOfAnyAsciiSearcher+Negate](byref,int):int:this
-       jmp      SHORT G_M48088_IG05
-						;; size=24 bbWeight=0.50 PerfScore 3.75
-G_M48088_IG04:
+       mov      rdx, gword ptr [rdx]
        add      rdx, 8
-       mov      rdi, bword ptr [rbp-0x10]
-       mov      esi, dword ptr [rbp-0x04]
        mov      rax, 0xD1FFAB1E      ; code for System.Buffers.IndexOfAnyAsciiSearcher:IndexOfAnyVectorized[System.Buffers.IndexOfAnyAsciiSearcher+Negate,System.Buffers.IndexOfAnyAsciiSearcher+Default](byref,int,byref):int
        call     [rax]System.Buffers.IndexOfAnyAsciiSearcher:IndexOfAnyVectorized[System.Buffers.IndexOfAnyAsciiSearcher+Negate,System.Buffers.IndexOfAnyAsciiSearcher+Default](byref,int,byref):int
-						;; size=23 bbWeight=0.50 PerfScore 2.75
-G_M48088_IG05:
        nop      
-						;; size=1 bbWeight=1 PerfScore 0.25
-G_M48088_IG06:
-       add      rsp, 16
+						;; size=30 bbWeight=1 PerfScore 6.00
+G_M48088_IG03:
        pop      rbp
        ret      
-						;; size=6 bbWeight=1 PerfScore 1.75
+						;; size=2 bbWeight=1 PerfScore 1.50
 
-; Total bytes of code 92, prolog size 10, PerfScore 25.20, instruction count 25, allocated bytes for code 92 (MethodHash=586b4427) for method System.Buffers.Text.Base64+Base64CharValidatable:IndexOfAnyExcept(System.ReadOnlySpan`1[ushort]):int (FullOpts)
+; Total bytes of code 36, prolog size 4, PerfScore 12.35, instruction count 10, allocated bytes for code 36 (MethodHash=586b4427) for method System.Buffers.Text.Base64+Base64CharValidatable:IndexOfAnyExcept(System.ReadOnlySpan`1[ushort]):int (FullOpts)
```

</details>


Overall seems to be a slight improvement for Regex

<details>
<summary>Regex benchmark results</summary>


### Perf_Regex_Industry_SliceSlice

| Toolchain |              Options |     Mean |   Error | Ratio |
|---------- |--------------------- |---------:|--------:|------:|
|      main |             Compiled | 473.1 ms | 6.91 ms |  1.00 |
|        pr |             Compiled | 455.7 ms | 1.64 ms |  0.96 |
|           |                      |          |         |       |
|      main | IgnoreCase, Compiled | 709.4 ms | 1.97 ms |  1.00 |
|        pr | IgnoreCase, Compiled | 709.2 ms | 2.12 ms |  1.00 |


### Perf_Regex_Industry_RustLang_Sherlock

| Toolchain |                              Pattern |  Options |             Mean |          Error | Ratio |
|---------- |------------------------------------- |--------- |-----------------:|---------------:|------:|
|      main |                                   .* | Compiled |    798,549.12 ns |   5,683.298 ns |  1.00 |
|        pr |                                   .* | Compiled |    823,663.43 ns |   9,133.668 ns |  1.03 |
|           |                                      |          |                  |                |       |
|      main |                           (?i)Holmes | Compiled |     85,117.48 ns |     697.361 ns |  1.00 |
|        pr |                           (?i)Holmes | Compiled |     85,117.21 ns |     713.527 ns |  1.00 |
|           |                                      |          |                  |                |       |
|      main |             (?i)Sher[a-z]+\|Hol[a-z]+ | Compiled |    703,678.45 ns |   4,730.359 ns |  1.00 |
|        pr |             (?i)Sher[a-z]+\|Hol[a-z]+ | Compiled |    701,771.58 ns |   5,629.408 ns |  1.00 |
|           |                                      |          |                  |                |       |
|      main |                         (?i)Sherlock | Compiled |     56,515.81 ns |     547.958 ns |  1.00 |
|        pr |                         (?i)Sherlock | Compiled |     56,315.56 ns |     268.100 ns |  1.00 |
|           |                                      |          |                  |                |       |
|      main |                  (?i)Sherlock Holmes | Compiled |     56,270.02 ns |     473.305 ns |  1.00 |
|        pr |                  (?i)Sherlock Holmes | Compiled |     55,911.93 ns |     406.218 ns |  0.99 |
|           |                                      |          |                  |                |       |
|      main |           (?i)Sherlock\|Holmes\|Watson | Compiled |    826,406.58 ns |   8,737.846 ns |  1.00 |
|        pr |           (?i)Sherlock\|Holmes\|Watson | Compiled |    819,068.84 ns |   9,151.341 ns |  0.99 |
|           |                                      |          |                  |                |       |
|      main | (?i)Sherlock\|(...)er\|John\|Baker [49] | Compiled |  1,736,080.19 ns |  11,954.994 ns |  1.00 |
|        pr | (?i)Sherlock\|(...)er\|John\|Baker [49] | Compiled |  1,693,613.21 ns |  12,089.156 ns |  0.98 |
|           |                                      |          |                  |                |       |
|      main |                              (?i)the | Compiled |    408,989.03 ns |   2,985.069 ns |  1.00 |
|        pr |                              (?i)the | Compiled |    416,752.52 ns |   2,813.352 ns |  1.02 |
|           |                                      |          |                  |                |       |
|      main | (?m)^Sherlock(...)rlock Holmes$ [37] | Compiled |     49,308.97 ns |     534.313 ns |  1.00 |
|        pr | (?m)^Sherlock(...)rlock Holmes$ [37] | Compiled |     49,340.07 ns |     556.603 ns |  1.00 |
|           |                                      |          |                  |                |       |
|      main |                               (?s).* | Compiled |         53.05 ns |       0.476 ns |  1.00 |
|        pr |                               (?s).* | Compiled |         52.97 ns |       0.200 ns |  1.00 |
|           |                                      |          |                  |                |       |
|      main |                              [^\\n]* | Compiled |    813,008.75 ns |   8,003.114 ns |  1.00 |
|        pr |                              [^\\n]* | Compiled |    806,846.97 ns |   5,795.755 ns |  0.99 |
|           |                                      |          |                  |                |       |
|      main |                     [a-q][^u-z]{13}x | Compiled |     35,882.13 ns |     588.960 ns |  1.00 |
|        pr |                     [a-q][^u-z]{13}x | Compiled |     36,172.07 ns |     338.241 ns |  1.01 |
|           |                                      |          |                  |                |       |
|      main |                         [a-zA-Z]+ing | Compiled |  3,534,267.01 ns |  21,696.203 ns |  1.00 |
|        pr |                         [a-zA-Z]+ing | Compiled |  3,520,875.87 ns |  29,773.484 ns |  1.00 |
|           |                                      |          |                  |                |       |
|      main |                          \\b\\w+n\\b | Compiled |  8,315,633.51 ns | 106,259.166 ns |  1.00 |
|        pr |                          \\b\\w+n\\b | Compiled |  8,075,193.70 ns | 114,927.130 ns |  0.97 |
|           |                                      |          |                  |                |       |
|      main |                               \\p{L} | Compiled | 10,449,981.19 ns | 114,976.724 ns |  1.00 |
|        pr |                               \\p{L} | Compiled | 10,313,895.58 ns |  81,089.130 ns |  0.99 |
|           |                                      |          |                  |                |       |
|      main |                              \\p{Ll} | Compiled | 10,180,677.31 ns | 190,903.367 ns |  1.00 |
|        pr |                              \\p{Ll} | Compiled | 10,283,964.06 ns | 226,219.747 ns |  1.01 |
|           |                                      |          |                  |                |       |
|      main |                              \\p{Lu} | Compiled |    491,024.59 ns |  16,920.356 ns |  1.00 |
|        pr |                              \\p{Lu} | Compiled |    479,731.83 ns |   3,335.590 ns |  0.98 |
|           |                                      |          |                  |                |       |
|      main |              \\s[a-zA-Z]{0,12}ing\\s | Compiled |  3,868,198.99 ns |   7,235.956 ns |  1.00 |
|        pr |              \\s[a-zA-Z]{0,12}ing\\s | Compiled |  3,893,177.63 ns |  20,065.318 ns |  1.01 |
|           |                                      |          |                  |                |       |
|      main |                                 \\w+ | Compiled |  5,106,160.01 ns | 179,273.894 ns |  1.00 |
|        pr |                                 \\w+ | Compiled |  4,981,989.76 ns |  52,194.406 ns |  0.98 |
|           |                                      |          |                  |                |       |
|      main |                       \\w+\\s+Holmes | Compiled |  3,027,514.95 ns |   7,991.676 ns |  1.00 |
|        pr |                       \\w+\\s+Holmes | Compiled |  3,067,955.66 ns |  24,257.065 ns |  1.01 |
|           |                                      |          |                  |                |       |
|      main |               \\w+\\s+Holmes\\s+\\w+ | Compiled |  3,063,962.72 ns |  55,800.505 ns |  1.00 |
|        pr |               \\w+\\s+Holmes\\s+\\w+ | Compiled |  3,023,497.71 ns |   7,488.420 ns |  0.99 |
|           |                                      |          |                  |                |       |
|      main |                                  aei | Compiled |     53,782.69 ns |     245.684 ns |  1.00 |
|        pr |                                  aei | Compiled |     53,429.59 ns |     235.059 ns |  0.99 |
|           |                                      |          |                  |                |       |
|      main |                                  aqj | Compiled |     41,417.83 ns |     480.492 ns |  1.00 |
|        pr |                                  aqj | Compiled |     41,417.82 ns |     366.348 ns |  1.00 |
|           |                                      |          |                  |                |       |
|      main |                               Holmes | Compiled |     62,375.99 ns |     398.244 ns |  1.00 |
|        pr |                               Holmes | Compiled |     60,441.77 ns |   1,310.037 ns |  0.97 |
|           |                                      |          |                  |                |       |
|      main | Holmes.{0,25}(...).{0,25}Holmes [39] | Compiled |     65,651.09 ns |     447.743 ns |  1.00 |
|        pr | Holmes.{0,25}(...).{0,25}Holmes [39] | Compiled |     66,178.52 ns |     251.919 ns |  1.01 |
|           |                                      |          |                  |                |       |
|      main |                 Sher[a-z]+\|Hol[a-z]+ | Compiled |     69,989.95 ns |     314.014 ns |  1.00 |
|        pr |                 Sher[a-z]+\|Hol[a-z]+ | Compiled |     70,662.48 ns |     748.390 ns |  1.01 |
|           |                                      |          |                  |                |       |
|      main |                             Sherlock | Compiled |     47,965.71 ns |   1,501.142 ns |  1.00 |
|        pr |                             Sherlock | Compiled |     46,314.21 ns |     497.869 ns |  0.97 |
|           |                                      |          |                  |                |       |
|      main |                      Sherlock Holmes | Compiled |     47,004.90 ns |     492.846 ns |  1.00 |
|        pr |                      Sherlock Holmes | Compiled |     47,470.82 ns |     828.347 ns |  1.01 |
|           |                                      |          |                  |                |       |
|      main |                   Sherlock\\s+Holmes | Compiled |     49,807.98 ns |     669.379 ns |  1.00 |
|        pr |                   Sherlock\\s+Holmes | Compiled |     48,251.21 ns |   1,189.570 ns |  0.97 |
|           |                                      |          |                  |                |       |
|      main |                      Sherlock\|Holmes | Compiled |     68,393.54 ns |   1,048.419 ns |  1.00 |
|        pr |                      Sherlock\|Holmes | Compiled |     68,868.75 ns |   1,157.104 ns |  1.01 |
|           |                                      |          |                  |                |       |
|      main |               Sherlock\|Holmes\|Watson | Compiled |     92,706.84 ns |   1,291.153 ns |  1.00 |
|        pr |               Sherlock\|Holmes\|Watson | Compiled |     89,613.81 ns |     316.457 ns |  0.97 |
|           |                                      |          |                  |                |       |
|      main | Sherlock\|Holm(...)er\|John\|Baker [45] | Compiled |    190,483.91 ns |   2,410.551 ns |  1.00 |
|        pr | Sherlock\|Holm(...)er\|John\|Baker [45] | Compiled |    186,409.86 ns |     938.477 ns |  0.98 |
|           |                                      |          |                  |                |       |
|      main |                      Sherlock\|Street | Compiled |     38,216.45 ns |     186.622 ns |  1.00 |
|        pr |                      Sherlock\|Street | Compiled |     38,127.93 ns |     192.193 ns |  1.00 |
|           |                                      |          |                  |                |       |
|      main |                                  the | Compiled |    328,277.13 ns |   1,606.118 ns |  1.00 |
|        pr |                                  the | Compiled |    324,914.77 ns |     953.162 ns |  0.99 |
|           |                                      |          |                  |                |       |
|      main |                                  The | Compiled |     70,545.06 ns |     329.177 ns |  1.00 |
|        pr |                                  The | Compiled |     71,840.54 ns |   1,164.975 ns |  1.02 |
|           |                                      |          |                  |                |       |
|      main |                          the\\s+\\w+ | Compiled |    444,779.24 ns |   4,650.472 ns |  1.00 |
|        pr |                          the\\s+\\w+ | Compiled |    443,691.85 ns |   4,464.689 ns |  1.00 |
|           |                                      |          |                  |                |       |
|      main |                                  zqj | Compiled |     46,169.68 ns |     547.976 ns |  1.00 |
|        pr |                                  zqj | Compiled |     45,307.75 ns |     450.939 ns |  0.98 |


### Perf_Regex_Industry_BoostDocs_Simple

| Toolchain | Id |  Options |     Mean |    Error | Ratio |
|---------- |--- |--------- |---------:|---------:|------:|
|      main |  0 | Compiled | 33.32 ns | 0.133 ns |  1.00 |
|        pr |  0 | Compiled | 33.41 ns | 0.168 ns |  1.00 |
|           |    |          |          |          |       |
|      main |  1 | Compiled | 56.37 ns | 0.475 ns |  1.00 |
|        pr |  1 | Compiled | 55.19 ns | 0.208 ns |  0.98 |
|           |    |          |          |          |       |
|      main |  2 | Compiled | 63.36 ns | 0.222 ns |  1.00 |
|        pr |  2 | Compiled | 65.02 ns | 1.170 ns |  1.02 |
|           |    |          |          |          |       |
|      main |  3 | Compiled | 92.81 ns | 0.900 ns |  1.00 |
|        pr |  3 | Compiled | 94.12 ns | 0.797 ns |  1.01 |
|           |    |          |          |          |       |
|      main |  4 | Compiled | 82.25 ns | 0.578 ns |  1.00 |
|        pr |  4 | Compiled | 84.74 ns | 0.503 ns |  1.03 |
|           |    |          |          |          |       |
|      main |  5 | Compiled | 84.34 ns | 1.879 ns |  1.00 |
|        pr |  5 | Compiled | 83.15 ns | 1.085 ns |  0.99 |
|           |    |          |          |          |       |
|      main |  6 | Compiled | 37.36 ns | 0.138 ns |  1.00 |
|        pr |  6 | Compiled | 37.42 ns | 0.397 ns |  1.00 |
|           |    |          |          |          |       |
|      main |  7 | Compiled | 37.20 ns | 0.173 ns |  1.00 |
|        pr |  7 | Compiled | 36.77 ns | 0.125 ns |  0.99 |
|           |    |          |          |          |       |
|      main |  8 | Compiled | 37.29 ns | 0.141 ns |  1.00 |
|        pr |  8 | Compiled | 36.89 ns | 0.109 ns |  0.99 |
|           |    |          |          |          |       |
|      main |  9 | Compiled | 35.88 ns | 0.300 ns |  1.00 |
|        pr |  9 | Compiled | 35.32 ns | 0.102 ns |  0.98 |
|           |    |          |          |          |       |
|      main | 10 | Compiled | 37.01 ns | 0.389 ns |  1.00 |
|        pr | 10 | Compiled | 36.72 ns | 0.299 ns |  0.99 |
|           |    |          |          |          |       |
|      main | 11 | Compiled | 36.26 ns | 0.321 ns |  1.00 |
|        pr | 11 | Compiled | 36.70 ns | 0.426 ns |  1.01 |
|           |    |          |          |          |       |
|      main | 12 | Compiled | 41.44 ns | 0.502 ns |  1.00 |
|        pr | 12 | Compiled | 40.61 ns | 0.408 ns |  0.98 |
|           |    |          |          |          |       |
|      main | 13 | Compiled | 41.33 ns | 0.438 ns |  1.00 |
|        pr | 13 | Compiled | 40.55 ns | 0.528 ns |  0.98 |


### Perf_Regex_Industry_Mariomkas

| Method | Toolchain |                                 Pattern |  Options |        Mean |     Error | Ratio |
|------- |---------- |---------------------------------------- |--------- |------------:|----------:|------:|
|   Ctor |      main |    (?:(?:25[0-5](...)]?[0-9][0-9]) [87] | Compiled |    23.50 μs |  0.554 μs |  1.00 |
|   Ctor |        pr |    (?:(?:25[0-5](...)]?[0-9][0-9]) [87] | Compiled |    22.99 μs |  0.209 μs |  0.98 |
|        |           |                                         |          |             |           |       |
|  Count |      main |    (?:(?:25[0-5](...)]?[0-9][0-9]) [87] | Compiled | 3,335.45 μs | 34.881 μs |  1.00 |
|  Count |        pr |    (?:(?:25[0-5](...)]?[0-9][0-9]) [87] | Compiled | 3,328.27 μs | 27.286 μs |  1.00 |
|        |           |                                         |          |             |           |       |
|   Ctor |      main | [\\w]+://[^/\\s(...)?(?:#[^\\s]*)? [51] | Compiled |    20.95 μs |  0.316 μs |  1.00 |
|   Ctor |        pr | [\\w]+://[^/\\s(...)?(?:#[^\\s]*)? [51] | Compiled |    20.55 μs |  0.184 μs |  0.98 |
|        |           |                                         |          |             |           |       |
|  Count |      main | [\\w]+://[^/\\s(...)?(?:#[^\\s]*)? [51] | Compiled | 1,264.20 μs | 15.433 μs |  1.00 |
|  Count |        pr | [\\w]+://[^/\\s(...)?(?:#[^\\s]*)? [51] | Compiled | 1,273.16 μs | 13.892 μs |  1.01 |
|        |           |                                         |          |             |           |       |
|   Ctor |      main |     [\\w\\.+-]+@[\\w\\.-]+\\.[\\w\\.-]+ | Compiled |    16.57 μs |  0.235 μs |  1.00 |
|   Ctor |        pr |     [\\w\\.+-]+@[\\w\\.-]+\\.[\\w\\.-]+ | Compiled |    16.25 μs |  0.281 μs |  0.98 |
|        |           |                                         |          |             |           |       |
|  Count |      main |     [\\w\\.+-]+@[\\w\\.-]+\\.[\\w\\.-]+ | Compiled |   510.35 μs |  8.704 μs |  1.00 |
|  Count |        pr |     [\\w\\.+-]+@[\\w\\.-]+\\.[\\w\\.-]+ | Compiled |   512.56 μs |  7.421 μs |  1.00 |


### Perf_Regex_Industry_Leipzig

| Toolchain |                             Pattern |  Options |       Mean |      Error | Ratio |
|---------- |------------------------------------ |--------- |-----------:|-----------:|------:|
|      main | .{0,2}(Tom\|Sawyer\|Huckleberry\|Finn) | Compiled | 257.041 ms |  5.7381 ms |  1.00 |
|        pr | .{0,2}(Tom\|Sawyer\|Huckleberry\|Finn) | Compiled | 246.693 ms |  1.9807 ms |  0.96 |
|           |                                     |          |            |            |       |
|      main | .{2,4}(Tom\|Sawyer\|Huckleberry\|Finn) | Compiled | 302.817 ms |  2.4238 ms |  1.00 |
|        pr | .{2,4}(Tom\|Sawyer\|Huckleberry\|Finn) | Compiled | 328.873 ms | 36.9452 ms |  1.09 |
|           |                                     |          |            |            |       |
|      main |     (?i)Tom\|Sawyer\|Huckleberry\|Finn | Compiled |  23.502 ms |  0.2097 ms |  1.00 |
|        pr |     (?i)Tom\|Sawyer\|Huckleberry\|Finn | Compiled |  22.848 ms |  0.2486 ms |  0.97 |
|           |                                     |          |            |            |       |
|      main |                           (?i)Twain | Compiled |   3.744 ms |  0.0451 ms |  1.00 |
|        pr |                           (?i)Twain | Compiled |   3.674 ms |  0.0263 ms |  0.98 |
|           |                                     |          |            |            |       |
|      main |      ([A-Za-z]awyer\|[A-Za-z]inn)\\s | Compiled |  11.619 ms |  0.1049 ms |  1.00 |
|        pr |      ([A-Za-z]awyer\|[A-Za-z]inn)\\s | Compiled |  11.584 ms |  0.1061 ms |  1.00 |
|           |                                     |          |            |            |       |
|      main |                          [a-z]shing | Compiled |   2.657 ms |  0.0258 ms |  1.00 |
|        pr |                          [a-z]shing | Compiled |   2.667 ms |  0.0129 ms |  1.00 |
|           |                                     |          |            |            |       |
|      main |                             \\p{Sm} | Compiled |   2.477 ms |  0.0326 ms |  1.00 |
|        pr |                             \\p{Sm} | Compiled |   2.470 ms |  0.0341 ms |  1.00 |
|           |                                     |          |            |            |       |
|      main |          Huck[a-zA-Z]+\|Saw[a-zA-Z]+ | Compiled |   2.586 ms |  0.0433 ms |  1.00 |
|        pr |          Huck[a-zA-Z]+\|Saw[a-zA-Z]+ | Compiled |   2.730 ms |  0.0408 ms |  1.06 |
|           |                                     |          |            |            |       |
|      main |   Tom.{10,25}river\|river.{10,25}Tom | Compiled |   7.973 ms |  0.0958 ms |  1.00 |
|        pr |   Tom.{10,25}river\|river.{10,25}Tom | Compiled |   7.964 ms |  0.1412 ms |  1.00 |
|           |                                     |          |            |            |       |
|      main |         Tom\|Sawyer\|Huckleberry\|Finn | Compiled |   4.381 ms |  0.0452 ms |  1.00 |
|        pr |         Tom\|Sawyer\|Huckleberry\|Finn | Compiled |   4.468 ms |  0.0550 ms |  1.02 |
|           |                                     |          |            |            |       |
|      main |                               Twain | Compiled |   2.666 ms |  0.0548 ms |  1.00 |
|        pr |                               Twain | Compiled |   2.645 ms |  0.0357 ms |  0.99 |


</details>