### PR TITLE
Improve getExactClasses to support classes as base types

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2196,12 +2196,6 @@ namespace Internal.JitInterface
                 return 1;
             }
 
-            if (!type.IsInterface)
-            {
-                // TODO: handle classes
-                return 0;
-            }
-
             TypeDesc[] implClasses = _compilation.GetImplementingClasses(type);
             if (implClasses == null || implClasses.Length > maxExactClasses)
             {


### PR DESCRIPTION
Fixes #88547

```csharp
using System.Runtime.CompilerServices;

public class ClassA
{
    public virtual int GetValue() => 42;
}

public class ClassB : ClassA
{
    // we don't even need to override GetValue here
}

class MyClass
{
    static void Main()
    {
        Test(new ClassB());
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    static int Test(ClassA c) => c.GetValue();
}
```

Old codegen:

```asm
; Method MyClass:Test(ClassA):int (FullOpts)
       sub      rsp, 40
       mov      rax, qword ptr [rcx]
       call     [rax+30H]ClassA:GetValue():int:this
       nop
       add      rsp, 40
       ret
; Total bytes of code: 16
```

New codegen:

```asm
00007FF66DD8AFB0  cmp         dword ptr [rcx],ecx
00007FF66DD8AFB2  mov         eax,2Ah
00007FF66DD8AFB7  ret
```

Cc @dotnet/ilc-contrib @EgorBo 