### PR TITLE
[iOS][Android] Refactor invoking native handler in HttpClientHandler

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.InvokeNativeHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.InvokeNativeHandler.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Security;
 using System.Reflection;
@@ -33,115 +35,116 @@ namespace System.Net.Http
 #error Unknown target
 #endif
 
-        private ICredentials? GetDefaultProxyCredentials()
-            => (ICredentials?)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_DefaultProxyCredentials")!);
+        private static ICredentials? GetDefaultProxyCredentials(HttpMessageHandler nativeHandler)
+            => (ICredentials?)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_DefaultProxyCredentials")!);
 
-        private void SetDefaultProxyCredentials(ICredentials? value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_DefaultProxyCredentials")!, value);
+        private static void SetDefaultProxyCredentials(HttpMessageHandler nativeHandler, ICredentials? value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_DefaultProxyCredentials")!, new object?[] { value });
 
-        private int GetMaxConnectionsPerServer()
-            => (int)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_MaxConnectionsPerServer")!);
+        private static int GetMaxConnectionsPerServer(HttpMessageHandler nativeHandler)
+            => (int)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_MaxConnectionsPerServer")!);
 
-        private void SetMaxConnectionsPerServer(int value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_MaxConnectionsPerServer")!, value);
+        private static void SetMaxConnectionsPerServer(HttpMessageHandler nativeHandler, int value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_MaxConnectionsPerServer")!, new object?[] { value });
 
-        private int GetMaxResponseHeadersLength()
-            => (int)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_MaxResponseHeadersLength")!);
+        private static int GetMaxResponseHeadersLength(HttpMessageHandler nativeHandler)
+            => (int)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_MaxResponseHeadersLength")!);
 
-        private void SetMaxResponseHeadersLength(int value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_MaxResponseHeadersLength")!, value);
+        private static void SetMaxResponseHeadersLength(HttpMessageHandler nativeHandler, int value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_MaxResponseHeadersLength")!, new object?[] { value });
 
-        private ClientCertificateOption GetClientCertificateOptions()
-            => (ClientCertificateOption)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_ClientCertificateOptions")!);
+        private static ClientCertificateOption GetClientCertificateOptions(HttpMessageHandler nativeHandler)
+            => (ClientCertificateOption)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_ClientCertificateOptions")!);
 
-        private void SetClientCertificateOptions(ClientCertificateOption value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_ClientCertificateOptions")!, value);
+        private static void SetClientCertificateOptions(HttpMessageHandler nativeHandler, ClientCertificateOption value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_ClientCertificateOptions")!, new object?[] { value });
 
-        private X509CertificateCollection GetClientCertificates()
-            => (X509CertificateCollection)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_ClientCertificates")!);
+        private static X509CertificateCollection GetClientCertificates(HttpMessageHandler nativeHandler)
+            => (X509CertificateCollection)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_ClientCertificates")!);
 
-        private Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool> GetServerCertificateCustomValidationCallback()
-            => (Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_ServerCertificateCustomValidationCallback")!);
+        private static Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool> GetServerCertificateCustomValidationCallback(HttpMessageHandler nativeHandler)
+            => (Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_ServerCertificateCustomValidationCallback")!);
 
-        private void SetServerCertificateCustomValidationCallback(Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>? value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_ServerCertificateCustomValidationCallback")!, value);
+        private static void SetServerCertificateCustomValidationCallback(HttpMessageHandler nativeHandler, Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>? value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_ServerCertificateCustomValidationCallback")!, new object?[] { value });
 
-        private bool GetCheckCertificateRevocationList()
-            => (bool)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_CheckCertificateRevocationList")!);
+        private static bool GetCheckCertificateRevocationList(HttpMessageHandler nativeHandler)
+            => (bool)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_CheckCertificateRevocationList")!);
 
-        private void SetCheckCertificateRevocationList(bool value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_CheckCertificateRevocationList")!, value);
+        private static void SetCheckCertificateRevocationList(HttpMessageHandler nativeHandler, bool value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_CheckCertificateRevocationList")!, new object?[] { value });
 
-        private SslProtocols GetSslProtocols()
-            => (SslProtocols)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_SslProtocols")!);
+        private static SslProtocols GetSslProtocols(HttpMessageHandler nativeHandler)
+            => (SslProtocols)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_SslProtocols")!);
 
-        private void SetSslProtocols(SslProtocols value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_SslProtocols")!, value);
+        private static void SetSslProtocols(HttpMessageHandler nativeHandler, SslProtocols value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_SslProtocols")!, new object?[] { value });
 
-        private IDictionary<string, object?> GetProperties()
-            => (IDictionary<string, object?>)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_Properties")!);
+        private static IDictionary<string, object?> GetProperties(HttpMessageHandler nativeHandler)
+            => (IDictionary<string, object?>)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_Properties")!);
 
-        private bool GetSupportsAutomaticDecompression()
-            => (bool)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_SupportsAutomaticDecompression")!);
+        private static bool GetSupportsAutomaticDecompression(HttpMessageHandler nativeHandler)
+            => (bool)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_SupportsAutomaticDecompression")!);
 
-        private bool GetSupportsProxy()
-            => (bool)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_SupportsProxy")!);
+        private static bool GetSupportsProxy(HttpMessageHandler nativeHandler)
+            => (bool)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_SupportsProxy")!);
 
-        private bool GetSupportsRedirectConfiguration()
-            => (bool)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_SupportsRedirectConfiguration")!);
+        private static bool GetSupportsRedirectConfiguration(HttpMessageHandler nativeHandler)
+            => (bool)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_SupportsRedirectConfiguration")!);
 
-        private DecompressionMethods GetAutomaticDecompression()
-            => (DecompressionMethods)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_AutomaticDecompression")!);
+        private static DecompressionMethods GetAutomaticDecompression(HttpMessageHandler nativeHandler)
+            => (DecompressionMethods)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_AutomaticDecompression")!);
 
-        private void SetAutomaticDecompression(DecompressionMethods value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_AutomaticDecompression")!, value);
+        private static void SetAutomaticDecompression(HttpMessageHandler nativeHandler, DecompressionMethods value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_AutomaticDecompression")!, new object?[] { value });
 
-        private bool GetUseProxy()
-            => (bool)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_UseProxy")!);
+        private static bool GetUseProxy(HttpMessageHandler nativeHandler)
+            => (bool)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_UseProxy")!);
 
-        private void SetUseProxy(bool value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_UseProxy")!, value);
+        private static void SetUseProxy(HttpMessageHandler nativeHandler, bool value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_UseProxy")!, new object?[] { value });
 
-        private IWebProxy GetProxy()
-            => (IWebProxy)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_Proxy")!);
+        private static IWebProxy GetProxy(HttpMessageHandler nativeHandler)
+            => (IWebProxy)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_Proxy")!);
 
-        private void SetProxy(IWebProxy value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_Proxy")!, value);
+        private static void SetProxy(HttpMessageHandler nativeHandler, IWebProxy value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_Proxy")!, new object?[] { value });
 
-        private bool GetPreAuthenticate()
-            => (bool)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_PreAuthenticate")!);
+        private static bool GetPreAuthenticate(HttpMessageHandler nativeHandler)
+            => (bool)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_PreAuthenticate")!);
 
-        private void SetPreAuthenticate(bool value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_PreAuthenticate")!, value);
+        private static void SetPreAuthenticate(HttpMessageHandler nativeHandler, bool value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_PreAuthenticate")!, new object?[] { value });
 
-        private int GetMaxAutomaticRedirections()
-            => (int)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_MaxAutomaticRedirections")!);
+        private static int GetMaxAutomaticRedirections(HttpMessageHandler nativeHandler)
+            => (int)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_MaxAutomaticRedirections")!);
 
-        private void SetMaxAutomaticRedirections(int value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_MaxAutomaticRedirections")!, value);
+        private static void SetMaxAutomaticRedirections(HttpMessageHandler nativeHandler, int value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_MaxAutomaticRedirections")!, new object?[] { value });
 
-        private bool GetUseCookies() => (bool)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_UseCookies")!);
+        private static bool GetUseCookies(HttpMessageHandler nativeHandler)
+            => (bool)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_UseCookies")!);
 
-        private void SetUseCookies(bool value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_UseCookies")!, value);
+        private static void SetUseCookies(HttpMessageHandler nativeHandler, bool value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_UseCookies")!, new object?[] { value });
 
-        private CookieContainer GetCookieContainer()
-            => (CookieContainer)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_CookieContainer")!);
+        private static CookieContainer GetCookieContainer(HttpMessageHandler nativeHandler)
+            => (CookieContainer)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_CookieContainer")!);
 
-        private void SetCookieContainer(CookieContainer value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_CookieContainer")!, value);
+        private static void SetCookieContainer(HttpMessageHandler nativeHandler, CookieContainer value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_CookieContainer")!, new object?[] { value });
 
-        private bool GetAllowAutoRedirect()
-            => (bool)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_AllowAutoRedirect")!);
+        private static bool GetAllowAutoRedirect(HttpMessageHandler nativeHandler)
+            => (bool)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_AllowAutoRedirect")!);
 
-        private void SetAllowAutoRedirect(bool value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_AllowAutoRedirect")!, value);
+        private static void SetAllowAutoRedirect(HttpMessageHandler nativeHandler, bool value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_AllowAutoRedirect")!, new object?[] { value });
 
-        private ICredentials GetCredentials()
-            => (ICredentials)InvokeNativeHandlerGetter(() => Type.GetType(NativeHandlerType)!.GetMethod("get_Credentials")!);
+        private static ICredentials GetCredentials(HttpMessageHandler nativeHandler)
+            => (ICredentials)NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("get_Credentials")!);
 
-        private void SetCredentials(ICredentials? value)
-            => InvokeNativeHandlerSetter(() => Type.GetType(NativeHandlerType)!.GetMethod("set_Credentials")!, value);
+        private static void SetCredentials(HttpMessageHandler nativeHandler, ICredentials? value)
+            => NativeHandlerInvoker.Invoke(nativeHandler, static () => Type.GetType(NativeHandlerType)!.GetMethod("set_Credentials")!, new object?[] { value });
 
         private static HttpMessageHandler CreateNativeHandler()
         {
@@ -153,18 +156,14 @@ namespace System.Net.Http
 
             return (HttpMessageHandler)_nativeHandlerMethod!.Invoke(null, null)!;
         }
+    }
 
-        private object InvokeNativeHandlerGetter(Func<MethodInfo> getMethod, [CallerMemberName] string? cachingKey = null)
-        {
-            return InvokeNativeHandlerMethod(getMethod, parameters: null, cachingKey!);
-        }
-
-        private void InvokeNativeHandlerSetter(Func<MethodInfo> getMethod, object? value, [CallerMemberName] string? cachingKey = null)
-        {
-            InvokeNativeHandlerMethod(getMethod, parameters: new object?[] { value }, cachingKey!);
-        }
-
-        private object InvokeNativeHandlerMethod(Func<MethodInfo> getMethod, object?[]? parameters, string cachingKey)
+#pragma warning disable SA1400 // Access modifier should be declared https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3659
+    file static class NativeHandlerInvoker
+#pragma warning restore SA1400 // Access modifier should be declared
+    {
+        private static readonly ConcurrentDictionary<int, MethodInfo?> s_cachedMethods = new();
+        internal static object Invoke(HttpMessageHandler nativeHandler, Func<MethodInfo> getMethod, object?[]? parameters = null, [CallerLineNumber] int cachingKey = 0)
         {
             MethodInfo? method;
 
@@ -176,7 +175,7 @@ namespace System.Net.Http
 
             try
             {
-                return method!.Invoke(_nativeHandler, parameters)!;
+                return method!.Invoke(nativeHandler, parameters)!;
             }
             catch (TargetInvocationException e)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
@@ -1,10 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.Net.Http.Metrics;
@@ -20,8 +18,6 @@ namespace System.Net.Http
 {
     public partial class HttpClientHandler : HttpMessageHandler
     {
-        private static readonly ConcurrentDictionary<string, MethodInfo?> s_cachedMethods = new();
-
         private readonly HttpMessageHandler? _nativeHandler;
         private IMeterFactory? _nativeMeterFactory;
         private MetricsHandler? _nativeMetricsHandler;
@@ -139,7 +135,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetUseCookies();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetUseCookies(_nativeHandler!);
                 }
                 else
                 {
@@ -150,7 +147,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetUseCookies(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetUseCookies(_nativeHandler!, value);
                 }
                 else
                 {
@@ -166,7 +164,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetCookieContainer();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetCookieContainer(_nativeHandler!);
                 }
                 else
                 {
@@ -179,7 +178,8 @@ namespace System.Net.Http
 
                 if (IsNativeHandlerEnabled)
                 {
-                    SetCookieContainer(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetCookieContainer(_nativeHandler!, value);
                 }
                 else
                 {
@@ -195,7 +195,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetDefaultProxyCredentials();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetDefaultProxyCredentials(_nativeHandler!);
                 }
                 else
                 {
@@ -206,7 +207,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetDefaultProxyCredentials(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetDefaultProxyCredentials(_nativeHandler!, value);
                 }
                 else
                 {
@@ -226,7 +228,8 @@ namespace System.Net.Http
                 ICredentials? creds;
                 if (IsNativeHandlerEnabled)
                 {
-                    creds = GetCredentials();
+                    Debug.Assert(_nativeHandler is not null);
+                    creds = GetCredentials(_nativeHandler!);
                 }
                 else
                 {
@@ -241,7 +244,8 @@ namespace System.Net.Http
                 {
                     if (IsNativeHandlerEnabled)
                     {
-                        SetCredentials(CredentialCache.DefaultCredentials);
+                        Debug.Assert(_nativeHandler is not null);
+                        SetCredentials(_nativeHandler!, CredentialCache.DefaultCredentials);
                     }
                     else
                     {
@@ -252,11 +256,12 @@ namespace System.Net.Http
                 {
                     if (IsNativeHandlerEnabled)
                     {
-                        ICredentials? creds = GetCredentials();
+                        Debug.Assert(_nativeHandler is not null);
+                        ICredentials? creds = GetCredentials(_nativeHandler!);
 
                         if (creds == CredentialCache.DefaultCredentials)
                         {
-                            SetCredentials(null!);
+                            SetCredentials(_nativeHandler!, null!);
                         }
                     }
                     else
@@ -277,7 +282,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetCredentials();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetCredentials(_nativeHandler!);
                 }
                 else
                 {
@@ -289,7 +295,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetCredentials(value!);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetCredentials(_nativeHandler!, value!);
                 }
                 else
                 {
@@ -304,7 +311,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetAllowAutoRedirect();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetAllowAutoRedirect(_nativeHandler!);
                 }
                 else
                 {
@@ -315,7 +323,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetAllowAutoRedirect(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetAllowAutoRedirect(_nativeHandler!, value);
                 }
                 else
                 {
@@ -331,7 +340,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetMaxConnectionsPerServer();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetMaxConnectionsPerServer(_nativeHandler!);
                 }
                 else
                 {
@@ -342,7 +352,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetMaxConnectionsPerServer(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetMaxConnectionsPerServer(_nativeHandler!, value);
                 }
                 else
                 {
@@ -388,7 +399,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetMaxResponseHeadersLength();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetMaxResponseHeadersLength(_nativeHandler!);
                 }
                 else
                 {
@@ -399,7 +411,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetMaxResponseHeadersLength(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetMaxResponseHeadersLength(_nativeHandler!, value);
                 }
                 else
                 {
@@ -414,7 +427,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetClientCertificateOptions();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetClientCertificateOptions(_nativeHandler!);
                 }
                 else
                 {
@@ -425,7 +439,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetClientCertificateOptions(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetClientCertificateOptions(_nativeHandler!, value);
                 }
                 else
                 {
@@ -457,7 +472,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetClientCertificates();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetClientCertificates(_nativeHandler!);
                 }
                 else
                 {
@@ -479,7 +495,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetServerCertificateCustomValidationCallback();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetServerCertificateCustomValidationCallback(_nativeHandler!);
                 }
                 else
                 {
@@ -490,7 +507,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetServerCertificateCustomValidationCallback(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetServerCertificateCustomValidationCallback(_nativeHandler!, value);
                 }
                 else
                 {
@@ -509,7 +527,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetCheckCertificateRevocationList();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetCheckCertificateRevocationList(_nativeHandler!);
                 }
                 else
                 {
@@ -520,7 +539,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetCheckCertificateRevocationList(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetCheckCertificateRevocationList(_nativeHandler!, value);
                 }
                 else
                 {
@@ -537,7 +557,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetSslProtocols();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetSslProtocols(_nativeHandler!);
                 }
                 else
                 {
@@ -548,7 +569,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetSslProtocols(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetSslProtocols(_nativeHandler!, value);
                 }
                 else
                 {
@@ -564,7 +586,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetProperties();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetProperties(_nativeHandler!);
                 }
                 else
                 {
@@ -579,7 +602,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetSupportsAutomaticDecompression();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetSupportsAutomaticDecompression(_nativeHandler!);
                 }
                 else
                 {
@@ -594,7 +618,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetSupportsProxy();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetSupportsProxy(_nativeHandler!);
                 }
                 else
                 {
@@ -609,7 +634,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetSupportsRedirectConfiguration();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetSupportsRedirectConfiguration(_nativeHandler!);
                 }
                 else
                 {
@@ -625,7 +651,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetAutomaticDecompression();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetAutomaticDecompression(_nativeHandler!);
                 }
                 else
                 {
@@ -636,7 +663,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetAutomaticDecompression(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetAutomaticDecompression(_nativeHandler!, value);
                 }
                 else
                 {
@@ -652,7 +680,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetUseProxy();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetUseProxy(_nativeHandler!);
                 }
                 else
                 {
@@ -663,7 +692,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetUseProxy(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetUseProxy(_nativeHandler!, value);
                 }
                 else
                 {
@@ -681,7 +711,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetProxy();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetProxy(_nativeHandler!);
                 }
                 else
                 {
@@ -692,7 +723,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetProxy(value!);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetProxy(_nativeHandler!, value!);
                 }
                 else
                 {
@@ -708,7 +740,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetPreAuthenticate();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetPreAuthenticate(_nativeHandler!);
                 }
                 else
                 {
@@ -719,7 +752,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetPreAuthenticate(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetPreAuthenticate(_nativeHandler!, value);
                 }
                 else
                 {
@@ -735,7 +769,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    return GetMaxAutomaticRedirections();
+                    Debug.Assert(_nativeHandler is not null);
+                    return GetMaxAutomaticRedirections(_nativeHandler!);
                 }
                 else
                 {
@@ -746,7 +781,8 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    SetMaxAutomaticRedirections(value);
+                    Debug.Assert(_nativeHandler is not null);
+                    SetMaxAutomaticRedirections(_nativeHandler!, value);
                 }
                 else
                 {


### PR DESCRIPTION
This is a follow-up to #91520 to address @marek-safar's comments.

I explored the idea of using `[CallerLineNumber]` as the caching key. To make it harder to cause collisions, I wrapped the invoking method in a `file` scoped static class. I'm still not sure it's a good idea so I'm keeping this PR as a draft for now.

In the long term, we should be able to replace all of this logic with `[UnsafeAccessor]` methods once the new API proposal for `[UnsafeAccessorType]` is approved and implemented.