### PR TITLE
Implement support for `InlineArray` in the trimmer

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCases/TestDatabase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCases/TestDatabase.cs
@@ -29,6 +29,11 @@ namespace Mono.Linker.Tests.TestCases
 			return TestNamesBySuiteName ();
 		}
 
+		public static IEnumerable<object[]> InlineArrays ()
+		{
+			return TestNamesBySuiteName();
+		}
+
 		public static IEnumerable<object[]> LinkXml()
 		{
 			return TestNamesBySuiteName();

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCases/TestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCases/TestSuites.cs
@@ -31,6 +31,13 @@ namespace Mono.Linker.Tests.TestCases
 		}
 
 		[Theory]
+		[MemberData(nameof(TestDatabase.InlineArrays), MemberType = typeof(TestDatabase))]
+		public void InlineArrays(string t)
+		{
+			Run(t);
+		}
+
+		[Theory]
 		[MemberData (nameof (TestDatabase.LinkXml), MemberType = typeof (TestDatabase))]
 		public void LinkXml (string t)
 		{

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TestCaseCompilationMetadataProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TestCaseCompilationMetadataProvider.cs
@@ -129,9 +129,11 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 				yield return Path.Combine (referenceDir, "mscorlib.dll");
 				yield return Path.Combine (referenceDir, "System.Collections.dll");
+				yield return Path.Combine (referenceDir, "System.Collections.Immutable.dll");
 				yield return Path.Combine (referenceDir, "System.ComponentModel.TypeConverter.dll");
 				yield return Path.Combine (referenceDir, "System.Console.dll");
 				yield return Path.Combine (referenceDir, "System.Linq.Expressions.dll");
+				yield return Path.Combine (referenceDir, "System.Memory.dll");
 				yield return Path.Combine (referenceDir, "System.ObjectModel.dll");
 				yield return Path.Combine (referenceDir, "System.Runtime.dll");
 				yield return Path.Combine (referenceDir, "System.Runtime.Extensions.dll");

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -3318,9 +3318,21 @@ namespace Mono.Linker.Steps
 			if (type?.HasFields != true)
 				return;
 
-			// keep fields for types with explicit layout and for enums
-			if (!type.IsAutoLayout || type.IsEnum)
+			// keep fields for types with explicit layout, for enums and for InlineArray types
+			if (!type.IsAutoLayout || type.IsEnum || TypeIsInlineArrayType(type))
 				MarkFields (type, includeStatic: type.IsEnum, reason: new DependencyInfo (DependencyKind.MemberOfType, type));
+		}
+
+		static bool TypeIsInlineArrayType(TypeDefinition type)
+		{
+			if (!type.IsValueType)
+				return false;
+
+			foreach (var customAttribute in type.CustomAttributes)
+				if (customAttribute.AttributeType.IsTypeOf ("System.Runtime.CompilerServices", "InlineArrayAttribute"))
+					return true;
+
+			return false;
 		}
 
 		protected virtual void MarkRequirementsForInstantiatedTypes (TypeDefinition type)

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -150,6 +150,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task InlineArrayDataflow ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task MakeGenericDataFlow ()
 		{
 			return RunTest ();

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/InlineArraysTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/InlineArraysTests.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ILLink.RoslynAnalyzer.Tests
+{
+	public sealed partial class InlineArraysTests : LinkerTestBase
+	{
+		protected override string TestSuiteName => "InlineArrays";
+
+		[Fact]
+		public Task InlineArray ()
+		{
+			return RunTest (nameof (InlineArray));
+		}
+
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/InlineArrayDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/InlineArrayDataflow.cs
@@ -63,7 +63,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public Type value;
 		}
 
-		// Currently tracking og annotations on inline array values is not implemented
+		// Currently tracking of annotations on inline array values is not implemented
 		[ExpectedWarning("IL2065", "GetProperty", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 		static void AccessAnnotatedTypeArray ()
 		{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/InlineArrayDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/InlineArrayDataflow.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SkipKeptItemsValidation]
+	[ExpectedNoWarnings]
+	public class InlineArrayDataflow
+	{
+		public static void Main()
+		{
+			AccessPrimitiveTypeArray ();
+			AccessUnannotatedTypeArray ();
+			AccessAnnotatedTypeArray ();
+		}
+
+		public int TestProperty { get; set; }
+
+		[InlineArray (5)]
+		struct PrimitiveTypeArray
+		{
+			public BindingFlags value;
+		}
+
+		// This case will fallback to not understanding the binding flags and will end up marking all properties
+		static void AccessPrimitiveTypeArray ()
+		{
+			PrimitiveTypeArray a = new PrimitiveTypeArray ();
+			ref var item = ref a[1];
+			item = BindingFlags.Public;
+
+			typeof (InlineArrayDataflow).GetProperty (nameof (TestProperty), a[1]);
+		}
+
+		[InlineArray (5)]
+		struct UnannotatedTypeArray
+		{
+			public Type value;
+		}
+
+		// Analyzer doesn't understand inline arrays currently - so it doesn't produce a warning here
+		[ExpectedWarning ("IL2065", "GetProperty", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+		static void AccessUnannotatedTypeArray ()
+		{
+			UnannotatedTypeArray a = new UnannotatedTypeArray ();
+			ref var item = ref a[2];
+			item = typeof (InlineArrayDataflow);
+
+			a[2].GetProperty (nameof (TestProperty));
+		}
+
+		[InlineArray (5)]
+		struct AnnotatedTypeArray
+		{
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]
+			public Type value;
+		}
+
+		// Currently tracking og annotations on inline array values is not implemented
+		[ExpectedWarning("IL2065", "GetProperty", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+		static void AccessAnnotatedTypeArray ()
+		{
+			AnnotatedTypeArray a = new AnnotatedTypeArray ();
+			ref var item = ref a[3];
+			item = typeof (InlineArrayDataflow);
+
+			a[3].GetProperty (nameof (TestProperty));
+		}
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/InlineArrays/InlineArray.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/InlineArrays/InlineArray.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.InlineArrays
+{
+	[ExpectedNoWarnings]
+	public class InlineArray
+	{
+		public static void Main()
+		{
+			InlineArrayUsage.Test ();
+			CollectionLiteralsOfArrays.Test ();
+		}
+
+		[Kept]
+		class InlineArrayUsage
+		{
+			// NativeAOT will remove most of the struct type information as it's not needed
+			// in the generated native code. Eventually we might come up with a better test infra to validate this.
+			[Kept (By = Tool.Trimmer)]
+			public struct StructWithFixedBuffer
+			{
+				[Kept (By = Tool.Trimmer)]
+				public FixedBuffer Buffer;
+
+				[Kept (By = Tool.Trimmer)]
+				[KeptAttributeAttribute (typeof(InlineArrayAttribute), By = Tool.Trimmer)]
+				[InlineArray (8)]
+				public partial struct FixedBuffer
+				{
+					[Kept (By = Tool.Trimmer)]
+					public int e0;
+				}
+			}
+
+			[Kept (By = Tool.Trimmer)]
+			public struct StructWithAutoLayoutBuffer
+			{
+				[Kept (By = Tool.Trimmer)]
+				public AutoLayoutBuffer Buffer;
+
+				[Kept (By = Tool.Trimmer)]
+				[KeptAttributeAttribute (typeof (InlineArrayAttribute), By = Tool.Trimmer)]
+				[InlineArray (8)]
+				[StructLayout (LayoutKind.Auto)]
+				public struct AutoLayoutBuffer
+				{
+					[Kept (By = Tool.Trimmer)]
+					public int e0;
+				}
+			}
+
+			[Kept]
+			public static void Test ()
+			{
+				var s = new StructWithFixedBuffer ();
+				s.Buffer[0] = 5;
+
+				var sa = new StructWithAutoLayoutBuffer ();
+				_ = sa.Buffer[1];
+			}
+		}
+
+		[Kept]
+		[KeptMember (".cctor()")]
+		class CollectionLiteralsOfArrays
+		{
+			[Kept]
+			public static readonly ImmutableArray<string> ImmutableValues = ["one", "two"];
+			[Kept]
+			public static readonly string[] ArrayValues = ["one", "two"];
+
+			[Kept]
+			public static void Test()
+			{
+				_ = CollectionLiteralsOfArrays.ImmutableValues[0];
+				_ = CollectionLiteralsOfArrays.ArrayValues[1];
+			}
+		}
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -119,6 +119,11 @@ namespace Mono.Linker.Tests.TestCases
 			return NUnitCasesBySuiteName ("Inheritance.VirtualMethods");
 		}
 
+		public static IEnumerable<TestCaseData> InlineArrayTests ()
+		{
+			return NUnitCasesBySuiteName ("InlineArrays");
+		}
+
 		public static IEnumerable<TestCaseData> InteropTests ()
 		{
 			return NUnitCasesBySuiteName ("Interop");

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestSuites.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestSuites.cs
@@ -142,6 +142,12 @@ namespace Mono.Linker.Tests.TestCases
 			Run (testCase);
 		}
 
+		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.InlineArrayTests))]
+		public void InlineArrayTests (TestCase testCase)
+		{
+			Run (testCase);
+		}
+
 		[TestCaseSource (typeof (TestDatabase), nameof (TestDatabase.InteropTests))]
 		public void InteropTests (TestCase testCase)
 		{

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompilationMetadataProvider.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompilationMetadataProvider.cs
@@ -148,9 +148,11 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 				yield return Path.Combine (referenceDir, "mscorlib.dll");
 				yield return Path.Combine (referenceDir, "System.Collections.dll");
+				yield return Path.Combine (referenceDir, "System.Collections.Immutable.dll");
 				yield return Path.Combine (referenceDir, "System.ComponentModel.TypeConverter.dll");
 				yield return Path.Combine (referenceDir, "System.Console.dll");
 				yield return Path.Combine (referenceDir, "System.Linq.Expressions.dll");
+				yield return Path.Combine (referenceDir, "System.Memory.dll");
 				yield return Path.Combine (referenceDir, "System.ObjectModel.dll");
 				yield return Path.Combine (referenceDir, "System.Runtime.dll");
 				yield return Path.Combine (referenceDir, "System.Runtime.Extensions.dll");


### PR DESCRIPTION
Types annotated with `InlineArray` need to preserve all of their fields, even if otherwise this would not be the case. It's possible to have a struct with `LayoutKind.Auto` and with `InlineArray` - trimmer would normally trim fields on such struct. This leads to corruption since the field is never accessed directly.

This changes the marking to preserve all fields on a type with `InlineArray` attribute just like we would for explicit layout struct and similar other types.

Adds tests to cover both the explicit usage of `InlineArray` attribute as well as the compiler generate usage via collection literals.

This should resolve the trimming part of https://github.com/dotnet/runtime/issues/92022
And it also adds tests for https://github.com/dotnet/runtime/issues/88684