### PR TITLE
Fix URL for syslib diagnostics

### DIFF
--- a/src/libraries/Common/src/Roslyn/DiagnosticDescriptorHelper.cs
+++ b/src/libraries/Common/src/Roslyn/DiagnosticDescriptorHelper.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.DotnetRuntime.Extensions
             LocalizableString? description = null,
             params string[] customTags)
         {
-            string helpLink = $"https://learn.microsoft.com/dotnet/fundamentals/syslib-diagnostics/{id.ToLowerInvariant()}.md";
+            string helpLink = $"https://learn.microsoft.com/dotnet/fundamentals/syslib-diagnostics/{id.ToLowerInvariant()}";
 
             return new DiagnosticDescriptor(id, title, messageFormat, category, defaultSeverity, isEnabledByDefault, description, helpLink, customTags);
         }


### PR DESCRIPTION
I was testing the fix for https://github.com/dotnet/runtime/issues/85181 and found that the links were off for syslib-diagnostics.  We didn't need to append the `.md`.  This will fix these.

@gewarren are you OK with this approach - or do you think it would be better to create fwlinks / aka.ms links?  Those could potentially handle changes to the target URL or could have a better default landing page if the diagnostic page didn't exist.  Not sure if it's worth the overhead though.  I guess the compiler itself isn't using FWLinks and that's good enough for them -- should be good for us too.

This needs backport to 8.0 as well.