### PR TITLE
[NativeAOT] Fix iOS library build by linking standard C++ library by default

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -50,6 +50,9 @@ The .NET Foundation licenses this file to you under the MIT license.
 
       <EventPipeName>libeventpipe-disabled</EventPipeName>
       <EventPipeName Condition="'$(EventSourceSupport)' == 'true'">libeventpipe-enabled</EventPipeName>
+
+      <LinkStandardCPlusPlusLibrary Condition="'$(LinkStandardCPlusPlusLibrary)' == '' and '$(NativeLib)' != '' and '$(_IsiOSLikePlatform)' == 'true' and '$(InvariantGlobalization)' != 'true'">true</LinkStandardCPlusPlusLibrary>
+      <LinkStandardCPlusPlusLibrary Condition="'$(LinkStandardCPlusPlusLibrary)' == ''">false</LinkStandardCPlusPlusLibrary>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -51,8 +51,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <EventPipeName>libeventpipe-disabled</EventPipeName>
       <EventPipeName Condition="'$(EventSourceSupport)' == 'true'">libeventpipe-enabled</EventPipeName>
 
-      <LinkStandardCPlusPlusLibrary Condition="'$(LinkStandardCPlusPlusLibrary)' == '' and '$(NativeLib)' != '' and '$(_IsiOSLikePlatform)' == 'true' and '$(InvariantGlobalization)' != 'true'">true</LinkStandardCPlusPlusLibrary>
-      <LinkStandardCPlusPlusLibrary Condition="'$(LinkStandardCPlusPlusLibrary)' == ''">false</LinkStandardCPlusPlusLibrary>
+      <LinkStandardCPlusPlusLibrary Condition="'$(LinkStandardCPlusPlusLibrary)' == '' and '$(_IsiOSLikePlatform)' == 'true' and '$(InvariantGlobalization)' != 'true'">true</LinkStandardCPlusPlusLibrary>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR fixes building an iOS-like NativeAOT libraries by linking standard C++ library by default.

Recently we started statically linking ICU libraries when targeting iOS-like platforms in: https://github.com/dotnet/runtime/pull/90430
However globalization and ICU support has a dependency on the standard C++ lib which is not included by NativeAOT build integration targets and produces a build error when trying to build NativeAOT iOS library:
```
Undefined symbols for architecture arm64:
    "std::__1::__call_once(unsigned long volatile&, void*, void (*)(void*))", referenced from:
        void std::__1::call_once<void (&)()>(std::__1::once_flag&, void (&)()) in libicuuc.a(umutex.ao)
        ...
```

This is not visible when build iOS apps, as we use `AppleAppBuilder` and `Xamarin` application bundlers that are taking care of native linking. 

NativeAOT with iOS in library mode is not officially supported (this is tracked in: https://github.com/dotnet/runtime/issues/88737), but this fix is a prerequisite of going in the right direction and unblocking customers who are using the experimental support.  The official support for iOS library mode will come in a separate PR.
 
---
Fixes: https://github.com/dotnet/runtime/issues/91997