### PR TITLE
Bring back CopyOutputSymbolsToPublishDirectory

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -93,7 +93,10 @@
     <!-- replace apphost with binary we generated during native compilation -->
     <Delete Files="$(PublishDir)\$(TargetName)$(NativeBinaryExt)" />
     <Copy SourceFiles="$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)" DestinationFolder="$(PublishDir)" />
+  </Target>
 
+  <Target Name="_CopyAotSymbols" AfterTargets="CopyNativeBinary"
+          Condition="'$(CopyOutputSymbolsToPublishDirectory)' == 'true'">
     <!-- dotnet CLI produces managed debug symbols, which we will delete and copy native symbols instead -->
     <Delete Files="$(PublishDir)\$(TargetName).pdb" />
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -95,7 +95,7 @@
     <Copy SourceFiles="$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)" DestinationFolder="$(PublishDir)" />
   </Target>
 
-  <Target Name="_CopyAotSymbols" AfterTargets="CopyNativeBinary"
+  <Target Name="_CopyAotSymbols" AfterTargets="Publish"
           Condition="'$(CopyOutputSymbolsToPublishDirectory)' == 'true'">
     <!-- dotnet CLI produces managed debug symbols, which we will delete and copy native symbols instead -->
     <Delete Files="$(PublishDir)\$(TargetName).pdb" />


### PR DESCRIPTION
I accidentally removed this property from AOT compilation when adding support for Mac dsym bundles. This change re-enables support for suppressing debugging symbols in the output.

Fixes #92188