### PR TITLE
JIT: add missing xarch RMW case

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -5485,6 +5485,13 @@ void emitter::emitInsRMW(instruction ins, emitAttr attr, GenTreeStoreInd* storeI
     {
         assert(!src->isContained()); // there must be one non-contained src
 
+        if (addr->isContained() && addr->OperIs(GT_LCL_ADDR))
+        {
+            GenTreeLclVarCommon* lclVar = addr->AsLclVarCommon();
+            emitIns_S_R(ins, attr, src->GetRegNum(), lclVar->GetLclNum(), lclVar->GetLclOffs());
+            return;
+        }
+
         // ind, reg
         id = emitNewInstrAmd(attr, offset);
         emitHandleMemOp(storeInd, id, emitInsModeFormat(ins, IF_ARD_RRD), ins);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_92218/Runtime_92218.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_92218/Runtime_92218.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Xunit;
+
+public struct MutableStruct
+{
+    private long _internalValue;
+
+    public long InternalValue
+    {
+        get => Volatile.Read(ref _internalValue);
+        private set => Volatile.Write(ref _internalValue, value);
+    }
+
+    public void Add(long value) => AddInternal(value);
+    private void AddInternal(long value) => InternalValue += value;
+    public MutableStruct(long value) => InternalValue = value;
+}
+
+public static class Runtime_92218
+{
+    [Fact]
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public static void Problem()
+    {
+        var test = new MutableStruct(420);
+        var from = new MutableStruct(42);
+
+        var wrapper = -new TimeSpan(3);
+
+        while (test.InternalValue >= from.InternalValue)
+        {
+            test.Add(wrapper.Ticks);
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_92218/Runtime_92218.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_92218/Runtime_92218.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Handle the case where we're indirectly updating a local with a value that is not a constant.

Fixes #92218.