### PR TITLE
[workloads] Opt into using package groups

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -166,7 +166,7 @@
       <SwixWorkloadPackProjects Include="@(SwixProjects)" Condition="'%(PackageType)' == 'msi-pack'"
                                 ManifestOutputPath="$(VStemp)\p\%(SwixProjects.SdkFeatureBand)"
                                 ZipFile="Workload.VSDrop.mono.net.$(MajorVersion).$(MinorVersion)-%(SwixProjects.SdkFeatureBand).packs.zip"/>
-      <SwixComponentsAndManifests Include="@(SwixProjects)" Condition="('%(PackageType)' == 'msi-manifest') Or ('%(PackageType)' == 'component' And '%(IsPreview)' == 'false')"
+      <SwixComponentsAndManifests Include="@(SwixProjects)" Condition="('%(PackageType)' == 'msi-manifest') Or ('%(PackageType)' == 'manifest-package-group') Or ('%(PackageType)' == 'component' And '%(IsPreview)' == 'false')"
                                   ManifestOutputPath="$(VStemp)\c\%(SwixProjects.SdkFeatureBand)"
                                   ZipFile="Workload.VSDrop.mono.net.$(MajorVersion).$(MinorVersion)-%(SwixProjects.SdkFeatureBand).components.zip"/>
       <SwixPreviewComponentsAndManifests Include="@(SwixProjects)" Condition="('%(PackageType)' == 'msi-manifest') Or ('%(PackageType)' == 'component' And '%(IsPreview)' == 'true')"


### PR DESCRIPTION
This is to make sure the MSI's we generate for VS are recognized as the same. Enabling sxs workloads by itself caused the package id's that wrap the manifest MSI's to be different. This prevents that from happening.