### PR TITLE
[main] Bump Microsoft.Private.IntelliSense package version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -205,7 +205,7 @@
     <GrpcToolsVersion>2.45.0</GrpcToolsVersion>
     <CompilerPlatformTestingVersion>1.1.2-beta1.23323.1</CompilerPlatformTestingVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>8.0.0-preview-20230828.1</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>8.0.0-preview-20230918.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>9.0.0-alpha.1.23460.2</MicrosoftNETILLinkTasksVersion>
     <!-- Mono Cecil -->


### PR DESCRIPTION
Generated from https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=386331&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=11e7ea89-affe-5194-cdc6-0171c3394706 

Manually pushed to dotnet8-transport: https://dnceng.visualstudio.com/public/_artifacts/feed/dotnet8-transport/NuGet/Microsoft.Private.Intellisense/overview/8.0.0-preview-20230918.1