### PR TITLE
Fix si.ibAllocated in FrozenObjectHeapManager

### DIFF
--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -184,6 +184,8 @@ void FrozenObjectSegment::RegisterOrUpdate(uint8_t* current, size_t sizeCommited
         si.ibCommit = sizeCommited;
         si.ibReserved = m_Size;
 
+        assert((size_t)current >= (size_t)si.pvMem);
+
         // NOTE: RegisterFrozenSegment may take a GC lock inside.
         m_SegmentHandle = GCHeapUtilities::GetGCHeap()->RegisterFrozenSegment(&si);
         if (m_SegmentHandle == nullptr)

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -180,7 +180,7 @@ void FrozenObjectSegment::RegisterOrUpdate(uint8_t* current, size_t sizeCommited
         segment_info si;
         si.pvMem = m_pStart;
         si.ibFirstObject = sizeof(ObjHeader);
-        si.ibAllocated = (size_t)current;
+        si.ibAllocated = (size_t)current - (size_t)si.pvMem;
         si.ibCommit = sizeCommited;
         si.ibReserved = m_Size;
 


### PR DESCRIPTION
`ibAllocated` is expected to be a real size of a segment, not a pointer to the end.

Regressed in https://github.com/dotnet/runtime/pull/90847
