### PR TITLE
Clarify MatchAbbreviatedMonthName comment

### DIFF
--- a/src/libraries/System.Globalization.Calendars/tests/Misc/MiscCalendars.cs
+++ b/src/libraries/System.Globalization.Calendars/tests/Misc/MiscCalendars.cs
@@ -49,10 +49,12 @@ namespace System.Globalization.Tests
         [InlineData(@"Thg 10", 10)]
         [InlineData(@"Thg 11", 11)]
         [InlineData(@"Thg 12", 12)]
-        public void VietnameseTest_MatchAbbreviatedMonthName_ContinuesSearchAfterMatch(string monthAbberavition, int expectedMonthNum)
+        //[InlineData(@"Thg 13", 13)] Needs supported calendar with 13 months
+        public static void VietnameseTest_MatchAbbreviatedMonthName_ContinuesSearchAfterMatch(string monthAbberavition, int expectedMonthNum)
         {
-            var vi = new System.Globalization.CultureInfo("vi-VN");
-            Assert.Equal(expectedMonthNum, DateTime.ParseExact(monthAbberavition, "MMM", vi.DateTimeFormat).Month);
+            var dtfi = new System.Globalization.CultureInfo("vi-VN").DateTimeFormat;
+            dtfi.AbbreviatedMonthNames = new string[] { "Thg 1", "Thg 2", "Thg 3", "Thg 4", "Thg 5", "Thg 6", "Thg 7", "Thg 8", "Thg 9", "Thg 10", "Thg 11", "Thg 12", "Thg 13" }; // 13 months
+            Assert.Equal(expectedMonthNum, DateTime.ParseExact(monthAbberavition, "MMM", dtfi).Month);
         }
     }
 }

--- a/src/libraries/System.Globalization.Calendars/tests/Misc/MiscCalendars.cs
+++ b/src/libraries/System.Globalization.Calendars/tests/Misc/MiscCalendars.cs
@@ -42,5 +42,17 @@ namespace System.Globalization.Tests
             DateTime dTest = jCal.ToDateTime(1, 1, 8, 0, 0, 0, 0, 4);
             Assert.Equal(dTest, new DateTime(1989, 1, 8));
         }
+        
+        [Theory]
+        [InlineData(@"Thg 1", 1)]
+        [InlineData(@"Thg 2", 2)]
+        [InlineData(@"Thg 10", 10)]
+        [InlineData(@"Thg 11", 11)]
+        [InlineData(@"Thg 12", 12)]
+        public void VietnameseTest_MatchAbbreviatedMonthName_ContinuesSearchAfterMatch(string monthAbberavition, int expectedMonthNum)
+        {
+            var vi = new System.Globalization.CultureInfo("vi-VN");
+            Assert.Equal(expectedMonthNum, DateTime.ParseExact(monthAbberavition, "MMM", vi.DateTimeFormat).Month);
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -3352,9 +3352,9 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
                 {
                     // Scan the month names (note that some calendars has 13 months) and find
                     // the matching month name which has the max string length.
-                    // We need to do this because some cultures (e.g. "cs-CZ") which have
-                    // abbreviated month names with the same prefix.
-                    int monthsInYear = (dtfi.GetMonthName(13).Length == 0 ? 12 : 13);
+                    // We need to do this because some cultures which have abbreviated
+                    // month names with the same prefix (e.g. "vi-VN" culture has those conflicts "Thg1", "Thg10", "Thg11")
+                    int monthsInYear = (dtfi.GetAbbreviatedMonthName(13).Length == 0 ? 12 : 13);
                     for (int i = 1; i <= monthsInYear; i++)
                     {
                         string searchStr = dtfi.GetAbbreviatedMonthName(i);


### PR DESCRIPTION
### Context

When admiring the code of `MatchAbbreviatedMonthName` (credit to @cincuranet for pointing such gem) I found 2 nits:
 * comment incorrectly mentions cs-CZ culture as having month abberavitions with same prefixes.
 * the number of months is tested via `GetMonthName` (probably copied from `MatchMonthName`?), while following code calls `GetAbbreviatedMonthName`. Materializing `monthNames` is unnecessary here.

### Details

Getting all the cultures (from my system) that have conflicting prefixes of abberavited month names:

```csharp
    foreach (var cultureInfo in CultureInfo.GetCultures(CultureTypes.AllCultures))
    {
        DateTimeFormatInfo dtfi = cultureInfo.DateTimeFormat;

        int monthsInYear = (dtfi.GetAbbreviatedMonthName(13).Length == 0 ? 12 : 13);

        List<string> monthsAbbreviations =
            Enumerable.Range(1, monthsInYear)
                .Select(dtfi.GetAbbreviatedMonthName)
                .ToList();

        List<string> conflictingTuples = 
            // month indexes combinations
        Enumerable.Range(0, monthsInYear)
            .SelectMany(m1 => Enumerable.Range(m1 + 1, monthsInYear - m1 - 1).Select(m2 => (m1, m2)))
            // that are conflicting
            .Where(tpl =>
                monthsAbbreviations[tpl.m1].StartsWith(monthsAbbreviations[tpl.m2], true, cultureInfo)
                ||
                monthsAbbreviations[tpl.m2].StartsWith(monthsAbbreviations[tpl.m1], true, cultureInfo)
            )
            .Select(tpl => monthsAbbreviations[tpl.m1] + " : " + monthsAbbreviations[tpl.m2])
            .ToList();

        if (conflictingTuples.Any())
        {
            Console.WriteLine($"{cultureInfo.DisplayName} ({cultureInfo.Name}) : " + string.Join(", ", conflictingTuples));
        }
        else
        {
            // Console.WriteLine(cultureInfo.DisplayName + ": OK");
        }
    }
```

```
Tibetan (bo) : ???? : ?????, ???? : ?????, ???? : ?????
Tibetan (China) (bo-CN) : ???? : ?????, ???? : ?????, ???? : ?????
Tibetan (India) (bo-IN) : ???? : ?????, ???? : ?????, ???? : ?????
Duala (dua) : di : di?, di : di?
Duala (Cameroon) (dua-CM) : di : di?, di : di?
Dzongkha (dz) : ???? : ?????, ???? : ?????, ???? : ?????
Dzongkha (Bhutan) (dz-BT) : ???? : ?????, ???? : ?????, ???? : ?????
Ewondo (ewo) : nga : ngad, nga : ngab
Ewondo (Cameroon) (ewo-CM) : nga : ngad, nga : ngab
Guarani (gn) : Jasypo : Jasypotei, Jasypo : Jasypokoi, Jasypo : Jasypoapy, Jasypo : Jasyporundy, Jasypa : Jasypatei, Jasypa : Jasypakoi
Guarani (Paraguay) (gn-PY) : Jasypo : Jasypotei, Jasypo : Jasypokoi, Jasypo : Jasypoapy, Jasypo : Jasyporundy, Jasypa : Jasypatei, Jasypa : Jasypakoi
Bafia (ksf) : ?1 : ?10, ?1 : ?11, ?1 : ?12
Bafia (Cameroon) (ksf-CM) : ?1 : ?10, ?1 : ?11, ?1 : ?12
Cornish (kw) : Meu : Me, Me : Met
Cornish (United Kingdom) (kw-GB) : Meu : Me, Me : Met
Luba-Katanga (lu) : Lus : Lush
Luba-Katanga (Congo [DRC]) (lu-CD) : Lus : Lush
Kwasio (nmg) : ng1 : ng10, ng1 : ng11
Kwasio (Cameroon) (nmg-CM) : ng1 : ng10, ng1 : ng11
Rombo (rof) : M1 : M10, M1 : M11, M1 : M12
Rombo (Tanzania) (rof-TZ) : M1 : M10, M1 : M11, M1 : M12
Vietnamese (vi) : Thg 1 : Thg 10, Thg 1 : Thg 11, Thg 1 : Thg 12
Vietnamese (Vietnam) (vi-VN) : Thg 1 : Thg 10, Thg 1 : Thg 11, Thg 1 : Thg 12
Yangben (yav) : o.1 : o.10, o.1 : o.11, o.1 : o.12
Yangben (Cameroon) (yav-CM) : o.1 : o.10, o.1 : o.11, o.1 : o.12
```

*Conclusion:* Conflicts exist, so the code is correct - it cannot short circuit exit matching after first match identified. However the culture mentioned in the comment is not one of the cases. It originaly confused me - I thought the code was copy-pasted from `MatchMonthName` - where cs-CZ realy hase conflicting prefixes of full month names ("červen", "červenec").