### PR TITLE
Properly handle debugger-enumerating interior pointers and enregistered refs

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7781,8 +7781,9 @@ HRESULT DacStackReferenceWalker::Next(ULONG count, DacGcReference stackRefs[], U
         stackRefs[i].i64ExtraData = 0;
 
         const SOSStackRefData &sosStackRef = mList.Get(i);
-        if (sosStackRef.Address == 0 || sosStackRef.Flags & GC_CALL_INTERIOR)
+        if (sosStackRef.Flags & GC_CALL_INTERIOR | sosStackRef.Address == 0)
         {
+            // Direct pointer case - interior pointer, Frame ref, or enregistered var.
             stackRefs[i].pObject = CLRDATA_ADDRESS_TO_TADDR(sosStackRef.Object) | 1;
         }
         else

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7781,7 +7781,7 @@ HRESULT DacStackReferenceWalker::Next(ULONG count, DacGcReference stackRefs[], U
         stackRefs[i].i64ExtraData = 0;
 
         const SOSStackRefData &sosStackRef = mList.Get(i);
-        if (sosStackRef.Flags & GC_CALL_INTERIOR | sosStackRef.Address == 0)
+        if (sosStackRef.Flags & GC_CALL_INTERIOR || sosStackRef.Address == 0)
         {
             // Direct pointer case - interior pointer, Frame ref, or enregistered var.
             stackRefs[i].pObject = CLRDATA_ADDRESS_TO_TADDR(sosStackRef.Object) | 1;

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7781,7 +7781,7 @@ HRESULT DacStackReferenceWalker::Next(ULONG count, DacGcReference stackRefs[], U
         stackRefs[i].i64ExtraData = 0;
 
         const SOSStackRefData &sosStackRef = mList.Get(i);
-        if (sosStackRef.Flags & GC_CALL_INTERIOR)
+        if (sosStackRef.Address == 0 || sosStackRef.Flags & GC_CALL_INTERIOR)
         {
             stackRefs[i].pObject = CLRDATA_ADDRESS_TO_TADDR(sosStackRef.Object) | 1;
         }

--- a/src/coreclr/debug/di/rsclass.cpp
+++ b/src/coreclr/debug/di/rsclass.cpp
@@ -132,6 +132,7 @@ HRESULT CordbClass::GetStaticFieldValue(mdFieldDef fieldDef,
     IMetaDataImport * pImport = NULL;
     EX_TRY
     {
+        RSLockHolder lockHolder(GetProcess()->GetProcessLock());
         pImport = GetModule()->GetMetaDataImporter(); // throws
 
         // Validate the token.
@@ -1191,4 +1192,3 @@ HRESULT CordbClass::SearchFieldInfo(
     // Well, the field doesn't even belong to this class...
     ThrowHR(E_INVALIDARG);
 }
-


### PR DESCRIPTION
There is an ancient bug in the dac root walking code.  If we hit an interior pointer on a callstack that lives outside of the GC heap, we will report that pointer as-is to ICorDebug (specifically `CordbRefEnum::Next`).  This is despite the fact that ICorDebug *specifically* requests that the dac only enumerate pointers to real objects.  This non-gc pointer will be treated as a real object pointer and will cause a failed HRESULT in CordbRefEnum.  Since this call is wrapped with `IfFailThrow` it will halt all further processing of roots, leading to not fully capturing the object graph for memory analysis.

This code makes a small, targeted change to not enumerate non-GC pointers when the caller requests we specifically only enumerate pointers to real objects.

This is not a recent regression, but rather a bug that has likely existed since the original code was written.

FYI @asundheim.