### PR TITLE
fix ReceiveFrom with dual mode socket

### DIFF
--- a/src/libraries/System.Net.Primitives/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Primitives/src/Resources/Strings.resx
@@ -64,7 +64,7 @@
     <value>This property is not implemented by this class.</value>
   </data>
   <data name="net_InvalidAddressFamily" xml:space="preserve">
-    <value>The AddressFamily {0} is not valid for the {1} end point, use {2} instead.</value>
+    <value>The AddressFamily {0} is not valid for the {1} end point.</value>
   </data>
   <data name="net_InvalidSocketAddressSize" xml:space="preserve">
     <value>The supplied {0} is an invalid size for the {1} end point.</value>

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPEndPoint.cs
@@ -155,8 +155,8 @@ namespace System.Net
         {
             ArgumentNullException.ThrowIfNull(socketAddress);
 
-            if (socketAddress.Family != AddressFamily.InterNetwork && socketAddress.Family != AddressFamily.InterNetworkV6)
-            {
+            if (socketAddress.Family is not (AddressFamily.InterNetwork or AddressFamily.InterNetworkV6))
+                {
                 throw new ArgumentException(SR.Format(SR.net_InvalidAddressFamily, socketAddress.Family.ToString(), GetType().FullName), nameof(socketAddress));
             }
 

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPEndPoint.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPEndPoint.cs
@@ -155,9 +155,9 @@ namespace System.Net
         {
             ArgumentNullException.ThrowIfNull(socketAddress);
 
-            if (socketAddress.Family != AddressFamily)
+            if (socketAddress.Family != AddressFamily.InterNetwork && socketAddress.Family != AddressFamily.InterNetworkV6)
             {
-                throw new ArgumentException(SR.Format(SR.net_InvalidAddressFamily, socketAddress.Family.ToString(), GetType().FullName, AddressFamily.ToString()), nameof(socketAddress));
+                throw new ArgumentException(SR.Format(SR.net_InvalidAddressFamily, socketAddress.Family.ToString(), GetType().FullName), nameof(socketAddress));
             }
 
             int minSize = AddressFamily == AddressFamily.InterNetworkV6 ? SocketAddress.IPv6AddressSize : SocketAddress.IPv4AddressSize;

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPEndPointTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPEndPointTest.cs
@@ -195,8 +195,7 @@ namespace System.Net.Primitives.Functional.Tests
 
         public static IEnumerable<object[]> Create_InvalidAddressFamily_TestData()
         {
-            yield return new object[] { new IPEndPoint(2, 500), new SocketAddress(Sockets.AddressFamily.InterNetworkV6) };
-            yield return new object[] { new IPEndPoint(IPAddress.Parse("192.169.0.9"), 500), new SocketAddress(Sockets.AddressFamily.InterNetworkV6) };
+            yield return new object[] { new IPEndPoint(2, 500), new SocketAddress(Sockets.AddressFamily.Unknown) };
             yield return new object[] { new IPEndPoint(IPAddress.Parse("0:0:0:0:0:0:0:1"), 500), new SocketAddress(Sockets.AddressFamily.InterNetwork) };
         }
 

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPEndPointTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPEndPointTest.cs
@@ -143,6 +143,19 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Equal(expected, endPoint.ToString());
         }
 
+        [Fact]
+        public static void Create_DifferentAF_Success()
+        {
+            SocketAddress sa = new SocketAddress(AddressFamily.InterNetwork, SocketAddress.GetMaximumAddressSize(AddressFamily.InterNetworkV6));
+            var ep = new IPEndPoint(IPAddress.IPv6Any, 0);
+            Assert.NotNull(ep.Create(sa));
+
+            sa = new SocketAddress(AddressFamily.InterNetworkV6);
+            ep = new IPEndPoint(IPAddress.Any, 0);
+
+            Assert.NotNull(ep.Create(sa));
+        }
+
         public static IEnumerable<object[]> Serialize_TestData()
         {
             yield return new object[] { new IPAddress(2), 16 };

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -927,13 +927,13 @@ namespace System.Net.Sockets
                     {
                         try
                         {
-                            if (_remoteEndPoint!.AddressFamily == _socketAddress!.Family)
-                            {
-                                _remoteEndPoint = _remoteEndPoint!.Create(_socketAddress);
-                            }
-                            else if (_remoteEndPoint!.AddressFamily == AddressFamily.InterNetworkV6 && _socketAddress.Family == AddressFamily.InterNetwork)
+                            if (_remoteEndPoint!.AddressFamily == AddressFamily.InterNetworkV6 && _socketAddress!.Family == AddressFamily.InterNetwork)
                             {
                                 _remoteEndPoint = new IPEndPoint(_socketAddress.GetIPAddress().MapToIPv6(), _socketAddress.GetPort());
+                            }
+                            else
+                            {
+                                _remoteEndPoint = _remoteEndPoint!.Create(_socketAddress!);
                             }
                         }
                         catch
@@ -949,7 +949,14 @@ namespace System.Net.Sockets
                     {
                         try
                         {
-                            _remoteEndPoint = _remoteEndPoint!.Create(_socketAddress!);
+                            if (_remoteEndPoint!.AddressFamily == AddressFamily.InterNetworkV6 && _socketAddress!.Family == AddressFamily.InterNetwork)
+                            {
+                                _remoteEndPoint = new IPEndPoint(_socketAddress.GetIPAddress().MapToIPv6(), _socketAddress.GetPort());
+                            }
+                            else
+                            {
+                                _remoteEndPoint = _remoteEndPoint!.Create(_socketAddress!);
+                            }
                         }
                         catch
                         {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
@@ -171,6 +171,52 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        public async Task ReceiveSent_DualMode_Success(bool ipv4)
+        {
+            const int Offset = 10;
+            const int DatagramSize = 256;
+            const int DatagramsToSend = 16;
+
+            IPAddress address = ipv4 ? IPAddress.Loopback : IPAddress.IPv6Loopback;
+            using Socket receiver = new Socket(SocketType.Dgram, ProtocolType.Udp);
+            using Socket sender = new Socket(SocketType.Dgram, ProtocolType.Udp);
+            if (receiver.DualMode != true || sender.DualMode != true)
+            {
+                throw new SkipException("DualMode not available");
+            }
+
+            ConfigureNonBlocking(sender);
+            ConfigureNonBlocking(receiver);
+
+            receiver.BindToAnonymousPort(address);
+            sender.BindToAnonymousPort(address);
+
+            byte[] sendBuffer = new byte[DatagramSize];
+            var receiveInternalBuffer = new byte[DatagramSize + Offset];
+            var emptyBuffer = new byte[Offset];
+            ArraySegment<byte> receiveBuffer = new ArraySegment<byte>(receiveInternalBuffer, Offset, DatagramSize);
+
+            Random rnd = new Random(0);
+
+            for (int i = 0; i < DatagramsToSend; i++)
+            {
+                rnd.NextBytes(sendBuffer);
+                sender.SendTo(sendBuffer, receiver.LocalEndPoint);
+
+                IPEndPoint remoteEp = new IPEndPoint(ipv4 ? IPAddress.Any : IPAddress.IPv6Any, 0);
+
+                SocketReceiveFromResult result = await ReceiveFromAsync(receiver, receiveBuffer, remoteEp);
+
+                Assert.Equal(DatagramSize, result.ReceivedBytes);
+                AssertExtensions.SequenceEqual(emptyBuffer, new ReadOnlySpan<byte>(receiveInternalBuffer, 0, Offset));
+                AssertExtensions.SequenceEqual(sendBuffer, new ReadOnlySpan<byte>(receiveInternalBuffer, Offset, DatagramSize));
+                Assert.Equal(sender.LocalEndPoint, result.RemoteEndPoint);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
         public void ReceiveSent_SocketAddress_Success(bool ipv4)
         {
             const int DatagramSize = 256;


### PR DESCRIPTION
Fixes #92006

This is regression against 7.0
It seems like the old internal code handled cases when IPv4 `EndPoint` was passed to `ReceiveFrom` on dual mode socket and the received address is actually IPv4 mapped into IPv6. But that case fails now and we fail to set `RemoteEndPoint` leaving whatever was there - in case of the provided repro creating loop or possibly sending message to wrong peer. 

After thinking about it I see no reason why `IPEndPoint.Create` needs to really care about `AddressFamily` as long as it is IP. The documentation claims that it needs to be correct type but it does not talk about IPv4 vs IPv6. And we allocate new `EndPoint` so the actual value of the old one does not matter. It will also make it easier to consume new API from #88970 as we exposed `SocketAddresses` to consumers and they may need to eat with it. 

The regression was introduced by PR #89841