### PR TITLE
Ensure the adapter name 100% matching when parsing proc/net/dev

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -415,7 +415,13 @@ namespace System.Net.NetworkInformation
                         Span<Range> pieces = stackalloc Range[18]; // [0]-[16] used, +1 to ensure any additional segment goes into [17]
                         ReadOnlySpan<char> lineSpan = line;
                         pieces = pieces.Slice(0, lineSpan.SplitAny(pieces, " :", StringSplitOptions.RemoveEmptyEntries));
-                        if (!lineSpan[pieces[0]].SequenceEqual(name)) continue; // Ensure the adapter name 100% matching
+
+                        if (!lineSpan[pieces[0]].SequenceEqual(name))
+                        {
+                            // The adapter name doesn't exactly match.
+                            continue;
+                        }
+
                         return new IPInterfaceStatisticsTable()
                         {
                             BytesReceived = ParseUInt64AndClampToInt64(lineSpan[pieces[1]]),

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -414,7 +414,12 @@ namespace System.Net.NetworkInformation
                     if (line.Contains(name))
                     {
                         ReadOnlySpan<char> lineSpan = line;
-                        lineSpan.SplitAny(pieces, " :", StringSplitOptions.RemoveEmptyEntries);
+                        int pieceCount = lineSpan.SplitAny(pieces, " :", StringSplitOptions.RemoveEmptyEntries);
+
+                        if (pieceCount < 17)
+                        {
+                            continue;
+                        }
 
                         if (!lineSpan[pieces[0]].SequenceEqual(name))
                         {

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -407,16 +407,15 @@ namespace System.Net.NetworkInformation
             {
                 sr.ReadLine();
                 sr.ReadLine();
-                int index = 0;
                 while (!sr.EndOfStream)
                 {
                     string line = sr.ReadLine()!;
                     if (line.Contains(name))
                     {
-                        Span<Range> pieces = stackalloc Range[18]; // [0] skipped, [1]-[16] used, +1 to ensure any additional segment goes into [17]
+                        Span<Range> pieces = stackalloc Range[18]; // [0]-[16] used, +1 to ensure any additional segment goes into [17]
                         ReadOnlySpan<char> lineSpan = line;
                         pieces = pieces.Slice(0, lineSpan.SplitAny(pieces, " :", StringSplitOptions.RemoveEmptyEntries));
-
+                        if (!lineSpan[pieces[0]].SequenceEqual(name)) continue; // Ensure the adapter name 100% matching
                         return new IPInterfaceStatisticsTable()
                         {
                             BytesReceived = ParseUInt64AndClampToInt64(lineSpan[pieces[1]]),
@@ -438,7 +437,6 @@ namespace System.Net.NetworkInformation
                             CompressedPacketsTransmitted = ParseUInt64AndClampToInt64(lineSpan[pieces[16]]),
                         };
                     }
-                    index += 1;
                 }
 
                 throw ExceptionHelper.CreateForParseFailure();

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -407,14 +407,14 @@ namespace System.Net.NetworkInformation
             {
                 sr.ReadLine();
                 sr.ReadLine();
+                Span<Range> pieces = stackalloc Range[18]; // [0]-[16] used, +1 to ensure any additional segment goes into [17]
                 while (!sr.EndOfStream)
                 {
                     string line = sr.ReadLine()!;
                     if (line.Contains(name))
                     {
-                        Span<Range> pieces = stackalloc Range[18]; // [0]-[16] used, +1 to ensure any additional segment goes into [17]
                         ReadOnlySpan<char> lineSpan = line;
-                        pieces = pieces.Slice(0, lineSpan.SplitAny(pieces, " :", StringSplitOptions.RemoveEmptyEntries));
+                        lineSpan.SplitAny(pieces, " :", StringSplitOptions.RemoveEmptyEntries);
 
                         if (!lineSpan[pieces[0]].SequenceEqual(name))
                         {

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkFiles/dev
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkFiles/dev
@@ -1,4 +1,5 @@
 Inter-|   Receive                                                |  Transmit
  face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+wlan0a:   20000     394    2    4    6     8         10        12    429496730000     208    1    2    3     4       5          6
  wlan0:   26622     394    2    4    6     8         10        12    429496730000     208    1    2    3     4       5          6
     lo:   18446744073709551615     302    0    0    0     0          0         0    30008     302    0    0    0     0       0          0


### PR DESCRIPTION
Fix #91982

* Add a mock adapter `wlan0a` in `FunctionalTests/NetworkFiles/dev` to reveal the issue.

* Add checking the adapter name.

* Remove unused variable `index`.