### PR TITLE
6 more naive methods for Tensor Primitives.

### DIFF
--- a/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.cs
+++ b/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.cs
@@ -20,6 +20,7 @@ namespace System.Numerics.Tensors
         public static void Divide(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { }
         public static float Dot(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y) { throw null; }
         public static void Exp(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
+        public static float L2Normalize(System.ReadOnlySpan<float> x) { throw null; }
         public static void Log(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
         public static void Multiply(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.Span<float> destination) { }
         public static void Multiply(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { }
@@ -27,7 +28,6 @@ namespace System.Numerics.Tensors
         public static void MultiplyAdd(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, float addend, System.Span<float> destination) { }
         public static void MultiplyAdd(System.ReadOnlySpan<float> x, float y, System.ReadOnlySpan<float> addend, System.Span<float> destination) { }
         public static void Negate(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
-        public static float Normalize(System.ReadOnlySpan<float> x) { throw null; }
         public static void Sigmoid(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
         public static void Sinh(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
         public static void SoftMax(System.ReadOnlySpan<float> x, System.Span<float> destination) { }

--- a/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.cs
+++ b/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.cs
@@ -6,27 +6,33 @@
 
 namespace System.Numerics.Tensors
 {
-    public static class TensorPrimitives
+    public static partial class TensorPrimitives
     {
-        public static void Add(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { throw null; }
-        public static void Add(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.Span<float> destination) { throw null; }
-        public static void AddMultiply(System.ReadOnlySpan<float> x, float y, System.ReadOnlySpan<float> multiplier, System.Span<float> destination) { throw null; }
-        public static void AddMultiply(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, float multiplier, System.Span<float> destination) { throw null; }
-        public static void AddMultiply(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.ReadOnlySpan<float> multiplier, System.Span<float> destination) { throw null; }
-        public static void Cosh(System.ReadOnlySpan<float> x, System.Span<float> destination) { throw null; }
-        public static void Divide(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { throw null; }
-        public static void Divide(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.Span<float> destination) { throw null; }
-        public static void Exp(System.ReadOnlySpan<float> x, System.Span<float> destination) { throw null; }
-        public static void Log(System.ReadOnlySpan<float> x, System.Span<float> destination) { throw null; }
-        public static void Multiply(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { throw null; }
-        public static void Multiply(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.Span<float> destination) { throw null; }
-        public static void MultiplyAdd(System.ReadOnlySpan<float> x, float y, System.ReadOnlySpan<float> addend, System.Span<float> destination) { throw null; }
-        public static void MultiplyAdd(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, float addend, System.Span<float> destination) { throw null; }
-        public static void MultiplyAdd(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.ReadOnlySpan<float> addend, System.Span<float> destination) { throw null; }
-        public static void Negate(System.ReadOnlySpan<float> x, System.Span<float> destination) { throw null; }
-        public static void Subtract(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { throw null; }
-        public static void Subtract(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.Span<float> destination) { throw null; }
-        public static void Sinh(System.ReadOnlySpan<float> x, System.Span<float> destination) { throw null; }
-        public static void Tanh(System.ReadOnlySpan<float> x, System.Span<float> destination) { throw null; }
+        public static void Add(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.Span<float> destination) { }
+        public static void Add(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { }
+        public static void AddMultiply(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.ReadOnlySpan<float> multiplier, System.Span<float> destination) { }
+        public static void AddMultiply(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, float multiplier, System.Span<float> destination) { }
+        public static void AddMultiply(System.ReadOnlySpan<float> x, float y, System.ReadOnlySpan<float> multiplier, System.Span<float> destination) { }
+        public static void Cosh(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
+        public static float CosineSimilarity(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y) { throw null; }
+        public static float Distance(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y) { throw null; }
+        public static void Divide(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.Span<float> destination) { }
+        public static void Divide(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { }
+        public static float Dot(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y) { throw null; }
+        public static void Exp(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
+        public static void Log(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
+        public static void Multiply(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.Span<float> destination) { }
+        public static void Multiply(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { }
+        public static void MultiplyAdd(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.ReadOnlySpan<float> addend, System.Span<float> destination) { }
+        public static void MultiplyAdd(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, float addend, System.Span<float> destination) { }
+        public static void MultiplyAdd(System.ReadOnlySpan<float> x, float y, System.ReadOnlySpan<float> addend, System.Span<float> destination) { }
+        public static void Negate(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
+        public static float Normalize(System.ReadOnlySpan<float> x) { throw null; }
+        public static void Sigmoid(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
+        public static void Sinh(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
+        public static void SoftMax(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
+        public static void Subtract(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.Span<float> destination) { }
+        public static void Subtract(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { }
+        public static void Tanh(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/Resources/Strings.resx
+++ b/src/libraries/System.Numerics.Tensors/src/Resources/Strings.resx
@@ -120,6 +120,9 @@
   <data name="Argument_DestinationTooShort" xml:space="preserve">
     <value>Destination is too short.</value>
   </data>
+  <data name="Argument_SpansMustBeNonEmpty" xml:space="preserve">
+    <value>Input span arguments must not be empty.</value>
+  </data>
   <data name="Argument_SpansMustHaveSameLength" xml:space="preserve">
     <value>Input span arguments must all have the same length.</value>
   </data>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+
 namespace System.Numerics.Tensors
 {
     /// <summary>Performs primitive tensor operations over spans of memory.</summary>
@@ -251,6 +253,137 @@ namespace System.Numerics.Tensors
             for (int i = 0; i < x.Length; i++)
             {
                 destination[i] = MathF.Tanh(x[i]);
+            }
+        }
+
+        /// <summary>Computes the cosine similarity between two non-zero vectors.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <returns>The cosine similarity between the two vectors.</returns>
+        public static float CosineSimilarity(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
+        {
+            if (x.Length != y.Length)
+            {
+                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+            }
+
+            var dotprod = 0f;
+            var magx = 0f;
+            var magy = 0f;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                dotprod += x[i] * y[i];
+                magx += MathF.Pow(x[i], 2);
+                magy += MathF.Pow(y[i], 2);
+            }
+
+            return dotprod / (MathF.Sqrt(magx) * MathF.Sqrt(magy));
+        }
+
+        /// <summary>
+        /// Compute the distance between two points in Euclidean space.
+        /// </summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <returns>The Euclidean distance.</returns>
+        public static float Distance(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
+        {
+            if (x.Length != y.Length)
+            {
+                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+            }
+
+            var distance = 0f;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                distance += MathF.Pow(x[i] - y[i], 2);
+            }
+
+            return MathF.Sqrt(distance);
+        }
+
+        /// <summary>
+        /// A mathematical operation that takes two vectors and returns a scalar.
+        /// </summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <returns>The dot product.</returns>
+        public static float Dot(ReadOnlySpan<float> x, ReadOnlySpan<float> y) // BLAS1: dot
+        {
+            if (x.Length != y.Length)
+            {
+                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+            }
+
+            var dotprod = 0f;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                dotprod += x[i] * y[i];
+            }
+
+            return dotprod;
+        }
+
+        /// <summary>
+        /// A mathematical operation that takes a vector and returns the L2 norm.
+        /// </summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <returns>The L2 norm.</returns>
+        public static float Normalize(ReadOnlySpan<float> x) // BLAS1: nrm2
+        {
+            var magx = 0f;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                magx += MathF.Pow(x[i], 2);
+            }
+
+            return MathF.Sqrt(magx);
+        }
+
+        /// <summary>
+        /// A function that takes a collection of real numbers and returns a probability distribution.
+        /// </summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor.</param>
+        public static void SoftMax(ReadOnlySpan<float> x, Span<float> destination)
+        {
+            if (x.Length > destination.Length)
+            {
+                ThrowHelper.ThrowArgument_DestinationTooShort();
+            }
+
+            var expSum = 0f;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                expSum += MathF.Pow((float)Math.E, x[i]);
+            }
+
+            for (int i = 0; i < destination.Length; i++)
+            {
+                destination[i] = MathF.Exp(x[i]) / expSum;
+            }
+        }
+
+        /// <summary>
+        /// A function that takes a real number and returns a value between 0 and 1.
+        /// </summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor.</param>
+        public static void Sigmoid(ReadOnlySpan<float> x, Span<float> destination)
+        {
+            if (x.Length > destination.Length)
+            {
+                ThrowHelper.ThrowArgument_DestinationTooShort();
+            }
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                destination[i] = 1f / (1 + MathF.Exp(-x[i]));
             }
         }
     }

--- a/src/libraries/System.Numerics.Tensors/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/ThrowHelper.cs
@@ -14,5 +14,9 @@ namespace System
         [DoesNotReturn]
         public static void ThrowArgument_SpansMustHaveSameLength() =>
             throw new ArgumentException(SR.Argument_SpansMustHaveSameLength);
+
+        [DoesNotReturn]
+        public static void ThrowArgument_SpansMustBeNonEmpty() =>
+            throw new ArgumentException(SR.Argument_SpansMustBeNonEmpty);
     }
 }

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
@@ -713,12 +713,30 @@ namespace System.Numerics.Tensors.Tests
             Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(x, y));
         }
 
+        [Fact]
+        public static void CosineSimilarity_ThrowsForEmpty_x_y()
+        {
+            float[] x = [];
+            float[] y = [];
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(x, y));
+        }
+
         [Theory]
         [InlineData(new float[] { 3, 2, 0, 5 }, new float[] { 1, 0, 0, 0 }, 0.49f)]
         [InlineData(new float[] { 1, 1, 1, 1, 1, 0 }, new float[] { 1, 1, 1, 1, 0, 1 }, 0.80f)]
         public static void CosineSimilarity(float[] x, float[] y, float expectedResult)
         {
             Assert.Equal(expectedResult, TensorPrimitives.CosineSimilarity(x, y), .01f);
+        }
+
+        [Fact]
+        public static void Distance_ThrowsForEmpty_x_y()
+        {
+            float[] x = [];
+            float[] y = [];
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(x, y));
         }
 
         [Theory]
@@ -755,6 +773,7 @@ namespace System.Numerics.Tensors.Tests
         [InlineData(new float[] { 1, 3, -5 }, new float[] { 4, -2, -1 }, 3)]
         [InlineData(new float[] { 1, 2, 3 }, new float[] { 4, 5, 6 }, 32)]
         [InlineData(new float[] { 1, 2, 3, 10, 8 }, new float[] { 4, 5, 6, -2, 7 }, 68)]
+        [InlineData(new float[] { }, new float[] { }, 0)]
         public static void Dot(float[] x, float[] y, float expectedResult)
         {
             Assert.Equal(expectedResult, TensorPrimitives.Dot(x, y), .001f);
@@ -765,9 +784,10 @@ namespace System.Numerics.Tensors.Tests
         [InlineData(new float[] { 3, 4 }, 5)]
         [InlineData(new float[] { 3 }, 3)]
         [InlineData(new float[] { 3, 4, 1, 2 }, 5.477)]
-        public static void Normalize(float[] x, float expectedResult)
+        [InlineData(new float[] { }, 0f)]
+        public static void L2Normalize(float[] x, float expectedResult)
         {
-            Assert.Equal(expectedResult, TensorPrimitives.Normalize(x), .001f);
+            Assert.Equal(expectedResult, TensorPrimitives.L2Normalize(x), .001f);
         }
 
         [Theory]
@@ -790,10 +810,33 @@ namespace System.Numerics.Tensors.Tests
             var dest = new float[x.Length];
             TensorPrimitives.SoftMax(x, dest);
 
-            for (int i = 0; i < dest.Length; i++)
+            for (int i = 0; i < x.Length; i++)
             {
                 Assert.Equal(expectedResult[i], dest[i], .001f);
             }
+        }
+
+        [Fact]
+        public static void SoftMax_DestinationLongerThanSource()
+        {
+            var x = new float[] { 3, 1, .2f };
+            var expectedResult = new float[] { 0.8360188f, 0.11314284f, 0.05083836f };
+            var dest = new float[x.Length + 1];
+            TensorPrimitives.SoftMax(x, dest);
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                Assert.Equal(expectedResult[i], dest[i], .001f);
+            }
+        }
+
+        [Fact]
+        public static void SoftMax_ThrowsForEmpty_x_y()
+        {
+            var x = new float[] { };
+            var dest = new float[x.Length];
+
+            AssertExtensions.Throws<ArgumentException>(() => TensorPrimitives.SoftMax(x, dest));
         }
 
         [Theory]
@@ -815,10 +858,33 @@ namespace System.Numerics.Tensors.Tests
             var dest = new float[x.Length];
             TensorPrimitives.Sigmoid(x, dest);
 
-            for (int i = 0; i < dest.Length; i++)
+            for (int i = 0; i < x.Length; i++)
             {
                 Assert.Equal(expectedResult[i], dest[i], .001f);
             }
+        }
+
+        [Fact]
+        public static void Sigmoid_DestinationLongerThanSource()
+        {
+            var x = new float[] { -5, -4.5f, -4 };
+            var expectedResult = new float[] { 0.0066f, 0.0109f, 0.0179f };
+            var dest = new float[x.Length + 1];
+            TensorPrimitives.Sigmoid(x, dest);
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                Assert.Equal(expectedResult[i], dest[i], .001f);
+            }
+        }
+
+        [Fact]
+        public static void Sigmoid_ThrowsForEmpty_x_y()
+        {
+            var x = new float[] { };
+            var dest = new float[x.Length];
+
+            AssertExtensions.Throws<ArgumentException>(() => TensorPrimitives.Sigmoid(x, dest));
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
@@ -702,5 +702,123 @@ namespace System.Numerics.Tensors.Tests
 
             AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Tanh(x, destination));
         }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void CosineSimilarity_ThrowsForMismatchedLengths_x_y(int tensorLength)
+        {
+            float[] x = CreateAndFillTensor(tensorLength);
+            float[] y = CreateAndFillTensor(tensorLength - 1);
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(x, y));
+        }
+
+        [Theory]
+        [InlineData(new float[] { 3, 2, 0, 5 }, new float[] { 1, 0, 0, 0 }, 0.49f)]
+        [InlineData(new float[] { 1, 1, 1, 1, 1, 0 }, new float[] { 1, 1, 1, 1, 0, 1 }, 0.80f)]
+        public static void CosineSimilarity(float[] x, float[] y, float expectedResult)
+        {
+            Assert.Equal(expectedResult, TensorPrimitives.CosineSimilarity(x, y), .01f);
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Distance_ThrowsForMismatchedLengths_x_y(int tensorLength)
+        {
+            float[] x = CreateAndFillTensor(tensorLength);
+            float[] y = CreateAndFillTensor(tensorLength - 1);
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(x, y));
+        }
+
+        [Theory]
+        [InlineData(new float[] { 3, 2 }, new float[] { 4, 1 }, 1.4142f)]
+        [InlineData(new float[] { 0, 4 }, new float[] { 6, 2 }, 6.3245f)]
+        [InlineData(new float[] { 1, 2, 3 }, new float[] { 4, 5, 6 }, 5.1961f)]
+        [InlineData(new float[] { 5, 1, 6, 10 }, new float[] { 7, 2, 8, 4 }, 6.7082f)]
+        public static void Distance(float[] x, float[] y, float expectedResult)
+        {
+            Assert.Equal(expectedResult, TensorPrimitives.Distance(x, y), .001f);
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Dot_ThrowsForMismatchedLengths_x_y(int tensorLength)
+        {
+            float[] x = CreateAndFillTensor(tensorLength);
+            float[] y = CreateAndFillTensor(tensorLength - 1);
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Dot(x, y));
+        }
+
+        [Theory]
+        [InlineData(new float[] { 1, 3, -5 }, new float[] { 4, -2, -1 }, 3)]
+        [InlineData(new float[] { 1, 2, 3 }, new float[] { 4, 5, 6 }, 32)]
+        [InlineData(new float[] { 1, 2, 3, 10, 8 }, new float[] { 4, 5, 6, -2, 7 }, 68)]
+        public static void Dot(float[] x, float[] y, float expectedResult)
+        {
+            Assert.Equal(expectedResult, TensorPrimitives.Dot(x, y), .001f);
+        }
+
+        [Theory]
+        [InlineData(new float[] { 1, 2, 3 }, 3.7416)]
+        [InlineData(new float[] { 3, 4 }, 5)]
+        [InlineData(new float[] { 3 }, 3)]
+        [InlineData(new float[] { 3, 4, 1, 2 }, 5.477)]
+        public static void Normalize(float[] x, float expectedResult)
+        {
+            Assert.Equal(expectedResult, TensorPrimitives.Normalize(x), .001f);
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void SoftMax_ThrowsForTooShortDestination(int tensorLength)
+        {
+            float[] x = CreateAndFillTensor(tensorLength);
+            float[] destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.SoftMax(x, destination));
+        }
+
+        [Theory]
+        [InlineData(new float[] { 3, 1, .2f }, new float[] { 0.8360188f, 0.11314284f, 0.05083836f })]
+        [InlineData(new float[] { 3, 4, 1 }, new float[] { 0.2594f, 0.7052f, 0.0351f })]
+        [InlineData(new float[] { 5, 3 }, new float[] { 0.8807f, 0.1192f })]
+        [InlineData(new float[] { 4, 2, 1, 9 }, new float[] { 0.0066f, 9.04658e-4f, 3.32805e-4f, 0.9920f})]
+        public static void SoftMax(float[] x, float[] expectedResult)
+        {
+            var dest = new float[x.Length];
+            TensorPrimitives.SoftMax(x, dest);
+
+            for (int i = 0; i < dest.Length; i++)
+            {
+                Assert.Equal(expectedResult[i], dest[i], .001f);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Sigmoid_ThrowsForTooShortDestination(int tensorLength)
+        {
+            float[] x = CreateAndFillTensor(tensorLength);
+            float[] destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Sigmoid(x, destination));
+        }
+
+        [Theory]
+        [InlineData(new float[] { -5, -4.5f, -4 }, new float[] { 0.0066f, 0.0109f, 0.0179f })]
+        [InlineData(new float[] { 4.5f, 5 }, new float[] { 0.9890f, 0.9933f })]
+        [InlineData(new float[] { 0, -3, 3, .5f }, new float[] { 0.5f, 0.0474f, 0.9525f, 0.6224f })]
+        public static void Sigmoid(float[] x, float[] expectedResult)
+        {
+            var dest = new float[x.Length];
+            TensorPrimitives.Sigmoid(x, dest);
+
+            for (int i = 0; i < dest.Length; i++)
+            {
+                Assert.Equal(expectedResult[i], dest[i], .001f);
+            }
+        }
     }
 }


### PR DESCRIPTION
Added in naive implementations for
* CosineSimilarty
* Distance
* Dot
* Normalize
* SoftMax
* Sigmoid

@tannergooding @stephentoub @jeffhandley should we rename normalize as discussed since its not really the operation we are doing?