### PR TITLE
[RISC-V] Replace Riscv with RiscV

### DIFF
--- a/src/coreclr/gcinfo/gcinfodumper.cpp
+++ b/src/coreclr/gcinfo/gcinfodumper.cpp
@@ -226,7 +226,7 @@ BOOL GcInfoDumper::ReportPointerRecord (
 #undef REG
 #elif defined(TARGET_RISCV64)
 #undef REG
-#define REG(reg, field) { offsetof(Riscv64VolatileContextPointer, field) }
+#define REG(reg, field) { offsetof(RiscV64VolatileContextPointer, field) }
         REG(zero, R0),
         REG(a0, A0),
         REG(a1, A1),

--- a/src/coreclr/inc/regdisp.h
+++ b/src/coreclr/inc/regdisp.h
@@ -211,7 +211,7 @@ typedef struct _Loongarch64VolatileContextPointer
 #endif
 
 #if defined(TARGET_RISCV64)
-typedef struct _Riscv64VolatileContextPointer
+typedef struct _RiscV64VolatileContextPointer
 {
     PDWORD64 R0;
     PDWORD64 A0;
@@ -229,7 +229,7 @@ typedef struct _Riscv64VolatileContextPointer
     PDWORD64 T4;
     PDWORD64 T5;
     PDWORD64 T6;
-} Riscv64VolatileContextPointer;
+} RiscV64VolatileContextPointer;
 #endif
 
 struct REGDISPLAY : public REGDISPLAY_BASE {
@@ -242,7 +242,7 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
 #endif
 
 #ifdef TARGET_RISCV64
-    Riscv64VolatileContextPointer    volatileCurrContextPointers;
+    RiscV64VolatileContextPointer    volatileCurrContextPointers;
 #endif
 
     REGDISPLAY()

--- a/src/coreclr/inc/targetosarch.h
+++ b/src/coreclr/inc/targetosarch.h
@@ -54,7 +54,7 @@ public:
     static const bool IsArm32 = true;
     static const bool IsArmArch = true;
     static const bool IsLoongArch64 = false;
-    static const bool IsRiscv64 = false;
+    static const bool IsRiscV64 = false;
 #elif defined(TARGET_ARM64)
     static const bool IsX86 = false;
     static const bool IsX64 = false;
@@ -62,7 +62,7 @@ public:
     static const bool IsArm32 = false;
     static const bool IsArmArch = true;
     static const bool IsLoongArch64 = false;
-    static const bool IsRiscv64 = false;
+    static const bool IsRiscV64 = false;
 #elif defined(TARGET_AMD64)
     static const bool IsX86 = false;
     static const bool IsX64 = true;
@@ -70,7 +70,7 @@ public:
     static const bool IsArm32 = false;
     static const bool IsArmArch = false;
     static const bool IsLoongArch64 = false;
-    static const bool IsRiscv64 = false;
+    static const bool IsRiscV64 = false;
 #elif defined(TARGET_X86)
     static const bool IsX86 = true;
     static const bool IsX64 = false;
@@ -78,7 +78,7 @@ public:
     static const bool IsArm32 = false;
     static const bool IsArmArch = false;
     static const bool IsLoongArch64 = false;
-    static const bool IsRiscv64 = false;
+    static const bool IsRiscV64 = false;
 #elif defined(TARGET_LOONGARCH64)
     static const bool IsX86 = false;
     static const bool IsX64 = false;
@@ -86,7 +86,7 @@ public:
     static const bool IsArm32 = false;
     static const bool IsArmArch = false;
     static const bool IsLoongArch64 = true;
-    static const bool IsRiscv64 = false;
+    static const bool IsRiscV64 = false;
 #elif defined(TARGET_RISCV64)
     static const bool IsX86 = false;
     static const bool IsX64 = false;
@@ -94,7 +94,7 @@ public:
     static const bool IsArm32 = false;
     static const bool IsArmArch = false;
     static const bool IsLoongArch64 = false;
-    static const bool IsRiscv64 = true;
+    static const bool IsRiscV64 = true;
 #else
 #error Unknown architecture
 #endif

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -7562,7 +7562,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                     assert(!jmp->idAddr()->iiaHasInstrCount());
                     emitOutputLJ(NULL, adr, jmp);
 #elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-                    // For LoongArch64 and Riscv64 `emitFwdJumps` is always false.
+                    // For LoongArch64 and RiscV64 `emitFwdJumps` is always false.
                     unreached();
 #else
 #error Unsupported or unset target architecture
@@ -7578,7 +7578,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                     assert(!jmp->idAddr()->iiaHasInstrCount());
                     emitOutputLJ(NULL, adr, jmp);
 #elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-                    // For LoongArch64 and Riscv64 `emitFwdJumps` is always false.
+                    // For LoongArch64 and RiscV64 `emitFwdJumps` is always false.
                     unreached();
 #else
 #error Unsupported or unset target architecture

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -38,7 +38,7 @@ inline bool compMacOsArm64Abi()
 }
 inline bool compFeatureArgSplit()
 {
-    return TargetArchitecture::IsLoongArch64 || TargetArchitecture::IsArm32 || TargetArchitecture::IsRiscv64 ||
+    return TargetArchitecture::IsLoongArch64 || TargetArchitecture::IsArm32 || TargetArchitecture::IsRiscV64 ||
            (TargetOS::IsWindows && TargetArchitecture::IsArm64);
 }
 inline bool compUnixX86Abi()

--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -467,7 +467,7 @@ UNATIVE_OFFSET Compiler::unwindGetCurrentOffset(FuncInfoDsc* func)
 
 #elif defined(TARGET_RISCV64)
 
-// See unwindRiscV64.cpp
+// See unwindRiscv64.cpp
 
 #else // TARGET*
 

--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -467,7 +467,7 @@ UNATIVE_OFFSET Compiler::unwindGetCurrentOffset(FuncInfoDsc* func)
 
 #elif defined(TARGET_RISCV64)
 
-// See unwindRiscv64.cpp
+// See unwindRiscV64.cpp
 
 #else // TARGET*
 

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -1826,7 +1826,7 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
                 pMethodTable = thValueType.AsNativeValueType();
             }
             _ASSERTE(pMethodTable != nullptr);
-            flags = MethodTable::GetRiscv64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable);
+            flags = MethodTable::GetRiscV64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable);
             if (flags & STRUCT_HAS_FLOAT_FIELDS_MASK)
             {
                 cFPRegs = (flags & STRUCT_FLOAT_FIELD_ONLY_TWO) ? 2 : 1;
@@ -2040,7 +2040,7 @@ void ArgIteratorTemplate<ARGITERATOR_BASE>::ComputeReturnFlags()
                 assert(!thValueType.IsTypeDesc());
 
                 MethodTable *pMethodTable = thValueType.AsMethodTable();
-                flags = (MethodTable::GetRiscv64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable) & 0xff) << RETURN_FP_SIZE_SHIFT;
+                flags = (MethodTable::GetRiscV64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable) & 0xff) << RETURN_FP_SIZE_SHIFT;
                 break;
             }
 #else

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -9527,7 +9527,7 @@ uint32_t CEEInfo::getRISCV64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
     uint32_t size = STRUCT_NO_FLOAT_FIELD;
 
 #if defined(TARGET_RISCV64)
-    size = (uint32_t)MethodTable::GetRiscv64PassStructInRegisterFlags(cls);
+    size = (uint32_t)MethodTable::GetRiscV64PassStructInRegisterFlags(cls);
 #endif // TARGET_RISCV64
 
     EE_TO_JIT_TRANSITION_LEAF();

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3534,7 +3534,7 @@ _End_arg:
 
 #if defined(TARGET_RISCV64)
 
-bool MethodTable::IsRiscv64OnlyOneField(MethodTable * pMT)
+bool MethodTable::IsRiscV64OnlyOneField(MethodTable * pMT)
 {
     TypeHandle th(pMT);
 
@@ -3568,7 +3568,7 @@ bool MethodTable::IsRiscv64OnlyOneField(MethodTable * pMT)
                     pMethodTable  = pFieldStart->GetApproxFieldTypeHandleThrowing().GetMethodTable();
                     if (pMethodTable->GetNumIntroducedInstanceFields() == 1)
                     {
-                        ret = IsRiscv64OnlyOneField(pMethodTable);
+                        ret = IsRiscV64OnlyOneField(pMethodTable);
                     }
                 }
             }
@@ -3621,7 +3621,7 @@ bool MethodTable::IsRiscv64OnlyOneField(MethodTable * pMT)
                     if (nfc == NativeFieldCategory::NESTED)
                     {
                         pMethodTable = pNativeFieldDescs->GetNestedNativeMethodTable();
-                        ret = IsRiscv64OnlyOneField(pMethodTable);
+                        ret = IsRiscV64OnlyOneField(pMethodTable);
                     }
                     else if (nfc != NativeFieldCategory::ILLEGAL)
                     {
@@ -3640,7 +3640,7 @@ _End_arg:
     return ret;
 }
 
-int MethodTable::GetRiscv64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
+int MethodTable::GetRiscV64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
 {
     TypeHandle th(cls);
 
@@ -3679,7 +3679,7 @@ int MethodTable::GetRiscv64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
                 else if (fieldType == ELEMENT_TYPE_VALUETYPE)
                 {
                     pMethodTable  = pFieldStart->GetApproxFieldTypeHandleThrowing().GetMethodTable();
-                    size = GetRiscv64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable);
+                    size = GetRiscV64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable);
                 }
             }
             else if (numIntroducedFields == 2)
@@ -3722,9 +3722,9 @@ int MethodTable::GetRiscv64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
                 else if (fieldType == ELEMENT_TYPE_VALUETYPE)
                 {
                     pMethodTable  = pFieldFirst->GetApproxFieldTypeHandleThrowing().GetMethodTable();
-                    if (IsRiscv64OnlyOneField(pMethodTable))
+                    if (IsRiscV64OnlyOneField(pMethodTable))
                     {
-                        size = GetRiscv64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable);
+                        size = GetRiscV64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable);
                         if ((size & STRUCT_FLOAT_FIELD_ONLY_ONE) != 0)
                         {
                             size = pFieldFirst[0].GetSize() == 8 ? STRUCT_FIRST_FIELD_DOUBLE : STRUCT_FLOAT_FIELD_FIRST;
@@ -3778,9 +3778,9 @@ int MethodTable::GetRiscv64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
                 else if (fieldType == ELEMENT_TYPE_VALUETYPE)
                 {
                     pMethodTable  = pFieldSecond[0].GetApproxFieldTypeHandleThrowing().GetMethodTable();
-                    if (IsRiscv64OnlyOneField(pMethodTable))
+                    if (IsRiscV64OnlyOneField(pMethodTable))
                     {
-                        int size2 = GetRiscv64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable);
+                        int size2 = GetRiscV64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable);
                         if ((size2 & STRUCT_FLOAT_FIELD_ONLY_ONE) != 0)
                         {
                             if (pFieldSecond[0].GetSize() == 8)
@@ -3901,7 +3901,7 @@ int MethodTable::GetRiscv64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
                     if (nfc == NativeFieldCategory::NESTED)
                     {
                         pMethodTable = pNativeFieldDescs->GetNestedNativeMethodTable();
-                        size = GetRiscv64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable);
+                        size = GetRiscV64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable);
                         return size;
                     }
                     else if (nfc == NativeFieldCategory::FLOAT)
@@ -3985,13 +3985,13 @@ int MethodTable::GetRiscv64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
 
                         MethodTable* pMethodTable2 = pNativeFieldDescs->GetNestedNativeMethodTable();
 
-                        if (!IsRiscv64OnlyOneField(pMethodTable2))
+                        if (!IsRiscV64OnlyOneField(pMethodTable2))
                         {
                             size = STRUCT_NO_FLOAT_FIELD;
                             goto _End_arg;
                         }
 
-                        size = GetRiscv64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable2);
+                        size = GetRiscV64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable2);
                         if ((size & STRUCT_FLOAT_FIELD_ONLY_ONE) != 0)
                         {
                             if (pFieldStart->GetSize() == 8)
@@ -4081,13 +4081,13 @@ int MethodTable::GetRiscv64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
 
                         MethodTable* pMethodTable2 = pNativeFieldDescs[1].GetNestedNativeMethodTable();
 
-                        if (!IsRiscv64OnlyOneField(pMethodTable2))
+                        if (!IsRiscV64OnlyOneField(pMethodTable2))
                         {
                             size = STRUCT_NO_FLOAT_FIELD;
                             goto _End_arg;
                         }
 
-                        if ((GetRiscv64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable2) & STRUCT_FLOAT_FIELD_ONLY_ONE) != 0)
+                        if ((GetRiscV64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable2) & STRUCT_FLOAT_FIELD_ONLY_ONE) != 0)
                         {
                             if (pFieldStart[1].GetSize() == 4)
                             {

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -775,8 +775,8 @@ public:
 #endif
 
 #if defined(TARGET_RISCV64)
-    static bool IsRiscv64OnlyOneField(MethodTable * pMT);
-    static int GetRiscv64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE clh);
+    static bool IsRiscV64OnlyOneField(MethodTable * pMT);
+    static int GetRiscV64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE clh);
 #endif
 
 #if defined(UNIX_AMD64_ABI_ITF)


### PR DESCRIPTION
We changed the casing from Riscv to RiscV since the V component is a different pronounced word.
https://github.com/dotnet/runtime/issues/73437#issuecomment-1716122572

cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @alpencolt @gbalykov @clamp03 @Sirntar @yurai007