### PR TITLE
Add a few missing xml comments for APIs in threading and tasks

### DIFF
--- a/src/libraries/Common/src/System/Threading/Tasks/TaskToAsyncResult.cs
+++ b/src/libraries/Common/src/System/Threading/Tasks/TaskToAsyncResult.cs
@@ -52,6 +52,7 @@ namespace System.Threading.Tasks
             Unwrap(asyncResult).GetAwaiter().GetResult();
 
         /// <summary>Waits for the <see cref="Task{TResult}"/> wrapped by the <see cref="IAsyncResult"/> returned by <see cref="Begin"/> to complete.</summary>
+        /// <typeparam name="TResult">The type of the result produced.</typeparam>
         /// <param name="asyncResult">The <see cref="IAsyncResult"/> for which to wait.</param>
         /// <returns>The result of the <see cref="Task{TResult}"/> wrapped by the <see cref="IAsyncResult"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="asyncResult"/> is null.</exception>
@@ -85,6 +86,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Extracts the underlying <see cref="Task{TResult}"/> from an <see cref="IAsyncResult"/> created by <see cref="Begin"/>.</summary>
+        /// <typeparam name="TResult">The type of the result produced by the returned task.</typeparam>
         /// <param name="asyncResult">The <see cref="IAsyncResult"/> created by <see cref="Begin"/>.</param>
         /// <returns>The <see cref="Task{TResult}"/> wrapped by the <see cref="IAsyncResult"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="asyncResult"/> is null.</exception>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -276,6 +276,10 @@ namespace System.Threading
         }
 
         /// <summary>Communicates a request for cancellation asynchronously.</summary>
+        /// <returns>
+        /// A task that will complete after cancelable operations and callbacks registered with the associated
+        /// <see cref="CancellationToken" /> have completed.
+        /// </returns>
         /// <remarks>
         /// <para>
         /// The associated <see cref="CancellationToken" /> will be notified of the cancellation


### PR DESCRIPTION
Fills in some missing XML comments, see https://github.com/dotnet/dotnet-api-docs/pull/9299