### PR TITLE
Unify on one version of the ESRP tasks

### DIFF
--- a/eng/pipelines/common/macos-sign-with-entitlements.yml
+++ b/eng/pipelines/common/macos-sign-with-entitlements.yml
@@ -3,10 +3,11 @@ parameters:
 
 steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK 2.1.808'
+    displayName: Install .NET 6 SDK for signing.
     inputs:
-      packageType: sdk
-      version: 2.1.808
+      packageType: 'sdk'
+      version: '6.0.x'
+      installationPath: '$(Agent.TempDirectory)/dotnet'
 
   - ${{ each file in parameters.filesToSign }}:
     - script: codesign -s - -f --entitlements ${{ file.entitlementsFile }} ${{ file.path }}/${{ file.name }}
@@ -28,7 +29,7 @@ steps:
       includeRootFolder: true
       replaceExistingArchive: true
 
-  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  - task: EsrpCodeSigning@1
     displayName: 'ESRP CodeSigning'
     inputs:
       ConnectedServiceName: 'ESRP CodeSigning'
@@ -48,6 +49,10 @@ steps:
             "toolVersion": "1.0"
           }
         ]  
+    env:
+      DOTNET_MULTILEVEL_LOOKUP: 0
+      DOTNET_ROOT: '$(Agent.TempDirectory)/dotnet'
+      DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR: '$(Agent.TempDirectory)/dotnet'
 
   - task: ExtractFiles@1
     displayName: 'Extract MacOS after signing'

--- a/eng/pipelines/common/macos-sign-with-entitlements.yml
+++ b/eng/pipelines/common/macos-sign-with-entitlements.yml
@@ -1,5 +1,6 @@
 parameters:
   filesToSign: []
+  timeoutInMinutes: '30'
 
 steps:
   - task: UseDotNet@2
@@ -29,7 +30,7 @@ steps:
       includeRootFolder: true
       replaceExistingArchive: true
 
-  - task: EsrpCodeSigning@1
+  - task: EsrpCodeSigning@4
     displayName: 'ESRP CodeSigning'
     inputs:
       ConnectedServiceName: 'ESRP CodeSigning'
@@ -49,6 +50,10 @@ steps:
             "toolVersion": "1.0"
           }
         ]  
+      SessionTimeout: ${{ parameters.timeoutInMinutes }}
+      MaxConcurrency: '50'
+      MaxRetryAttempts: '5'
+      PendingAnalysisWaitTimeoutMinutes: '5'
     env:
       DOTNET_MULTILEVEL_LOOKUP: 0
       DOTNET_ROOT: '$(Agent.TempDirectory)/dotnet'

--- a/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+++ b/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
@@ -12,7 +12,7 @@ steps:
       version: '6.0.x'
       installationPath: '$(Agent.TempDirectory)/dotnet'
 
-  - task: EsrpCodeSigning@1
+  - task: EsrpCodeSigning@4
     displayName: Sign Diagnostic Binaries
     inputs:
       ConnectedServiceName: 'dotnetesrp-diagnostics-dnceng'
@@ -48,6 +48,7 @@ steps:
       SessionTimeout: ${{ parameters.timeoutInMinutes }}
       MaxConcurrency: '50'
       MaxRetryAttempts: '5'
+      PendingAnalysisWaitTimeoutMinutes: '5'
     env:
       DOTNET_MULTILEVEL_LOOKUP: 0
       DOTNET_ROOT: '$(Agent.TempDirectory)/dotnet'


### PR DESCRIPTION
Change the macos signing steps to use the same sigining tool version as the Windows signing steps.
Upgrade code signing task version to get a version that uses .NET 6.0 across the board.

Official build at: https://dev.azure.com/dnceng/internal/_build/results?buildId=2273647&view=results
