### PR TITLE
Minimize net diff of binder-gen visibility/identifier-clash fix

### DIFF
--- a/src/libraries/Common/src/SourceGenerators/TypeModelHelper.cs
+++ b/src/libraries/Common/src/SourceGenerators/TypeModelHelper.cs
@@ -1,78 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text;
 using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace SourceGenerators
 {
     internal static class TypeModelHelper
     {
-        private static readonly SymbolDisplayFormat s_minimalDisplayFormat = new SymbolDisplayFormat(
-            globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
-            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
-            genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
-            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
-
-        public static string ToIdentifierCompatibleSubstring(this ITypeSymbol type, bool useUniqueName)
-        {
-            if (type is IArrayTypeSymbol arrayType)
-            {
-                int rank = arrayType.Rank;
-                string suffix = rank == 1 ? "Array" : $"Array{rank}D"; // Array, Array2D, Array3D, ...
-                return ToIdentifierCompatibleSubstring(arrayType.ElementType, useUniqueName) + suffix;
-            }
-
-            StringBuilder? sb = null;
-            string? symbolName = null;
-
-            if (useUniqueName)
-            {
-                string uniqueDisplayString = type.ToMinimalDisplayString();
-                PopulateIdentifierCompatibleSubstring(sb = new(), uniqueDisplayString);
-            }
-            else
-            {
-                symbolName = type.Name;
-            }
-
-#if DEBUG
-            bool usingUniqueName = (symbolName is null || sb is not null) && useUniqueName;
-            bool usingSymbolName = (symbolName is not null && sb is null) && !useUniqueName;
-            bool configuredNameCorrectly = (usingUniqueName && !usingSymbolName) || (!usingUniqueName && usingSymbolName);
-            Debug.Assert(configuredNameCorrectly);
-#endif
-
-            if (type is not INamedTypeSymbol namedType || !namedType.IsGenericType)
-            {
-                return symbolName ?? sb!.ToString();
-            }
-
-            if (sb is null)
-            {
-                (sb = new()).Append(symbolName!);
-            }
-
-            Debug.Assert(sb.Length > 0);
-
-            if (namedType.GetAllTypeArgumentsInScope() is List<ITypeSymbol> typeArgsInScope)
-            {
-                foreach (ITypeSymbol genericArg in typeArgsInScope)
-                {
-                    sb.Append(ToIdentifierCompatibleSubstring(genericArg, useUniqueName));
-                }
-            }
-
-            return sb.ToString();
-        }
-
-        /// <summary>
-        /// Type name, prefixed with containing type names if it is nested (e.g. ContainingType.NestedType).
-        /// </summary>
-        public static string ToMinimalDisplayString(this ITypeSymbol type) => type.ToDisplayString(s_minimalDisplayFormat);
-
         public static List<ITypeSymbol>? GetAllTypeArgumentsInScope(this INamedTypeSymbol type)
         {
             if (!type.IsGenericType)
@@ -94,25 +29,6 @@ namespace SourceGenerators
                 if (!current.TypeArguments.IsEmpty)
                 {
                     (args ??= new()).AddRange(current.TypeArguments);
-                }
-            }
-        }
-
-        private static void PopulateIdentifierCompatibleSubstring(StringBuilder sb, string input)
-        {
-            foreach (char c in input)
-            {
-                if (c is '[')
-                {
-                    sb.Append("Array");
-                }
-                else if (c is ',')
-                {
-                    sb.Append("Comma");
-                }
-                else if (char.IsLetterOrDigit(c))
-                {
-                    sb.Append(c);
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
@@ -930,25 +930,4 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             }
         }
     }
-
-    internal static class ParserExtensions
-    {
-        public static void RegisterCacheEntry<TKey, TValue, TEntry>(this Dictionary<TKey, TValue> cache, TKey key, TEntry entry)
-            where TKey : notnull
-            where TValue : ICollection<TEntry>, new()
-        {
-            if (!cache.TryGetValue(key, out TValue? entryCollection))
-            {
-                cache[key] = entryCollection = new TValue();
-            }
-
-            entryCollection.Add(entry);
-        }
-
-        public static void Deconstruct(this KeyValuePair<TypeSpec, List<InterceptorLocationInfo>> source, out ComplexTypeSpec Key, out List<InterceptorLocationInfo> Value)
-        {
-            Key = (ComplexTypeSpec)source.Key;
-            Value = source.Value;
-        }
-    }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
@@ -67,11 +67,11 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 return _sourceGenSpec;
             }
 
-            private static bool IsValidRootConfigType(ITypeSymbol? type)
+            private bool IsValidRootConfigType(ITypeSymbol? type)
             {
                 if (type is null ||
                     type.SpecialType is SpecialType.System_Object or SpecialType.System_Void ||
-                    !IsAccessibleFromGenBinders(type) ||
+                    !_typeSymbols.Compilation.IsSymbolAccessibleWithin(type, _typeSymbols.Compilation.Assembly) ||
                     type.TypeKind is TypeKind.TypeParameter or TypeKind.Pointer or TypeKind.Error ||
                     type.IsRefLikeType ||
                     ContainsGenericParameters(type))
@@ -80,27 +80,6 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 }
 
                 return true;
-
-                static bool IsAccessibleFromGenBinders(ITypeSymbol type)
-                {
-                    if (type is IArrayTypeSymbol array)
-                    {
-                        return IsAccessibleFromGenBinders(array.ElementType);
-                    }
-
-                    if (type is INamedTypeSymbol namedType && namedType.GetAllTypeArgumentsInScope() is List<ITypeSymbol> typeArgsInScope)
-                    {
-                        foreach (ITypeSymbol genericArg in typeArgsInScope)
-                        {
-                            if (!IsAccessibleFromGenBinders(genericArg))
-                            {
-                                return false;
-                            }
-                        }
-                    }
-
-                    return type.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal or Accessibility.Friend;
-                }
             }
 
             private TypeSpec? GetTargetTypeForRootInvocation(ITypeSymbol? type, Location? invocationLocation)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj
@@ -37,6 +37,7 @@
     <Compile Include="Parser\BinderInvocation.cs" />
     <Compile Include="Parser\ConfigurationBinder.cs" />
     <Compile Include="Parser\Diagnostics.cs" />
+    <Compile Include="Parser\Extensions.cs" />
     <Compile Include="Parser\OptionsBuilderConfigurationExtensions.cs" />
     <Compile Include="Parser\OptionsConfigurationServiceCollectionExtensions.cs" />
     <Compile Include="Specs\InterceptorLocationInfo.cs" />

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Parser/Extensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Parser/Extensions.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using SourceGenerators;
+
+namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
+{
+    internal static class ParserExtensions
+    {
+        private static readonly SymbolDisplayFormat s_minimalDisplayFormat = new SymbolDisplayFormat(
+            globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
+            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
+            genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+        public static void RegisterCacheEntry<TKey, TValue, TEntry>(this Dictionary<TKey, TValue> cache, TKey key, TEntry entry)
+            where TKey : notnull
+            where TValue : ICollection<TEntry>, new()
+        {
+            if (!cache.TryGetValue(key, out TValue? entryCollection))
+            {
+                cache[key] = entryCollection = new TValue();
+            }
+
+            entryCollection.Add(entry);
+        }
+
+        public static void Deconstruct(this KeyValuePair<TypeSpec, List<InterceptorLocationInfo>> source, out ComplexTypeSpec Key, out List<InterceptorLocationInfo> Value)
+        {
+            Key = (ComplexTypeSpec)source.Key;
+            Value = source.Value;
+        }
+
+        public static string ToMinimalDisplayString(this ITypeSymbol type) => type.ToDisplayString(s_minimalDisplayFormat);
+
+        public static string ToIdentifierCompatibleSubstring(this ITypeSymbol type, string? displayString = null)
+        {
+            if (type is IArrayTypeSymbol arrayType)
+            {
+                int rank = arrayType.Rank;
+                string suffix = rank == 1 ? "Array" : $"Array{rank}D"; // Array, Array2D, Array3D, ...
+                return ToIdentifierCompatibleSubstring(arrayType.ElementType) + suffix;
+            }
+
+            displayString ??= type.ToMinimalDisplayString();
+            StringBuilder? sb = null;
+
+            foreach (char c in displayString)
+            {
+                if (c is '[')
+                {
+                    GetSb().Append("Array");
+                }
+                else if (c is ',')
+                {
+                    GetSb().Append("Comma");
+                }
+                else if (char.IsLetterOrDigit(c))
+                {
+                    GetSb().Append(c);
+                }
+
+                StringBuilder GetSb() => sb ??= new();
+            }
+
+            displayString = sb?.ToString() ?? displayString;
+
+            if (type is not INamedTypeSymbol namedType || !namedType.IsGenericType)
+            {
+                return displayString;
+            }
+
+            if (sb is null)
+            {
+                (sb = new()).Append(displayString);
+            }
+
+            Debug.Assert(sb.Length > 0);
+
+            if (namedType.GetAllTypeArgumentsInScope() is List<ITypeSymbol> typeArgsInScope)
+            {
+                foreach (ITypeSymbol genericArg in typeArgsInScope)
+                {
+                    sb.Append(ToIdentifierCompatibleSubstring(genericArg));
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Parser/Extensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Parser/Extensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using SourceGenerators;
@@ -11,10 +10,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 {
     internal static class ParserExtensions
     {
-        private static readonly SymbolDisplayFormat s_minimalDisplayFormat = new SymbolDisplayFormat(
+        private static readonly SymbolDisplayFormat s_identifierCompatibleFormat = new SymbolDisplayFormat(
             globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
-            genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+            genericsOptions: SymbolDisplayGenericsOptions.None,
             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
         public static void RegisterCacheEntry<TKey, TValue, TEntry>(this Dictionary<TKey, TValue> cache, TKey key, TEntry entry)
@@ -35,9 +34,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             Value = source.Value;
         }
 
-        public static string ToMinimalDisplayString(this ITypeSymbol type) => type.ToDisplayString(s_minimalDisplayFormat);
-
-        public static string ToIdentifierCompatibleSubstring(this ITypeSymbol type, string? displayString = null)
+        public static string ToIdentifierCompatibleSubstring(this ITypeSymbol type)
         {
             if (type is IArrayTypeSymbol arrayType)
             {
@@ -46,40 +43,16 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 return ToIdentifierCompatibleSubstring(arrayType.ElementType) + suffix;
             }
 
-            displayString ??= type.ToMinimalDisplayString();
-            StringBuilder? sb = null;
+            string displayString = type.ContainingType is null
+                ? type.Name
+                : type.ToDisplayString(s_identifierCompatibleFormat).Replace(".", string.Empty);
 
-            foreach (char c in displayString)
-            {
-                if (c is '[')
-                {
-                    GetSb().Append("Array");
-                }
-                else if (c is ',')
-                {
-                    GetSb().Append("Comma");
-                }
-                else if (char.IsLetterOrDigit(c))
-                {
-                    GetSb().Append(c);
-                }
-
-                StringBuilder GetSb() => sb ??= new();
-            }
-
-            displayString = sb?.ToString() ?? displayString;
-
-            if (type is not INamedTypeSymbol namedType || !namedType.IsGenericType)
+            if (type is not INamedTypeSymbol { IsGenericType: true } namedType)
             {
                 return displayString;
             }
 
-            if (sb is null)
-            {
-                (sb = new()).Append(displayString);
-            }
-
-            Debug.Assert(sb.Length > 0);
+            StringBuilder sb = new(displayString);
 
             if (namedType.GetAllTypeArgumentsInScope() is List<ITypeSymbol> typeArgsInScope)
             {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/KnownTypeSymbols.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/KnownTypeSymbols.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 {
     internal sealed record KnownTypeSymbols
     {
+        public CSharpCompilation Compilation { get; }
+
         public INamedTypeSymbol String { get; }
         public INamedTypeSymbol? CultureInfo { get; }
         public INamedTypeSymbol? DateOnly { get; }
@@ -57,6 +59,8 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
         public KnownTypeSymbols(CSharpCompilation compilation)
         {
+            Compilation = compilation;
+
             // Primitives (needed because they are Microsoft.CodeAnalysis.SpecialType.None)
             CultureInfo = compilation.GetBestTypeByMetadataName(typeof(CultureInfo));
             DateOnly = compilation.GetBestTypeByMetadataName("System.DateOnly");

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Types/TypeSpec.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Types/TypeSpec.cs
@@ -9,12 +9,18 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
     [DebuggerDisplay("Name={DisplayString}, Kind={SpecKind}")]
     internal abstract record TypeSpec
     {
+        private static readonly SymbolDisplayFormat s_minimalDisplayFormat = new SymbolDisplayFormat(
+            globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
+            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
+            genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
         public TypeSpec(ITypeSymbol type)
         {
             Namespace = type.ContainingNamespace?.ToDisplayString();
-            DisplayString = type.ToMinimalDisplayString();
+            DisplayString = type.ToDisplayString(s_minimalDisplayFormat);
             Name = (Namespace is null ? string.Empty : Namespace + ".") + DisplayString.Replace(".", "+");
-            IdentifierCompatibleSubstring = type.ToIdentifierCompatibleSubstring(DisplayString);
+            IdentifierCompatibleSubstring = type.ToIdentifierCompatibleSubstring();
             IsValueType = type.IsValueType;
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Types/TypeSpec.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/Types/TypeSpec.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
-using SourceGenerators;
 
 namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 {
@@ -15,7 +14,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             Namespace = type.ContainingNamespace?.ToDisplayString();
             DisplayString = type.ToMinimalDisplayString();
             Name = (Namespace is null ? string.Empty : Namespace + ".") + DisplayString.Replace(".", "+");
-            IdentifierCompatibleSubstring = type.ToIdentifierCompatibleSubstring(useUniqueName: true);
+            IdentifierCompatibleSubstring = type.ToIdentifierCompatibleSubstring(DisplayString);
             IsValueType = type.IsValueType;
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/EmptyConfigType.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/EmptyConfigType.generated.txt
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
         /// <summary>Attempts to bind the given object instance to configuration values by matching property names against configuration keys recursively.</summary>
         [InterceptsLocation(@"src-0.cs", 15, 23)]
-        public static void Bind_TypeWithNoMembersWrapper(this IConfiguration configuration, object? instance)
+        public static void Bind_TypeWithNoMembers_Wrapper(this IConfiguration configuration, object? instance)
         {
             if (configuration is null)
             {
@@ -56,11 +56,11 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         #endregion IConfiguration extensions.
 
         #region Core binding extensions.
-        private readonly static Lazy<HashSet<string>> s_configKeys_TypeWithNoMembersWrapper = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Member" });
+        private readonly static Lazy<HashSet<string>> s_configKeys_TypeWithNoMembers_Wrapper = new(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Member" });
 
         public static void BindCore(IConfiguration configuration, ref TypeWithNoMembers_Wrapper instance, BinderOptions? binderOptions)
         {
-            ValidateConfigurationKeys(typeof(TypeWithNoMembers_Wrapper), s_configKeys_TypeWithNoMembersWrapper, configuration, binderOptions);
+            ValidateConfigurationKeys(typeof(TypeWithNoMembers_Wrapper), s_configKeys_TypeWithNoMembers_Wrapper, configuration, binderOptions);
 
             if (AsConfigWithChildren(configuration.GetSection("Member")) is IConfigurationSection section0)
             {


### PR DESCRIPTION
Follow up to https://github.com/dotnet/runtime/pull/91657. Primarily reverts JSON changes made in that PR.

https://github.com/dotnet/runtime/pull/91967 shows the overall diff of the bug fix and addresses feedback to switch to use the Roslyn API for accessibility checks.