### PR TITLE
[Mono]: Add missing case for constrained gsharedvt call.

### DIFF
--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -2892,7 +2892,8 @@ info_equal (gpointer data1, gpointer data2, MonoRgctxInfoType info_type)
 		return data1 == data2;
 	case MONO_RGCTX_INFO_VIRT_METHOD:
 	case MONO_RGCTX_INFO_VIRT_METHOD_CODE:
-	case MONO_RGCTX_INFO_VIRT_METHOD_BOX_TYPE: {
+	case MONO_RGCTX_INFO_VIRT_METHOD_BOX_TYPE:
+	case MONO_RGCTX_INFO_GSHAREDVT_CONSTRAINED_CALL_INFO: {
 		MonoJumpInfoVirtMethod *info1 = (MonoJumpInfoVirtMethod *)data1;
 		MonoJumpInfoVirtMethod *info2 = (MonoJumpInfoVirtMethod *)data2;
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/commit/1b788f4dc3e3a8829488e52c032ad6a70671e070 added a new value to our MonoRgctxInfoType enum type, but appears that all cases where not full adjusted. Running System.Buffers tests in full AOT hits the assert in `info_equal` about missing case, https://github.com/dotnet/runtime/blob/0dc5903679606b072adac70a268cdb77d1147b3e/src/mono/mono/mini/mini-generic-sharing.c#L2908.

This commit adds the new enum value and align handling similar to other cases added by [that commit](https://github.com/dotnet/runtime/commit/1b788f4dc3e3a8829488e52c032ad6a70671e070). After the fix System.Buffers test pass using full AOT.