### PR TITLE
Use Utf8JsonWriterCache in JsonNode.To{Json}String

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfT.cs
@@ -72,8 +72,17 @@ namespace System.Text.Json.Nodes
                 return element.ValueKind;
             }
 
-            using PooledByteBufferWriter output = WriteToPooledBuffer();
-            return JsonElement.ParseValue(output.WrittenMemory.Span, options: default).ValueKind;
+            Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriterAndBuffer(default, JsonSerializerOptions.BufferSizeDefault, out PooledByteBufferWriter output);
+            try
+            {
+                WriteTo(writer);
+                writer.Flush();
+                return JsonElement.ParseValue(output.WrittenMemory.Span, options: default).ValueKind;
+            }
+            finally
+            {
+                Utf8JsonWriterCache.ReturnWriterAndBuffer(writer, output);
+            }
         }
 
         internal sealed override bool DeepEqualsCore(JsonNode? otherNode)
@@ -107,9 +116,21 @@ namespace System.Text.Json.Nodes
                 }
             }
 
-            using PooledByteBufferWriter thisOutput = WriteToPooledBuffer();
-            using PooledByteBufferWriter otherOutput = otherNode.WriteToPooledBuffer();
+            using PooledByteBufferWriter thisOutput = WriteToPooledBuffer(this);
+            using PooledByteBufferWriter otherOutput = WriteToPooledBuffer(otherNode);
             return thisOutput.WrittenMemory.Span.SequenceEqual(otherOutput.WrittenMemory.Span);
+
+            static PooledByteBufferWriter WriteToPooledBuffer(
+                JsonNode node,
+                JsonSerializerOptions? options = null,
+                JsonWriterOptions writerOptions = default,
+                int bufferSize = JsonSerializerOptions.BufferSizeDefault)
+            {
+                var bufferWriter = new PooledByteBufferWriter(bufferSize);
+                using var writer = new Utf8JsonWriter(bufferWriter, writerOptions);
+                node.WriteTo(writer, options);
+                return bufferWriter;
+            }
         }
 
         internal TypeToConvert ConvertJsonElement<TypeToConvert>()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriterCache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriterCache.cs
@@ -13,7 +13,10 @@ namespace System.Text.Json
         [ThreadStatic]
         private static ThreadLocalState? t_threadLocalState;
 
-        public static Utf8JsonWriter RentWriterAndBuffer(JsonSerializerOptions options, out PooledByteBufferWriter bufferWriter)
+        public static Utf8JsonWriter RentWriterAndBuffer(JsonSerializerOptions options, out PooledByteBufferWriter bufferWriter) =>
+            RentWriterAndBuffer(options.GetWriterOptions(), options.DefaultBufferSize, out bufferWriter);
+
+        public static Utf8JsonWriter RentWriterAndBuffer(JsonWriterOptions options, int defaultBufferSize, out PooledByteBufferWriter bufferWriter)
         {
             ThreadLocalState state = t_threadLocalState ??= new();
             Utf8JsonWriter writer;
@@ -24,14 +27,14 @@ namespace System.Text.Json
                 bufferWriter = state.BufferWriter;
                 writer = state.Writer;
 
-                bufferWriter.InitializeEmptyInstance(options.DefaultBufferSize);
-                writer.Reset(bufferWriter, options.GetWriterOptions());
+                bufferWriter.InitializeEmptyInstance(defaultBufferSize);
+                writer.Reset(bufferWriter, options);
             }
             else
             {
                 // We're in a recursive JsonSerializer call -- return fresh instances.
-                bufferWriter = new PooledByteBufferWriter(options.DefaultBufferSize);
-                writer = new Utf8JsonWriter(bufferWriter, options.GetWriterOptions());
+                bufferWriter = new PooledByteBufferWriter(defaultBufferSize);
+                writer = new Utf8JsonWriter(bufferWriter, options);
             }
 
             return writer;


### PR DESCRIPTION
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Text.Json;
using System.Text.Json.Nodes;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[HideColumns("Error", "StdDev", "Median", "RatioSD", "Job")]
[MemoryDiagnoser(false)]
public class Tests
{
    private JsonNode _json = JsonNode.Parse("""
        {
          "employees": [
              {
                "Jane": {
                  "age": 30,
                  "position": "developer"
                }
              },
              {
                "John": {
                  "age": 30,
                  "position": "designer"
                }
              }]
        }
        """);
    private JsonNode _value = JsonValue.Create(42);

    [Benchmark] public new string ToString() => _json.ToString();
    [Benchmark] public string ToJsonString() => _json.ToJsonString();
    [Benchmark] public JsonValueKind GetValueKind() => _value.GetValueKind();
}
```

| Method       | Toolchain         | Mean     | Ratio | Allocated | Alloc Ratio |
|------------- |------------------ |---------:|------:|----------:|------------:|
| ToString     | \main\corerun.exe | 596.4 ns |  1.00 |     600 B |        1.00 |
| ToString     | \pr\corerun.exe   | 566.2 ns |  0.95 |     448 B |        0.75 |
|              |                   |          |       |           |             |
| ToJsonString | \main\corerun.exe | 486.9 ns |  1.00 |     376 B |        1.00 |
| ToJsonString | \pr\corerun.exe   | 471.9 ns |  0.97 |     224 B |        0.60 |
|              |                   |          |       |           |             |
| GetValueKind | \main\corerun.exe | 180.6 ns |  1.00 |     296 B |        1.00 |
| GetValueKind | \pr\corerun.exe   | 163.6 ns |  0.91 |     144 B |        0.49 |