### PR TITLE
Switch `BundleExtractToSpecificPath` and `BundleAndRun` to using built test assets

### DIFF
--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
@@ -1,16 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.IO;
+using System.Threading;
 using BundleTests.Helpers;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
 using Microsoft.NET.HostModel.Bundle;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading;
 using Xunit;
 
 namespace AppHost.Bundle.Tests
@@ -25,39 +22,38 @@ namespace AppHost.Bundle.Tests
         }
 
         [Fact]
-        private void Bundle_Extraction_To_Specific_Path_Succeeds()
+        private void AbsolutePath()
         {
-            var fixture = sharedTestState.TestFixture.Copy();
-            var hostName = BundleHelper.GetHostName(fixture);
+            SingleFileTestApp app = sharedTestState.SelfContainedApp;
 
             // Publish the bundle
             BundleOptions options = BundleOptions.BundleNativeBinaries;
-            Bundler bundler = BundleSelfContainedApp(fixture, out string singleFile, options);
+            Manifest manifest;
+            string singleFile = sharedTestState.SelfContainedApp.Bundle(options, out manifest);
 
             // Verify expected files in the bundle directory
-            var bundleDir = BundleHelper.GetBundleDir(fixture);
-            bundleDir.Should().HaveFile(hostName);
-            bundleDir.Should().NotHaveFiles(BundleHelper.GetBundledFiles(fixture));
+            var bundleDir = Directory.GetParent(singleFile);
+            bundleDir.Should().OnlyHaveFiles(new[]
+            {
+                Binaries.GetExeFileNameForCurrentPlatform(app.Name),
+                $"{app.Name}.pdb"
+            });
 
-            // Create a directory for extraction.
-            var extractBaseDir = BundleHelper.GetExtractionRootDir(fixture);
-            extractBaseDir.Should().NotHaveDirectory(BundleHelper.GetAppBaseName(fixture));
+            // Directory for extraction.
+            string extractBaseDir = app.GetNewExtractionRootPath();
 
             // Run the bundled app for the first time, and extract files to
             // $DOTNET_BUNDLE_EXTRACT_BASE_DIR/<app>/bundle-id
             Command.Create(singleFile)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir.FullName)
+                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir)
                 .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("Hello World");
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World");
 
-            var extractDir = BundleHelper.GetExtractionDir(fixture, bundler);
-            extractDir.Should().HaveFiles(BundleHelper.GetExtractedFiles(fixture, BundleOptions.BundleNativeBinaries));
-            extractDir.Should().NotHaveFiles(BundleHelper.GetFilesNeverExtracted(fixture));
+            var extractDir = app.GetExtractionDir(extractBaseDir, manifest);
+            extractDir.Should().OnlyHaveFiles(BundleHelper.GetExtractedFiles(manifest, options));
         }
 
         [InlineData("./foo", BundleOptions.BundleAllContent)]
@@ -70,7 +66,7 @@ namespace AppHost.Bundle.Tests
         [InlineData("foo/bar", BundleOptions.BundleNativeBinaries)]
         [InlineData("foo\\bar", BundleOptions.BundleNativeBinaries)]
         [Theory]
-        private void Bundle_Extraction_To_Relative_Path_Succeeds(string relativePath, BundleOptions bundleOptions)
+        private void RelativePath(string relativePath, BundleOptions bundleOptions)
         {
             // As we don't modify user defined environment variables, we will not convert
             // any forward slashes to the standard Windows dir separator ('\'), thus
@@ -84,56 +80,51 @@ namespace AppHost.Bundle.Tests
             if (relativePath == "foo\\bar" && !OperatingSystem.IsWindows())
                 return;
 
-            var fixture = sharedTestState.TestFixture.Copy();
-            var bundler = BundleSelfContainedApp(fixture, out var singleFile, bundleOptions);
+            Manifest manifest;
+            string singleFile = sharedTestState.SelfContainedApp.Bundle(bundleOptions, out manifest);
 
             // Run the bundled app (extract files to <path>)
-            var cmd = Command.Create(singleFile);
-            cmd.WorkingDirectory(Path.GetDirectoryName(singleFile))
+            Command.Create(singleFile)
+                .WorkingDirectory(Path.GetDirectoryName(singleFile))
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, relativePath)
                 .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("Hello World");
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World");
 
-            var extractedFiles = BundleHelper.GetExtractedFiles(fixture, bundleOptions);
-            var extractedDir = new DirectoryInfo(Path.Combine(Path.GetDirectoryName(singleFile),
-                relativePath,
-                fixture.TestProject.ProjectName,
-                bundler.BundleManifest.BundleID));
-
-            extractedDir.Should().HaveFiles(extractedFiles);
+            using (TestArtifact extractionRoot = new TestArtifact(Path.Combine(Path.GetDirectoryName(singleFile), relativePath)))
+            {
+                var extractedDir = sharedTestState.SelfContainedApp.GetExtractionDir(extractionRoot.Location, manifest);
+                var extractedFiles = BundleHelper.GetExtractedFiles(manifest, bundleOptions);
+                extractedDir.Should().OnlyHaveFiles(extractedFiles);
+            }
         }
 
         [Fact]
-        private void Bundle_extraction_is_reused()
+        private void ExtractionDirectoryReused()
         {
-            var fixture = sharedTestState.TestFixture.Copy();
+            var app = sharedTestState.SelfContainedApp;
 
             // Publish the bundle
+            Manifest manifest;
             BundleOptions options = BundleOptions.BundleNativeBinaries;
-            Bundler bundler = BundleSelfContainedApp(fixture, out string singleFile, options);
+            string singleFile = app.Bundle(options, out manifest);
 
-            // Create a directory for extraction.
-            var extractBaseDir = BundleHelper.GetExtractionRootDir(fixture);
+            // Directory for extraction.
+            string extractBaseDir = app.GetNewExtractionRootPath();
 
             // Run the bunded app for the first time, and extract files to
             // $DOTNET_BUNDLE_EXTRACT_BASE_DIR/<app>/bundle-id
             Command.Create(singleFile)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir.FullName)
+                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir)
                 .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("Hello World");
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World");
 
-            var extractDir = BundleHelper.GetExtractionDir(fixture, bundler);
-
+            var extractDir = app.GetExtractionDir(extractBaseDir, manifest);
             extractDir.Refresh();
             DateTime firstWriteTime = extractDir.LastWriteTimeUtc;
 
@@ -146,47 +137,43 @@ namespace AppHost.Bundle.Tests
             Command.Create(singleFile)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir.FullName)
+                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir)
                 .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("Hello World");
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World");
 
             extractDir.Should().NotBeModifiedAfter(firstWriteTime);
         }
 
         [Fact]
-        private void Bundle_extraction_can_recover_missing_files()
+        private void RecoverMissingFiles()
         {
-            var fixture = sharedTestState.TestFixture.Copy();
-            var hostName = BundleHelper.GetHostName(fixture);
-            var appName = Path.GetFileNameWithoutExtension(hostName);
+            var app = sharedTestState.SelfContainedApp;
 
             // Publish the bundle
+            Manifest manifest;
             BundleOptions options = BundleOptions.BundleNativeBinaries;
-            Bundler bundler = BundleSelfContainedApp(fixture, out string singleFile, options);
+            string singleFile = app.Bundle(options, out manifest);
 
-            // Create a directory for extraction.
-            var extractBaseDir = BundleHelper.GetExtractionRootDir(fixture);
+            // Directory for extraction.
+            string extractBaseDir = app.GetNewExtractionRootPath();
 
             // Run the bunded app for the first time, and extract files to
             // $DOTNET_BUNDLE_EXTRACT_BASE_DIR/<app>/bundle-id
             Command.Create(singleFile)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir.FullName)
+                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir)
                 .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("Hello World");
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World");
 
             // Remove the extracted files, but keep the extraction directory
-            var extractDir = BundleHelper.GetExtractionDir(fixture, bundler);
-            var extractedFiles = BundleHelper.GetExtractedFiles(fixture, BundleOptions.BundleNativeBinaries);
+            var extractDir = app.GetExtractionDir(extractBaseDir, manifest);
+            var extractedFiles = BundleHelper.GetExtractedFiles(manifest, options);
 
-            Array.ForEach(extractedFiles, file => File.Delete(Path.Combine(extractDir.FullName, file)));
+            foreach (string file in extractedFiles)
+                File.Delete(Path.Combine(extractDir.FullName, file));
 
             extractDir.Should().Exist();
             extractDir.Should().NotHaveFiles(extractedFiles);
@@ -195,21 +182,19 @@ namespace AppHost.Bundle.Tests
             Command.Create(singleFile)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir.FullName)
+                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir)
                 .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("Hello World");
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World");
 
-            extractDir.Should().HaveFiles(extractedFiles);
+            extractDir.Should().OnlyHaveFiles(extractedFiles);
         }
 
         [Fact]
-        private void Bundle_extraction_to_nonexisting_default()
+        private void NonexistentDefault_Fails()
         {
             string nonExistentPath = Path.Combine(
-                sharedTestState.DefaultBundledAppFixture.TestProject.OutputDirectory,
+                Path.GetDirectoryName(sharedTestState.BundledAppExecutablePath),
                 "nonexistent");
 
             string defaultExpansionEnvVariable = OperatingSystem.IsWindows() ? "TMP" : "HOME";
@@ -217,7 +202,7 @@ namespace AppHost.Bundle.Tests
                 $"Failed to determine default extraction location. Check if 'TMP'" :
                 $"Default extraction directory [{nonExistentPath}] either doesn't exist or is not accessible for read/write.";
 
-            Command.Create(sharedTestState.DefaultBundledAppExecutablePath)
+            Command.Create(sharedTestState.BundledAppExecutablePath)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .EnvironmentVariable(defaultExpansionEnvVariable, nonExistentPath)
@@ -227,56 +212,50 @@ namespace AppHost.Bundle.Tests
 
         [Fact]
         [SkipOnPlatform(TestPlatforms.Windows, "On Windows the default extraction path is determined by calling GetTempPath which looks at multiple places and can't really be undefined.")]
-        private void Bundle_extraction_fallsback_to_getpwuid_when_HOME_env_var_is_undefined()
+        private void UndefinedHOME_getpwuidFallback()
         {
             string home = Environment.GetEnvironmentVariable("HOME");
-            // suppose we are testing on a system where HOME is not set, use System.Environment (which also fallsback to getpwuid)
             if (string.IsNullOrEmpty(home))
             {
+                // HOME is not set. Use System.Environment (which also fallsback to getpwuid)
                 home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             }
 
-            DirectoryInfo sharedExtractDirInfo = BundleHelper.GetExtractionDir(sharedTestState.TestFixture, sharedTestState.DefaultBundledAppBundler);
-            string sharedExtractDir = sharedExtractDirInfo.FullName;
-            string extractDirSubPath = sharedExtractDir.Substring(sharedExtractDir.LastIndexOf("extract/") + "extract/".Length);
-            string realExtractDir = Path.Combine(home, ".net", extractDirSubPath);
-            var expectedExtractDir = new DirectoryInfo(realExtractDir);
-
-            Command.Create(sharedTestState.DefaultBundledAppExecutablePath)
+            Command.Create(sharedTestState.BundledAppExecutablePath)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .EnvironmentVariable("HOME", null)
                 .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("Hello World");
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World");
 
-            var extractedFiles = BundleHelper.GetExtractedFiles(sharedTestState.TestFixture, BundleOptions.BundleNativeBinaries);
+            DirectoryInfo expectedExtractDir = sharedTestState.SelfContainedApp.GetExtractionDir(Path.Combine(home, ".net"), sharedTestState.BundledAppManifest);
+            var extractedFiles = BundleHelper.GetExtractedFiles(sharedTestState.BundledAppManifest, BundleOptions.BundleNativeBinaries);
             expectedExtractDir.Should().HaveFiles(extractedFiles);
         }
 
         public class SharedTestState : SharedTestStateBase, IDisposable
         {
-            public TestProjectFixture TestFixture { get; }
+            public string BundledAppExecutablePath { get; }
+            public Manifest BundledAppManifest { get; }
 
-            public TestProjectFixture DefaultBundledAppFixture { get; }
-            public string DefaultBundledAppExecutablePath { get; }
-            public Bundler DefaultBundledAppBundler { get; }
+            public SingleFileTestApp SelfContainedApp { get; }
 
             public SharedTestState()
             {
-                TestFixture = PreparePublishedSelfContainedTestProject("StandaloneApp");
+                SelfContainedApp = SingleFileTestApp.CreateSelfContained("HelloWorld");
 
-                DefaultBundledAppFixture = TestFixture.Copy();
-                DefaultBundledAppBundler = BundleSelfContainedApp(DefaultBundledAppFixture, out var singleFile, BundleOptions.BundleNativeBinaries);
-                DefaultBundledAppExecutablePath = singleFile;
+                // Copy over mockcoreclr so that the app will have a native binary
+                File.Copy(Binaries.CoreClr.MockPath, Path.Combine(SelfContainedApp.NonBundledLocation, Binaries.CoreClr.MockName));
+
+                // Create a bundled app that can be used by multiple tests
+                BundledAppExecutablePath = SelfContainedApp.Bundle(BundleOptions.BundleNativeBinaries, out Manifest manifest);
+                BundledAppManifest = manifest;
             }
 
             public void Dispose()
             {
-                DefaultBundledAppFixture.Dispose();
-                TestFixture.Dispose();
+                SelfContainedApp.Dispose();
             }
         }
     }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Helpers/BundleHelper.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Helpers/BundleHelper.cs
@@ -52,44 +52,37 @@ namespace BundleTests.Helpers
             return Path.GetFileNameWithoutExtension(GetAppName(fixture));
         }
 
-        public static string[] GetBundledFiles(TestProjectFixture fixture)
+        public static List<string> GetExtractedFiles(Manifest manifest, BundleOptions bundleOptions)
         {
-            string appBaseName = GetAppBaseName(fixture);
-            return new string[] { $"{appBaseName}.dll", $"{appBaseName}.deps.json", $"{appBaseName}.runtimeconfig.json" };
-        }
-
-        public static string[] GetExtractedFiles(TestProjectFixture fixture, BundleOptions bundleOptions)
-        {
-            switch (bundleOptions & ~BundleOptions.EnableCompression)
+            List<string> expected = new List<string>();
+            foreach (FileEntry file in manifest.Files)
             {
-                case BundleOptions.None:
-                case BundleOptions.BundleOtherFiles:
-                case BundleOptions.BundleSymbolFiles:
-                    throw new ArgumentException($"Bundle option {bundleOptions} doesn't extract any files to disk.");
+                if (!ShouldBeExtracted(file.Type, bundleOptions))
+                    continue;
 
-                case BundleOptions.BundleAllContent:
-                    return Directory.GetFiles(GetPublishPath(fixture))
-                        .Select(f => Path.GetFileName(f))
-                        .Except(GetFilesNeverExtracted(fixture)).ToArray();
-
-                case BundleOptions.BundleNativeBinaries:
-                    return new string[] { Path.GetFileName(fixture.TestProject.CoreClrDll) };
-
-                default:
-                    throw new ArgumentException("Unsupported bundle option.");
+                expected.Add(file.RelativePath);
             }
-        }
 
-        public static string[] GetFilesNeverExtracted(TestProjectFixture fixture)
-        {
-            string appBaseName = GetAppBaseName(fixture);
-            return new string[] { $"{appBaseName}",
-                                  $"{appBaseName}.dll",
-                                  $"{appBaseName}.exe",
-                                  $"{appBaseName}.pdb",
-                                  $"{appBaseName}.runtimeconfig.dev.json",
-                                  Path.GetFileName(fixture.TestProject.HostFxrDll),
-                                  Path.GetFileName(fixture.TestProject.HostPolicyDll) };
+            return expected;
+
+            static bool ShouldBeExtracted(FileType type, BundleOptions options)
+            {
+                switch (type)
+                {
+                    case FileType.Assembly:
+                    case FileType.DepsJson:
+                    case FileType.RuntimeConfigJson:
+                        return options.HasFlag(BundleOptions.BundleAllContent);
+                    case FileType.NativeBinary:
+                        return options.HasFlag(BundleOptions.BundleNativeBinaries);
+                    case FileType.Symbols:
+                        return options.HasFlag(BundleOptions.BundleSymbolFiles);
+                    case FileType.Unknown:
+                        return options.HasFlag(BundleOptions.BundleOtherFiles);
+                    default:
+                        return false;
+                }
+            }
         }
 
         public static string GetPublishPath(TestProjectFixture fixture)

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleAndRun.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleAndRun.cs
@@ -21,22 +21,21 @@ namespace Microsoft.NET.HostModel.Tests
             sharedTestState = fixture;
         }
 
-        private void RunTheApp(string path)
+        private void RunTheApp(string path, bool selfContained)
         {
             Command.Create(path)
                 .CaptureStdErr()
                 .CaptureStdOut()
+                .DotNetRoot(selfContained ? null : RepoDirectoriesProvider.Default.BuiltDotnet)
                 .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("Hello World!");
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World!");
         }
 
-        private string MakeUniversalBinary(string path, string rid)
+        private string MakeUniversalBinary(string path, Architecture architecture)
         {
             string fatApp = path + ".fat";
-            string arch = BundleHelper.GetTargetArch(rid) == Architecture.Arm64 ? "arm64" : "x86_64";
+            string arch = architecture == Architecture.Arm64 ? "arm64" : "x86_64";
 
             // We will create a universal binary with just one arch slice and run it.
             // It is enough for testing purposes. The code that finds the releavant slice
@@ -51,66 +50,36 @@ namespace Microsoft.NET.HostModel.Tests
             return fatApp;
         }
 
-        private void BundleRun(TestProjectFixture fixture, string publishPath)
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        private void RunApp(bool selfContained)
         {
-            var hostName = BundleHelper.GetHostName(fixture);
-
-            // Run the App normally
-            RunTheApp(Path.Combine(publishPath, hostName));
-
             // Bundle to a single-file
-            string singleFile = BundleHelper.BundleApp(fixture);
+            string singleFile = selfContained
+                ? sharedTestState.SelfContainedApp.Bundle()
+                : sharedTestState.FrameworkDependentApp.Bundle();
 
-            // check that the file structure is understood by codesign
-            var targetOS = BundleHelper.GetTargetOS(fixture.CurrentRid);
+            // Run the bundled app
+            RunTheApp(singleFile, selfContained);
 
-            // Run the extracted app
-            RunTheApp(singleFile);
-
-            if (targetOS == OSPlatform.OSX)
+            if (OperatingSystem.IsMacOS())
             {
-                string fatApp = MakeUniversalBinary(singleFile, fixture.CurrentRid);
+                string fatApp = MakeUniversalBinary(singleFile, RuntimeInformation.OSArchitecture);
 
                 // Run the fat app
-                RunTheApp(fatApp);
+                RunTheApp(fatApp, selfContained);
             }
         }
 
-        private string RelativePath(string path)
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AdditionalContentAfterBundleMetadata(bool selfContained)
         {
-            return Path.GetRelativePath(Directory.GetCurrentDirectory(), path)
-                       .TrimEnd(Path.DirectorySeparatorChar);
-        }
-
-        [Fact]
-        public void TestWithAbsolutePaths()
-        {
-            var fixture = sharedTestState.TestFixture.Copy();
-            string publishDir = BundleHelper.GetPublishPath(fixture);
-            BundleRun(fixture, publishDir);
-        }
-
-        [Fact]
-        public void TestWithRelativePaths()
-        {
-            var fixture = sharedTestState.TestFixture.Copy();
-            string publishDir = RelativePath(BundleHelper.GetPublishPath(fixture));
-            BundleRun(fixture, publishDir);
-        }
-
-        [Fact]
-        public void TestWithRelativePathsDirSeparator()
-        {
-            var fixture = sharedTestState.TestFixture.Copy();
-            string publishDir = RelativePath(BundleHelper.GetPublishPath(fixture)) + Path.DirectorySeparatorChar;
-            BundleRun(fixture, publishDir);
-        }
-
-        [Fact]
-        public void TestWithAdditionalContentAfterBundleMetadata()
-        {
-            var fixture = sharedTestState.TestFixture.Copy();
-            string singleFile = BundleHelper.BundleApp(fixture);
+            string singleFile = selfContained
+                ? sharedTestState.SelfContainedApp.Bundle()
+                : sharedTestState.FrameworkDependentApp.Bundle();
 
             using (var file = File.OpenWrite(singleFile))
             {
@@ -119,35 +88,24 @@ namespace Microsoft.NET.HostModel.Tests
                 file.Write(blob, 0, blob.Length);
             }
 
-            Command.Create(singleFile)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute()
-                .Should().Pass()
-                .And.HaveStdOutContaining("Hello World!");
+            RunTheApp(singleFile, selfContained);
         }
 
         public class SharedTestState : IDisposable
         {
-            public TestProjectFixture TestFixture { get; set; }
-            public TestProjectFixture LegacyFixture { get; set; }
-            public RepoDirectoriesProvider RepoDirectories { get; set; }
+            public SingleFileTestApp FrameworkDependentApp { get; }
+            public SingleFileTestApp SelfContainedApp { get; }
 
             public SharedTestState()
             {
-                RepoDirectories = new RepoDirectoriesProvider();
-
-                TestFixture = new TestProjectFixture("StandaloneApp", RepoDirectories);
-                TestFixture
-                    .EnsureRestoredForRid(TestFixture.CurrentRid)
-                    .PublishProject(runtime: TestFixture.CurrentRid,
-                                    selfContained: true,
-                                    outputDirectory: BundleHelper.GetPublishPath(TestFixture));
+                FrameworkDependentApp = SingleFileTestApp.CreateFrameworkDependent("HelloWorld");
+                SelfContainedApp = SingleFileTestApp.CreateSelfContained("HelloWorld");
             }
 
             public void Dispose()
             {
-                TestFixture.Dispose();
+                FrameworkDependentApp.Dispose();
+                SelfContainedApp.Dispose();
             }
         }
     }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleAndRun.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleAndRun.cs
@@ -33,17 +33,6 @@ namespace Microsoft.NET.HostModel.Tests
                 .HaveStdOutContaining("Hello World!");
         }
 
-        private void CheckFileSigned(string path)
-        {
-            // Check if the file is signed (it should have been signed by the bundler)
-            Command.Create("codesign", $"-v {path}")
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute()
-                .Should()
-                .Pass();
-        }
-
         private string MakeUniversalBinary(string path, string rid)
         {
             string fatApp = path + ".fat";
@@ -74,10 +63,6 @@ namespace Microsoft.NET.HostModel.Tests
 
             // check that the file structure is understood by codesign
             var targetOS = BundleHelper.GetTargetOS(fixture.CurrentRid);
-            if (targetOS == OSPlatform.OSX)
-            {
-                CheckFileSigned(singleFile);
-            }
 
             // Run the extracted app
             RunTheApp(singleFile);

--- a/src/installer/tests/TestUtils/SingleFileTestApp.cs
+++ b/src/installer/tests/TestUtils/SingleFileTestApp.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             return fileSpecs;
         }
 
-        public string Bundle(BundleOptions options, Version? bundleVersion = null)
+        public string Bundle(BundleOptions options = BundleOptions.None, Version? bundleVersion = null)
         {
             return Bundle(options, out _, bundleVersion);
         }

--- a/src/installer/tests/TestUtils/SingleFileTestApp.cs
+++ b/src/installer/tests/TestUtils/SingleFileTestApp.cs
@@ -75,6 +75,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public string Bundle(BundleOptions options, Version? bundleVersion = null)
         {
+            return Bundle(options, out _, bundleVersion);
+        }
+
+        public string Bundle(BundleOptions options, out Manifest manifest, Version? bundleVersion = null)
+        {
             string bundleDirectory = SharedFramework.CalculateUniqueTestDirectory(Path.Combine(Location, "bundle"));
             var bundler = new Bundler(
                 Binaries.GetExeFileNameForCurrentPlatform(AppName),
@@ -113,7 +118,18 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 File.Copy(spec.SourcePath, outputFilePath, true);
             }
 
+            manifest = bundler.BundleManifest;
             return singleFile;
+        }
+
+        public string GetNewExtractionRootPath()
+        {
+            return SharedFramework.CalculateUniqueTestDirectory(Path.Combine(Location, "extract"));
+        }
+
+        public DirectoryInfo GetExtractionDir(string root, Manifest manifest)
+        {
+            return new DirectoryInfo(Path.Combine(root, Name, manifest.BundleID));
         }
 
         private void PopulateBuiltAppDirectory()

--- a/src/native/corehost/bundle/extractor.cpp
+++ b/src/native/corehost/bundle/extractor.cpp
@@ -63,7 +63,7 @@ pal::string_t& extractor_t::extraction_dir()
         append_path(&m_extraction_dir, host_name.c_str());
         append_path(&m_extraction_dir, m_bundle_id.c_str());
 
-        trace::info(_X("Files embedded within the bundled will be extracted to [%s] directory."), m_extraction_dir.c_str());
+        trace::info(_X("Files embedded within the bundle will be extracted to [%s] directory."), m_extraction_dir.c_str());
     }
 
     return m_extraction_dir;


### PR DESCRIPTION
- Make `BundleExtractToSpecificPath` and `BundleAndRun` tests use built test asset project (`HelloWorld`)
  - The `BundleExtractToSpecificPath` tests explicitly include `mockcoreclr` so that it will have native binaries to bundle
- Remove redundant `BundleAndRun.TestWith*Paths*` tests
  - These were running a self-contained (not bundled) application by invoking it using relative / absolute paths, which does not seem particularly useful. There was no difference in how they bundled the application or ran the bundled application.
- Move codesign check to `BundlerConsistencyTests` - trying to separate tests targeting the `Bundler` API from tests targeting single-file activation

Fixes https://github.com/dotnet/runtime/issues/91039