### PR TITLE
[wasm] [debugger] Evaluation of methods on enums

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -440,40 +440,41 @@ namespace Microsoft.WebAssembly.Diagnostics
             var signature = methodDef.Signature;
             var sigReader = Assembly.asmMetadataReader.GetBlobReader(signature);
             var decoder = new SignatureDecoder<ElementType, object>(_signatureTypeProvider, Assembly.asmMetadataReader, genericContext: null);
-            var methodSignature = decoder.DecodeMethodSignature(ref sigReader);
+            MethodSignature<ElementType> methodSignature = decoder.DecodeMethodSignature(ref sigReader);
 
             var paramsHandles = methodDef.GetParameters().ToArray();
             var paramsCnt = paramsHandles.Length;
             var paramsInfo = new ParameterInfo[paramsCnt];
 
-            for (int i = 0; i < paramsCnt; i++)
+            int paramInx = 0;
+            foreach (var paramHandle in paramsHandles)
             {
-                var parameter = Assembly.asmMetadataReader.GetParameter(paramsHandles[i]);
+                var parameter = Assembly.asmMetadataReader.GetParameter(paramHandle);
                 var paramName = Assembly.EnCGetString(parameter.Name);
-                var isOptional = parameter.Attributes.HasFlag(ParameterAttributes.Optional) && parameter.Attributes.HasFlag(ParameterAttributes.HasDefault);
-                if (!isOptional)
+                if (string.IsNullOrEmpty(paramName))
                 {
-                    try
-                    {
-                        paramsInfo[i] = new ParameterInfo(paramName, methodSignature.ParameterTypes[i]);
-                    }
-                    catch (Exception)
-                    {
-                        // ToDo:
-                        // why do we get System.IndexOutOfRangeException: Index was outside the bounds of the array.
-                        // for provider param in method System.Enum.ToString(format, provider)?
-                        paramsInfo[i] = new ParameterInfo(paramName);
-                    }
                     continue;
                 }
-                var constantHandle = parameter.GetDefaultValue();
-                var blobHandle = Assembly.asmMetadataReader.GetConstant(constantHandle);
-                var paramBytes = Assembly.asmMetadataReader.GetBlobBytes(blobHandle.Value);
-                paramsInfo[i] = new ParameterInfo(
-                    paramName,
-                    blobHandle.TypeCode,
-                    paramBytes
-                );
+                var isOptional = parameter.Attributes.HasFlag(ParameterAttributes.Optional) && parameter.Attributes.HasFlag(ParameterAttributes.HasDefault);
+                if (isOptional)
+                {
+                    var constantHandle = parameter.GetDefaultValue();
+                    var blobHandle = Assembly.asmMetadataReader.GetConstant(constantHandle);
+                    var paramBytes = Assembly.asmMetadataReader.GetBlobBytes(blobHandle.Value);
+                    paramsInfo[paramInx] = new ParameterInfo(
+                        paramName,
+                        blobHandle.TypeCode,
+                        paramBytes
+                    );
+                }
+                else
+                {
+                    paramsInfo[paramInx] = new ParameterInfo(
+                        paramName,
+                        methodSignature.ParameterTypes[paramInx]
+                    );
+                }
+                paramInx++;
             }
             _parametersInfo = paramsInfo;
             return paramsInfo;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -453,7 +453,17 @@ namespace Microsoft.WebAssembly.Diagnostics
                 var isOptional = parameter.Attributes.HasFlag(ParameterAttributes.Optional) && parameter.Attributes.HasFlag(ParameterAttributes.HasDefault);
                 if (!isOptional)
                 {
-                    paramsInfo[i] = new ParameterInfo(paramName, methodSignature.ParameterTypes[i]);
+                    try
+                    {
+                        paramsInfo[i] = new ParameterInfo(paramName, methodSignature.ParameterTypes[i]);
+                    }
+                    catch (Exception)
+                    {
+                        // ToDo:
+                        // why do we get System.IndexOutOfRangeException: Index was outside the bounds of the array.
+                        // for provider param in method System.Enum.ToString(format, provider)?
+                        paramsInfo[i] = new ParameterInfo(paramName);
+                    }
                     continue;
                 }
                 var constantHandle = parameter.GetDefaultValue();

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -742,7 +742,7 @@ namespace DebuggerTests
                 await EvaluateOnCallFrameAndCheck(id,
                    ("s_valueTypeEnum.ToString()", TString("no")),
                    ("mc.valueTypeEnum.ToString()", TString("yes"))
-                   // ("mc.valueTypeEnum.HasFlag(SampleEnum.no)", TBool(true)) // ToDo: FAILING
+                   // ("mc.valueTypeEnum.HasFlag(SampleEnum.no)", TBool(true)) // ToDo: https://github.com/dotnet/runtime/issues/92262
                 );
            });
     }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -714,7 +714,7 @@ namespace DebuggerTests
 
         [Fact]
         public async Task EvaluateSumBetweenObjectAndString() => await CheckInspectLocalsAtBreakpointSite(
-             $"DebuggerTests.SumObjectAndString", "run", 7, "DebuggerTests.SumObjectAndString.run",
+            $"DebuggerTests.SumObjectAndString", "run", 7, "DebuggerTests.SumObjectAndString.run",
             $"window.setTimeout(function() {{ invoke_static_method ('[debugger-test] DebuggerTests.SumObjectAndString:run'); 1 }})",
             wait_for_event_fn: async (pause_location) =>
             {
@@ -729,6 +729,20 @@ namespace DebuggerTests
                     ("myClass+dt", "Cannot evaluate '(myClass+dt\n)': (3,9): error CS0019: Operator '+' cannot be applied to operands of type 'object' and 'object'"),
                     ("myClass+1", "Cannot evaluate '(myClass+1\n)': (2,9): error CS0019: Operator '+' cannot be applied to operands of type 'object' and 'int'"),
                     ("dt+1", "Cannot evaluate '(dt+1\n)': (2,9): error CS0019: Operator '+' cannot be applied to operands of type 'object' and 'int'")
+                );
+           });
+
+        [Fact]
+        public async Task EvaluateMethodsOnEnum() => await CheckInspectLocalsAtBreakpointSite(
+            $"DebuggerTests.EvaluateMethodsOnEnum", "run", 2, "DebuggerTests.EvaluateMethodsOnEnum.run",
+            $"window.setTimeout(function() {{ invoke_static_method ('[debugger-test] DebuggerTests.EvaluateMethodsOnEnum:run'); 1 }})",
+            wait_for_event_fn: async (pause_location) =>
+            {
+                var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+                await EvaluateOnCallFrameAndCheck(id,
+                   ("s_valueTypeEnum.ToString()", TString("no")),
+                   ("mc.valueTypeEnum.ToString()", TString("yes"))
+                   // ("mc.valueTypeEnum.HasFlag(SampleEnum.no)", TBool(true)) // ToDo: FAILING
                 );
            });
     }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -2041,6 +2041,20 @@ namespace DebuggerTests
             var localString = "aB.c[";
         }
     }
+
+    public static class EvaluateMethodsOnEnum
+    {
+        public static SampleEnum s_valueTypeEnum = SampleEnum.no;
+        public class MemberClass
+        {
+            public SampleEnum valueTypeEnum = SampleEnum.yes;
+        }
+        public static void run()
+        {
+            MemberClass mc = new();
+            Console.WriteLine("Break here");
+        }
+    }
 }
 
 namespace DebuggerTestsV2


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/69299.

- Adding tests for calling methods on enums.
- Fixing evaluation of `ToString` overload with parameters and potentially other functions that might have empty-named parameter handles in method signature.

Original error:
```
System.IndexOutOfRangeException: Index was outside the bounds of the array
```

Reason:
parameter handle array and `methodSignature.ParameterTypes` array were not in sync, handle array had 3 elements, one of them invalid (with empty name) while method signature types had 2 elements. When we ignore invalid handles, the logic works fine. https://learn.microsoft.com/en-us/dotnet/api/system.enum.tostring

Out of scope:
- passing objects as method arguments. "mc.valueTypeEnum.HasFlag(SampleEnum.no)" is not evaluated correctly because we do not have the mechanism for object-params. Delegated to issue https://github.com/dotnet/runtime/issues/92262