### PR TITLE
[release/6.0-staging] Check for <framework_name>.deps.json when enumerating framework paths

### DIFF
--- a/src/installer/tests/HostActivation.Tests/MultilevelSharedFxLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/MultilevelSharedFxLookup.cs
@@ -106,6 +106,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             _builtSharedUberFxDir = Path.Combine(_builtDotnet, "shared", "Microsoft.UberFramework", _sharedFxVersion);
             SharedFramework.CreateUberFrameworkArtifacts(_builtSharedFxDir, _builtSharedUberFxDir, SystemCollectionsImmutableAssemblyVersion, SystemCollectionsImmutableFileVersion);
 
+            // Empty Microsoft.NETCore.App directory - should not be recognized as a valid framework
+            Directory.CreateDirectory(Path.Combine(_exeSharedFxBaseDir, "9999.9.9"));
+
             // Trace messages used to identify from which folder the framework was picked
             _hostPolicyDllName = Path.GetFileName(fixture.TestProject.HostPolicyDll);
             _exeSelectedMessage = $"The expected {_hostPolicyDllName} directory is [{_exeSharedFxBaseDir}";
@@ -237,7 +240,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.0.0");
+                .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.0.0")
+                .And.HaveStdErrContaining("Ignoring FX version [9999.9.9] without .deps.json");
         }
 
         [Fact]
@@ -341,7 +345,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.0.0-dummy2")
                 .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.0.2")
                 .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.0.3")
-                .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.0.0-dummy3");
+                .And.HaveStdOutContaining("Microsoft.NETCore.App 9999.0.0-dummy3")
+                .And.HaveStdErrContaining("Ignoring FX version [9999.9.9] without .deps.json");
         }
     }
 }

--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 Directory.CreateDirectory(WorkingDir);
 
-                // start with an empty global.json, it will be ignored, but prevent one lying on disk 
+                // start with an empty global.json, it will be ignored, but prevent one lying on disk
                 // on a given machine from impacting the test.
                 File.WriteAllText(GlobalJson, "{}");
 
@@ -117,12 +117,22 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 foreach ((string fwName, string[] fwVersions) in ProgramFilesGlobalFrameworks)
                 {
                     foreach (string fwVersion in fwVersions)
-                        Directory.CreateDirectory(Path.Combine(ProgramFilesGlobalFrameworksDir, fwName, fwVersion));
+                        AddFrameworkDirectory(ProgramFilesGlobalFrameworksDir, fwName, fwVersion);
                 }
                 foreach ((string fwName, string[] fwVersions) in LocalFrameworks)
                 {
                     foreach (string fwVersion in fwVersions)
-                        Directory.CreateDirectory(Path.Combine(LocalFrameworksDir, fwName, fwVersion));
+                        AddFrameworkDirectory(LocalFrameworksDir, fwName, fwVersion);
+
+                    // Empty framework directory - this should not be recognized as a valid framework directory
+                    Directory.CreateDirectory(Path.Combine(LocalFrameworksDir, fwName, "9.9.9"));
+                }
+
+                static void AddFrameworkDirectory(string frameworkDir, string name, string version)
+                {
+                    string versionDir = Path.Combine(frameworkDir, name, version);
+                    Directory.CreateDirectory(versionDir);
+                    File.WriteAllText(Path.Combine(versionDir, $"{name}.deps.json"), string.Empty);
                 }
             }
         }
@@ -230,7 +240,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void Hostfxr_resolve_sdk2_with_global_json_and_disallowing_previews()
         {
-            // With global.json specifying a preview, roll forward to preview 
+            // With global.json specifying a preview, roll forward to preview
             // since flag has no impact if global.json specifies a preview.
             // Also check that global.json that impacted resolution is reported.
 
@@ -511,7 +521,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void Hostfxr_get_dotnet_environment_info_global_install_path()
         {
             var f = new SdkResolutionFixture(sharedTestState);
-            
+
             f.Dotnet.Exec(f.AppDll, new[] { "hostfxr_get_dotnet_environment_info" })
             .CaptureStdOut()
             .CaptureStdErr()

--- a/src/installer/tests/TestUtils/DotNetBuilder.cs
+++ b/src/installer/tests/TestUtils/DotNetBuilder.cs
@@ -51,8 +51,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public DotNetBuilder AddMicrosoftNETCoreAppFrameworkMockHostPolicy(string version)
         {
             // ./shared/Microsoft.NETCore.App/<version> - create a mock of the root framework
-            string netCoreAppPath = Path.Combine(_path, "shared", "Microsoft.NETCore.App", version);
-            Directory.CreateDirectory(netCoreAppPath);
+            string netCoreAppPath = AddFramework(Constants.MicrosoftNETCoreApp, version);
 
             // ./shared/Microsoft.NETCore.App/<version>/hostpolicy.dll - this is a mock, will not actually load CoreCLR
             string mockHostPolicyFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("mockhostpolicy");
@@ -122,8 +121,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public DotNetBuilder AddMicrosoftNETCoreAppFrameworkMockCoreClr(string version, Action<NetCoreAppBuilder> customizer = null)
         {
             // ./shared/Microsoft.NETCore.App/<version> - create a mock of the root framework
-            string netCoreAppPath = Path.Combine(_path, "shared", "Microsoft.NETCore.App", version);
-            Directory.CreateDirectory(netCoreAppPath);
+            string netCoreAppPath = AddFramework(Constants.MicrosoftNETCoreApp, version);
 
             string hostPolicyFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("hostpolicy");
             string coreclrFileName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("coreclr");
@@ -131,9 +129,9 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
             string currentRid = _repoDirectories.TargetRID;
 
-            NetCoreAppBuilder.ForNETCoreApp("Microsoft.NETCore.App", currentRid)
+            NetCoreAppBuilder.ForNETCoreApp(Constants.MicrosoftNETCoreApp, currentRid)
                 .WithStandardRuntimeFallbacks()
-                .WithProject("Microsoft.NETCore.App", version, p => p
+                .WithProject(Constants.MicrosoftNETCoreApp, version, p => p
                     .WithNativeLibraryGroup(null, g => g
                         // ./shared/Microsoft.NETCore.App/<version>/coreclr.dll - this is a mock, will not actually run CoreClr
                         .WithAsset((new NetCoreAppBuilder.RuntimeFileBuilder($"runtimes/{currentRid}/native/{coreclrFileName}"))
@@ -158,19 +156,18 @@ namespace Microsoft.DotNet.CoreSetup.Test
         /// <param name="version">Framework version</param>
         /// <param name="runtimeConfigCustomizer">Customization function for the runtime config</param>
         /// <remarks>
-        /// The added mock framework will only contain a runtime.config.json file.
+        /// The added mock framework will only contain a deps.json and a runtime.config.json file.
         /// </remarks>
         public DotNetBuilder AddFramework(
             string name,
             string version,
             Action<RuntimeConfig> runtimeConfigCustomizer)
         {
-            // ./shared/<name>/<version> - create a mock of effectively empty non-root framework
-            string path = Path.Combine(_path, "shared", name, version);
-            Directory.CreateDirectory(path);
+            // ./shared/<name>/<version> - create a mock of the framework
+            string path = AddFramework(name, version);
 
             // ./shared/<name>/<version>/<name>.runtimeconfig.json - runtime config which can be customized
-            RuntimeConfig runtimeConfig = new RuntimeConfig(Path.Combine(path, name + ".runtimeconfig.json"));
+            RuntimeConfig runtimeConfig = new RuntimeConfig(Path.Combine(path, $"{name}.runtimeconfig.json"));
             runtimeConfigCustomizer(runtimeConfig);
             runtimeConfig.Save();
 
@@ -191,6 +188,27 @@ namespace Microsoft.DotNet.CoreSetup.Test
             dotnetRuntimeConfig.Save();
 
             return this;
+        }
+
+        /// <summary>
+        /// Add a minimal mock framework with the specified framework name and version
+        /// </summary>
+        /// <param name="name">Framework name</param>
+        /// <param name="version">Framework version</param>
+        /// <returns>Framework directory</returns>
+        /// <remarks>
+        /// The added mock framework will only contain a deps.json.
+        /// </remarks>
+        private string AddFramework(string name, string version)
+        {
+            // ./shared/<name>/<version> - create a mock of effectively the framework
+            string path = Path.Combine(_path, "shared", name, version);
+            Directory.CreateDirectory(path);
+
+            // ./shared/<name>/<version>/<name>.deps.json - empty file
+            File.WriteAllText(Path.Combine(path, $"{name}.deps.json"), string.Empty);
+
+            return path;
         }
 
         public DotNetCli Build()

--- a/src/native/corehost/fxr/framework_info.cpp
+++ b/src/native/corehost/fxr/framework_info.cpp
@@ -34,7 +34,7 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
 
 /*static*/ void framework_info::get_all_framework_infos(
     const pal::string_t& own_dir,
-    const pal::string_t& fx_name,
+    const pal::char_t* fx_name,
     std::vector<framework_info>* framework_infos)
 {
     std::vector<pal::string_t> hive_dir;
@@ -42,49 +42,58 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
 
     int32_t hive_depth = 0;
 
-    for (pal::string_t dir : hive_dir)
+    for (const pal::string_t& dir : hive_dir)
     {
         auto fx_shared_dir = dir;
         append_path(&fx_shared_dir, _X("shared"));
 
-        if (pal::directory_exists(fx_shared_dir))
+        if (!pal::directory_exists(fx_shared_dir))
+            continue;
+
+        std::vector<pal::string_t> fx_names;
+        if (fx_name != nullptr)
         {
-            std::vector<pal::string_t> fx_names;
-            if (fx_name.length())
-            {
-                // Use the provided framework name
-                fx_names.push_back(fx_name);
-            }
-            else
-            {
-                // Read all frameworks, including "Microsoft.NETCore.App"
-                pal::readdir_onlydirectories(fx_shared_dir, &fx_names);
-            }
+            // Use the provided framework name
+            fx_names.push_back(fx_name);
+        }
+        else
+        {
+            // Read all frameworks, including "Microsoft.NETCore.App"
+            pal::readdir_onlydirectories(fx_shared_dir, &fx_names);
+        }
 
-            for (pal::string_t fx_name : fx_names)
-            {
-                auto fx_dir = fx_shared_dir;
-                append_path(&fx_dir, fx_name.c_str());
+        for (const pal::string_t& fx_name_local : fx_names)
+        {
+            auto fx_dir = fx_shared_dir;
+            append_path(&fx_dir, fx_name_local.c_str());
 
-                if (pal::directory_exists(fx_dir))
+            if (!pal::directory_exists(fx_dir))
+                continue;
+
+            trace::verbose(_X("Gathering FX locations in [%s]"), fx_dir.c_str());
+
+            std::vector<pal::string_t> versions;
+            pal::readdir_onlydirectories(fx_dir, &versions);
+            for (const pal::string_t& ver : versions)
+            {
+                // Make sure we filter out any non-version folders.
+                fx_ver_t parsed;
+                if (!fx_ver_t::parse(ver, &parsed, false))
+                    continue;
+
+                // Check that the framework's .deps.json exists.
+                pal::string_t fx_version_dir = fx_dir;
+                append_path(&fx_version_dir, ver.c_str());
+                if (!library_exists_in_dir(fx_version_dir, fx_name_local + _X(".deps.json"), nullptr))
                 {
-                    trace::verbose(_X("Gathering FX locations in [%s]"), fx_dir.c_str());
-
-                    std::vector<pal::string_t> versions;
-                    pal::readdir_onlydirectories(fx_dir, &versions);
-                    for (const auto& ver : versions)
-                    {
-                        // Make sure we filter out any non-version folders.
-                        fx_ver_t parsed;
-                        if (fx_ver_t::parse(ver, &parsed, false))
-                        {
-                            trace::verbose(_X("Found FX version [%s]"), ver.c_str());
-
-                            framework_info info(fx_name, fx_dir, parsed, hive_depth);
-                            framework_infos->push_back(info);
-                        }
-                    }
+                    trace::verbose(_X("Ignoring FX version [%s] without .deps.json"), ver.c_str());
+                    continue;
                 }
+
+                trace::verbose(_X("Found FX version [%s]"), ver.c_str());
+
+                framework_info info(fx_name_local, fx_dir, parsed, hive_depth);
+                framework_infos->push_back(info);
             }
         }
 
@@ -97,7 +106,7 @@ bool compare_by_name_and_version(const framework_info &a, const framework_info &
 /*static*/ bool framework_info::print_all_frameworks(const pal::string_t& own_dir, const pal::string_t& leading_whitespace)
 {
     std::vector<framework_info> framework_infos;
-    get_all_framework_infos(own_dir, _X(""), &framework_infos);
+    get_all_framework_infos(own_dir, nullptr, &framework_infos);
     for (framework_info info : framework_infos)
     {
         trace::println(_X("%s%s %s [%s]"), leading_whitespace.c_str(), info.name.c_str(), info.version.as_str().c_str(), info.path.c_str());

--- a/src/native/corehost/fxr/framework_info.h
+++ b/src/native/corehost/fxr/framework_info.h
@@ -17,7 +17,7 @@ struct framework_info
 
     static void get_all_framework_infos(
         const pal::string_t& own_dir,
-        const pal::string_t& fx_name,
+        const pal::char_t* fx_name,
         std::vector<framework_info>* framework_infos);
 
     static bool print_all_frameworks(const pal::string_t& own_dir, const pal::string_t& leading_whitespace);

--- a/src/native/corehost/fxr/fx_resolver.cpp
+++ b/src/native/corehost/fxr/fx_resolver.cpp
@@ -174,9 +174,6 @@ namespace
 
         if (best_match == fx_ver_t())
         {
-            // This is not strictly necessary, we just need to return version which doesn't exist.
-            // But it's cleaner to return the desider reference then invalid -1.-1.-1 version.
-            best_match = fx_ref.get_fx_version_number();
             trace::verbose(_X("Framework reference didn't resolve to any available version."));
         }
         else if (trace::is_enabled())
@@ -211,7 +208,8 @@ namespace
         pal::string_t selected_fx_version;
         fx_ver_t selected_ver;
 
-        for (pal::string_t dir : hive_dir)
+        pal::string_t deps_file_name = fx_ref.get_fx_name() + _X(".deps.json");
+        for (pal::string_t& dir : hive_dir)
         {
             auto fx_dir = dir;
             trace::verbose(_X("Searching FX directory in [%s]"), fx_dir.c_str());
@@ -235,7 +233,7 @@ namespace
                     fx_ref.get_fx_version().c_str());
 
                 append_path(&fx_dir, fx_ref.get_fx_version().c_str());
-                if (pal::directory_exists(fx_dir))
+                if (library_exists_in_dir(fx_dir, deps_file_name, nullptr))
                 {
                     selected_fx_dir = fx_dir;
                     selected_fx_version = fx_ref.get_fx_version();
@@ -258,27 +256,39 @@ namespace
                 }
 
                 fx_ver_t resolved_ver = resolve_framework_reference_from_version_list(version_list, fx_ref);
-
-                pal::string_t resolved_ver_str = resolved_ver.as_str();
-                append_path(&fx_dir, resolved_ver_str.c_str());
-
-                if (pal::directory_exists(fx_dir))
+                while (resolved_ver != fx_ver_t())
                 {
-                    if (selected_ver != fx_ver_t())
+                    pal::string_t resolved_ver_str = resolved_ver.as_str();
+                    pal::string_t resolved_fx_dir = fx_dir;
+                    append_path(&resolved_fx_dir, resolved_ver_str.c_str());
+
+                    // Check that the framework's .deps.json exists. To minimize the file checks done in the most common
+                    // scenario (.deps.json exists), only check after resolving the version and if the .deps.json doesn't
+                    // exist, attempt resolving again without that version.
+                    if (!library_exists_in_dir(resolved_fx_dir, deps_file_name, nullptr))
                     {
-                        // Compare the previous hive_dir selection with the current hive_dir to see which one is the better match
-                        std::vector<fx_ver_t> version_list;
-                        version_list.push_back(resolved_ver);
-                        version_list.push_back(selected_ver);
+                        // Remove the version and try resolving again
+                        trace::verbose(_X("Ignoring FX version [%s] without .deps.json"), resolved_ver_str.c_str());
+                        version_list.erase(std::find(version_list.cbegin(), version_list.cend(), resolved_ver));
                         resolved_ver = resolve_framework_reference_from_version_list(version_list, fx_ref);
                     }
-
-                    if (resolved_ver != selected_ver)
+                    else
                     {
-                        trace::verbose(_X("Changing Selected FX version from [%s] to [%s]"), selected_fx_dir.c_str(), fx_dir.c_str());
-                        selected_ver = resolved_ver;
-                        selected_fx_dir = fx_dir;
-                        selected_fx_version = resolved_ver_str;
+                        if (selected_ver != fx_ver_t())
+                        {
+                            // Compare the previous hive_dir selection with the current hive_dir to see which one is the better match
+                            resolved_ver = resolve_framework_reference_from_version_list({ resolved_ver, selected_ver }, fx_ref);
+                        }
+
+                        if (resolved_ver != selected_ver)
+                        {
+                            trace::verbose(_X("Changing Selected FX version from [%s] to [%s]"), selected_fx_dir.c_str(), resolved_fx_dir.c_str());
+                            selected_ver = resolved_ver;
+                            selected_fx_dir = resolved_fx_dir;
+                            selected_fx_version = resolved_ver_str;
+                        }
+
+                        break;
                     }
                 }
             }

--- a/src/native/corehost/fxr/fx_resolver.messages.cpp
+++ b/src/native/corehost/fxr/fx_resolver.messages.cpp
@@ -100,14 +100,14 @@ void fx_resolver_t::display_missing_framework_error(
     if (fx_dir.length())
     {
         fx_ver_dirs = fx_dir;
-        framework_info::get_all_framework_infos(get_directory(fx_dir), fx_name, &framework_infos);
+        framework_info::get_all_framework_infos(get_directory(fx_dir), fx_name.c_str(), &framework_infos);
     }
     else
     {
         fx_ver_dirs = dotnet_root;
     }
 
-    framework_info::get_all_framework_infos(dotnet_root, fx_name, &framework_infos);
+    framework_info::get_all_framework_infos(dotnet_root, fx_name.c_str(), &framework_infos);
 
     // Display the error message about missing FX.
     if (fx_version.length())

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -425,7 +425,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_dotnet_environment_info(
     }
 
     std::vector<framework_info> framework_infos;
-    framework_info::get_all_framework_infos(dotnet_dir, _X(""), &framework_infos);
+    framework_info::get_all_framework_infos(dotnet_dir, nullptr, &framework_infos);
 
     std::vector<hostfxr_dotnet_environment_framework_info> environment_framework_infos;
     std::vector<pal::string_t> framework_versions;


### PR DESCRIPTION
This adds a check for the framework's .deps.json instead of just the existence of the directory. To avoid extra file checks in the normal/happy path (where all framework version folder are valid), when resolving, it only does the check after resolving the best version match. And if that version directory isn't valid, it tries resolving again without it.

Backport of #90035

## Customer Impact

The host treats the existence of a framework folder as a valid framework path. We've seen this cause issues as users can end up in this state without their knowledge - for example, uninstall leaves an empty folder, which would normally be harmless, except when we try to use it as a valid framework. This results in applications failing to run because we try to use that path as a framework. When users get into this state, it is not clear what is wrong and how to address it. They also remain in this broken state - typically until the framework is reinstalled or a newer version is installed.

See https://github.com/dotnet/runtime/issues/91806, https://github.com/dotnet/runtime/issues/48180

## Testing

Automated tests added. Manual validation.

## Risk

Low. The fix itself is fairly surgical - however, the change is on a path that every application will hit.