### PR TITLE
Use runsettings.targets to generate runsettings for host tests in local builds

### DIFF
--- a/eng/testing/runsettings.targets
+++ b/eng/testing/runsettings.targets
@@ -14,17 +14,18 @@
     <!-- Use an intermediate runsettings file if the app hasn't been built yet to enable VSTest discovery. -->
     <RunSettingsFilePath Condition="'$(RunSettingsFilePath)' == '' and Exists('$(RunSettingsIntermediateOutputFilePath)')">$(RunSettingsIntermediateOutputFilePath)</RunSettingsFilePath>
 
+    <GenerateRunSettingsFileDependsOn Condition="'$(EnableCoverageSupport)' == 'true'">$(GenerateRunSettingsFileDependsOn);SetupCoverageFilter</GenerateRunSettingsFileDependsOn>
     <PrepareForRunDependsOn>GenerateRunSettingsFile;$(PrepareForRunDependsOn)</PrepareForRunDependsOn>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(RunSettingsTestCaseFilter)' == ''">
     <_testFilter Condition="'$(_withCategories)' != ''">$(_withCategories.Replace(';', '&amp;amp;category='))</_testFilter>
     <_testFilter Condition="'$(_withoutCategories)' != ''">$(_testFilter)$(_withoutCategories.Replace(';', '&amp;amp;category!='))</_testFilter>
     <_testFilter>$(_testFilter.Trim('&amp;amp;'))</_testFilter>
   </PropertyGroup>
 
   <Target Name="GenerateRunSettingsFile"
-          DependsOnTargets="SetupCoverageFilter">
+          DependsOnTargets="$(GenerateRunSettingsFileDependsOn)">
     <PropertyGroup>
       <RunSettingsDotNetHostPath Condition="'$(RunSettingsDotNetHostPath)' == ''">$(NetCoreAppCurrentTestHostPath)$([System.IO.Path]::GetFileName('$(DotNetTool)'))</RunSettingsDotNetHostPath>
       <RunSettingsTestCaseFilter Condition="'$(RunSettingsTestCaseFilter)' == ''">$(_testFilter)</RunSettingsTestCaseFilter>

--- a/eng/testing/runsettings.targets
+++ b/eng/testing/runsettings.targets
@@ -26,6 +26,9 @@
   <Target Name="GenerateRunSettingsFile"
           DependsOnTargets="SetupCoverageFilter">
     <PropertyGroup>
+      <RunSettingsDotNetHostPath Condition="'$(RunSettingsDotNetHostPath)' == ''">$(NetCoreAppCurrentTestHostPath)$([System.IO.Path]::GetFileName('$(DotNetTool)'))</RunSettingsDotNetHostPath>
+      <RunSettingsTestCaseFilter Condition="'$(RunSettingsTestCaseFilter)' == ''">$(_testFilter)</RunSettingsTestCaseFilter>
+
       <RunSettingsFileContent>$([System.IO.File]::ReadAllText('$(RunSettingsInputFilePath)'))</RunSettingsFileContent>
       <RunSettingsFileContent Condition="'$(TestDisableParallelization)' == 'true'">$(RunSettingsFileContent.Replace('$$MAXCPUCOUNT$$', '1'))</RunSettingsFileContent>
       <RunSettingsFileContent Condition="'$(TestDisableParallelization)' != 'true'">$(RunSettingsFileContent.Replace('$$MAXCPUCOUNT$$', '0'))</RunSettingsFileContent>
@@ -38,21 +41,21 @@
                                                       .Replace('$$COVERAGE_ENABLED$$', '$([MSBuild]::ValueOrDefault('$(Coverage)', 'false'))')
                                                       .Replace('$$DISABLEPARALLELIZATION$$', '$([MSBuild]::ValueOrDefault('$(TestDisableParallelization)', 'false'))')
                                                       .Replace('$$DISABLEAPPDOMAIN$$', '$([MSBuild]::ValueOrDefault('$(TestDisableAppDomain)', 'false'))')
-                                                      .Replace('$$TESTCASEFILTER$$', '$(_testFilter)')
-                                                      .Replace('$$DOTNETHOSTPATH$$', '$(NetCoreAppCurrentTestHostPath)$([System.IO.Path]::GetFileName('$(DotNetTool)'))'))</RunSettingsFileContent>
+                                                      .Replace('$$TESTCASEFILTER$$', '$(RunSettingsTestCaseFilter)')
+                                                      .Replace('$$DOTNETHOSTPATH$$', '$(RunSettingsDotNetHostPath)'))</RunSettingsFileContent>
     </PropertyGroup>
 
     <WriteLinesToFile File="$(RunSettingsOutputFilePath)"
                       Lines="$(RunSettingsFileContent)"
                       WriteOnlyWhenDifferent="true"
                       Overwrite="true" />
-    
+
     <WriteLinesToFile File="$(VsCodeRunSettingsOutputFilePath)"
                       Lines="$(RunSettingsFileContent)"
                       WriteOnlyWhenDifferent="true"
                       Overwrite="true"
                       Condition="'$(CreateVsCodeRunSettingsFile)' == 'true'" />
-    
+
     <!-- Set RunSettingsFilePath property which is read by VSTest. -->
     <PropertyGroup>
       <RunSettingsFilePath>$(RunSettingsOutputFilePath)</RunSettingsFilePath>

--- a/src/installer/tests/Directory.Build.props
+++ b/src/installer/tests/Directory.Build.props
@@ -11,7 +11,8 @@
     <InternalNupkgCacheDir>$(ArtifactsObjDir)ExtraNupkgsForTestRestore\</InternalNupkgCacheDir>
     <TestArchitectures>$(TargetArchitecture)</TestArchitectures>
     <TestInfraTargetFramework>$(NetCoreAppToolCurrent)</TestInfraTargetFramework>
-    <TestRunnerAdditionalArguments>--filter category!=failing -v detailed</TestRunnerAdditionalArguments>
+    <TestCaseFilter>category!=failing</TestCaseFilter>
+    <TestRunnerAdditionalArguments>--filter $(TestCaseFilter) -v detailed</TestRunnerAdditionalArguments>
     <!-- Enable crash and hang dumps -->
     <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --blame-crash-dump-type full</TestRunnerAdditionalArguments>
     <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --blame-hang-timeout 5m --blame-hang-dump-type full</TestRunnerAdditionalArguments>

--- a/src/installer/tests/Directory.Build.targets
+++ b/src/installer/tests/Directory.Build.targets
@@ -134,7 +134,7 @@
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)testing\runsettings.targets"
-          Condition="'$(IsTestProject)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true'" />
+          Condition="'$(IsTestProject)' == 'true'" />
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
 </Project>

--- a/src/installer/tests/Directory.Build.targets
+++ b/src/installer/tests/Directory.Build.targets
@@ -129,17 +129,12 @@
 
   <!-- Properties used by runsettings.targets -->
   <PropertyGroup>
-    <_withoutCategories>$(_withoutCategories);failing</_withoutCategories>
     <RunSettingsDotNetHostPath>$(DotNetTool)</RunSettingsDotNetHostPath>
     <RunSettingsTestCaseFilter>$(TestCaseFilter)</RunSettingsTestCaseFilter>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)testing\runsettings.targets"
           Condition="'$(IsTestProject)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true'" />
-
-  <!-- GenerateRunSettingsFile target depends on SetupCoverageFilter. These tests don't actually care to enable coverage / determine filters,
-       so just create an empty target -->
-  <Target Name="SetupCoverageFilter" />
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
 </Project>

--- a/src/installer/tests/Directory.Build.targets
+++ b/src/installer/tests/Directory.Build.targets
@@ -127,5 +127,19 @@
     </ItemGroup>
   </Target>
 
+  <!-- Properties used by runsettings.targets -->
+  <PropertyGroup>
+    <_withoutCategories>$(_withoutCategories);failing</_withoutCategories>
+    <RunSettingsDotNetHostPath>$(DotNetTool)</RunSettingsDotNetHostPath>
+    <RunSettingsTestCaseFilter>$(TestCaseFilter)</RunSettingsTestCaseFilter>
+  </PropertyGroup>
+
+  <Import Project="$(RepositoryEngineeringDir)testing\runsettings.targets"
+          Condition="'$(IsTestProject)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true'" />
+
+  <!-- GenerateRunSettingsFile target depends on SetupCoverageFilter. These tests don't actually care to enable coverage / determine filters,
+       so just create an empty target -->
+  <Target Name="SetupCoverageFilter" />
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
 </Project>


### PR DESCRIPTION
- Allow configuration of `TestCaseFilter` and `DotNetHostPath` in `GenerateRunSettingsFile`
- Make host tests generate a .runsettings file for local builds

This should make running host tests in VS filter out tests that should be skipped (category of failing) by default.

cc @vitek-karas 