### PR TITLE
Update Newtonsoft.Json from 13.0.1 to 13.0.3

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -16,7 +16,12 @@
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Crossgen2.linux-x64/*8.*" />
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Runtime.linux-x64/*8.*" />
     <UsagePattern IdentityGlob="*Microsoft.DotNet.ILCompiler/*8.*" />
-    
+
+    <!-- This version is brought in transitively from NuGet.Packaging.6.2.4.
+         Once a newer version of NuGet.Packaging is referenced which has a
+         dependency on 13.0.3, this can be removed. -->
+    <UsagePattern IdentityGlob="Newtonsoft.Json/13.0.1" />
+
     <!-- Will be removed once https://github.com/NuGet/Home/issues/11059 is resolved -->
     <UsagePattern IdentityGlob="Nuget.*/*" />
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -100,9 +100,9 @@
       <Sha>3dd2c0ef203db8fe0e849557960b4cd009afbaac</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23214.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23468.1">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>de4dda48d0cf31e13182bc24107b2246c61ed483</Sha>
+      <Sha>e9d6489787a5ea5400a31dfa34aa6ad6b590de9b</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -191,7 +191,7 @@
     <NUnitVersion>3.12.0</NUnitVersion>
     <NUnitTestAdapterVersion>4.1.0</NUnitTestAdapterVersion>
     <CoverletCollectorVersion>6.0.0</CoverletCollectorVersion>
-    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
+    <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <NewtonsoftJsonBsonVersion>1.0.2</NewtonsoftJsonBsonVersion>
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <MoqVersion>4.18.4</MoqVersion>


### PR DESCRIPTION
.NET repos currently have a mix of Newtonsoft.Json versions that we're trying to get consolidated into the latest version. This is particularly necessary for the .NET's [source-build](https://github.com/dotnet/source-build) which can only reference one version of a dependency.

This was missed as part of the initial set of work to update all repos to 13.0.3.

Related to https://github.com/dotnet/source-build-externals/pull/195 and https://github.com/dotnet/source-build/issues/3629