### PR TITLE
[browser] Fix SIMD+EH check

### DIFF
--- a/src/mono/wasm/runtime/globals.ts
+++ b/src/mono/wasm/runtime/globals.ts
@@ -68,6 +68,12 @@ export function setRuntimeGlobals(globalObjects: GlobalObjects) {
         beforeOnRuntimeInitialized: createPromiseController<void>(),
         afterOnRuntimeInitialized: createPromiseController<void>(),
         afterPostRun: createPromiseController<void>(),
+        mono_wasm_exit: () => {
+            throw new Error("Mono shutdown");
+        },
+        abort: (reason: any) => {
+            throw reason;
+        }
     });
 
     Object.assign(globalObjects.module.config!, {}) as any;

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -41,10 +41,7 @@ import { assertNoProxies } from "./gc-handles";
 const MONO_PTHREAD_POOL_SIZE = 4;
 
 export async function configureRuntimeStartup(): Promise<void> {
-    
-
     await init_polyfills_async();
-
     await checkMemorySnapshotSize();
 }
 
@@ -465,7 +462,7 @@ async function instantiate_wasm_module(
         Module.addRunDependency("instantiate_wasm_module");
 
         const wasmFeaturePromise = ensureUsedWasmFeatures();
-        
+
         replace_linker_placeholders(imports);
         const assetToLoad = await loaderHelpers.wasmDownloadPromise.promise;
         

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -367,12 +367,6 @@ function mono_wasm_pre_init_essential(isWorker: boolean): void {
     }
 
     init_c_exports();
-    runtimeHelpers.mono_wasm_exit = () => {
-        throw new Error("Mono shutdown");
-    };
-    runtimeHelpers.abort = (reason: any) => {
-        throw reason;
-    };
     cwraps_internal(INTERNAL);
     if (WasmEnableLegacyJsInterop && !linkerDisableLegacyJsInterop) {
         cwraps_mono_api(MONO);
@@ -473,7 +467,7 @@ async function instantiate_wasm_module(
         replace_linker_placeholders(imports);
         const assetToLoad = await loaderHelpers.wasmDownloadPromise.promise;
 
-        await ensureWasmUsedFeatures();
+        await ensureUsedWasmFeatures();
         await instantiate_wasm_asset(assetToLoad, imports, successCallback);
         assetToLoad.pendingDownloadInternal = null as any; // GC
         assetToLoad.pendingDownload = null as any; // GC
@@ -505,7 +499,7 @@ async function instantiate_wasm_module(
     Module.removeRunDependency("instantiate_wasm_module");
 }
 
-async function ensureWasmUsedFeatures() {
+async function ensureUsedWasmFeatures() {
     if (linkerWasmEnableSIMD) {
         mono_assert(await loaderHelpers.simd(), "This browser/engine doesn't support WASM SIMD. Please use a modern version. See also https://aka.ms/dotnet-wasm-features");
     }

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -464,10 +464,12 @@ async function instantiate_wasm_module(
         await runtimeHelpers.beforePreInit.promise;
         Module.addRunDependency("instantiate_wasm_module");
 
+        const wasmFeaturePromise = ensureUsedWasmFeatures();
+        
         replace_linker_placeholders(imports);
         const assetToLoad = await loaderHelpers.wasmDownloadPromise.promise;
-
-        await ensureUsedWasmFeatures();
+        
+        await wasmFeaturePromise;
         await instantiate_wasm_asset(assetToLoad, imports, successCallback);
         assetToLoad.pendingDownloadInternal = null as any; // GC
         assetToLoad.pendingDownload = null as any; // GC


### PR DESCRIPTION
- Before this change the `linkerWasmEnableSIMD` and `linkerWasmEnableEH` used in `configureRuntimeStartup` to check support for these features always had the default (`true`) value. Throwing assert error even when SIMD and EH was disabled for build.
- Call `cwraps.mono_wasm_abort` from `runtimeHelpers.abort` only after cwraps are ready (`onRuntimeInitializedAsync`).