### PR TITLE
Move symbols archive out of main intermediate package

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -53,6 +53,11 @@
 
   <Target Name="CategorizeRuntimeSupplementalArtifacts"
           BeforeTargets="GetCategorizedIntermediateNupkgContents">
+    <PropertyGroup>
+      <!-- Symbols archive is too big for main intermediate package, add it to a different one. -->
+      <SymbolsIntermediateNupkgCategory>runtime</SymbolsIntermediateNupkgCategory>
+    </PropertyGroup>
+
     <ItemGroup>
       <!--
         Runtime artifacts are too large to fit into a single package (Azure DevOps feeds 500 mb constraint).


### PR DESCRIPTION
Due to package size increase in 9.0 (see https://github.com/dotnet/runtime/issues/92240) adding symbols package to the main intermediate nupkg would bring it over AzDO limit (500MB).

Arcade change (https://github.com/dotnet/arcade/pull/14040) enables repos to specify different intermediate package for symbols archive.

This PR moves the archive to the "runtime" package.