### PR TITLE
Explicitly clear DOTNET_BUNDLE_EXTRACT_BASE_DIR in tests that expect it is not set

### DIFF
--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
@@ -43,7 +43,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(bundledApp.Path)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir)
+                .EnvironmentVariable(Constants.BundleExtractBase.EnvironmentVariable, extractBaseDir)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
@@ -85,7 +85,7 @@ namespace AppHost.Bundle.Tests
                 .WorkingDirectory(Path.GetDirectoryName(singleFile))
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, relativePath)
+                .EnvironmentVariable(Constants.BundleExtractBase.EnvironmentVariable, relativePath)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
@@ -112,7 +112,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(bundledApp.Path)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir)
+                .EnvironmentVariable(Constants.BundleExtractBase.EnvironmentVariable, extractBaseDir)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
@@ -130,7 +130,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(bundledApp.Path)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir)
+                .EnvironmentVariable(Constants.BundleExtractBase.EnvironmentVariable, extractBaseDir)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
@@ -152,7 +152,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(bundledApp.Path)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir)
+                .EnvironmentVariable(Constants.BundleExtractBase.EnvironmentVariable, extractBaseDir)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
@@ -171,7 +171,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(bundledApp.Path)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractBaseDir)
+                .EnvironmentVariable(Constants.BundleExtractBase.EnvironmentVariable, extractBaseDir)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");
@@ -195,6 +195,7 @@ namespace AppHost.Bundle.Tests
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .EnvironmentVariable(defaultExpansionEnvVariable, nonExistentPath)
+                .EnvironmentVariable(Constants.BundleExtractBase.EnvironmentVariable, null)
                 .Execute().Should().Fail()
                 .And.HaveStdErrContaining(expectedErrorMessagePart);
         }
@@ -215,6 +216,7 @@ namespace AppHost.Bundle.Tests
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .EnvironmentVariable("HOME", null)
+                .EnvironmentVariable(Constants.BundleExtractBase.EnvironmentVariable, null)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World");

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/NetCoreApp3CompatModeTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/NetCoreApp3CompatModeTests.cs
@@ -33,7 +33,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(singleFile, "executing_assembly_location trusted_platform_assemblies assembly_location System.Console")
                 .CaptureStdOut()
                 .CaptureStdErr()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractionBaseDir.FullName)
+                .EnvironmentVariable(Constants.BundleExtractBase.EnvironmentVariable, extractionBaseDir.FullName)
                 .Execute()
                 .Should()
                 .Pass()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
@@ -48,7 +48,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(singleFile, "fullyqualifiedname codebase appcontext cmdlineargs executing_assembly_location basedirectory")
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, extractionBaseDir.FullName)
+                .EnvironmentVariable(Constants.BundleExtractBase.EnvironmentVariable, extractionBaseDir.FullName)
                 .Execute()
                 .Should()
                 .Pass()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Helpers/BundleHelper.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Helpers/BundleHelper.cs
@@ -14,7 +14,6 @@ namespace BundleTests.Helpers
 {
     public static class BundleHelper
     {
-        public const string DotnetBundleExtractBaseEnvVariable = "DOTNET_BUNDLE_EXTRACT_BASE_DIR";
         public const string CoreServicingEnvVariable = "CORE_SERVICING";
 
         public static string GetHostPath(TestProjectFixture fixture)

--- a/src/installer/tests/TestUtils/Constants.cs
+++ b/src/installer/tests/TestUtils/Constants.cs
@@ -49,6 +49,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
             public const string RuntimeConfigPropertyName = "additionalProbingPaths";
         }
 
+        public static class BundleExtractBase
+        {
+            public const string EnvironmentVariable = "DOTNET_BUNDLE_EXTRACT_BASE_DIR";
+        }
+
         public static class DepsFile
         {
             public const string CommandLineArgument = "--depsfile";


### PR DESCRIPTION
Hit this when I ran the tests in an environment where I had forgotten I had `DOTNET_BUNDLE_EXTRACT_BASE_DIR` set.