### PR TITLE
Don't generate AddMask as it requires more explicit consideration of semantics

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10796,8 +10796,6 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
             return node;
         }
 #if defined(TARGET_XARCH)
-        case NI_AVX512F_Add:
-        case NI_AVX512BW_Add:
         case NI_AVX512F_And:
         case NI_AVX512DQ_And:
         case NI_AVX512F_AndNot:
@@ -10839,13 +10837,6 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
 
             switch (intrinsicId)
             {
-                case NI_AVX512F_Add:
-                case NI_AVX512BW_Add:
-                {
-                    maskIntrinsicId = NI_AVX512F_AddMask;
-                    break;
-                }
-
                 case NI_AVX512F_And:
                 case NI_AVX512DQ_And:
                 {


### PR DESCRIPTION
This resolves #92261 and should be backported to release/8.0

The general issue is that `ConvertToMask(ConvertToVector(Mask) + ConvertToVector(Mask))` and `Mask + Mask` differ in their semantics, particularly for floating-point. Where-as they do not differ in semantics for bitwise operations.

As such, addition requires additional handling and shouldn't have been included in the initial handling set here.

