### PR TITLE
[wasm] Fix chrome update script to use 'chromium dash', instead of 'omahaproxy'

### DIFF
--- a/eng/testing/bump-chrome-version.proj
+++ b/eng/testing/bump-chrome-version.proj
@@ -17,7 +17,7 @@
     </GetChromeVersions>
 
     <GetChromeVersions
-                OSIdentifier="win"
+                OSIdentifier="Windows"
                 OSPrefix="Win_x64"
                 Channel="$(ChromeChannel)"
                 MaxMajorVersionsToCheck="1"

--- a/eng/testing/wasm-provisioning.targets
+++ b/eng/testing/wasm-provisioning.targets
@@ -25,7 +25,7 @@
     <FirefoxBinaryName>firefox</FirefoxBinaryName>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(ChromeOSIdentifier)' == 'linux'">
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('linux'))">
     <ChromeDirName>chrome-linux</ChromeDirName>
     <ChromeDriverDirName>chromedriver_linux64</ChromeDriverDirName>
     <ChromeBinaryName>chrome</ChromeBinaryName>
@@ -40,7 +40,7 @@
     <ChromeDriverUrl>$(linux_ChromeBaseSnapshotUrl)/chromedriver_linux64.zip</ChromeDriverUrl>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(ChromeOSIdentifier)' == 'win'">
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <ChromeDirName>chrome-win</ChromeDirName>
     <ChromeDriverDirName>chromedriver_win32</ChromeDriverDirName>
     <ChromeBinaryName>chrome.exe</ChromeBinaryName>

--- a/eng/testing/wasm-provisioning.targets
+++ b/eng/testing/wasm-provisioning.targets
@@ -5,8 +5,8 @@
     -->
     <ChromeChannel>stable</ChromeChannel>
 
-    <ChromeOSIdentifier Condition="$([MSBuild]::IsOSPlatform('windows'))">win</ChromeOSIdentifier>
-    <ChromeOSIdentifier Condition="$([MSBuild]::IsOSPlatform('linux'))">linux</ChromeOSIdentifier>
+    <ChromeOSIdentifier Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</ChromeOSIdentifier>
+    <ChromeOSIdentifier Condition="$([MSBuild]::IsOSPlatform('linux'))">Linux</ChromeOSIdentifier>
     <ChromeOSIdentifier Condition="'$(ChromeOSIdentifier)' == ''">unsupported-platform</ChromeOSIdentifier>
 
     <!-- disable by default on unsupported platforms -->

--- a/src/mono/wasm/wasm.code-workspace
+++ b/src/mono/wasm/wasm.code-workspace
@@ -14,6 +14,9 @@
 		},
 		{
 			"path": "../../tasks/WasmAppBuilder"
+		},
+		{
+			"path": "../../tasks/WasmBuildTasks"
 		}
 	],
 	"settings": {


### PR DESCRIPTION
`https://chromiumdash.appspot.com` is the recommended way to get the chrome release versions now, instead of `http://omahaproxy.appspot.com`. This PR updates the task to do that.