### PR TITLE
Adding AVX512 path to Base64 encoding/Decoding

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -1297,3 +1297,37 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+License notice for Avx512Vbmi base64 encoding / decoding
+--------------------------------------------------------
+
+Copyright (c) 2015-2018, Wojciech Muła
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------
+
+Aspects of base64 encoding / decoding are based on algorithm described in "Base64 encoding and decoding at almost the speed of a memory
+copy", Wojciech Muła and Daniel Lemire. https://arxiv.org/pdf/1910.05109.pdf

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Decoder.cs
@@ -705,20 +705,20 @@ namespace System.Buffers.Text
                 if (Avx512Vbmi.IsSupported)
                 {
                     origIndex = Avx512Vbmi.PermuteVar64x8x2(vbmiLookup0, str, vbmiLookup1);
-                    ulong errorMask = (Vector512.BitwiseOr(origIndex.AsInt32(), str.AsInt32()).AsSByte()).ExtractMostSignificantBits();
-                    if (errorMask != 0)
+                    Vector512<sbyte> errorVec = (origIndex.AsInt32() | str.AsInt32()).AsSByte();
+                    if (errorVec.ExtractMostSignificantBits() != 0)
                     {
                         break;
                     }
                 }
                 else
                 {
-                    Vector512<sbyte> hiNibbles = Vector512.BitwiseAnd(Avx512F.ShiftRightLogical(str.AsInt32(), 4).AsSByte(), mask2F);
+                    Vector512<sbyte> hiNibbles = (Avx512F.ShiftRightLogical(str.AsInt32(), 4).AsSByte() & mask2F);
 
-                    Vector512<sbyte> loNibbles = Vector512.BitwiseAnd(str, mask2F);
+                    Vector512<sbyte> loNibbles = (str & mask2F);
                     Vector512<sbyte> hi = Avx512BW.Shuffle(lutHi, hiNibbles);
                     Vector512<sbyte> lo = Avx512BW.Shuffle(lutLo, loNibbles);
-                    if (!Vector512.EqualsAll(Vector512.BitwiseAnd(hi, lo), Vector512<sbyte>.Zero))
+                    if (!Vector512.EqualsAll((hi & lo), Vector512<sbyte>.Zero))
                     {
                         break;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Decoder.cs
@@ -69,7 +69,7 @@ namespace System.Buffers.Text
                 if (maxSrcLength >= 24)
                 {
                     byte* end = srcMax - 88;
-                    if (Vector512.IsHardwareAccelerated && Avx512BW.IsSupported && (end >= src))
+                    if (Vector512.IsHardwareAccelerated && Avx512Vbmi.IsSupported && (end >= src))
                     {
                         Avx512Decode(ref src, ref dest, end, maxSrcLength, destLength, srcBytes, destBytes);
 
@@ -632,7 +632,7 @@ namespace System.Buffers.Text
         [CompExactlyDependsOn(typeof(Avx512Vbmi))]
         private static unsafe void Avx512Decode(ref byte* srcBytes, ref byte* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, byte* destStart)
         {
-            // Reference for VBMI implementation : https://arxiv.org/pdf/1910.05109.pdf
+            // Reference for VBMI implementation : https://github.com/WojciechMula/base64simd/tree/master/decode
             // If we have AVX512 support, pick off 64 bytes at a time for as long as we can,
             // but make sure that we quit before seeing any == markers at the end of the
             // string. Also, because we write 16 zeroes at the end of the output, ensure
@@ -643,8 +643,6 @@ namespace System.Buffers.Text
 
             // The JIT won't hoist these "constants", so help it
             // JIT will remove the Non VBMI path constants when VBMI is available and vice-versa.
-
-            // Vbmi path constants
             Vector512<sbyte> vbmiLookup0 = Vector512.Create(
                 0x80808080, 0x80808080, 0x80808080, 0x80808080,
                 0x80808080, 0x80808080, 0x80808080, 0x80808080,
@@ -661,37 +659,12 @@ namespace System.Buffers.Text
                 0x2c2d2e28, 0x36303132, 0x393a3435, 0x3c3d3e38,
                 0x00000000, 0x00000000, 0x00000000, 0x00000000).AsByte();
 
-            // Non Vbmi path constants
-            Vector512<sbyte> lutHi = Vector512.Create(
-                0x10, 0x10, 0x01, 0x02, 0x04, 0x08, 0x04, 0x08, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10,
-                0x10, 0x10, 0x01, 0x02, 0x04, 0x08, 0x04, 0x08, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10,
-                0x10, 0x10, 0x01, 0x02, 0x04, 0x08, 0x04, 0x08, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10,
-                0x10, 0x10, 0x01, 0x02, 0x04, 0x08, 0x04, 0x08, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10);
-
-            Vector512<sbyte> lutLo = Vector512.Create(
-                0x15, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x13, 0x1A, 0x1B, 0x1B, 0x1B, 0x1A,
-                0x15, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x13, 0x1A, 0x1B, 0x1B, 0x1B, 0x1A,
-                0x15, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x13, 0x1A, 0x1B, 0x1B, 0x1B, 0x1A,
-                0x15, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x13, 0x1A, 0x1B, 0x1B, 0x1B, 0x1A);
-            Vector512<sbyte> mask2F = Vector512.Create((sbyte)'/');
-            Vector512<sbyte> lutShift = Vector512.Create(
-                0, 16, 19, 4, -65, -65, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 16, 19, 4, -65, -65, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 16, 19, 4, -65, -65, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 16, 19, 4, -65, -65, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0);
-            Vector512<sbyte> packBytesInLaneMask = Vector512.Create(
-                        2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12, -1, -1, -1, -1,
-                        18, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12, -1, -1, -1, -1,
-                        2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12, -1, -1, -1, -1,
-                        2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12, -1, -1, -1, -1);
-            Vector512<int> packLanesControl = Vector512.Create(0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14, 0, 0, 0, 0);
-
-            // Common path constants
             Vector512<sbyte> mergeConstant0 = Vector512.Create(0x01400140).AsSByte();
             Vector512<short> mergeConstant1 = Vector512.Create(0x00011000).AsInt16();
 
-            // The fastest version of this algorithm requires AVX512VBMI support.
-            // The fallback path uses AVX512BW and AVX512F instructions.
+            // This algorithm requires AVX512VBMI support.
+            // Vbmi was first introduced in CannonLake and is avaialable from IceLake on.
+            // This makes it okay to use Vbmi instructions since Vector512.IsHardwareAccelerated returns True only from IceLake on.
             do
             {
                 AssertRead<Vector512<sbyte>>(src, srcStart, sourceLength);
@@ -702,32 +675,13 @@ namespace System.Buffers.Text
                 // After this, we have indices which are verified to have upper 2 bits set to 0 in each byte.
                 // origIndex      = [...|00dddddd|00cccccc|00bbbbbb|00aaaaaa]
                 Vector512<sbyte> origIndex;
-                if (Avx512Vbmi.IsSupported)
+
+                origIndex = Avx512Vbmi.PermuteVar64x8x2(vbmiLookup0, str, vbmiLookup1);
+                Vector512<sbyte> errorVec = (origIndex.AsInt32() | str.AsInt32()).AsSByte();
+                if (errorVec.ExtractMostSignificantBits() != 0)
                 {
-                    origIndex = Avx512Vbmi.PermuteVar64x8x2(vbmiLookup0, str, vbmiLookup1);
-                    Vector512<sbyte> errorVec = (origIndex.AsInt32() | str.AsInt32()).AsSByte();
-                    if (errorVec.ExtractMostSignificantBits() != 0)
-                    {
-                        break;
-                    }
+                    break;
                 }
-                else
-                {
-                    Vector512<sbyte> hiNibbles = (Avx512F.ShiftRightLogical(str.AsInt32(), 4).AsSByte() & mask2F);
-
-                    Vector512<sbyte> loNibbles = (str & mask2F);
-                    Vector512<sbyte> hi = Avx512BW.Shuffle(lutHi, hiNibbles);
-                    Vector512<sbyte> lo = Avx512BW.Shuffle(lutLo, loNibbles);
-                    if (!Vector512.EqualsAll((hi & lo), Vector512<sbyte>.Zero))
-                    {
-                        break;
-                    }
-                    Vector512<sbyte> eq2F = Vector512.Equals(str, mask2F);
-                    Vector512<sbyte> shift = Avx512BW.Shuffle(lutShift, Vector512.Add(eq2F, hiNibbles));
-                    origIndex = Vector512.Add(str, shift);
-                }
-
-
 
                 // Step 2: Now we need to reshuffle bits to remove the 0 bits.
                 // multiAdd1: [...|0000cccc|ccdddddd|0000aaaa|aabbbbbb]
@@ -736,16 +690,7 @@ namespace System.Buffers.Text
                 Vector512<int> multiAdd2 = Avx512BW.MultiplyAddAdjacent(multiAdd1, mergeConstant1);
 
                 // Step 3: Pack 48 bytes
-                if (Avx512Vbmi.IsSupported)
-                {
-                    str = Avx512Vbmi.PermuteVar64x8(multiAdd2.AsByte(), vbmiPackedLanesControl).AsSByte();
-                }
-                else
-                {
-                    Vector512<int> packed = Avx512BW.Shuffle(multiAdd2.AsSByte(), packBytesInLaneMask).AsInt32();
-                    str = Avx512F.PermuteVar16x32(packed, packLanesControl).AsSByte();
-
-                }
+                str = Avx512Vbmi.PermuteVar64x8(multiAdd2.AsByte(), vbmiPackedLanesControl).AsSByte();
 
                 AssertWrite<Vector512<sbyte>>(dest, destStart, destLength);
                 Vector512.Store(str.AsByte(), dest);

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
@@ -257,11 +257,7 @@ namespace System.Buffers.Text
                 0x0d0e0c0d, 0x10110f10, 0x13141213, 0x16171516,
                 0x191a1819, 0x1c1d1b1c, 0x1f201e1f, 0x22232122,
                 0x25262425, 0x28292728, 0x2b2c2a2b, 0x2e2f2d2e).AsSByte();
-            Vector512<sbyte> vbmiLookup = Vector512.Create(
-                (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F', (byte)'G', (byte)'H', (byte)'I', (byte)'J', (byte)'K', (byte)'L', (byte)'M', (byte)'N', (byte)'O', (byte)'P',
-                (byte)'Q', (byte)'R', (byte)'S', (byte)'T', (byte)'U', (byte)'V', (byte)'W', (byte)'X', (byte)'Y', (byte)'Z', (byte)'a', (byte)'b', (byte)'c', (byte)'d', (byte)'e', (byte)'f',
-                (byte)'g', (byte)'h', (byte)'i', (byte)'j', (byte)'k', (byte)'l', (byte)'m', (byte)'n', (byte)'o', (byte)'p', (byte)'q', (byte)'r', (byte)'s', (byte)'t', (byte)'u', (byte)'v',
-                (byte)'w', (byte)'x', (byte)'y', (byte)'z', (byte)'0', (byte)'1', (byte)'2', (byte)'3', (byte)'4', (byte)'5', (byte)'6', (byte)'7', (byte)'8', (byte)'9', (byte)'+', (byte)'/').AsSByte();
+            Vector512<sbyte> vbmiLookup = Vector512.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"u8).AsSByte();
 
             // Non VBMI path constants
             Vector512<int> rearrangeVec = Vector512.Create(0, 1, 2, -1, 3, 4, 5, -1, 6, 7, 8, -1, 9, 10, 11, -1);

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
@@ -249,7 +249,6 @@ namespace System.Buffers.Text
             byte* dest = destBytes;
 
             // The JIT won't hoist these "constants", so help it
-            // JIT will remove the Non VBMI path constants when VBMI is available and vice-versa.
             Vector512<sbyte> shuffleVecVbmi = Vector512.Create(
                 0x01020001, 0x04050304, 0x07080607, 0x0a0b090a,
                 0x0d0e0c0d, 0x10110f10, 0x13141213, 0x16171516,
@@ -266,7 +265,6 @@ namespace System.Buffers.Text
 
             // This algorithm requires AVX512VBMI support.
             // Vbmi was first introduced in CannonLake and is avaialable from IceLake on.
-            // This makes it okay to use Vbmi instructions since Vector512.IsHardwareAccelerated returns True only from IceLake on.
 
             // str = [...|PONM|LKJI|HGFE|DCBA]
             Vector512<sbyte> str = Vector512.Load(src).AsSByte();
@@ -295,7 +293,7 @@ namespace System.Buffers.Text
                 str = Avx512Vbmi.PermuteVar64x8(vbmiLookup, str);
 
                 AssertWrite<Vector512<sbyte>>(dest, destStart, destLength);
-                Vector512.Store(str.AsByte(), dest);
+                str.Store((sbyte*)dest);
 
                 src += 48;
                 dest += 64;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
@@ -68,7 +68,7 @@ namespace System.Buffers.Text
                 if (maxSrcLength >= 16)
                 {
                     byte* end = srcMax - 64;
-                    if (Vector512.IsHardwareAccelerated && Avx512BW.IsSupported && (end >= src))
+                    if (Vector512.IsHardwareAccelerated && Avx512Vbmi.IsSupported && (end >= src))
                     {
                         Avx512Encode(ref src, ref dest, end, maxSrcLength, destLength, srcBytes, destBytes);
 
@@ -240,7 +240,7 @@ namespace System.Buffers.Text
         [CompExactlyDependsOn(typeof(Avx512Vbmi))]
         private static unsafe void Avx512Encode(ref byte* srcBytes, ref byte* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, byte* destStart)
         {
-            // Reference for VBMI implementation : https://arxiv.org/pdf/1910.05109.pdf
+            // Reference for VBMI implementation : https://github.com/WojciechMula/base64simd/tree/master/encode
             // If we have AVX512 support, pick off 48 bytes at a time for as long as we can.
             // But because we read 64 bytes at a time, ensure we have enough room to do a
             // full 64-byte read without segfaulting.
@@ -250,8 +250,6 @@ namespace System.Buffers.Text
 
             // The JIT won't hoist these "constants", so help it
             // JIT will remove the Non VBMI path constants when VBMI is available and vice-versa.
-
-            // VBMI path constants
             Vector512<sbyte> shuffleVecVbmi = Vector512.Create(
                 0x01020001, 0x04050304, 0x07080607, 0x0a0b090a,
                 0x0d0e0c0d, 0x10110f10, 0x13141213, 0x16171516,
@@ -259,46 +257,25 @@ namespace System.Buffers.Text
                 0x25262425, 0x28292728, 0x2b2c2a2b, 0x2e2f2d2e).AsSByte();
             Vector512<sbyte> vbmiLookup = Vector512.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"u8).AsSByte();
 
-            // Non VBMI path constants
-            Vector512<int> rearrangeVec = Vector512.Create(0, 1, 2, -1, 3, 4, 5, -1, 6, 7, 8, -1, 9, 10, 11, -1);
-            Vector512<sbyte> shuffleVec = Vector512.Create(0x01020001, 0x04050304, 0x07080607, 0x0a0b090a, 0x01020001, 0x04050304, 0x07080607, 0x0a0b090a,
-                0x01020001, 0x04050304, 0x07080607, 0x0a0b090a, 0x01020001, 0x04050304, 0x07080607, 0x0a0b090a).AsSByte();
-            Vector512<sbyte> lut = Vector512.Create(
-                65, 71, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -19, -16, 0, 0,
-                65, 71, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -19, -16, 0, 0,
-                65, 71, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -19, -16, 0, 0,
-                65, 71, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -19, -16, 0, 0);
-            Vector512<byte> const51 = Vector512.Create((byte)51);
-            Vector512<sbyte> const25 = Vector512.Create((sbyte)25);
-
-            // Common constants
             Vector512<ushort> maskAC = Vector512.Create((uint)0x0fc0fc00).AsUInt16();
             Vector512<uint> maskBB = Vector512.Create((uint)0x3f003f00);
             Vector512<ushort> shiftAC = Vector512.Create((uint)0x0006000a).AsUInt16();
             Vector512<ushort> shiftBB = Vector512.Create((uint)0x00080004).AsUInt16();
 
             AssertRead<Vector256<sbyte>>(src, srcStart, sourceLength);
-            // The fastest version of this algorithm requires AVX512VBMI support.
-            // The fallback path uses AVX512BW and AVX512F instructions.
-            // Both versions work on the input data as four 128 byte lanes.
+
+            // This algorithm requires AVX512VBMI support.
+            // Vbmi was first introduced in CannonLake and is avaialable from IceLake on.
+            // This makes it okay to use Vbmi instructions since Vector512.IsHardwareAccelerated returns True only from IceLake on.
+
             // str = [...|PONM|LKJI|HGFE|DCBA]
             Vector512<sbyte> str = Vector512.Load(src).AsSByte();
 
             while (true)
             {
                 // Step 1 : Split 48 bytes into 64 bytes with each byte using 6-bits from input
-                if (Avx512Vbmi.IsSupported)
-                {
-                    // str = [...|KLJK|HIGH|EFDE|BCAB]
-                    str = Avx512Vbmi.PermuteVar64x8(str, shuffleVecVbmi);
-                }
-                else
-                {
-                    // shuf1 = [...|0000|LKJI|HGFE|DCBA]
-                    Vector512<sbyte> shuf1 = Avx512F.PermuteVar16x32(str.AsInt32(), rearrangeVec).AsSByte();
-                    // str = [...|KLJK|HIGH|EFDE|BCAB]
-                    str = Avx512BW.Shuffle(shuf1, shuffleVec);
-                }
+                // str = [...|KLJK|HIGH|EFDE|BCAB]
+                str = Avx512Vbmi.PermuteVar64x8(str, shuffleVecVbmi);
 
                 // TO-DO- This can be achieved faster with multishift
                 // Consider the first 4 bytes - BCAB
@@ -315,18 +292,7 @@ namespace System.Buffers.Text
                 str = Vector512.ConditionalSelect(maskBB, temp3.AsUInt32(), temp2.AsUInt32()).AsSByte();
 
                 // Step 2: Now we have the indices calculated. Next step is to use these indices to translate.
-                if (Avx512Vbmi.IsSupported)
-                {
-                    str = Avx512Vbmi.PermuteVar64x8(vbmiLookup, str);
-                }
-                else
-                {
-                    Vector512<byte> indices = Avx512BW.SubtractSaturate(str.AsByte(), const51);
-                    Vector512<sbyte> mask = Vector512.GreaterThan(str, const25);
-                    Vector512<sbyte> tmp = Vector512.Subtract(indices.AsSByte(), mask);
-                    // Add offsets to input values:
-                    str = Vector512.Add(str, Avx512BW.Shuffle(lut, tmp));
-                }
+                str = Avx512Vbmi.PermuteVar64x8(vbmiLookup, str);
 
                 AssertWrite<Vector512<sbyte>>(dest, destStart, destLength);
                 Vector512.Store(str.AsByte(), dest);


### PR DESCRIPTION
### Overview

This PR implements an AVX512 code path for Base64 encoding/Decoding. This is based on the work by _Wojciech Muła_ and _Daniel Lemire_. There is a fast `AVX512VBMI` path and the fallback uses `AVX512F/BW` - I'll refer to these as **VBMI_AVAILABLE** and **VBMI_UNAVAILABLE** here on. For performance purposes, this will be compared to an AVX2 implementation which will be referred to as **BASE_Version**
Reference for the algorithm:

- https://arxiv.org/pdf/1910.05109.pdf


This version uses intrinsics directly and not generic vector libraries due to lack of current support in JIt/Vector libraries to produce optimal code. Some additional support which would be required in order to use generic vector library for implementing this would be

1. Add `ShuffleUnsafe` for Vector512
2. Extend `Vector512.Shuffle()` to lower to intrinsics instead of going to fallback for more cases.
3. Expand `Vector512 `surface area to incorporate more high level functions

Even the current implementation can be further optimized by adding the `multishift()` implementation. This is a further optimization

### Generated code

(Will be focusing on the actual encoding/decoding code within the loop only)


### **Encoding**

**VBMI_AVAILABLE**

![image](https://github.com/dotnet/runtime/assets/17969209/aa9206a7-33cc-49ad-9455-4df368d1b6e7)

**VBMI_UNAVAILABLE**

![image](https://github.com/dotnet/runtime/assets/17969209/31a95785-7c7e-482f-a5e3-234cd89f223c)

**BASE_VERSION**
![image](https://github.com/dotnet/runtime/assets/17969209/cd1ffd83-d536-4c74-b74f-25bbcb6ffa01)


### **Decoding**

**VBMI_AVAILABLE**

![image](https://github.com/dotnet/runtime/assets/17969209/919f2f25-1190-4bef-af27-829da0f241a5)


**VBMI_UNAVAILABLE**

![image](https://github.com/dotnet/runtime/assets/17969209/81747fd1-4ac9-4a77-9d47-6324590a54e8)

**BASE_VERSION**
![image](https://github.com/dotnet/runtime/assets/17969209/0b934bf7-9c0b-47ec-9169-dbf03d5ab556)


### Performance

### ON ICX -
**BASE_VERSION** vs **VBMI_UNAVAILABLE**

![image](https://github.com/dotnet/runtime/assets/17969209/b3d7d43d-312f-4058-a25c-ccff9f2e54b7)


**BASE_VERSION** vs **VBMI_AVAILABLE**
![image](https://github.com/dotnet/runtime/assets/17969209/7a4cfaed-c8b1-4515-9e8f-92f60b6c26c1)