### PR TITLE
Update HttpClientJsonExtensions.Get.AsyncEnumerable.cs

### DIFF
--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Get.AsyncEnumerable.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Get.AsyncEnumerable.cs
@@ -134,7 +134,7 @@ namespace System.Net.Http.Json
             Uri? requestUri,
             JsonSerializerOptions? options,
             CancellationToken cancellationToken)
-        {        
+        {
             return Core(client, requestUri, options, cancellationToken);
 
             static async IAsyncEnumerable<TValue?> Core(

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Get.AsyncEnumerable.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Get.AsyncEnumerable.cs
@@ -135,6 +135,11 @@ namespace System.Net.Http.Json
             JsonSerializerOptions? options,
             CancellationToken cancellationToken)
         {
+            if (client is null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            
             return Core(client, requestUri, options, cancellationToken);
 
             static async IAsyncEnumerable<TValue?> Core(

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Get.AsyncEnumerable.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Get.AsyncEnumerable.cs
@@ -139,7 +139,7 @@ namespace System.Net.Http.Json
             {
                 throw new ArgumentNullException(nameof(client));
             }
-            
+
             return Core(client, requestUri, options, cancellationToken);
 
             static async IAsyncEnumerable<TValue?> Core(

--- a/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
+++ b/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
@@ -599,6 +599,24 @@ namespace System.Net.Http.Json.Functional.Tests
                 Assert.True(m.Value > 0);
             }
         }
+
+        [Fact]
+        public async Task GetFromJsonAsAsyncEnumerable_CustomSerializerOptions()
+        {
+            using var client = new HttpClient(new CustomResponseHandler((r, c) =>
+            {
+                string json = """[{"Value":1},{"Value":2}]""";
+                HttpResponseMessage response = new()
+                {
+                    Content = new StringContent(json)
+                };
+                return Task.FromResult(response);
+            }));
+            await foreach (var m in client.GetFromJsonAsAsyncEnumerable<TestModel>("http://dummyUrl", JsonSerializerOptions.Default))
+            {
+                Assert.True(m.Value > 0);
+            }
+        }
     }
 }
 

--- a/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
+++ b/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
@@ -580,6 +580,25 @@ namespace System.Net.Http.Json.Functional.Tests
                 await Task.Delay(TimeSpan.FromMilliseconds(10));
             }
         }
+
+        [Fact]
+        public async Task GetFromJsonAsAsyncEnumerable_SerializerCaseInsensitiveTest()
+        {
+            using var client = new HttpClient(new CustomResponseHandler((r, c) =>
+            {
+                string json = """[{"value":1},{"value":2}]""";
+                HttpResponseMessage response = new()
+                {
+                    Content = new StringContent(json)
+                };
+                return Task.FromResult(response);
+            }));
+
+            await foreach (var m in client.GetFromJsonAsAsyncEnumerable<TestModel>("http://dummyUrl"))
+            {
+                Assert.True(m.Value > 0);
+            }
+        }
     }
 }
 
@@ -592,4 +611,9 @@ file sealed class CustomResponseHandler : HttpMessageHandler
 
     protected override Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, CancellationToken cancellationToken) => _func(request, cancellationToken);
+}
+
+file sealed class TestModel
+{
+    public int Value { get; set; }
 }

--- a/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
+++ b/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
@@ -582,7 +582,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
-        public async Task GetFromJsonAsAsyncEnumerable_SerializerCaseInsensitiveTest()
+        public async Task GetFromJsonAsAsyncEnumerable_SerializerUsesCamelCase()
         {
             using var client = new HttpClient(new CustomResponseHandler((r, c) =>
             {


### PR DESCRIPTION
Update `jsonTypeInfo` for `ReadFromJsonAsAsyncEnumerable`

fixes #92179 