### PR TITLE
Support setting ACLs on file paths longer than `MAX_PATH`

### DIFF
--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSystemSecurity.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSystemSecurity.cs
@@ -121,7 +121,7 @@ namespace System.Security.AccessControl
             try
             {
                 AccessControlSections persistRules = GetAccessControlSectionsFromChanges();
-                base.Persist(fullPath, persistRules);
+                base.Persist(PathInternal.EnsureExtendedPrefixIfNeeded(fullPath), persistRules);
                 OwnerModified = GroupModified = AuditRulesModified = AccessRulesModified = false;
             }
             finally

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -149,12 +149,7 @@ namespace System.IO
             using var directory = new TempAclDirectory();
 
             const int MaxShortPath = 260;
-            int fileNameLength = MaxShortPath - directory.Path.Length;
-
-            if (fileNameLength < 1)
-            {
-                fileNameLength = 1;
-            }
+            int fileNameLength = Math.Max(MaxShortPath - directory.Path.Length, 1);
 
             string path = Path.Combine(directory.Path, new string('1', fileNameLength) + ".txt");
             using var file = new TempFile(path, 1);

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -144,6 +144,30 @@ namespace System.IO
         }
 
         [Fact]
+        public void SetAccessControl_FileInfo_FileSecurity_Success_NameLongerThanMaxShortPath()
+        {
+            using var directory = new TempAclDirectory();
+
+            const int MaxShortPath = 260;
+            int fileNameLength = MaxShortPath - directory.Path.Length;
+
+            if (fileNameLength < 1)
+            {
+                fileNameLength = 1;
+            }
+
+            string path = Path.Combine(directory.Path, new string('1', fileNameLength) + ".txt");
+            using var file = new TempFile(path, 1);
+            var fileInfo = new FileInfo(file.Path);
+            FileSecurity fileSecurity = fileInfo.GetAccessControl(AccessControlSections.Access);
+
+            var newAccessRule = new FileSystemAccessRule(Helpers.s_NetworkServiceNTAccount, FileSystemRights.Write, AccessControlType.Allow);
+            fileSecurity.SetAccessRule(newAccessRule);
+
+            fileInfo.SetAccessControl(fileSecurity);
+        }
+
+        [Fact]
         public void SetAccessControl_FileStream_FileSecurity_InvalidArguments()
         {
             Assert.Throws<ArgumentNullException>("fileStream", () => FileSystemAclExtensions.SetAccessControl((FileStream)null, fileSecurity: null));


### PR DESCRIPTION
fix #91980 

by guarding `FileSystemSecurity.Persist(string)` with `PathInternal.EnsureExtendedPrefixIfNeeded`, as the ctor does.