### PR TITLE
Optimize unboxing in `System.Data.Common.ObjectStorage:Set`

### DIFF
--- a/src/libraries/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
@@ -233,7 +233,7 @@ namespace System.Data.Common
                 return;
             }
 
-            if (_dataType == typeof(object) || value.GetType() == typeof(object))
+            if (_dataType == typeof(object) || _dataType.IsInstanceOfType(value))
             {
                 _values[recordNo] = value;
                 return;

--- a/src/libraries/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
@@ -236,50 +236,49 @@ namespace System.Data.Common
             }
             else
             {
-                Type valType = value.GetType();
-                if (_dataType == typeof(Guid) && valType == typeof(string))
+                if (_dataType == typeof(Guid) && value is string)
                 {
                     _values[recordNo] = new Guid((string)value);
                 }
                 else if (_dataType == typeof(byte[]))
                 {
-                    if (valType == typeof(bool))
+                    if (value is bool)
                     {
                         _values[recordNo] = BitConverter.GetBytes((bool)value);
                     }
-                    else if (valType == typeof(char))
+                    else if (value is char)
                     {
                         _values[recordNo] = BitConverter.GetBytes((char)value);
                     }
-                    else if (valType == typeof(short))
+                    else if (value is short)
                     {
                         _values[recordNo] = BitConverter.GetBytes((short)value);
                     }
-                    else if (valType == typeof(int))
+                    else if (value is int)
                     {
                         _values[recordNo] = BitConverter.GetBytes((int)value);
                     }
-                    else if (valType == typeof(long))
+                    else if (value is long)
                     {
                         _values[recordNo] = BitConverter.GetBytes((long)value);
                     }
-                    else if (valType == typeof(ushort))
+                    else if (value is ushort)
                     {
                         _values[recordNo] = BitConverter.GetBytes((ushort)value);
                     }
-                    else if (valType == typeof(uint))
+                    else if (value is uint)
                     {
                         _values[recordNo] = BitConverter.GetBytes((uint)value);
                     }
-                    else if (valType == typeof(ulong))
+                    else if (value is ulong)
                     {
                         _values[recordNo] = BitConverter.GetBytes((ulong)value);
                     }
-                    else if (valType == typeof(float))
+                    else if (value is float)
                     {
                         _values[recordNo] = BitConverter.GetBytes((float)value);
                     }
-                    else if (valType == typeof(double))
+                    else if (value is double)
                     {
                         _values[recordNo] = BitConverter.GetBytes((double)value);
                     }

--- a/src/libraries/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
@@ -226,72 +226,89 @@ namespace System.Data.Common
         public override void Set(int recordNo, object value)
         {
             Debug.Assert(null != value, "null value");
+
             if (_nullValue == value)
             {
                 _values[recordNo] = null;
+                return;
             }
-            else if (_dataType == typeof(object) || _dataType.IsInstanceOfType(value))
+
+            if (_dataType == typeof(object) || value.GetType() == typeof(object))
             {
                 _values[recordNo] = value;
+                return;
             }
-            else
+
+            if (_dataType == typeof(Guid) && value.GetType() == typeof(string))
             {
-                if (_dataType == typeof(Guid) && value is string)
+                _values[recordNo] = new Guid((string)value);
+                return;
+            }
+
+            if (_dataType == typeof(byte[]))
+            {
+                if (value.GetType() == typeof(bool))
                 {
-                    _values[recordNo] = new Guid((string)value);
+                    _values[recordNo] = BitConverter.GetBytes((bool)value);
+                    return;
                 }
-                else if (_dataType == typeof(byte[]))
+
+                if (value.GetType() == typeof(char))
                 {
-                    if (value is bool)
-                    {
-                        _values[recordNo] = BitConverter.GetBytes((bool)value);
-                    }
-                    else if (value is char)
-                    {
-                        _values[recordNo] = BitConverter.GetBytes((char)value);
-                    }
-                    else if (value is short)
-                    {
-                        _values[recordNo] = BitConverter.GetBytes((short)value);
-                    }
-                    else if (value is int)
-                    {
-                        _values[recordNo] = BitConverter.GetBytes((int)value);
-                    }
-                    else if (value is long)
-                    {
-                        _values[recordNo] = BitConverter.GetBytes((long)value);
-                    }
-                    else if (value is ushort)
-                    {
-                        _values[recordNo] = BitConverter.GetBytes((ushort)value);
-                    }
-                    else if (value is uint)
-                    {
-                        _values[recordNo] = BitConverter.GetBytes((uint)value);
-                    }
-                    else if (value is ulong)
-                    {
-                        _values[recordNo] = BitConverter.GetBytes((ulong)value);
-                    }
-                    else if (value is float)
-                    {
-                        _values[recordNo] = BitConverter.GetBytes((float)value);
-                    }
-                    else if (value is double)
-                    {
-                        _values[recordNo] = BitConverter.GetBytes((double)value);
-                    }
-                    else
-                    {
-                        throw ExceptionBuilder.StorageSetFailed();
-                    }
+                    _values[recordNo] = BitConverter.GetBytes((char)value);
+                    return;
                 }
-                else
+
+                if (value.GetType() == typeof(short))
                 {
-                    throw ExceptionBuilder.StorageSetFailed();
+                    _values[recordNo] = BitConverter.GetBytes((short)value);
+                    return;
+                }
+
+                if (value.GetType() == typeof(int))
+                {
+                    _values[recordNo] = BitConverter.GetBytes((int)value);
+                    return;
+                }
+
+                if (value.GetType() == typeof(long))
+                {
+                    _values[recordNo] = BitConverter.GetBytes((long)value);
+                    return;
+                }
+
+                if (value.GetType() == typeof(ushort))
+                {
+                    _values[recordNo] = BitConverter.GetBytes((ushort)value);
+                    return;
+                }
+
+                if (value.GetType() == typeof(uint))
+                {
+                    _values[recordNo] = BitConverter.GetBytes((uint)value);
+                    return;
+                }
+
+                if (value.GetType() == typeof(ulong))
+                {
+                    _values[recordNo] = BitConverter.GetBytes((ulong)value);
+                    return;
+                }
+
+                if (value.GetType() == typeof(float))
+                {
+                    _values[recordNo] = BitConverter.GetBytes((float)value);
+                    return;
+                }
+
+                if (value.GetType() == typeof(double))
+                {
+                    _values[recordNo] = BitConverter.GetBytes((double)value);
+                    return;
                 }
             }
+
+            throw ExceptionBuilder.StorageSetFailed();
         }
 
         public override void SetCapacity(int capacity)


### PR DESCRIPTION
Inline `value.GetType()` instead of using a local, to enable a JIT optimization.

Diffs: https://www.diffchecker.com/QgpKJ9UD/

```
Top method improvements (bytes):
        -456 (-32.50 % of base) : System.Data.Common.dasm - System.Data.Common.ObjectStorage:Set(int,System.Object):this (FullOpts)
```