### PR TITLE
`IDispatch` should accept `HRESULT` as valuetype

### DIFF
--- a/src/coreclr/vm/callsiteinspect.cpp
+++ b/src/coreclr/vm/callsiteinspect.cpp
@@ -433,7 +433,8 @@ void CallsiteInspect::PropagateOutParametersBackToCallsite(
                 *(ARG_SLOT *)(frame->GetReturnValuePtr()) = retVal;
             }
 #ifdef ENREGISTERED_RETURNTYPE_MAXSIZE
-            else if (argit.HasNonStandardByvalReturn())
+            else if (argit.HasNonStandardByvalReturn()
+                    && !(flags & CallsiteDetails::HResultReturn))
             {
                 // In these cases, put the pointer to the return buffer into
                 // the frame's return value slot.

--- a/src/coreclr/vm/callsiteinspect.h
+++ b/src/coreclr/vm/callsiteinspect.h
@@ -25,6 +25,7 @@ struct CallsiteDetails
         BeginInvoke     = 0x01,
         EndInvoke       = 0x02,
         Ctor            = 0x04,
+        HResultReturn   = 0x08,
     };
     INT32 Flags;
 };

--- a/src/coreclr/vm/clrtocomcall.cpp
+++ b/src/coreclr/vm/clrtocomcall.cpp
@@ -443,7 +443,12 @@ static CallsiteDetails CreateCallsiteDetails(_In_ FramedMethodFrame *pFrame)
     }
 
     // If the signature is marked preserve sig, then the return
-    // is required to be an HRESULT.
+    // is required to be an HRESULT, per COM rules. We set a flag to
+    // indicate this state to avoid issues when a C# developers define
+    // an HRESULT in C# as a ValueClass with a single int field. This
+    // is convenient but does violate the COM ABI. Setting the flag
+    // lets us permit this convention and allow either a 4 byte primitive
+    // or the commonly used C# type "struct HResult { int Value; }".
     if (IsMiPreserveSig(pMD->GetImplAttrs()))
         callsiteFlags |= CallsiteDetails::HResultReturn;
 

--- a/src/coreclr/vm/clrtocomcall.cpp
+++ b/src/coreclr/vm/clrtocomcall.cpp
@@ -364,7 +364,7 @@ UINT32 CLRToCOMEventCallWorker(ComPlusMethodFrame* pFrame, ComPlusCallMethodDesc
     return 0;
 }
 
-CallsiteDetails CreateCallsiteDetails(_In_ FramedMethodFrame *pFrame)
+static CallsiteDetails CreateCallsiteDetails(_In_ FramedMethodFrame *pFrame)
 {
     CONTRACTL
     {
@@ -442,10 +442,15 @@ CallsiteDetails CreateCallsiteDetails(_In_ FramedMethodFrame *pFrame)
         SigTypeContext::InitTypeContext(pMD, actualType, &typeContext);
     }
 
+    // If the signature is marked preserve sig, then the return
+    // is required to be an HRESULT.
+    if (IsMiPreserveSig(pMD->GetImplAttrs()))
+        callsiteFlags |= CallsiteDetails::HResultReturn;
+
     _ASSERTE(!signature.IsEmpty() && pModule != nullptr);
 
     // Create details
-    return CallsiteDetails{ { signature, pModule, &typeContext }, pFrame, pMD, fIsDelegate };
+    return CallsiteDetails{ { signature, pModule, &typeContext }, pFrame, pMD, fIsDelegate, callsiteFlags };
 }
 
 UINT32 CLRToCOMLateBoundWorker(

--- a/src/coreclr/vm/clrtocomcall.cpp
+++ b/src/coreclr/vm/clrtocomcall.cpp
@@ -444,7 +444,7 @@ static CallsiteDetails CreateCallsiteDetails(_In_ FramedMethodFrame *pFrame)
 
     // If the signature is marked preserve sig, then the return
     // is required to be an HRESULT, per COM rules. We set a flag to
-    // indicate this state to avoid issues when a C# developers define
+    // indicate this state to avoid issues when a C# developer defines
     // an HRESULT in C# as a ValueClass with a single int field. This
     // is convenient but does violate the COM ABI. Setting the flag
     // lets us permit this convention and allow either a 4 byte primitive

--- a/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
@@ -139,6 +139,21 @@ namespace NetClient
                 Assert.Equal(GetErrorCodeFromHResult(e.HResult), errorCode);
                 // Failing HRESULT exceptions contain CLR generated messages
             }
+
+            // Calling methods through IDispatch::Invoke() (i.e., late-bound) doesn't
+            // propagate the HRESULT when marked with PreserveSig. It is always 0.
+            {
+                Console.WriteLine($"Calling {nameof(DispatchTesting.TriggerException)} (PreserveSig) with {nameof(IDispatchTesting_Exception.Int)} {errorCode}...");
+                var dispatchTesting2 = (IDispatchTestingPreserveSig1)dispatchTesting;
+                Assert.Equal(0, dispatchTesting2.TriggerException(IDispatchTesting_Exception.Int, errorCode));
+            }
+
+            {
+                // Validate the HRESULT as a value type construct works for IDispatch.
+                Console.WriteLine($"Calling {nameof(DispatchTesting.TriggerException)} (PreserveSig, ValueType) with {nameof(IDispatchTesting_Exception.Int)} {errorCode}...");
+                var dispatchTesting3 = (IDispatchTestingPreserveSig2)dispatchTesting;
+                Assert.Equal(0, dispatchTesting3.TriggerException(IDispatchTesting_Exception.Int, errorCode).Value);
+            }
         }
 
         static void Validate_StructNotSupported()

--- a/src/tests/Interop/COM/NETServer/DispatchTesting.cs
+++ b/src/tests/Interop/COM/NETServer/DispatchTesting.cs
@@ -57,6 +57,7 @@ public class DispatchTesting : Server.Contract.IDispatchTesting
         case IDispatchTesting_Exception.Disp:
             throw new Exception();
         case IDispatchTesting_Exception.HResult:
+        case IDispatchTesting_Exception.Int:
             throw new System.ComponentModel.Win32Exception(errorCode);
         }
     }

--- a/src/tests/Interop/COM/NativeServer/DispatchTesting.h
+++ b/src/tests/Interop/COM/NativeServer/DispatchTesting.h
@@ -243,6 +243,8 @@ public: // IDispatchTesting
             return DISP_E_EXCEPTION;
         case IDispatchTesting_Exception_HResult:
             return HRESULT_FROM_WIN32(errorCode);
+        case IDispatchTesting_Exception_Int:
+            return errorCode;
         default:
             return S_FALSE; // Return a success case to indicate failure to trigger a failure.
         }

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -271,6 +271,7 @@ namespace Server.Contract
     {
         void Reserved1();
         void Reserved2();
+        void Reserved3();
 
         [PreserveSig]
         int TriggerException(IDispatchTesting_Exception excep, int errorCode);
@@ -283,6 +284,7 @@ namespace Server.Contract
     {
         void Reserved1();
         void Reserved2();
+        void Reserved3();
 
         [PreserveSig]
         HRESULT TriggerException(IDispatchTesting_Exception excep, int errorCode);

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -209,6 +209,7 @@ namespace Server.Contract
     {
         Disp,
         HResult,
+        Int,
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -218,6 +219,12 @@ namespace Server.Contract
         public float y;
         public float z;
         public float w;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct HRESULT
+    {
+        public int Value;
     }
 
     [ComVisible(true)]
@@ -255,6 +262,30 @@ namespace Server.Contract
 
         [DispId(/*DISPID_NEWENUM*/-4)]
         System.Collections.IEnumerator GetEnumerator();
+    }
+
+    [ComVisible(true)]
+    [Guid("a5e04c1c-474e-46d2-bbc0-769d04e12b54")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIDispatch)]
+    public interface IDispatchTestingPreserveSig1
+    {
+        void Reserved1();
+        void Reserved2();
+
+        [PreserveSig]
+        int TriggerException(IDispatchTesting_Exception excep, int errorCode);
+    }
+
+    [ComVisible(true)]
+    [Guid("a5e04c1c-474e-46d2-bbc0-769d04e12b54")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIDispatch)]
+    public interface IDispatchTestingPreserveSig2
+    {
+        void Reserved1();
+        void Reserved2();
+
+        [PreserveSig]
+        HRESULT TriggerException(IDispatchTesting_Exception excep, int errorCode);
     }
 
     [ComVisible(true)]

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
@@ -385,6 +385,7 @@ enum IDispatchTesting_Exception
 {
     IDispatchTesting_Exception_Disp,
     IDispatchTesting_Exception_HResult,
+    IDispatchTesting_Exception_Int,
 };
 
 struct __declspec(uuid("a5e04c1c-474e-46d2-bbc0-769d04e12b54"))


### PR DESCRIPTION
This is a regression from .NET Framework.
The current behavior has existed since
`IDispatch` was introduced into .NET Core.
Added tests for the current behavior.