### PR TITLE
Fix options Validation with objects have indexers

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/DataAnnotationValidateOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/DataAnnotationValidateOptions.cs
@@ -95,7 +95,8 @@ namespace Microsoft.Extensions.Options
 
             foreach (PropertyInfo propertyInfo in options.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public))
             {
-                if (propertyInfo.GetMethod is null)
+                // Indexers are properties which take parameters. Ignore them.
+                if (propertyInfo.GetMethod is null || propertyInfo.GetMethod.GetParameters().Length > 0)
                 {
                     continue;
                 }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/OptionsRuntimeTests.cs
@@ -178,6 +178,30 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
+        public void TestObjectsWithIndexerProperties()
+        {
+            DataAnnotationValidateOptions<MyDictionaryOptions> dataAnnotationValidateOptions1 = new("MyDictionaryOptions");
+            MyDictionaryOptionsOptionsValidator sourceGenOptionsValidator1 = new();
+
+            var options1 = new MyDictionaryOptions();
+            ValidateOptionsResult result1 = sourceGenOptionsValidator1.Validate("MyDictionaryOptions", options1);
+            ValidateOptionsResult result2 = dataAnnotationValidateOptions1.Validate("MyDictionaryOptions", options1);
+
+            Assert.True(result1.Succeeded);
+            Assert.True(result2.Succeeded);
+
+            DataAnnotationValidateOptions<MyListOptions<string>> dataAnnotationValidateOptions2 = new("MyListOptions");
+            MyListOptionsOptionsValidator sourceGenOptionsValidator2 = new();
+
+            var options2 = new MyListOptions<string>() { Prop = "test" };
+            result1 = sourceGenOptionsValidator2.Validate("MyListOptions", options2);
+            result2 = dataAnnotationValidateOptions2.Validate("MyListOptions", options2);
+
+            Assert.True(result1.Succeeded);
+            Assert.True(result2.Succeeded);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
         public void TestValidationWithCyclicReferences()
         {
             NestedOptions nestedOptions = new()
@@ -301,6 +325,12 @@ namespace Microsoft.Gen.OptionsValidation.Unit.Test
     public partial class MySourceGenOptionsValidator : IValidateOptions<MyOptions>
     {
     }
+
+    public class MyDictionaryOptions : Dictionary<string, string> { [Required] public string Prop { get; set; } = "test"; }
+    [OptionsValidator] public partial class MyDictionaryOptionsOptionsValidator : IValidateOptions<MyDictionaryOptions> { }
+
+    public class MyListOptions<T> : List<T> { [Required] public T Prop { get; set; } = default; }
+    [OptionsValidator] public partial class MyListOptionsOptionsValidator : IValidateOptions<MyListOptions<string>> { }
 
 #if NET8_0_OR_GREATER
     public class OptionsUsingNewAttributes


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/92276

In .NET 8.0, we have introduced support for object validation using the newly introduced attributes ValidateObjectMembersAttribute and ValidateEnumeratedItemsAttribute. However, an issue arises when an object contains an indexer (e.g., in collections) because the validation process attempts to retrieve the property value using reflection, which expects a parameter and results in an exception being thrown.

The solution here is to exclude indexers from the validation process, ensuring that only properties are validated.