### PR TITLE
Revert "[release/8.0] Update dependencies from dotnet/roslyn"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -358,18 +358,18 @@
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>99168dcff56809205e7ef8530d1256f3a07fab1f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.8.0-3.23459.2">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.8.0-3.23451.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>d080175cabfe297ebf079af099279b61913bcc28</Sha>
+      <Sha>3686f3061a9202260a0de4d06e91855b0fa21e8c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis" Version="4.8.0-3.23459.2">
+    <Dependency Name="Microsoft.CodeAnalysis" Version="4.8.0-3.23451.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>d080175cabfe297ebf079af099279b61913bcc28</Sha>
+      <Sha>3686f3061a9202260a0de4d06e91855b0fa21e8c</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.8.0-3.23459.2">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.8.0-3.23451.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>d080175cabfe297ebf079af099279b61913bcc28</Sha>
+      <Sha>3686f3061a9202260a0de4d06e91855b0fa21e8c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0-beta1.23458.2">
       <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -42,9 +42,9 @@
       Any tools that contribute to the design-time experience should use the MicrosoftCodeAnalysisVersion_LatestVS property above to ensure
       they do not break the local dev experience.
     -->
-    <MicrosoftCodeAnalysisCSharpVersion>4.8.0-3.23459.2</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeAnalysisVersion>4.8.0-3.23459.2</MicrosoftCodeAnalysisVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.8.0-3.23459.2</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>4.8.0-3.23451.1</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisVersion>4.8.0-3.23451.1</MicrosoftCodeAnalysisVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.8.0-3.23451.1</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <!--
     For source generator support we need to target multiple versions of Roslyn in order to be able to run on older versions of Roslyn.


### PR DESCRIPTION
Reverts dotnet/runtime#91482

Failures were introduced to the branch when I merged this. The [latest open deps flow PR](https://github.com/dotnet/runtime/pull/91913) is _still_ showing the failure. Since it has not yet been fixed, the backout is the appropriate approach to address the problem. 