### PR TITLE
[browser] Remove duplicated marshaling of return value for JSExport

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportCodeGenerator.cs
@@ -205,7 +205,6 @@ namespace Microsoft.Interop.JavaScript
                      IdentifierName(nativeIdentifier), invocation));
 
                 statements.Add(statement);
-                statements.AddRange(_marshallers.ManagedReturnMarshaller.Generator.Generate(_marshallers.ManagedReturnMarshaller.TypeInfo, _context with { CurrentStage = StubCodeContext.Stage.Marshal }));
             }
             return TryStatement(SingletonList(CatchClause()
                         .WithDeclaration(CatchDeclaration(IdentifierName(Constants.ExceptionGlobal)).WithIdentifier(Identifier("ex")))

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportCodeGenerator.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Interop.JavaScript
 
         public BlockSyntax GenerateJSExportBody()
         {
-            StatementSyntax invoke = InvokeSyntax();
+            List<StatementSyntax> invoke = InvokeSyntax();
             GeneratedStatements statements = GeneratedStatements.Create(_marshallers, _context);
             bool shouldInitializeVariables = !statements.GuaranteedUnmarshal.IsEmpty || !statements.CleanupCallerAllocated.IsEmpty || !statements.CleanupCalleeAllocated.IsEmpty;
             VariableDeclarations declarations = VariableDeclarations.GenerateDeclarationsForUnmanagedToManaged(_marshallers, _context, shouldInitializeVariables);
@@ -79,7 +79,7 @@ namespace Microsoft.Interop.JavaScript
             var tryStatements = new List<StatementSyntax>();
             tryStatements.AddRange(statements.Unmarshal);
 
-            tryStatements.Add(invoke);
+            tryStatements.AddRange(invoke);
 
             if (!(statements.GuaranteedUnmarshal.IsEmpty && statements.CleanupCalleeAllocated.IsEmpty))
             {
@@ -93,6 +93,18 @@ namespace Microsoft.Interop.JavaScript
             tryStatements.AddRange(statements.Marshal);
 
             List<StatementSyntax> allStatements = setupStatements;
+
+            // Wrap unmarshall, invocation and return value marshalling in try-catch.
+            // In case of exception, marshal exception instead of return value.
+            var tryInvokeAndMarshal = TryStatement(SingletonList(CatchClause()
+                        .WithDeclaration(CatchDeclaration(IdentifierName(Constants.ExceptionGlobal)).WithIdentifier(Identifier("ex")))
+                        .WithBlock(Block(SingletonList<StatementSyntax>(
+                            ExpressionStatement(InvocationExpression(
+                                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                                IdentifierName(Constants.ArgumentException), IdentifierName(Constants.ToJSMethod)))
+                            .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(IdentifierName("ex")))))))))))
+                .WithBlock(Block(tryStatements));
+
             List<StatementSyntax> finallyStatements = new List<StatementSyntax>();
             if (!(statements.GuaranteedUnmarshal.IsEmpty && statements.CleanupCalleeAllocated.IsEmpty))
             {
@@ -100,15 +112,13 @@ namespace Microsoft.Interop.JavaScript
             }
 
             finallyStatements.AddRange(statements.CleanupCallerAllocated);
+
             if (finallyStatements.Count > 0)
             {
-                allStatements.Add(
-                    TryStatement(Block(tryStatements), default, FinallyClause(Block(finallyStatements))));
+                tryInvokeAndMarshal = TryStatement(Block(tryInvokeAndMarshal), default, FinallyClause(Block(finallyStatements)));
             }
-            else
-            {
-                allStatements.AddRange(tryStatements);
-            }
+
+            allStatements.Add(tryInvokeAndMarshal);
 
             return Block(allStatements);
         }
@@ -175,7 +185,7 @@ namespace Microsoft.Interop.JavaScript
                     Argument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(1)))))))))))));
         }
 
-        private TryStatementSyntax InvokeSyntax()
+        private List<StatementSyntax> InvokeSyntax()
         {
             var statements = new List<StatementSyntax>();
             var arguments = new List<ArgumentSyntax>();
@@ -206,14 +216,7 @@ namespace Microsoft.Interop.JavaScript
 
                 statements.Add(statement);
             }
-            return TryStatement(SingletonList(CatchClause()
-                        .WithDeclaration(CatchDeclaration(IdentifierName(Constants.ExceptionGlobal)).WithIdentifier(Identifier("ex")))
-                        .WithBlock(Block(SingletonList<StatementSyntax>(
-                            ExpressionStatement(InvocationExpression(
-                                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                IdentifierName(Constants.ArgumentException), IdentifierName(Constants.ToJSMethod)))
-                            .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(IdentifierName("ex")))))))))))
-                .WithBlock(Block(statements));
+            return statements;
 
         }
 


### PR DESCRIPTION
- Remove duplicated marshaling of return value for JSExport
- Move unmarshal arguments into try block, so it behaves the as marshaling return value. Exceptions from unmarshal and marshal are all transfered to JS as exception

Before

```c#
[global::System.Diagnostics.DebuggerNonUserCode]
internal static unsafe void __Wrapper_X_1038483311(global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument* __arguments_buffer)
{
    int a;
    int b;
    ref global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument __arg_exception = ref __arguments_buffer[0];
    ref global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument __arg_return = ref __arguments_buffer[1];
    int __retVal = default;
    // Setup - Perform required setup.
    ref global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument __b_native__js_arg = ref __arguments_buffer[3];
    ref global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument __a_native__js_arg = ref __arguments_buffer[2];
    // Unmarshal - Convert native data to managed data.
    __b_native__js_arg.ToManaged(out b);
    __a_native__js_arg.ToManaged(out a);
    try
    {
        __retVal = Sample.Test.X(a, b);
        __arg_return.ToJS(__retVal);
    }
    catch (global::System.Exception ex)
    {
        __arg_exception.ToJS(ex);
    }

    // Marshal - Convert managed data to native data.
    __arg_return.ToJS(__retVal);
}
```

After
```c#
[global::System.Diagnostics.DebuggerNonUserCode]
internal static unsafe void __Wrapper_X_313009907(global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument* __arguments_buffer)
{
    int a;
    int b;
    ref global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument __arg_exception = ref __arguments_buffer[0];
    ref global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument __arg_return = ref __arguments_buffer[1];
    int __retVal = default;
    // Setup - Perform required setup.
    ref global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument __b_native__js_arg = ref __arguments_buffer[3];
    ref global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument __a_native__js_arg = ref __arguments_buffer[2];
    try
    {
        // Unmarshal - Convert native data to managed data.
        __b_native__js_arg.ToManaged(out b);
        __a_native__js_arg.ToManaged(out a);
        __retVal = Sample.Test.X(a, b);
        // Marshal - Convert managed data to native data.
        __arg_return.ToJS(__retVal);
    }
    catch (global::System.Exception ex)
    {
        __arg_exception.ToJS(ex);
    }
}
```

Fixes https://github.com/dotnet/runtime/issues/92400