### PR TITLE
Refactor out TargetFramework concept from Microsoft.Interop.SourceGeneration

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportCodeGenerator.cs
@@ -20,8 +20,6 @@ namespace Microsoft.Interop.JavaScript
         private readonly JSSignatureContext _signatureContext;
 
         public JSExportCodeGenerator(
-            TargetFramework targetFramework,
-            Version targetFrameworkVersion,
             ImmutableArray<TypePositionInfo> argTypes,
             JSExportData attributeData,
             JSSignatureContext signatureContext,
@@ -29,7 +27,10 @@ namespace Microsoft.Interop.JavaScript
             IMarshallingGeneratorFactory generatorFactory)
         {
             _signatureContext = signatureContext;
-            NativeToManagedStubCodeContext innerContext = new NativeToManagedStubCodeContext(targetFramework, targetFrameworkVersion, ReturnIdentifier, ReturnIdentifier);
+            NativeToManagedStubCodeContext innerContext = new NativeToManagedStubCodeContext(ReturnIdentifier, ReturnIdentifier)
+            {
+                CodeEmitOptions = new(SkipInit: true)
+            };
             _context = new JSExportCodeContext(attributeData, innerContext);
 
             _marshallers = BoundGenerators.Create(argTypes, generatorFactory, _context, new EmptyJSGenerator(), out var bindingFailures);
@@ -39,7 +40,10 @@ namespace Microsoft.Interop.JavaScript
             if (_marshallers.ManagedReturnMarshaller.Generator.UsesNativeIdentifier(_marshallers.ManagedReturnMarshaller.TypeInfo, null))
             {
                 // If we need a different native return identifier, then recreate the context with the correct identifier before we generate any code.
-                innerContext = new NativeToManagedStubCodeContext(targetFramework, targetFrameworkVersion, ReturnIdentifier, ReturnNativeIdentifier);
+                innerContext = new NativeToManagedStubCodeContext(ReturnIdentifier, ReturnNativeIdentifier)
+                {
+                    CodeEmitOptions = new(SkipInit: true)
+                };
                 _context = new JSExportCodeContext(attributeData, innerContext);
             }
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportGenerator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Interop.JavaScript
             ContainingSyntax StubMethodSyntaxTemplate,
             MethodSignatureDiagnosticLocations DiagnosticLocation,
             JSExportData JSExportData,
-            MarshallingGeneratorFactoryKey<(TargetFramework TargetFramework, Version TargetFrameworkVersion, JSGeneratorOptions)> GeneratorFactoryKey,
+            MarshallingGeneratorFactoryKey<JSGeneratorOptions> GeneratorFactoryKey,
             SequenceEqualImmutableArray<DiagnosticInfo> Diagnostics);
 
         public static class StepNames
@@ -214,14 +214,14 @@ namespace Microsoft.Interop.JavaScript
                 methodSyntaxTemplate,
                 locations,
                 jsExportData,
-                CreateGeneratorFactory(environment, options),
+                CreateGeneratorFactory(options),
                 new SequenceEqualImmutableArray<DiagnosticInfo>(generatorDiagnostics.Diagnostics.ToImmutableArray()));
         }
 
-        private static MarshallingGeneratorFactoryKey<(TargetFramework, Version, JSGeneratorOptions)> CreateGeneratorFactory(StubEnvironment env, JSGeneratorOptions options)
+        private static MarshallingGeneratorFactoryKey<JSGeneratorOptions> CreateGeneratorFactory(JSGeneratorOptions options)
         {
             JSGeneratorFactory jsGeneratorFactory = new JSGeneratorFactory();
-            return MarshallingGeneratorFactoryKey.Create((env.TargetFramework, env.TargetFrameworkVersion, options), jsGeneratorFactory);
+            return MarshallingGeneratorFactoryKey.Create(options, jsGeneratorFactory);
         }
 
         private static NamespaceDeclarationSyntax GenerateRegSource(
@@ -294,8 +294,6 @@ namespace Microsoft.Interop.JavaScript
 
             // Generate stub code
             var stubGenerator = new JSExportCodeGenerator(
-                incrementalContext.GeneratorFactoryKey.Key.TargetFramework,
-                incrementalContext.GeneratorFactoryKey.Key.TargetFrameworkVersion,
                 incrementalContext.SignatureContext.SignatureContext.ElementTypeInformation,
                 incrementalContext.JSExportData,
                 incrementalContext.SignatureContext,

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportCodeGenerator.cs
@@ -27,8 +27,6 @@ namespace Microsoft.Interop.JavaScript
         private readonly JSSignatureContext _signatureContext;
 
         public JSImportCodeGenerator(
-            TargetFramework targetFramework,
-            Version targetFrameworkVersion,
             ImmutableArray<TypePositionInfo> argTypes,
             JSImportData attributeData,
             JSSignatureContext signatureContext,
@@ -36,7 +34,10 @@ namespace Microsoft.Interop.JavaScript
             IMarshallingGeneratorFactory generatorFactory)
         {
             _signatureContext = signatureContext;
-            ManagedToNativeStubCodeContext innerContext = new ManagedToNativeStubCodeContext(targetFramework, targetFrameworkVersion, ReturnIdentifier, ReturnIdentifier);
+            ManagedToNativeStubCodeContext innerContext = new ManagedToNativeStubCodeContext(ReturnIdentifier, ReturnIdentifier)
+            {
+                CodeEmitOptions = new(SkipInit: true)
+            };
             _context = new JSImportCodeContext(attributeData, innerContext);
             _marshallers = BoundGenerators.Create(argTypes, generatorFactory, _context, new EmptyJSGenerator(), out var bindingFailures);
 
@@ -45,7 +46,10 @@ namespace Microsoft.Interop.JavaScript
             if (_marshallers.ManagedReturnMarshaller.Generator.UsesNativeIdentifier(_marshallers.ManagedReturnMarshaller.TypeInfo, null))
             {
                 // If we need a different native return identifier, then recreate the context with the correct identifier before we generate any code.
-                innerContext = new ManagedToNativeStubCodeContext(targetFramework, targetFrameworkVersion, ReturnIdentifier, ReturnNativeIdentifier);
+                innerContext = new ManagedToNativeStubCodeContext(ReturnIdentifier, ReturnNativeIdentifier)
+                {
+                    CodeEmitOptions = new(SkipInit: true)
+                };
                 _context = new JSImportCodeContext(attributeData, innerContext);
             }
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Interop.JavaScript
             ContainingSyntax StubMethodSyntaxTemplate,
             MethodSignatureDiagnosticLocations DiagnosticLocation,
             JSImportData JSImportData,
-            MarshallingGeneratorFactoryKey<(TargetFramework TargetFramework, Version TargetFrameworkVersion, JSGeneratorOptions)> GeneratorFactoryKey,
+            MarshallingGeneratorFactoryKey<JSGeneratorOptions> GeneratorFactoryKey,
             SequenceEqualImmutableArray<DiagnosticInfo> Diagnostics);
 
         public static class StepNames
@@ -201,15 +201,15 @@ namespace Microsoft.Interop.JavaScript
                 methodSyntaxTemplate,
                 locations,
                 jsImportData,
-                CreateGeneratorFactory(environment, options),
+                CreateGeneratorFactory(options),
                 new SequenceEqualImmutableArray<DiagnosticInfo>(generatorDiagnostics.Diagnostics.ToImmutableArray()));
         }
 
-        private static MarshallingGeneratorFactoryKey<(TargetFramework, Version, JSGeneratorOptions)> CreateGeneratorFactory(StubEnvironment env, JSGeneratorOptions options)
+        private static MarshallingGeneratorFactoryKey<JSGeneratorOptions> CreateGeneratorFactory(JSGeneratorOptions options)
         {
             JSGeneratorFactory jsGeneratorFactory = new JSGeneratorFactory();
 
-            return MarshallingGeneratorFactoryKey.Create((env.TargetFramework, env.TargetFrameworkVersion, options), jsGeneratorFactory);
+            return MarshallingGeneratorFactoryKey.Create(options, jsGeneratorFactory);
         }
 
         private static (MemberDeclarationSyntax, ImmutableArray<DiagnosticInfo>) GenerateSource(
@@ -219,8 +219,6 @@ namespace Microsoft.Interop.JavaScript
 
             // Generate stub code
             var stubGenerator = new JSImportCodeGenerator(
-                incrementalContext.GeneratorFactoryKey.Key.TargetFramework,
-                incrementalContext.GeneratorFactoryKey.Key.TargetFrameworkVersion,
                 incrementalContext.SignatureContext.SignatureContext.ElementTypeInformation,
                 incrementalContext.JSImportData,
                 incrementalContext.SignatureContext,

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSSignatureContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSSignatureContext.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Interop.JavaScript
                 useSiteAttributeParsers,
                 ImmutableArray.Create<IMarshallingInfoAttributeParser>(new JSMarshalAsAttributeParser(env.Compilation)),
                 ImmutableArray.Create<ITypeBasedMarshallingInfoProvider>(new FallbackJSMarshallingInfoProvider()));
-            SignatureContext sigContext = SignatureContext.Create(method, jsMarshallingAttributeParser, env, typeof(JSImportGenerator).Assembly);
+            SignatureContext sigContext = SignatureContext.Create(method, jsMarshallingAttributeParser, env, new CodeEmitOptions(SkipInit: true), typeof(JSImportGenerator).Assembly);
 
             string stubTypeFullName = method.ContainingType.ToDisplayString(TypeContainingTypesAndNamespacesStyle);
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSStubCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSStubCodeContext.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Interop.JavaScript
         {
             return _inner.GetIdentifiers(info);
         }
-
-        public override (TargetFramework framework, Version version) GetTargetFramework() => _inner.GetTargetFramework();
     }
 
     internal sealed record JSImportCodeContext : JSStubCodeContext
@@ -27,6 +25,7 @@ namespace Microsoft.Interop.JavaScript
             _inner = inner;
             Direction = MarshalDirection.ManagedToUnmanaged;
             AttributeData = attributeData;
+            CodeEmitOptions = inner.CodeEmitOptions;
         }
 
         public JSImportData AttributeData { get; set; }
@@ -39,6 +38,7 @@ namespace Microsoft.Interop.JavaScript
             _inner = inner;
             Direction = MarshalDirection.UnmanagedToManaged;
             AttributeData = attributeData;
+            CodeEmitOptions = inner.CodeEmitOptions;
         }
 
         public JSExportData AttributeData { get; set; }

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceAnalyzer.cs
@@ -41,11 +41,8 @@ namespace Microsoft.Interop.Analyzers
                     return;
                 }
 
-                TargetFrameworkSettings targetFramework = context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.GetTargetFrameworkSettings();
                 var env = new StubEnvironment(
                     context.Compilation,
-                    targetFramework.TargetFramework,
-                    targetFramework.Version,
                     context.Compilation.GetEnvironmentFlags());
 
                 context.RegisterSymbolAction(context =>
@@ -81,6 +78,7 @@ namespace Microsoft.Interop.Analyzers
                             method,
                             CreateComImportMarshallingInfoParser(env, diagnostics, method, comImportAttribute),
                             env,
+                            new CodeEmitOptions(SkipInit: true),
                             typeof(ConvertComImportToGeneratedComInterfaceAnalyzer).Assembly);
 
                         var managedToUnmanagedFactory = ComInterfaceGeneratorHelpers.CreateGeneratorFactory(env, MarshalDirection.ManagedToUnmanaged);

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceAnalyzer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Interop.Analyzers
                     context.Compilation,
                     targetFramework.TargetFramework,
                     targetFramework.Version,
-                    context.Compilation.SourceModule.GetAttributes().Any(attr => attr.AttributeClass.ToDisplayString() == TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute));
+                    context.Compilation.GetEnvironmentFlags());
 
                 context.RegisterSymbolAction(context =>
                 {
@@ -89,8 +89,8 @@ namespace Microsoft.Interop.Analyzers
                         mayRequireAdditionalWork = diagnostics.Diagnostics.Any();
                         bool anyExplicitlyUnsupportedInfo = false;
 
-                        var managedToNativeStubCodeContext = new ManagedToNativeStubCodeContext(env.TargetFramework, env.TargetFrameworkVersion, "return", "nativeReturn");
-                        var nativeToManagedStubCodeContext = new NativeToManagedStubCodeContext(env.TargetFramework, env.TargetFrameworkVersion, "return", "nativeReturn");
+                        var managedToNativeStubCodeContext = new ManagedToNativeStubCodeContext("return", "nativeReturn");
+                        var nativeToManagedStubCodeContext = new NativeToManagedStubCodeContext("return", "nativeReturn");
 
                         var forwarder = new Forwarder();
                         // We don't actually need the bound generators. We just need them to be attempted to be bound to determine if the generator will be able to bind them.

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -267,6 +267,7 @@ namespace Microsoft.Interop
                     generatedComInterfaceAttributeData,
                     generatedComAttribute),
                 environment,
+                new CodeEmitOptions(SkipInit: true),
                 typeof(VtableIndexStubGenerator).Assembly);
 
             if (!symbol.MethodImplementationFlags.HasFlag(MethodImplAttributes.PreserveSig))

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGeneratorHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGeneratorHelpers.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Interop
 {
     internal static class ComInterfaceGeneratorHelpers
     {
-        public static MarshallingGeneratorFactoryKey<(TargetFramework, Version)> CreateGeneratorFactory(StubEnvironment env, MarshalDirection direction)
+        public static MarshallingGeneratorFactoryKey<FactoryKey> CreateGeneratorFactory(StubEnvironment env, MarshalDirection direction)
         {
             IMarshallingGeneratorFactory generatorFactory;
 
@@ -18,16 +18,9 @@ namespace Microsoft.Interop
 
             generatorFactory = new NoMarshallingInfoErrorMarshallingFactory(generatorFactory, TypeNames.GeneratedComInterfaceAttribute_ShortName);
 
-            // The presence of System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute is tied to TFM,
-            // so we use TFM in the generator factory key instead of the Compilation as the compilation changes on every keystroke.
-            IAssemblySymbol coreLibraryAssembly = env.Compilation.GetSpecialType(SpecialType.System_Object).ContainingAssembly;
-            ITypeSymbol? disabledRuntimeMarshallingAttributeType = coreLibraryAssembly.GetTypeByMetadataName(TypeNames.System_Runtime_CompilerServices_DisableRuntimeMarshallingAttribute);
-            bool runtimeMarshallingDisabled = disabledRuntimeMarshallingAttributeType is not null
-                && env.Compilation.Assembly.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, disabledRuntimeMarshallingAttributeType));
-
             // Since the char type can go into the P/Invoke signature here, we can only use it when
             // runtime marshalling is disabled.
-            generatorFactory = new CharMarshallingGeneratorFactory(generatorFactory, useBlittableMarshallerForUtf16: runtimeMarshallingDisabled, TypeNames.GeneratedComInterfaceAttribute_ShortName);
+            generatorFactory = new CharMarshallingGeneratorFactory(generatorFactory, useBlittableMarshallerForUtf16: env.EnvironmentFlags.HasFlag(EnvironmentFlags.DisableRuntimeMarshalling), TypeNames.GeneratedComInterfaceAttribute_ShortName);
 
             InteropGenerationOptions interopGenerationOptions = new(UseMarshalType: true);
             generatorFactory = new MarshalAsMarshallingGeneratorFactory(interopGenerationOptions, generatorFactory);
@@ -38,14 +31,14 @@ namespace Microsoft.Interop
                 // Since the char type in an array will not be part of the P/Invoke signature, we can
                 // use the regular blittable marshaller in all cases.
                 new CharMarshallingGeneratorFactory(generatorFactory, useBlittableMarshallerForUtf16: true, TypeNames.GeneratedComInterfaceAttribute_ShortName),
-                new AttributedMarshallingModelOptions(runtimeMarshallingDisabled, MarshalMode.ElementIn, MarshalMode.ElementRef, MarshalMode.ElementOut));
+                new AttributedMarshallingModelOptions(env.EnvironmentFlags.HasFlag(EnvironmentFlags.DisableRuntimeMarshalling), MarshalMode.ElementIn, MarshalMode.ElementRef, MarshalMode.ElementOut));
             // We don't need to include the later generator factories for collection elements
             // as the later generator factories only apply to parameters.
             generatorFactory = new AttributedMarshallingModelGeneratorFactory(
                 generatorFactory,
                 elementFactory,
                 new AttributedMarshallingModelOptions(
-                    runtimeMarshallingDisabled,
+                    env.EnvironmentFlags.HasFlag(EnvironmentFlags.DisableRuntimeMarshalling),
                     direction == MarshalDirection.ManagedToUnmanaged
                         ? MarshalMode.ManagedToUnmanagedIn
                         : MarshalMode.UnmanagedToManagedOut,
@@ -62,7 +55,7 @@ namespace Microsoft.Interop
 
             generatorFactory = new ByValueContentsMarshalKindValidator(generatorFactory);
 
-            return MarshallingGeneratorFactoryKey.Create((env.TargetFramework, env.TargetFrameworkVersion), generatorFactory);
+            return MarshallingGeneratorFactoryKey.Create(new FactoryKey(env.EnvironmentFlags.HasFlag(EnvironmentFlags.DisableRuntimeMarshalling)), generatorFactory);
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/IncrementalMethodStubGenerationContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/IncrementalMethodStubGenerationContext.cs
@@ -7,6 +7,8 @@ using System;
 
 namespace Microsoft.Interop
 {
+    internal record struct FactoryKey(bool RuntimeMarshallingDisabled);
+
     internal abstract record GeneratedMethodContextBase(ManagedTypeInfo OriginalDefiningType, SequenceEqualImmutableArray<DiagnosticInfo> Diagnostics);
 
     internal sealed record IncrementalMethodStubGenerationContext(
@@ -17,8 +19,8 @@ namespace Microsoft.Interop
         SequenceEqualImmutableArray<FunctionPointerUnmanagedCallingConventionSyntax> CallingConvention,
         VirtualMethodIndexData VtableIndexData,
         MarshallingInfo ExceptionMarshallingInfo,
-        MarshallingGeneratorFactoryKey<(TargetFramework TargetFramework, Version TargetFrameworkVersion)> ManagedToUnmanagedGeneratorFactory,
-        MarshallingGeneratorFactoryKey<(TargetFramework TargetFramework, Version TargetFrameworkVersion)> UnmanagedToManagedGeneratorFactory,
+        MarshallingGeneratorFactoryKey<FactoryKey> ManagedToUnmanagedGeneratorFactory,
+        MarshallingGeneratorFactoryKey<FactoryKey> UnmanagedToManagedGeneratorFactory,
         ManagedTypeInfo TypeKeyOwner,
         ManagedTypeInfo DeclaringType,
         SequenceEqualImmutableArray<DiagnosticInfo> Diagnostics,

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ManagedStubCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ManagedStubCodeContext.cs
@@ -13,7 +13,5 @@ namespace Microsoft.Interop
         public override bool SingleFrameSpansNativeContext => throw new NotImplementedException();
 
         public override bool AdditionalTemporaryStateLivesAcrossStages => throw new NotImplementedException();
-
-        public override (TargetFramework framework, Version version) GetTargetFramework() => throw new NotImplementedException();
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ManagedToNativeVTableMethodGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ManagedToNativeVTableMethodGenerator.cs
@@ -43,8 +43,6 @@ namespace Microsoft.Interop
         private readonly ManagedToNativeStubCodeContext _context;
 
         public ManagedToNativeVTableMethodGenerator(
-            TargetFramework targetFramework,
-            Version targetFrameworkVersion,
             ImmutableArray<TypePositionInfo> argTypes,
             bool setLastError,
             bool implicitThis,
@@ -74,7 +72,7 @@ namespace Microsoft.Interop
                 argTypes = newArgTypes.ToImmutableArray();
             }
 
-            _context = new ManagedToNativeStubCodeContext(targetFramework, targetFrameworkVersion, ReturnIdentifier, ReturnIdentifier);
+            _context = new ManagedToNativeStubCodeContext(ReturnIdentifier, ReturnIdentifier);
             _marshallers = BoundGenerators.Create(argTypes, generatorFactory, _context, new Forwarder(), out var bindingFailures);
 
             diagnosticsBag.ReportGeneratorDiagnostics(bindingFailures);
@@ -82,7 +80,7 @@ namespace Microsoft.Interop
             if (_marshallers.ManagedReturnMarshaller.Generator.UsesNativeIdentifier(_marshallers.ManagedReturnMarshaller.TypeInfo, _context))
             {
                 // If we need a different native return identifier, then recreate the context with the correct identifier before we generate any code.
-                _context = new ManagedToNativeStubCodeContext(targetFramework, targetFrameworkVersion, ReturnIdentifier, $"{ReturnIdentifier}{StubCodeContext.GeneratedNativeIdentifierSuffix}");
+                _context = new ManagedToNativeStubCodeContext(ReturnIdentifier, $"{ReturnIdentifier}{StubCodeContext.GeneratedNativeIdentifierSuffix}");
             }
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/UnmanagedToManagedStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/UnmanagedToManagedStubGenerator.cs
@@ -20,13 +20,11 @@ namespace Microsoft.Interop
         private readonly NativeToManagedStubCodeContext _context;
 
         public UnmanagedToManagedStubGenerator(
-            TargetFramework targetFramework,
-            Version targetFrameworkVersion,
             ImmutableArray<TypePositionInfo> argTypes,
             GeneratorDiagnosticsBag diagnosticsBag,
             IMarshallingGeneratorFactory generatorFactory)
         {
-            _context = new NativeToManagedStubCodeContext(targetFramework, targetFrameworkVersion, ReturnIdentifier, ReturnIdentifier);
+            _context = new NativeToManagedStubCodeContext(ReturnIdentifier, ReturnIdentifier);
             _marshallers = BoundGenerators.Create(argTypes, generatorFactory, _context, new Forwarder(), out var bindingDiagnostics);
 
             diagnosticsBag.ReportGeneratorDiagnostics(bindingDiagnostics);
@@ -34,7 +32,7 @@ namespace Microsoft.Interop
             if (_marshallers.NativeReturnMarshaller.Generator.UsesNativeIdentifier(_marshallers.NativeReturnMarshaller.TypeInfo, _context))
             {
                 // If we need a different native return identifier, then recreate the context with the correct identifier before we generate any code.
-                _context = new NativeToManagedStubCodeContext(targetFramework, targetFrameworkVersion, ReturnIdentifier, $"{ReturnIdentifier}{StubCodeContext.GeneratedNativeIdentifierSuffix}");
+                _context = new NativeToManagedStubCodeContext(ReturnIdentifier, $"{ReturnIdentifier}{StubCodeContext.GeneratedNativeIdentifierSuffix}");
             }
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Interop
 
             // Generate stub code
             var stubGenerator = new ManagedToNativeVTableMethodGenerator(
-                methodStub.ManagedToUnmanagedGeneratorFactory.Key.TargetFramework,
-                methodStub.ManagedToUnmanagedGeneratorFactory.Key.TargetFrameworkVersion,
                 methodStub.SignatureContext.ElementTypeInformation,
                 methodStub.VtableIndexData.SetLastError,
                 methodStub.VtableIndexData.ImplicitThisParameter,
@@ -71,8 +69,6 @@ namespace Microsoft.Interop
 
             // Generate stub code
             var stubGenerator = new UnmanagedToManagedStubGenerator(
-                methodStub.UnmanagedToManagedGeneratorFactory.Key.TargetFramework,
-                methodStub.UnmanagedToManagedGeneratorFactory.Key.TargetFrameworkVersion,
                 elements,
                 diagnostics,
                 methodStub.UnmanagedToManagedGeneratorFactory.GeneratorFactory);
@@ -172,8 +168,6 @@ namespace Microsoft.Interop
             var diagnostics = new GeneratorDiagnosticsBag(new DiagnosticDescriptorProvider(), method.DiagnosticLocation, SR.ResourceManager, typeof(FxResources.Microsoft.Interop.ComInterfaceGenerator.SR));
 
             var stubGenerator = new UnmanagedToManagedStubGenerator(
-                method.UnmanagedToManagedGeneratorFactory.Key.TargetFramework,
-                method.UnmanagedToManagedGeneratorFactory.Key.TargetFrameworkVersion,
                 AddImplicitElementInfos(method),
                 diagnostics,
                 method.UnmanagedToManagedGeneratorFactory.GeneratorFactory);

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VtableIndexStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VtableIndexStubGenerator.cs
@@ -274,7 +274,12 @@ namespace Microsoft.Interop
             }
 
             // Create the stub.
-            var signatureContext = SignatureContext.Create(symbol, DefaultMarshallingInfoParser.Create(environment, generatorDiagnostics, symbol, virtualMethodIndexData, virtualMethodIndexAttr), environment, typeof(VtableIndexStubGenerator).Assembly);
+            var signatureContext = SignatureContext.Create(
+                symbol,
+                DefaultMarshallingInfoParser.Create(environment, generatorDiagnostics, symbol, virtualMethodIndexData, virtualMethodIndexAttr),
+                environment,
+                new CodeEmitOptions(SkipInit: true),
+                typeof(VtableIndexStubGenerator).Assembly);
 
             var containingSyntaxContext = new ContainingSyntaxContext(syntax);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VtableIndexStubGeneratorHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VtableIndexStubGeneratorHelpers.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Interop
 {
     internal static class VtableIndexStubGeneratorHelpers
     {
-        public static MarshallingGeneratorFactoryKey<(TargetFramework, Version)> CreateGeneratorFactory(StubEnvironment env, MarshalDirection direction)
+        public static MarshallingGeneratorFactoryKey<FactoryKey> CreateGeneratorFactory(StubEnvironment env, MarshalDirection direction)
         {
             IMarshallingGeneratorFactory generatorFactory;
 
@@ -18,16 +18,9 @@ namespace Microsoft.Interop
 
             generatorFactory = new NoMarshallingInfoErrorMarshallingFactory(generatorFactory, TypeNames.VirtualMethodIndexAttribute_ShortName);
 
-            // The presence of System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute is tied to TFM,
-            // so we use TFM in the generator factory key instead of the Compilation as the compilation changes on every keystroke.
-            IAssemblySymbol coreLibraryAssembly = env.Compilation.GetSpecialType(SpecialType.System_Object).ContainingAssembly;
-            ITypeSymbol? disabledRuntimeMarshallingAttributeType = coreLibraryAssembly.GetTypeByMetadataName(TypeNames.System_Runtime_CompilerServices_DisableRuntimeMarshallingAttribute);
-            bool runtimeMarshallingDisabled = disabledRuntimeMarshallingAttributeType is not null
-                && env.Compilation.Assembly.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, disabledRuntimeMarshallingAttributeType));
-
             // Since the char type can go into the P/Invoke signature here, we can only use it when
             // runtime marshalling is disabled.
-            generatorFactory = new CharMarshallingGeneratorFactory(generatorFactory, useBlittableMarshallerForUtf16: runtimeMarshallingDisabled, TypeNames.VirtualMethodIndexAttribute_ShortName);
+            generatorFactory = new CharMarshallingGeneratorFactory(generatorFactory, useBlittableMarshallerForUtf16: env.EnvironmentFlags.HasFlag(EnvironmentFlags.DisableRuntimeMarshalling), TypeNames.VirtualMethodIndexAttribute_ShortName);
 
             InteropGenerationOptions interopGenerationOptions = new(UseMarshalType: true);
             generatorFactory = new MarshalAsMarshallingGeneratorFactory(interopGenerationOptions, generatorFactory);
@@ -36,14 +29,14 @@ namespace Microsoft.Interop
                 // Since the char type in an array will not be part of the P/Invoke signature, we can
                 // use the regular blittable marshaller in all cases.
                 new CharMarshallingGeneratorFactory(generatorFactory, useBlittableMarshallerForUtf16: true, TypeNames.VirtualMethodIndexAttribute_ShortName),
-                new AttributedMarshallingModelOptions(runtimeMarshallingDisabled, MarshalMode.ElementIn, MarshalMode.ElementRef, MarshalMode.ElementOut));
+                new AttributedMarshallingModelOptions(env.EnvironmentFlags.HasFlag(EnvironmentFlags.DisableRuntimeMarshalling), MarshalMode.ElementIn, MarshalMode.ElementRef, MarshalMode.ElementOut));
             // We don't need to include the later generator factories for collection elements
             // as the later generator factories only apply to parameters.
             generatorFactory = new AttributedMarshallingModelGeneratorFactory(
                 generatorFactory,
                 elementFactory,
                 new AttributedMarshallingModelOptions(
-                    runtimeMarshallingDisabled,
+                    env.EnvironmentFlags.HasFlag(EnvironmentFlags.DisableRuntimeMarshalling),
                     direction == MarshalDirection.ManagedToUnmanaged
                         ? MarshalMode.ManagedToUnmanagedIn
                         : MarshalMode.UnmanagedToManagedOut,
@@ -58,7 +51,7 @@ namespace Microsoft.Interop
 
             generatorFactory = new ByValueContentsMarshalKindValidator(generatorFactory);
 
-            return MarshallingGeneratorFactoryKey.Create((env.TargetFramework, env.TargetFrameworkVersion), generatorFactory);
+            return MarshallingGeneratorFactoryKey.Create(new FactoryKey(env.EnvironmentFlags.HasFlag(EnvironmentFlags.DisableRuntimeMarshalling)), generatorFactory);
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Interop.Analyzers
                         context.Compilation,
                         targetFramework.TargetFramework,
                         targetFramework.Version,
-                        context.Compilation.SourceModule.GetAttributes().Any(attr => attr.AttributeClass.ToDisplayString() == TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute));
+                        context.Compilation.GetEnvironmentFlags());
 
                     context.RegisterSymbolAction(symbolContext => AnalyzeSymbol(symbolContext, libraryImportAttrType, env), SymbolKind.Method);
                 });
@@ -121,7 +121,7 @@ namespace Microsoft.Interop.Analyzers
             bool mayRequireAdditionalWork = diagnostics.Diagnostics.Any();
             bool anyExplicitlyUnsupportedInfo = false;
 
-            var stubCodeContext = new ManagedToNativeStubCodeContext(env.TargetFramework, env.TargetFrameworkVersion, "return", "nativeReturn");
+            var stubCodeContext = new ManagedToNativeStubCodeContext("return", "nativeReturn");
 
             var forwarder = new Forwarder();
             // We don't actually need the bound generators. We just need them to be attempted to be bound to determine if the generator will be able to bind them.

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
@@ -60,15 +60,13 @@ namespace Microsoft.Interop.Analyzers
 
                     StubEnvironment env = new StubEnvironment(
                         context.Compilation,
-                        targetFramework.TargetFramework,
-                        targetFramework.Version,
                         context.Compilation.GetEnvironmentFlags());
 
-                    context.RegisterSymbolAction(symbolContext => AnalyzeSymbol(symbolContext, libraryImportAttrType, env), SymbolKind.Method);
+                    context.RegisterSymbolAction(symbolContext => AnalyzeSymbol(symbolContext, libraryImportAttrType, env, targetFramework), SymbolKind.Method);
                 });
         }
 
-        private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol libraryImportAttrType, StubEnvironment env)
+        private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol libraryImportAttrType, StubEnvironment env, TargetFrameworkSettings tf)
         {
             var method = (IMethodSymbol)context.Symbol;
 
@@ -114,9 +112,14 @@ namespace Microsoft.Interop.Analyzers
             // later user work.
             GeneratorDiagnosticsBag diagnostics = new(new DiagnosticDescriptorProvider(), new MethodSignatureDiagnosticLocations((MethodDeclarationSyntax)method.DeclaringSyntaxReferences[0].GetSyntax()), SR.ResourceManager, typeof(FxResources.Microsoft.Interop.LibraryImportGenerator.SR));
             AttributeData dllImportAttribute = method.GetAttributes().First(attr => attr.AttributeClass.ToDisplayString() == TypeNames.DllImportAttribute);
-            SignatureContext targetSignatureContext = SignatureContext.Create(method, DefaultMarshallingInfoParser.Create(env, diagnostics, method, CreateInteropAttributeDataFromDllImport(dllImportData), dllImportAttribute), env, typeof(ConvertToLibraryImportAnalyzer).Assembly);
+            SignatureContext targetSignatureContext = SignatureContext.Create(
+                method,
+                DefaultMarshallingInfoParser.Create(env, diagnostics, method, CreateInteropAttributeDataFromDllImport(dllImportData), dllImportAttribute),
+                env,
+                new CodeEmitOptions(SkipInit: tf.TargetFramework == TargetFramework.Net),
+                typeof(ConvertToLibraryImportAnalyzer).Assembly);
 
-            var generatorFactoryKey = LibraryImportGeneratorHelpers.CreateGeneratorFactory(env, new LibraryImportGeneratorOptions(context.Options.AnalyzerConfigOptionsProvider.GlobalOptions));
+            var generatorFactoryKey = LibraryImportGeneratorHelpers.CreateGeneratorFactory(env, tf, new LibraryImportGeneratorOptions(context.Options.AnalyzerConfigOptionsProvider.GlobalOptions));
 
             bool mayRequireAdditionalWork = diagnostics.Diagnostics.Any();
             bool anyExplicitlyUnsupportedInfo = false;

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -329,12 +329,11 @@ namespace Microsoft.Interop
 
             // Generate stub code
             var stubGenerator = new PInvokeStubCodeGenerator(
-                pinvokeStub.GeneratorFactoryKey.Key.TargetFramework,
-                pinvokeStub.GeneratorFactoryKey.Key.Version,
                 pinvokeStub.SignatureContext.ElementTypeInformation,
                 pinvokeStub.LibraryImportData.SetLastError && !options.GenerateForwarders,
                 diagnostics,
-                pinvokeStub.GeneratorFactoryKey.GeneratorFactory);
+                pinvokeStub.GeneratorFactoryKey.GeneratorFactory,
+                new StubCodeContext.CodeOptions(UnsafeSkipInit: pinvokeStub.GeneratorFactoryKey.Key.TargetFramework == TargetFramework.Net));
 
             // Check if the generator should produce a forwarder stub - regular DllImport.
             // This is done if the signature is blittable or the target framework is not supported.

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Interop
             MethodSignatureDiagnosticLocations DiagnosticLocation,
             SequenceEqualImmutableArray<AttributeSyntax> ForwardedAttributes,
             LibraryImportData LibraryImportData,
-            MarshallingGeneratorFactoryKey<(TargetFramework TargetFramework, Version Version, LibraryImportGeneratorOptions Options)> GeneratorFactoryKey,
+            MarshallingGeneratorFactoryKey<(TargetFrameworkSettings TargetFramework, LibraryImportGeneratorOptions Options)> GeneratorFactoryKey,
             SequenceEqualImmutableArray<DiagnosticInfo> Diagnostics);
 
         public static class StepNames
@@ -64,14 +64,15 @@ namespace Microsoft.Interop
             IncrementalValueProvider<LibraryImportGeneratorOptions> stubOptions = context.AnalyzerConfigOptionsProvider
                 .Select(static (options, ct) => new LibraryImportGeneratorOptions(options.GlobalOptions));
 
+            IncrementalValueProvider<TargetFrameworkSettings> targetFramework = context.AnalyzerConfigOptionsProvider.Select((options, ct) => options.GlobalOptions.GetTargetFrameworkSettings());
             IncrementalValueProvider<StubEnvironment> stubEnvironment = context.CreateStubEnvironmentProvider();
 
             // Validate environment that is being used to generate stubs.
-            context.RegisterDiagnostics(stubEnvironment.Combine(attributedMethods.Collect()).SelectMany((data, ct) =>
+            context.RegisterDiagnostics(context.CompilationProvider.Combine(attributedMethods.Collect()).Combine(targetFramework).SelectMany((data, ct) =>
             {
-                if (data.Right.IsEmpty // no attributed methods
-                    || data.Left.Compilation.Options is CSharpCompilationOptions { AllowUnsafe: true } // Unsafe code enabled
-                    || data.Left.TargetFramework != TargetFramework.Net) // Non-.NET 5 scenarios use forwarders and don't need unsafe code
+                if (data.Left.Right.IsEmpty // no attributed methods
+                    || data.Left.Left.Options is CSharpCompilationOptions { AllowUnsafe: true } // Unsafe code enabled
+                    || data.Right.TargetFramework != TargetFramework.Net) // Downlevel scenarios use forwarders and don't need unsafe code
                 {
                     return ImmutableArray<DiagnosticInfo>.Empty;
                 }
@@ -82,15 +83,17 @@ namespace Microsoft.Interop
             IncrementalValuesProvider<(MemberDeclarationSyntax, ImmutableArray<DiagnosticInfo>)> generateSingleStub = methodsToGenerate
                 .Combine(stubEnvironment)
                 .Combine(stubOptions)
+                .Combine(targetFramework)
                 .Select(static (data, ct) => new
                 {
-                    data.Left.Left.Syntax,
-                    data.Left.Left.Symbol,
-                    Environment = data.Left.Right,
-                    Options = data.Right
+                    data.Left.Left.Left.Syntax,
+                    data.Left.Left.Left.Symbol,
+                    Environment = data.Left.Left.Right,
+                    Options = data.Left.Right,
+                    TargetFramework = data.Right
                 })
                 .Select(
-                    static (data, ct) => CalculateStubInformation(data.Syntax, data.Symbol, data.Environment, data.Options, ct)
+                    static (data, ct) => CalculateStubInformation(data.Syntax, data.Symbol, data.Environment, data.TargetFramework, data.Options, ct)
                 )
                 .WithTrackingName(StepNames.CalculateStubInformation)
                 .Combine(stubOptions)
@@ -211,6 +214,7 @@ namespace Microsoft.Interop
             MethodDeclarationSyntax originalSyntax,
             IMethodSymbol symbol,
             StubEnvironment environment,
+            TargetFrameworkSettings targetFramework,
             LibraryImportGeneratorOptions options,
             CancellationToken ct)
         {
@@ -284,7 +288,12 @@ namespace Microsoft.Interop
             }
 
             // Create the stub.
-            var signatureContext = SignatureContext.Create(symbol, DefaultMarshallingInfoParser.Create(environment, generatorDiagnostics, symbol, libraryImportData, generatedDllImportAttr), environment, typeof(LibraryImportGenerator).Assembly);
+            var signatureContext = SignatureContext.Create(
+                symbol,
+                DefaultMarshallingInfoParser.Create(environment, generatorDiagnostics, symbol, libraryImportData, generatedDllImportAttr),
+                environment,
+                new CodeEmitOptions(SkipInit: targetFramework.TargetFramework == TargetFramework.Net),
+                typeof(LibraryImportGenerator).Assembly);
 
             var containingTypeContext = new ContainingSyntaxContext(originalSyntax);
 
@@ -298,7 +307,7 @@ namespace Microsoft.Interop
                 locations,
                 new SequenceEqualImmutableArray<AttributeSyntax>(additionalAttributes.ToImmutableArray(), SyntaxEquivalentComparer.Instance),
                 LibraryImportData.From(libraryImportData),
-                LibraryImportGeneratorHelpers.CreateGeneratorFactory(environment, options),
+                LibraryImportGeneratorHelpers.CreateGeneratorFactory(environment, targetFramework, options),
                 new SequenceEqualImmutableArray<DiagnosticInfo>(generatorDiagnostics.Diagnostics.ToImmutableArray())
                 );
         }
@@ -315,8 +324,7 @@ namespace Microsoft.Interop
 
             bool supportsTargetFramework = !pinvokeStub.LibraryImportData.SetLastError
                 || options.GenerateForwarders
-                || (pinvokeStub.GeneratorFactoryKey.Key.TargetFramework == TargetFramework.Net
-                    && pinvokeStub.GeneratorFactoryKey.Key.Version.Major >= 6);
+                || (pinvokeStub.GeneratorFactoryKey.Key.TargetFramework is (TargetFramework.Net, { Major: >= 6 }));
 
             foreach (TypePositionInfo typeInfo in pinvokeStub.SignatureContext.ElementTypeInformation)
             {
@@ -333,7 +341,7 @@ namespace Microsoft.Interop
                 pinvokeStub.LibraryImportData.SetLastError && !options.GenerateForwarders,
                 diagnostics,
                 pinvokeStub.GeneratorFactoryKey.GeneratorFactory,
-                new StubCodeContext.CodeOptions(UnsafeSkipInit: pinvokeStub.GeneratorFactoryKey.Key.TargetFramework == TargetFramework.Net));
+                new CodeEmitOptions(SkipInit: pinvokeStub.GeneratorFactoryKey.Key.TargetFramework is (TargetFramework.Net, _)));
 
             // Check if the generator should produce a forwarder stub - regular DllImport.
             // This is done if the signature is blittable or the target framework is not supported.

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGeneratorHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGeneratorHelpers.cs
@@ -34,16 +34,9 @@ namespace Microsoft.Interop
 
                 generatorFactory = new NoMarshallingInfoErrorMarshallingFactory(generatorFactory, TypeNames.LibraryImportAttribute_ShortName);
 
-                // The presence of System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute is tied to TFM,
-                // so we use TFM in the generator factory key instead of the Compilation as the compilation changes on every keystroke.
-                IAssemblySymbol coreLibraryAssembly = env.Compilation.GetSpecialType(SpecialType.System_Object).ContainingAssembly;
-                ITypeSymbol? disabledRuntimeMarshallingAttributeType = coreLibraryAssembly.GetTypeByMetadataName(TypeNames.System_Runtime_CompilerServices_DisableRuntimeMarshallingAttribute);
-                bool runtimeMarshallingDisabled = disabledRuntimeMarshallingAttributeType is not null
-                    && env.Compilation.Assembly.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, disabledRuntimeMarshallingAttributeType));
-
                 // Since the char type can go into the P/Invoke signature here, we can only use it when
                 // runtime marshalling is disabled.
-                generatorFactory = new CharMarshallingGeneratorFactory(generatorFactory, useBlittableMarshallerForUtf16: runtimeMarshallingDisabled, TypeNames.LibraryImportAttribute_ShortName);
+                generatorFactory = new CharMarshallingGeneratorFactory(generatorFactory, useBlittableMarshallerForUtf16: env.EnvironmentFlags.HasFlag(EnvironmentFlags.DisableRuntimeMarshalling), TypeNames.LibraryImportAttribute_ShortName);
 
                 InteropGenerationOptions interopGenerationOptions = new(options.UseMarshalType);
                 generatorFactory = new MarshalAsMarshallingGeneratorFactory(interopGenerationOptions, generatorFactory);
@@ -54,13 +47,13 @@ namespace Microsoft.Interop
                         // Since the char type in an array will not be part of the P/Invoke signature, we can
                         // use the regular blittable marshaller in all cases.
                         new CharMarshallingGeneratorFactory(generatorFactory, useBlittableMarshallerForUtf16: true, TypeNames.LibraryImportAttribute_ShortName),
-                        new AttributedMarshallingModelOptions(runtimeMarshallingDisabled, MarshalMode.ElementIn, MarshalMode.ElementRef, MarshalMode.ElementOut));
+                        new AttributedMarshallingModelOptions(env.EnvironmentFlags.HasFlag(EnvironmentFlags.DisableRuntimeMarshalling), MarshalMode.ElementIn, MarshalMode.ElementRef, MarshalMode.ElementOut));
                     // We don't need to include the later generator factories for collection elements
                     // as the later generator factories only apply to parameters.
                     generatorFactory = new AttributedMarshallingModelGeneratorFactory(
                         generatorFactory,
                         elementFactory,
-                        new AttributedMarshallingModelOptions(runtimeMarshallingDisabled, MarshalMode.ManagedToUnmanagedIn, MarshalMode.ManagedToUnmanagedRef, MarshalMode.ManagedToUnmanagedOut));
+                        new AttributedMarshallingModelOptions(env.EnvironmentFlags.HasFlag(EnvironmentFlags.DisableRuntimeMarshalling), MarshalMode.ManagedToUnmanagedIn, MarshalMode.ManagedToUnmanagedRef, MarshalMode.ManagedToUnmanagedOut));
                 }
 
                 generatorFactory = new ByValueContentsMarshalKindValidator(generatorFactory);

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGeneratorHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGeneratorHelpers.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Interop
 {
     internal static class LibraryImportGeneratorHelpers
     {
-        public static MarshallingGeneratorFactoryKey<(TargetFramework, Version, LibraryImportGeneratorOptions)> CreateGeneratorFactory(StubEnvironment env, LibraryImportGeneratorOptions options)
+        public static MarshallingGeneratorFactoryKey<(TargetFrameworkSettings, LibraryImportGeneratorOptions)> CreateGeneratorFactory(StubEnvironment env, TargetFrameworkSettings tf, LibraryImportGeneratorOptions options)
         {
             IMarshallingGeneratorFactory generatorFactory;
 
@@ -21,7 +21,7 @@ namespace Microsoft.Interop
             }
             else
             {
-                if (env.TargetFramework != TargetFramework.Net || env.TargetFrameworkVersion.Major < 7)
+                if (tf.TargetFramework != TargetFramework.Net || tf.Version.Major < 7)
                 {
                     // If we're using our downstream support, fall back to the Forwarder marshaller when the TypePositionInfo is unhandled.
                     generatorFactory = new ForwarderMarshallingGeneratorFactory();
@@ -41,7 +41,7 @@ namespace Microsoft.Interop
                 InteropGenerationOptions interopGenerationOptions = new(options.UseMarshalType);
                 generatorFactory = new MarshalAsMarshallingGeneratorFactory(interopGenerationOptions, generatorFactory);
 
-                if (env.TargetFramework == TargetFramework.Net || env.TargetFrameworkVersion.Major >= 7)
+                if (tf.TargetFramework == TargetFramework.Net || tf.Version.Major >= 7)
                 {
                     IMarshallingGeneratorFactory elementFactory = new AttributedMarshallingModelGeneratorFactory(
                         // Since the char type in an array will not be part of the P/Invoke signature, we can
@@ -59,7 +59,7 @@ namespace Microsoft.Interop
                 generatorFactory = new ByValueContentsMarshalKindValidator(generatorFactory);
             }
 
-            return MarshallingGeneratorFactoryKey.Create((env.TargetFramework, env.TargetFrameworkVersion, options), generatorFactory);
+            return MarshallingGeneratorFactoryKey.Create((tf, options), generatorFactory);
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubCodeGenerator.cs
@@ -46,16 +46,15 @@ namespace Microsoft.Interop
         private readonly ManagedToNativeStubCodeContext _context;
 
         public PInvokeStubCodeGenerator(
-            TargetFramework targetFramework,
-            Version targetFrameworkVersion,
             ImmutableArray<TypePositionInfo> argTypes,
             bool setLastError,
             GeneratorDiagnosticsBag diagnosticsBag,
-            IMarshallingGeneratorFactory generatorFactory)
+            IMarshallingGeneratorFactory generatorFactory,
+            StubCodeContext.CodeOptions codeEmitOptions)
         {
             _setLastError = setLastError;
 
-            _context = new ManagedToNativeStubCodeContext(targetFramework, targetFrameworkVersion, ReturnIdentifier, ReturnIdentifier);
+            _context = new ManagedToNativeStubCodeContext(ReturnIdentifier, ReturnIdentifier);
             _marshallers = BoundGenerators.Create(argTypes, generatorFactory, _context, new Forwarder(), out var bindingDiagnostics);
 
             diagnosticsBag.ReportGeneratorDiagnostics(bindingDiagnostics);
@@ -63,8 +62,10 @@ namespace Microsoft.Interop
             if (_marshallers.ManagedReturnMarshaller.Generator.UsesNativeIdentifier(_marshallers.ManagedReturnMarshaller.TypeInfo, _context))
             {
                 // If we need a different native return identifier, then recreate the context with the correct identifier before we generate any code.
-                _context = new ManagedToNativeStubCodeContext(targetFramework, targetFrameworkVersion, ReturnIdentifier, $"{ReturnIdentifier}{StubCodeContext.GeneratedNativeIdentifierSuffix}");
+                _context = new ManagedToNativeStubCodeContext(ReturnIdentifier, $"{ReturnIdentifier}{StubCodeContext.GeneratedNativeIdentifierSuffix}");
             }
+
+            _context = _context with { CodeEmitOptions = codeEmitOptions };
 
             bool noMarshallingNeeded = true;
 

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/PInvokeStubCodeGenerator.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Interop
             bool setLastError,
             GeneratorDiagnosticsBag diagnosticsBag,
             IMarshallingGeneratorFactory generatorFactory,
-            StubCodeContext.CodeOptions codeEmitOptions)
+            CodeEmitOptions codeEmitOptions)
         {
             _setLastError = setLastError;
 

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/TargetFrameworkSettings.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/TargetFrameworkSettings.cs
@@ -13,14 +13,26 @@ namespace Microsoft.Interop
     // which will be faster than the reflection-based ones.
     public readonly record struct TargetFrameworkSettings(TargetFramework TargetFramework, Version Version);
 
-    public static class AnalyzerConfigOptionsExtensions
+    /// <summary>
+    /// Target framework identifier
+    /// </summary>
+    public enum TargetFramework
+    {
+        Unknown,
+        Framework,
+        Core,
+        Standard,
+        Net
+    }
+
+    public static class TargetFrameworkSettingsExtensions
     {
         private static readonly Version FirstNonCoreVersion = new(5, 0);
 
         // Parse from the informational version as that is the only version that always matches the TFM version
         // even in debug builds.
         private static readonly Version ThisAssemblyVersion = Version.Parse(
-            typeof(AnalyzerConfigOptionsExtensions).Assembly
+            typeof(TargetFrameworkSettingsExtensions).Assembly
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split('-', '+')[0]);
 
         public static TargetFrameworkSettings GetTargetFrameworkSettings(this AnalyzerConfigOptions options)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/CodeEmitOptions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/CodeEmitOptions.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Interop
+{
+    /// <summary>
+    /// Code options for codegen in this context.
+    /// These options are used for providing optional optimizations depending on available APIs.
+    /// </summary>
+    /// <param name="SkipInit">Skip initialization of locals when possible.</param>
+    public record struct CodeEmitOptions(bool SkipInit);
+}

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/CompilationExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/CompilationExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Interop
+{
+    public static class CompilationExtensions
+    {
+        public static EnvironmentFlags GetEnvironmentFlags(this Compilation compilation)
+        {
+            EnvironmentFlags flags = EnvironmentFlags.None;
+            if (compilation.SourceModule.GetAttributes().Any(attr => attr.AttributeClass.ToDisplayString() == TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute))
+            {
+                flags |= EnvironmentFlags.SkipLocalsInit;
+            }
+            if (compilation.SourceModule.GetAttributes().Any(attr => attr.AttributeClass.ToDisplayString() == TypeNames.System_Runtime_CompilerServices_DisableRuntimeMarshallingAttribute))
+            {
+                flags |= EnvironmentFlags.DisableRuntimeMarshalling;
+            }
+            return flags;
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/IncrementalGeneratorInitializationContextExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/IncrementalGeneratorInitializationContextExtensions.cs
@@ -44,14 +44,10 @@ namespace Microsoft.Interop
 
         public static IncrementalValueProvider<StubEnvironment> CreateStubEnvironmentProvider(this IncrementalGeneratorInitializationContext context)
         {
-            var tfmVersion = context.AnalyzerConfigOptionsProvider
-                .Select((options, ct) => options.GlobalOptions.GetTargetFrameworkSettings());
-
-            return tfmVersion
+            return context.CompilationProvider
                 .Combine(context.CreateEnvironmentFlagsProvider())
-                .Combine(context.CompilationProvider)
                 .Select((data, ct) =>
-                    new StubEnvironment(data.Right, data.Left.Left.TargetFramework, data.Left.Left.Version, data.Left.Right));
+                    new StubEnvironment(data.Left, data.Right));
         }
 
         public static void RegisterDiagnostics(this IncrementalGeneratorInitializationContext context, IncrementalValuesProvider<DiagnosticInfo> diagnostics)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/IncrementalGeneratorInitializationContextExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/IncrementalGeneratorInitializationContextExtensions.cs
@@ -14,11 +14,8 @@ namespace Microsoft.Interop
 {
     public static class IncrementalGeneratorInitializationContextExtensions
     {
-        public static IncrementalValueProvider<StubEnvironment> CreateStubEnvironmentProvider(this IncrementalGeneratorInitializationContext context)
+        public static IncrementalValueProvider<EnvironmentFlags> CreateEnvironmentFlagsProvider(this IncrementalGeneratorInitializationContext context)
         {
-            var tfmVersion = context.AnalyzerConfigOptionsProvider
-                .Select((options, ct) => options.GlobalOptions.GetTargetFrameworkSettings());
-
             var isModuleSkipLocalsInit = context.SyntaxProvider
                 .ForAttributeWithMetadataName(
                     TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute,
@@ -28,10 +25,30 @@ namespace Microsoft.Interop
                     // SkipLocalsInit attributes. So the result we return here is meaningless.
                     (context, ct) => true)
                 .Collect()
-                .Select((topLevelAttrs, ct) => !topLevelAttrs.IsEmpty);
+                .Select((topLevelAttrs, ct) => !topLevelAttrs.IsEmpty ? EnvironmentFlags.SkipLocalsInit : EnvironmentFlags.None);
+
+            var disabledRuntimeMarshalling = context.SyntaxProvider
+                .ForAttributeWithMetadataName(
+                    TypeNames.System_Runtime_CompilerServices_DisableRuntimeMarshallingAttribute,
+                    // DisableRuntimeMarshalling is only available at the top level.
+                    (node, ct) => true,
+                    // Only allow DisableRuntimeMarshalling attributes from the attribute type in the core assembly.
+                    // Otherwise the runtime isn't going to respect it and invalid behavior can happen.
+                    (context, ct) => SymbolEqualityComparer.Default.Equals(context.Attributes[0].AttributeClass.ContainingAssembly, context.SemanticModel.Compilation.GetSpecialType(SpecialType.System_Object).ContainingAssembly))
+                .Where(valid => valid)
+                .Collect()
+                .Select((topLevelAttrs, ct) => !topLevelAttrs.IsEmpty ? EnvironmentFlags.DisableRuntimeMarshalling : EnvironmentFlags.None);
+
+            return isModuleSkipLocalsInit.Combine(disabledRuntimeMarshalling).Select((data, ct) => data.Left | data.Right);
+        }
+
+        public static IncrementalValueProvider<StubEnvironment> CreateStubEnvironmentProvider(this IncrementalGeneratorInitializationContext context)
+        {
+            var tfmVersion = context.AnalyzerConfigOptionsProvider
+                .Select((options, ct) => options.GlobalOptions.GetTargetFrameworkSettings());
 
             return tfmVersion
-                .Combine(isModuleSkipLocalsInit)
+                .Combine(context.CreateEnvironmentFlagsProvider())
                 .Combine(context.CompilationProvider)
                 .Select((data, ct) =>
                     new StubEnvironment(data.Right, data.Left.Left.TargetFramework, data.Left.Left.Version, data.Left.Right));

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/LinearCollectionElementMarshallingCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/LinearCollectionElementMarshallingCodeContext.cs
@@ -35,10 +35,8 @@ namespace Microsoft.Interop
             _nativeSpanIdentifier = nativeSpanIdentifier;
             ParentContext = parentContext;
             Direction = ParentContext.Direction;
+            CodeEmitOptions = ParentContext.CodeEmitOptions;
         }
-
-        public override (TargetFramework framework, Version version) GetTargetFramework()
-            => ParentContext!.GetTargetFramework();
 
         /// <summary>
         /// Get managed and native instance identifiers for the <paramref name="info"/>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedToNativeStubCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedToNativeStubCodeContext.cs
@@ -11,28 +11,18 @@ namespace Microsoft.Interop
 
         public override bool AdditionalTemporaryStateLivesAcrossStages => true;
 
-        private readonly TargetFramework _framework;
-        private readonly Version _frameworkVersion;
-
         private const string InvokeReturnIdentifier = "__invokeRetVal";
         private const string InvokeReturnIdentifierNative = "__invokeRetValUnmanaged";
         private readonly string _returnIdentifier;
         private readonly string _nativeReturnIdentifier;
 
         public ManagedToNativeStubCodeContext(
-            TargetFramework targetFramework,
-            Version targetFrameworkVersion,
             string returnIdentifier,
             string nativeReturnIdentifier)
         {
-            _framework = targetFramework;
-            _frameworkVersion = targetFrameworkVersion;
             _returnIdentifier = returnIdentifier;
             _nativeReturnIdentifier = nativeReturnIdentifier;
         }
-
-        public override (TargetFramework framework, Version version) GetTargetFramework()
-            =>  (_framework, _frameworkVersion);
 
         public override (string managed, string native) GetIdentifiers(TypePositionInfo info)
         {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Interop
         {
             if (info.ManagedType is not PointerTypeInfo
                 && info.ManagedType is not ValueTypeInfo { IsByRefLike: true }
-                && context.CodeEmitOptions.UnsafeSkipInit)
+                && context.CodeEmitOptions.SkipInit)
             {
                 // Use the Unsafe.SkipInit<T> API when available and
                 // managed type is usable as a generic parameter.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -243,10 +243,9 @@ namespace Microsoft.Interop
         // private static readonly InvocationExpressionSyntax SkipInitInvocation =
         public static StatementSyntax SkipInitOrDefaultInit(TypePositionInfo info, StubCodeContext context)
         {
-            (TargetFramework fmk, _) = context.GetTargetFramework();
             if (info.ManagedType is not PointerTypeInfo
                 && info.ManagedType is not ValueTypeInfo { IsByRefLike: true }
-                && fmk is TargetFramework.Net)
+                && context.CodeEmitOptions.UnsafeSkipInit)
             {
                 // Use the Unsafe.SkipInit<T> API when available and
                 // managed type is usable as a generic parameter.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
@@ -8,18 +8,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace Microsoft.Interop
 {
     /// <summary>
-    /// Target framework identifier
-    /// </summary>
-    public enum TargetFramework
-    {
-        Unknown,
-        Framework,
-        Core,
-        Standard,
-        Net
-    }
-
-    /// <summary>
     /// An enumeration describing how a <see cref="TypePositionInfo"/> should be represented in its corresponding native signature element (parameter, field, or return value).
     /// </summary>
     public enum SignatureBehavior

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/UnmanagedToManagedOwnershipTrackingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/UnmanagedToManagedOwnershipTrackingStrategy.cs
@@ -200,8 +200,6 @@ namespace Microsoft.Interop
 
         public override bool AdditionalTemporaryStateLivesAcrossStages => _innerContext.AdditionalTemporaryStateLivesAcrossStages;
 
-        public override (TargetFramework framework, Version version) GetTargetFramework() => _innerContext.GetTargetFramework();
-
         public override (string managed, string native) GetIdentifiers(TypePositionInfo info)
         {
             var (managed, _) = _innerContext.GetIdentifiers(info);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/NativeToManagedStubCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/NativeToManagedStubCodeContext.cs
@@ -13,29 +13,19 @@ namespace Microsoft.Interop
 
         public override bool AdditionalTemporaryStateLivesAcrossStages => true;
 
-        private readonly TargetFramework _framework;
-        private readonly Version _frameworkVersion;
-
         private const string InvokeReturnIdentifier = "__invokeRetVal";
         private const string InvokeReturnIdentifierNative = "__invokeRetValUnmanaged";
         private readonly string _returnIdentifier;
         private readonly string _nativeReturnIdentifier;
 
         public NativeToManagedStubCodeContext(
-            TargetFramework targetFramework,
-            Version targetFrameworkVersion,
             string returnIdentifier,
             string nativeReturnIdentifier)
         {
-            _framework = targetFramework;
-            _frameworkVersion = targetFrameworkVersion;
             _returnIdentifier = returnIdentifier;
             _nativeReturnIdentifier = nativeReturnIdentifier;
             Direction = MarshalDirection.UnmanagedToManaged;
         }
-
-        public override (TargetFramework framework, Version version) GetTargetFramework()
-            =>  (_framework, _frameworkVersion);
 
         public override (string managed, string native) GetIdentifiers(TypePositionInfo info)
         {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Interop
 
         private static bool MethodIsSkipLocalsInit(StubEnvironment env, IMethodSymbol method)
         {
-            if (env.ModuleSkipLocalsInit)
+            if (env.EnvironmentFlags.HasFlag(EnvironmentFlags.SkipLocalsInit))
             {
                 return true;
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
@@ -71,32 +71,30 @@ namespace Microsoft.Interop
             IMethodSymbol method,
             MarshallingInfoParser marshallingInfoParser,
             StubEnvironment env,
+            CodeEmitOptions options,
             Assembly generatorInfoAssembly)
         {
             ImmutableArray<TypePositionInfo> typeInfos = GenerateTypeInformation(method, marshallingInfoParser, env);
 
             ImmutableArray<AttributeListSyntax>.Builder additionalAttrs = ImmutableArray.CreateBuilder<AttributeListSyntax>();
 
-            if (env.TargetFramework != TargetFramework.Unknown)
-            {
-                string generatorName = generatorInfoAssembly.GetName().Name;
-                string generatorVersion = generatorInfoAssembly.GetName().Version.ToString();
-                // Define additional attributes for the stub definition.
-                additionalAttrs.Add(
-                    AttributeList(
-                        SingletonSeparatedList(
-                            Attribute(
-                                NameSyntaxes.System_CodeDom_Compiler_GeneratedCodeAttribute,
-                                AttributeArgumentList(
-                                    SeparatedList(
-                                        new[]
-                                        {
+            string generatorName = generatorInfoAssembly.GetName().Name;
+            string generatorVersion = generatorInfoAssembly.GetName().Version.ToString();
+            // Define additional attributes for the stub definition.
+            additionalAttrs.Add(
+                AttributeList(
+                    SingletonSeparatedList(
+                        Attribute(
+                            NameSyntaxes.System_CodeDom_Compiler_GeneratedCodeAttribute,
+                            AttributeArgumentList(
+                                SeparatedList(
+                                    new[]
+                                    {
                                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(generatorName))),
                                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(generatorVersion)))
-                                        }))))));
-            }
+                                    }))))));
 
-            if (env.TargetFrameworkVersion >= new Version(5, 0) && !MethodIsSkipLocalsInit(env, method))
+            if (options.SkipInit && !MethodIsSkipLocalsInit(env, method))
             {
                 additionalAttrs.Add(
                     AttributeList(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubCodeContext.cs
@@ -80,14 +80,7 @@ namespace Microsoft.Interop
             GuaranteedUnmarshal
         }
 
-        /// <summary>
-        /// Code options for codegen in this context.
-        /// These options are used for providing optional optimizations depending on available APIs.
-        /// </summary>
-        /// <param name="UnsafeSkipInit"></param>
-        public record struct CodeOptions(bool UnsafeSkipInit);
-
-        public CodeOptions CodeEmitOptions { get; init; } = new(UnsafeSkipInit: true);
+        public CodeEmitOptions CodeEmitOptions { get; init; } = new(SkipInit: true);
 
         /// <summary>
         /// The current stage being generated.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubCodeContext.cs
@@ -81,17 +81,20 @@ namespace Microsoft.Interop
         }
 
         /// <summary>
+        /// Code options for codegen in this context.
+        /// These options are used for providing optional optimizations depending on available APIs.
+        /// </summary>
+        /// <param name="UnsafeSkipInit"></param>
+        public record struct CodeOptions(bool UnsafeSkipInit);
+
+        public CodeOptions CodeEmitOptions { get; init; } = new(UnsafeSkipInit: true);
+
+        /// <summary>
         /// The current stage being generated.
         /// </summary>
         public Stage CurrentStage { get; init; } = Stage.Invalid;
 
         public MarshalDirection Direction { get; init; } = MarshalDirection.ManagedToUnmanaged;
-
-        /// <summary>
-        /// Gets the currently targeted framework and version for stub code generation.
-        /// </summary>
-        /// <returns>A framework value and version.</returns>
-        public abstract (TargetFramework framework, Version version) GetTargetFramework();
 
         /// <summary>
         /// The stub emits code that runs in a single stack frame and the frame spans over the native context.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubEnvironment.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubEnvironment.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Interop
 
     public sealed record StubEnvironment(
         Compilation Compilation,
-        TargetFramework TargetFramework,
-        Version TargetFrameworkVersion,
         EnvironmentFlags EnvironmentFlags)
     {
         private Optional<INamedTypeSymbol?> _lcidConversionAttrType;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubEnvironment.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubEnvironment.cs
@@ -6,11 +6,19 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Interop
 {
+    [Flags]
+    public enum EnvironmentFlags
+    {
+        None = 0,
+        SkipLocalsInit = 0x1,
+        DisableRuntimeMarshalling = 0x2,
+    }
+
     public sealed record StubEnvironment(
         Compilation Compilation,
         TargetFramework TargetFramework,
         Version TargetFrameworkVersion,
-        bool ModuleSkipLocalsInit)
+        EnvironmentFlags EnvironmentFlags)
     {
         private Optional<INamedTypeSymbol?> _lcidConversionAttrType;
         public INamedTypeSymbol? LcidConversionAttrType


### PR DESCRIPTION
Refactor the concept of TargetFramework out of Micrsoft.Interop.SourceGeneration. Replace it with a CodeEmitOptions struct for us to introduce emit switches based on TFM features (in particular, the ability to skip initialization of locals was only introduced in .NET 5, so we need to have a switch for it). As all other use cases of the TFM are downlevel-support-specific in LibraryImportGenerator, move the TFM types into LibraryImportGenerator.