### PR TITLE
Doc fix-ups to InstrumentRule

### DIFF
--- a/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/InstrumentRule.cs
+++ b/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/src/Metrics/InstrumentRule.cs
@@ -7,43 +7,43 @@ using System.Diagnostics.Metrics;
 namespace Microsoft.Extensions.Diagnostics.Metrics
 {
     /// <summary>
-    /// A set of parameters used to determine which instruments are enabled for which listeners. Unspecified
+    /// Contains a set of parameters used to determine which instruments are enabled for which listeners. Unspecified
     /// parameters match anything.
     /// </summary>
     /// <remarks>
-    /// The most specific rule that matches a given instrument will be used. The priority of parameters is as follows:
-    /// - MeterName, either an exact match, or the longest prefix match. See <see cref="Meter.Name"/>.
-    /// - InstrumentName, an exact match. <see cref="Instrument.Name"/>.
-    /// - ListenerName, an exact match. <see cref="IMetricsListener.Name"/>.
-    /// - Scopes
+    /// <para>The most specific rule that matches a given instrument will be used. The priority of parameters is as follows:</para>
+    /// <para>- MeterName, either an exact match, or the longest prefix match. See <see cref="Meter.Name">Meter.Name</see>.</para>
+    /// <para>- InstrumentName, an exact match. <see cref="Instrument.Name">Instrument.Name</see>.</para>
+    /// <para>- ListenerName, an exact match. <see cref="IMetricsListener.Name">IMetricsListener.Name</see>.</para>
+    /// <para>- Scopes</para>
     /// </remarks>
-    /// <param name="meterName">The <see cref="Meter.Name"/> or prefix.</param>
-    /// <param name="instrumentName">The <see cref="Instrument.Name"/>.</param>
-    /// <param name="listenerName">The <see cref="IMetricsListener.Name"/>.</param>
+    /// <param name="meterName">The <see cref="Meter.Name">Meter.Name</see> or prefix.</param>
+    /// <param name="instrumentName">The <see cref="Instrument.Name">Instrument.Name</see>.</param>
+    /// <param name="listenerName">The <see cref="IMetricsListener.Name">IMetricsListener.Name</see>.</param>
     /// <param name="scopes">The <see cref="MeterScope"/>'s to consider.</param>
     /// <param name="enable">Enables or disabled the matched instrument for this listener.</param>
     public class InstrumentRule(string? meterName, string? instrumentName, string? listenerName, MeterScope scopes, bool enable)
     {
         /// <summary>
-        /// The <see cref="Meter.Name"/>, either an exact match or the longest prefix match. Only full segment matches are considered.
-        /// All meters are matched if this is null.
+        /// Gets the <see cref="Meter.Name">Meter.Name</see>, either an exact match or the longest prefix match. Only full segment matches are considered.
+        /// All meters are matched if this is <see langword="null" />.
         /// </summary>
         public string? MeterName { get; } = meterName;
 
         /// <summary>
-        /// The <see cref="Instrument.Name"/>, an exact match.
-        /// All instruments for the given meter are matched if this is null.
+        /// Gets the <see cref="Instrument.Name">Instrument.Name</see>, an exact match.
+        /// All instruments for the given meter are matched if this is <see langword="null" />.
         /// </summary>
         public string? InstrumentName { get; } = instrumentName;
 
         /// <summary>
-        /// The <see cref="IMetricsListener.Name"/>, an exact match.
-        /// All listeners are matched if this is null.
+        /// Gets the <see cref="IMetricsListener.Name">IMetricsListener.Name</see>, an exact match.
+        /// All listeners are matched if this is <see langword="null" />.
         /// </summary>
         public string? ListenerName { get; } = listenerName;
 
         /// <summary>
-        /// The <see cref="MeterScope"/>. This is used to distinguish between meters created via <see cref="Meter"/> constructors (<see cref="MeterScope.Global"/>)
+        /// Gets the <see cref="MeterScope"/>. This is used to distinguish between meters created via <see cref="Meter"/> constructors (<see cref="MeterScope.Global"/>)
         /// and those created via Dependency Injection with <see cref="IMeterFactory.Create(MeterOptions)"/> (<see cref="MeterScope.Local"/>)."/>.
         /// </summary>
         public MeterScope Scopes { get; } = scopes == MeterScope.None
@@ -51,7 +51,7 @@ namespace Microsoft.Extensions.Diagnostics.Metrics
             : scopes;
 
         /// <summary>
-        /// Indicates if the instrument should be enabled for the listener.
+        /// Gets a value that indicates whether the instrument should be enabled for the listener.
         /// </summary>
         public bool Enable { get; } = enable;
     }


### PR DESCRIPTION
Changed the crefs to display the type and property name to distinguish between the Name properties on [learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/api/Microsoft.Extensions.Diagnostics.Metrics.InstrumentRule?view=dotnet-plat-ext-8.0):

<img width="450" alt="image" src="https://github.com/dotnet/runtime/assets/24882762/a7d201fe-4ac9-45ab-af4d-ab289c7520fe">

Also made some other improvements.