### PR TITLE
Fix asserts about arm64 hardware intrinsic register selection

### DIFF
--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -287,10 +287,13 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
             {
                 if (isRMW)
                 {
-                    assert(targetReg != op2Reg);
-                    assert(targetReg != op3Reg);
+                    if (targetReg != op1Reg)
+                    {
+                        assert(targetReg != op2Reg);
+                        assert(targetReg != op3Reg);
 
-                    GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                        GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                    }
 
                     HWIntrinsicImmOpHelper helper(this, intrin.op4, node);
 
@@ -317,10 +320,13 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
             {
                 if (isRMW)
                 {
-                    assert(targetReg != op2Reg);
-                    assert(targetReg != op3Reg);
+                    if (targetReg != op1Reg)
+                    {
+                        assert(targetReg != op2Reg);
+                        assert(targetReg != op3Reg);
 
-                    GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                        GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                    }
 
                     GetEmitter()->emitIns_R_R_R_I(ins, emitSize, targetReg, op2Reg, op3Reg, 0, opt);
                 }
@@ -400,9 +406,13 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                     }
                     else if (isRMW)
                     {
-                        assert(targetReg != op2Reg);
+                        if (targetReg != op1Reg)
+                        {
+                            assert(targetReg != op2Reg);
 
-                        GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                            GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg,
+                                                      /* canSkip */ true);
+                        }
                         GetEmitter()->emitIns_R_R(ins, emitSize, targetReg, op2Reg, opt);
                     }
                     else
@@ -413,10 +423,13 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
 
                 case 3:
                     assert(isRMW);
-                    assert(targetReg != op2Reg);
-                    assert(targetReg != op3Reg);
+                    if (targetReg != op1Reg)
+                    {
+                        assert(targetReg != op2Reg);
+                        assert(targetReg != op3Reg);
 
-                    GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                        GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                    }
                     GetEmitter()->emitIns_R_R_R(ins, emitSize, targetReg, op2Reg, op3Reg, opt);
                     break;
 
@@ -652,9 +665,12 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
             case NI_AdvSimd_InsertScalar:
             {
                 assert(isRMW);
-                assert(targetReg != op3Reg);
+                if (targetReg != op1Reg)
+                {
+                    assert(targetReg != op3Reg);
 
-                GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                    GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                }
 
                 HWIntrinsicImmOpHelper helper(this, intrin.op2, node);
 
@@ -670,9 +686,12 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
             case NI_AdvSimd_Arm64_InsertSelectedScalar:
             {
                 assert(isRMW);
-                assert(targetReg != op3Reg);
+                if (targetReg != op1Reg)
+                {
+                    assert(targetReg != op3Reg);
 
-                GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                    GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                }
 
                 const int resultIndex = (int)intrin.op2->AsIntCon()->gtIconVal;
                 const int valueIndex  = (int)intrin.op4->AsIntCon()->gtIconVal;
@@ -683,9 +702,12 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
             case NI_AdvSimd_LoadAndInsertScalar:
             {
                 assert(isRMW);
-                assert(targetReg != op3Reg);
+                if (targetReg != op1Reg)
+                {
+                    assert(targetReg != op3Reg);
 
-                GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                    GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                }
 
                 HWIntrinsicImmOpHelper helper(this, intrin.op2, node);
 
@@ -1063,7 +1085,6 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                 unsigned regCount = 0;
                 op1Reg            = intrin.op1->GetRegNum();
                 op3Reg            = intrin.op3->GetRegNum();
-                assert(targetReg != op3Reg);
                 if (intrin.op2->OperIsFieldList())
                 {
                     GenTreeFieldList* fieldList  = intrin.op2->AsFieldList();
@@ -1108,7 +1129,11 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                         break;
                 }
 
-                GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                if (targetReg != op1Reg)
+                {
+                    assert(targetReg != op3Reg);
+                    GetEmitter()->emitIns_Mov(INS_mov, emitTypeSize(node), targetReg, op1Reg, /* canSkip */ true);
+                }
                 GetEmitter()->emitIns_R_R_R(ins, emitSize, targetReg, op2Reg, op3Reg, opt);
                 break;
             }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91209/Runtime_91209.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91209/Runtime_91209.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.aa
+
+// Found by Antigen
+//
+// Test ARM64 read-modify-write (RMW) intrinsics with identical target/accumulator local to arguments
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Numerics;
+using Xunit;
+
+public class Runtime_91209
+{
+    //////////////////////////// test AdvSimd.MultiplyAddByScalar()
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<int> GetVector64IntValue()
+    {
+        return Vector64.Create(6);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<int> Problem1()
+    {
+        Vector64<int> l = GetVector64IntValue();
+        return AdvSimd.MultiplyAddByScalar(l, l, l);
+    }
+
+    [Fact]
+    public static int Test1()
+    {
+        Console.WriteLine("Test1");
+        Vector64<int> r1 = Problem1();
+        return (r1.GetElement(0) + r1.GetElement(1)) == 84 ? 100 : 101;
+    }
+
+    //////////////////////////// test AdvSimd.MultiplyAdd()
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<sbyte> GetVector64SbyteValue()
+    {
+        return Vector64.Create((sbyte)2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<sbyte> Problem2()
+    {
+        Vector64<sbyte> l = GetVector64SbyteValue();
+        return AdvSimd.MultiplyAdd(l, l, l);
+    }
+
+    [Fact]
+    public static int Test2()
+    {
+        Console.WriteLine("Test2");
+        Vector64<sbyte> r1 = Problem2();
+        return (r1.GetElement(0) + r1.GetElement(1)) == 12 ? 100 : 101;
+    }
+
+    //////////////////////////// test AdvSimd.VectorTableLookupExtension()
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<byte> GetVector64ByteValue()
+    {
+        return Vector64.Create((byte)2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<byte> Problem3()
+    {
+        Vector64<byte> l = GetVector64ByteValue();
+        Vector128<byte> t = Vector128.Create((byte)7);
+        return AdvSimd.VectorTableLookupExtension(l, (t,t), l);
+    }
+
+    [Fact]
+    public static int Test3()
+    {
+        Console.WriteLine("Test3");
+        Vector64<byte> r1 = Problem3();
+        return r1.GetElement(2) == 7 ? 100 : 101;
+    }
+
+    //////////////////////////// test AdvSimd.VectorTableLookupExtension() with identical table + target
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<byte> GetVector128ByteValue()
+    {
+        return Vector128.Create((byte)7);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<byte> Problem4()
+    {
+        Vector128<byte> l = GetVector128ByteValue();
+        return AdvSimd.VectorTableLookupExtension(Vector128.GetLower<byte>(l), (l,l), Vector128.GetLower<byte>(l));
+    }
+
+    [Fact]
+    public static int Test4()
+    {
+        Console.WriteLine("Test4");
+        Vector64<byte> r1 = Problem4();
+        return r1.GetElement(7) == 7 ? 100 : 101;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91209/Runtime_91209.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91209/Runtime_91209.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'arm64'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91209/Runtime_91209.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91209/Runtime_91209.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Optimize>True</Optimize>
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'arm64'">true</CLRTestTargetUnsupported>
+    <!-- Needed for CLRTestTargetUnsupported -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <CLRTestTargetUnsupported Condition="('$(TargetArchitecture)' != 'arm64') OR ('$(RuntimeFlavor)' != 'coreclr')">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
There are a bunch of asserts in arm64 hardware intrinsics codegen, for intrinsics with read-modify-write behavior, that the target register is not the same as the non-RMW operand registers, since we do a `mov` to the target register which could trash those argument registers. However, if the target register and the `op1` register are the same, then no `mov` is necessary, and also, the register allocator should already have ensured proper lifetime conflict resolution.

So, put the asserts under a check that the `mov` is required.

Fixes #91209