### PR TITLE
[release/8.0] Metrics Feature Switch

### DIFF
--- a/docs/workflow/trimming/feature-switches.md
+++ b/docs/workflow/trimming/feature-switches.md
@@ -13,6 +13,7 @@ configurations but their defaults might vary as any SDK can set the defaults dif
 | EnableUnsafeBinaryFormatterSerialization | System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization | BinaryFormatter serialization support is trimmed when set to false |
 | EventSourceSupport | System.Diagnostics.Tracing.EventSource.IsSupported | Any EventSource related code or logic is trimmed when set to false |
 | InvariantGlobalization | System.Globalization.Invariant | All globalization specific code and data is trimmed when set to true |
+| MetricsSupport | System.Diagnostics.Metrics.Meter.IsSupported | Any Metrics related code or logic is trimmed when set to false |
 | PredefinedCulturesOnly | System.Globalization.PredefinedCulturesOnly |  Don't allow creating a culture for which the platform does not have data |
 | HybridGlobalization | System.Globalization.Hybrid |  Properties connected with the mixed: platform-specific + icu-based globalization will be trimmed  |
 | UseSystemResourceKeys | System.Resources.UseSystemResourceKeys |  Any localizable resources for system assemblies is trimmed when set to true |

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/ILLink/ILLink.Substitutions.Shared.xml
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/ILLink/ILLink.Substitutions.Shared.xml
@@ -1,0 +1,10 @@
+<linker>
+  <assembly fullname="System.Diagnostics.DiagnosticSource" feature="System.Diagnostics.Metrics.Meter.IsSupported" featurevalue="false">
+    <type fullname="System.Diagnostics.Metrics.Meter">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Diagnostics.Metrics.Instrument">
+      <method signature="System.Boolean get_Enabled()" body="stub" value="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -21,6 +21,10 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>
+    <ILLinkSubstitutionsXmls Include="ILLink/ILLink.Substitutions.Shared.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="System\Diagnostics\Activity.cs" />
     <Compile Include="System\Diagnostics\Activity.Current.net46.cs" />
     <Compile Include="System\Diagnostics\ActivityStatusCode.cs" />

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Instrument.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Instrument.cs
@@ -64,6 +64,12 @@ namespace System.Diagnostics.Metrics
         /// </summary>
         protected void Publish()
         {
+            // All instruments call Publish when they are created. We don't want to publish the instrument if the Meter is not supported.
+            if (!Meter.IsSupported)
+            {
+                return;
+            }
+
             List<MeterListener>? allListeners = null;
             lock (Instrument.SyncObject)
             {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Meter.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/Meter.cs
@@ -17,6 +17,11 @@ namespace System.Diagnostics.Metrics
         private Dictionary<string, List<Instrument>> _nonObservableInstrumentsCache = new();
         internal bool Disposed { get; private set; }
 
+        internal static bool IsSupported { get; } = InitializeIsSupported();
+
+        private static bool InitializeIsSupported() =>
+            AppContext.TryGetSwitch("System.Diagnostics.Metrics.Meter.IsSupported", out bool isSupported) ? isSupported : true;
+
         /// <summary>
         /// Initialize a new instance of the Meter using the <see cref="MeterOptions" />.
         /// </summary>
@@ -76,6 +81,11 @@ namespace System.Diagnostics.Metrics
                 Tags = tagList;
             }
             Scope = scope;
+
+            if (!IsSupported)
+            {
+                return;
+            }
 
             lock (Instrument.SyncObject)
             {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MeterListener.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MeterListener.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 namespace System.Diagnostics.Metrics
 {
     /// <summary>
-    /// A delegate to represent the Meterlistener callbacks used in measurements recording operation.
+    /// A delegate to represent the MeterListener callbacks used in measurements recording operation.
     /// </summary>
     public delegate void MeasurementCallback<T>(Instrument instrument, T measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state) where T : struct;
 
@@ -56,6 +56,11 @@ namespace System.Diagnostics.Metrics
         /// <param name="state">A state object which will be passed back to the callback getting measurements events.</param>
         public void EnableMeasurementEvents(Instrument instrument, object? state = null)
         {
+            if (!Meter.IsSupported)
+            {
+                return;
+            }
+
             bool oldStateStored = false;
             bool enabled = false;
             object? oldState = null;
@@ -92,6 +97,11 @@ namespace System.Diagnostics.Metrics
         /// <returns>The state object originally passed to <see cref="EnableMeasurementEvents" /> method.</returns>
         public object? DisableMeasurementEvents(Instrument instrument)
         {
+            if (!Meter.IsSupported)
+            {
+                return default;
+            }
+
             object? state =  null;
             lock (Instrument.SyncObject)
             {
@@ -114,6 +124,11 @@ namespace System.Diagnostics.Metrics
         /// <param name="measurementCallback">The callback which can be used to get measurement recording of numeric type T.</param>
         public void SetMeasurementEventCallback<T>(MeasurementCallback<T>? measurementCallback) where T : struct
         {
+            if (!Meter.IsSupported)
+            {
+                return;
+            }
+
             measurementCallback ??= (instrument, measurement, tags, state) => { /* no-op */};
 
             if (typeof(T) == typeof(byte))
@@ -155,6 +170,11 @@ namespace System.Diagnostics.Metrics
         /// </summary>
         public void Start()
         {
+            if (!Meter.IsSupported)
+            {
+                return;
+            }
+
             List<Instrument>? publishedInstruments = null;
             lock (Instrument.SyncObject)
             {
@@ -184,6 +204,11 @@ namespace System.Diagnostics.Metrics
         /// </summary>
         public void RecordObservableInstruments()
         {
+            if (!Meter.IsSupported)
+            {
+                return;
+            }
+
             List<Exception>? exceptionsList = null;
             DiagNode<Instrument>? current = _enabledMeasurementInstruments.First;
             while (current is not null)
@@ -215,6 +240,11 @@ namespace System.Diagnostics.Metrics
         /// </summary>
         public void Dispose()
         {
+            if (!Meter.IsSupported)
+            {
+                return;
+            }
+
             Dictionary<Instrument, object?>? callbacksArguments = null;
             Action<Instrument, object?>? measurementsCompleted = MeasurementsCompleted;
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Compile Include="DiagnosticSourceEventSourceBridgeTests.cs" />
+    <Compile Include="TestNotSupported.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\src\System\Diagnostics\Metrics\Aggregator.cs" Link="Aggregator.cs" />

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestNotSupported.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestNotSupported.cs
@@ -24,11 +24,13 @@ namespace System.Diagnostics.Metrics.Tests
             RemoteExecutor.Invoke((val) =>
             {
                 bool isSupported = bool.Parse(val);
+
                 Meter meter = new Meter("IsSupportedTest");
                 Counter<long> counter = meter.CreateCounter<long>("counter");
                 bool instrumentsPublished = false;
                 bool instrumentCompleted = false;
                 long counterValue = 100;
+
                 using (MeterListener listener = new MeterListener
                 {
                     InstrumentPublished = (instruments, theListener) => instrumentsPublished = true,
@@ -38,10 +40,13 @@ namespace System.Diagnostics.Metrics.Tests
                     listener.EnableMeasurementEvents(counter, null);
                     listener.SetMeasurementEventCallback<long>((inst, measurement, tags, state) => counterValue = measurement);
                     listener.Start();
+
                     Assert.Equal(isSupported, counter.Enabled);
+
                     counter.Add(20);
                 }
                 meter.Dispose();
+
                 Assert.Equal(isSupported, instrumentsPublished);
                 Assert.Equal(isSupported, instrumentCompleted);
                 Assert.Equal(isSupported ? 20 : 100, counterValue);

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestNotSupported.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestNotSupported.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.RemoteExecutor;
+using System.Diagnostics.Metrics;
+using Xunit;
+
+namespace System.Diagnostics.Metrics.Tests
+{
+    public class MetricsNotSupportedTest
+    {
+        /// <summary>
+        /// Tests using Metrics when the System.Diagnostics.Metrics.Meter.IsSupported
+        /// feature switch is set to disable all metrics operations.
+        /// </summary>
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IsSupportedSwitch(bool value)
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            options.RuntimeConfigurationOptions.Add("System.Diagnostics.Metrics.Meter.IsSupported", value);
+
+            RemoteExecutor.Invoke((val) =>
+            {
+                bool isSupported = bool.Parse(val);
+                Meter meter = new Meter("IsSupportedTest");
+                Counter<long> counter = meter.CreateCounter<long>("counter");
+                bool instrumentsPublished = false;
+                bool instrumentCompleted = false;
+                long counterValue = 100;
+                using (MeterListener listener = new MeterListener
+                {
+                    InstrumentPublished = (instruments, theListener) => instrumentsPublished = true,
+                    MeasurementsCompleted = (instruments, state) => instrumentCompleted = true
+                })
+                {
+                    listener.EnableMeasurementEvents(counter, null);
+                    listener.SetMeasurementEventCallback<long>((inst, measurement, tags, state) => counterValue = measurement);
+                    listener.Start();
+                    Assert.Equal(isSupported, counter.Enabled);
+                    counter.Add(20);
+                }
+                meter.Dispose();
+                Assert.Equal(isSupported, instrumentsPublished);
+                Assert.Equal(isSupported, instrumentCompleted);
+                Assert.Equal(isSupported ? 20 : 100, counterValue);
+            }, value.ToString(), options).Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/89880

Backport of #91767 to release/8.0

/cc @tarekgh

## Customer Impact

The introduction of a feature switch enables the option to disable the metrics feature, aiding in trimming and AOT scenarios. This modification addresses and resolves the performance regression observed in Xamarin app startup scenarios. For additional information, please refer to the following issue: https://github.com/dotnet/runtime/issues/89880.

## Testing

Successfully ran all regressions test and added a new test covering testing when the new switch is enabled. 

## Risk
We haven't made any alterations or adjustments to the code or logic when the new switch is left disabled. Therefore, any modifications will only become apparent when the switch is activated. The risk of this change adversely affecting any existing, functional functionality is exceedingly low.

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is `release/X.0-staging`, not `release/X.0`.

- If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
