### PR TITLE
Avoid marking property/event attributes multiple times

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -3537,7 +3537,8 @@ namespace Mono.Linker.Steps
 
 		protected internal void MarkProperty (PropertyDefinition prop, in DependencyInfo reason)
 		{
-			Tracer.AddDirectDependency (prop, reason, marked: false);
+			if (!Annotations.MarkProcessed (prop, reason))
+				return;
 
 			using var propertyScope = ScopeStack.PushScope (new MessageOrigin (prop));
 

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -3549,8 +3549,8 @@ namespace Mono.Linker.Steps
 
 		protected internal virtual void MarkEvent (EventDefinition evt, in DependencyInfo reason)
 		{
-			// Record the event without marking it in Annotations.
-			Tracer.AddDirectDependency (evt, reason, marked: false);
+			if (!Annotations.MarkProcessed (evt, reason))
+				return;
 
 			using var eventScope = ScopeStack.PushScope (new MessageOrigin (evt));
 

--- a/src/tools/illink/src/linker/Linker/Annotations.cs
+++ b/src/tools/illink/src/linker/Linker/Annotations.cs
@@ -272,7 +272,6 @@ namespace Mono.Linker
 
 		public bool MarkProcessed (IMetadataTokenProvider provider, in DependencyInfo reason)
 		{
-			Debug.Assert (!(reason.Kind == DependencyKind.AlreadyMarked));
 			Tracer.AddDirectDependency (provider, reason, marked: true);
 			// The item may or may not be pending.
 			marked_pending.Remove (provider);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
@@ -136,6 +136,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				[KeptAttributeAttribute (typeof (AttributePropertyRequiresPropertiesAttribute))]
 				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
 				[ExpectedWarning ("IL2111", nameof (AttributePropertyRequiresPropertiesAttribute) + "." + nameof (RequiresPublicProperties),
+					// https://github.com/dotnet/runtime/issues/92131
 					ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 				[AttributePropertyRequiresProperties (RequiresPublicProperties = typeof (AttributePropertyRequiresPropertiesAttribute))]
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
@@ -135,7 +135,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				[field: Kept]
 				[KeptAttributeAttribute (typeof (AttributePropertyRequiresPropertiesAttribute))]
 				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
-				[ExpectedWarning ("IL2111", nameof (AttributePropertyRequiresPropertiesAttribute) + "." + nameof (RequiresPublicProperties), ProducedBy = Tool.Trimmer)]
+				[ExpectedWarning ("IL2111", nameof (AttributePropertyRequiresPropertiesAttribute) + "." + nameof (RequiresPublicProperties),
+					ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 				[AttributePropertyRequiresProperties (RequiresPublicProperties = typeof (AttributePropertyRequiresPropertiesAttribute))]
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]
 				public Type RequiresPublicProperties {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
@@ -24,8 +24,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		[ExpectedWarning ("IL2026", "--ClassWithKeptPublicMethods--", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 		public static void Main ()
 		{
-			typeof (AttributePropertyDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicConstructorsAttribute));
-			typeof (AttributePropertyDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
+			typeof (AttributePropertyDataflow).GetMethod (nameof (Main)).GetCustomAttribute (typeof (KeepsPublicConstructorsAttribute));
+			typeof (AttributePropertyDataflow).GetMethod (nameof (Main)).GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
 			RecursivePropertyDataFlow.Test ();
 			RecursiveEventDataFlow.Test ();
 			RecursiveFieldDataFlow.Test ();
@@ -172,6 +172,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			public static void Test ()
 			{
+				typeof (RecursivePropertyDataFlow).GetProperty (nameof (Property)).GetCustomAttribute (typeof (KeepsPublicPropertiesAttribute));
 				Property = 0;
 			}
 		}
@@ -190,6 +191,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			public static void Test ()
 			{
+				typeof (RecursiveEventDataFlow).GetEvent (nameof (Event)).GetCustomAttribute (typeof (KeepsPublicEventsAttribute));
 				Event += (sender, e) => { };
 			}
 		}
@@ -205,6 +207,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			public static void Test ()
 			{
+				typeof (RecursiveMethodDataFlow).GetField (nameof (field)).GetCustomAttribute (typeof (KeepsPublicFieldsAttribute));
 				field = 0;
 			}
 		}
@@ -220,6 +223,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[Kept]
 			public static void Test ()
 			{
+				typeof (RecursiveMethodDataFlow).GetMethod (nameof (Method)).GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
 				Method ();
 			}
 		}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AttributePropertyDataflow.cs
@@ -26,6 +26,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			typeof (AttributePropertyDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicConstructorsAttribute));
 			typeof (AttributePropertyDataflow).GetMethod ("Main").GetCustomAttribute (typeof (KeepsPublicMethodsAttribute));
+			RecursivePropertyDataFlow.Test ();
 		}
 
 		[Kept]
@@ -116,6 +117,41 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[field: Kept]
 			[Kept]
 			public Type[] Types { get; [Kept] set; }
+		}
+
+		[Kept]
+		class RecursivePropertyDataFlow
+		{
+			[Kept]
+			[KeptBaseType (typeof (Attribute))]
+			class AttributePropertyRequiresPropertiesAttribute : Attribute
+			{
+				[Kept]
+				public AttributePropertyRequiresPropertiesAttribute ()
+				{
+				}
+
+				[Kept]
+				[field: Kept]
+				[KeptAttributeAttribute (typeof (AttributePropertyRequiresPropertiesAttribute))]
+				[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+				[ExpectedWarning ("IL2111", nameof (AttributePropertyRequiresPropertiesAttribute) + "." + nameof (RequiresPublicProperties), ProducedBy = Tool.Trimmer)]
+				[AttributePropertyRequiresProperties (RequiresPublicProperties = typeof (AttributePropertyRequiresPropertiesAttribute))]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)]
+				public Type RequiresPublicProperties {
+					[Kept]
+					get;
+					[Kept]
+					set;
+				}
+			}
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (AttributePropertyRequiresPropertiesAttribute))]
+			[AttributePropertyRequiresProperties (RequiresPublicProperties = typeof (int))]
+			public static void Test ()
+			{
+			}
 		}
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
@@ -246,11 +246,6 @@ namespace Mono.Linker.Tests.Cases.Reflection
 			public delegate void MyEventHandler (object sender, int i);
 
 			[Kept]
-			// ILLink always keeps event methods when an event is kept, so this generates warnings
-			// on the event itself (since an event access is considered to reference the annotated add method),
-			// and on the add method (if it is accessed through reflection).
-			[ExpectedWarning ("IL2026", "--RUC on add_RUCEvent--", ProducedBy = Tool.Trimmer)]
-			[ExpectedWarning ("IL2026", "--RUC on add_RUCEvent--", ProducedBy = Tool.Trimmer)]
 			[ExpectedWarning ("IL2026", "--RUC on add_RUCEvent--", ProducedBy = Tool.Trimmer)]
 			public event MyEventHandler RUCEvent {
 				[Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/BasicRequires.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/BasicRequires.cs
@@ -138,7 +138,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		class OnEventMethod
 		{
 			[ExpectedWarning ("IL2026", "--EventToTestRemove.remove--", ProducedBy = Tool.Trimmer)]
-			[ExpectedWarning ("IL2026", "--EventToTestRemove.remove--", ProducedBy = Tool.Trimmer)]
 			static event EventHandler EventToTestRemove {
 				add { }
 				[RequiresUnreferencedCode ("Message for --EventToTestRemove.remove--")]
@@ -147,7 +146,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				remove { }
 			}
 
-			[ExpectedWarning ("IL2026", "--EventToTestAdd.add--", ProducedBy = Tool.Trimmer)]
 			[ExpectedWarning ("IL2026", "--EventToTestAdd.add--", ProducedBy = Tool.Trimmer)]
 			static event EventHandler EventToTestAdd {
 				[RequiresUnreferencedCode ("Message for --EventToTestAdd.add--")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnAttribute.cs
@@ -112,14 +112,9 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 		static int _fieldWithAttributeWhichRequires;
 
 		[ExpectedWarning ("IL2026", "--AttributeWhichRequiresAttribute.ctor--")]
-		// https://github.com/dotnet/runtime/issues/83581
-		[ExpectedWarning ("IL2026", "--AttributeWhichRequiresAttribute.ctor--", ProducedBy = Tool.Trimmer)] // Trimmer can produce duplicate warnings for property access
-		[ExpectedWarning ("IL2026", "--AttributeWhichRequiresAttribute.ctor--", ProducedBy = Tool.Trimmer)] // Trimmer can produce duplicate warnings for property access
 		[ExpectedWarning ("IL3002", "--AttributeWhichRequiresAttribute.ctor--", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 		[ExpectedWarning ("IL3050", "--AttributeWhichRequiresAttribute.ctor--", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 		[ExpectedWarning ("IL2026", "--AttributeWhichRequiresOnPropertyAttribute.PropertyWhichRequires--")]
-		[ExpectedWarning ("IL2026", "--AttributeWhichRequiresOnPropertyAttribute.PropertyWhichRequires--", ProducedBy = Tool.Trimmer)] // Trimmer can produce duplicate warnings for property access
-		[ExpectedWarning ("IL2026", "--AttributeWhichRequiresOnPropertyAttribute.PropertyWhichRequires--", ProducedBy = Tool.Trimmer)] // Trimmer can produce duplicate warnings for property access
 		[ExpectedWarning ("IL3002", "--AttributeWhichRequiresOnPropertyAttribute.PropertyWhichRequires--", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 		[ExpectedWarning ("IL3050", "--AttributeWhichRequiresOnPropertyAttribute.PropertyWhichRequires--", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 		[AttributeWhichRequires]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
@@ -494,8 +494,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 
 			// These should not be reported https://github.com/mono/linker/issues/2218
 			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.Event.add", ProducedBy = Tool.Trimmer)]
-			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.Event.add", ProducedBy = Tool.Trimmer)]
-			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.Event.remove", ProducedBy = Tool.Trimmer)]
 			[ExpectedWarning ("IL2026", "MemberTypesWithRequires.Event.remove", ProducedBy = Tool.Trimmer)]
 			public static event EventHandler Event;
 		}
@@ -851,10 +849,6 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				// These should be reported only in TestDirectReflectionAccess
 				// https://github.com/mono/linker/issues/2218
 				[ExpectedWarning ("IL2026", "StaticEvent.add", ProducedBy = Tool.Trimmer)]
-				[ExpectedWarning ("IL2026", "StaticEvent.add", ProducedBy = Tool.Trimmer)]
-				[ExpectedWarning ("IL2026", "StaticEvent.add", ProducedBy = Tool.Trimmer)]
-				[ExpectedWarning ("IL2026", "StaticEvent.remove", ProducedBy = Tool.Trimmer)]
-				[ExpectedWarning ("IL2026", "StaticEvent.remove", ProducedBy = Tool.Trimmer)]
 				[ExpectedWarning ("IL2026", "StaticEvent.remove", ProducedBy = Tool.Trimmer)]
 				public static event EventHandler StaticEvent;
 			}


### PR DESCRIPTION
This tracks whether properties have been marked yet, and avoids marking them multiple times. Fixes a recursion issue where marking a property can cause marking of attributes which may cause marking of the same property.

I removed the `AlreadyMarked` assert because https://github.com/dotnet/runtime/pull/84620 propagates the `Kind` from methods to properties - so it can look as if a property is being marked from a descriptor the first time it is encountered.

Fixes https://github.com/dotnet/runtime/issues/92064

Fixes the illink part of https://github.com/dotnet/runtime/issues/83581. That issue mentions a problem with the analyzer behavior, but the testcase I'm fixing in this PR doesn't seem to show duplicate warnings from the analyzer. Can we consider https://github.com/dotnet/runtime/issues/83581 fixed by this change?