### PR TITLE
[H/3] Remove waiting on tasks from H3 request stream dispose

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
@@ -196,7 +196,7 @@ namespace System.Net.Test.Common
             }
         }
 
-        public async Task<byte[]> ReadRequestBodyAsync()
+        public async Task<byte[]> ReadRequestBodyAsync(int minimumBytes = -1)
         {
             var buffer = new MemoryStream();
 
@@ -211,6 +211,10 @@ namespace System.Net.Test.Common
                         break;
                     case null:
                         return buffer.ToArray();
+                }
+                if (minimumBytes >= 0 && buffer.Length >= minimumBytes)
+                {
+                    return buffer.ToArray();
                 }
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -31,8 +31,6 @@ namespace System.Net.Http
         private TaskCompletionSource<bool>? _expect100ContinueCompletionSource; // True indicates we should send content (e.g. received 100 Continue).
         private bool _disposed;
         private readonly CancellationTokenSource _requestBodyCancellationSource;
-        private Task? _sendRequestTask; // Set with SendContentAsync, must be awaited before QuicStream.DisposeAsync();
-        private Task? _readResponseTask; // Set with ReadResponseAsync, must be awaited before QuicStream.DisposeAsync();
 
         // Allocated when we receive a :status header.
         private HttpResponseMessage? _response;
@@ -90,24 +88,8 @@ namespace System.Net.Http
             {
                 _disposed = true;
                 AbortStream();
-                // We aborted both sides, thus both task should unblock and should be finished before disposing the QuicStream.
-                WaitUnfinished(_sendRequestTask);
-                WaitUnfinished(_readResponseTask);
                 _stream.Dispose();
                 DisposeSyncHelper();
-            }
-
-            static void WaitUnfinished(Task? task)
-            {
-                if (task is not null && !task.IsCompleted)
-                {
-                    try
-                    {
-                        task.GetAwaiter().GetResult();
-                    }
-                    catch // Exceptions from both tasks are logged via _connection.LogException() in case they're not awaited in SendAsync, so the exception can be ignored here.
-                    { }
-                }
             }
         }
 
@@ -125,24 +107,8 @@ namespace System.Net.Http
             {
                 _disposed = true;
                 AbortStream();
-                // We aborted both sides, thus both task should unblock and should be finished before disposing the QuicStream.
-                await AwaitUnfinished(_sendRequestTask).ConfigureAwait(false);
-                await AwaitUnfinished(_readResponseTask).ConfigureAwait(false);
                 await _stream.DisposeAsync().ConfigureAwait(false);
                 DisposeSyncHelper();
-            }
-
-            static async ValueTask AwaitUnfinished(Task? task)
-            {
-                if (task is not null && !task.IsCompleted)
-                {
-                    try
-                    {
-                        await task.ConfigureAwait(false);
-                    }
-                    catch // Exceptions from both tasks are logged via _connection.LogException() in case they're not awaited in SendAsync, so the exception can be ignored here.
-                    { }
-                }
             }
         }
 
@@ -192,39 +158,40 @@ namespace System.Net.Http
                     await FlushSendBufferAsync(endStream: _request.Content == null, _requestBodyCancellationSource.Token).ConfigureAwait(false);
                 }
 
+                Task sendRequestTask;
                 if (_request.Content != null)
                 {
-                    _sendRequestTask = SendContentAsync(_request.Content!, _requestBodyCancellationSource.Token);
+                    sendRequestTask = SendContentAsync(_request.Content!, _requestBodyCancellationSource.Token);
                 }
                 else
                 {
-                    _sendRequestTask = Task.CompletedTask;
+                    sendRequestTask = Task.CompletedTask;
                 }
 
                 // In parallel, send content and read response.
                 // Depending on Expect 100 Continue usage, one will depend on the other making progress.
-                _readResponseTask = ReadResponseAsync(_requestBodyCancellationSource.Token);
+                Task readResponseTask = ReadResponseAsync(_requestBodyCancellationSource.Token);
                 bool sendContentObserved = false;
 
                 // If we're not doing duplex, wait for content to finish sending here.
                 // If we are doing duplex and have the unlikely event that it completes here, observe the result.
                 // See Http2Connection.SendAsync for a full comment on this logic -- it is identical behavior.
-                if (_sendRequestTask.IsCompleted ||
+                if (sendRequestTask.IsCompleted ||
                     _request.Content?.AllowDuplex != true ||
-                    await Task.WhenAny(_sendRequestTask, _readResponseTask).ConfigureAwait(false) == _sendRequestTask ||
-                    _sendRequestTask.IsCompleted)
+                    await Task.WhenAny(sendRequestTask, readResponseTask).ConfigureAwait(false) == sendRequestTask ||
+                    sendRequestTask.IsCompleted)
                 {
                     try
                     {
-                        await _sendRequestTask.ConfigureAwait(false);
+                        await sendRequestTask.ConfigureAwait(false);
                         sendContentObserved = true;
                     }
                     catch
                     {
-                        // Exceptions will be bubbled up from _sendRequestTask here,
-                        // which means the result of _readResponseTask won't be observed directly:
+                        // Exceptions will be bubbled up from sendRequestTask here,
+                        // which means the result of readResponseTask won't be observed directly:
                         // Do a background await to log any exceptions.
-                        _connection.LogExceptions(_readResponseTask);
+                        _connection.LogExceptions(readResponseTask);
                         throw;
                     }
                 }
@@ -232,11 +199,11 @@ namespace System.Net.Http
                 {
                     // Duplex is being used, so we can't wait for content to finish sending.
                     // Do a background await to log any exceptions.
-                    _connection.LogExceptions(_sendRequestTask);
+                    _connection.LogExceptions(sendRequestTask);
                 }
 
                 // Wait for the response headers to be read.
-                await _readResponseTask.ConfigureAwait(false);
+                await readResponseTask.ConfigureAwait(false);
 
                 Debug.Assert(_response != null && _response.Content != null);
                 // Set our content stream.

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -713,8 +713,9 @@ public sealed partial class QuicStream
             await valueTask.ConfigureAwait(false);
         }
         Debug.Assert(_startedTcs.IsCompleted);
-        Debug.Assert(_receiveTcs.IsCompleted);
-        Debug.Assert(_sendTcs.IsCompleted);
+        // TODO: If there was and ongoing read/write when dispose was called, MsQuic events might be processed, but the continuations may not thus the state can still be in Ready.
+        //Debug.Assert(_receiveTcs.IsCompleted);
+        //Debug.Assert(_sendTcs.IsCompleted);
         _handle.Dispose();
 
         // TODO: memory leak if not disposed

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -1509,6 +1509,7 @@ namespace System.Net.Quic.Tests
                 {
                     // Writes must be closed, but whether successfully or not depends on the timing.
                     // Peer might have aborted reading side before receiving all the data.
+                    // Manicka TODO await writes closed
                     Assert.True(stream.WritesClosed.IsCompleted);
                 }
             }


### PR DESCRIPTION
The waiting on tasks was added due to HTTP stress crashing on `QuicStream` asserts:
https://github.com/dotnet/runtime/blob/9c8ff4c1c12c488da660739333e36eb55afe9c56/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs#L716-L717
H3 stream is issuing reads and writes on QuicStream in parallel. So if one ends on cancellation and decides to dispose the stream, the DisposeAsync might run in parallel with pending Write/Read.
Basically, this change reverts these to commits: https://github.com/dotnet/runtime/pull/90253/commits/d6f50614018da68494bd97672713b59be89c8512, https://github.com/dotnet/runtime/pull/90253/commits/f6261e94aaea6518ad2d1d5d35d6758877183c51 from https://github.com/dotnet/runtime/pull/90253.

Fixes #92390

The asserts still need to addressed, but we don't have a running stress atm.

cc @JamesNK 