### PR TITLE
Revert "Emit less metadata for not-reflection-visible types (#91660)"

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -625,8 +625,7 @@ namespace ILCompiler.DependencyAnalysis
 
             // Ask the metadata manager
             // if we have any dependencies due to presence of the EEType.
-            bool isFullType = factory.MaximallyConstructableType(_type) == this;
-            factory.MetadataManager.GetDependenciesDueToEETypePresence(ref dependencies, factory, _type, isFullType);
+            factory.MetadataManager.GetDependenciesDueToEETypePresence(ref dependencies, factory, _type);
 
             if (_type is MetadataType mdType)
                 ModuleUseBasedDependencyAlgorithm.AddDependenciesDueToModuleUse(ref dependencies, factory, mdType.Module);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -25,7 +25,7 @@ namespace ILCompiler.DependencyAnalysis
             DependencyList dependencyList = null;
 
             // Ask the metadata manager if we have any dependencies due to the presence of the EEType.
-            factory.MetadataManager.GetDependenciesDueToEETypePresence(ref dependencyList, factory, _type, isFullType: true);
+            factory.MetadataManager.GetDependenciesDueToEETypePresence(ref dependencyList, factory, _type);
 
             return dependencyList;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -458,12 +458,7 @@ namespace ILCompiler.DependencyAnalysis
 
             _typesWithMetadata = new NodeCache<MetadataType, TypeMetadataNode>(type =>
             {
-                return new TypeMetadataNode(type, includeCustomAttributes: true);
-            });
-
-            _typesWithMetadataWithoutCustomAttributes = new NodeCache<MetadataType, TypeMetadataNode>(type =>
-            {
-                return new TypeMetadataNode(type, includeCustomAttributes: false);
+                return new TypeMetadataNode(type);
             });
 
             _methodsWithMetadata = new NodeCache<MethodDesc, MethodMetadataNode>(method =>
@@ -1159,16 +1154,6 @@ namespace ILCompiler.DependencyAnalysis
             // in the dependency graph otherwise.
             Debug.Assert(MetadataManager is UsageBasedMetadataManager);
             return _typesWithMetadata.GetOrAdd(type);
-        }
-
-        private NodeCache<MetadataType, TypeMetadataNode> _typesWithMetadataWithoutCustomAttributes;
-
-        internal TypeMetadataNode TypeMetadataWithoutCustomAttributes(MetadataType type)
-        {
-            // These are only meaningful for UsageBasedMetadataManager. We should not have them
-            // in the dependency graph otherwise.
-            Debug.Assert(MetadataManager is UsageBasedMetadataManager);
-            return _typesWithMetadataWithoutCustomAttributes.GetOrAdd(type);
         }
 
         private NodeCache<MethodDesc, MethodMetadataNode> _methodsWithMetadata;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -24,13 +24,11 @@ namespace ILCompiler.DependencyAnalysis
     internal sealed class TypeMetadataNode : DependencyNodeCore<NodeFactory>
     {
         private readonly MetadataType _type;
-        private readonly bool _includeCustomAttributes;
 
-        public TypeMetadataNode(MetadataType type, bool includeCustomAttributes)
+        public TypeMetadataNode(MetadataType type)
         {
             Debug.Assert(type.IsTypeDefinition);
             _type = type;
-            _includeCustomAttributes = includeCustomAttributes;
         }
 
         public MetadataType Type => _type;
@@ -39,21 +37,13 @@ namespace ILCompiler.DependencyAnalysis
         {
             DependencyList dependencies = new DependencyList();
 
-            if (_includeCustomAttributes)
-                CustomAttributeBasedDependencyAlgorithm.AddDependenciesDueToCustomAttributes(ref dependencies, factory, ((EcmaType)_type));
+            CustomAttributeBasedDependencyAlgorithm.AddDependenciesDueToCustomAttributes(ref dependencies, factory, ((EcmaType)_type));
 
             DefType containingType = _type.ContainingType;
             if (containingType != null)
-            {
-                TypeMetadataNode metadataNode = _includeCustomAttributes
-                    ? factory.TypeMetadata((MetadataType)containingType)
-                    : factory.TypeMetadataWithoutCustomAttributes((MetadataType)containingType);
-                dependencies.Add(metadataNode, "Containing type of a reflectable type");
-            }
+                dependencies.Add(factory.TypeMetadata((MetadataType)containingType), "Containing type of a reflectable type");
             else
-            {
                 dependencies.Add(factory.ModuleMetadata(_type.Module), "Containing module of a reflectable type");
-            }
 
             var mdManager = (UsageBasedMetadataManager)factory.MetadataManager;
 
@@ -110,7 +100,7 @@ namespace ILCompiler.DependencyAnalysis
         /// Decomposes a constructed type into individual <see cref="TypeMetadataNode"/> units that will be needed to
         /// express the constructed type in metadata.
         /// </summary>
-        public static void GetMetadataDependencies(ref DependencyList dependencies, NodeFactory nodeFactory, TypeDesc type, string reason, bool isFullType = true)
+        public static void GetMetadataDependencies(ref DependencyList dependencies, NodeFactory nodeFactory, TypeDesc type, string reason)
         {
             MetadataManager mdManager = nodeFactory.MetadataManager;
 
@@ -120,13 +110,13 @@ namespace ILCompiler.DependencyAnalysis
                 case TypeFlags.SzArray:
                 case TypeFlags.ByRef:
                 case TypeFlags.Pointer:
-                    GetMetadataDependencies(ref dependencies, nodeFactory, ((ParameterizedType)type).ParameterType, reason, isFullType);
+                    GetMetadataDependencies(ref dependencies, nodeFactory, ((ParameterizedType)type).ParameterType, reason);
                     break;
                 case TypeFlags.FunctionPointer:
                     var pointerType = (FunctionPointerType)type;
-                    GetMetadataDependencies(ref dependencies, nodeFactory, pointerType.Signature.ReturnType, reason, isFullType);
+                    GetMetadataDependencies(ref dependencies, nodeFactory, pointerType.Signature.ReturnType, reason);
                     foreach (TypeDesc paramType in pointerType.Signature)
-                        GetMetadataDependencies(ref dependencies, nodeFactory, paramType, reason, isFullType);
+                        GetMetadataDependencies(ref dependencies, nodeFactory, paramType, reason);
                     break;
 
                 case TypeFlags.SignatureMethodVariable:
@@ -136,22 +126,27 @@ namespace ILCompiler.DependencyAnalysis
                 default:
                     Debug.Assert(type.IsDefType);
 
-                    var typeDefinition = (MetadataType)type.GetTypeDefinition();
+                    TypeDesc typeDefinition = type.GetTypeDefinition();
                     if (typeDefinition != type)
                     {
+                        if (mdManager.CanGenerateMetadata((MetadataType)typeDefinition))
+                        {
+                            dependencies ??= new DependencyList();
+                            dependencies.Add(nodeFactory.TypeMetadata((MetadataType)typeDefinition), reason);
+                        }
+
                         foreach (TypeDesc typeArg in type.Instantiation)
                         {
-                            GetMetadataDependencies(ref dependencies, nodeFactory, typeArg, reason, isFullType);
+                            GetMetadataDependencies(ref dependencies, nodeFactory, typeArg, reason);
                         }
                     }
-
-                    if (mdManager.CanGenerateMetadata(typeDefinition))
+                    else
                     {
-                        dependencies ??= new DependencyList();
-                        TypeMetadataNode node = isFullType
-                            ? nodeFactory.TypeMetadata(typeDefinition)
-                            : nodeFactory.TypeMetadataWithoutCustomAttributes(typeDefinition);
-                        dependencies.Add(node, reason);
+                        if (mdManager.CanGenerateMetadata((MetadataType)type))
+                        {
+                            dependencies ??= new DependencyList();
+                            dependencies.Add(nodeFactory.TypeMetadata((MetadataType)type), reason);
+                        }
                     }
                     break;
             }
@@ -159,7 +154,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override string GetName(NodeFactory factory)
         {
-            return $"Reflectable type: {_type}{(!_includeCustomAttributes ? " (No custom attributes)" : "")}";
+            return "Reflectable type: " + _type.ToString();
         }
 
         protected override void OnMarked(NodeFactory factory)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -478,13 +478,13 @@ namespace ILCompiler
         /// <summary>
         /// This method is an extension point that can provide additional metadata-based dependencies to generated EETypes.
         /// </summary>
-        public virtual void GetDependenciesDueToEETypePresence(ref DependencyList dependencies, NodeFactory factory, TypeDesc type, bool isFullType)
+        public virtual void GetDependenciesDueToEETypePresence(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
         {
             MetadataCategory category = GetMetadataCategory(type);
 
             if ((category & MetadataCategory.Description) != 0)
             {
-                GetMetadataDependenciesDueToReflectability(ref dependencies, factory, type, isFullType);
+                GetMetadataDependenciesDueToReflectability(ref dependencies, factory, type);
             }
         }
 
@@ -493,7 +493,7 @@ namespace ILCompiler
             // MetadataManagers can override this to provide additional dependencies caused by using a module
         }
 
-        protected virtual void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, TypeDesc type, bool isFullType)
+        protected virtual void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
         {
             // MetadataManagers can override this to provide additional dependencies caused by the emission of metadata
             // (E.g. dependencies caused by the type having custom attributes applied to it: making sure we compile the attribute constructor

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -271,9 +271,9 @@ namespace ILCompiler
             }
         }
 
-        protected override void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, TypeDesc type, bool isFullType)
+        protected override void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
         {
-            TypeMetadataNode.GetMetadataDependencies(ref dependencies, factory, type, "Reflectable type", isFullType);
+            TypeMetadataNode.GetMetadataDependencies(ref dependencies, factory, type, "Reflectable type");
 
             if (type.IsDelegate)
             {
@@ -385,9 +385,9 @@ namespace ILCompiler
             return false;
         }
 
-        public override void GetDependenciesDueToEETypePresence(ref DependencyList dependencies, NodeFactory factory, TypeDesc type, bool isFullType)
+        public override void GetDependenciesDueToEETypePresence(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
         {
-            base.GetDependenciesDueToEETypePresence(ref dependencies, factory, type, isFullType);
+            base.GetDependenciesDueToEETypePresence(ref dependencies, factory, type);
 
             DataflowAnalyzedTypeDefinitionNode.GetDependencies(ref dependencies, factory, FlowAnnotations, type);
         }
@@ -970,7 +970,7 @@ namespace ILCompiler
 
             public bool GeneratesMetadata(MetadataType typeDef)
             {
-                return _factory.TypeMetadata(typeDef).Marked || _factory.TypeMetadataWithoutCustomAttributes(typeDef).Marked;
+                return _factory.TypeMetadata(typeDef).Marked;
             }
 
             public bool GeneratesMetadata(EcmaModule module, CustomAttributeHandle caHandle)

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -67,6 +67,7 @@ internal static class ReflectionTest
         TestByRefTypeLoad.Run();
         TestGenericLdtoken.Run();
         TestAbstractGenericLdtoken.Run();
+        TestTypeHandlesVisibleFromIDynamicInterfaceCastable.Run();
 
         //
         // Mostly functionality tests
@@ -2454,6 +2455,35 @@ internal static class ReflectionTest
             catch (NullReferenceException)
             {
             }
+        }
+    }
+
+    class TestTypeHandlesVisibleFromIDynamicInterfaceCastable
+    {
+        class MyAttribute : Attribute { }
+
+        [My]
+        interface IUnusedInterface { }
+
+        class Foo : IDynamicInterfaceCastable
+        {
+            public RuntimeTypeHandle GetInterfaceImplementation(RuntimeTypeHandle interfaceType) => throw new NotImplementedException();
+
+            public bool IsInterfaceImplemented(RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
+            {
+                Type t = Type.GetTypeFromHandle(interfaceType);
+                if (t.GetCustomAttribute<MyAttribute>() == null)
+                    throw new Exception();
+
+                return true;
+            }
+        }
+
+        public static void Run()
+        {
+            object myObject = new Foo();
+            if (myObject is not IUnusedInterface)
+                throw new Exception();
         }
     }
 

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -21,7 +21,6 @@ class DeadCodeElimination
         TestStaticVirtualMethodOptimizations.Run();
         TestTypeEquals.Run();
         TestBranchesInGenericCodeRemoval.Run();
-        TestLimitedMetadataBlobs.Run();
 
         return 100;
     }
@@ -378,51 +377,6 @@ class DeadCodeElimination
             ThrowIfNotPresent(typeof(TestBranchesInGenericCodeRemoval), nameof(UsedFromVirtual));
         }
     }
-
-    class TestLimitedMetadataBlobs
-    {
-        class MyAttribute : Attribute
-        {
-            public MyAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type t) { }
-        }
-
-        class ShouldNotBeNeeded
-        {
-        }
-
-        [My(typeof(ShouldNotBeNeeded))]
-        interface INeverImplemented
-        {
-            void Never();
-        }
-
-        static INeverImplemented s_instance;
-#if !DEBUG
-        static Type s_type;
-#endif
-
-        internal static void Run()
-        {
-            Console.WriteLine("Testing generation of limited metadata blobs");
-
-            // Force a reference to the interface from a dispatch cell
-            if (s_instance != null)
-                s_instance.Never();
-
-            // Following is for release only since it relies on optimizing the typeof into an unconstructed
-            // MethodTable.
-#if !DEBUG
-            // Force another reference from an LDTOKEN
-            if (s_type == typeof(INeverImplemented))
-                s_type = typeof(object);
-#endif
-
-            ThrowIfPresent(typeof(TestLimitedMetadataBlobs), nameof(ShouldNotBeNeeded));
-            ThrowIfPresent(typeof(TestLimitedMetadataBlobs), nameof(MyAttribute));
-            ThrowIfNotPresent(typeof(TestLimitedMetadataBlobs), nameof(INeverImplemented));
-        }
-    }
-
 
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
         Justification = "That's the point")]


### PR DESCRIPTION
This is a revert of #91660 (first commit, no need to review that, really) and a regression test (second commit).

This fixes an issue discovered in the SDK repo: https://github.com/dotnet/sdk/pull/35293#issuecomment-1716272628

The compiler assumes MethodTables used in casts and interface dispatch are not reflection visible. As we found the hard way in the above PR, this is not true when `IDynamicInterfaceCastable` is present. With `IDynamicInterfaceCastable`, any (interface) type handle used in cast or interface dispatch could be reflection visible in user code.

The compiler had this wrong assumption for a while (the regression test I'm adding would fail on .NET 7). The only reason why we haven't already seen this in .NET 7 was that crossgen2 PDB writing was written with a manual ComWrapper in .NET 7, vs in .NET 8 it uses the generator that does a bunch of reflection on the type handle for whatever reason.

We'll probably also want to upgrade the places within the compiler that hand out NecessaryEEType for dispatch/cast to interfaces to hand out ConstructedEEType instead but I don't want to do that as part of a .NET 8 fix. This has been broken in 7.0 too and it is also observable (NecessaryEETypes don't have a populated interface list), but nothing known fails on this right now.

So thanks to IDynamicInterfaceCastable, the problem #91660 was trying to solve is totally unfixable and WinForms apps will always bring half of WPF with them.

Cc @dotnet/ilc-contrib 