### PR TITLE
Re-enable TestCallingConventions for x86 GCStress

### DIFF
--- a/src/tests/baseservices/callconvs/TestCallingConventions.csproj
+++ b/src/tests/baseservices/callconvs/TestCallingConventions.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Temporarily disable under GCStress due to failure. Tracking: https://github.com/dotnet/runtime/issues/78620 -->
-    <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'x86'">true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestCallingConventions.cs" />


### PR DESCRIPTION
Fixes #78620