### PR TITLE
[mono][wasm] Only catch the exception thrown by mono_llvm_cpp_throw_e…

### DIFF
--- a/src/mono/mono/mini/llvm-intrinsics.h
+++ b/src/mono/mono/mini/llvm-intrinsics.h
@@ -107,7 +107,7 @@ INTRINS_OVR_TAG(SIMD_CEIL, ceil, Generic, Scalar | V64 | V128 | R4 | R8)
 INTRINS_OVR_TAG(SIMD_TRUNC, trunc, Generic, Scalar | V64 | V128 | R4 | R8)
 INTRINS_OVR_TAG(SIMD_ROUND, round, Generic, Scalar | V64 | V128 | R4 | R8)
 INTRINS_OVR_TAG(SIMD_NEAREST, nearbyint, Generic, V64 | V128 | R4 | R8)
-
+INTRINS(EH_TYPEID_FOR, eh_typeid_for, Generic)
 #if LLVM_API_VERSION >= 1400
 INTRINS_OVR_TAG(ROUNDEVEN, roundeven, Generic, Scalar | V64 | V128 | R4 | R8)
 #endif
@@ -302,6 +302,9 @@ INTRINS_OVR(WASM_SUB_SAT_SIGNED_V8, wasm_sub_sat_signed, Wasm, sse_i2_t)
 INTRINS_OVR(WASM_SUB_SAT_UNSIGNED_V16, wasm_sub_sat_unsigned, Wasm, sse_i1_t)
 INTRINS_OVR(WASM_SUB_SAT_UNSIGNED_V8, wasm_sub_sat_unsigned, Wasm, sse_i2_t)
 INTRINS(WASM_SWIZZLE, wasm_swizzle, Wasm)
+INTRINS(WASM_GET_EXCEPTION, wasm_get_exception, Wasm)
+INTRINS(WASM_GET_EHSELECTOR, wasm_get_ehselector, Wasm)
+INTRINS(WASM_RETHROW, wasm_rethrow, Wasm)
 #endif
 #if defined(TARGET_ARM64)
 INTRINS_OVR(BITREVERSE_I32, bitreverse, Generic, LLVMInt32Type ())


### PR DESCRIPTION
…xception() in AOT-ed code.

Part of the fix for https://github.com/dotnet/runtime/issues/90692.