### PR TITLE
JIT: Initialize jitstdout lazily

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2011,7 +2011,7 @@ void CodeGen::genEmitMachineCode()
 #if TRACK_LSRA_STATS
         if (JitConfig.DisplayLsraStats() == 3)
         {
-            compiler->m_pLinearScan->dumpLsraStatsSummary(jitstdout);
+            compiler->m_pLinearScan->dumpLsraStatsSummary(jitstdout());
         }
 #endif // TRACK_LSRA_STATS
 
@@ -2104,7 +2104,7 @@ void CodeGen::genEmitUnwindDebugGCandEH()
         genCreateAndStoreGCInfo(codeSize, prologSize, epilogSize DEBUGARG(codePtr));
 
 #ifdef DEBUG
-    FILE* dmpf = jitstdout;
+    FILE* dmpf = jitstdout();
 
     compiler->opts.dmpHex = false;
     if (!strcmp(compiler->info.compMethodName, "<name of method you want the hex dump for"))
@@ -2157,7 +2157,7 @@ void CodeGen::genEmitUnwindDebugGCandEH()
         fflush(dmpf);
     }
 
-    if (dmpf != jitstdout)
+    if (dmpf != jitstdout())
     {
         fclose(dmpf);
     }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -1331,7 +1331,7 @@ void Compiler::compStartup()
     // Static vars of ValueNumStore
     ValueNumStore::ValidateValueNumStoreStatics();
 
-    compDisplayStaticSizes(jitstdout());
+    compDisplayStaticSizes();
 }
 
 /*****************************************************************************
@@ -1392,9 +1392,6 @@ void Compiler::compShutdown()
     GenTree::ReportOperBashing(jitstdout());
 #endif
 
-    // Where should we write our statistics output?
-    FILE* fout = jitstdout();
-
 #ifdef FEATURE_JIT_METHOD_PERF
     if (compJitTimeLogFilename != nullptr)
     {
@@ -1445,7 +1442,7 @@ void Compiler::compShutdown()
         unsigned countLarge = 0;
         unsigned countSmall = 0;
 
-        fprintf(fout, "\nGenTree operator counts (approximate):\n\n");
+        printf("\nGenTree operator counts (approximate):\n\n");
 
         for (OperInfo oper : opers)
         {
@@ -1465,8 +1462,8 @@ void Compiler::compShutdown()
             // Let's not show anything below a threshold
             if (percentage >= 0.5)
             {
-                fprintf(fout, "    GT_%-17s   %7u (%4.1lf%%) %3u bytes each\n", GenTree::OpName(oper.Oper), count,
-                        percentage, size);
+                jitprintf("    GT_%-17s   %7u (%4.1lf%%) %3u bytes each\n", GenTree::OpName(oper.Oper), count,
+                          percentage, size);
                 remainingCount -= count;
             }
             else
@@ -1484,14 +1481,14 @@ void Compiler::compShutdown()
 
         if (remainingCount > 0)
         {
-            fprintf(fout, "    All other GT_xxx ...   %7u (%4.1lf%%) ... %4.1lf%% small + %4.1lf%% large\n",
-                    remainingCount, 100.0 * remainingCount / totalCount, 100.0 * remainingCountSmall / totalCount,
-                    100.0 * remainingCountLarge / totalCount);
+            jitprintf("    All other GT_xxx ...   %7u (%4.1lf%%) ... %4.1lf%% small + %4.1lf%% large\n", remainingCount,
+                      100.0 * remainingCount / totalCount, 100.0 * remainingCountSmall / totalCount,
+                      100.0 * remainingCountLarge / totalCount);
         }
-        fprintf(fout, "    -----------------------------------------------------\n");
-        fprintf(fout, "    Total    .......   %11u --ALL-- ... %4.1lf%% small + %4.1lf%% large\n", totalCount,
-                100.0 * countSmall / totalCount, 100.0 * countLarge / totalCount);
-        fprintf(fout, "\n");
+        jitprintf("    -----------------------------------------------------\n");
+        jitprintf("    Total    .......   %11u --ALL-- ... %4.1lf%% small + %4.1lf%% large\n", totalCount,
+                  100.0 * countSmall / totalCount, 100.0 * countLarge / totalCount);
+        jitprintf("\n");
     }
 
 #endif // COUNT_AST_OPERS
@@ -1500,49 +1497,49 @@ void Compiler::compShutdown()
 
     if (grossVMsize && grossNCsize)
     {
-        fprintf(fout, "\n");
-        fprintf(fout, "--------------------------------------\n");
-        fprintf(fout, "Function and GC info size stats\n");
-        fprintf(fout, "--------------------------------------\n");
+        jitprintf("\n");
+        jitprintf("--------------------------------------\n");
+        jitprintf("Function and GC info size stats\n");
+        jitprintf("--------------------------------------\n");
 
-        fprintf(fout, "[%7u VM, %8u %6s %4u%%] %s\n", grossVMsize, grossNCsize, Target::g_tgtCPUName,
-                100 * grossNCsize / grossVMsize, "Total (excluding GC info)");
+        jitprintf("[%7u VM, %8u %6s %4u%%] %s\n", grossVMsize, grossNCsize, Target::g_tgtCPUName,
+                  100 * grossNCsize / grossVMsize, "Total (excluding GC info)");
 
-        fprintf(fout, "[%7u VM, %8u %6s %4u%%] %s\n", grossVMsize, totalNCsize, Target::g_tgtCPUName,
-                100 * totalNCsize / grossVMsize, "Total (including GC info)");
+        jitprintf("[%7u VM, %8u %6s %4u%%] %s\n", grossVMsize, totalNCsize, Target::g_tgtCPUName,
+                  100 * totalNCsize / grossVMsize, "Total (including GC info)");
 
         if (gcHeaderISize || gcHeaderNSize)
         {
-            fprintf(fout, "\n");
+            jitprintf("\n");
 
-            fprintf(fout, "GC tables   : [%7uI,%7uN] %7u byt  (%u%% of IL, %u%% of %s).\n",
-                    gcHeaderISize + gcPtrMapISize, gcHeaderNSize + gcPtrMapNSize, totalNCsize - grossNCsize,
-                    100 * (totalNCsize - grossNCsize) / grossVMsize, 100 * (totalNCsize - grossNCsize) / grossNCsize,
-                    Target::g_tgtCPUName);
+            jitprintf("GC tables   : [%7uI,%7uN] %7u byt  (%u%% of IL, %u%% of %s).\n", gcHeaderISize + gcPtrMapISize,
+                      gcHeaderNSize + gcPtrMapNSize, totalNCsize - grossNCsize,
+                      100 * (totalNCsize - grossNCsize) / grossVMsize, 100 * (totalNCsize - grossNCsize) / grossNCsize,
+                      Target::g_tgtCPUName);
 
-            fprintf(fout, "GC headers  : [%7uI,%7uN] %7u byt, [%4.1fI,%4.1fN] %4.1f byt/meth\n", gcHeaderISize,
-                    gcHeaderNSize, gcHeaderISize + gcHeaderNSize, (float)gcHeaderISize / (genMethodICnt + 0.001),
-                    (float)gcHeaderNSize / (genMethodNCnt + 0.001),
-                    (float)(gcHeaderISize + gcHeaderNSize) / genMethodCnt);
+            jitprintf("GC headers  : [%7uI,%7uN] %7u byt, [%4.1fI,%4.1fN] %4.1f byt/meth\n", gcHeaderISize,
+                      gcHeaderNSize, gcHeaderISize + gcHeaderNSize, (float)gcHeaderISize / (genMethodICnt + 0.001),
+                      (float)gcHeaderNSize / (genMethodNCnt + 0.001),
+                      (float)(gcHeaderISize + gcHeaderNSize) / genMethodCnt);
 
-            fprintf(fout, "GC ptr maps : [%7uI,%7uN] %7u byt, [%4.1fI,%4.1fN] %4.1f byt/meth\n", gcPtrMapISize,
-                    gcPtrMapNSize, gcPtrMapISize + gcPtrMapNSize, (float)gcPtrMapISize / (genMethodICnt + 0.001),
-                    (float)gcPtrMapNSize / (genMethodNCnt + 0.001),
-                    (float)(gcPtrMapISize + gcPtrMapNSize) / genMethodCnt);
+            jitprintf("GC ptr maps : [%7uI,%7uN] %7u byt, [%4.1fI,%4.1fN] %4.1f byt/meth\n", gcPtrMapISize,
+                      gcPtrMapNSize, gcPtrMapISize + gcPtrMapNSize, (float)gcPtrMapISize / (genMethodICnt + 0.001),
+                      (float)gcPtrMapNSize / (genMethodNCnt + 0.001),
+                      (float)(gcPtrMapISize + gcPtrMapNSize) / genMethodCnt);
         }
         else
         {
-            fprintf(fout, "\n");
+            jitprintf("\n");
 
-            fprintf(fout, "GC tables   take up %u bytes (%u%% of instr, %u%% of %6s code).\n",
-                    totalNCsize - grossNCsize, 100 * (totalNCsize - grossNCsize) / grossVMsize,
-                    100 * (totalNCsize - grossNCsize) / grossNCsize, Target::g_tgtCPUName);
+            jitprintf("GC tables   take up %u bytes (%u%% of instr, %u%% of %6s code).\n", totalNCsize - grossNCsize,
+                      100 * (totalNCsize - grossNCsize) / grossVMsize, 100 * (totalNCsize - grossNCsize) / grossNCsize,
+                      Target::g_tgtCPUName);
         }
 
 #ifdef DEBUG
 #if DOUBLE_ALIGN
-        fprintf(fout, "%u out of %u methods generated with double-aligned stack\n",
-                Compiler::s_lvaDoubleAlignedProcsCount, genMethodCnt);
+        jitprintf("%u out of %u methods generated with double-aligned stack\n", Compiler::s_lvaDoubleAlignedProcsCount,
+                  genMethodCnt);
 #endif
 #endif
     }
@@ -1550,110 +1547,110 @@ void Compiler::compShutdown()
 #endif // DISPLAY_SIZES
 
 #if CALL_ARG_STATS
-    compDispCallArgStats(fout);
+    compDispCallArgStats(jitstdout());
 #endif
 
 #if COUNT_BASIC_BLOCKS
-    fprintf(fout, "--------------------------------------------------\n");
-    fprintf(fout, "Basic block count frequency table:\n");
-    fprintf(fout, "--------------------------------------------------\n");
-    bbCntTable.dump(fout);
-    fprintf(fout, "--------------------------------------------------\n");
+    jitprintf("--------------------------------------------------\n");
+    jitprintf("Basic block count frequency table:\n");
+    jitprintf("--------------------------------------------------\n");
+    bbCntTable.dump(jitstdout());
+    jitprintf("--------------------------------------------------\n");
 
-    fprintf(fout, "\n");
+    jitprintf("\n");
 
-    fprintf(fout, "--------------------------------------------------\n");
-    fprintf(fout, "IL method size frequency table for methods with a single basic block:\n");
-    fprintf(fout, "--------------------------------------------------\n");
-    bbOneBBSizeTable.dump(fout);
-    fprintf(fout, "--------------------------------------------------\n");
+    jitprintf("--------------------------------------------------\n");
+    jitprintf("IL method size frequency table for methods with a single basic block:\n");
+    jitprintf("--------------------------------------------------\n");
+    bbOneBBSizeTable.dump(jitstdout());
+    jitprintf("--------------------------------------------------\n");
 
-    fprintf(fout, "--------------------------------------------------\n");
-    fprintf(fout, "fgComputeDoms `while (change)` iterations:\n");
-    fprintf(fout, "--------------------------------------------------\n");
-    domsChangedIterationTable.dump(fout);
-    fprintf(fout, "--------------------------------------------------\n");
+    jitprintf("--------------------------------------------------\n");
+    jitprintf("fgComputeDoms `while (change)` iterations:\n");
+    jitprintf("--------------------------------------------------\n");
+    domsChangedIterationTable.dump(jitstdout());
+    jitprintf("--------------------------------------------------\n");
 
-    fprintf(fout, "--------------------------------------------------\n");
-    fprintf(fout, "fgComputeReachabilitySets `while (change)` iterations:\n");
-    fprintf(fout, "--------------------------------------------------\n");
-    computeReachabilitySetsIterationTable.dump(fout);
-    fprintf(fout, "--------------------------------------------------\n");
+    jitprintf("--------------------------------------------------\n");
+    jitprintf("fgComputeReachabilitySets `while (change)` iterations:\n");
+    jitprintf("--------------------------------------------------\n");
+    computeReachabilitySetsIterationTable.dump(jitstdout());
+    jitprintf("--------------------------------------------------\n");
 
-    fprintf(fout, "--------------------------------------------------\n");
-    fprintf(fout, "fgComputeReachability `while (change)` iterations:\n");
-    fprintf(fout, "--------------------------------------------------\n");
-    computeReachabilityIterationTable.dump(fout);
-    fprintf(fout, "--------------------------------------------------\n");
+    jitprintf("--------------------------------------------------\n");
+    jitprintf("fgComputeReachability `while (change)` iterations:\n");
+    jitprintf("--------------------------------------------------\n");
+    computeReachabilityIterationTable.dump(jitstdout());
+    jitprintf("--------------------------------------------------\n");
 
 #endif // COUNT_BASIC_BLOCKS
 
 #if COUNT_LOOPS
 
-    fprintf(fout, "\n");
-    fprintf(fout, "---------------------------------------------------\n");
-    fprintf(fout, "Loop stats\n");
-    fprintf(fout, "---------------------------------------------------\n");
-    fprintf(fout, "Total number of methods with loops is %5u\n", totalLoopMethods);
-    fprintf(fout, "Total number of              loops is %5u\n", totalLoopCount);
-    fprintf(fout, "Maximum number of loops per method is %5u\n", maxLoopsPerMethod);
-    fprintf(fout, "# of methods overflowing nat loop table is %5u\n", totalLoopOverflows);
-    fprintf(fout, "Total number of 'unnatural' loops is %5u\n", totalUnnatLoopCount);
-    fprintf(fout, "# of methods overflowing unnat loop limit is %5u\n", totalUnnatLoopOverflows);
-    fprintf(fout, "Total number of loops with an         iterator is %5u\n", iterLoopCount);
-    fprintf(fout, "Total number of loops with a constant iterator is %5u\n", constIterLoopCount);
+    jitprintf("\n");
+    jitprintf("---------------------------------------------------\n");
+    jitprintf("Loop stats\n");
+    jitprintf("---------------------------------------------------\n");
+    jitprintf("Total number of methods with loops is %5u\n", totalLoopMethods);
+    jitprintf("Total number of              loops is %5u\n", totalLoopCount);
+    jitprintf("Maximum number of loops per method is %5u\n", maxLoopsPerMethod);
+    jitprintf("# of methods overflowing nat loop table is %5u\n", totalLoopOverflows);
+    jitprintf("Total number of 'unnatural' loops is %5u\n", totalUnnatLoopCount);
+    jitprintf("# of methods overflowing unnat loop limit is %5u\n", totalUnnatLoopOverflows);
+    jitprintf("Total number of loops with an         iterator is %5u\n", iterLoopCount);
+    jitprintf("Total number of loops with a constant iterator is %5u\n", constIterLoopCount);
 
-    fprintf(fout, "--------------------------------------------------\n");
-    fprintf(fout, "Loop count frequency table:\n");
-    fprintf(fout, "--------------------------------------------------\n");
-    loopCountTable.dump(fout);
-    fprintf(fout, "--------------------------------------------------\n");
-    fprintf(fout, "Loop exit count frequency table:\n");
-    fprintf(fout, "--------------------------------------------------\n");
-    loopExitCountTable.dump(fout);
-    fprintf(fout, "--------------------------------------------------\n");
+    jitprintf("--------------------------------------------------\n");
+    jitprintf("Loop count frequency table:\n");
+    jitprintf("--------------------------------------------------\n");
+    loopCountTable.dump(jitstdout());
+    jitprintf("--------------------------------------------------\n");
+    jitprintf("Loop exit count frequency table:\n");
+    jitprintf("--------------------------------------------------\n");
+    loopExitCountTable.dump(jitstdout());
+    jitprintf("--------------------------------------------------\n");
 
 #endif // COUNT_LOOPS
 
 #if MEASURE_NODE_SIZE
 
-    fprintf(fout, "\n");
-    fprintf(fout, "---------------------------------------------------\n");
-    fprintf(fout, "GenTree node allocation stats\n");
-    fprintf(fout, "---------------------------------------------------\n");
+    jitprintf("\n");
+    jitprintf("---------------------------------------------------\n");
+    jitprintf("GenTree node allocation stats\n");
+    jitprintf("---------------------------------------------------\n");
 
-    fprintf(fout, "Allocated %6I64u tree nodes (%7I64u bytes total, avg %4I64u bytes per method)\n",
-            genNodeSizeStats.genTreeNodeCnt, genNodeSizeStats.genTreeNodeSize,
-            genNodeSizeStats.genTreeNodeSize / genMethodCnt);
+    jitprintf("Allocated %6I64u tree nodes (%7I64u bytes total, avg %4I64u bytes per method)\n",
+              genNodeSizeStats.genTreeNodeCnt, genNodeSizeStats.genTreeNodeSize,
+              genNodeSizeStats.genTreeNodeSize / genMethodCnt);
 
-    fprintf(fout, "Allocated %7I64u bytes of unused tree node space (%3.2f%%)\n",
-            genNodeSizeStats.genTreeNodeSize - genNodeSizeStats.genTreeNodeActualSize,
-            (float)(100 * (genNodeSizeStats.genTreeNodeSize - genNodeSizeStats.genTreeNodeActualSize)) /
-                genNodeSizeStats.genTreeNodeSize);
+    jitprintf("Allocated %7I64u bytes of unused tree node space (%3.2f%%)\n",
+              genNodeSizeStats.genTreeNodeSize - genNodeSizeStats.genTreeNodeActualSize,
+              (float)(100 * (genNodeSizeStats.genTreeNodeSize - genNodeSizeStats.genTreeNodeActualSize)) /
+                  genNodeSizeStats.genTreeNodeSize);
 
-    fprintf(fout, "\n");
-    fprintf(fout, "---------------------------------------------------\n");
-    fprintf(fout, "Distribution of per-method GenTree node counts:\n");
-    genTreeNcntHist.dump(fout);
+    jitprintf("\n");
+    jitprintf("---------------------------------------------------\n");
+    jitprintf("Distribution of per-method GenTree node counts:\n");
+    genTreeNcntHist.dump(jitstdout());
 
-    fprintf(fout, "\n");
-    fprintf(fout, "---------------------------------------------------\n");
-    fprintf(fout, "Distribution of per-method GenTree node  allocations (in bytes):\n");
-    genTreeNsizHist.dump(fout);
+    jitprintf("\n");
+    jitprintf("---------------------------------------------------\n");
+    jitprintf("Distribution of per-method GenTree node  allocations (in bytes):\n");
+    genTreeNsizHist.dump(jitstdout());
 
 #endif // MEASURE_NODE_SIZE
 
 #if MEASURE_BLOCK_SIZE
 
-    fprintf(fout, "\n");
-    fprintf(fout, "---------------------------------------------------\n");
-    fprintf(fout, "BasicBlock and FlowEdge/BasicBlockList allocation stats\n");
-    fprintf(fout, "---------------------------------------------------\n");
+    jitprintf("\n");
+    jitprintf("---------------------------------------------------\n");
+    jitprintf("BasicBlock and FlowEdge/BasicBlockList allocation stats\n");
+    jitprintf("---------------------------------------------------\n");
 
-    fprintf(fout, "Allocated %6u basic blocks (%7u bytes total, avg %4u bytes per method)\n", BasicBlock::s_Count,
-            BasicBlock::s_Size, BasicBlock::s_Size / genMethodCnt);
-    fprintf(fout, "Allocated %6u flow nodes (%7u bytes total, avg %4u bytes per method)\n", genFlowNodeCnt,
-            genFlowNodeSize, genFlowNodeSize / genMethodCnt);
+    jitprintf("Allocated %6u basic blocks (%7u bytes total, avg %4u bytes per method)\n", BasicBlock::s_Count,
+              BasicBlock::s_Size, BasicBlock::s_Size / genMethodCnt);
+    jitprintf("Allocated %6u flow nodes (%7u bytes total, avg %4u bytes per method)\n", genFlowNodeCnt, genFlowNodeSize,
+              genFlowNodeSize / genMethodCnt);
 
 #endif // MEASURE_BLOCK_SIZE
 
@@ -1661,21 +1658,21 @@ void Compiler::compShutdown()
 
     if (s_dspMemStats)
     {
-        fprintf(fout, "\nAll allocations:\n");
+        jitprintf("\nAll allocations:\n");
         ArenaAllocator::dumpAggregateMemStats(jitstdout());
 
-        fprintf(fout, "\nLargest method:\n");
+        jitprintf("\nLargest method:\n");
         ArenaAllocator::dumpMaxMemStats(jitstdout());
 
-        fprintf(fout, "\n");
-        fprintf(fout, "---------------------------------------------------\n");
-        fprintf(fout, "Distribution of total memory allocated per method (in KB):\n");
-        memAllocHist.dump(fout);
+        jitprintf("\n");
+        jitprintf("---------------------------------------------------\n");
+        jitprintf("Distribution of total memory allocated per method (in KB):\n");
+        memAllocHist.dump(jitstdout());
 
-        fprintf(fout, "\n");
-        fprintf(fout, "---------------------------------------------------\n");
-        fprintf(fout, "Distribution of total memory used      per method (in KB):\n");
-        memUsedHist.dump(fout);
+        jitprintf("\n");
+        jitprintf("---------------------------------------------------\n");
+        jitprintf("Distribution of total memory used      per method (in KB):\n");
+        memUsedHist.dump(jitstdout());
     }
 
 #endif // MEASURE_MEM_ALLOC
@@ -1692,22 +1689,22 @@ void Compiler::compShutdown()
 #if TRACK_ENREG_STATS
     if (JitConfig.JitEnregStats() != 0)
     {
-        s_enregisterStats.Dump(fout);
+        s_enregisterStats.Dump(jitstdout());
     }
 #endif // TRACK_ENREG_STATS
 
 #if MEASURE_PTRTAB_SIZE
 
-    fprintf(fout, "\n");
-    fprintf(fout, "---------------------------------------------------\n");
-    fprintf(fout, "GC pointer table stats\n");
-    fprintf(fout, "---------------------------------------------------\n");
+    jitprintf("\n");
+    jitprintf("---------------------------------------------------\n");
+    jitprintf("GC pointer table stats\n");
+    jitprintf("---------------------------------------------------\n");
 
-    fprintf(fout, "Reg pointer descriptor size (internal): %8u (avg %4u per method)\n", GCInfo::s_gcRegPtrDscSize,
-            GCInfo::s_gcRegPtrDscSize / genMethodCnt);
+    jitprintf("Reg pointer descriptor size (internal): %8u (avg %4u per method)\n", GCInfo::s_gcRegPtrDscSize,
+              GCInfo::s_gcRegPtrDscSize / genMethodCnt);
 
-    fprintf(fout, "Total pointer table size: %8u (avg %4u per method)\n", GCInfo::s_gcTotalPtrTabSize,
-            GCInfo::s_gcTotalPtrTabSize / genMethodCnt);
+    jitprintf("Total pointer table size: %8u (avg %4u per method)\n", GCInfo::s_gcTotalPtrTabSize,
+              GCInfo::s_gcTotalPtrTabSize / genMethodCnt);
 
 #endif // MEASURE_PTRTAB_SIZE
 
@@ -1715,37 +1712,37 @@ void Compiler::compShutdown()
 
     if (genMethodCnt != 0)
     {
-        fprintf(fout, "\n");
-        fprintf(fout, "A total of %6u methods compiled", genMethodCnt);
+        jitprintf("\n");
+        jitprintf("A total of %6u methods compiled", genMethodCnt);
 #if DISPLAY_SIZES
         if (genMethodICnt || genMethodNCnt)
         {
-            fprintf(fout, " (%u interruptible, %u non-interruptible)", genMethodICnt, genMethodNCnt);
+            jitprintf(" (%u interruptible, %u non-interruptible)", genMethodICnt, genMethodNCnt);
         }
 #endif // DISPLAY_SIZES
-        fprintf(fout, ".\n");
+        jitprintf(".\n");
     }
 
 #endif // MEASURE_NODE_SIZE || MEASURE_BLOCK_SIZE || MEASURE_PTRTAB_SIZE || DISPLAY_SIZES
 
 #if EMITTER_STATS
-    emitterStats(fout);
+    emitterStats(jitstdout());
 #endif
 
 #if MEASURE_FATAL
-    fprintf(fout, "\n");
-    fprintf(fout, "---------------------------------------------------\n");
-    fprintf(fout, "Fatal errors stats\n");
-    fprintf(fout, "---------------------------------------------------\n");
-    fprintf(fout, "   badCode:             %u\n", fatal_badCode);
-    fprintf(fout, "   noWay:               %u\n", fatal_noWay);
-    fprintf(fout, "   implLimitation:      %u\n", fatal_implLimitation);
-    fprintf(fout, "   NOMEM:               %u\n", fatal_NOMEM);
-    fprintf(fout, "   noWayAssertBody:     %u\n", fatal_noWayAssertBody);
+    jitprintf("\n");
+    jitprintf("---------------------------------------------------\n");
+    jitprintf("Fatal errors stats\n");
+    jitprintf("---------------------------------------------------\n");
+    jitprintf("   badCode:             %u\n", fatal_badCode);
+    jitprintf("   noWay:               %u\n", fatal_noWay);
+    jitprintf("   implLimitation:      %u\n", fatal_implLimitation);
+    jitprintf("   NOMEM:               %u\n", fatal_NOMEM);
+    jitprintf("   noWayAssertBody:     %u\n", fatal_noWayAssertBody);
 #ifdef DEBUG
-    fprintf(fout, "   noWayAssertBodyArgs: %u\n", fatal_noWayAssertBodyArgs);
+    jitprintf("   noWayAssertBodyArgs: %u\n", fatal_noWayAssertBodyArgs);
 #endif // DEBUG
-    fprintf(fout, "   NYI:                 %u\n", fatal_NYI);
+    jitprintf("   NYI:                 %u\n", fatal_NYI);
 #endif // MEASURE_FATAL
 }
 
@@ -1754,14 +1751,14 @@ void Compiler::compShutdown()
  */
 
 /* static */
-void Compiler::compDisplayStaticSizes(FILE* fout)
+void Compiler::compDisplayStaticSizes()
 {
 #if MEASURE_NODE_SIZE
-    GenTree::DumpNodeSizes(fout);
+    GenTree::DumpNodeSizes();
 #endif
 
 #if EMITTER_STATS
-    emitterStaticStats(fout);
+    emitterStaticStats();
 #endif
 }
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -1442,7 +1442,7 @@ void Compiler::compShutdown()
         unsigned countLarge = 0;
         unsigned countSmall = 0;
 
-        printf("\nGenTree operator counts (approximate):\n\n");
+        jitprintf("\nGenTree operator counts (approximate):\n\n");
 
         for (OperInfo oper : opers)
         {

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -154,7 +154,7 @@ void Compiler::JitLogEE(unsigned level, const char* fmt, ...)
     if (verbose)
     {
         va_start(args, fmt);
-        vflogf(jitstdout, fmt, args);
+        vflogf(jitstdout(), fmt, args);
         va_end(args);
     }
 
@@ -1229,13 +1229,14 @@ void DisplayNowayAssertMap()
             fout = _wfopen(strJitMeasureNowayAssertFile, W("a"));
             if (fout == nullptr)
             {
-                fprintf(jitstdout, "Failed to open JitMeasureNowayAssertFile \"%ws\"\n", strJitMeasureNowayAssertFile);
+                fprintf(jitstdout(), "Failed to open JitMeasureNowayAssertFile \"%ws\"\n",
+                        strJitMeasureNowayAssertFile);
                 return;
             }
         }
         else
         {
-            fout = jitstdout;
+            fout = jitstdout();
         }
 
         // Iterate noway assert map, create sorted table by occurrence, dump it.
@@ -1252,7 +1253,7 @@ void DisplayNowayAssertMap()
 
         jitstd::sort(nacp, nacp + count, NowayAssertCountMap::compare());
 
-        if (fout == jitstdout)
+        if (fout == jitstdout())
         {
             // Don't output the header if writing to a file, since we'll be appending to existing dumps in that case.
             fprintf(fout, "\nnoway_assert counts:\n");
@@ -1265,7 +1266,7 @@ void DisplayNowayAssertMap()
                     nacp[i].fl.m_condStr);
         }
 
-        if (fout != jitstdout)
+        if (fout != jitstdout())
         {
             fclose(fout);
             fout = nullptr;
@@ -1330,7 +1331,7 @@ void Compiler::compStartup()
     // Static vars of ValueNumStore
     ValueNumStore::ValidateValueNumStoreStatics();
 
-    compDisplayStaticSizes(jitstdout);
+    compDisplayStaticSizes(jitstdout());
 }
 
 /*****************************************************************************
@@ -1388,11 +1389,11 @@ void Compiler::compShutdown()
 #endif
 
 #if NODEBASH_STATS
-    GenTree::ReportOperBashing(jitstdout);
+    GenTree::ReportOperBashing(jitstdout());
 #endif
 
     // Where should we write our statistics output?
-    FILE* fout = jitstdout;
+    FILE* fout = jitstdout();
 
 #ifdef FEATURE_JIT_METHOD_PERF
     if (compJitTimeLogFilename != nullptr)
@@ -1661,10 +1662,10 @@ void Compiler::compShutdown()
     if (s_dspMemStats)
     {
         fprintf(fout, "\nAll allocations:\n");
-        ArenaAllocator::dumpAggregateMemStats(jitstdout);
+        ArenaAllocator::dumpAggregateMemStats(jitstdout());
 
         fprintf(fout, "\nLargest method:\n");
-        ArenaAllocator::dumpMaxMemStats(jitstdout);
+        ArenaAllocator::dumpMaxMemStats(jitstdout());
 
         fprintf(fout, "\n");
         fprintf(fout, "---------------------------------------------------\n");
@@ -1684,7 +1685,7 @@ void Compiler::compShutdown()
     if (JitConfig.DisplayLoopHoistStats() != 0)
 #endif // DEBUG
     {
-        PrintAggregateLoopHoistStats(jitstdout);
+        PrintAggregateLoopHoistStats(jitstdout());
     }
 #endif // LOOP_HOIST_STATS
 
@@ -5149,7 +5150,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 #if TRACK_LSRA_STATS
     if (JitConfig.DisplayLsraStats() == 2)
     {
-        m_pLinearScan->dumpLsraStatsCsv(jitstdout);
+        m_pLinearScan->dumpLsraStatsCsv(jitstdout());
     }
 #endif // TRACK_LSRA_STATS
 
@@ -5875,7 +5876,7 @@ int Compiler::compCompile(CORINFO_MODULE_HANDLE classPtr,
     }
 #endif // FUNC_INFO_LOGGING
 
-    // if (s_compMethodsCount==0) setvbuf(jitstdout, NULL, _IONBF, 0);
+    // if (s_compMethodsCount==0) setvbuf(jitstdout(), NULL, _IONBF, 0);
 
     if (compIsForInlining())
     {
@@ -6359,7 +6360,7 @@ void Compiler::compCompileFinish()
     if (s_dspMemStats || verbose)
     {
         printf("\nAllocations for %s (MethodHash=%08x)\n", info.compFullName, info.compMethodHash());
-        compArenaAllocator->dumpMemStats(jitstdout);
+        compArenaAllocator->dumpMemStats(jitstdout());
     }
 #endif // DEBUG
 #endif // MEASURE_MEM_ALLOC

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10349,7 +10349,7 @@ public:
                   InlineInfo*           inlineInfo);
     void compDone();
 
-    static void compDisplayStaticSizes(FILE* fout);
+    static void compDisplayStaticSizes();
 
     //------------ Some utility functions --------------
 

--- a/src/coreclr/jit/disasm.cpp
+++ b/src/coreclr/jit/disasm.cpp
@@ -1478,12 +1478,12 @@ void DisAssembler::disAsmCode(BYTE* hotCodePtr, size_t hotCodeSize, BYTE* coldCo
     }
 #else  // !DEBUG
     // NOTE: non-DEBUG builds always use jitstdout currently!
-    disAsmFile = jitstdout;
+    disAsmFile = jitstdout();
 #endif // !DEBUG
 
     if (disAsmFile == nullptr)
     {
-        disAsmFile = jitstdout;
+        disAsmFile = jitstdout();
     }
 
     // As this writes to a common file, this is not reentrant.
@@ -1519,7 +1519,7 @@ void DisAssembler::disAsmCode(BYTE* hotCodePtr, size_t hotCodeSize, BYTE* coldCo
     DisasmBuffer(disAsmFile, /* printIt */ true);
     fprintf(disAsmFile, "\n");
 
-    if (disAsmFile != jitstdout)
+    if (disAsmFile != jitstdout())
     {
         fclose(disAsmFile);
     }

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -31,8 +31,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 /*****************************************************************************/
 
-FILE* jitstdout = nullptr;
-
 ICorJitHost* g_jitHost        = nullptr;
 bool         g_jitInitialized = false;
 
@@ -71,16 +69,25 @@ extern "C" DLLEXPORT void jitStartup(ICorJitHost* jitHost)
 
     assert(!JitConfig.isInitialized());
     JitConfig.initialize(jitHost);
+    Compiler::compStartup();
 
+    g_jitInitialized = true;
+}
+
+static FILE* s_jitstdout;
+
+static FILE* jitstdoutInit()
+{
     const WCHAR* jitStdOutFile = JitConfig.JitStdOutFile();
+    FILE*        file          = nullptr;
     if (jitStdOutFile != nullptr)
     {
-        jitstdout = _wfopen(jitStdOutFile, W("a"));
-        assert(jitstdout != nullptr);
+        file = _wfopen(jitStdOutFile, W("a"));
+        assert(file != nullptr);
     }
 
 #if !defined(HOST_UNIX)
-    if (jitstdout == nullptr)
+    if (file == nullptr)
     {
         int stdoutFd = _fileno(procstdout());
         // Check fileno error output(s) -1 may overlap with errno result
@@ -89,32 +96,50 @@ extern "C" DLLEXPORT void jitStartup(ICorJitHost* jitHost)
         // or bogus and avoid making further calls.
         if ((stdoutFd != -1) && (stdoutFd != -2) && (errno != EINVAL))
         {
-            int jitstdoutFd = _dup(_fileno(procstdout()));
+            int jitstdoutFd = _dup(stdoutFd);
             // Check the error status returned by dup.
             if (jitstdoutFd != -1)
             {
                 _setmode(jitstdoutFd, _O_TEXT);
-                jitstdout = _fdopen(jitstdoutFd, "w");
-                assert(jitstdout != nullptr);
+                file = _fdopen(jitstdoutFd, "w");
+                assert(file != nullptr);
 
                 // Prevent the FILE* from buffering its output in order to avoid calls to
                 // `fflush()` throughout the code.
-                setvbuf(jitstdout, nullptr, _IONBF, 0);
+                setvbuf(file, nullptr, _IONBF, 0);
             }
         }
     }
 #endif // !HOST_UNIX
 
-    // If jitstdout is still null, fallback to whatever procstdout() was
-    // initially set to.
-    if (jitstdout == nullptr)
+    if (file == nullptr)
     {
-        jitstdout = procstdout();
+        file = procstdout();
     }
 
-    Compiler::compStartup();
+    FILE* observed = InterlockedCompareExchangeT(&s_jitstdout, file, nullptr);
 
-    g_jitInitialized = true;
+    if (observed != nullptr)
+    {
+        if (file != procstdout())
+        {
+            fclose(file);
+        }
+
+        return observed;
+    }
+
+    return file;
+}
+
+FILE* jitstdout()
+{
+    if (s_jitstdout != nullptr)
+    {
+        return s_jitstdout;
+    }
+
+    return jitstdoutInit();
 }
 
 #ifndef DEBUG
@@ -122,7 +147,7 @@ void jitprintf(const char* fmt, ...)
 {
     va_list vl;
     va_start(vl, fmt);
-    vfprintf(jitstdout, fmt, vl);
+    vfprintf(jitstdout(), fmt, vl);
     va_end(vl);
 }
 #endif
@@ -136,14 +161,14 @@ void jitShutdown(bool processIsTerminating)
 
     Compiler::compShutdown();
 
-    if (jitstdout != procstdout())
+    if (s_jitstdout != procstdout())
     {
         // When the process is terminating, the fclose call is unnecessary and is also prone to
         // crashing since the UCRT itself often frees the backing memory earlier on in the
         // termination sequence.
         if (!processIsTerminating)
         {
-            fclose(jitstdout);
+            fclose(s_jitstdout);
         }
     }
 

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -143,7 +143,6 @@ FILE* jitstdout()
     return jitstdoutInit();
 }
 
-#ifndef DEBUG
 void jitprintf(const char* fmt, ...)
 {
     va_list vl;
@@ -151,7 +150,6 @@ void jitprintf(const char* fmt, ...)
     vfprintf(jitstdout(), fmt, vl);
     va_end(vl);
 }
-#endif
 
 void jitShutdown(bool processIsTerminating)
 {

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -161,7 +161,7 @@ void jitShutdown(bool processIsTerminating)
 
     Compiler::compShutdown();
 
-    if (s_jitstdout != procstdout())
+    if ((s_jitstdout != nullptr) && (s_jitstdout != procstdout()))
     {
         // When the process is terminating, the fclose call is unnecessary and is also prone to
         // crashing since the UCRT itself often frees the backing memory earlier on in the

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -143,6 +143,7 @@ FILE* jitstdout()
     return jitstdoutInit();
 }
 
+// Like printf/logf, but only outputs to jitstdout -- skips call back into EE.
 void jitprintf(const char* fmt, ...)
 {
     va_list vl;

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -74,7 +74,7 @@ extern "C" DLLEXPORT void jitStartup(ICorJitHost* jitHost)
     g_jitInitialized = true;
 }
 
-static FILE* s_jitstdout;
+static FILE* volatile s_jitstdout;
 
 static FILE* jitstdoutInit()
 {
@@ -134,9 +134,10 @@ static FILE* jitstdoutInit()
 
 FILE* jitstdout()
 {
-    if (s_jitstdout != nullptr)
+    FILE* file = s_jitstdout;
+    if (file != nullptr)
     {
-        return s_jitstdout;
+        return file;
     }
 
     return jitstdoutInit();

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -162,14 +162,15 @@ void jitShutdown(bool processIsTerminating)
 
     Compiler::compShutdown();
 
-    if ((s_jitstdout != nullptr) && (s_jitstdout != procstdout()))
+    FILE* file = s_jitstdout;
+    if ((file != nullptr) && (file != procstdout()))
     {
         // When the process is terminating, the fclose call is unnecessary and is also prone to
         // crashing since the UCRT itself often frees the backing memory earlier on in the
         // termination sequence.
         if (!processIsTerminating)
         {
-            fclose(s_jitstdout);
+            fclose(file);
         }
     }
 

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -215,7 +215,7 @@ unsigned emitter::emitInt32CnsCnt;
 unsigned emitter::emitNegCnsCnt;
 unsigned emitter::emitPow2CnsCnt;
 
-void emitterStaticStats(FILE* fout)
+void emitterStaticStats()
 {
     // The IG buffer size depends on whether we are storing a debug info pointer or not. For our purposes
     // here, do not include that.
@@ -226,6 +226,8 @@ void emitterStaticStats(FILE* fout)
     // insGroup members
 
     insGroup* igDummy = nullptr;
+
+    FILE* fout = jitstdout();
 
     fprintf(fout, "\n");
     fprintf(fout, "insGroup:\n");

--- a/src/coreclr/jit/error.cpp
+++ b/src/coreclr/jit/error.cpp
@@ -370,7 +370,7 @@ int logf(const char* fmt, ...)
     {
         // if the EE refuses to log it, we try to send it to stdout
         va_start(args, fmt);
-        written = vflogf(jitstdout, fmt, args);
+        written = vflogf(jitstdout(), fmt, args);
         va_end(args);
     }
 #if 0  // Enable this only when you need it
@@ -431,7 +431,7 @@ void gcDump_logf(const char* fmt, ...)
     {
         // if the EE refuses to log it, we try to send it to stdout
         va_start(args, fmt);
-        vflogf(jitstdout, fmt, args);
+        vflogf(jitstdout(), fmt, args);
         va_end(args);
     }
 #if 0  // Enable this only when you need it

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -674,7 +674,7 @@ FILE* Compiler::fgOpenFlowGraphFile(bool* wbDontClose, Phases phase, PhasePositi
     }
     else if (strcmp(filename, "stdout") == 0)
     {
-        fgxFile      = jitstdout;
+        fgxFile      = jitstdout();
         *wbDontClose = true;
     }
     else if (strcmp(filename, "stderr") == 0)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -481,9 +481,11 @@ void GenTree::ReportOperBashing(FILE* f)
 
 #if MEASURE_NODE_SIZE
 
-void GenTree::DumpNodeSizes(FILE* fp)
+void GenTree::DumpNodeSizes()
 {
     // Dump the sizes of the various GenTree flavors
+
+    FILE* fp = jitstdout();
 
     fprintf(fp, "Small tree node size = %zu bytes\n", TREE_NODE_SZ_SMALL);
     fprintf(fp, "Large tree node size = %zu bytes\n", TREE_NODE_SZ_LARGE);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -2311,7 +2311,7 @@ public:
     void SetIndirExceptionFlags(Compiler* comp);
 
 #if MEASURE_NODE_SIZE
-    static void DumpNodeSizes(FILE* fp);
+    static void DumpNodeSizes();
 #endif
 
 #ifdef DEBUG

--- a/src/coreclr/jit/host.h
+++ b/src/coreclr/jit/host.h
@@ -55,7 +55,7 @@ void jitprintf(const char* fmt, ...);
 #define _HOST_H_
 /*****************************************************************************/
 
-extern FILE* jitstdout;
+FILE* jitstdout();
 
 inline FILE* procstdout()
 {

--- a/src/coreclr/jit/host.h
+++ b/src/coreclr/jit/host.h
@@ -3,6 +3,10 @@
 
 /*****************************************************************************/
 
+// Like printf/logf, but only outputs to jitstdout -- skips call back into VM
+// in DEBUG builds.
+void jitprintf(const char* fmt, ...);
+
 #ifdef DEBUG
 
 #undef printf
@@ -44,7 +48,6 @@ extern "C" void ANALYZER_NORETURN __cdecl assertAbort(const char* why, const cha
 // Re-define printf in Release to use jitstdout (can be overwritten with DOTNET_JitStdOutFile=file)
 #undef printf
 #define printf jitprintf
-void jitprintf(const char* fmt, ...);
 
 #undef assert
 #define assert(p) (void)0

--- a/src/coreclr/jit/host.h
+++ b/src/coreclr/jit/host.h
@@ -3,8 +3,6 @@
 
 /*****************************************************************************/
 
-// Like printf/logf, but only outputs to jitstdout -- skips call back into VM
-// in DEBUG builds.
 void jitprintf(const char* fmt, ...);
 
 #ifdef DEBUG

--- a/src/coreclr/jit/inline.cpp
+++ b/src/coreclr/jit/inline.cpp
@@ -480,7 +480,7 @@ void InlineContext::DumpData(unsigned indent)
     {
         const char* inlineReason = InlGetObservationString(m_Observation);
         printf("%*s%u,\"%s\",\"%s\",", indent, "", GetOrdinal(), inlineReason, calleeName);
-        m_Policy->DumpData(jitstdout);
+        m_Policy->DumpData(jitstdout());
         printf("\n");
     }
 

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1421,7 +1421,7 @@ PhaseStatus LinearScan::doLinearScan()
 #endif
         )
     {
-        dumpLsraStats(jitstdout);
+        dumpLsraStats(jitstdout());
     }
 #endif // TRACK_LSRA_STATS
 


### PR DESCRIPTION
Avoid duplicating a handle and doing several I/O operations on the startup path. Fixes #91856 as a side effect.