### PR TITLE
Use snprintf in pal_icushim.c

### DIFF
--- a/src/native/libs/System.Globalization.Native/pal_icushim.c
+++ b/src/native/libs/System.Globalization.Native/pal_icushim.c
@@ -33,6 +33,14 @@ FOR_ALL_ICU_FUNCTIONS
 
 #define MaxICUVersionStringLength 33
 
+#else
+
+#define VERSION_PREFIX_NONE ""
+#define VERSION_PREFIX_SUSE "suse"
+
+// .[suse]x.x.x, considering the max number of decimal digits for each component
+#define MaxICUVersionStringLength (sizeof(VERSION_PREFIX_SUSE) + 33)
+
 #endif
 
 static void* libicuuc = NULL;
@@ -213,12 +221,6 @@ static int FindICULibs(char* symbolName, char* symbolVersion)
 }
 
 #else // !TARGET_WINDOWS && !TARGET_OSX && !TARGET_ANDROID
-
-#define VERSION_PREFIX_NONE ""
-#define VERSION_PREFIX_SUSE "suse"
-
-// .[suse]x.x.x, considering the max number of decimal digits for each component
-#define MaxICUVersionStringLength (sizeof(VERSION_PREFIX_SUSE) + 33)
 
 // Version ranges to search for each of the three version components
 // The rationale for major version range is that we support versions higher or

--- a/src/native/libs/System.Globalization.Native/pal_icushim.c
+++ b/src/native/libs/System.Globalization.Native/pal_icushim.c
@@ -44,7 +44,7 @@ ucol_safeClone_func ucol_safeClone_ptr = NULL;
 
 #define PER_FUNCTION_BLOCK(fn, lib, required) \
     c_static_assert_msg((sizeof(#fn) + MaxICUVersionStringWithSuffixLength + 1) <= sizeof(symbolName), "The symbolName is too small for symbol " #fn); \
-    sprintf(symbolName, #fn "%s", symbolVersion); \
+    snprintf(symbolName, SYMBOL_NAME_SIZE, #fn "%s", symbolVersion); \
     fn##_ptr = (TYPEOF(fn)*)dlsym(lib, symbolName); \
     if (fn##_ptr == NULL && required) { fprintf(stderr, "Cannot get symbol %s from " #lib "\nError: %s\n", symbolName, dlerror()); abort(); }
 
@@ -55,24 +55,24 @@ static int FindSymbolVersion(int majorVer, int minorVer, int subVer, char* symbo
     if (dlsym(libicuuc, "u_strlen") == NULL)
     {
         // Now try just the _majorVer added
-        sprintf(symbolVersion, "_%d%s", majorVer, suffix);
-        sprintf(symbolName, "u_strlen%s", symbolVersion);
+        snprintf(symbolVersion, MaxICUVersionStringWithSuffixLength, "_%d%s", majorVer, suffix);
+        snprintf(symbolName, SYMBOL_NAME_SIZE, "u_strlen%s", symbolVersion);
         if (dlsym(libicuuc, symbolName) == NULL)
         {
             if (minorVer == -1)
                 return false;
 
             // Now try the _majorVer_minorVer added
-            sprintf(symbolVersion, "_%d_%d%s", majorVer, minorVer, suffix);
-            sprintf(symbolName, "u_strlen%s", symbolVersion);
+            snprintf(symbolVersion, MaxICUVersionStringWithSuffixLength, "_%d_%d%s", majorVer, minorVer, suffix);
+            snprintf(symbolName, SYMBOL_NAME_SIZE, "u_strlen%s", symbolVersion);
             if (dlsym(libicuuc, symbolName) == NULL)
             {
                 if (subVer == -1)
                     return false;
 
                 // Finally, try the _majorVer_minorVer_subVer added
-                sprintf(symbolVersion, "_%d_%d_%d%s", majorVer, minorVer, subVer, suffix);
-                sprintf(symbolName, "u_strlen%s", symbolVersion);
+                snprintf(symbolVersion, MaxICUVersionStringWithSuffixLength, "_%d_%d_%d%s", majorVer, minorVer, subVer, suffix);
+                snprintf(symbolName, SYMBOL_NAME_SIZE, "u_strlen%s", symbolVersion);
                 if (dlsym(libicuuc, symbolName) == NULL)
                 {
                     return false;


### PR DESCRIPTION
When AddressSanitizer is enabled on macOS, the toolchain deprecates `sprintf`. Switch to `snprintf` for better bounds checking and to help fix the macOS ASAN build.