### PR TITLE
Fix type parameter mapping logic in ILLink/ILCompiler

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
@@ -158,8 +158,10 @@ namespace ILCompiler.Dataflow
                                     break;
 
                                 case ILOpcode.stsfld:
+                                case ILOpcode.ldsfld:
                                     {
                                         // Same as above, but stsfld instead of a call to the constructor
+                                        // Ldsfld may also trigger a cctor that creates a closure environment
                                         FieldDesc? field = methodBody.GetObject(reader.ReadILToken()) as FieldDesc;
                                         if (field == null)
                                             continue;
@@ -417,6 +419,7 @@ namespace ILCompiler.Dataflow
                                 break;
 
                             case ILOpcode.stsfld:
+                            case ILOpcode.ldsfld:
                                 {
                                     if (body.GetObject(reader.ReadILToken()) is FieldDesc { OwningType: MetadataType owningType }
                                         && compilerGeneratedType == owningType.GetTypeDefinition())

--- a/src/tools/illink/src/linker/Linker.Dataflow/CompilerGeneratedState.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/CompilerGeneratedState.cs
@@ -180,7 +180,8 @@ namespace Mono.Linker.Dataflow
 
 						case OperandType.InlineField: {
 								// Same as above, but stsfld instead of a call to the constructor
-								if (instruction.OpCode.Code is not Code.Stsfld)
+								// Ldsfld may also trigger a cctor that creates a closure environment
+								if (instruction.OpCode.Code is not (Code.Stsfld or Code.Ldsfld))
 									continue;
 
 								FieldDefinition? field = _context.TryResolve ((FieldReference) instruction.Operand);
@@ -390,7 +391,8 @@ namespace Mono.Linker.Dataflow
 							handled = true;
 						}
 						break;
-					case Code.Stsfld: {
+					case Code.Stsfld:
+					case Code.Ldsfld: {
 							if (instr.Operand is FieldReference { DeclaringType: GenericInstanceType typeRef }
 								&& compilerGeneratedType == context.TryResolve (typeRef)) {
 								return typeRef;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedTypes.cs
@@ -43,7 +43,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			CapturingLocalFunctionInsideIterator<int> ();
 			LambdaInsideAsync<int> ();
 			LocalFunctionInsideAsync<int> ();
-			NestedStaticLambda.Test ();
+			NestedStaticLambda.Test<int> ();
 		}
 
 		private static void UseIterator ()
@@ -356,14 +356,15 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class NestedStaticLambda
 		{
-			public static class Container<T> {
-				public static Func<Func<T, T>, Func<T, T>> M =
-					(Func<T, T> x) => v => x(x(v));
+			public static class Container<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] T> {
+				public static Func<Func<T, T>, Func<T, T>> NestedLambda =
+					(Func<T, T> x) => v => x(v);
 			}
 
-			public static void Test ()
+			[ExpectedWarning ("IL2091", "T", nameof (Container<T>), nameof (DynamicallyAccessedMemberTypes.PublicMethods))]
+			public static void Test<T> ()
 			{
-				Container<int>.M ((int i) => i) (1);
+				Container<T>.NestedLambda ((T t) => t) (default (T));
 			}
 		}
 	}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedTypes.cs
@@ -43,6 +43,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			CapturingLocalFunctionInsideIterator<int> ();
 			LambdaInsideAsync<int> ();
 			LocalFunctionInsideAsync<int> ();
+			NestedStaticLambda.Test ();
 		}
 
 		private static void UseIterator ()
@@ -351,6 +352,19 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			void LocalFunction () => typeof (T).GetMethods ();
 			await Task.Delay (0);
 			LocalFunction ();
+		}
+
+		class NestedStaticLambda
+		{
+			public static class Container<T> {
+				public static Func<Func<T, T>, Func<T, T>> M =
+					(Func<T, T> x) => v => x(x(v));
+			}
+
+			public static void Test ()
+			{
+				Container<int>.M ((int i) => i) (1);
+			}
 		}
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedTypes.cs
@@ -361,7 +361,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 					(Func<T, T> x) => v => x(v);
 			}
 
-			[ExpectedWarning ("IL2091", "T", nameof (Container<T>), nameof (DynamicallyAccessedMemberTypes.PublicMethods))]
+			[ExpectedWarning ("IL2091", "T", nameof (Container<T>), nameof (DynamicallyAccessedMemberTypes.PublicMethods),
+				// https://github.com/dotnet/runtime/issues/84918
+				ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 			public static void Test<T> ()
 			{
 				Container<T>.NestedLambda ((T t) => t) (default (T));


### PR DESCRIPTION
The compiler-generated code for `Container<T>` in this testcase contains two closure types, one for each lambda in the expression `(Func<T, T> x) => v => x(x(v));`. The outer closure environment type is instantiated by its cctor, which stores an instance into a static field. It is never directly instantiated from another type - instead, the cctor is triggered when the cctor of `Container<T>` access this static field.

This case was missing from the compiler-generated type parameter mapping logic. We need to discover the substituted generic typeref for the outer closure environment from the `ldsfld`.

Fixes https://github.com/dotnet/runtime/issues/91880.