### PR TITLE
[RISC-V] Atomics

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -2634,16 +2634,30 @@ void CodeGen::genLockedInstructions(GenTreeOp* treeNode)
 
     assert(!data->isContainedIntOrIImmed());
 
-    genTreeOps op = treeNode->gtOper;
-    // clang-format off
-    instruction ins =
-        op == GT_XORR ? (is4 ? INS_amoor_w   : INS_amoor_d) :
-        op == GT_XAND ? (is4 ? INS_amoand_w  : INS_amoand_d) :
-        op == GT_XCHG ? (is4 ? INS_amoswap_w : INS_amoswap_d) :
-        op == GT_XADD ? (is4 ? INS_amoadd_w  : INS_amoadd_d) :
-        (assert(!"Unexpected treeNode->gtOper"), INS_none);
-    // clang-format on
+    instruction ins = INS_none;
+    switch (treeNode->gtOper)
+    {
+        case GT_XORR:
+            ins = is4 ? INS_amoor_w : INS_amoor_d;
+            break;
+        case GT_XAND:
+            ins = is4 ? INS_amoand_w : INS_amoand_d;
+            break;
+        case GT_XCHG:
+            ins = is4 ? INS_amoswap_w : INS_amoswap_d;
+            break;
+        case GT_XADD:
+            ins = is4 ? INS_amoadd_w : INS_amoadd_d;
+            break;
+        default:
+            noway_assert(!"Unexpected treeNode->gtOper");
+    }
     GetEmitter()->emitIns_R_R_R(ins, dataSize, targetReg, addrReg, dataReg);
+
+    if (targetReg != REG_R0)
+    {
+        genProduceReg(treeNode);
+    }
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -805,6 +805,11 @@ void emitter::emitIns_R_R_R(
         {
             code |= 0x7 << 12;
         }
+        else if (INS_lr_w <= ins && ins <= INS_amomaxu_d)
+        {
+            // For now all atomics are seq. consistent as Interlocked.* APIs don't expose acquire/release ordering
+            code |= 0b11 << 25;
+        }
     }
     else
     {
@@ -2912,7 +2917,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             {
                 imm20 |= 0xfff00000;
             }
-            printf("lui          %s, %d\n", rd, imm20);
+            printf("lui            %s, %d\n", rd, imm20);
             return;
         }
         case 0x17: // AUIPC
@@ -2923,7 +2928,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             {
                 imm20 |= 0xfff00000;
             }
-            printf("auipc        %s, %d\n", rd, imm20);
+            printf("auipc          %s, %d\n", rd, imm20);
             return;
         }
         case 0x13:
@@ -2939,35 +2944,35 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             switch (opcode2)
             {
                 case 0x0: // ADDI
-                    printf("addi         %s, %s, %d\n", rd, rs1, imm12);
+                    printf("addi           %s, %s, %d\n", rd, rs1, imm12);
                     return;
-                case 0x1:                                                       // SLLI
-                    printf("slli         %s, %s, %d\n", rd, rs1, imm12 & 0x3f); // 6 BITS for SHAMT in RISCV64
+                case 0x1:                                                         // SLLI
+                    printf("slli           %s, %s, %d\n", rd, rs1, imm12 & 0x3f); // 6 BITS for SHAMT in RISCV64
                     return;
                 case 0x2: // SLTI
-                    printf("slti         %s, %s, %d\n", rd, rs1, imm12);
+                    printf("slti           %s, %s, %d\n", rd, rs1, imm12);
                     return;
                 case 0x3: // SLTIU
-                    printf("sltiu        %s, %s, %d\n", rd, rs1, imm12);
+                    printf("sltiu          %s, %s, %d\n", rd, rs1, imm12);
                     return;
                 case 0x4: // XORI
-                    printf("xori         %s, %s, 0x%x\n", rd, rs1, imm12);
+                    printf("xori           %s, %s, 0x%x\n", rd, rs1, imm12);
                     return;
                 case 0x5: // SRLI & SRAI
                     if (((code >> 30) & 0x1) == 0)
                     {
-                        printf("srli         %s, %s, %d\n", rd, rs1, imm12 & 0x3f); // 6BITS for SHAMT in RISCV64
+                        printf("srli           %s, %s, %d\n", rd, rs1, imm12 & 0x3f); // 6BITS for SHAMT in RISCV64
                     }
                     else
                     {
-                        printf("srai         %s, %s, %d\n", rd, rs1, imm12 & 0x3f); // 6BITS for SHAMT in RISCV64
+                        printf("srai           %s, %s, %d\n", rd, rs1, imm12 & 0x3f); // 6BITS for SHAMT in RISCV64
                     }
                     return;
                 case 0x6: // ORI
-                    printf("ori          %s, %s, 0x%x\n", rd, rs1, imm12 & 0xfff);
+                    printf("ori            %s, %s, 0x%x\n", rd, rs1, imm12 & 0xfff);
                     return;
                 case 0x7: // ANDI
-                    printf("andi         %s, %s, 0x%x\n", rd, rs1, imm12 & 0xfff);
+                    printf("andi           %s, %s, 0x%x\n", rd, rs1, imm12 & 0xfff);
                     return;
                 default:
                     printf("RISCV64 illegal instruction: 0x%08X\n", code);
@@ -2987,19 +2992,19 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             switch (opcode2)
             {
                 case 0x0: // ADDIW
-                    printf("addiw        %s, %s, %d\n", rd, rs1, imm12);
+                    printf("addiw          %s, %s, %d\n", rd, rs1, imm12);
                     return;
-                case 0x1:                                                       // SLLIW
-                    printf("slliw        %s, %s, %d\n", rd, rs1, imm12 & 0x3f); // 6 BITS for SHAMT in RISCV64
+                case 0x1:                                                         // SLLIW
+                    printf("slliw          %s, %s, %d\n", rd, rs1, imm12 & 0x3f); // 6 BITS for SHAMT in RISCV64
                     return;
                 case 0x5: // SRLIW & SRAIW
                     if (((code >> 30) & 0x1) == 0)
                     {
-                        printf("srliw        %s, %s, %d\n", rd, rs1, imm12 & 0x1f); // 5BITS for SHAMT in RISCV64
+                        printf("srliw          %s, %s, %d\n", rd, rs1, imm12 & 0x1f); // 5BITS for SHAMT in RISCV64
                     }
                     else
                     {
-                        printf("sraiw        %s, %s, %d\n", rd, rs1, imm12 & 0x1f); // 5BITS for SHAMT in RISCV64
+                        printf("sraiw          %s, %s, %d\n", rd, rs1, imm12 & 0x1f); // 5BITS for SHAMT in RISCV64
                     }
                     return;
                 default:
@@ -3021,40 +3026,40 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                     case 0x0: // ADD & SUB
                         if (((code >> 30) & 0x1) == 0)
                         {
-                            printf("add          %s, %s, %s\n", rd, rs1, rs2);
+                            printf("add            %s, %s, %s\n", rd, rs1, rs2);
                         }
                         else
                         {
-                            printf("sub          %s, %s, %s\n", rd, rs1, rs2);
+                            printf("sub            %s, %s, %s\n", rd, rs1, rs2);
                         }
                         return;
                     case 0x1: // SLL
-                        printf("sll          %s, %s, %s\n", rd, rs1, rs2);
+                        printf("sll            %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x2: // SLT
-                        printf("slt          %s, %s, %s\n", rd, rs1, rs2);
+                        printf("slt            %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x3: // SLTU
-                        printf("sltu         %s, %s, %s\n", rd, rs1, rs2);
+                        printf("sltu           %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x4: // XOR
-                        printf("xor          %s, %s, %s\n", rd, rs1, rs2);
+                        printf("xor            %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x5: // SRL & SRA
                         if (((code >> 30) & 0x1) == 0)
                         {
-                            printf("srl          %s, %s, %s\n", rd, rs1, rs2);
+                            printf("srl            %s, %s, %s\n", rd, rs1, rs2);
                         }
                         else
                         {
-                            printf("sra          %s, %s, %s\n", rd, rs1, rs2);
+                            printf("sra            %s, %s, %s\n", rd, rs1, rs2);
                         }
                         return;
                     case 0x6: // OR
-                        printf("or           %s, %s, %s\n", rd, rs1, rs2);
+                        printf("or             %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x7: // AND
-                        printf("and          %s, %s, %s\n", rd, rs1, rs2);
+                        printf("and            %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     default:
                         printf("RISCV64 illegal instruction: 0x%08X\n", code);
@@ -3066,28 +3071,28 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 switch (opcode3)
                 {
                     case 0x0: // MUL
-                        printf("mul          %s, %s, %s\n", rd, rs1, rs2);
+                        printf("mul            %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x1: // MULH
-                        printf("mulh         %s, %s, %s\n", rd, rs1, rs2);
+                        printf("mulh           %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x2: // MULHSU
-                        printf("mulhsu       %s, %s, %s\n", rd, rs1, rs2);
+                        printf("mulhsu         %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x3: // MULHU
-                        printf("mulhu        %s, %s, %s\n", rd, rs1, rs2);
+                        printf("mulhu          %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x4: // DIV
-                        printf("div          %s, %s, %s\n", rd, rs1, rs2);
+                        printf("div            %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x5: // DIVU
-                        printf("divu         %s, %s, %s\n", rd, rs1, rs2);
+                        printf("divu           %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x6: // REM
-                        printf("rem          %s, %s, %s\n", rd, rs1, rs2);
+                        printf("rem            %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x7: // REMU
-                        printf("remu         %s, %s, %s\n", rd, rs1, rs2);
+                        printf("remu           %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     default:
                         printf("RISCV64 illegal instruction: 0x%08X\n", code);
@@ -3115,24 +3120,24 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                     case 0x0: // ADDW & SUBW
                         if (((code >> 30) & 0x1) == 0)
                         {
-                            printf("addw         %s, %s, %s\n", rd, rs1, rs2);
+                            printf("addw           %s, %s, %s\n", rd, rs1, rs2);
                         }
                         else
                         {
-                            printf("subw         %s, %s, %s\n", rd, rs1, rs2);
+                            printf("subw           %s, %s, %s\n", rd, rs1, rs2);
                         }
                         return;
                     case 0x1: // SLLW
-                        printf("sllw         %s, %s, %s\n", rd, rs1, rs2);
+                        printf("sllw           %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x5: // SRLW & SRAW
                         if (((code >> 30) & 0x1) == 0)
                         {
-                            printf("srlw         %s, %s, %s\n", rd, rs1, rs2);
+                            printf("srlw           %s, %s, %s\n", rd, rs1, rs2);
                         }
                         else
                         {
-                            printf("sraw         %s, %s, %s\n", rd, rs1, rs2);
+                            printf("sraw           %s, %s, %s\n", rd, rs1, rs2);
                         }
                         return;
                     default:
@@ -3145,19 +3150,19 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 switch (opcode3)
                 {
                     case 0x0: // MULW
-                        printf("mulw         %s, %s, %s\n", rd, rs1, rs2);
+                        printf("mulw           %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x4: // DIVW
-                        printf("divw         %s, %s, %s\n", rd, rs1, rs2);
+                        printf("divw           %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x5: // DIVUW
-                        printf("divuw        %s, %s, %s\n", rd, rs1, rs2);
+                        printf("divuw          %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x6: // REMW
-                        printf("remw         %s, %s, %s\n", rd, rs1, rs2);
+                        printf("remw           %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     case 0x7: // REMUW
-                        printf("remuw        %s, %s, %s\n", rd, rs1, rs2);
+                        printf("remuw          %s, %s, %s\n", rd, rs1, rs2);
                         return;
                     default:
                         printf("RISCV64 illegal instruction: 0x%08X\n", code);
@@ -3184,16 +3189,16 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             switch (opcode2)
             {
                 case 0: // SB
-                    printf("sb           %s, %d(%s)\n", rs2, offset, rs1);
+                    printf("sb             %s, %d(%s)\n", rs2, offset, rs1);
                     return;
                 case 1: // SH
-                    printf("sh           %s, %d(%s)\n", rs2, offset, rs1);
+                    printf("sh             %s, %d(%s)\n", rs2, offset, rs1);
                     return;
                 case 2: // SW
-                    printf("sw           %s, %d(%s)\n", rs2, offset, rs1);
+                    printf("sw             %s, %d(%s)\n", rs2, offset, rs1);
                     return;
                 case 3: // SD
-                    printf("sd           %s, %d(%s)\n", rs2, offset, rs1);
+                    printf("sd             %s, %d(%s)\n", rs2, offset, rs1);
                     return;
                 default:
                     printf("RISCV64 illegal instruction: 0x%08X\n", code);
@@ -3214,22 +3219,22 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             switch (opcode2)
             {
                 case 0: // BEQ
-                    printf("beq          %s, %s, %d\n", rs1, rs2, offset);
+                    printf("beq            %s, %s, %d\n", rs1, rs2, offset);
                     return;
                 case 1: // BNE
-                    printf("bne          %s, %s, %d\n", rs1, rs2, offset);
+                    printf("bne            %s, %s, %d\n", rs1, rs2, offset);
                     return;
                 case 4: // BLT
-                    printf("blt          %s, %s, %d\n", rs1, rs2, offset);
+                    printf("blt            %s, %s, %d\n", rs1, rs2, offset);
                     return;
                 case 5: // BGE
-                    printf("bge          %s, %s, %d\n", rs1, rs2, offset);
+                    printf("bge            %s, %s, %d\n", rs1, rs2, offset);
                     return;
                 case 6: // BLTU
-                    printf("bltu         %s, %s, %d\n", rs1, rs2, offset);
+                    printf("bltu           %s, %s, %d\n", rs1, rs2, offset);
                     return;
                 case 7: // BGEU
-                    printf("bgeu         %s, %s, %d\n", rs1, rs2, offset);
+                    printf("bgeu           %s, %s, %d\n", rs1, rs2, offset);
                     return;
                 default:
                     printf("RISCV64 illegal instruction: 0x%08X\n", code);
@@ -3250,25 +3255,25 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             switch (opcode2)
             {
                 case 0: // LB
-                    printf("lb           %s, %d(%s)\n", rd, offset, rs1);
+                    printf("lb             %s, %d(%s)\n", rd, offset, rs1);
                     return;
                 case 1: // LH
-                    printf("lh           %s, %d(%s)\n", rd, offset, rs1);
+                    printf("lh             %s, %d(%s)\n", rd, offset, rs1);
                     return;
                 case 2: // LW
-                    printf("lw           %s, %d(%s)\n", rd, offset, rs1);
+                    printf("lw             %s, %d(%s)\n", rd, offset, rs1);
                     return;
                 case 3: // LD
-                    printf("ld           %s, %d(%s)\n", rd, offset, rs1);
+                    printf("ld             %s, %d(%s)\n", rd, offset, rs1);
                     return;
                 case 4: // LBU
-                    printf("lbu          %s, %d(%s)\n", rd, offset, rs1);
+                    printf("lbu            %s, %d(%s)\n", rd, offset, rs1);
                     return;
                 case 5: // LHU
-                    printf("lhu          %s, %d(%s)\n", rd, offset, rs1);
+                    printf("lhu            %s, %d(%s)\n", rd, offset, rs1);
                     return;
                 case 6: // LWU
-                    printf("lwu          %s, %d(%s)\n", rd, offset, rs1);
+                    printf("lwu            %s, %d(%s)\n", rd, offset, rs1);
                     return;
                 default:
                     printf("RISCV64 illegal instruction: 0x%08X\n", code);
@@ -3284,7 +3289,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             {
                 offset |= 0xfffff000;
             }
-            printf("jalr         %s, %d(%s)", rd, offset, rs1);
+            printf("jalr           %s, %d(%s)", rd, offset, rs1);
             CORINFO_METHOD_HANDLE handle = (CORINFO_METHOD_HANDLE)id->idDebugOnlyInfo()->idMemCookie;
             // Target for ret call is unclear, e.g.:
             //   jalr zero, 0(ra)
@@ -3307,7 +3312,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             {
                 offset |= 0xfff00000;
             }
-            printf("jal          %s, %d", rd, offset);
+            printf("jal            %s, %d", rd, offset);
             CORINFO_METHOD_HANDLE handle = (CORINFO_METHOD_HANDLE)id->idDebugOnlyInfo()->idMemCookie;
             if (handle != 0)
             {
@@ -3322,7 +3327,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
         {
             int pred = ((code) >> 24) & 0xf;
             int succ = ((code) >> 20) & 0xf;
-            printf("fence        %d, %d\n", pred, succ);
+            printf("fence          %d, %d\n", pred, succ);
             return;
         }
         case 0x73:
@@ -3353,32 +3358,32 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             switch (opcode2)
             {
                 case 0x00: // FADD.S
-                    printf("fadd.s       %s, %s, %s\n", fd, fs1, fs2);
+                    printf("fadd.s         %s, %s, %s\n", fd, fs1, fs2);
                     return;
                 case 0x04: // FSUB.S
-                    printf("fsub.s       %s, %s, %s\n", fd, fs1, fs2);
+                    printf("fsub.s         %s, %s, %s\n", fd, fs1, fs2);
                     return;
                 case 0x08: // FMUL.S
-                    printf("fmul.s       %s, %s, %s\n", fd, fs1, fs2);
+                    printf("fmul.s         %s, %s, %s\n", fd, fs1, fs2);
                     return;
                 case 0x0C: // FDIV.S
-                    printf("fdiv.s       %s, %s, %s\n", fd, fs1, fs2);
+                    printf("fdiv.s         %s, %s, %s\n", fd, fs1, fs2);
                     return;
                 case 0x2C: // FSQRT.S
-                    printf("fsqrt.s      %s, %s\n", fd, fs1);
+                    printf("fsqrt.s        %s, %s\n", fd, fs1);
                     return;
                 case 0x10:            // FSGNJ.S & FSGNJN.S & FSGNJX.S
                     if (opcode4 == 0) // FSGNJ.S
                     {
-                        printf("fsgnj.s      %s, %s, %s\n", fd, fs1, fs2);
+                        printf("fsgnj.s        %s, %s, %s\n", fd, fs1, fs2);
                     }
                     else if (opcode4 == 1) // FSGNJN.S
                     {
-                        printf("fsgnjn.s     %s, %s, %s\n", fd, fs1, fs2);
+                        printf("fsgnjn.s       %s, %s, %s\n", fd, fs1, fs2);
                     }
                     else if (opcode4 == 2) // FSGNJX.S
                     {
-                        printf("fsgnjx.s     %s, %s, %s\n", fd, fs1, fs2);
+                        printf("fsgnjx.s       %s, %s, %s\n", fd, fs1, fs2);
                     }
                     else
                     {
@@ -3388,11 +3393,11 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 case 0x14:            // FMIN.S & FMAX.S
                     if (opcode4 == 0) // FMIN.S
                     {
-                        printf("fmin.s       %s, %s, %s\n", fd, fs1, fs2);
+                        printf("fmin.s         %s, %s, %s\n", fd, fs1, fs2);
                     }
                     else if (opcode4 == 1) // FMAX.S
                     {
-                        printf("fmax.s       %s, %s, %s\n", fd, fs1, fs2);
+                        printf("fmax.s         %s, %s, %s\n", fd, fs1, fs2);
                     }
                     else
                     {
@@ -3402,19 +3407,19 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 case 0x60:            // FCVT.W.S & FCVT.WU.S & FCVT.L.S & FCVT.LU.S
                     if (opcode3 == 0) // FCVT.W.S
                     {
-                        printf("fcvt.w.s     %s, %s\n", xd, fs1);
+                        printf("fcvt.w.s       %s, %s\n", xd, fs1);
                     }
                     else if (opcode3 == 1) // FCVT.WU.S
                     {
-                        printf("fcvt.wu.s    %s, %s\n", xd, fs1);
+                        printf("fcvt.wu.s      %s, %s\n", xd, fs1);
                     }
                     else if (opcode3 == 2) // FCVT.L.S
                     {
-                        printf("fcvt.l.s     %s, %s\n", xd, fs1);
+                        printf("fcvt.l.s       %s, %s\n", xd, fs1);
                     }
                     else if (opcode3 == 3) // FCVT.LU.S
                     {
-                        printf("fcvt.lu.s    %s, %s\n", xd, fs1);
+                        printf("fcvt.lu.s      %s, %s\n", xd, fs1);
                     }
                     else
                     {
@@ -3424,11 +3429,11 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 case 0x70:            // FMV.X.W & FCLASS.S
                     if (opcode4 == 0) // FMV.X.W
                     {
-                        printf("fmv.x.w      %s, %s\n", xd, fs1);
+                        printf("fmv.x.w        %s, %s\n", xd, fs1);
                     }
                     else if (opcode4 == 1) // FCLASS.S
                     {
-                        printf("fclass.s     %s, %s\n", xd, fs1);
+                        printf("fclass.s       %s, %s\n", xd, fs1);
                     }
                     else
                     {
@@ -3438,15 +3443,15 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 case 0x50:            // FLE.S & FLT.S & FEQ.S
                     if (opcode4 == 0) // FLE.S
                     {
-                        printf("fle.s        %s, %s, %s\n", xd, fs1, fs2);
+                        printf("fle.s          %s, %s, %s\n", xd, fs1, fs2);
                     }
                     else if (opcode4 == 1) // FLT.S
                     {
-                        printf("flt.s        %s, %s, %s\n", xd, fs1, fs2);
+                        printf("flt.s          %s, %s, %s\n", xd, fs1, fs2);
                     }
                     else if (opcode4 == 2) // FEQ.S
                     {
-                        printf("feq.s        %s, %s, %s\n", xd, fs1, fs2);
+                        printf("feq.s          %s, %s, %s\n", xd, fs1, fs2);
                     }
                     else
                     {
@@ -3456,19 +3461,19 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 case 0x68:            // FCVT.S.W & FCVT.S.WU & FCVT.S.L & FCVT.S.LU
                     if (opcode3 == 0) // FCVT.S.W
                     {
-                        printf("fcvt.s.w     %s, %s\n", fd, xs1);
+                        printf("fcvt.s.w       %s, %s\n", fd, xs1);
                     }
                     else if (opcode3 == 1) // FCVT.S.WU
                     {
-                        printf("fcvt.s.wu    %s, %s\n", fd, xs1);
+                        printf("fcvt.s.wu      %s, %s\n", fd, xs1);
                     }
                     else if (opcode3 == 2) // FCVT.S.L
                     {
-                        printf("fcvt.s.l     %s, %s\n", fd, xs1);
+                        printf("fcvt.s.l       %s, %s\n", fd, xs1);
                     }
                     else if (opcode3 == 3) // FCVT.S.LU
                     {
-                        printf("fcvt.s.lu    %s, %s\n", fd, xs1);
+                        printf("fcvt.s.lu      %s, %s\n", fd, xs1);
                     }
 
                     else
@@ -3477,35 +3482,35 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                     }
                     return;
                 case 0x78: // FMV.W.X
-                    printf("fmv.w.x      %s, %s\n", fd, xs1);
+                    printf("fmv.w.x        %s, %s\n", fd, xs1);
                     return;
                 case 0x1: // FADD.D
-                    printf("fadd.d       %s, %s, %s\n", fd, fs1, fs2);
+                    printf("fadd.d         %s, %s, %s\n", fd, fs1, fs2);
                     return;
                 case 0x5: // FSUB.D
-                    printf("fsub.d       %s, %s, %s\n", fd, fs1, fs2);
+                    printf("fsub.d         %s, %s, %s\n", fd, fs1, fs2);
                     return;
                 case 0x9: // FMUL.D
-                    printf("fmul.d       %s, %s, %s\n", fd, fs1, fs2);
+                    printf("fmul.d         %s, %s, %s\n", fd, fs1, fs2);
                     return;
                 case 0xd: // FDIV.D
-                    printf("fdiv.d       %s, %s, %s\n", fd, fs1, fs2);
+                    printf("fdiv.d         %s, %s, %s\n", fd, fs1, fs2);
                     return;
                 case 0x2d: // FSQRT.D
-                    printf("fsqrt.d      %s, %s\n", fd, fs1);
+                    printf("fsqrt.d        %s, %s\n", fd, fs1);
                     return;
                 case 0x11:            // FSGNJ.D & FSGNJN.D & FSGNJX.D
                     if (opcode4 == 0) // FSGNJ.D
                     {
-                        printf("fsgnj.d      %s, %s, %s\n", fd, fs1, fs2);
+                        printf("fsgnj.d        %s, %s, %s\n", fd, fs1, fs2);
                     }
                     else if (opcode4 == 1) // FSGNJN.D
                     {
-                        printf("fsgnjn.d     %s, %s, %s\n", fd, fs1, fs2);
+                        printf("fsgnjn.d       %s, %s, %s\n", fd, fs1, fs2);
                     }
                     else if (opcode4 == 2) // FSGNJX.D
                     {
-                        printf("fsgnjx.d     %s, %s, %s\n", fd, fs1, fs2);
+                        printf("fsgnjx.d       %s, %s, %s\n", fd, fs1, fs2);
                     }
                     else
                     {
@@ -3515,11 +3520,11 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 case 0x15:            // FMIN.D & FMAX.D
                     if (opcode4 == 0) // FMIN.D
                     {
-                        printf("fmin.d       %s, %s, %s\n", fd, fs1, fs2);
+                        printf("fmin.d         %s, %s, %s\n", fd, fs1, fs2);
                     }
                     else if (opcode4 == 1) // FMAX.D
                     {
-                        printf("fmax.d       %s, %s, %s\n", fd, fs1, fs2);
+                        printf("fmax.d         %s, %s, %s\n", fd, fs1, fs2);
                     }
                     else
                     {
@@ -3529,7 +3534,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 case 0x20:            // FCVT.S.D
                     if (opcode3 == 1) // FCVT.S.D
                     {
-                        printf("fcvt.s.d     %s, %s\n", fd, fs1);
+                        printf("fcvt.s.d       %s, %s\n", fd, fs1);
                     }
                     else
                     {
@@ -3539,7 +3544,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 case 0x21:            // FCVT.D.S
                     if (opcode3 == 0) // FCVT.D.S
                     {
-                        printf("fcvt.d.s     %s, %s\n", fd, fs1);
+                        printf("fcvt.d.s       %s, %s\n", fd, fs1);
                     }
                     else
                     {
@@ -3549,15 +3554,15 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 case 0x51:            // FLE.D & FLT.D & FEQ.D
                     if (opcode4 == 0) // FLE.D
                     {
-                        printf("fle.d        %s, %s, %s\n", xd, fs1, fs2);
+                        printf("fle.d          %s, %s, %s\n", xd, fs1, fs2);
                     }
                     else if (opcode4 == 1) // FLT.D
                     {
-                        printf("flt.d        %s, %s, %s\n", xd, fs1, fs2);
+                        printf("flt.d          %s, %s, %s\n", xd, fs1, fs2);
                     }
                     else if (opcode4 == 2) // FEQ.D
                     {
-                        printf("feq.d        %s, %s, %s\n", xd, fs1, fs2);
+                        printf("feq.d          %s, %s, %s\n", xd, fs1, fs2);
                     }
                     else
                     {
@@ -3568,19 +3573,19 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
 
                     if (opcode3 == 0) // FCVT.W.D
                     {
-                        printf("fcvt.w.d     %s, %s\n", xd, fs1);
+                        printf("fcvt.w.d       %s, %s\n", xd, fs1);
                     }
                     else if (opcode3 == 1) // FCVT.WU.D
                     {
-                        printf("fcvt.wu.d    %s, %s\n", xd, fs1);
+                        printf("fcvt.wu.d      %s, %s\n", xd, fs1);
                     }
                     else if (opcode3 == 2) // FCVT.L.D
                     {
-                        printf("fcvt.l.d     %s, %s\n", xd, fs1);
+                        printf("fcvt.l.d       %s, %s\n", xd, fs1);
                     }
                     else if (opcode3 == 3) // FCVT.LU.D
                     {
-                        printf("fcvt.lu.d    %s, %s\n", xd, fs1);
+                        printf("fcvt.lu.d      %s, %s\n", xd, fs1);
                     }
                     else
                     {
@@ -3590,19 +3595,19 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 case 0x69:            // FCVT.D.W & FCVT.D.WU & FCVT.D.L & FCVT.D.LU
                     if (opcode3 == 0) // FCVT.D.W
                     {
-                        printf("fcvt.d.w     %s, %s\n", fd, xs1);
+                        printf("fcvt.d.w       %s, %s\n", fd, xs1);
                     }
                     else if (opcode3 == 1) // FCVT.D.WU
                     {
-                        printf("fcvt.d.wu    %s, %s\n", fd, xs1);
+                        printf("fcvt.d.wu      %s, %s\n", fd, xs1);
                     }
                     else if (opcode3 == 2)
                     {
-                        printf("fcvt.d.l     %s, %s\n", fd, xs1);
+                        printf("fcvt.d.l       %s, %s\n", fd, xs1);
                     }
                     else if (opcode3 == 3)
                     {
-                        printf("fcvt.d.lu    %s, %s\n", fd, xs1);
+                        printf("fcvt.d.lu      %s, %s\n", fd, xs1);
                     }
 
                     else
@@ -3614,11 +3619,11 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 case 0x71:            // FMV.X.D & FCLASS.D
                     if (opcode4 == 0) // FMV.X.D
                     {
-                        printf("fmv.x.d      %s, %s\n", xd, fs1);
+                        printf("fmv.x.d        %s, %s\n", xd, fs1);
                     }
                     else if (opcode4 == 1) // FCLASS.D
                     {
-                        printf("fclass.d     %s, %s\n", xd, fs1);
+                        printf("fclass.d       %s, %s\n", xd, fs1);
                     }
                     else
                     {
@@ -3627,7 +3632,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                     return;
                 case 0x79: // FMV.D.X
                     assert(opcode4 == 0);
-                    printf("fmv.d.x      %s, %s\n", fd, xs1);
+                    printf("fmv.d.x        %s, %s\n", fd, xs1);
                     return;
                 default:
                     NYI_RISCV64("illegal ins within emitDisInsName!");
@@ -3648,11 +3653,11 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             }
             if (opcode2 == 2) // FSW
             {
-                printf("fsw          %s, %d(%s)\n", rs2, offset, rs1);
+                printf("fsw            %s, %d(%s)\n", rs2, offset, rs1);
             }
             else if (opcode2 == 3) // FSD
             {
-                printf("fsd          %s, %d(%s)\n", rs2, offset, rs1);
+                printf("fsd            %s, %d(%s)\n", rs2, offset, rs1);
             }
             else
             {
@@ -3672,11 +3677,11 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             }
             if (opcode2 == 2) // FLW
             {
-                printf("flw          %s, %d(%s)\n", rd, offset, rs1);
+                printf("flw            %s, %d(%s)\n", rd, offset, rs1);
             }
             else if (opcode2 == 3) // FLD
             {
-                printf("fld          %s, %d(%s)\n", rd, offset, rs1);
+                printf("fld            %s, %d(%s)\n", rd, offset, rs1);
             }
             else
             {
@@ -3684,48 +3689,90 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             }
             return;
         }
-        case 0b0101111: // AMO - atomic memory operation
+        case 0x2f: // AMO - atomic memory operation
         {
-            unsigned int funct5 = code >> 27;
-            // clang-format off
-            const char* name =
-                funct5 == 0b00010 ? "lr" :
-                funct5 == 0b00011 ? "sc" :
-                funct5 == 0b00001 ? "amoswap" :
-                funct5 == 0b00000 ? "amoadd" :
-                funct5 == 0b00100 ? "amoxor" :
-                funct5 == 0b01100 ? "amoand" :
-                funct5 == 0b01000 ? "amoor" :
-                funct5 == 0b10000 ? "amomin" :
-                funct5 == 0b10100 ? "amomax" :
-                funct5 == 0b11000 ? "amominu" :
-                funct5 == 0b11100 ? "amomaxu" :
-                (assert(!"Illegal funct5 within atomic memory operation, emitDisInsName"), "?");
-            // clang-format on
+            bool        hasDataReg = true;
+            const char* name;
+            switch (code >> 27) // funct5
+            {
+                case 0b00010:
+                    name       = "lr";
+                    hasDataReg = false;
+                    break;
+                case 0b00011:
+                    name = "sc";
+                    break;
+                case 0b00001:
+                    name = "amoswap";
+                    break;
+                case 0b00000:
+                    name = "amoadd";
+                    break;
+                case 0b00100:
+                    name = "amoxor";
+                    break;
+                case 0b01100:
+                    name = "amoand";
+                    break;
+                case 0b01000:
+                    name = "amoor";
+                    break;
+                case 0b10000:
+                    name = "amomin";
+                    break;
+                case 0b10100:
+                    name = "amomax";
+                    break;
+                case 0b11000:
+                    name = "amominu";
+                    break;
+                case 0b11100:
+                    name = "amomaxu";
+                    break;
+                default:
+                    assert(!"Illegal funct5 within atomic memory operation, emitDisInsName");
+                    name = "?";
+            }
 
-            unsigned int funct3 = (code >> 12) & 0x7;
-            // clang-format off
-            char width =
-                funct3 == 0b010 ? 'w' :
-                funct3 == 0b011 ? 'd' :
-                (assert(!"Illegal width tag within atomic memory operation, emitDisInsName"), '?');
-            // clang-format on
+            char width;
+            switch ((code >> 12) & 0x7) // funct3: width
+            {
+                case 0x2:
+                    width = 'w';
+                    break;
+                case 0x3:
+                    width = 'd';
+                    break;
+                default:
+                    assert(!"Illegal width tag within atomic memory operation, emitDisInsName");
+                    width = '?';
+            }
 
-            const char* aq = code & (1 << 25) ? "a" : "";
-            const char* rl = code & (1 << 26) ? "r" : "";
+            const char* aq = code & (1 << 25) ? "aq" : "";
+            const char* rl = code & (1 << 26) ? "rl" : "";
 
             int len = printf("%s.%c.%s%s", name, width, aq, rl);
             if (len <= 0)
             {
                 return;
             }
-            assert(len <= 12);
+            static const int INS_LEN = 14;
+            assert(len <= INS_LEN);
 
             const char* dest = RegNames[(code >> 7) & 0x1f];
             const char* addr = RegNames[(code >> 15) & 0x1f];
-            const char* data = RegNames[(code >> 20) & 0x1f];
 
-            printf("%*s %s, %s, %s\n", 12 - len, "", dest, addr, data);
+            int dataReg = (code >> 20) & 0x1f;
+            if (hasDataReg)
+            {
+                const char* data = RegNames[dataReg];
+                printf("%*s %s, %s, (%s)\n", INS_LEN - len, "", dest, data, addr);
+            }
+            else
+            {
+                assert(dataReg == REG_R0);
+                printf("%*s %s, (%s)\n", INS_LEN - len, "", dest, addr);
+            }
             return;
         }
         default:

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3687,6 +3687,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
         case 0b0101111: // AMO - atomic memory operation
         {
             unsigned int funct5 = code >> 27;
+            // clang-format off
             const char* name =
                 funct5 == 0b00010 ? "lr" :
                 funct5 == 0b00011 ? "sc" :
@@ -3700,15 +3701,19 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 funct5 == 0b11000 ? "amominu" :
                 funct5 == 0b11100 ? "amomaxu" :
                 (assert(!"Illegal funct5 within atomic memory operation, emitDisInsName"), "?");
+            // clang-format on
 
             unsigned int funct3 = (code >> 12) & 0x7;
+            // clang-format off
             char width =
                 funct3 == 0b010 ? 'w' :
                 funct3 == 0b011 ? 'd' :
                 (assert(!"Illegal width tag within atomic memory operation, emitDisInsName"), '?');
+            // clang-format on
 
             const char* aq = code & (1 << 25) ? "a" : "";
             const char* rl = code & (1 << 26) ? "r" : "";
+
             int len = printf("%s.%c.%s%s", name, width, aq, rl);
             if (len <= 0)
             {
@@ -3716,7 +3721,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             }
             assert(len <= 12);
 
-            const char* dest = RegNames[(code >>  7) & 0x1f];
+            const char* dest = RegNames[(code >> 7) & 0x1f];
             const char* addr = RegNames[(code >> 15) & 0x1f];
             const char* data = RegNames[(code >> 20) & 0x1f];
 

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3314,8 +3314,8 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 // want to make this *not* make the var address-taken -- but atomic instructions
                 // on a local are probably pretty useless anyway, so we probably don't care.
 
-                genTreeOps oper = (ni == NI_System_Threading_Interlocked_ExchangeAdd) ? GT_XADD : GT_XCHG;
-                op1 = gtNewOperNode(oper, genActualType(callType), op1, op2);
+                op1 = gtNewOperNode(ni == NI_System_Threading_Interlocked_ExchangeAdd ? GT_XADD : GT_XCHG,
+                                    genActualType(callType), op1, op2);
                 op1->gtFlags |= GTF_GLOB_REF | GTF_ASG;
                 retNode = op1;
                 break;

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3247,7 +3247,6 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 #endif // defined(TARGET_ARM64) || defined(TARGET_RISCV64)
 
 #if defined(TARGET_XARCH) || defined(TARGET_ARM64) || defined(TARGET_RISCV64)
-#ifndef TARGET_RISCV64
             // TODO-ARM-CQ: reenable treating InterlockedCmpXchg32 operation as intrinsic
             case NI_System_Threading_Interlocked_CompareExchange:
             {
@@ -3279,7 +3278,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 retNode = node;
                 break;
             }
-#endif // !TARGET_RISCV64
+
             case NI_System_Threading_Interlocked_Exchange:
             case NI_System_Threading_Interlocked_ExchangeAdd:
             {

--- a/src/coreclr/jit/instrsriscv64.h
+++ b/src/coreclr/jit/instrsriscv64.h
@@ -241,8 +241,8 @@ INST(fcvt_d_l,      "fcvt.d.l",       0,   0xd2200053)
 INST(fcvt_d_lu,     "fcvt.d.lu",      0,   0xd2300053)
 INST(fmv_d_x,       "fmv.d.x",        0,   0xf2000053)
 
-// RV32A + RV64A (R_R_R)
-// For now all of them are seqentially consistent because the Interlocked.* APIs don't specify acquire/release ordering
+// RV32A + RV64A (R-type, R_R_R)
+// For now all of them are seqentially consistent because the Interlocked.* APIs don't expose acquire/release ordering
 INST(lr_w,          "lr.w",           0,   (0b00010 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
 INST(lr_d,          "lr.d",           0,   (0b00010 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
 INST(sc_w,          "sc.w",           0,   (0b00011 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)

--- a/src/coreclr/jit/instrsriscv64.h
+++ b/src/coreclr/jit/instrsriscv64.h
@@ -241,6 +241,31 @@ INST(fcvt_d_l,      "fcvt.d.l",       0,   0xd2200053)
 INST(fcvt_d_lu,     "fcvt.d.lu",      0,   0xd2300053)
 INST(fmv_d_x,       "fmv.d.x",        0,   0xf2000053)
 
+// RV32A + RV64A (R_R_R)
+// For now all of them are seqentially consistent because the Interlocked.* APIs don't specify acquire/release ordering
+INST(lr_w,          "lr.w",           0,   (0b00010 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
+INST(lr_d,          "lr.d",           0,   (0b00010 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
+INST(sc_w,          "sc.w",           0,   (0b00011 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
+INST(sc_d,          "sc.d",           0,   (0b00011 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
+INST(amoswap_w,     "amoswap.w",      0,   (0b00001 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
+INST(amoswap_d,     "amoswap.d",      0,   (0b00001 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
+INST(amoadd_w,      "amoadd.w",       0,   (0b00000 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
+INST(amoadd_d,      "amoadd.d",       0,   (0b00000 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
+INST(amoxor_w,      "amoxor.w",       0,   (0b00100 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
+INST(amoxor_d,      "amoxor.d",       0,   (0b00100 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
+INST(amoand_w,      "amoand.w",       0,   (0b01100 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
+INST(amoand_d,      "amoand.d",       0,   (0b01100 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
+INST(amoor_w,       "amoor.w",        0,   (0b01000 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
+INST(amoor_d,       "amoor.d",        0,   (0b01000 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
+INST(amomin_w,      "amomin.w",       0,   (0b10000 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
+INST(amomin_d,      "amomin.d",       0,   (0b10000 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
+INST(amomax_w,      "amomax.w",       0,   (0b10100 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
+INST(amomax_d,      "amomax.d",       0,   (0b10100 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
+INST(amominu_w,     "amominu.w",      0,   (0b11000 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
+INST(amominu_d,     "amominu.d",      0,   (0b11000 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
+INST(amomaxu_w,     "amomaxu.w",      0,   (0b11100 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
+INST(amomaxu_d,     "amomaxu.d",      0,   (0b11100 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
+
 // clang-format on
 /*****************************************************************************/
 #undef INST

--- a/src/coreclr/jit/instrsriscv64.h
+++ b/src/coreclr/jit/instrsriscv64.h
@@ -242,30 +242,28 @@ INST(fcvt_d_lu,     "fcvt.d.lu",      0,   0xd2300053)
 INST(fmv_d_x,       "fmv.d.x",        0,   0xf2000053)
 
 // RV32A + RV64A (R-type, R_R_R)
-// For now all of them are seqentially consistent because the Interlocked.* APIs don't expose acquire/release ordering
-INST(lr_w,          "lr.w",           0,   (0b00010 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
-INST(lr_d,          "lr.d",           0,   (0b00010 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
-INST(sc_w,          "sc.w",           0,   (0b00011 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
-INST(sc_d,          "sc.d",           0,   (0b00011 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
-INST(amoswap_w,     "amoswap.w",      0,   (0b00001 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
-INST(amoswap_d,     "amoswap.d",      0,   (0b00001 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
-INST(amoadd_w,      "amoadd.w",       0,   (0b00000 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
-INST(amoadd_d,      "amoadd.d",       0,   (0b00000 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
-INST(amoxor_w,      "amoxor.w",       0,   (0b00100 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
-INST(amoxor_d,      "amoxor.d",       0,   (0b00100 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
-INST(amoand_w,      "amoand.w",       0,   (0b01100 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
-INST(amoand_d,      "amoand.d",       0,   (0b01100 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
-INST(amoor_w,       "amoor.w",        0,   (0b01000 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
-INST(amoor_d,       "amoor.d",        0,   (0b01000 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
-INST(amomin_w,      "amomin.w",       0,   (0b10000 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
-INST(amomin_d,      "amomin.d",       0,   (0b10000 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
-INST(amomax_w,      "amomax.w",       0,   (0b10100 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
-INST(amomax_d,      "amomax.d",       0,   (0b10100 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
-INST(amominu_w,     "amominu.w",      0,   (0b11000 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
-INST(amominu_d,     "amominu.d",      0,   (0b11000 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
-INST(amomaxu_w,     "amomaxu.w",      0,   (0b11100 << 27) | (0b11 << 25) | (0b010 << 12) | 0b0101111)
-INST(amomaxu_d,     "amomaxu.d",      0,   (0b11100 << 27) | (0b11 << 25) | (0b011 << 12) | 0b0101111)
-
+INST(lr_w,          "lr.w",           0,   0x1000202f) // funct5:00010
+INST(lr_d,          "lr.d",           0,   0x1000302f) // funct5:00010
+INST(sc_w,          "sc.w",           0,   0x1800202f) // funct5:00011
+INST(sc_d,          "sc.d",           0,   0x1800302f) // funct5:00011
+INST(amoswap_w,     "amoswap.w",      0,   0x0800202f) // funct5:00001
+INST(amoswap_d,     "amoswap.d",      0,   0x0800302f) // funct5:00001
+INST(amoadd_w,      "amoadd.w",       0,   0x0000202f) // funct5:00000
+INST(amoadd_d,      "amoadd.d",       0,   0x0000302f) // funct5:00000
+INST(amoxor_w,      "amoxor.w",       0,   0x2000202f) // funct5:00100
+INST(amoxor_d,      "amoxor.d",       0,   0x2000302f) // funct5:00100
+INST(amoand_w,      "amoand.w",       0,   0x6000202f) // funct5:01100
+INST(amoand_d,      "amoand.d",       0,   0x6000302f) // funct5:01100
+INST(amoor_w,       "amoor.w",        0,   0x4000202f) // funct5:01000
+INST(amoor_d,       "amoor.d",        0,   0x4000302f) // funct5:01000
+INST(amomin_w,      "amomin.w",       0,   0x8000202f) // funct5:10000
+INST(amomin_d,      "amomin.d",       0,   0x8000302f) // funct5:10000
+INST(amomax_w,      "amomax.w",       0,   0xa000202f) // funct5:10100
+INST(amomax_d,      "amomax.d",       0,   0xa000302f) // funct5:10100
+INST(amominu_w,     "amominu.w",      0,   0xc000202f) // funct5:11000
+INST(amominu_d,     "amominu.d",      0,   0xc000302f) // funct5:11000
+INST(amomaxu_w,     "amomaxu.w",      0,   0xe000202f) // funct5:11100
+INST(amomaxu_d,     "amomaxu.d",      0,   0xe000302f) // funct5:11100
 // clang-format on
 /*****************************************************************************/
 #undef INST

--- a/src/coreclr/jit/lowerriscv64.cpp
+++ b/src/coreclr/jit/lowerriscv64.cpp
@@ -64,12 +64,6 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
 
         switch (parentNode->OperGet())
         {
-            case GT_CMPXCHG:
-            case GT_LOCKADD:
-            case GT_XADD:
-                NYI_RISCV64("GT_CMPXCHG,GT_LOCKADD,GT_XADD");
-                break;
-
             case GT_ADD:
             case GT_EQ:
             case GT_NE:

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1004,7 +1004,7 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_XADD:
         case GT_XCHG:
         {
-            assert(dstCount == (tree->TypeGet() == TYP_VOID) ? 0 : 1);
+            assert(dstCount == (tree->TypeIs(TYP_VOID) ? 0 : 1));
             srcCount = tree->gtGetOp2()->isContained() ? 1 : 2;
 
             if (!compiler->compOpportunisticallyDependsOn(InstructionSet_Atomics))

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -395,17 +395,14 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_XADD:
         case GT_XCHG:
         {
-            assert(dstCount == (tree->TypeGet() == TYP_VOID) ? 0 : 1);
+            assert(dstCount == tree->TypeIs(TYP_VOID) ? 0 : 1);
             GenTree* addr = tree->gtGetOp1();
             GenTree* data = tree->gtGetOp2();
             assert(!addr->isContained() && !data->isContained());
             srcCount = 2;
 
-            buildInternalIntRegisterDefForNode(tree);
-
             BuildUse(addr);
             BuildUse(data);
-            buildInternalRegisterUses();
             if (dstCount == 1)
             {
                 BuildDef(tree);

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -373,12 +373,29 @@ int LinearScan::BuildNode(GenTree* tree)
         break;
 
         case GT_LOCKADD:
+            assert(!"-----unimplemented on RISCV64----");
+            break;
+
         case GT_XORR:
         case GT_XAND:
         case GT_XADD:
         case GT_XCHG:
         {
-            NYI_RISCV64("-----unimplemented on RISCV64 yet----");
+            assert(dstCount == (tree->TypeGet() == TYP_VOID) ? 0 : 1);
+            GenTree* addr = tree->gtGetOp1();
+            GenTree* data = tree->gtGetOp2();
+            assert(!addr->isContained() && !data->isContained());
+            srcCount = 2;
+
+            buildInternalIntRegisterDefForNode(tree);
+
+            BuildUse(addr);
+            BuildUse(data);
+            buildInternalRegisterUses();
+            if (dstCount == 1)
+            {
+                BuildDef(tree);
+            }
         }
         break;
 

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -373,7 +373,7 @@ int LinearScan::BuildNode(GenTree* tree)
             srcCount = 3;
             assert(dstCount == 1);
 
-            buildInternalIntRegisterDefForNode(tree);  // temp reg for store conditional error
+            buildInternalIntRegisterDefForNode(tree); // temp reg for store conditional error
             // Extend lifetimes of argument regs because they may be reused during retries
             setDelayFree(BuildUse(cas->gtOpLocation));
             setDelayFree(BuildUse(cas->gtOpValue));

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -395,7 +395,7 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_XADD:
         case GT_XCHG:
         {
-            assert(dstCount == tree->TypeIs(TYP_VOID) ? 0 : 1);
+            assert(dstCount == (tree->TypeIs(TYP_VOID) ? 0 : 1));
             GenTree* addr = tree->gtGetOp1();
             GenTree* data = tree->gtGetOp2();
             assert(!addr->isContained() && !data->isContained());


### PR DESCRIPTION
Add atomic instructions (RV64A) to JIT.
Intrinsify calls to Interlocked.ExchangeAdd|Exchange|And|Or|CompareExchange.

Part of #84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov @clamp03 @sirntar @yurai007
