### PR TITLE
Update the assert for BlendVariable

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -8602,9 +8602,14 @@ void emitter::emitIns_SIMD_R_R_R_R(
         // SSE4.1 blendv* hardcode the mask vector (op3) in XMM0
         emitIns_Mov(INS_movaps, attr, REG_XMM0, op3Reg, /* canSkip */ true);
 
-        // Ensure we aren't overwriting op2 or oop3 (which should be REG_XMM0)
+        // Ensure we aren't overwriting op2 or op3 (which should be REG_XMM0)
         assert((op2Reg != targetReg) || (op1Reg == targetReg));
-        assert(targetReg != REG_XMM0);
+
+        // If targetReg == REG_XMM0, it means that op3 was last use and we decided to
+        // reuse REG_XMM0 for destination i.e. targetReg. In such case, make sure
+        // that XMM0 value after the (op3Reg -> XMM0) move done above is not
+        // overwritten by op1Reg.
+        assert((targetReg != REG_XMM0) || (op1Reg == op3Reg));
 
         emitIns_Mov(INS_movaps, attr, targetReg, op1Reg, /* canSkip */ true);
         emitIns_R_R(ins, attr, targetReg, op2Reg);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91798/Runtime_91798.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91798/Runtime_91798.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+// There was an issue with Sse41.BlendVariable where we might reuse XMM0
+// for targetReg.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Xunit;
+
+public class TestClass_91798
+{
+    Vector128<uint> v128_uint_75 = Vector128.Create((uint)2, 1, 0, 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public Vector128<uint> Method0()
+    {
+        return Sse41.BlendVariable(v128_uint_75, Vector128<uint>.One, v128_uint_75);
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        TestClass_91798 obj = new TestClass_91798();
+        obj.Method0();
+    }
+}
+/*
+Environment:
+
+set DOTNET_EnableSSE42=0
+
+Assert failure(PID 8884 [0x000022b4], Thread: 14588 [0x38fc]): Assertion failed '(targetReg != REG_XMM0)' in 'TestClass_91798:Method0():System.Runtime.Intrinsics.Vector128`1[uint]:this' during 'Generate code' (IL size 23; hash 0x557a6266; FullOpts)
+
+    File: D:\git\runtime2\src\coreclr\jit\emitxarch.cpp Line: 8612
+    Image: d:\git\runtime2\artifacts\tests\coreclr\windows.x64.Checked\tests\Core_Root\corerun.exe
+*/
+

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91798/Runtime_91798.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91798/Runtime_91798.cs
@@ -23,8 +23,11 @@ public class TestClass_91798
     [Fact]
     public static void TestEntryPoint()
     {
-        TestClass_91798 obj = new TestClass_91798();
-        obj.Method0();
+        if (Sse41.IsSupported)
+        {
+            TestClass_91798 obj = new TestClass_91798();
+            obj.Method0();
+        }
     }
 }
 /*

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91798/Runtime_91798.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91798/Runtime_91798.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_EnableSSE42" Value="0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
For `BlendVariable()`, `op3` should be present in XMM0. However, sometimes `targetReg` can get `XMM0` allocated because `op3` might be last use. In such case, make sure that we do not overwrite the `targetReg` i.e. XMM0 with `op1Reg`.

Fixes: #91798