### PR TITLE
Use strategy in StrategyBasedComWrappers.ComputeVtables

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/StrategyBasedComWrappers.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/StrategyBasedComWrappers.cs
@@ -76,7 +76,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <inheritdoc cref="ComWrappers.ComputeVtables" />
         protected sealed override unsafe ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
         {
-            if (obj.GetType().GetCustomAttribute(typeof(ComExposedClassAttribute<>)) is IComExposedDetails details)
+            if (GetOrCreateInterfaceDetailsStrategy().GetComExposedTypeDetails(obj.GetType().TypeHandle))
             {
                 return details.GetComInterfaceEntries(out count);
             }

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/StrategyBasedComWrappers.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/StrategyBasedComWrappers.cs
@@ -76,7 +76,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <inheritdoc cref="ComWrappers.ComputeVtables" />
         protected sealed override unsafe ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
         {
-            if (GetOrCreateInterfaceDetailsStrategy().GetComExposedTypeDetails(obj.GetType().TypeHandle))
+            if (GetOrCreateInterfaceDetailsStrategy().GetComExposedTypeDetails(obj.GetType().TypeHandle) is { } details)
             {
                 return details.GetComInterfaceEntries(out count);
             }


### PR DESCRIPTION
We didn't actually use the strategy object here, so users like WinForms can't actually use it to override behavior. This is stopping WinForms from onboarding to StrategyBasedComWrappers.

I think this is worth backporting to 8.0 as the fixed bug significantly limits the utility of other RCW/CCW systems' ability to interact with source-generated COM.