### PR TITLE
JIT: Fix invalid containment of vector broadcasts

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -19636,8 +19636,8 @@ GenTree* Compiler::gtNewSimdBinOpNode(
     }
     else
     {
-        assert(op2->TypeIs(type, simdBaseType, genActualType(simdBaseType)) ||
-               (op2->TypeIs(TYP_SIMD12) && type == TYP_SIMD16));
+        assert((genActualType(op2) == genActualType(type)) || (genActualType(op2) == genActualType(simdBaseType)) ||
+               (op2->TypeIs(TYP_SIMD12) && (type == TYP_SIMD16)));
     }
 
     NamedIntrinsic intrinsic = NI_Illegal;

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -7956,6 +7956,9 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* parentNode, GenTre
                         // The memory form of this already takes a pointer and should be treated like a MemoryLoad
                         supportsGeneralLoads = !childNode->OperIsHWIntrinsic();
                     }
+
+                    supportsGeneralLoads =
+                        supportsGeneralLoads && (genTypeSize(childNode) >= genTypeSize(parentNode->GetSimdBaseType()));
                     break;
                 }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_83387/Runtime_83387.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_83387/Runtime_83387.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Runtime_83387
+{
+    [MethodImpl(MethodImplOptions.NoOptimization)]
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        (ushort A, ushort R) c = (1, 65535);
+        Vector128<uint> v1 = Vector128.Create((uint)100);
+        v1 = v1 * c.A;
+        return (int)v1.ToScalar();
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_83387/Runtime_83387.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_83387/Runtime_83387.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The containment checks for vector broadcasts were missing a size check, meaning that a uint broadcast could contain a ubyte/ushort indirection. That would lead to out-of-bounds reads.

Fix #83387