### PR TITLE
Fix assert about maximum fragment split size

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3143,7 +3143,7 @@ void emitter::emitSplit(emitLocation*         startLoc,
     } // end for loop
 
     splitIfNecessary();
-    assert(curSize < maxSplitSize);
+    assert(curSize < UW_MAX_FRAGMENT_SIZE_BYTES);
 }
 
 /*****************************************************************************


### PR DESCRIPTION
We want to support arbitrary `DOTNET_JitSplitFunctionSize` values for stressing the unwind fragment splitting logic, but there are limitations to the smallest size that can be split. Thus, we can exceed a specified minimum. Loosen an assert that the last fragment be less than the specified split size, since it might exceed that minimum, e.g., by being a large epilog. Leave the assert specifying the hard requirement of maximum fragment size.

Fixes #91251