### PR TITLE
Improve performance of BigInteger.Multiply(large, small)

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs
@@ -162,6 +162,21 @@ namespace System.Numerics
             Debug.Assert(left.Length >= right.Length);
             Debug.Assert(bits.Length == left.Length + right.Length);
 
+            if (left.Length - right.Length < 3)
+            {
+                MultiplyNearLength(left, right, bits);
+            }
+            else
+            {
+                MultiplyFarLength(left, right, bits);
+            }
+        }
+
+        private static void MultiplyFarLength(ReadOnlySpan<uint> left, ReadOnlySpan<uint> right, Span<uint> bits)
+        {
+            Debug.Assert(left.Length - right.Length >= 3);
+            Debug.Assert(bits.Length == left.Length + right.Length);
+
             // Executes different algorithms for computing z = a * b
             // based on the actual length of b. If b is "small" enough
             // we stick to the classic "grammar-school" method; for the
@@ -211,41 +226,67 @@ namespace System.Numerics
                 // Say we want to compute z = a * b ...
 
                 // ... we need to determine our new length (just the half)
-                int n = (left.Length + 1) >> 1;
-                if (right.Length <= n)
+                int n = left.Length >> 1;
+                if (right.Length <= n + 1)
                 {
                     // ... split left like a = (a_1 << n) + a_0
                     ReadOnlySpan<uint> leftLow = left.Slice(0, n);
                     ReadOnlySpan<uint> leftHigh = left.Slice(n);
 
+                    // ... split right like b = (b_1 << n) + b_0
+                    ReadOnlySpan<uint> rightLow;
+                    uint rightHigh;
+                    if (n < right.Length)
+                    {
+                        Debug.Assert(right.Length == n + 1);
+                        rightLow = right.Slice(0, n);
+                        rightHigh = right[n];
+                    }
+                    else
+                    {
+                        rightLow = right;
+                        rightHigh = 0;
+                    }
+
                     // ... prepare our result array (to reuse its memory)
-                    Span<uint> bitsLow = bits.Slice(0, n + right.Length);
+                    Span<uint> bitsLow = bits.Slice(0, n + rightLow.Length);
                     Span<uint> bitsHigh = bits.Slice(n);
 
-                    int carryLength = right.Length;
+                    int carryLength = rightLow.Length;
                     uint[]? carryFromPool = null;
                     Span<uint> carry = ((uint)carryLength <= StackAllocThreshold ?
                                       stackalloc uint[StackAllocThreshold]
                                       : carryFromPool = ArrayPool<uint>.Shared.Rent(carryLength)).Slice(0, carryLength);
 
                     // ... compute low
-                    Multiply(leftLow, right, bitsLow);
-                    Span<uint> carryOrig = bits.Slice(n, right.Length);
+                    Multiply(leftLow, rightLow, bitsLow);
+                    Span<uint> carryOrig = bits.Slice(n, rightLow.Length);
                     carryOrig.CopyTo(carry);
                     carryOrig.Clear();
 
-
-                    // ... compute high
-                    if (leftHigh.Length < right.Length)
+                    if (rightHigh != 0)
                     {
-                        Debug.Assert(right.Length == n);
-                        Debug.Assert(left.Length == 2 * n - 1);
-                        Debug.Assert(leftHigh.Length == n - 1);
-                        Multiply(right, leftHigh, bitsHigh);
+                        // ... compute high
+                        MultiplyNearLength(leftHigh, rightLow, bitsHigh.Slice(0, leftHigh.Length + n));
+
+                        int upperRightLength = left.Length + 1;
+                        uint[]? upperRightFromPool = null;
+                        Span<uint> upperRight = ((uint)upperRightLength <= StackAllocThreshold ?
+                                          stackalloc uint[StackAllocThreshold]
+                                          : upperRightFromPool = ArrayPool<uint>.Shared.Rent(upperRightLength)).Slice(0, upperRightLength);
+                        upperRight.Clear();
+
+                        Multiply(left, rightHigh, upperRight);
+
+                        AddSelf(bitsHigh, upperRight);
+
+                        if (upperRightFromPool != null)
+                            ArrayPool<uint>.Shared.Return(upperRightFromPool);
                     }
                     else
                     {
-                        Multiply(leftHigh, right, bitsHigh);
+                        // ... compute high
+                        Multiply(leftHigh, rightLow, bitsHigh);
                     }
 
                     AddSelf(bitsHigh, carry);
@@ -256,6 +297,8 @@ namespace System.Numerics
                 else
                 {
                     int n2 = n << 1;
+
+                    Debug.Assert(left.Length > right.Length);
 
                     // ... split left like a = (a_1 << n) + a_0
                     ReadOnlySpan<uint> leftLow = left.Slice(0, n);
@@ -270,12 +313,12 @@ namespace System.Numerics
                     Span<uint> bitsHigh = bits.Slice(n2);
 
                     // ... compute z_0 = a_0 * b_0 (multiply again)
-                    Multiply(leftLow, rightLow, bitsLow);
+                    MultiplyNearLength(rightLow, leftLow, bitsLow);
 
                     // ... compute z_2 = a_1 * b_1 (multiply again)
-                    Multiply(leftHigh, rightHigh, bitsHigh);
+                    MultiplyFarLength(leftHigh, rightHigh, bitsHigh);
 
-                    int leftFoldLength = n + 1;
+                    int leftFoldLength = leftHigh.Length + 1;
                     uint[]? leftFoldFromPool = null;
                     Span<uint> leftFold = ((uint)leftFoldLength <= StackAllocThreshold ?
                                           stackalloc uint[StackAllocThreshold]
@@ -296,14 +339,17 @@ namespace System.Numerics
                                       : coreFromPool = ArrayPool<uint>.Shared.Rent(coreLength)).Slice(0, coreLength);
                     core.Clear();
 
+                    Debug.Assert(bits.Length - n >= core.Length);
+                    Debug.Assert(rightLow.Length >= rightHigh.Length);
+
                     // ... compute z_a = a_1 + a_0 (call it fold...)
-                    Add(leftLow, leftHigh, leftFold);
+                    Add(leftHigh, leftLow, leftFold);
 
                     // ... compute z_b = b_1 + b_0 (call it fold...)
                     Add(rightLow, rightHigh, rightFold);
 
                     // ... compute z_1 = z_a * z_b - z_0 - z_2
-                    Multiply(leftFold, rightFold, core);
+                    MultiplyNearLength(leftFold, rightFold, core);
 
                     if (leftFoldFromPool != null)
                         ArrayPool<uint>.Shared.Return(leftFoldFromPool);
@@ -314,12 +360,131 @@ namespace System.Numerics
                     SubtractCore(bitsLow, bitsHigh, core);
 
                     // ... and finally merge the result! :-)
-                    Debug.Assert(bits.Slice(n).Length >= ActualLength(core));
-                    AddSelf(bits.Slice(n), core.Slice(0, ActualLength(core)));
+                    AddSelf(bits.Slice(n), core);
 
                     if (coreFromPool != null)
                         ArrayPool<uint>.Shared.Return(coreFromPool);
                 }
+            }
+        }
+        private static void MultiplyNearLength(ReadOnlySpan<uint> left, ReadOnlySpan<uint> right, Span<uint> bits)
+        {
+            Debug.Assert(left.Length - right.Length < 3);
+            Debug.Assert(bits.Length == left.Length + right.Length);
+
+            // Executes different algorithms for computing z = a * b
+            // based on the actual length of b. If b is "small" enough
+            // we stick to the classic "grammar-school" method; for the
+            // rest we switch to implementations with less complexity
+            // albeit more overhead (which needs to pay off!).
+
+            // NOTE: useful thresholds needs some "empirical" testing,
+            // which are smaller in DEBUG mode for testing purpose.
+
+            if (right.Length < MultiplyThreshold)
+            {
+                // Switching to managed references helps eliminating
+                // index bounds check...
+                ref uint resultPtr = ref MemoryMarshal.GetReference(bits);
+
+                // Multiplies the bits using the "grammar-school" method.
+                // Envisioning the "rhombus" of a pen-and-paper calculation
+                // should help getting the idea of these two loops...
+                // The inner multiplication operations are safe, because
+                // z_i+j + a_j * b_i + c <= 2(2^32 - 1) + (2^32 - 1)^2 =
+                // = 2^64 - 1 (which perfectly matches with ulong!).
+
+                for (int i = 0; i < right.Length; i++)
+                {
+                    ulong carry = 0UL;
+                    for (int j = 0; j < left.Length; j++)
+                    {
+                        ref uint elementPtr = ref Unsafe.Add(ref resultPtr, i + j);
+                        ulong digits = elementPtr + carry + (ulong)left[j] * right[i];
+                        elementPtr = unchecked((uint)digits);
+                        carry = digits >> 32;
+                    }
+                    Unsafe.Add(ref resultPtr, i + left.Length) = (uint)carry;
+                }
+            }
+            else
+            {
+                // Based on the Toom-Cook multiplication we split left/right
+                // into two smaller values, doing recursive multiplication.
+                // The special form of this multiplication, where we
+                // split both operands into two operands, is also known
+                // as the Karatsuba algorithm...
+
+                // https://en.wikipedia.org/wiki/Toom-Cook_multiplication
+                // https://en.wikipedia.org/wiki/Karatsuba_algorithm
+
+                // Say we want to compute z = a * b ...
+
+                // ... we need to determine our new length (just the half)
+                int n = right.Length >> 1;
+                int n2 = n << 1;
+
+                // ... split left like a = (a_1 << n) + a_0
+                ReadOnlySpan<uint> leftLow = left.Slice(0, n);
+                ReadOnlySpan<uint> leftHigh = left.Slice(n);
+
+                // ... split right like b = (b_1 << n) + b_0
+                ReadOnlySpan<uint> rightLow = right.Slice(0, n);
+                ReadOnlySpan<uint> rightHigh = right.Slice(n);
+
+                // ... prepare our result array (to reuse its memory)
+                Span<uint> bitsLow = bits.Slice(0, n2);
+                Span<uint> bitsHigh = bits.Slice(n2);
+
+                // ... compute z_0 = a_0 * b_0 (multiply again)
+                MultiplyNearLength(leftLow, rightLow, bitsLow);
+
+                // ... compute z_2 = a_1 * b_1 (multiply again)
+                MultiplyNearLength(leftHigh, rightHigh, bitsHigh);
+
+                int leftFoldLength = leftHigh.Length + 1;
+                uint[]? leftFoldFromPool = null;
+                Span<uint> leftFold = ((uint)leftFoldLength <= StackAllocThreshold ?
+                                      stackalloc uint[StackAllocThreshold]
+                                      : leftFoldFromPool = ArrayPool<uint>.Shared.Rent(leftFoldLength)).Slice(0, leftFoldLength);
+                leftFold.Clear();
+
+                int rightFoldLength = rightHigh.Length + 1;
+                uint[]? rightFoldFromPool = null;
+                Span<uint> rightFold = ((uint)rightFoldLength <= StackAllocThreshold ?
+                                       stackalloc uint[StackAllocThreshold]
+                                       : rightFoldFromPool = ArrayPool<uint>.Shared.Rent(rightFoldLength)).Slice(0, rightFoldLength);
+                rightFold.Clear();
+
+                int coreLength = leftFoldLength + rightFoldLength;
+                uint[]? coreFromPool = null;
+                Span<uint> core = ((uint)coreLength <= StackAllocThreshold ?
+                                  stackalloc uint[StackAllocThreshold]
+                                  : coreFromPool = ArrayPool<uint>.Shared.Rent(coreLength)).Slice(0, coreLength);
+                core.Clear();
+
+                // ... compute z_a = a_1 + a_0 (call it fold...)
+                Add(leftHigh, leftLow, leftFold);
+
+                // ... compute z_b = b_1 + b_0 (call it fold...)
+                Add(rightHigh, rightLow, rightFold);
+
+                // ... compute z_1 = z_a * z_b - z_0 - z_2
+                MultiplyNearLength(leftFold, rightFold, core);
+
+                if (leftFoldFromPool != null)
+                    ArrayPool<uint>.Shared.Return(leftFoldFromPool);
+
+                if (rightFoldFromPool != null)
+                    ArrayPool<uint>.Shared.Return(rightFoldFromPool);
+
+                SubtractCore(bitsHigh, bitsLow, core);
+
+                // ... and finally merge the result! :-)
+                AddSelf(bits.Slice(n), core);
+
+                if (coreFromPool != null)
+                    ArrayPool<uint>.Shared.Return(coreFromPool);
             }
         }
 

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/multiply.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/multiply.cs
@@ -205,6 +205,28 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void RunMultiplyKaratsubaBoundary()
+        {
+            Random random = new Random(s_seed);
+            byte[] tempByteArray1 = new byte[0];
+            byte[] tempByteArray2 = new byte[0];
+
+            // Multiply Method - One Large BigInteger
+            for (int i = 0; i < s_samples; i++)
+            {
+                for (int d1 = -2; d1 <= 2; d1++)
+                {
+                    tempByteArray1 = GetRandomByteArray(random, BigIntegerCalculator.MultiplyThreshold + d1);
+                    for (int d2 = -4; d2 <= 4; d2++)
+                    {
+                        tempByteArray2 = GetRandomByteArray(random, (BigIntegerCalculator.MultiplyThreshold + 1) * 2 + d2);
+                        VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "bMultiply");
+                    }
+                }
+            }
+        }
+
+        [Fact]
         public static void RunMultiply_OnePositiveOneNegative()
         {
             Random random = new Random(s_seed);

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_multiply.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_multiply.cs
@@ -159,6 +159,27 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void RunMultiplyKaratsubaBoundary()
+        {
+            byte[] tempByteArray1 = new byte[0];
+            byte[] tempByteArray2 = new byte[0];
+
+            // Multiply Method - One Large BigInteger
+            for (int i = 0; i < s_samples; i++)
+            {
+                for (int d1 = -2; d1 <= 2; d1++)
+                {
+                    tempByteArray1 = GetRandomByteArray(s_random, BigIntegerCalculator.MultiplyThreshold + d1);
+                    for (int d2 = -4; d2 <= 4; d2++)
+                    {
+                        tempByteArray2 = GetRandomByteArray(s_random, (BigIntegerCalculator.MultiplyThreshold + 1) * 2 + d2);
+                        VerifyMultiplyString(Print(tempByteArray1) + Print(tempByteArray2) + "b*");
+                    }
+                }
+            }
+        }
+
+        [Fact]
         public static void RunMultiplyTests()
         {
             byte[] tempByteArray1 = new byte[0];


### PR DESCRIPTION
BigInteger.Multiply is based on [Karatsuba algorithm](https://en.wikipedia.org/wiki/Karatsuba_algorithm). If implemented correctly, the computational complexity of multiply is $\Theta(n^{\log_2 3})$ where n is number of digits.

However, in the current implementation, it is not. This is because it the half of the smaller value is used when the larger one should be. 
https://github.com/dotnet/runtime/blob/353d5ead13cf66b81ad2579adb8f495afb0438a6/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs#L214



## Benchmark
```

BenchmarkDotNet v0.13.8, Windows 11 (10.0.22621.2283/22H2/2022Update/SunValley2)
13th Gen Intel Core i5-13500, 1 CPU, 20 logical and 14 physical cores
.NET SDK 8.0.100-rc.1.23415.11
  [Host]   : .NET 8.0.0 (8.0.23.41404), X64 RyuJIT AVX2
  ShortRun : .NET 8.0.0 (8.0.23.41404), X64 RyuJIT AVX2

Job=ShortRun  Toolchain=.NET 8.0  IterationCount=3  
LaunchCount=1  WarmupCount=3  

```
| Method      | largeLength | smallLength | Mean          | Error       | StdDev    | Ratio | RatioSD |
|------------ |------------ |------------ |--------------:|------------:|----------:|------:|--------:|
| **PR_Multiply** | **1000**        | **1000**        |     **0.0375 ms** |   **0.0442 ms** | **0.0024 ms** |  **1.37** |    **0.09** |
| Multiply    | 1000        | 1000        |     0.0274 ms |   0.0002 ms | 0.0000 ms |  1.00 |    0.00 |
|             |             |             |               |             |           |       |         |
| **PR_Multiply** | **10000**       | **1000**        |     **0.3143 ms** |   **0.0750 ms** | **0.0041 ms** |  **0.58** |    **0.01** |
| Multiply    | 10000       | 1000        |     0.5409 ms |   0.0160 ms | 0.0009 ms |  1.00 |    0.00 |
|             |             |             |               |             |           |       |         |
| **PR_Multiply** | **10000**       | **10000**       |     **1.1306 ms** |   **0.2769 ms** | **0.0152 ms** |  **1.29** |    **0.02** |
| Multiply    | 10000       | 10000       |     0.8797 ms |   0.0351 ms | 0.0019 ms |  1.00 |    0.00 |
|             |             |             |               |             |           |       |         |
| **PR_Multiply** | **100000**      | **1000**        |     **3.0304 ms** |   **0.1180 ms** | **0.0065 ms** |  **0.52** |    **0.00** |
| Multiply    | 100000      | 1000        |     5.7730 ms |   0.6991 ms | 0.0383 ms |  1.00 |    0.00 |
|             |             |             |               |             |           |       |         |
| **PR_Multiply** | **100000**      | **10000**       |    **11.0477 ms** |   **0.7075 ms** | **0.0388 ms** |  **0.23** |    **0.00** |
| Multiply    | 100000      | 10000       |    48.9797 ms |   1.8604 ms | 0.1020 ms |  1.00 |    0.00 |
|             |             |             |               |             |           |       |         |
| **PR_Multiply** | **100000**      | **100000**      |    **39.4357 ms** |   **0.2381 ms** | **0.0131 ms** |  **1.25** |    **0.00** |
| Multiply    | 100000      | 100000      |    31.6607 ms |   0.2959 ms | 0.0162 ms |  1.00 |    0.00 |
|             |             |             |               |             |           |       |         |
| **PR_Multiply** | **1000000**     | **1000**        |    **30.2207 ms** |   **1.4899 ms** | **0.0817 ms** |  **0.48** |    **0.00** |
| Multiply    | 1000000     | 1000        |    63.0998 ms |  10.1509 ms | 0.5564 ms |  1.00 |    0.00 |
|             |             |             |               |             |           |       |         |
| **PR_Multiply** | **1000000**     | **10000**       |   **120.0384 ms** |   **8.3355 ms** | **0.4569 ms** |  **0.21** |    **0.00** |
| Multiply    | 1000000     | 10000       |   582.8313 ms |  39.3648 ms | 2.1577 ms |  1.00 |    0.00 |
|             |             |             |               |             |           |       |         |
| **PR_Multiply** | **1000000**     | **100000**      |   **448.9208 ms** |   **3.7954 ms** | **0.2080 ms** |  **0.09** |    **0.00** |
| Multiply    | 1000000     | 100000      | 5,091.4759 ms | 151.9431 ms | 8.3285 ms |  1.00 |    0.00 |
|             |             |             |               |             |           |       |         |
| **PR_Multiply** | **1000000**     | **995000**      | **1,608.9999 ms** |  **75.3231 ms** | **4.1287 ms** |  **1.09** |    **0.00** |
| Multiply    | 1000000     | 995000      | 1,482.7404 ms |  58.9864 ms | 3.2332 ms |  1.00 |    0.00 |
|             |             |             |               |             |           |       |         |
| **PR_Multiply** | **1000000**     | **1000000**     | **1,627.7224 ms** |  **63.8822 ms** | **3.5016 ms** |  **1.35** |    **0.01** |
| Multiply    | 1000000     | 1000000     | 1,209.0913 ms |  45.2731 ms | 2.4816 ms |  1.00 |    0.00 |

```cs
public class BigIntegerMultiplyBenchmark
{
    static ReadOnlySpan<byte> MakeBytes(int length)
    {
        var random = new Random(918);
        var bytes = new byte[length];
        random.NextBytes(bytes);
        return bytes;
    }

    public IEnumerable<object[]> LengthArguments()
    {
        var lengths = new int[] { 1000, 10000, 100000, 1000000 };
        for (int i = lengths.Length - 1; i >= 0; i--)
        {
            if (i == lengths.Length - 1)
            {
                yield return new object[] { lengths[i], (int)(0.995 * lengths[i]), };
            }
            for (int j = i; j >= 0; j--)
            {
                yield return new object[] { lengths[i], lengths[j], };
            }
        }
    }

    [Benchmark]
    [ArgumentsSource(nameof(LengthArguments))]
    public PrBigInteger PR_Multiply(int largeLength, int smallLength)
    {
        return (new PrBigInteger(MakeBytes(smallLength)) * new PrBigInteger(MakeBytes(largeLength)));
    }

    [Benchmark(Baseline = true)]
    [ArgumentsSource(nameof(LengthArguments))]
    public BigInteger Multiply(int largeLength, int smallLength)
    {
        return (new BigInteger(MakeBytes(smallLength)) * new BigInteger(MakeBytes(largeLength)));
    }
}
```