### PR TITLE
[mono] Fix naming of MonoEnableLLVM flag in Mono README

### DIFF
--- a/docs/workflow/building/mono/README.md
+++ b/docs/workflow/building/mono/README.md
@@ -55,11 +55,11 @@ build.cmd mono --build
 ### Useful Build Arguments
 Here are a list of build arguments that may be of use:
 
-`/p:MonoEnableLlvm=true` - Builds mono w/ LLVM
+`/p:MonoEnableLLVM=true` - Builds mono w/ LLVM
 
-`/p:MonoEnableLlvm=true /p:MonoLLVMDir=path/to/llvm` - Builds mono w/ LLVM from a custom path
+`/p:MonoEnableLLVM=true /p:MonoLLVMDir=path/to/llvm` - Builds mono w/ LLVM from a custom path
 
-`/p:MonoEnableLlvm=true /p:MonoLLVMDir=path/to/llvm /p:MonoLLVMUseCxx11Abi=true` - Builds mono w/ LLVM
+`/p:MonoEnableLLVM=true /p:MonoLLVMDir=path/to/llvm /p:MonoLLVMUseCxx11Abi=true` - Builds mono w/ LLVM
 from a custom path (and that LLVM was built with C++11 ABI)
 
 For `build.sh`


### PR DESCRIPTION
Use `/p:MonoEnableLLVM` instead of `/p: MonoEnableLlvm`.