### PR TITLE
Add trim analysis warnings for delegate creation

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using ILLink.RoslynAnalyzer.TrimAnalysis;
 using ILLink.Shared.DataFlow;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis;
@@ -420,6 +421,32 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		public override TValue VisitInvocation (IInvocationOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
 			=> ProcessMethodCall (operation, operation.TargetMethod, operation.Instance, operation.Arguments, state);
+
+		public override TValue VisitDelegateCreation (IDelegateCreationOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
+		{
+			if (operation.Target is IFlowAnonymousFunctionOperation lambda) {
+				VisitFlowAnonymousFunction (lambda, state);
+
+				// Instance of a lambda or local function should be the instance of the containing method.
+				// Don't need to track a dataflow value, since the delegate creation will warn if the
+				// lambda or local function has an annotated this parameter.
+				var instance = TopValue;
+				return HandleDelegateCreation (lambda.Symbol, instance, operation);
+			}
+
+			Debug.Assert (operation.Target is IMethodReferenceOperation);
+			if (operation.Target is not IMethodReferenceOperation methodReference)
+				return TopValue;
+
+			TValue instanceValue = Visit (methodReference.Instance, state);
+			IMethodSymbol? method = methodReference.Method;
+			Debug.Assert (method != null);
+			if (method == null)
+				return TopValue;
+			return HandleDelegateCreation (method, instanceValue, operation);
+		}
+
+		public abstract TValue HandleDelegateCreation (IMethodSymbol methodReference, TValue instance, IOperation operation);
 
 		public override TValue VisitPropertyReference (IPropertyReferenceOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
 		{

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -443,6 +443,15 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			Debug.Assert (method != null);
 			if (method == null)
 				return TopValue;
+
+			// Track references to local functions
+			if (method.OriginalDefinition.ContainingSymbol is IMethodSymbol) {
+				var localFunction = method.OriginalDefinition;
+				Debug.Assert (localFunction.MethodKind == MethodKind.LocalFunction);;
+				var localFunctionCFG = ControlFlowGraph.GetLocalFunctionControlFlowGraphInScope (localFunction);
+				InterproceduralState.TrackMethod (new MethodBodyValue (localFunction, localFunctionCFG));
+			}
+
 			return HandleDelegateCreation (method, instanceValue, operation);
 		}
 

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/DiagnosticContext.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/DiagnosticContext.cs
@@ -22,12 +22,25 @@ namespace ILLink.Shared.TrimAnalysis
 
 		public static DiagnosticContext CreateDisabled () => new () { Location = null };
 
+		public Diagnostic CreateDiagnostic (DiagnosticId id, params string[] args)
+		{
+			return Diagnostic.Create (DiagnosticDescriptors.GetDiagnosticDescriptor (id), Location, args);
+		}
+
+		public void AddDiagnostic (Diagnostic diagnostic)
+		{
+			if (Location == null)
+				return;
+
+			Diagnostics.Add (diagnostic);
+		}
+
 		public partial void AddDiagnostic (DiagnosticId id, params string[] args)
 		{
 			if (Location == null)
 				return;
 
-			Diagnostics.Add (Diagnostic.Create (DiagnosticDescriptors.GetDiagnosticDescriptor (id), Location, args));
+			Diagnostics.Add (CreateDiagnostic (id, args));
 		}
 
 		public partial void AddDiagnostic (DiagnosticId id, ValueWithDynamicallyAccessedMembers actualValue, ValueWithDynamicallyAccessedMembers expectedAnnotationsValue, params string[] args)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisReflectionAccessPattern.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisReflectionAccessPattern.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using ILLink.Shared;
+using ILLink.Shared.DataFlow;
+using ILLink.Shared.TrimAnalysis;
+using ILLink.Shared.TypeSystemProxy;
+using Microsoft.CodeAnalysis;
+
+using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.SingleValue>;
+
+namespace ILLink.RoslynAnalyzer.TrimAnalysis
+{
+	public readonly record struct TrimAnalysisReflectionAccessPattern
+	{
+		public IMethodSymbol ReferencedMethod { init; get; }
+		public MultiValue Instance { init; get; }
+		public IOperation Operation { init; get; }
+		public ISymbol OwningSymbol { init; get; }
+
+		public TrimAnalysisReflectionAccessPattern (
+			IMethodSymbol referencedMethod,
+			MultiValue instance,
+			IOperation operation,
+			ISymbol owningSymbol)
+		{
+			ReferencedMethod = referencedMethod;
+			Instance = instance.DeepCopy ();
+			Operation = operation;
+			OwningSymbol = owningSymbol;
+		}
+
+		public TrimAnalysisReflectionAccessPattern Merge (ValueSetLattice<SingleValue> lattice, TrimAnalysisReflectionAccessPattern other)
+		{
+			Debug.Assert (Operation == other.Operation);
+			Debug.Assert (SymbolEqualityComparer.Default.Equals (ReferencedMethod, other.ReferencedMethod));
+
+			return new TrimAnalysisReflectionAccessPattern (
+				ReferencedMethod,
+				lattice.Meet (Instance, other.Instance),
+				Operation,
+				OwningSymbol);
+		}
+
+		public IEnumerable<Diagnostic> CollectDiagnostics ()
+		{
+			DiagnosticContext diagnosticContext = new (Operation.Syntax.GetLocation ());
+			foreach (var diagnostic in ReflectionAccessAnalyzer.GetDiagnosticsForReflectionAccessToDAMOnMethod (diagnosticContext, ReferencedMethod))
+				yield return diagnostic;
+		}
+	}
+}

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -311,6 +311,18 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			}
 		}
 
+		public override MultiValue HandleDelegateCreation (IMethodSymbol method, MultiValue instance, IOperation operation)
+		{
+			TrimAnalysisPatterns.Add (new TrimAnalysisReflectionAccessPattern (
+				method,
+				instance,
+				operation,
+				OwningSymbol
+			));
+
+			return TopValue;
+		}
+
 		static bool TryGetConstantValue (IOperation operation, out MultiValue constValue)
 		{
 			if (operation.ConstantValue.HasValue) {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
@@ -324,6 +324,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter))]
 			[ExpectedWarning ("IL2111", nameof (IWithAnnotatedMethod.AnnotatedMethod))]
 			[ExpectedWarning ("IL2111", nameof (IWithAnnotatedMethod.AnnotatedMethod))]
+			[ExpectedWarning ("IL2118", nameof (LdftnOnLambdaTriggersLamdaAnalysis), ProducedBy = Tool.Trimmer)]
+			[ExpectedWarning ("IL2118", nameof (LdftnOnLocalMethodTriggersLocalMethodAnalysis), ProducedBy = Tool.Trimmer)]
 			static void DynamicallyAccessedMembersAll1 ()
 			{
 				typeof (AnnotatedMethodParameters).RequiresAll ();
@@ -335,6 +337,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter))]
 			[ExpectedWarning ("IL2111", nameof (IWithAnnotatedMethod.AnnotatedMethod))]
 			[ExpectedWarning ("IL2111", nameof (IWithAnnotatedMethod.AnnotatedMethod))]
+			[ExpectedWarning ("IL2118", nameof (LdftnOnLambdaTriggersLamdaAnalysis), ProducedBy = Tool.Trimmer)]
+			[ExpectedWarning ("IL2118", nameof (LdftnOnLocalMethodTriggersLocalMethodAnalysis), ProducedBy = Tool.Trimmer)]
 			static void DynamicallyAccessedMembersAll2 ()
 			{
 				typeof (AnnotatedMethodParameters).RequiresAll ();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
@@ -288,6 +288,24 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				{ }
 			}
 
+			static void LdftnOnLambdaTriggersLamdaAnalysis ()
+			{
+				var _ = new Action<Type> (
+					[ExpectedWarning ("IL2067", nameof (type), nameof (DataFlowTypeExtensions.RequiresAll))]
+					(Type type) => { type.RequiresAll (); });
+			}
+
+			static void LdftnOnLocalMethodTriggersLocalMethodAnalysis ()
+			{
+				var _ = new Action<Type> (LocalMethod);
+
+				[ExpectedWarning ("IL2067", nameof (type), nameof (DataFlowTypeExtensions.RequiresAll))]
+				void LocalMethod (Type type)
+				{
+					type.RequiresAll ();
+				}
+			}
+
 			interface IWithAnnotatedMethod
 			{
 				public void AnnotatedMethod ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)] Type type);
@@ -343,6 +361,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				Ldftn ();
 				LdftnOnLambda ();
 				LdftnOnLocalMethod ();
+				LdftnOnLambdaTriggersLamdaAnalysis ();
+				LdftnOnLocalMethodTriggersLocalMethodAnalysis ();
 				Ldvirtftn ();
 				DynamicallyAccessedMembersAll1 ();
 				DynamicallyAccessedMembersAll2 ();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AnnotatedMembersAccessedViaReflection.cs
@@ -8,10 +8,12 @@ using System.Runtime.InteropServices;
 using Mono.Linker.Tests.Cases.DataFlow;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
 	[SkipKeptItemsValidation]
+	[SandboxDependency ("Dependencies/TestSystemTypeBase.cs")]
 	[ExpectedNoWarnings]
 	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "These tests are not targeted at AOT scenarios")]
 	class AnnotatedMembersAccessedViaReflection
@@ -19,6 +21,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		public static void Main ()
 		{
 			AnnotatedField.Test ();
+			AnnotatedMethodThisParameter.Test ();
 			AnnotatedMethodParameters.Test ();
 			AnnotatedMethodReturnValue.Test ();
 			AnnotatedProperty.Test ();
@@ -150,6 +153,54 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 		}
 
+		public class AnnotatedMethodThisParameter : TestSystemTypeBase
+		{
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			public void MethodWithAnnotatedThisParameter ()
+			{ }
+
+			[ExpectedWarning ("IL2111", nameof (MethodWithAnnotatedThisParameter))]
+			static void Reflection ()
+			{
+				typeof (AnnotatedMethodThisParameter).GetMethod (nameof (MethodWithAnnotatedThisParameter)).Invoke (null, null);
+			}
+
+			[ExpectedWarning ("IL2111", nameof (MethodWithAnnotatedThisParameter))]
+			void Ldftn ()
+			{
+				var _ = new Action (MethodWithAnnotatedThisParameter);
+			}
+
+			[ExpectedWarning ("IL2111")]
+			void LdftnOnLambda ()
+			{
+				var _ = new Action (
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+					() => MethodWithAnnotatedThisParameter ());
+			}
+
+			[ExpectedWarning ("IL2111")]
+			void LdftnOnLocalMethod ()
+			{
+				var _ = new Action (LocalMethod);
+
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				void LocalMethod ()
+				{
+					MethodWithAnnotatedThisParameter ();
+				}
+			}
+
+			public static void Test ()
+			{
+				var instance = new AnnotatedMethodThisParameter ();
+				Reflection ();
+				instance.Ldftn ();
+				instance.LdftnOnLambda ();
+				instance.LdftnOnLocalMethod ();
+			}
+		}
+
 		class AnnotatedMethodParameters
 		{
 			public static void MethodWithSingleAnnotatedParameter (
@@ -213,11 +264,28 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				typeof (AnnotatedMethodParameters).RequiresPublicMethods ();
 			}
 
-			// Action delegate is not handled correctly https://github.com/dotnet/runtime/issues/84918
-			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter), ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2111", nameof (MethodWithSingleAnnotatedParameter))]
 			static void Ldftn ()
 			{
 				var _ = new Action<Type> (AnnotatedMethodParameters.MethodWithSingleAnnotatedParameter);
+			}
+
+			[ExpectedWarning ("IL2111")]
+			static void 
+			LdftnOnLambda ()
+			{
+				var _ = new Action<Type> (
+					([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type) => { });
+			}
+
+			[ExpectedWarning ("IL2111")]
+			static void LdftnOnLocalMethod ()
+			{
+				var _ = new Action<Type> (LocalMethod);
+
+				void LocalMethod (
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
+				{ }
 			}
 
 			interface IWithAnnotatedMethod
@@ -225,8 +293,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				public void AnnotatedMethod ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors)] Type type);
 			}
 
-			// Action delegate is not handled correctly https://github.com/dotnet/runtime/issues/84918
-			[ExpectedWarning ("IL2111", nameof (IWithAnnotatedMethod.AnnotatedMethod), ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2111", nameof (IWithAnnotatedMethod.AnnotatedMethod))]
 			static void Ldvirtftn ()
 			{
 				IWithAnnotatedMethod instance = null;
@@ -274,6 +341,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				DynamicallyAccessedMembers ();
 				DynamicallyAccessedMembersSuppressedByRUC ();
 				Ldftn ();
+				LdftnOnLambda ();
+				LdftnOnLocalMethod ();
 				Ldvirtftn ();
 				DynamicallyAccessedMembersAll1 ();
 				DynamicallyAccessedMembersAll2 ();
@@ -369,8 +438,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				var _ = new Func<Type> ((new AnnotatedMethodReturnValue ()).InstanceMethodWithAnnotatedReturnValue);
 			}
 
-			// Action delegate is not handled correctly https://github.com/dotnet/runtime/issues/84918
-			[ExpectedWarning ("IL2111", nameof (VirtualMethodWithAnnotatedReturnValue), ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2111", nameof (VirtualMethodWithAnnotatedReturnValue))]
 			static void LdftnOnVirtual ()
 			{
 				var _ = new Func<Type> ((new AnnotatedMethodReturnValue ()).VirtualMethodWithAnnotatedReturnValue);
@@ -689,8 +757,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			   [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
 			{ }
 
-			// Action delegate is not handled correctly https://github.com/dotnet/runtime/issues/84918
-			[ExpectedWarning ("IL2111", nameof (GenericWithAnnotatedMethod<TestType>.AnnotatedMethod), ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2111", nameof (GenericWithAnnotatedMethod<TestType>.AnnotatedMethod))]
 			public static void GenericTypeWithStaticMethodViaLdftn ()
 			{
 				var _ = new Action<Type> (GenericWithAnnotatedMethod<TestType>.AnnotatedMethod);
@@ -708,8 +775,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				GenericMethodWithAnnotation<TestType> (typeof (TestType));
 			}
 
-			// Action delegate is not handled correctly https://github.com/dotnet/runtime/issues/84918
-			[ExpectedWarning ("IL2111", nameof (GenericMethodWithAnnotation), ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2111", nameof (GenericMethodWithAnnotation))]
 			public static void GenericMethodWithAnnotationViaLdftn ()
 			{
 				var _ = new Action<Type> (GenericMethodWithAnnotation<TestType>);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeAccessedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/CompilerGeneratedCodeAccessedViaReflection.cs
@@ -282,8 +282,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				lambda ();
 			}
 
-			[ExpectedWarning ("IL2111", "<" + nameof (LambdaWithCorrectParameter) + ">",
-				ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2111")]
 			static void LambdaWithCorrectParameter ()
 			{
 				var lambda =
@@ -630,20 +629,20 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 			}
 
-			[ExpectedWarning ("IL2111", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2111")]
 			static void TestMethodThroughDelegate ()
 			{
 				Action<Type> a = AnnotatedMethod;
 			}
 
-			[ExpectedWarning ("IL2111", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2111")]
 			static void TestLambdaThroughDelegate ()
 			{
 				Action<Type> a = ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type) => { };
 				a (null);
 			}
 
-			[ExpectedWarning ("IL2111", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2111")]
 			static void TestLocalFunctionThroughDelegate ()
 			{
 				Action<Type> a = LocalFunction;
@@ -676,7 +675,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class DAMReflectionAccessToCompilerGeneratedCode
 		{
 			// ldftn access - this MUST warn since the action can be called without the annotation
-			[ExpectedWarning ("IL2111", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2111")]
 			static void Lambda ()
 			{
 				Action<Type> a = ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type) => {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeHierarchyReflectionWarnings.cs
@@ -933,7 +933,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		class CompilerGeneratedCodeDAM
 		{
 			[Kept]
-			[ExpectedWarning ("IL2111", nameof (LambdaWithDAM))]
+			[ExpectedWarning ("IL2111")]
 			static void LambdaWithDAM ()
 			{
 				Action<Type> a =


### PR DESCRIPTION
The ILLink analyzer was not producing warnings for annotated methods, lambdas, or local functions accessed for delegate creation.

Some ExpectedWarnings for ILLink/NativeAot were updated to avoid relying on the name of the compiler-generated methods for lambdas or local functions, because the analyzer reports the warnings as:

IL2111: Method 'lambda expression' with parameters... is accessed via reflection.

Fixes https://github.com/dotnet/runtime/issues/84918