### PR TITLE
Fix Excessive Encoding in Test Logs

### DIFF
--- a/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.IO;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text;
+using System.Xml;
+
 namespace XUnitWrapperLibrary;
 
 public class TestSummary
@@ -42,8 +45,13 @@ public class TestSummary
             testResultSb.Append($@"<test name=""{Name}"" type=""{ContainingTypeName}"""
                               + $@" method=""{MethodName}"" time=""{Duration.TotalSeconds:F6}""");
 
+            // It is possible for tests to have illegal XML characters in their output.
+            // So, we have to sanitize said output before writing it down to the XML log
+            // because otherwise, the python XML parser crashes. The way we clean it
+            // is by replacing said characters with their hexadecimal notation.
+
             string outputElement = !string.IsNullOrWhiteSpace(Output)
-                                 ? $"<output><![CDATA[{Output}]]></output>"
+                                 ? $"<output><![CDATA[{SanitizeOutput(Output)}]]></output>"
                                  : string.Empty;
 
             if (Exception is not null)
@@ -93,6 +101,60 @@ public class TestSummary
             }
 
             return testResultSb.ToString();
+        }
+
+        private string SanitizeOutput(string output)
+        {
+            Dictionary<char, string>? invalidChars = FindInvalidXMLChars(output);
+
+            // All green, we can print the test's output as is.
+            if (invalidChars is null)
+                return output;
+
+            StringBuilder sanitizedOutput = new StringBuilder();
+            foreach (char ch in output)
+            {
+                string? invalidCharHexCode = string.Empty;
+
+                // If this character is in the lookup dictionary, then print its
+                // hex string instead.
+                if (invalidChars.TryGetValue(ch, out invalidCharHexCode))
+                {
+                    sanitizedOutput.AppendFormat("_0x{0}_", invalidCharHexCode);
+                }
+                else
+                {
+                    sanitizedOutput.Append(ch);
+                }
+            }
+
+            return sanitizedOutput.ToString();
+        }
+
+        private Dictionary<char, string>? FindInvalidXMLChars(string xmlStr)
+        {
+            // First, we need to know whether the output string has any illegal chars
+            // for XML, and which ones if so.
+
+            IEnumerable<char> invalidCharsFound = xmlStr.ToCharArray()
+                                                        .Where(ch => !XmlConvert.IsXmlChar(ch));
+
+            // All green, we can return.
+            if (invalidCharsFound.Count() == 0)
+                return null;
+
+            // Now that we know which illegal chars appeared, we pair them up with
+            // their respective hexadecimal notations, which will later be printed
+            // onto the test's log.
+
+            Dictionary<char, string> invalidCharsHexCodes = new Dictionary<char, string>();
+            foreach (char ch in invalidCharsFound)
+            {
+                int charCode = Convert.ToInt32(ch);
+                invalidCharsHexCodes.TryAdd(ch, charCode.ToString("X"));
+            }
+
+            return invalidCharsHexCodes;
         }
     }
 

--- a/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Text;
-using System.Xml;
 namespace XUnitWrapperLibrary;
 
 public class TestSummary
@@ -44,7 +43,7 @@ public class TestSummary
                               + $@" method=""{MethodName}"" time=""{Duration.TotalSeconds:F6}""");
 
             string outputElement = !string.IsNullOrWhiteSpace(Output)
-                                 ? $"<output><![CDATA[{XmlConvert.EncodeName(Output)}]]></output>"
+                                 ? $"<output><![CDATA[{Output}]]></output>"
                                  : string.Empty;
 
             if (Exception is not null)
@@ -97,10 +96,10 @@ public class TestSummary
         }
     }
 
-    public int PassedTests { get; private set; }
-    public int FailedTests { get; private set; }
-    public int SkippedTests { get; private set; }
-    public int TotalTests { get; private set; }
+    public int PassedTests { get; private set; } = 0;
+    public int FailedTests { get; private set; } = 0;
+    public int SkippedTests { get; private set; } = 0;
+    public int TotalTests { get; private set; } = 0;
 
     private readonly List<TestResult> _testResults = new();
     private DateTime _testRunStart = DateTime.Now;

--- a/src/tests/JIT/Regression/VS-ia64-JIT/M00/b119026/bug.cs
+++ b/src/tests/JIT/Regression/VS-ia64-JIT/M00/b119026/bug.cs
@@ -2,31 +2,50 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 
+using System;
 using Xunit;
+
 public class test
 {
     static short si16;
     static uint su32;
+
     [Fact]
-    public static void TestEntryPoint()
+    public static int TestEntryPoint()
     {
-        si16 = -1;
-        su32 = (uint)si16;
-        System.Console.WriteLine(su32);
-        if (su32 == uint.MaxValue)
-            System.Console.WriteLine("Pass");
-        else
-            System.Console.WriteLine("Fail");
+        int exitCode = -1;
         short i16 = -1;
-        uint u32 = (uint)i16;
-        System.Console.WriteLine(u32);
+        uint u32 = (uint) i16;
+
+        Console.WriteLine(u32);
+
         if (u32 == uint.MaxValue)
         {
             System.Console.WriteLine("Pass");
+            exitCode = 100;
         }
         else
         {
             System.Console.WriteLine("Fail");
+            exitCode = 101;
         }
+
+        si16 = -1;
+        su32 = (uint) si16;
+
+        Console.WriteLine(su32);
+
+        if (su32 == uint.MaxValue)
+        {
+            System.Console.WriteLine("Pass");
+        }
+        else
+        {
+            System.Console.WriteLine("Fail");
+            if (exitCode == 100)
+                exitCode = 101;
+        }
+
+        return exitCode;
     }
 }

--- a/src/tests/JIT/Regression/VS-ia64-JIT/M00/b119026/charbug.cs
+++ b/src/tests/JIT/Regression/VS-ia64-JIT/M00/b119026/charbug.cs
@@ -2,33 +2,50 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 
+using System;
 using Xunit;
+
 public class test
 {
     static sbyte si8;
     static char sc;
+
     [Fact]
     public static int TestEntryPoint()
     {
+        int exitCode = -1;
         sbyte i8 = -1;
-        char c = (char)i8;
-        System.Console.WriteLine("{0}: {1}", c, ((ushort)c));
+        char c = (char) i8;
+
+        Console.WriteLine("{0:X}: {1}", Convert.ToUInt32(c), ((ushort)c));
+
         if (c == char.MaxValue)
-            System.Console.WriteLine("Pass");
+        {
+            Console.WriteLine("Pass");
+            exitCode = 100;
+        }
         else
-            System.Console.WriteLine("Fail");
+        {
+            Console.WriteLine("Fail");
+            exitCode = 101;
+        }
+
         si8 = -1;
         sc = (char)si8;
-        System.Console.WriteLine("{0}: {1}", sc, ((ushort)sc));
+
+        Console.WriteLine("{0:X}: {1}", Convert.ToUInt32(sc), ((ushort)sc));
+
         if (sc == char.MaxValue)
         {
             System.Console.WriteLine("Pass");
-            return 100;
         }
         else
         {
             System.Console.WriteLine("Fail");
-            return 1;
+            if (exitCode == 100)
+                exitCode = 101;
         }
+
+        return exitCode;
     }
 }


### PR DESCRIPTION
Fixes #92092. At some point during the refactoring of the test logs generation systems, we added some encoding to the tests' recorded outputs. However, this encoding replaced every non-alphanumeric character with a hex code, including the most common ones like brackets, parentheses, and spaces. This, in turn, rendered the logs visually unappealing and very difficult to read, which complicated all test investigations. This PR fixes that and makes the logs easily readable again.