### PR TITLE
[wasm] Fix performance-setup.sh to track change in BDN

### DIFF
--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -430,7 +430,7 @@ if [[ -n "$wasm_bundle_directory" ]]; then
     fi
 
     # Workaround: escaping the quotes around `--wasmArgs=..` so they get retained for the actual command line
-    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --wasmEngine $javascript_engine_path --wasmArgs=\\\"$wasm_args\\\" --cli \$HELIX_CORRELATION_PAYLOAD/dotnet/dotnet --wasmDataDir \$HELIX_CORRELATION_PAYLOAD/wasm-data"
+    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --wasmEngine $javascript_engine_path \\\"--wasmArgs=$wasm_args\\\" --cli \$HELIX_CORRELATION_PAYLOAD/dotnet/dotnet --wasmDataDir \$HELIX_CORRELATION_PAYLOAD/wasm-data"
     if [[ "$wasmaot" == "true" ]]; then
         extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --aotcompilermode wasm --buildTimeout 3600"
     fi

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -430,7 +430,7 @@ if [[ -n "$wasm_bundle_directory" ]]; then
     fi
 
     # Workaround: escaping the quotes around `--wasmArgs=..` so they get retained for the actual command line
-    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --wasmEngine $javascript_engine_path --wasmArgs \\\"$wasm_args\\\" --cli \$HELIX_CORRELATION_PAYLOAD/dotnet/dotnet --wasmDataDir \$HELIX_CORRELATION_PAYLOAD/wasm-data"
+    extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --wasmEngine $javascript_engine_path --wasmArgs=\\\"$wasm_args\\\" --cli \$HELIX_CORRELATION_PAYLOAD/dotnet/dotnet --wasmDataDir \$HELIX_CORRELATION_PAYLOAD/wasm-data"
     if [[ "$wasmaot" == "true" ]]; then
         extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --aotcompilermode wasm --buildTimeout 3600"
     fi


### PR DESCRIPTION
`dotnet/performance` got an update for `dotnet/BenchmarkDotNet` via
https://github.com/dotnet/performance/pull/3331 . And that bdn update
includes https://github.com/dotnet/BenchmarkDotNet/pull/2375, which
subtly changes how the arguments get parsed, and breaks the existing
scripts:

```
$ pushd "/home/helixbot/work/B807097D/w/AED609DF/e/performance/artifacts/bin/for-running/MicroBenchmarks"
$ dotnet exec MicroBenchmarks.dll --wasmArgs "--experimental-wasm-eh --expose_wasm --module" ...
MicroBenchmarks 1.0.0-dev
© Microsoft Corporation. All rights reserved.

ERROR(S):
  Option 'experimental-wasm-eh --expose_wasm --module' is unknown.
```

Fixes https://github.com/dotnet/runtime/issues/92066 .
