### PR TITLE
[wasm] Endian fix for Webcil

### DIFF
--- a/src/tasks/Microsoft.NET.WebAssembly.Webcil/Microsoft.NET.WebAssembly.Webcil.csproj
+++ b/src/tasks/Microsoft.NET.WebAssembly.Webcil/Microsoft.NET.WebAssembly.Webcil.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <!-- we need to keep the version of System.Reflection.Metadata in sync with dotnet/msbuild and dotnet/sdk -->
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" /> 
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
   </ItemGroup>

--- a/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilConverter.cs
+++ b/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilConverter.cs
@@ -175,7 +175,7 @@ public class WebcilConverter
                                 SectionStart: firstWCSection);
     }
 
-    private static void WriteHeader(Stream s, WebcilHeader header)
+    private static void WriteHeader(Stream s, WebcilHeader webcilHeader)
     {
         if (!BitConverter.IsLittleEndian)
         {
@@ -187,7 +187,7 @@ public class WebcilConverter
             webcilHeader.pe_debug_rva = BinaryPrimitives.ReverseEndianness(webcilHeader.pe_debug_rva);
             webcilHeader.pe_debug_size = BinaryPrimitives.ReverseEndianness(webcilHeader.pe_debug_size);
         }
-        WriteStructure(s, header);
+        WriteStructure(s, webcilHeader);
     }
 
     private static void WriteSectionHeaders(Stream s, ImmutableArray<WebcilSectionHeader> sectionsHeaders)

--- a/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilConverter.cs
+++ b/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilConverter.cs
@@ -177,6 +177,16 @@ public class WebcilConverter
 
     private static void WriteHeader(Stream s, WebcilHeader header)
     {
+        if (!BitConverter.IsLittleEndian)
+        {
+            webcilHeader.version_major = BinaryPrimitives.ReverseEndianness(webcilHeader.version_major);
+            webcilHeader.version_minor = BinaryPrimitives.ReverseEndianness(webcilHeader.version_minor);
+            webcilHeader.coff_sections = BinaryPrimitives.ReverseEndianness(webcilHeader.coff_sections);
+            webcilHeader.pe_cli_header_rva = BinaryPrimitives.ReverseEndianness(webcilHeader.pe_cli_header_rva);
+            webcilHeader.pe_cli_header_size = BinaryPrimitives.ReverseEndianness(webcilHeader.pe_cli_header_size);
+            webcilHeader.pe_debug_rva = BinaryPrimitives.ReverseEndianness(webcilHeader.pe_debug_rva);
+            webcilHeader.pe_debug_size = BinaryPrimitives.ReverseEndianness(webcilHeader.pe_debug_size);
+        }
         WriteStructure(s, header);
     }
 
@@ -201,21 +211,6 @@ public class WebcilConverter
             );
         }
         WriteStructure(s, sectionHeader);
-    }
-
-    private static void WriteStructure(Stream s, WebcilHeader webcilHeader)
-    {
-        if (!BitConverter.IsLittleEndian)
-        {
-            webcilHeader.version_major = BinaryPrimitives.ReverseEndianness(webcilHeader.version_major);
-            webcilHeader.version_minor = BinaryPrimitives.ReverseEndianness(webcilHeader.version_minor);
-            webcilHeader.coff_sections = BinaryPrimitives.ReverseEndianness(webcilHeader.coff_sections);
-            webcilHeader.pe_cli_header_rva = BinaryPrimitives.ReverseEndianness(webcilHeader.pe_cli_header_rva);
-            webcilHeader.pe_cli_header_size = BinaryPrimitives.ReverseEndianness(webcilHeader.pe_cli_header_size);
-            webcilHeader.pe_debug_rva = BinaryPrimitives.ReverseEndianness(webcilHeader.pe_debug_rva);
-            webcilHeader.pe_debug_size = BinaryPrimitives.ReverseEndianness(webcilHeader.pe_debug_size);
-        }
-        WriteStructure(s, webcilHeader);
     }
 
 #if NETCOREAPP2_1_OR_GREATER


### PR DESCRIPTION
'dotnet new blazorwasm' command failed on s390x and was throwing a not implemented exception

The issue was with with the WebCil writer and reader, specific endianness conversions relating to the webcil payload were not implemented for big endian machines.

We considered fixing the generic implementation, but there were only two structures in use: WebcilHeader and WebcilSectionHeader, so it was easier to handle them explicitly.

fixes #91893 
cc: @omajid @iii-i @uweigand 