### PR TITLE
Prevent restoring illink for native-binplace.proj

### DIFF
--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -6,6 +6,10 @@
          we only enable it in specific projects. so to avoid duplicating this property in coreclr, we can first scope it to src/libraries.
          This property needs to be declared before the ..\..\Directory.Build.props import. -->
     <SkipArcadeNoWarnCS1591>true</SkipArcadeNoWarnCS1591>
+
+    <!-- Prevent native-binplace.proj from being treated as a source project, to avoid importing illink targets
+         and thereby avoid hitting a static graph restore bug: https://github.com/dotnet/runtime/issues/92194 -->
+    <IsSourceProject Condition="'$(MSBuildProjectFile)' == 'native-binplace.proj'">false</IsSourceProject>
   </PropertyGroup>
 
   <Import Project="..\..\Directory.Build.props" />

--- a/src/libraries/native-binplace.proj
+++ b/src/libraries/native-binplace.proj
@@ -6,7 +6,6 @@
     <BinPlaceRuntime>false</BinPlaceRuntime>
     <BinPlaceNative>true</BinPlaceNative>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <IsSourceProject>false</IsSourceProject>
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/src/libraries/native-binplace.proj
+++ b/src/libraries/native-binplace.proj
@@ -6,6 +6,7 @@
     <BinPlaceRuntime>false</BinPlaceRuntime>
     <BinPlaceNative>true</BinPlaceNative>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <IsSourceProject>false</IsSourceProject>
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />


### PR DESCRIPTION
FIxes https://github.com/dotnet/runtime/issues/92194. The reference to illink from `native-binplace.proj`, built as a reference of `build-native.proj`, was hitting a nuget bug with static graph restore. The bug seems to be specific to something about the project file (maybe the language-specific targets, since `native-binplace.proj` imports the `Microsoft.NET.Sdk`, but doesn't have a `csproj` extension).

Fixed by explicitly marking this as not a source project, which will prevent the import of illink.targets. See the related discussion in https://github.com/dotnet/runtime/pull/91233#discussion_r1309072044.