### PR TITLE
JIT: fix self-conflicting HFA arg prolog handling for arm64

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -417,10 +417,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestNativeAot)' == 'true' and '$(RunDisabledNativeAotTests)' != 'true'">
-    <!-- https://github.com/dotnet/runtime/issues/83167 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Numerics.Vectors\tests\System.Numerics.Vectors.Tests.csproj"
-                       Condition="'$(TargetArchitecture)' == 'arm64'" />
-
     <!-- https://github.com/dotnet/runtime/issues/72908 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.MetadataLoadContext\tests\System.Reflection.MetadataLoadContext.Tests.csproj" />
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_83167/Runtime_83167.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_83167/Runtime_83167.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_83167
+{
+    [MethodImpl(MethodImplOptions.NoOptimization)]
+    [Fact]
+    public static int Problem()
+    {
+        Plane p = new Plane (new Vector3(2.0f, 3.0f, 4.0f), 1.0f);
+        int pH = p.GetHashCode();
+        EqualityComparer<Plane> c = EqualityComparer<Plane>.Default;
+        int cH = c.GetHashCode(p);
+        if (pH != cH)
+        {
+            Console.WriteLine($"Failed: {pH:X8} != {cH:X8}");
+            return 101;
+        }
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_83167/Runtime_83167.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_83167/Runtime_83167.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix prolog handling in the case where the in-body destination register
for an HFA overlaps with one of the HFA argument registers. For instance
the HFA is passed in `s0-s3` and needs to end up in `v3`.

This requires special handling because the dependence analysis done in
`genFnPrologCalleeRegArgs` only tracks entire registers, not parts of
registers.

Fixes #83167