### PR TITLE
Ensure that embedded broadcast checks the base type of the parent node

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -8205,7 +8205,7 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* parentNode, GenTre
             var_types parentBaseType = parentNode->GetSimdBaseType();
             var_types childBaseType  = hwintrinsic->GetSimdBaseType();
 
-            if (varTypeIsSmall(parentBaseType) || varTypeIsSmall(childBaseType))
+            if (varTypeIsSmall(parentBaseType) || (genTypeSize(parentBaseType) != genTypeSize(childBaseType)))
             {
                 // early return if either base type is not embedded broadcast compatible.
                 return false;
@@ -8251,12 +8251,11 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* parentNode, GenTre
             var_types parentBaseType = parentNode->GetSimdBaseType();
             var_types childBaseType  = hwintrinsic->GetSimdBaseType();
 
-            if (varTypeIsSmall(parentBaseType))
+            if (varTypeIsSmall(parentBaseType) || (genTypeSize(parentBaseType) != genTypeSize(childBaseType)))
             {
                 // early return if either base type is not embedded broadcast compatible.
                 return false;
             }
-            assert(!varTypeIsSmall(childBaseType));
 
             return parentNode->OperIsEmbBroadcastCompatible();
         }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -8202,10 +8202,12 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* parentNode, GenTre
         case NI_AVX2_BroadcastScalarToVector256:
         case NI_AVX512F_BroadcastScalarToVector512:
         {
-            var_types baseType = hwintrinsic->GetSimdBaseType();
-            if (varTypeIsSmall(baseType))
+            var_types parentBaseType = parentNode->GetSimdBaseType();
+            var_types childBaseType  = hwintrinsic->GetSimdBaseType();
+
+            if (varTypeIsSmall(parentBaseType) || varTypeIsSmall(childBaseType))
             {
-                // early return if the base type is not embedded broadcast compatible.
+                // early return if either base type is not embedded broadcast compatible.
                 return false;
             }
 
@@ -8213,7 +8215,7 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* parentNode, GenTre
             if (intrinsicId == NI_SSE3_MoveAndDuplicate)
             {
                 // NI_SSE3_MoveAndDuplicate is for Vector128<double> only.
-                assert(baseType == TYP_DOUBLE);
+                assert(childBaseType == TYP_DOUBLE);
             }
 
             if (comp->compOpportunisticallyDependsOn(InstructionSet_AVX512F_VL) &&
@@ -8246,6 +8248,16 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* parentNode, GenTre
         case NI_AVX_BroadcastScalarToVector128:
         case NI_AVX_BroadcastScalarToVector256:
         {
+            var_types parentBaseType = parentNode->GetSimdBaseType();
+            var_types childBaseType  = hwintrinsic->GetSimdBaseType();
+
+            if (varTypeIsSmall(parentBaseType))
+            {
+                // early return if either base type is not embedded broadcast compatible.
+                return false;
+            }
+            assert(!varTypeIsSmall(childBaseType));
+
             return parentNode->OperIsEmbBroadcastCompatible();
         }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_92357/Runtime_92357.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_92357/Runtime_92357.cs
@@ -13,6 +13,11 @@ public static class Runtime_92357
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public static void Problem()
     {
+        if (!Avx2.IsSupported)
+        {
+            return;
+        }
+
         int y = 5;
 
         Vector256<short> actual = Test(Vector256.Create((short)1), ref y);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_92357/Runtime_92357.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_92357/Runtime_92357.cs
@@ -18,17 +18,30 @@ public static class Runtime_92357
             return;
         }
 
-        int y = 5;
+        int y1 = 5;
 
-        Vector256<short> actual = Test(Vector256.Create((short)1), ref y);
-        Vector256<short> expected = Vector256.Create(10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0);
+        Vector256<short> actual1 = Test1(Vector256.Create((short)1), ref y1);
+        Vector256<short> expected1 = Vector256.Create(10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0);
 
-        Assert.Equal(expected, actual);
+        Assert.Equal(expected1, actual1);
+
+        long y2 = 5;
+
+        Vector256<int> actual2 = Test2(Vector256.Create((int)1), ref y2);
+        Vector256<int> expected2 = Vector256.Create(10, 0, 10, 0, 10, 0, 10, 0);
+
+        Assert.Equal(expected2, actual2);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
-    public static Vector256<short> Test(Vector256<short> x, ref int y)
+    public static Vector256<short> Test1(Vector256<short> x, ref int y)
     {
         return Avx2.MultiplyLow(x + x, Vector256.Create(y).AsInt16());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static Vector256<int> Test2(Vector256<int> x, ref long y)
+    {
+        return Avx2.MultiplyLow(x + x, Vector256.Create(y).AsInt32());
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_92357/Runtime_92357.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_92357/Runtime_92357.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Xunit;
+
+public static class Runtime_92357
+{
+    [Fact]
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public static void Problem()
+    {
+        int y = 5;
+
+        Vector256<short> actual = Test(Vector256.Create((short)1), ref y);
+        Vector256<short> expected = Vector256.Create(10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static Vector256<short> Test(Vector256<short> x, ref int y)
+    {
+        return Avx2.MultiplyLow(x + x, Vector256.Create(y).AsInt16());
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_92357/Runtime_92357.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_92357/Runtime_92357.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
`IsContainableHWIntrinsicOp` was only checking the base type of the broadcast node, which meant that scenarios such as `MultiplyLow(vector256Int16, Vector256.Create(int32).AsInt16())` would incorrectly try to contain the child node.

This ensures that we check both the base type of the broadcast (which indicates how many bytes it reads from memory) and the base type of the parent node (which indicates how many bytes it would read from memory).