### PR TITLE
Add remaining set of TensorPrimitives APIs for .NET 8

### DIFF
--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2734,7 +2734,7 @@ float FloatingPointUtils::maximumNumber(float x, float y)
 //
 // It propagates NaN inputs back to the caller and
 // otherwise returns the lesser of the inputs. It
-// treats +0 as lesser than -0 as per the specification.
+// treats +0 as greater than -0 as per the specification.
 //
 // Arguments:
 //    val1 - left operand
@@ -2763,7 +2763,7 @@ double FloatingPointUtils::minimum(double val1, double val2)
 //
 // It propagates NaN inputs back to the caller and
 // otherwise returns the input with a lesser magnitude.
-// It treats +0 as lesser than -0 as per the specification.
+// It treats +0 as greater than -0 as per the specification.
 //
 // Arguments:
 //    x - left operand
@@ -2856,7 +2856,7 @@ double FloatingPointUtils::minimumNumber(double x, double y)
 //
 // It propagates NaN inputs back to the caller and
 // otherwise returns the lesser of the inputs. It
-// treats +0 as lesser than -0 as per the specification.
+// treats +0 as greater than -0 as per the specification.
 //
 // Arguments:
 //    val1 - left operand
@@ -2885,7 +2885,7 @@ float FloatingPointUtils::minimum(float val1, float val2)
 //
 // It propagates NaN inputs back to the caller and
 // otherwise returns the input with a lesser magnitude.
-// It treats +0 as lesser than -0 as per the specification.
+// It treats +0 as greater than -0 as per the specification.
 //
 // Arguments:
 //    x - left operand

--- a/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.Unix.cs
@@ -30,6 +30,8 @@ namespace System.Buffers
 
             public override bool IsReadonly => false;
 
+            public override int Length => _elementCount;
+
             public override Memory<T> Memory => _memoryManager.Memory;
 
             public override Span<T> Span
@@ -83,10 +85,7 @@ namespace System.Buffers
                     // no-op; the handle will be disposed separately
                 }
 
-                public override Span<T> GetSpan()
-                {
-                    throw new NotImplementedException();
-                }
+                public override Span<T> GetSpan() => _impl.Span;
 
                 public override MemoryHandle Pin(int elementIndex)
                 {

--- a/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.Windows.cs
@@ -81,6 +81,8 @@ namespace System.Buffers
 
             public override bool IsReadonly => (Protection != VirtualAllocProtection.PAGE_READWRITE);
 
+            public override int Length => _elementCount;
+
             internal VirtualAllocProtection Protection
             {
                 get
@@ -189,10 +191,7 @@ namespace System.Buffers
                     // no-op; the handle will be disposed separately
                 }
 
-                public override Span<T> GetSpan()
-                {
-                    throw new NotImplementedException();
-                }
+                public override Span<T> GetSpan() => _impl.Span;
 
                 public override MemoryHandle Pin(int elementIndex)
                 {

--- a/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.cs
@@ -14,6 +14,9 @@ namespace System.Buffers
         /// </summary>
         public abstract bool IsReadonly { get; }
 
+        /// <summary>Gets the length of the <see cref="BoundedMemory{T}"/> instance.</summary>
+        public abstract int Length { get; }
+
         /// <summary>
         /// Gets the <see cref="Memory{Byte}"/> which represents this native memory.
         /// This <see cref="BoundedMemory{T}"/> instance must be kept alive while working with the <see cref="Memory{Byte}"/>.
@@ -44,5 +47,23 @@ namespace System.Buffers
         /// OS does not support marking the memory block as read+write.
         /// </summary>
         public abstract void MakeWriteable();
+
+        /// <summary>
+        /// Gets the <see cref="Span{Byte}"/> which represents this native memory.
+        /// This <see cref="BoundedMemory{T}"/> instance must be kept alive while working with the <see cref="Span{Byte}"/>.
+        /// </summary>
+        public static implicit operator Span<T>(BoundedMemory<T> boundedMemory) => boundedMemory.Span;
+
+        /// <summary>
+        /// Gets the <see cref="ReadOnlySpan{Byte}"/> which represents this native memory.
+        /// This <see cref="BoundedMemory{T}"/> instance must be kept alive while working with the <see cref="ReadOnlySpan{Byte}"/>.
+        /// </summary>
+        public static implicit operator ReadOnlySpan<T>(BoundedMemory<T> boundedMemory) => boundedMemory.Span;
+
+        /// <summary>
+        /// Gets a reference to the element at the specified index.
+        /// This <see cref="BoundedMemory{T}"/> instance must be kept alive while working with the reference.
+        /// </summary>
+        public ref T this[int index] => ref Span[index];
     }
 }

--- a/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.cs
+++ b/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.cs
@@ -20,19 +20,33 @@ namespace System.Numerics.Tensors
         public static void Divide(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { }
         public static float Dot(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y) { throw null; }
         public static void Exp(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
+        public static int IndexOfMax(System.ReadOnlySpan<float> x) { throw null; }
+        public static int IndexOfMaxMagnitude(System.ReadOnlySpan<float> x) { throw null; }
+        public static int IndexOfMin(System.ReadOnlySpan<float> x) { throw null; }
+        public static int IndexOfMinMagnitude(System.ReadOnlySpan<float> x) { throw null; }
         public static float L2Normalize(System.ReadOnlySpan<float> x) { throw null; }
         public static void Log(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
+        public static float Max(System.ReadOnlySpan<float> x) { throw null; }
+        public static float MaxMagnitude(System.ReadOnlySpan<float> x) { throw null; }
+        public static float Min(System.ReadOnlySpan<float> x) { throw null; }
+        public static float MinMagnitude(System.ReadOnlySpan<float> x) { throw null; }
         public static void Multiply(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.Span<float> destination) { }
         public static void Multiply(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { }
         public static void MultiplyAdd(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.ReadOnlySpan<float> addend, System.Span<float> destination) { }
         public static void MultiplyAdd(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, float addend, System.Span<float> destination) { }
         public static void MultiplyAdd(System.ReadOnlySpan<float> x, float y, System.ReadOnlySpan<float> addend, System.Span<float> destination) { }
         public static void Negate(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
+        public static float Product(System.ReadOnlySpan<float> x) { throw null; }
+        public static float ProductOfDifferences(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y) { throw null; }
+        public static float ProductOfSums(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y) { throw null; }
         public static void Sigmoid(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
         public static void Sinh(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
         public static void SoftMax(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
         public static void Subtract(System.ReadOnlySpan<float> x, System.ReadOnlySpan<float> y, System.Span<float> destination) { }
         public static void Subtract(System.ReadOnlySpan<float> x, float y, System.Span<float> destination) { }
+        public static float Sum(System.ReadOnlySpan<float> x) { throw null; }
+        public static float SumOfMagnitudes(System.ReadOnlySpan<float> x) { throw null; }
+        public static float SumOfSquares(System.ReadOnlySpan<float> x) { throw null; }
         public static void Tanh(System.ReadOnlySpan<float> x, System.Span<float> destination) { }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.csproj
+++ b/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.csproj
@@ -8,6 +8,10 @@
     <Compile Include="System.Numerics.Tensors.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <Compile Include="System.Numerics.Tensors.netcore.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>

--- a/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/ref/System.Numerics.Tensors.netcore.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the https://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.Numerics.Tensors
+{
+    public static partial class TensorPrimitives
+    {
+        public static void ConvertToHalf(System.ReadOnlySpan<float> source, System.Span<System.Half> destination) { throw null; }
+        public static void ConvertToSingle(System.ReadOnlySpan<System.Half> source, System.Span<float> destination) { throw null; }
+    }
+}

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.cs
@@ -533,7 +533,6 @@ namespace System.Numerics.Tensors
                 ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
             }
 
-            float result = float.PositiveInfinity;
             float resultMag = float.PositiveInfinity;
 
             for (int i = 0; i < x.Length; i++)
@@ -555,18 +554,16 @@ namespace System.Numerics.Tensors
 
                     if (currentMag < resultMag)
                     {
-                        result = current;
                         resultMag = currentMag;
                     }
                 }
                 else if (IsNegative(current))
                 {
-                    result = current;
                     resultMag = currentMag;
                 }
             }
 
-            return result;
+            return resultMag;
         }
 
         /// <summary>Computes the index of the maximum element in <paramref name="x"/>.</summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.cs
@@ -410,5 +410,448 @@ namespace System.Numerics.Tensors
                 destination[i] = 1f / (1 + MathF.Exp(-x[i]));
             }
         }
+
+        /// <summary>Computes the maximum element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The maximum element in <paramref name="x"/>.</returns>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be greater than zero.</exception>
+        public static float Max(ReadOnlySpan<float> x)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            float result = float.NegativeInfinity;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                // This matches the IEEE 754:2019 `maximum` function.
+                // It propagates NaN inputs back to the caller and
+                // otherwise returns the greater of the inputs.
+                // It treats +0 as greater than -0 as per the specification.
+
+                float current = x[i];
+
+                if (current != result)
+                {
+                    if (float.IsNaN(current))
+                    {
+                        return current;
+                    }
+
+                    if (result < current)
+                    {
+                        result = current;
+                    }
+                }
+                else if (IsNegative(result))
+                {
+                    result = current;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Computes the minimum element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The minimum element in <paramref name="x"/>.</returns>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be greater than zero.</exception>
+        public static float Min(ReadOnlySpan<float> x)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            float result = float.PositiveInfinity;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                // This matches the IEEE 754:2019 `minimum` function
+                // It propagates NaN inputs back to the caller and
+                // otherwise returns the lesser of the inputs.
+                // It treats +0 as greater than -0 as per the specification.
+
+                float current = x[i];
+
+                if (current != result)
+                {
+                    if (float.IsNaN(current))
+                    {
+                        return current;
+                    }
+
+                    if (current < result)
+                    {
+                        result = current;
+                    }
+                }
+                else if (IsNegative(current))
+                {
+                    result = current;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Computes the maximum magntude of any element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The maximum magnitude of any element in <paramref name="x"/>.</returns>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be greater than zero.</exception>
+        public static float MaxMagnitude(ReadOnlySpan<float> x)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            float result = float.NegativeInfinity;
+            float resultMag = float.NegativeInfinity;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                // This matches the IEEE 754:2019 `maximumMagnitude` function.
+                // It propagates NaN inputs back to the caller and
+                // otherwise returns the input with a greater magnitude.
+                // It treats +0 as greater than -0 as per the specification.
+
+                float current = x[i];
+                float currentMag = Math.Abs(current);
+
+                if (currentMag != resultMag)
+                {
+                    if (float.IsNaN(currentMag))
+                    {
+                        return currentMag;
+                    }
+
+                    if (resultMag < currentMag)
+                    {
+                        result = current;
+                        resultMag = currentMag;
+                    }
+                }
+                else if (IsNegative(result))
+                {
+                    result = current;
+                    resultMag = currentMag;
+                }
+            }
+
+            return resultMag;
+        }
+
+        /// <summary>Computes the minimum magntude of any element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The minimum magnitude of any element in <paramref name="x"/>.</returns>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be greater than zero.</exception>
+        public static float MinMagnitude(ReadOnlySpan<float> x)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            float result = float.PositiveInfinity;
+            float resultMag = float.PositiveInfinity;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                // This matches the IEEE 754:2019 `minimumMagnitude` function.
+                // It propagates NaN inputs back to the caller and
+                // otherwise returns the input with a lesser magnitude.
+                // It treats +0 as greater than -0 as per the specification.
+
+                float current = x[i];
+                float currentMag = Math.Abs(current);
+
+                if (currentMag != resultMag)
+                {
+                    if (float.IsNaN(currentMag))
+                    {
+                        return currentMag;
+                    }
+
+                    if (currentMag < resultMag)
+                    {
+                        result = current;
+                        resultMag = currentMag;
+                    }
+                }
+                else if (IsNegative(current))
+                {
+                    result = current;
+                    resultMag = currentMag;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Computes the index of the maximum element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The index of the maximum element in <paramref name="x"/>, or -1 if <paramref name="x"/> is empty.</returns>
+        public static unsafe int IndexOfMax(ReadOnlySpan<float> x)
+        {
+            int result = -1;
+
+            if (!x.IsEmpty)
+            {
+                float max = float.NegativeInfinity;
+
+                for (int i = 0; i < x.Length; i++)
+                {
+                    // This matches the IEEE 754:2019 `maximum` function.
+                    // It propagates NaN inputs back to the caller and
+                    // otherwise returns the greater of the inputs.
+                    // It treats +0 as greater than -0 as per the specification.
+
+                    float current = x[i];
+
+                    if (current != max)
+                    {
+                        if (float.IsNaN(current))
+                        {
+                            return i;
+                        }
+
+                        if (max < current)
+                        {
+                            result = i;
+                            max = current;
+                        }
+                    }
+                    else if (IsNegative(max))
+                    {
+                        result = i;
+                        max = current;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Computes the index of the minimum element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The index of the minimum element in <paramref name="x"/>, or -1 if <paramref name="x"/> is empty.</returns>
+        public static unsafe int IndexOfMin(ReadOnlySpan<float> x)
+        {
+            int result = -1;
+
+            if (!x.IsEmpty)
+            {
+                float min = float.PositiveInfinity;
+
+                for (int i = 0; i < x.Length; i++)
+                {
+                    // This matches the IEEE 754:2019 `minimum` function.
+                    // It propagates NaN inputs back to the caller and
+                    // otherwise returns the lesser of the inputs.
+                    // It treats +0 as greater than -0 as per the specification.
+
+                    float current = x[i];
+
+                    if (current != min)
+                    {
+                        if (float.IsNaN(current))
+                        {
+                            return i;
+                        }
+
+                        if (current < min)
+                        {
+                            result = i;
+                            min = current;
+                        }
+                    }
+                    else if (IsNegative(current))
+                    {
+                        result = i;
+                        min = current;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Computes the index of the element in <paramref name="x"/> with the maximum magnitude.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The index of the element with the maximum magnitude, or -1 if <paramref name="x"/> is empty.</returns>
+        /// <remarks>This method corresponds to the <c>iamax</c> method defined by <c>BLAS1</c>.</remarks>
+        public static unsafe int IndexOfMaxMagnitude(ReadOnlySpan<float> x)
+        {
+            int result = -1;
+
+            if (!x.IsEmpty)
+            {
+                float max = float.NegativeInfinity;
+                float maxMag = float.NegativeInfinity;
+
+                for (int i = 0; i < x.Length; i++)
+                {
+                    // This matches the IEEE 754:2019 `maximumMagnitude` function.
+                    // It propagates NaN inputs back to the caller and
+                    // otherwise returns the input with a greater magnitude.
+                    // It treats +0 as greater than -0 as per the specification.
+
+                    float current = x[i];
+                    float currentMag = Math.Abs(current);
+
+                    if (currentMag != maxMag)
+                    {
+                        if (float.IsNaN(currentMag))
+                        {
+                            return i;
+                        }
+
+                        if (maxMag < currentMag)
+                        {
+                            result = i;
+                            max = current;
+                            maxMag = currentMag;
+                        }
+                    }
+                    else if (IsNegative(max))
+                    {
+                        result = i;
+                        max = current;
+                        maxMag = currentMag;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Computes the index of the element in <paramref name="x"/> with the minimum magnitude.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The index of the element with the minimum magnitude, or -1 if <paramref name="x"/> is empty.</returns>
+        public static unsafe int IndexOfMinMagnitude(ReadOnlySpan<float> x)
+        {
+            int result = -1;
+
+            if (!x.IsEmpty)
+            {
+                float minMag = float.PositiveInfinity;
+
+                for (int i = 0; i < x.Length; i++)
+                {
+                    // This matches the IEEE 754:2019 `minimumMagnitude` function
+                    // It propagates NaN inputs back to the caller and
+                    // otherwise returns the input with a lesser magnitude.
+                    // It treats +0 as greater than -0 as per the specification.
+
+                    float current = x[i];
+                    float currentMag = Math.Abs(current);
+
+                    if (currentMag != minMag)
+                    {
+                        if (float.IsNaN(currentMag))
+                        {
+                            return i;
+                        }
+
+                        if (currentMag < minMag)
+                        {
+                            result = i;
+                            minMag = currentMag;
+                        }
+                    }
+                    else if (IsNegative(current))
+                    {
+                        result = i;
+                        minMag = currentMag;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Computes the sum of all elements in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The result of adding all elements in <paramref name="x"/>, or zero if <paramref name="x"/> is empty.</returns>
+        public static float Sum(ReadOnlySpan<float> x) =>
+            Aggregate<LoadIdentity, AddOperator>(0.0f, x);
+
+        /// <summary>Computes the sum of the squares of every element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The result of adding every element in <paramref name="x"/> multiplied by itself, or zero if <paramref name="x"/> is empty.</returns>
+        /// <remarks>This method effectively does <c><see cref="TensorPrimitives" />.Sum(<see cref="TensorPrimitives" />.Multiply(<paramref name="x" />, <paramref name="x" />))</c>.</remarks>
+        public static float SumOfSquares(ReadOnlySpan<float> x) =>
+            Aggregate<LoadSquared, AddOperator>(0.0f, x);
+
+        /// <summary>Computes the sum of the absolute values of every element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The result of adding the absolute value of every element in <paramref name="x"/>, or zero if <paramref name="x"/> is empty.</returns>
+        /// <remarks>
+        ///     <para>This method effectively does <c><see cref="TensorPrimitives" />.Sum(<see cref="TensorPrimitives" />.Abs(<paramref name="x" />))</c>.</para>
+        ///     <para>This method corresponds to the <c>asum</c> method defined by <c>BLAS1</c>.</para>
+        /// </remarks>
+        public static float SumOfMagnitudes(ReadOnlySpan<float> x) =>
+            Aggregate<LoadAbsolute, AddOperator>(0.0f, x);
+
+        /// <summary>Computes the product of all elements in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The result of multiplying all elements in <paramref name="x"/>.</returns>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be greater than zero.</exception>
+        public static float Product(ReadOnlySpan<float> x)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            return Aggregate<LoadIdentity, MultiplyOperator>(1.0f, x);
+        }
+
+        /// <summary>Computes the product of the element-wise result of: <c><paramref name="x" /> + <paramref name="y" /></c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <returns>The result of multiplying the element-wise additions of the elements in each tensor.</returns>
+        /// <exception cref="ArgumentException">Length of both input spans must be greater than zero.</exception>
+        /// <exception cref="ArgumentException"><paramref name="x"/> and <paramref name="y"/> must have the same length.</exception>
+        /// <remarks>This method effectively does <c><see cref="TensorPrimitives" />.Product(<see cref="TensorPrimitives" />.Add(<paramref name="x" />, <paramref name="y" />))</c>.</remarks>
+        public static float ProductOfSums(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            if (x.Length != y.Length)
+            {
+                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+            }
+
+            return Aggregate<AddOperator, MultiplyOperator>(1.0f, x, y);
+        }
+
+        /// <summary>Computes the product of the element-wise result of: <c><paramref name="x" /> - <paramref name="y" /></c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <returns>The result of multiplying the element-wise subtraction of the elements in the second tensor from the first tensor.</returns>
+        /// <exception cref="ArgumentException">Length of both input spans must be greater than zero.</exception>
+        /// <exception cref="ArgumentException"><paramref name="x"/> and <paramref name="y"/> must have the same length.</exception>
+        /// <remarks>This method effectively does <c><see cref="TensorPrimitives" />.Product(<see cref="TensorPrimitives" />.Subtract(<paramref name="x" />, <paramref name="y" />))</c>.</remarks>
+        public static float ProductOfDifferences(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            if (x.Length != y.Length)
+            {
+                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+            }
+
+            return Aggregate<SubtractOperator, MultiplyOperator>(1.0f, x, y);
+        }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
@@ -74,7 +74,7 @@ namespace System.Numerics.Tensors
                 Vector512<float> ySumOfSquaresVector = Vector512<float>.Zero;
 
                 // Process vectors, summing their dot products and squares, as long as there's a vector's worth remaining.
-                int oneVectorFromEnd = x.Length - Vector<float>.Count;
+                int oneVectorFromEnd = x.Length - Vector512<float>.Count;
                 do
                 {
                     Vector512<float> xVec = Vector512.LoadUnsafe(ref xRef, (uint)i);
@@ -105,15 +105,15 @@ namespace System.Numerics.Tensors
                 Vector256<float> ySumOfSquaresVector = Vector256<float>.Zero;
 
                 // Process vectors, summing their dot products and squares, as long as there's a vector's worth remaining.
-                int oneVectorFromEnd = x.Length - Vector<float>.Count;
+                int oneVectorFromEnd = x.Length - Vector256<float>.Count;
                 do
                 {
                     Vector256<float> xVec = Vector256.LoadUnsafe(ref xRef, (uint)i);
                     Vector256<float> yVec = Vector256.LoadUnsafe(ref yRef, (uint)i);
 
-                    dotProductVector += (xVec * yVec);
-                    xSumOfSquaresVector += (xVec * xVec);
-                    ySumOfSquaresVector += (yVec * yVec);
+                    dotProductVector += xVec * yVec;
+                    xSumOfSquaresVector += xVec * xVec;
+                    ySumOfSquaresVector += yVec * yVec;
 
                     i += Vector256<float>.Count;
                 }
@@ -134,15 +134,15 @@ namespace System.Numerics.Tensors
                 Vector128<float> ySumOfSquaresVector = Vector128<float>.Zero;
 
                 // Process vectors, summing their dot products and squares, as long as there's a vector's worth remaining.
-                int oneVectorFromEnd = x.Length - Vector<float>.Count;
+                int oneVectorFromEnd = x.Length - Vector128<float>.Count;
                 do
                 {
                     Vector128<float> xVec = Vector128.LoadUnsafe(ref xRef, (uint)i);
                     Vector128<float> yVec = Vector128.LoadUnsafe(ref yRef, (uint)i);
 
-                    dotProductVector += (xVec * yVec);
-                    xSumOfSquaresVector += (xVec * xVec);
-                    ySumOfSquaresVector += (yVec * yVec);
+                    dotProductVector += xVec * yVec;
+                    xSumOfSquaresVector += xVec * xVec;
+                    ySumOfSquaresVector += yVec * yVec;
 
                     i += Vector128<float>.Count;
                 }

--- a/src/libraries/System.Numerics.Tensors/tests/System.Numerics.Tensors.Tests.csproj
+++ b/src/libraries/System.Numerics.Tensors/tests/System.Numerics.Tensors.Tests.csproj
@@ -8,6 +8,10 @@
   <ItemGroup>
     <Compile Include="TensorPrimitivesTests.cs" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <Compile Include="TensorPrimitivesTests.netcore.cs" />
+  </ItemGroup>
   
   <ItemGroup>
     <!-- Some internal types are needed, so we reference the implementation assembly, rather than the reference assembly. -->

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.netcore.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using Xunit;
 
 namespace System.Numerics.Tensors.Tests
@@ -12,7 +13,7 @@ namespace System.Numerics.Tensors.Tests
         [MemberData(nameof(TensorLengths))]
         public static void ConvertToHalf(int tensorLength)
         {
-            float[] source = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> source = CreateAndFillTensor(tensorLength);
             foreach (int destLength in new[] { source.Length, source.Length + 1 })
             {
                 Half[] destination = new Half[destLength];
@@ -38,7 +39,7 @@ namespace System.Numerics.Tensors.Tests
         [MemberData(nameof(TensorLengths))]
         public static void ConvertToHalf_ThrowsForTooShortDestination(int tensorLength)
         {
-            float[] source = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> source = CreateAndFillTensor(tensorLength);
             Half[] destination = new Half[source.Length - 1];
 
             AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.ConvertToHalf(source, destination));
@@ -57,7 +58,8 @@ namespace System.Numerics.Tensors.Tests
 
             foreach (int destLength in new[] { source.Length, source.Length + 1 })
             {
-                float[] destination = new float[destLength];
+                using BoundedMemory<float> destination = CreateTensor(destLength);
+                destination.Span.Fill(0f);
 
                 TensorPrimitives.ConvertToSingle(source, destination);
 
@@ -81,7 +83,7 @@ namespace System.Numerics.Tensors.Tests
         public static void ConvertToSingle_ThrowsForTooShortDestination(int tensorLength)
         {
             Half[] source = new Half[tensorLength];
-            float[] destination = new float[source.Length - 1];
+            using BoundedMemory<float> destination = CreateTensor(source.Length - 1);
 
             AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.ConvertToSingle(source, destination));
         }

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.netcore.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Numerics.Tensors.Tests
+{
+    public static partial class TensorPrimitivesTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [MemberData(nameof(TensorLengths))]
+        public static void ConvertToHalf(int tensorLength)
+        {
+            float[] source = CreateAndFillTensor(tensorLength);
+            foreach (int destLength in new[] { source.Length, source.Length + 1 })
+            {
+                Half[] destination = new Half[destLength];
+
+                TensorPrimitives.ConvertToHalf(source, destination);
+
+                for (int i = 0; i < source.Length; i++)
+                {
+                    Assert.Equal((Half)source[i], destination[i]);
+                }
+
+                if (destination.Length > source.Length)
+                {
+                    for (int i = source.Length; i < destination.Length; i++)
+                    {
+                        Assert.Equal(Half.Zero, destination[i]);
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void ConvertToHalf_ThrowsForTooShortDestination(int tensorLength)
+        {
+            float[] source = CreateAndFillTensor(tensorLength);
+            Half[] destination = new Half[source.Length - 1];
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.ConvertToHalf(source, destination));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [MemberData(nameof(TensorLengths))]
+        public static void ConvertToSingle(int tensorLength)
+        {
+            Half[] source = new Half[tensorLength];
+            for (int i = 0; i < source.Length; i++)
+            {
+                source[i] = (Half)s_random.NextSingle();
+            }
+
+            foreach (int destLength in new[] { source.Length, source.Length + 1 })
+            {
+                float[] destination = new float[destLength];
+
+                TensorPrimitives.ConvertToSingle(source, destination);
+
+                for (int i = 0; i < source.Length; i++)
+                {
+                    Assert.Equal((float)source[i], destination[i]);
+                }
+
+                if (destination.Length > source.Length)
+                {
+                    for (int i = source.Length; i < destination.Length; i++)
+                    {
+                        Assert.Equal(0f, destination[i]);
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void ConvertToSingle_ThrowsForTooShortDestination(int tensorLength)
+        {
+            Half[] source = new Half[tensorLength];
+            float[] destination = new float[source.Length - 1];
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.ConvertToSingle(source, destination));
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1033,7 +1033,7 @@ namespace System
             //
             // It propagates NaN inputs back to the caller and
             // otherwise returns the lesser of the inputs. It
-            // treats +0 as lesser than -0 as per the specification.
+            // treats +0 as greater than -0 as per the specification.
 
             if (val1 != val2)
             {
@@ -1091,7 +1091,7 @@ namespace System
             //
             // It propagates NaN inputs back to the caller and
             // otherwise returns the lesser of the inputs. It
-            // treats +0 as lesser than -0 as per the specification.
+            // treats +0 as greater than -0 as per the specification.
 
             if (val1 != val2)
             {
@@ -1145,7 +1145,7 @@ namespace System
             //
             // It propagates NaN inputs back to the caller and
             // otherwise returns the input with a lesser magnitude.
-            // It treats +0 as lesser than -0 as per the specification.
+            // It treats +0 as greater than -0 as per the specification.
 
             double ax = Abs(x);
             double ay = Abs(y);

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -285,7 +285,7 @@ namespace System
             //
             // It propagates NaN inputs back to the caller and
             // otherwise returns the input with a lesser magnitude.
-            // It treats +0 as lesser than -0 as per the specification.
+            // It treats +0 as greater than -0 as per the specification.
 
             float ax = Abs(x);
             float ay = Abs(y);


### PR DESCRIPTION
Represents the last planned .NET 8 surface area for TensorPrimitives (but not the last PR to improve it).

Adds non-vectorized implementations of:
- Max
- MaxMagnitude
- IndexOfMax
- IndexOfMaxMagnitude
- Min
- MinMagnitude
- IndexOfMin
- IndexOfMinMagnitude
- ConvertToHalf (only on .NET Core)
- ConvertToSingle (only on .NET Core)

Adds vectorized implementations of:
- Sum
- SumOfSquares
- SumOfMagnitudes
- Product
- ProductOfSums
- ProductOfDifferences

Vectorizes the implementations of:
- CosineSimilarity
- Distance
- L2Normalize
- Dot

Beyond vectorizing the non-vectorized ones, the vectorized implementations should be improved further, including:
- Handling alignment better
- Vectorizing the remainder that doesn't fit in a vector rather than falling back to scalar