### PR TITLE
Add missing ArrayPool returns to failure branches

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Utf8.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Utf8.cs
@@ -97,6 +97,12 @@ namespace System.Globalization
 
             if (sourceStatus != OperationStatus.Done)
             {
+                if (sourceUtf16Array != null)
+                {
+                    // Return rented buffers if necessary
+                    ArrayPool<char>.Shared.Return(sourceUtf16Array);
+                }
+
                 return false;
             }
             sourceUtf16 = sourceUtf16.Slice(0, sourceUtf16Length);
@@ -122,6 +128,18 @@ namespace System.Globalization
 
             if (prefixStatus != OperationStatus.Done)
             {
+                // Return rented buffers if necessary
+
+                if (prefixUtf16Array != null)
+                {
+                    ArrayPool<char>.Shared.Return(prefixUtf16Array);
+                }
+
+                if (sourceUtf16Array != null)
+                {
+                    ArrayPool<char>.Shared.Return(sourceUtf16Array);
+                }
+
                 return false;
             }
             prefixUtf16 = prefixUtf16.Slice(0, prefixUtf16Length);

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs
@@ -310,6 +310,12 @@ namespace System.Numerics
 
             if (utf8TextStatus != OperationStatus.Done)
             {
+                if (utf16TextArray != null)
+                {
+                    // Return rented buffers if necessary
+                    ArrayPool<char>.Shared.Return(utf16TextArray);
+                }
+
                 ThrowHelper.ThrowFormatInvalidString();
             }
             utf16Text = utf16Text.Slice(0, utf16TextLength);
@@ -438,6 +444,12 @@ namespace System.Numerics
 
             if (utf8TextStatus != OperationStatus.Done)
             {
+                if (utf16TextArray != null)
+                {
+                    // Return rented buffers if necessary
+                    ArrayPool<char>.Shared.Return(utf16TextArray);
+                }
+
                 result = default;
                 return false;
             }
@@ -536,6 +548,12 @@ namespace System.Numerics
 
             if (utf8TextStatus != OperationStatus.Done)
             {
+                if (utf16TextArray != null)
+                {
+                    // Return rented buffers if necessary
+                    ArrayPool<char>.Shared.Return(utf16TextArray);
+                }
+
                 ThrowHelper.ThrowFormatInvalidString();
             }
             utf16Text = utf16Text.Slice(0, utf16TextLength);
@@ -577,6 +595,12 @@ namespace System.Numerics
 
             if (utf8TextStatus != OperationStatus.Done)
             {
+                if (utf16TextArray != null)
+                {
+                    // Return rented buffers if necessary
+                    ArrayPool<char>.Shared.Return(utf16TextArray);
+                }
+
                 result = default;
                 return false;
             }


### PR DESCRIPTION
#86875 added code that rents arrays from the ArrayPool but doesn't return them in failure branches. #88840 fixed one occurence of this and this PR fixes the other 6, both in Try and throwing methods.