### PR TITLE
[wasm] Update installation process of nodejs 18.x to move away from the

### DIFF
--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -62,14 +62,22 @@ jobs:
     - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.osGroup, 'windows')) }}:
       - HelixPerfUploadTokenValue: '$(PerfCommandUploadToken)'
     - ${{ if eq(parameters.runtimeType, 'wasm') }}:
+      # nodejs installation steps from https://github.com/nodesource/distributions
       - HelixPreCommandsWasmOnLinux: >-
           sudo apt-get -y remove nodejs &&
-          curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - &&
+          sudo apt-get update &&
+          sudo apt-get install -y ca-certificates curl gnupg &&
+          sudo mkdir -p /etc/apt/keyrings &&
+          sudo rm -f /etc/apt/keyrings/nodesource.gpg &&
+          curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor --batch -o /etc/apt/keyrings/nodesource.gpg &&
+          export NODE_MAJOR=18 &&
+          echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list &&
+          sudo apt-get update &&
+          sudo apt-get install nodejs -y &&
           sudo apt-get -y install nodejs &&
           test -n "$(V8Version)" &&
           npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
           $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 v8@$(V8Version) &&
-          find ~/.jsvu -ls &&
           export V8_ENGINE_PATH=~/.jsvu/bin/v8-$(V8Version) &&
           ${V8_ENGINE_PATH} -e 'console.log(`V8 version: ${this.version()}`)'
     - ${{ if ne(parameters.runtimeType, 'wasm') }}:

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -74,7 +74,6 @@ jobs:
           echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list &&
           sudo apt-get update &&
           sudo apt-get install nodejs -y &&
-          sudo apt-get -y install nodejs &&
           test -n "$(V8Version)" &&
           npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
           $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 v8@$(V8Version) &&


### PR DESCRIPTION
.. deprecated installation script. The instructions are from
https://github.com/nodesource/distributions .

```
                           SCRIPT DEPRECATION WARNING

  This script, located at https://deb.nodesource.com/setup_X, used to
  install Node.js is deprecated now and will eventually be made inactive.

  Please visit the NodeSource distributions Github and follow the
  instructions to migrate your repo.
  https://github.com/nodesource/distributions
```
