### PR TITLE
Change GetParametersNoCopy to GetParametersAsSpan and use it in a few more places

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
@@ -201,7 +201,7 @@ namespace Internal.Runtime.InteropServices
                     }
 
                     // Finally validate signature
-                    ParameterInfo[] methParams = method.GetParameters();
+                    ReadOnlySpan<ParameterInfo> methParams = method.GetParametersAsSpan();
                     if (method.ReturnType != typeof(void)
                         || methParams == null
                         || methParams.Length != 1

--- a/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
@@ -227,8 +227,7 @@ namespace System
                     }
                     else
                     {
-                        ParameterInfo[] parameters = rtMethod.GetParameters();
-                        return parameters[position]; // Point to the correct ParameterInfo of the method
+                        return rtMethod.GetParametersAsSpan()[position]; // Point to the correct ParameterInfo of the method
                     }
                 }
             }

--- a/src/coreclr/System.Private.CoreLib/src/System/Delegate.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Delegate.CoreCLR.cs
@@ -200,7 +200,7 @@ namespace System
                         {
                             // it's an open one, need to fetch the first arg of the instantiation
                             MethodInfo invoke = this.GetType().GetMethod("Invoke")!;
-                            declaringType = (RuntimeType)invoke.GetParameters()[0].ParameterType;
+                            declaringType = (RuntimeType)invoke.GetParametersAsSpan()[0].ParameterType;
                         }
                     }
                 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -94,7 +94,7 @@ namespace System.Reflection.Emit
             }
             if (opcode.StackBehaviourPop == StackBehaviour.Varpop)
             {
-                stackchange -= meth.GetParametersNoCopy().Length;
+                stackchange -= meth.GetParametersAsSpan().Length;
             }
             // Pop the "this" parameter if the method is non-static,
             //  and the instruction is not newobj/ldtoken/ldftn.
@@ -416,7 +416,7 @@ namespace System.Reflection.Emit
             if (rtMeth == null && dm == null)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeMethodInfo, nameof(methodInfo));
 
-            ParameterInfo[] paramInfo = methodInfo.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> paramInfo = methodInfo.GetParametersAsSpan();
             if (paramInfo != null && paramInfo.Length != 0)
             {
                 parameterTypes = new Type[paramInfo.Length];

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeModuleBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeModuleBuilder.cs
@@ -458,7 +458,7 @@ namespace System.Reflection.Emit
             }
 
             Debug.Assert(method is RuntimeMethodInfo || method is RuntimeConstructorInfo);
-            ParameterInfo[] parameters = method.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> parameters = method.GetParametersAsSpan();
 
             Type[] parameterTypes = new Type[parameters.Length];
             Type[][] requiredCustomModifiers = new Type[parameterTypes.Length][];

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
@@ -47,7 +47,7 @@ namespace System.Reflection
         // used by EE
         private IntPtr GetMethodDesc() { return MethodHandle.Value; }
 
-        internal virtual ParameterInfo[] GetParametersNoCopy() { return GetParameters(); }
+        internal virtual ReadOnlySpan<ParameterInfo> GetParametersAsSpan() { return GetParameters(); }
         #endregion
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.CoreCLR.cs
@@ -180,20 +180,11 @@ namespace System.Reflection
         // This seems to always returns System.Void.
         internal override Type GetReturnType() { return Signature.ReturnType; }
 
-        internal override ParameterInfo[] GetParametersNoCopy() =>
+        internal override ReadOnlySpan<ParameterInfo> GetParametersAsSpan() =>
             m_parameters ??= RuntimeParameterInfo.GetParameters(this, this, Signature);
 
-        public override ParameterInfo[] GetParameters()
-        {
-            ParameterInfo[] parameters = GetParametersNoCopy();
-
-            if (parameters.Length == 0)
-                return parameters;
-
-            ParameterInfo[] ret = new ParameterInfo[parameters.Length];
-            Array.Copy(parameters, ret, parameters.Length);
-            return ret;
-        }
+        public override ParameterInfo[] GetParameters() =>
+            GetParametersAsSpan().ToArray();
 
         public override MethodImplAttributes GetMethodImplementationFlags()
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -278,7 +278,7 @@ namespace System.Reflection
                 m_ctor = (RuntimeConstructorInfo)scope.ResolveMethod(caCtorToken, attributeType.GenericTypeArguments, null)!.MethodHandle.GetMethodInfo();
             }
 
-            ParameterInfo[] parameters = m_ctor.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> parameters = m_ctor.GetParametersAsSpan();
             if (parameters.Length != 0)
             {
                 m_ctorParams = new CustomAttributeCtorParameter[parameters.Length];
@@ -412,7 +412,7 @@ namespace System.Reflection
             // Ensure there is only a single constructor for 'pca', so it is safe to suppress IL2075
             ConstructorInfo[] allCtors = type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             Debug.Assert(allCtors.Length == 1);
-            Debug.Assert(allCtors[0].GetParameters().Length == 0);
+            Debug.Assert(allCtors[0].GetParametersAsSpan().Length == 0);
 #endif
 
             m_ctor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)[0];

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
@@ -63,10 +63,14 @@ namespace System.Reflection
         #region Object Overrides
         public override string ToString()
         {
-            if (m_addMethod == null || m_addMethod.GetParametersNoCopy().Length == 0)
+            ReadOnlySpan<ParameterInfo> parameters;
+            if (m_addMethod == null ||
+                (parameters = m_addMethod.GetParametersAsSpan()).Length == 0)
+            {
                 throw new InvalidOperationException(SR.InvalidOperation_NoPublicAddMethod);
+            }
 
-            return m_addMethod.GetParametersNoCopy()[0].ParameterType.FormatTypeName() + " " + Name;
+            return parameters[0].ParameterType.FormatTypeName() + " " + Name;
         }
 
         public override bool Equals(object? obj) =>

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
@@ -240,7 +240,7 @@ namespace System.Reflection
         #endregion
 
         #region MethodBase Overrides
-        internal override ParameterInfo[] GetParametersNoCopy() =>
+        internal override ReadOnlySpan<ParameterInfo> GetParametersAsSpan() =>
             FetchNonReturnParameters();
 
         public override ParameterInfo[] GetParameters()

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -261,23 +261,10 @@ namespace System.Reflection
             return m_setterMethod;
         }
 
-        public override ParameterInfo[] GetIndexParameters()
-        {
-            ParameterInfo[] indexParams = GetIndexParametersNoCopy();
+        public override ParameterInfo[] GetIndexParameters() =>
+            GetIndexParametersSpan().ToArray();
 
-            int numParams = indexParams.Length;
-
-            if (numParams == 0)
-                return indexParams;
-
-            ParameterInfo[] ret = new ParameterInfo[numParams];
-
-            Array.Copy(indexParams, ret, numParams);
-
-            return ret;
-        }
-
-        internal ParameterInfo[] GetIndexParametersNoCopy()
+        internal ReadOnlySpan<ParameterInfo> GetIndexParametersSpan()
         {
             // @History - Logic ported from RTM
 
@@ -285,14 +272,14 @@ namespace System.Reflection
             if (m_parameters == null)
             {
                 int numParams = 0;
-                ParameterInfo[]? methParams = null;
+                ReadOnlySpan<ParameterInfo> methParams = default;
 
                 // First try to get the Get method.
                 RuntimeMethodInfo? m = GetGetMethod(true);
                 if (m != null)
                 {
                     // There is a Get method so use it.
-                    methParams = m.GetParametersNoCopy();
+                    methParams = m.GetParametersAsSpan();
                     numParams = methParams.Length;
                 }
                 else
@@ -302,7 +289,7 @@ namespace System.Reflection
 
                     if (m != null)
                     {
-                        methParams = m.GetParametersNoCopy();
+                        methParams = m.GetParametersAsSpan();
                         numParams = methParams.Length - 1;
                     }
                 }

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2290,7 +2290,7 @@ namespace System
             // Check if argumentTypes supplied
             if (argumentTypes != null)
             {
-                ParameterInfo[] parameterInfos = methodBase.GetParametersNoCopy();
+                ReadOnlySpan<ParameterInfo> parameterInfos = methodBase.GetParametersAsSpan();
 
                 if (argumentTypes.Length != parameterInfos.Length)
                 {
@@ -2848,8 +2848,7 @@ namespace System
             {
                 ConstructorInfo firstCandidate = candidates[0];
 
-                ParameterInfo[] parameters = firstCandidate.GetParametersNoCopy();
-                if (parameters == null || parameters.Length == 0)
+                if (firstCandidate.GetParametersAsSpan().IsEmpty)
                 {
                     return firstCandidate;
                 }
@@ -3817,7 +3816,7 @@ namespace System
                     throw new MissingMethodException(SR.Format(SR.MissingConstructor_Name, FullName));
                 }
 
-                if (invokeMethod.GetParametersNoCopy().Length == 0)
+                if (invokeMethod.GetParametersAsSpan().Length == 0)
                 {
                     if (args.Length != 0)
                     {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
@@ -938,7 +938,7 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Reflection.MethodBase.GetParametersNoCopy</Target>
+    <Target>M:System.Reflection.MethodBase.GetParametersAsSpan</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInheritanceRules.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInheritanceRules.cs
@@ -235,7 +235,7 @@ namespace Internal.Reflection.Extensions.NonPortable
 
                 if (e.Position >= 0)
                 {
-                    return methodParent.GetParametersNoCopy()[e.Position];
+                    return methodParent.GetParametersAsSpan()[e.Position];
                 }
                 else
                 {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInstantiator.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInstantiator.cs
@@ -40,11 +40,11 @@ namespace Internal.Reflection.Extensions.NonPortable
             // Find the public constructor that matches the supplied arguments.
             //
             ConstructorInfo? matchingCtor = null;
-            ParameterInfo[]? matchingParameters = null;
+            ReadOnlySpan<ParameterInfo> matchingParameters = default;
             IList<CustomAttributeTypedArgument> constructorArguments = cad.ConstructorArguments;
             foreach (ConstructorInfo ctor in attributeType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
             {
-                ParameterInfo[] parameters = ctor.GetParametersNoCopy();
+                ReadOnlySpan<ParameterInfo> parameters = ctor.GetParametersAsSpan();
                 if (parameters.Length != constructorArguments.Count)
                     continue;
                 int i;
@@ -68,7 +68,7 @@ namespace Internal.Reflection.Extensions.NonPortable
             //
             // Found the right constructor. Instantiate the Attribute.
             //
-            int arity = matchingParameters!.Length;
+            int arity = matchingParameters.Length;
             object?[] invokeArguments = new object[arity];
             for (int i = 0; i < arity; i++)
             {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ActivatorImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ActivatorImplementation.cs
@@ -99,7 +99,7 @@ namespace System
             binder ??= Type.DefaultBinder;
 
             MethodBase invokeMethod = binder.BindToMethod(bindingAttr, matches.ToArray(), ref args, null, culture, null, out object? state);
-            if (invokeMethod.GetParametersNoCopy().Length == 0)
+            if (invokeMethod.GetParametersAsSpan().Length == 0)
             {
                 if (args.Length != 0)
                 {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.cs
@@ -18,7 +18,7 @@ namespace System.Reflection
         internal ConstructorInvoker(RuntimeConstructorInfo constructor)
         {
             _methodBaseInvoker = constructor.MethodInvoker;
-            _parameterCount = constructor.GetParametersNoCopy().Length;
+            _parameterCount = constructor.GetParametersAsSpan().Length;
             _declaringTypeHandle = constructor.DeclaringType.TypeHandle;
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs
@@ -61,7 +61,7 @@ namespace System.Reflection
 
             // _isValueTypeInstanceMethod = method.DeclaringType?.IsValueType ?? false;
 
-            ParameterInfo[] parameters = method.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> parameters = method.GetParametersAsSpan();
 
             _argumentCount = parameters.Length;
 
@@ -579,7 +579,7 @@ namespace System.Reflection
 
         private unsafe object? GetCoercedDefaultValue(int index, in ArgumentInfo argumentInfo)
         {
-            object? defaultValue = Method.GetParametersNoCopy()[index].DefaultValue;
+            object? defaultValue = Method.GetParametersAsSpan()[index].DefaultValue;
             if (defaultValue == DBNull.Value)
                 throw new ArgumentException(SR.Arg_VarMissNull, "parameters");
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/MethodBase.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/MethodBase.NativeAot.cs
@@ -16,7 +16,7 @@ namespace System.Reflection
         public static MethodBase GetCurrentMethod() { throw NotImplemented.ByDesign; } //Implemented by toolchain.
 
         // This is not an api but needs to be declared public so that System.Private.Reflection.Core can access (and override it)
-        public virtual ParameterInfo[] GetParametersNoCopy() => GetParameters();
+        public virtual ReadOnlySpan<ParameterInfo> GetParametersAsSpan() => GetParameters();
 
         //
         // MethodBase MetadataDefinitionMethod { get; }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/MethodInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/MethodInvoker.cs
@@ -17,7 +17,7 @@ namespace System.Reflection
         internal MethodInvoker(RuntimeMethodInfo method)
         {
             _methodBaseInvoker = method.MethodInvoker;
-            _parameterCount = method.GetParametersNoCopy().Length;
+            _parameterCount = method.GetParametersAsSpan().Length;
         }
 
         internal MethodInvoker(RuntimeConstructorInfo constructor)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/MemberPolicies.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/MemberPolicies.cs
@@ -88,8 +88,8 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             if (method1.Name != method2.Name)
                 return false;
 
-            ParameterInfo[] p1 = method1.GetParametersNoCopy();
-            ParameterInfo[] p2 = method2.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> p1 = method1.GetParametersAsSpan();
+            ReadOnlySpan<ParameterInfo> p2 = method2.GetParametersAsSpan();
             if (p1.Length != p2.Length)
                 return false;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/Shared.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/Shared.cs
@@ -40,7 +40,7 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             #endregion
 
             #region ArgumentTypes
-            ParameterInfo[] parameterInfos = methodBase.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> parameterInfos = methodBase.GetParametersAsSpan();
 
             if (argumentTypes.Length != parameterInfos.Length)
             {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
@@ -72,7 +72,7 @@ namespace System.Reflection.Runtime.CustomAttributes
             int parameterCount = parameterTypes.Length;
             foreach (ConstructorInfo candidate in attributeType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
             {
-                ParameterInfo[] candidateParameters = candidate.GetParametersNoCopy();
+                ReadOnlySpan<ParameterInfo> candidateParameters = candidate.GetParametersAsSpan();
                 if (parameterCount != candidateParameters.Length)
                     continue;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
@@ -110,7 +110,7 @@ namespace System.Reflection.Runtime.EventInfos
         public sealed override string ToString()
         {
             MethodInfo addMethod = this.AddMethod;
-            ParameterInfo[] parameters = addMethod.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> parameters = addMethod.GetParametersAsSpan();
             if (parameters.Length == 0)
                 throw new InvalidOperationException(); // Legacy: Why is a ToString() intentionally throwing an exception?
             RuntimeParameterInfo runtimeParameterInfo = (RuntimeParameterInfo)(parameters[0]);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -304,7 +304,7 @@ namespace System.Reflection.Runtime.General
                 bindingFlags |= BindingFlags.IgnoreCase;
             }
             RuntimeMethodInfo invokeMethod = runtimeDelegateType.GetInvokeMethod();
-            ParameterInfo[] parameters = invokeMethod.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> parameters = invokeMethod.GetParametersAsSpan();
             int numParameters = parameters.Length;
             Type[] parameterTypes = new Type[numParameters];
             for (int i = 0; i < numParameters; i++)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/CustomMethodMapper.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/CustomMethodMapper.cs
@@ -30,7 +30,7 @@ namespace System.Reflection.Runtime.MethodInfos
             if (!map.TryGetValue(methodBase.MetadataDefinitionMethod, out CustomMethodInvokerAction? action))
                 return null;
 
-            ParameterInfo[] parameterInfos = methodBase.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> parameterInfos = methodBase.GetParametersAsSpan();
             Type[] parameterTypes = new Type[parameterInfos.Length];
             for (int i = 0; i < parameterInfos.Length; i++)
             {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
@@ -54,7 +54,7 @@ namespace System.Reflection.Runtime.MethodInfos
             return result;
         }
 
-        public sealed override ParameterInfo[] GetParametersNoCopy()
+        public sealed override ReadOnlySpan<ParameterInfo> GetParametersAsSpan()
         {
             return RuntimeParameters;
         }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodInfo.cs
@@ -151,7 +151,7 @@ namespace System.Reflection.Runtime.MethodInfos
             return result;
         }
 
-        public sealed override ParameterInfo[] GetParametersNoCopy()
+        public sealed override ReadOnlySpan<ParameterInfo> GetParametersAsSpan()
         {
             return RuntimeParameters;
         }
@@ -325,18 +325,16 @@ namespace System.Reflection.Runtime.MethodInfos
                 return null;
             }
 
-#pragma warning disable CA1859 // Use concrete types when possible for improved performance https://github.com/dotnet/roslyn-analyzers/issues/6751
-            IList<ParameterInfo> delegateParameters = invokeMethod.GetParametersNoCopy();
-            IList<ParameterInfo> targetParameters = this.GetParametersNoCopy();
-#pragma warning restore CA1859
-            IEnumerator<ParameterInfo> delegateParameterEnumerator = delegateParameters.GetEnumerator();
-            IEnumerator<ParameterInfo> targetParameterEnumerator = targetParameters.GetEnumerator();
+            ReadOnlySpan<ParameterInfo> delegateParameters = invokeMethod.GetParametersAsSpan();
+            ReadOnlySpan<ParameterInfo> targetParameters = this.GetParametersAsSpan();
+            ReadOnlySpan<ParameterInfo>.Enumerator delegateParameterEnumerator = delegateParameters.GetEnumerator();
+            ReadOnlySpan<ParameterInfo>.Enumerator targetParameterEnumerator = targetParameters.GetEnumerator();
 
             bool isStatic = this.IsStatic;
             bool isOpen;
             if (isStatic)
             {
-                if (delegateParameters.Count == targetParameters.Count)
+                if (delegateParameters.Length == targetParameters.Length)
                 {
                     // Open static: This is the "typical" case of calling a static method.
                     isOpen = true;
@@ -358,7 +356,7 @@ namespace System.Reflection.Runtime.MethodInfos
             }
             else
             {
-                if (delegateParameters.Count == targetParameters.Count)
+                if (delegateParameters.Length == targetParameters.Length)
                 {
                     // Closed instance: This is the "typical" case of invoking an instance method.
                     isOpen = false;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
@@ -33,8 +33,7 @@ namespace System.Reflection.Runtime.TypeInfos
             if (types.Length == 0 && candidates.Count == 1)
             {
                 ConstructorInfo firstCandidate = candidates[0];
-                ParameterInfo[] parameters = firstCandidate.GetParametersNoCopy();
-                if (parameters.Length == 0)
+                if (firstCandidate.GetParametersAsSpan().Length == 0)
                     return firstCandidate;
             }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.InvokeMember.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.InvokeMember.cs
@@ -363,7 +363,7 @@ namespace System.Reflection.Runtime.TypeInfos
                 #region Invoke
                 if (finalists == null &&
                     argCnt == 0 &&
-                    finalist.GetParametersNoCopy().Length == 0 &&
+                    finalist.GetParametersAsSpan().Length == 0 &&
                     (bindingFlags & BindingFlags.OptionalParamBinding) == 0)
                 {
                     //if (useCache && argCnt == props[0].GetParameters().Length)

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -1036,7 +1036,7 @@ namespace Internal.Reflection.Execution
             {
                 get
                 {
-                    ParameterInfo[] parameters = _methodBase.GetParametersNoCopy();
+                    ReadOnlySpan<ParameterInfo> parameters = _methodBase.GetParametersAsSpan();
                     LowLevelList<RuntimeTypeHandle> result = new LowLevelList<RuntimeTypeHandle>(parameters.Length);
 
                     for (int i = 0; i < parameters.Length; i++)
@@ -1081,7 +1081,7 @@ namespace Internal.Reflection.Execution
             {
                 get
                 {
-                    ParameterInfo[] parameters = _methodBase.GetParametersNoCopy();
+                    ReadOnlySpan<ParameterInfo> parameters = _methodBase.GetParametersAsSpan();
                     bool[] result = new bool[parameters.Length + 1];
 
                     MethodInfo reflectionMethodInfo = _methodBase as MethodInfo;
@@ -1101,8 +1101,8 @@ namespace Internal.Reflection.Execution
                 {
                     Debug.Assert(_metadataReader != null && !_methodHandle.Equals(default(MethodHandle)));
 
-                    _returnTypeAndParametersHandlesCache = new Handle[_methodBase.GetParametersNoCopy().Length + 1];
-                    _returnTypeAndParametersTypesCache = new Type[_methodBase.GetParametersNoCopy().Length + 1];
+                    _returnTypeAndParametersHandlesCache = new Handle[_methodBase.GetParametersAsSpan().Length + 1];
+                    _returnTypeAndParametersTypesCache = new Type[_methodBase.GetParametersAsSpan().Length + 1];
 
                     MethodSignature signature = _methodHandle.GetMethod(_metadataReader).Signature.GetMethodSignature(_metadataReader);
 
@@ -1116,7 +1116,7 @@ namespace Internal.Reflection.Execution
                     foreach (Handle paramSigHandle in signature.Parameters)
                     {
                         _returnTypeAndParametersHandlesCache[index] = paramSigHandle;
-                        _returnTypeAndParametersTypesCache[index] = _methodBase.GetParametersNoCopy()[index - 1].ParameterType;
+                        _returnTypeAndParametersTypesCache[index] = _methodBase.GetParametersAsSpan()[index - 1].ParameterType;
                         index++;
                     }
                 }

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/PayForPlayExperience/MissingMetadataExceptionCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/PayForPlayExperience/MissingMetadataExceptionCreator.cs
@@ -43,7 +43,7 @@ namespace Internal.Reflection.Execution.PayForPlayExperience
                     // write out actual parameters
                     friendlyName.Append('(');
                     first = true;
-                    foreach (ParameterInfo parameter in method.GetParametersNoCopy())
+                    foreach (ParameterInfo parameter in method.GetParametersAsSpan())
                     {
                         if (!first)
                             friendlyName.Append(',');

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidatorSupport.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/ConstraintValidatorSupport.cs
@@ -289,7 +289,7 @@ namespace Internal.Reflection.Execution
 
             foreach (var ctor in type.GetConstructors())
             {
-                if (!ctor.IsStatic && ctor.IsPublic && ctor.GetParametersNoCopy().Length == 0)
+                if (!ctor.IsStatic && ctor.IsPublic && ctor.GetParametersAsSpan().Length == 0)
                     return true;
             }
             return false;

--- a/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
@@ -68,7 +68,7 @@ namespace System.Runtime.InteropServices
 
             private void PreProcessSignature()
             {
-                ReadOnlySpan<ParameterInfo> parameters = Delegate.Method.GetParametersAsSpan();
+                ParameterInfo[] parameters = Delegate.Method.GetParameters();
                 _expectedParamsCount = parameters.Length;
 
                 Type?[]? targetTypes = null;

--- a/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
@@ -68,7 +68,7 @@ namespace System.Runtime.InteropServices
 
             private void PreProcessSignature()
             {
-                ParameterInfo[] parameters = Delegate.Method.GetParameters();
+                ReadOnlySpan<ParameterInfo> parameters = Delegate.Method.GetParametersAsSpan();
                 _expectedParamsCount = parameters.Length;
 
                 Type?[]? targetTypes = null;

--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -129,7 +129,7 @@ namespace System
                 obj: null,
                 invokeAttr: BindingFlags.DoNotWrapExceptions,
                 binder: null,
-                parameters: entry.GetParameters().Length > 0 ? new object?[] { args } : null,
+                parameters: entry.GetParametersAsSpan().Length > 0 ? new object?[] { args } : null,
                 culture: null);
 
             return result != null ? (int)result : 0;

--- a/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
@@ -52,7 +52,7 @@ namespace System
 
             for (i = 0; i < candidates.Length; i++)
             {
-                ParameterInfo[] par = candidates[i]!.GetParametersNoCopy();
+                ReadOnlySpan<ParameterInfo> par = candidates[i]!.GetParametersAsSpan();
 
                 // args.Length + 1 takes into account the possibility of a last paramArray that can be omitted
                 paramOrder[i] = new int[(par.Length > args.Length) ? par.Length : args.Length];
@@ -104,7 +104,7 @@ namespace System
                 if (candidates[i] == null)
                     continue;
 
-                ParameterInfo[] par = candidates[i]!.GetParametersNoCopy();
+                ReadOnlySpan<ParameterInfo> par = candidates[i]!.GetParametersAsSpan();
 
 #region Match method by parameter count
                 if (par.Length == 0)
@@ -306,7 +306,7 @@ namespace System
 
                 // If the parameters and the args are not the same length or there is a paramArray
                 //  then we need to create a argument array.
-                ParameterInfo[] parms = candidates[0]!.GetParametersNoCopy();
+                ReadOnlySpan<ParameterInfo> parms = candidates[0]!.GetParametersAsSpan();
 
                 if (parms.Length == args.Length)
                 {
@@ -397,7 +397,7 @@ namespace System
 
             // If the parameters and the args are not the same length or there is a paramArray
             //  then we need to create a argument array.
-            ParameterInfo[] parameters = bestMatch.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> parameters = bestMatch.GetParametersAsSpan();
             if (parameters.Length == args.Length)
             {
                 if (paramArrayTypes[currentMin] != null)
@@ -562,7 +562,7 @@ namespace System
             int CurIdx = 0;
             for (i = 0; i < candidates.Length; i++)
             {
-                ParameterInfo[] par = candidates[i].GetParametersNoCopy();
+                ReadOnlySpan<ParameterInfo> par = candidates[i].GetParametersAsSpan();
                 if (par.Length != types.Length)
                     continue;
                 for (j = 0; j < types.Length; j++)
@@ -797,7 +797,7 @@ namespace System
 
             for (int i = 0; i < match.Length; i++)
             {
-                ParameterInfo[] par = match[i].GetParametersNoCopy();
+                ReadOnlySpan<ParameterInfo> par = match[i].GetParametersAsSpan();
                 if (par.Length == 0)
                 {
                     continue;
@@ -861,8 +861,8 @@ namespace System
             return bestMatch;
         }
 
-        private static int FindMostSpecific(ParameterInfo[] p1, int[] paramOrder1, Type? paramArrayType1,
-                                            ParameterInfo[] p2, int[] paramOrder2, Type? paramArrayType2,
+        private static int FindMostSpecific(ReadOnlySpan<ParameterInfo> p1, int[] paramOrder1, Type? paramArrayType1,
+                                            ReadOnlySpan<ParameterInfo> p2, int[] paramOrder2, Type? paramArrayType2,
                                             Type[] types, object?[]? args)
         {
             // A method using params is always less specific than one not using params
@@ -1016,8 +1016,8 @@ namespace System
                                                   Type[] types, object?[]? args)
         {
             // Find the most specific method based on the parameters.
-            int res = FindMostSpecific(m1.GetParametersNoCopy(), paramOrder1, paramArrayType1,
-                                       m2.GetParametersNoCopy(), paramOrder2, paramArrayType2, types, args);
+            int res = FindMostSpecific(m1.GetParametersAsSpan(), paramOrder1, paramArrayType1,
+                                       m2.GetParametersAsSpan(), paramOrder2, paramArrayType2, types, args);
 
             // If the match was not ambiguous then return the result.
             if (res != 0)
@@ -1096,8 +1096,8 @@ namespace System
 
         public static bool CompareMethodSig(MethodBase m1, MethodBase m2)
         {
-            ParameterInfo[] params1 = m1.GetParametersNoCopy();
-            ParameterInfo[] params2 = m2.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> params1 = m1.GetParametersAsSpan();
+            ReadOnlySpan<ParameterInfo> params2 = m2.GetParametersAsSpan();
 
             if (params1.Length != params2.Length)
                 return false;
@@ -1181,7 +1181,7 @@ namespace System
         //  as the values and maps to the parameters of the method.  We store the mapping
         //  from the parameters to the names in the paramOrder array.  All parameters that
         //  don't have matching names are then stored in the array in order.
-        private static bool CreateParamOrder(int[] paramOrder, ParameterInfo[] pars, string[] names)
+        private static bool CreateParamOrder(int[] paramOrder, ReadOnlySpan<ParameterInfo> pars, string[] names)
         {
             bool[] used = new bool[pars.Length];
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
@@ -279,17 +279,19 @@ namespace System.Diagnostics
                         sb.Append(']');
                     }
 
-                    ParameterInfo[]? pi = null;
+                    ReadOnlySpan<ParameterInfo> pi = default;
+                    bool appendParameters = true;
                     try
                     {
-                        pi = mb.GetParameters();
+                        pi = mb.GetParametersAsSpan();
                     }
                     catch
                     {
                         // The parameter info cannot be loaded, so we don't
                         // append the parameter list.
+                        appendParameters = false;
                     }
-                    if (pi != null)
+                    if (appendParameters)
                     {
                         // arguments printing
                         sb.Append('(');

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -329,15 +329,10 @@ namespace System.Reflection.Emit
 
         public override MethodInfo GetBaseDefinition() => this;
 
-        public override ParameterInfo[] GetParameters()
-        {
-            ParameterInfo[] privateParameters = LoadParameters();
-            ParameterInfo[] parameters = new ParameterInfo[privateParameters.Length];
-            Array.Copy(privateParameters, parameters, privateParameters.Length);
-            return parameters;
-        }
+        public override ParameterInfo[] GetParameters() =>
+            GetParametersAsSpan().ToArray();
 
-        internal override ParameterInfo[] GetParametersNoCopy() => LoadParameters();
+        internal override ReadOnlySpan<ParameterInfo> GetParametersAsSpan() => LoadParameters();
 
         public override MethodImplAttributes GetMethodImplementationFlags() =>
             MethodImplAttributes.IL | MethodImplAttributes.NoInlining;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/EventInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/EventInfo.cs
@@ -45,7 +45,7 @@ namespace System.Reflection
             get
             {
                 MethodInfo m = GetAddMethod(true)!;
-                ParameterInfo[] p = m.GetParametersNoCopy();
+                ReadOnlySpan<ParameterInfo> p = m.GetParametersAsSpan();
                 Type del = typeof(Delegate);
                 for (int i = 0; i < p.Length; i++)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokerEmitUtil.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokerEmitUtil.cs
@@ -46,7 +46,7 @@ namespace System.Reflection
             }
 
             // Push the arguments.
-            ParameterInfo[] parameters = method.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> parameters = method.GetParametersAsSpan();
             for (int i = 0; i < parameters.Length; i++)
             {
                 RuntimeType parameterType = (RuntimeType)parameters[i].ParameterType;
@@ -114,7 +114,7 @@ namespace System.Reflection
             }
 
             // Push the arguments.
-            ParameterInfo[] parameters = method.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> parameters = method.GetParametersAsSpan();
             for (int i = 0; i < parameters.Length; i++)
             {
                 RuntimeType parameterType = (RuntimeType)parameters[i].ParameterType;
@@ -171,7 +171,7 @@ namespace System.Reflection
             }
 
             // Push the arguments.
-            ParameterInfo[] parameters = method.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> parameters = method.GetParametersAsSpan();
             for (int i = 0; i < parameters.Length; i++)
             {
                 il.Emit(OpCodes.Ldarg_2);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -125,7 +125,7 @@ namespace System.Reflection
 
         internal virtual Type[] GetParameterTypes()
         {
-            ParameterInfo[] paramInfo = GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> paramInfo = GetParametersAsSpan();
             if (paramInfo.Length == 0)
             {
                 return Type.EmptyTypes;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.cs
@@ -365,7 +365,7 @@ namespace System.Reflection
                 // Convert a Type.Missing to the default value.
                 if (ReferenceEquals(arg, Type.Missing))
                 {
-                    arg = HandleTypeMissing(_method.GetParametersNoCopy()[i], sigType);
+                    arg = HandleTypeMissing(_method.GetParametersAsSpan()[i], sigType);
                     shouldCopyBack[i] = true;
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
@@ -96,7 +96,7 @@ namespace System.Reflection
                 }
                 else
                 {
-                    ParameterInfo[] parameters = metaMethod.GetParameters();
+                    ReadOnlySpan<ParameterInfo> parameters = metaMethod.GetParametersAsSpan();
                     for (int i = 0; i < parameters.Length; i++)
                     {
                         if (parameter.Position == i &&
@@ -200,7 +200,7 @@ namespace System.Reflection
 
             if (setter != null)
             {
-                CheckNullabilityAttributes(nullability, setter.GetParameters()[^1].GetCustomAttributesData());
+                CheckNullabilityAttributes(nullability, setter.GetParametersAsSpan()[^1].GetCustomAttributesData());
             }
             else
             {
@@ -444,7 +444,7 @@ namespace System.Reflection
                 return method.ReturnType;
             }
 
-            return property.GetSetMethod(true)!.GetParameters()[0].ParameterType;
+            return property.GetSetMethod(true)!.GetParametersAsSpan()[0].ParameterType;
         }
 
         private void CheckGenericParameters(NullabilityInfo nullability, MemberInfo metaMember, Type metaType, Type? reflectedType)

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/ParameterInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/ParameterInfo.cs
@@ -65,7 +65,7 @@ namespace System.Reflection
             if (MemberImpl == null)
                 throw new SerializationException(SR.Serialization_InsufficientState);
 
-            ParameterInfo[] args;
+            ReadOnlySpan<ParameterInfo> args;
             switch (MemberImpl.MemberType)
             {
                 case MemberTypes.Constructor:
@@ -79,9 +79,9 @@ namespace System.Reflection
                     }
                     else
                     {
-                        args = ((MethodBase)MemberImpl).GetParametersNoCopy();
+                        args = ((MethodBase)MemberImpl).GetParametersAsSpan();
 
-                        if (args != null && PositionImpl < args.Length)
+                        if (PositionImpl < args.Length)
                             return args[PositionImpl];
                         else
                             throw new SerializationException(SR.Serialization_BadParameterInfo);
@@ -90,7 +90,7 @@ namespace System.Reflection
                 case MemberTypes.Property:
                     args = ((PropertyInfo)MemberImpl).GetIndexParameters();
 
-                    if (args != null && PositionImpl > -1 && PositionImpl < args.Length)
+                    if (PositionImpl > -1 && PositionImpl < args.Length)
                         return args[PositionImpl];
                     else
                         throw new SerializationException(SR.Serialization_BadParameterInfo);

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -658,7 +658,7 @@ namespace System
                 // Invoke
                 if (finalists == null &&
                     argCnt == 0 &&
-                    finalist.GetParametersNoCopy().Length == 0 &&
+                    finalist.GetParametersAsSpan().Length == 0 &&
                     (bindingFlags & BindingFlags.OptionalParamBinding) == 0)
                 {
                     return finalist.Invoke(target, bindingFlags, binder, providedArgs, culture);

--- a/src/libraries/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -209,7 +209,7 @@ namespace System
             Debug.Assert(initializeMethod != null &&
                          initializeMethod.IsStatic &&
                          initializeMethod.ReturnType == typeof(void) &&
-                         initializeMethod.GetParameters().Length == 0);
+                         initializeMethod.GetParametersAsSpan().Length == 0);
 
             initializeMethod.Invoke(null, null);
         }

--- a/src/mono/System.Private.CoreLib/src/System/Delegate.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Delegate.Mono.cs
@@ -210,7 +210,7 @@ namespace System
             if (invoke is null)
                 return null;
 
-            ParameterInfo[] delargs = invoke.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> delargs = invoke.GetParametersAsSpan();
             Type[] delargtypes = new Type[delargs.Length];
 
             for (int i = 0; i < delargs.Length; i++)
@@ -250,8 +250,8 @@ namespace System
                 return false;
             }
 
-            ParameterInfo[] delargs = invoke.GetParametersNoCopy();
-            ParameterInfo[] args = method.GetParametersNoCopy();
+            ReadOnlySpan<ParameterInfo> delargs = invoke.GetParametersAsSpan();
+            ReadOnlySpan<ParameterInfo> args = method.GetParametersAsSpan();
 
             bool argLengthMatch;
 
@@ -437,7 +437,7 @@ namespace System
             MethodInfo? invoke = GetType().GetMethod("Invoke");
             if (invoke != null && args != null)
             {
-                ParameterInfo[] delegateParameters = invoke.GetParameters();
+                ReadOnlySpan<ParameterInfo> delegateParameters = invoke.GetParametersAsSpan();
                 for (int i = 0; i < args.Length; i++)
                 {
                     if (args[i] == Type.Missing)

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -681,7 +681,7 @@ namespace System.Reflection
                     int position = parinfo.Position;
                     if (position == -1)
                         return bmethod.ReturnParameter;
-                    return bmethod.GetParameters()[position];
+                    return bmethod.GetParametersAsSpan()[position];
                 }
             }
             /*

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.Mono.cs
@@ -146,7 +146,7 @@ namespace System.Reflection.Emit
             return _nrefs - 1;
         }
 
-        internal override int GetParametersCount() => GetParametersNoCopy().Length;
+        internal override int GetParametersCount() => GetParametersAsSpan().Length;
 
         private sealed class DynamicMethodTokenGenerator : ITokenGenerator
         {

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/MethodBase.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/MethodBase.Mono.cs
@@ -39,7 +39,7 @@ namespace System.Reflection
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public static extern MethodBase? GetCurrentMethod();
 
-        internal virtual ParameterInfo[] GetParametersNoCopy()
+        internal virtual ReadOnlySpan<ParameterInfo> GetParametersAsSpan()
         {
             return GetParametersInternal();
         }

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.Mono.cs
@@ -190,7 +190,7 @@ namespace System.Reflection
                 sbName.Append(RuntimeMethodHandle.ConstructInstantiation(this));
 
             sbName.Append('(');
-            RuntimeParameterInfo.FormatParameters(sbName, GetParametersNoCopy(), CallingConvention);
+            RuntimeParameterInfo.FormatParameters(sbName, GetParametersAsSpan(), CallingConvention);
             sbName.Append(')');
 
             return sbName.ToString();

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -25,7 +25,7 @@ namespace System.Reflection
             this.marshalAs = marshalAs;
         }
 
-        internal static void FormatParameters(StringBuilder sb, ParameterInfo[] p, CallingConventions callingConvention)
+        internal static void FormatParameters(StringBuilder sb, ReadOnlySpan<ParameterInfo> p, CallingConventions callingConvention)
         {
             for (int i = 0; i < p.Length; ++i)
             {

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -419,7 +419,7 @@ namespace System
             #region If argumentTypes supplied
             if (argumentTypes != null)
             {
-                ParameterInfo[] parameterInfos = methodBase.GetParametersNoCopy();
+                ReadOnlySpan<ParameterInfo> parameterInfos = methodBase.GetParametersAsSpan();
 
                 if (argumentTypes.Length != parameterInfos.Length)
                 {
@@ -820,9 +820,7 @@ namespace System
             if (types.Length == 0 && candidates.Count == 1)
             {
                 ConstructorInfo firstCandidate = candidates[0];
-
-                ParameterInfo[] parameters = firstCandidate.GetParametersNoCopy();
-                if (parameters == null || parameters.Length == 0)
+                if (firstCandidate.GetParametersAsSpan().Length == 0)
                 {
                     return firstCandidate;
                 }
@@ -1557,7 +1555,7 @@ namespace System
                             throw new MissingMethodException(SR.Format(SR.MissingConstructor_Name, FullName));
                         }
 
-                        if (invokeMethod.GetParametersNoCopy().Length == 0)
+                        if (invokeMethod.GetParametersAsSpan().Length == 0)
                         {
                             if (args.Length != 0)
                             {


### PR DESCRIPTION
The internal GetParametersNoCopy avoids a defensive ParameterInfo[] copy, but it requires the callers to promise not to mutate the array. I'm changing the method to return a `ReadOnlySpan<ParameterInfo>`, which means a caller can't mutate it without using unsafe code, and enabling the compiler to flag any misuse.  I've then used it in a few more places. We might subsequently want to consider exposing it publicly.