### PR TITLE
Rename get_* to Get* in NativeAOT runtime

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -593,7 +593,7 @@ namespace Internal.Runtime
             }
         }
 
-        internal bool IsPointerType
+        internal bool IsPointer
         {
             get
             {
@@ -601,7 +601,7 @@ namespace Internal.Runtime
             }
         }
 
-        internal bool IsByRefType
+        internal bool IsByRef
         {
             get
             {
@@ -641,7 +641,7 @@ namespace Internal.Runtime
             }
         }
 
-        internal bool IsFunctionPointerType
+        internal bool IsFunctionPointer
         {
             get
             {
@@ -673,13 +673,13 @@ namespace Internal.Runtime
         {
             get
             {
-                Debug.Assert(IsFunctionPointerType);
+                Debug.Assert(IsFunctionPointer);
                 return _uBaseSize & ~FunctionPointerFlags.FlagsMask;
             }
 #if TYPE_LOADER_IMPLEMENTATION
             set
             {
-                Debug.Assert(IsFunctionPointerType);
+                Debug.Assert(IsFunctionPointer);
                 _uBaseSize = value | (_uBaseSize & FunctionPointerFlags.FlagsMask);
             }
 #endif
@@ -689,13 +689,13 @@ namespace Internal.Runtime
         {
             get
             {
-                Debug.Assert(IsFunctionPointerType);
+                Debug.Assert(IsFunctionPointer);
                 return (_uBaseSize & FunctionPointerFlags.IsUnmanaged) != 0;
             }
 #if TYPE_LOADER_IMPLEMENTATION
             set
             {
-                Debug.Assert(IsFunctionPointerType);
+                Debug.Assert(IsFunctionPointer);
                 if (value)
                     _uBaseSize |= FunctionPointerFlags.IsUnmanaged;
                 else
@@ -719,13 +719,13 @@ namespace Internal.Runtime
         {
             get
             {
-                Debug.Assert(IsFunctionPointerType);
+                Debug.Assert(IsFunctionPointer);
                 return _relatedType._pRelatedParameterType;
             }
 #if TYPE_LOADER_IMPLEMENTATION
             set
             {
-                Debug.Assert(IsDynamicType && IsFunctionPointerType);
+                Debug.Assert(IsDynamicType && IsFunctionPointer);
                 _relatedType._pRelatedParameterType = value;
             }
 #endif
@@ -924,7 +924,7 @@ namespace Internal.Runtime
             {
                 Debug.Assert(IsDynamicType);
                 Debug.Assert(!IsParameterizedType);
-                Debug.Assert(!IsFunctionPointerType);
+                Debug.Assert(!IsFunctionPointer);
                 Debug.Assert(IsCanonical);
                 _relatedType._pBaseType = value;
             }
@@ -1332,10 +1332,10 @@ namespace Internal.Runtime
 
             if (eField == EETypeField.ETF_FunctionPointerParameters)
             {
-                Debug.Assert(IsFunctionPointerType);
+                Debug.Assert(IsFunctionPointer);
                 return cbOffset;
             }
-            if (IsFunctionPointerType)
+            if (IsFunctionPointer)
             {
                 cbOffset += NumFunctionPointerParameters * relativeOrFullPointerOffset;
             }

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -834,7 +834,7 @@ namespace Internal.Runtime
             get
             {
                 Debug.Assert(IsValueType);
-                // get_BaseSize returns the GC size including space for the sync block index field, the MethodTable* and
+                // BaseSize returns the GC size including space for the sync block index field, the MethodTable* and
                 // padding for GC heap alignment. Must subtract all of these to get the size used for locals, array
                 // elements or fields of another type.
                 return BaseSize - ((uint)sizeof(ObjHeader) + (uint)sizeof(MethodTable*) + ValueTypeFieldPadding);

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
@@ -30,8 +30,8 @@ namespace System.Runtime
                 !pEEType->IsInterface &&
                 !pEEType->IsArray &&
                 !pEEType->IsString &&
-                !pEEType->IsPointerType &&
-                !pEEType->IsFunctionPointerType &&
+                !pEEType->IsPointer &&
+                !pEEType->IsFunctionPointer &&
                 !pEEType->IsByRefLike;
             if (!isValid)
                 Debug.Assert(false);
@@ -356,7 +356,7 @@ namespace System.Runtime
                         return (IntPtr)(delegate*<MethodTable*, object>)&InternalCalls.RhpNewFast;
 
                 case RuntimeHelperKind.IsInst:
-                    if (pEEType->HasGenericVariance || pEEType->IsParameterizedType || pEEType->IsFunctionPointerType)
+                    if (pEEType->HasGenericVariance || pEEType->IsParameterizedType || pEEType->IsFunctionPointer)
                         return (IntPtr)(delegate*<MethodTable*, object, object?>)&TypeCast.IsInstanceOfAny;
                     else if (pEEType->IsInterface)
                         return (IntPtr)(delegate*<MethodTable*, object?, object?>)&TypeCast.IsInstanceOfInterface;
@@ -364,7 +364,7 @@ namespace System.Runtime
                         return (IntPtr)(delegate*<MethodTable*, object?, object?>)&TypeCast.IsInstanceOfClass;
 
                 case RuntimeHelperKind.CastClass:
-                    if (pEEType->HasGenericVariance || pEEType->IsParameterizedType || pEEType->IsFunctionPointerType)
+                    if (pEEType->HasGenericVariance || pEEType->IsParameterizedType || pEEType->IsFunctionPointer)
                         return (IntPtr)(delegate*<MethodTable*, object, object>)&TypeCast.CheckCastAny;
                     else if (pEEType->IsInterface)
                         return (IntPtr)(delegate*<MethodTable*, object, object>)&TypeCast.CheckCastInterface;

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -180,7 +180,7 @@ namespace System.Runtime
         public static unsafe object? IsInstanceOfClass(MethodTable* pTargetType, object? obj)
         {
             Debug.Assert(!pTargetType->IsParameterizedType, "IsInstanceOfClass called with parameterized MethodTable");
-            Debug.Assert(!pTargetType->IsFunctionPointerType, "IsInstanceOfClass called with function pointer MethodTable");
+            Debug.Assert(!pTargetType->IsFunctionPointer, "IsInstanceOfClass called with function pointer MethodTable");
             Debug.Assert(!pTargetType->IsInterface, "IsInstanceOfClass called with interface MethodTable");
             Debug.Assert(!pTargetType->HasGenericVariance, "IsInstanceOfClass with variant MethodTable");
 
@@ -389,7 +389,7 @@ namespace System.Runtime
         public static unsafe object CheckCastClass(MethodTable* pTargetType, object obj)
         {
             Debug.Assert(!pTargetType->IsParameterizedType, "CheckCastClass called with parameterized MethodTable");
-            Debug.Assert(!pTargetType->IsFunctionPointerType, "CheckCastClass called with function pointer MethodTable");
+            Debug.Assert(!pTargetType->IsFunctionPointer, "CheckCastClass called with function pointer MethodTable");
             Debug.Assert(!pTargetType->IsInterface, "CheckCastClass called with interface MethodTable");
             Debug.Assert(!pTargetType->HasGenericVariance, "CheckCastClass with variant MethodTable");
 
@@ -407,7 +407,7 @@ namespace System.Runtime
         private static unsafe object CheckCastClassSpecial(MethodTable* pTargetType, object obj)
         {
             Debug.Assert(!pTargetType->IsParameterizedType, "CheckCastClass called with parameterized MethodTable");
-            Debug.Assert(!pTargetType->IsFunctionPointerType, "CheckCastClass called with function pointer MethodTable");
+            Debug.Assert(!pTargetType->IsFunctionPointer, "CheckCastClass called with function pointer MethodTable");
             Debug.Assert(!pTargetType->IsInterface, "CheckCastClass called with interface MethodTable");
             Debug.Assert(!pTargetType->HasGenericVariance, "CheckCastClass with variant MethodTable");
 
@@ -478,11 +478,11 @@ namespace System.Runtime
         {
             Debug.Assert(!pDerivedType->IsArray, "did not expect array type");
             Debug.Assert(!pDerivedType->IsParameterizedType, "did not expect parameterType");
-            Debug.Assert(!pDerivedType->IsFunctionPointerType, "did not expect function pointer");
+            Debug.Assert(!pDerivedType->IsFunctionPointer, "did not expect function pointer");
             Debug.Assert(!pBaseType->IsArray, "did not expect array type");
             Debug.Assert(!pBaseType->IsInterface, "did not expect interface type");
             Debug.Assert(!pBaseType->IsParameterizedType, "did not expect parameterType");
-            Debug.Assert(!pBaseType->IsFunctionPointerType, "did not expect function pointer");
+            Debug.Assert(!pBaseType->IsFunctionPointer, "did not expect function pointer");
             Debug.Assert(pBaseType->IsCanonical || pBaseType->IsGenericTypeDefinition, "unexpected MethodTable");
             Debug.Assert(pDerivedType->IsCanonical || pDerivedType->IsGenericTypeDefinition, "unexpected MethodTable");
 
@@ -504,7 +504,7 @@ namespace System.Runtime
         private static unsafe bool ImplementsInterface(MethodTable* pObjType, MethodTable* pTargetType, EETypePairList* pVisited)
         {
             Debug.Assert(!pTargetType->IsParameterizedType, "did not expect parameterized type");
-            Debug.Assert(!pTargetType->IsFunctionPointerType, "did not expect function pointer type");
+            Debug.Assert(!pTargetType->IsFunctionPointer, "did not expect function pointer type");
             Debug.Assert(pTargetType->IsInterface, "IsInstanceOfInterface called with non-interface MethodTable");
 
             int numInterfaces = pObjType->NumInterfaces;
@@ -1106,7 +1106,7 @@ namespace System.Runtime
                 {
                     MethodTable* pSourceRelatedParameterType = pSourceType->RelatedParameterType;
                     // Source type is also a parameterized type. Are the parameter types compatible?
-                    if (pSourceRelatedParameterType->IsPointerType)
+                    if (pSourceRelatedParameterType->IsPointer)
                     {
                         // If the parameter types are pointers, then only exact matches are correct.
                         // As we've already compared equality at the start of this function,
@@ -1114,14 +1114,14 @@ namespace System.Runtime
                         // int** is not compatible with uint**, nor is int*[] oompatible with uint*[].
                         return false;
                     }
-                    else if (pSourceRelatedParameterType->IsByRefType)
+                    else if (pSourceRelatedParameterType->IsByRef)
                     {
                         // Only allow exact matches for ByRef types - same as pointers above. This should
                         // be unreachable and it's only a defense in depth. ByRefs can't be parameters
                         // of any parameterized type.
                         return false;
                     }
-                    else if (pSourceRelatedParameterType->IsFunctionPointerType)
+                    else if (pSourceRelatedParameterType->IsFunctionPointer)
                     {
                         // If the parameter types are function pointers, then only exact matches are correct.
                         // As we've already compared equality at the start of this function,
@@ -1142,7 +1142,7 @@ namespace System.Runtime
                 return false;
             }
 
-            if (pTargetType->IsFunctionPointerType)
+            if (pTargetType->IsFunctionPointer)
             {
                 // Function pointers only cast if source and target are equivalent types.
                 return false;
@@ -1157,7 +1157,7 @@ namespace System.Runtime
             {
                 return false;
             }
-            else if (pSourceType->IsFunctionPointerType)
+            else if (pSourceType->IsFunctionPointer)
             {
                 return false;
             }
@@ -1228,7 +1228,7 @@ namespace System.Runtime
             {
                 retObj = IsInstanceOfInterface(pTargetType, obj);
             }
-            else if (pTargetType->IsParameterizedType || pTargetType->IsFunctionPointerType)
+            else if (pTargetType->IsParameterizedType || pTargetType->IsFunctionPointer)
             {
                 // We handled arrays above so this is for pointers and byrefs only.
                 retObj = null;
@@ -1269,7 +1269,7 @@ namespace System.Runtime
             {
                 obj = CheckCastInterface(pTargetType, obj);
             }
-            else if (pTargetType->IsParameterizedType || pTargetType->IsFunctionPointerType)
+            else if (pTargetType->IsParameterizedType || pTargetType->IsFunctionPointer)
             {
                 // We handled arrays above so this is for pointers and byrefs only.
                 // Nothing can be a boxed instance of these.

--- a/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
@@ -80,14 +80,14 @@ EXTERN_C NATIVEAOT_API int32_t __cdecl RhpEndNoGCRegion()
 
 COOP_PINVOKE_HELPER(void, RhSuppressFinalize, (OBJECTREF refObj))
 {
-    if (!refObj->get_EEType()->HasFinalizer())
+    if (!refObj->GetMethodTable()->HasFinalizer())
         return;
     GCHeapUtilities::GetGCHeap()->SetFinalizationRun(refObj);
 }
 
 COOP_PINVOKE_HELPER(FC_BOOL_RET, RhReRegisterForFinalize, (OBJECTREF refObj))
 {
-    if (!refObj->get_EEType()->HasFinalizer())
+    if (!refObj->GetMethodTable()->HasFinalizer())
         FC_RETURN_BOOL(true);
     FC_RETURN_BOOL(GCHeapUtilities::GetGCHeap()->RegisterForFinalization(-1, refObj));
 }

--- a/src/coreclr/nativeaot/Runtime/MethodTable.cpp
+++ b/src/coreclr/nativeaot/Runtime/MethodTable.cpp
@@ -25,7 +25,7 @@ bool MethodTable::Validate(bool assertOnFail /* default: true */)
         REPORT_FAILURE();
 
     // Verify object size is bigger than min_obj_size
-    size_t minObjSize = get_BaseSize();
+    size_t minObjSize = GetBaseSize();
     if (HasComponentSize())
     {
         // If it is an array, we will align the size to the nearest pointer alignment, even if there are
@@ -35,14 +35,14 @@ bool MethodTable::Validate(bool assertOnFail /* default: true */)
     if (minObjSize < (3 * sizeof(TADDR)))
         REPORT_FAILURE();
 
-    switch (get_Kind())
+    switch (GetKind())
     {
     case CanonicalEEType:
     {
         // If the parent type is NULL this had better look like Object.
         if (!IsInterface() && (m_RelatedType.m_pBaseType == NULL))
         {
-            if (get_IsValueType() ||
+            if (IsValueType() ||
                 HasFinalizer() ||
                 HasReferenceFields() ||
                 HasGenericVariance())
@@ -65,7 +65,7 @@ bool MethodTable::Validate(bool assertOnFail /* default: true */)
         if (GetComponentSize() == 0)
             REPORT_FAILURE();
 
-        if (get_IsValueType() ||
+        if (IsValueType() ||
             HasFinalizer() ||
             HasGenericVariance())
         {
@@ -93,13 +93,13 @@ bool MethodTable::Validate(bool assertOnFail /* default: true */)
 }
 
 //-----------------------------------------------------------------------------------------------------------
-MethodTable::Kinds MethodTable::get_Kind()
+MethodTable::Kinds MethodTable::GetKind()
 {
 	return (Kinds)(m_uFlags & (uint16_t)EETypeKindMask);
 }
 
 //-----------------------------------------------------------------------------------------------------------
-MethodTable * MethodTable::get_RelatedParameterType()
+MethodTable * MethodTable::GetRelatedParameterType()
 {
 	ASSERT(IsParameterizedType());
 

--- a/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
@@ -90,9 +90,9 @@ COOP_PINVOKE_HELPER(uint32_t, RhGetLoadedOSModules, (Array * pResultArray))
 
     // If a result array is passed then it should be an array type with pointer-sized components that are not
     // GC-references.
-    ASSERT(!pResultArray || pResultArray->get_EEType()->IsArray());
-    ASSERT(!pResultArray || !pResultArray->get_EEType()->HasReferenceFields());
-    ASSERT(!pResultArray || pResultArray->get_EEType()->RawGetComponentSize() == sizeof(void*));
+    ASSERT(!pResultArray || pResultArray->GetMethodTable()->IsArray());
+    ASSERT(!pResultArray || !pResultArray->GetMethodTable()->HasReferenceFields());
+    ASSERT(!pResultArray || pResultArray->GetMethodTable()->RawGetComponentSize() == sizeof(void*));
 
     uint32_t cResultArrayElements = pResultArray ? pResultArray->GetArrayLength() : 0;
     HANDLE * pResultElements = pResultArray ? (HANDLE*)(pResultArray + 1) : NULL;

--- a/src/coreclr/nativeaot/Runtime/ObjectLayout.cpp
+++ b/src/coreclr/nativeaot/Runtime/ObjectLayout.cpp
@@ -33,7 +33,7 @@ uint32_t Array::GetArrayLength()
 void* Array::GetArrayData()
 {
     uint8_t* pData = (uint8_t*)this;
-    pData += (get_EEType()->get_BaseSize() - sizeof(ObjHeader));
+    pData += (GetMethodTable()->GetBaseSize() - sizeof(ObjHeader));
     return pData;
 }
 
@@ -55,12 +55,12 @@ void ObjHeader::ClrBit(uint32_t uBit)
 
 size_t Object::GetSize()
 {
-    MethodTable * pEEType = get_EEType();
+    MethodTable * pEEType = GetMethodTable();
 
     // strings have component size2, all other non-arrays should have 0
     ASSERT(( pEEType->GetComponentSize() <= 2) || pEEType->IsArray());
 
-    size_t s = pEEType->get_BaseSize();
+    size_t s = pEEType->GetBaseSize();
     if (pEEType->HasComponentSize())
         s += (size_t)((Array*)this)->GetArrayLength() * pEEType->RawGetComponentSize();
 

--- a/src/coreclr/nativeaot/Runtime/ObjectLayout.h
+++ b/src/coreclr/nativeaot/Runtime/ObjectLayout.h
@@ -43,9 +43,9 @@ class Object
 
     PTR_EEType  m_pEEType;
 public:
-    MethodTable * get_EEType() const
+    MethodTable * GetMethodTable() const
         { return m_pEEType; }
-    MethodTable * get_SafeEEType() const
+    MethodTable * GetGCSafeMethodTable() const
 #ifdef TARGET_64BIT
         { return dac_cast<PTR_EEType>((dac_cast<TADDR>(m_pEEType)) & ~((uintptr_t)7)); }
 #else
@@ -66,11 +66,7 @@ public:
     //
     MethodTable * RawGetMethodTable() const
     {
-        return (MethodTable*)get_EEType();
-    }
-    MethodTable * GetGCSafeMethodTable() const
-    {
-        return (MethodTable *)get_SafeEEType();
+        return (MethodTable*)GetMethodTable();
     }
     void RawSetMethodTable(MethodTable * pMT)
     {

--- a/src/coreclr/nativeaot/Runtime/RestrictedCallouts.cpp
+++ b/src/coreclr/nativeaot/Runtime/RestrictedCallouts.cpp
@@ -224,7 +224,7 @@ bool RestrictedCallouts::InvokeRefCountedHandleCallbacks(Object * pObject)
     HandleTableRestrictedCallout * pCurrCallout = s_pHandleTableRestrictedCallouts;
     while (pCurrCallout)
     {
-        if (pObject->get_SafeEEType() == pCurrCallout->m_pTypeFilter)
+        if (pObject->GetGCSafeMethodTable() == pCurrCallout->m_pTypeFilter)
         {
             // Make the callout. Return true to our caller as soon as we see a true result here.
             if (((HandleTableRestrictedCallbackFunction)pCurrCallout->m_pCalloutMethod)(pObject))

--- a/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
@@ -307,7 +307,7 @@ int BulkTypeEventLogger::LogSingleType(MethodTable * pEEType)
         // Array
         pVal->fixedSizedData.Flags |= kEtwTypeFlagsArray;
         pVal->cTypeParameters = 1;
-        pVal->ullSingleTypeParameter = (ULONGLONG) pEEType->get_RelatedParameterType();
+        pVal->ullSingleTypeParameter = (ULONGLONG) pEEType->GetRelatedParameterType();
     }
     else
     {

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -129,7 +129,7 @@ Object* GcAllocInternal(MethodTable *pEEType, uint32_t uFlags, uintptr_t numElem
     ASSERT(!pThread->IsDoNotTriggerGcSet());
     ASSERT(pThread->IsCurrentThreadInCooperativeMode());
 
-    size_t cbSize = pEEType->get_BaseSize();
+    size_t cbSize = pEEType->GetBaseSize();
 
     if (pEEType->HasComponentSize())
     {
@@ -503,11 +503,11 @@ uint32_t RedhawkGCInterface::GetGCDescSize(void * pType)
 
 COOP_PINVOKE_HELPER(FC_BOOL_RET, RhCompareObjectContentsAndPadding, (Object* pObj1, Object* pObj2))
 {
-    ASSERT(pObj1->get_EEType()->IsEquivalentTo(pObj2->get_EEType()));
-    ASSERT(pObj1->get_EEType()->IsValueType());
+    ASSERT(pObj1->GetMethodTable()->IsEquivalentTo(pObj2->GetMethodTable()));
+    ASSERT(pObj1->GetMethodTable()->IsValueType());
 
-    MethodTable * pEEType = pObj1->get_EEType();
-    size_t cbFields = pEEType->get_BaseSize() - (sizeof(ObjHeader) + sizeof(MethodTable*));
+    MethodTable * pEEType = pObj1->GetMethodTable();
+    size_t cbFields = pEEType->GetBaseSize() - (sizeof(ObjHeader) + sizeof(MethodTable*));
 
     uint8_t * pbFields1 = (uint8_t*)pObj1 + sizeof(MethodTable*);
     uint8_t * pbFields2 = (uint8_t*)pObj2 + sizeof(MethodTable*);

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.h
@@ -176,14 +176,10 @@ public:
         GenericTypeDefEEType    = 0x00030000,
     };
 
-    uint32_t get_BaseSize()
+    uint32_t GetBaseSize()
         { return m_uBaseSize; }
 
-    PTR_Code get_Slot(uint16_t slotNumber);
-
-    PTR_PTR_Code get_SlotPtr(uint16_t slotNumber);
-
-    Kinds get_Kind();
+    Kinds GetKind();
 
     bool IsArray()
     {
@@ -195,25 +191,25 @@ public:
         { return GetElementType() == ElementType_SzArray; }
 
     bool IsParameterizedType()
-        { return (get_Kind() == ParameterizedEEType); }
+        { return (GetKind() == ParameterizedEEType); }
 
     bool IsGenericTypeDefinition()
-        { return (get_Kind() == GenericTypeDefEEType); }
+        { return (GetKind() == GenericTypeDefEEType); }
 
     bool IsCanonical()
-        { return get_Kind() == CanonicalEEType; }
+        { return GetKind() == CanonicalEEType; }
 
     bool IsInterface()
         { return GetElementType() == ElementType_Interface; }
 
-    MethodTable * get_RelatedParameterType();
+    MethodTable * GetRelatedParameterType();
 
     // A parameterized type shape less than SZARRAY_BASE_SIZE indicates that this is not
     // an array but some other parameterized type (see: ParameterizedTypeShapeConstants)
     // For arrays, this number uniquely captures both Sz/Md array flavor and rank.
-    uint32_t get_ParameterizedTypeShape() { return m_uBaseSize; }
+    uint32_t GetParameterizedTypeShape() { return m_uBaseSize; }
 
-    bool get_IsValueType()
+    bool IsValueType()
         { return GetElementType() < ElementType_Class; }
 
     bool HasFinalizer()
@@ -273,8 +269,8 @@ public:
 
         if (pThisEEType->IsParameterizedType() && pOtherEEType->IsParameterizedType())
         {
-            return pThisEEType->get_RelatedParameterType()->IsEquivalentTo(pOtherEEType->get_RelatedParameterType()) &&
-                pThisEEType->get_ParameterizedTypeShape() == pOtherEEType->get_ParameterizedTypeShape();
+            return pThisEEType->GetRelatedParameterType()->IsEquivalentTo(pOtherEEType->GetRelatedParameterType()) &&
+                pThisEEType->GetParameterizedTypeShape() == pOtherEEType->GetParameterizedTypeShape();
         }
 
         return false;
@@ -346,10 +342,8 @@ public:
 
 public:
     // Methods expected by the GC
-    uint32_t GetBaseSize() { return get_BaseSize(); }
     uint32_t ContainsPointers() { return HasReferenceFields(); }
     uint32_t ContainsPointersOrCollectible() { return HasReferenceFields(); }
-    bool IsValueType() { return get_IsValueType(); }
     UInt32_BOOL SanityCheck() { return Validate(); }
 };
 

--- a/src/coreclr/nativeaot/Runtime/inc/MethodTable.inl
+++ b/src/coreclr/nativeaot/Runtime/inc/MethodTable.inl
@@ -9,20 +9,6 @@ inline uint32_t MethodTable::GetHashCode()
     return m_uHashCode;
 }
 
-//-----------------------------------------------------------------------------------------------------------
-inline PTR_Code MethodTable::get_Slot(uint16_t slotNumber)
-{
-    ASSERT(slotNumber < m_usNumVtableSlots);
-    return *get_SlotPtr(slotNumber);
-}
-
-//-----------------------------------------------------------------------------------------------------------
-inline PTR_PTR_Code MethodTable::get_SlotPtr(uint16_t slotNumber)
-{
-    ASSERT(slotNumber < m_usNumVtableSlots);
-    return dac_cast<PTR_PTR_Code>(dac_cast<TADDR>(this) + offsetof(MethodTable, m_VTable)) + slotNumber;
-}
-
 #ifdef DACCESS_COMPILE
 inline bool MethodTable::DacVerify()
 {

--- a/src/coreclr/nativeaot/Runtime/interoplibinterface_objc.cpp
+++ b/src/coreclr/nativeaot/Runtime/interoplibinterface_objc.cpp
@@ -71,7 +71,7 @@ namespace
 
     bool TryGetTaggedMemory(_In_ Object * obj, _Out_ void ** tagged)
     {
-        void* fn = obj->get_EEType()
+        void* fn = obj->GetMethodTable()
                        ->GetTypeManagerPtr()
                        ->AsTypeManager()
                        ->GetClasslibFunction(ClasslibFunctionId::ObjectiveCMarshalTryGetTaggedMemory);
@@ -91,7 +91,7 @@ namespace
     // Not for use with ObjectiveCMarshalTryGetTaggedMemory.
     void * GetCallbackViaClasslibCallback(_In_ Object * object, _In_ ClasslibFunctionId id)
     {
-        void* fn = object->get_EEType()
+        void* fn = object->GetMethodTable()
                         ->GetTypeManagerPtr()
                         ->AsTypeManager()
                         ->GetClasslibFunction(id);

--- a/src/coreclr/nativeaot/Runtime/portable.cpp
+++ b/src/coreclr/nativeaot/Runtime/portable.cpp
@@ -62,7 +62,7 @@ COOP_PINVOKE_HELPER(Object *, RhpNewFast, (MethodTable* pEEType))
 
     Thread * pCurThread = ThreadStore::GetCurrentThread();
     gc_alloc_context * acontext = pCurThread->GetAllocContext();
-    size_t size = pEEType->get_BaseSize();
+    size_t size = pEEType->GetBaseSize();
 
     uint8_t* alloc_ptr = acontext->alloc_ptr;
     ASSERT(alloc_ptr <= acontext->alloc_limit);
@@ -107,7 +107,7 @@ COOP_PINVOKE_HELPER(Array *, RhpNewArray, (MethodTable * pArrayEEType, int numEl
     }
 #endif // !HOST_64BIT
 
-    size_t size = (size_t)pArrayEEType->get_BaseSize() + ((size_t)numElements * (size_t)pArrayEEType->RawGetComponentSize());
+    size_t size = (size_t)pArrayEEType->GetBaseSize() + ((size_t)numElements * (size_t)pArrayEEType->RawGetComponentSize());
     size = ALIGN_UP(size, sizeof(uintptr_t));
 
     uint8_t* alloc_ptr = acontext->alloc_ptr;
@@ -150,7 +150,7 @@ COOP_PINVOKE_HELPER(Object*, RhpNewFastAlign8, (MethodTable* pEEType))
     Thread* pCurThread = ThreadStore::GetCurrentThread();
     gc_alloc_context* acontext = pCurThread->GetAllocContext();
 
-    size_t size = pEEType->get_BaseSize();
+    size_t size = pEEType->GetBaseSize();
     size = (size + (sizeof(uintptr_t) - 1)) & ~(sizeof(uintptr_t) - 1);
 
     uint8_t* alloc_ptr = acontext->alloc_ptr;
@@ -184,7 +184,7 @@ COOP_PINVOKE_HELPER(Object*, RhpNewFastMisalign, (MethodTable* pEEType))
     Thread* pCurThread = ThreadStore::GetCurrentThread();
     gc_alloc_context* acontext = pCurThread->GetAllocContext();
 
-    size_t size = pEEType->get_BaseSize();
+    size_t size = pEEType->GetBaseSize();
 
     uint8_t* alloc_ptr = acontext->alloc_ptr;
     int requiresPadding = (((uint32_t)alloc_ptr) & 7) != 4;
@@ -230,7 +230,7 @@ COOP_PINVOKE_HELPER(Array*, RhpNewArrayAlign8, (MethodTable* pArrayEEType, int n
         return (Array*)AllocateObject(pArrayEEType, GC_ALLOC_ALIGN8, numElements);
     }
 
-    uint32_t baseSize = pArrayEEType->get_BaseSize();
+    uint32_t baseSize = pArrayEEType->GetBaseSize();
     size_t size = (size_t)baseSize + ((size_t)numElements * (size_t)pArrayEEType->RawGetComponentSize());
     size = ALIGN_UP(size, sizeof(uintptr_t));
 

--- a/src/coreclr/nativeaot/Runtime/profheapwalkhelper.cpp
+++ b/src/coreclr/nativeaot/Runtime/profheapwalkhelper.cpp
@@ -178,7 +178,7 @@ bool HeapWalkHelper(Object * pBO, void * pvContext)
         ETW::GCLog::ObjectReference(
             pProfilerWalkHeapContext,
             pBO,
-            ULONGLONG(pBO->get_SafeEEType()),
+            ULONGLONG(pBO->GetGCSafeMethodTable()),
             cNumRefs,
             (Object **) arrObjRef);
     }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Attribute.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Attribute.NativeAot.cs
@@ -40,7 +40,7 @@ namespace System
             {
                 int fieldOffset = __GetFieldHelper(i, out MethodTable* fieldType);
 
-                Debug.Assert(!fieldType->IsPointerType && !fieldType->IsFunctionPointerType);
+                Debug.Assert(!fieldType->IsPointer && !fieldType->IsFunctionPointer);
 
                 // Fetch the value of the field on both types
                 object thisResult = RuntimeImports.RhBoxAny(ref Unsafe.Add(ref thisRawData, fieldOffset), fieldType);
@@ -67,7 +67,7 @@ namespace System
             {
                 int fieldOffset = __GetFieldHelper(i, out MethodTable* fieldType);
 
-                Debug.Assert(!fieldType->IsPointerType && !fieldType->IsFunctionPointerType);
+                Debug.Assert(!fieldType->IsPointer && !fieldType->IsFunctionPointer);
 
                 object? fieldValue = RuntimeImports.RhBoxAny(ref Unsafe.Add(ref thisRawData, fieldOffset), fieldType);
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -111,7 +111,7 @@ namespace System
         {
             get
             {
-                return _value->IsPointerType;
+                return _value->IsPointer;
             }
         }
 
@@ -119,7 +119,7 @@ namespace System
         {
             get
             {
-                return _value->IsFunctionPointerType;
+                return _value->IsFunctionPointer;
             }
         }
 
@@ -127,7 +127,7 @@ namespace System
         {
             get
             {
-                return _value->IsByRefType;
+                return _value->IsByRef;
             }
         }
 
@@ -214,7 +214,7 @@ namespace System
         {
             get
             {
-                return !_value->IsParameterizedType && !_value->IsFunctionPointerType;
+                return !_value->IsParameterizedType && !_value->IsFunctionPointer;
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
@@ -138,7 +138,7 @@ namespace System
                 int fieldOffset = __GetFieldHelper(i, out MethodTable* fieldType);
                 ref byte fieldData = ref Unsafe.Add(ref data, fieldOffset);
 
-                Debug.Assert(!fieldType->IsPointerType && !fieldType->IsFunctionPointerType);
+                Debug.Assert(!fieldType->IsPointer && !fieldType->IsFunctionPointer);
 
                 if (fieldType->ElementType == EETypeElementType.Single)
                 {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -1025,7 +1025,7 @@ namespace Internal.Runtime.TypeLoader
                 {
                     unsafe
                     {
-                        Debug.Assert(typeAsParameterizedType.RuntimeTypeHandle.ToEETypePtr()->IsByRefType);
+                        Debug.Assert(typeAsParameterizedType.RuntimeTypeHandle.ToEETypePtr()->IsByRef);
                     }
                     TypeSystemContext.ByRefTypesCache.AddOrGetExisting(typeAsParameterizedType.RuntimeTypeHandle);
                 }
@@ -1034,7 +1034,7 @@ namespace Internal.Runtime.TypeLoader
                     Debug.Assert(typeAsParameterizedType is PointerType);
                     unsafe
                     {
-                        Debug.Assert(typeAsParameterizedType.RuntimeTypeHandle.ToEETypePtr()->IsPointerType);
+                        Debug.Assert(typeAsParameterizedType.RuntimeTypeHandle.ToEETypePtr()->IsPointer);
                     }
                     TypeSystemContext.PointerTypesCache.AddOrGetExisting(typeAsParameterizedType.RuntimeTypeHandle);
                 }
@@ -1259,7 +1259,7 @@ namespace Internal.Runtime.TypeLoader
                 pointerTypeHandle = EETypeCreator.CreatePointerEEType((uint)pointerType.GetHashCode(), pointeeTypeHandle, pointerType);
                 unsafe
                 {
-                    Debug.Assert(pointerTypeHandle.ToEETypePtr()->IsPointerType);
+                    Debug.Assert(pointerTypeHandle.ToEETypePtr()->IsPointer);
                 }
                 TypeSystemContext.PointerTypesCache.AddOrGetExisting(pointerTypeHandle);
 
@@ -1279,7 +1279,7 @@ namespace Internal.Runtime.TypeLoader
                 byRefTypeHandle = EETypeCreator.CreateByRefEEType((uint)byRefType.GetHashCode(), pointeeTypeHandle, byRefType);
                 unsafe
                 {
-                    Debug.Assert(byRefTypeHandle.ToEETypePtr()->IsByRefType);
+                    Debug.Assert(byRefTypeHandle.ToEETypePtr()->IsByRef);
                 }
                 TypeSystemContext.ByRefTypesCache.AddOrGetExisting(byRefTypeHandle);
 
@@ -1304,7 +1304,7 @@ namespace Internal.Runtime.TypeLoader
                 runtimeTypeHandle = EETypeCreator.CreateFunctionPointerEEType((uint)functionPointerType.GetHashCode(), returnTypeHandle, parameterHandles, functionPointerType);
                 unsafe
                 {
-                    Debug.Assert(runtimeTypeHandle.ToEETypePtr()->IsFunctionPointerType);
+                    Debug.Assert(runtimeTypeHandle.ToEETypePtr()->IsFunctionPointer);
                 }
                 TypeSystemContext.FunctionPointerTypesCache.AddOrGetExisting(runtimeTypeHandle);
 


### PR DESCRIPTION
A few methods in native AOT runtime data structures used get_ prefix for historic reasons.