### PR TITLE
Improve nullability check for generic `.ctor` parameters

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
@@ -89,9 +89,7 @@ namespace System.Reflection
             ParameterInfo? metaParameter;
             MemberInfo metaMember;
 
-            MemberInfo member = parameter.Member;
-
-            switch (member)
+            switch (parameter.Member)
             {
                 case ConstructorInfo ctor:
                     var metaCtor = (ConstructorInfo)GetMemberMetadataDefinition(ctor);
@@ -102,14 +100,7 @@ namespace System.Reflection
                 case MethodInfo method:
                     MethodInfo metaMethod = GetMethodMetadataDefinition(method);
                     metaMember = metaMethod;
-                    if (string.IsNullOrEmpty(parameter.Name))
-                    {
-                        metaParameter = metaMethod.ReturnParameter;
-                    }
-                    else
-                    {
-                        metaParameter = GetMetaParameter(metaMethod, parameter);
-                    }
+                    metaParameter = string.IsNullOrEmpty(parameter.Name) ? metaMethod.ReturnParameter : GetMetaParameter(metaMethod, parameter);
                     break;
 
                 default:

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
@@ -86,35 +86,56 @@ namespace System.Reflection
 
         private void CheckParameterMetadataType(ParameterInfo parameter, NullabilityInfo nullability)
         {
-            if (parameter.Member is MethodInfo method)
-            {
-                MethodInfo metaMethod = GetMethodMetadataDefinition(method);
-                ParameterInfo? metaParameter = null;
-                if (string.IsNullOrEmpty(parameter.Name))
-                {
-                    metaParameter = metaMethod.ReturnParameter;
-                }
-                else
-                {
-                    ReadOnlySpan<ParameterInfo> parameters = metaMethod.GetParametersAsSpan();
-                    for (int i = 0; i < parameters.Length; i++)
-                    {
-                        if (parameter.Position == i &&
-                            parameter.Name == parameters[i].Name)
-                        {
-                            metaParameter = parameters[i];
-                            break;
-                        }
-                    }
-                }
+            ParameterInfo? metaParameter;
+            MemberInfo metaMember;
 
-                if (metaParameter != null)
-                {
-                    CheckGenericParameters(nullability, metaMethod, metaParameter.ParameterType, parameter.Member.ReflectedType);
-                }
+            MemberInfo member = parameter.Member;
+
+            switch (member)
+            {
+                case ConstructorInfo ctor:
+                    var metaCtor = (ConstructorInfo)GetMemberMetadataDefinition(ctor);
+                    metaMember = metaCtor;
+                    metaParameter = GetMetaParameter(metaCtor, parameter);
+                    break;
+
+                case MethodInfo method:
+                    var metaMethod = GetMethodMetadataDefinition(method);
+                    metaMember = metaMethod;
+                    if (string.IsNullOrEmpty(parameter.Name))
+                    {
+                        metaParameter = metaMethod.ReturnParameter;
+                    }
+                    else
+                    {
+                        metaParameter = GetMetaParameter(metaMethod, parameter);
+                    }
+                    break;
+
+                default:
+                    return;
+            }
+
+            if (metaParameter != null)
+            {
+                CheckGenericParameters(nullability, metaMember, metaParameter.ParameterType, parameter.Member.ReflectedType);
             }
         }
 
+        private static ParameterInfo? GetMetaParameter(MethodBase metaMethod, ParameterInfo parameter)
+        {
+            ReadOnlySpan<ParameterInfo> parameters = metaMethod.GetParametersAsSpan();
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (parameter.Position == i &&
+                    parameter.Name == parameters[i].Name)
+                {
+                    return parameters[i];
+                }
+            }
+
+            return null;
+        }
         private static MethodInfo GetMethodMetadataDefinition(MethodInfo method)
         {
             if (method.IsGenericMethod && !method.IsGenericMethodDefinition)

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
@@ -100,7 +100,7 @@ namespace System.Reflection
                     break;
 
                 case MethodInfo method:
-                    var metaMethod = GetMethodMetadataDefinition(method);
+                    MethodInfo metaMethod = GetMethodMetadataDefinition(method);
                     metaMember = metaMethod;
                     if (string.IsNullOrEmpty(parameter.Name))
                     {

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -1318,48 +1318,51 @@ namespace System.Reflection.Tests
             Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[2].GenericTypeArguments[1].ReadState);
         }
 
+        private static Type EnsureReflection([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type) => type;
+
         public static IEnumerable<object[]> TestCtorParametersData() => new object[][]
         {
-            [typeof(GenericTypeWithCtor<>), NullabilityState.Nullable, NullabilityState.Nullable],
-            [typeof(GenericTypeWithCtor<int>), NullabilityState.NotNull, NullabilityState.NotNull],
-            [typeof(GenericTypeWithCtor<int?>), NullabilityState.Nullable, NullabilityState.Nullable],
-            [typeof(GenericTypeWithCtor<object>), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor<>)), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor<int?>)), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor<object>)), NullabilityState.Nullable, NullabilityState.Nullable],
 
-            [typeof(GenericTypeWithCtor_Disallow<>), NullabilityState.Nullable, NullabilityState.NotNull],
-            [typeof(GenericTypeWithCtor_Disallow<int>), NullabilityState.NotNull, NullabilityState.NotNull],
-            [typeof(GenericTypeWithCtor_Disallow<int?>), NullabilityState.Nullable, NullabilityState.NotNull],
-            [typeof(GenericTypeWithCtor_Disallow<object>), NullabilityState.Nullable, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Disallow<>)), NullabilityState.Nullable, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Disallow<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Disallow<int?>)), NullabilityState.Nullable, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Disallow<object>)), NullabilityState.Nullable, NullabilityState.NotNull],
 
-            [typeof(GenericTypeWithCtor_Maybe<>), NullabilityState.Nullable, NullabilityState.Nullable],
-            [typeof(GenericTypeWithCtor_Maybe<int>), NullabilityState.NotNull, NullabilityState.NotNull],
-            [typeof(GenericTypeWithCtor_Maybe<int?>), NullabilityState.Nullable, NullabilityState.Nullable],
-            [typeof(GenericTypeWithCtor_Maybe<object>), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Maybe<>)), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Maybe<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Maybe<int?>)), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Maybe<object>)), NullabilityState.Nullable, NullabilityState.Nullable],
 
-            [typeof(GenericTypeWithCtor_Allow<>), NullabilityState.Nullable, NullabilityState.Nullable],
-            [typeof(GenericTypeWithCtor_Allow<int>), NullabilityState.NotNull, NullabilityState.NotNull],
-            [typeof(GenericTypeWithCtor_Allow<int?>), NullabilityState.Nullable, NullabilityState.Nullable],
-            [typeof(GenericTypeWithCtor_Allow<object>), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Allow<>)), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Allow<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Allow<int?>)), NullabilityState.Nullable, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericTypeWithCtor_Allow<object>)), NullabilityState.Nullable, NullabilityState.Nullable],
 
-            [typeof(GenericNonNullableTypeWithCtor<>), NullabilityState.NotNull, NullabilityState.NotNull],
-            [typeof(GenericNonNullableTypeWithCtor<int>), NullabilityState.NotNull, NullabilityState.NotNull],
-            [typeof(GenericNonNullableTypeWithCtor<object>), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor<>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor<object>)), NullabilityState.NotNull, NullabilityState.NotNull],
 
-            [typeof(GenericNonNullableTypeWithCtor_Disallow<>), NullabilityState.NotNull, NullabilityState.NotNull],
-            [typeof(GenericNonNullableTypeWithCtor_Disallow<int>), NullabilityState.NotNull, NullabilityState.NotNull],
-            [typeof(GenericNonNullableTypeWithCtor_Disallow<object>), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Disallow<>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Disallow<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Disallow<object>)), NullabilityState.NotNull, NullabilityState.NotNull],
 
-            [typeof(GenericNonNullableTypeWithCtor_Maybe<>), NullabilityState.Nullable, NullabilityState.NotNull],
-            [typeof(GenericNonNullableTypeWithCtor_Maybe<int>), NullabilityState.NotNull, NullabilityState.NotNull],
-            [typeof(GenericNonNullableTypeWithCtor_Maybe<object>), NullabilityState.Nullable, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Maybe<>)), NullabilityState.Nullable, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Maybe<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Maybe<object>)), NullabilityState.Nullable, NullabilityState.NotNull],
 
-            [typeof(GenericNonNullableTypeWithCtor_Allow<>), NullabilityState.NotNull, NullabilityState.Nullable],
-            [typeof(GenericNonNullableTypeWithCtor_Allow<int>), NullabilityState.NotNull, NullabilityState.NotNull],
-            [typeof(GenericNonNullableTypeWithCtor_Allow<object>), NullabilityState.NotNull, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Allow<>)), NullabilityState.NotNull, NullabilityState.Nullable],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Allow<int>)), NullabilityState.NotNull, NullabilityState.NotNull],
+            [EnsureReflection(typeof(GenericNonNullableTypeWithCtor_Allow<object>)), NullabilityState.NotNull, NullabilityState.Nullable],
         };
 
         [Theory]
         [MemberData(nameof(TestCtorParametersData))]
-        public void TestCtorParameters(Type type, NullabilityState expectedRead, NullabilityState expectedWrite)
+        public void TestCtorParameters([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type,
+            NullabilityState expectedRead, NullabilityState expectedWrite)
         {
             var ctx = new NullabilityInfoContext();
 
@@ -1370,60 +1373,83 @@ namespace System.Reflection.Tests
             Assert.Equal(expectedWrite, info.WriteState);
         }
 
-        public static IEnumerable<object[]> TestMethodsWithGenericParametersData()
+        public static IEnumerable<object[]> TestMethodsWithOpenGenericParametersData()
         {
             const string MethodNullable = "GenericMethod";
             const string MethodNonNullable = "GenericNotNullMethod";
 
             return new object[][]
             {
-                [typeof(ClassWithGenericMethods), MethodNullable, null, NullabilityState.Nullable, NullabilityState.Nullable],
-                [typeof(ClassWithGenericMethods), MethodNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods), MethodNullable, typeof(int?), NullabilityState.Nullable, NullabilityState.Nullable],
-                [typeof(ClassWithGenericMethods), MethodNullable, typeof(object), NullabilityState.Nullable, NullabilityState.Nullable],
-
-                [typeof(ClassWithGenericMethods), MethodNonNullable, null, NullabilityState.NotNull, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods), MethodNonNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods), MethodNonNullable, typeof(object), NullabilityState.NotNull, NullabilityState.NotNull],
-
-                [typeof(ClassWithGenericMethods_Disallow), MethodNullable, null, NullabilityState.Nullable, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods_Disallow), MethodNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods_Disallow), MethodNullable, typeof(int?), NullabilityState.Nullable, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods_Disallow), MethodNullable, typeof(object), NullabilityState.Nullable, NullabilityState.NotNull],
-
-                [typeof(ClassWithGenericMethods_Disallow), MethodNonNullable, null, NullabilityState.NotNull, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods_Disallow), MethodNonNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods_Disallow), MethodNonNullable, typeof(object), NullabilityState.NotNull, NullabilityState.NotNull],
-
-                [typeof(ClassWithGenericMethods_Maybe), MethodNullable, null, NullabilityState.Nullable, NullabilityState.Nullable],
-                [typeof(ClassWithGenericMethods_Maybe), MethodNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods_Maybe), MethodNullable, typeof(int?), NullabilityState.Nullable, NullabilityState.Nullable],
-                [typeof(ClassWithGenericMethods_Maybe), MethodNullable, typeof(object), NullabilityState.Nullable, NullabilityState.Nullable],
-
-                [typeof(ClassWithGenericMethods_Maybe), MethodNonNullable, null, NullabilityState.Nullable, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods_Maybe), MethodNonNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods_Maybe), MethodNonNullable, typeof(object), NullabilityState.Nullable, NullabilityState.NotNull],
-
-                [typeof(ClassWithGenericMethods_Allow), MethodNullable, null, NullabilityState.Nullable, NullabilityState.Nullable],
-                [typeof(ClassWithGenericMethods_Allow), MethodNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods_Allow), MethodNullable, typeof(int?), NullabilityState.Nullable, NullabilityState.Nullable],
-                [typeof(ClassWithGenericMethods_Allow), MethodNullable, typeof(object), NullabilityState.Nullable, NullabilityState.Nullable],
-
-                [typeof(ClassWithGenericMethods_Allow), MethodNonNullable, null, NullabilityState.NotNull, NullabilityState.Nullable],
-                [typeof(ClassWithGenericMethods_Allow), MethodNonNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
-                [typeof(ClassWithGenericMethods_Allow), MethodNonNullable, typeof(object), NullabilityState.NotNull, NullabilityState.Nullable],
+                [EnsureReflection(typeof(ClassWithGenericMethods)), MethodNullable, NullabilityState.Nullable, NullabilityState.Nullable],
+                [EnsureReflection(typeof(ClassWithGenericMethods)), MethodNonNullable, NullabilityState.NotNull, NullabilityState.NotNull],
+                [EnsureReflection(typeof(ClassWithGenericMethods_Disallow)), MethodNullable, NullabilityState.Nullable, NullabilityState.NotNull],
+                [EnsureReflection(typeof(ClassWithGenericMethods_Disallow)), MethodNonNullable, NullabilityState.NotNull, NullabilityState.NotNull],
+                [EnsureReflection(typeof(ClassWithGenericMethods_Maybe)), MethodNullable, NullabilityState.Nullable, NullabilityState.Nullable],
+                [EnsureReflection(typeof(ClassWithGenericMethods_Maybe)), MethodNonNullable, NullabilityState.Nullable, NullabilityState.NotNull],
+                [EnsureReflection(typeof(ClassWithGenericMethods_Allow)), MethodNullable, NullabilityState.Nullable, NullabilityState.Nullable],
+                [EnsureReflection(typeof(ClassWithGenericMethods_Allow)), MethodNonNullable, NullabilityState.NotNull, NullabilityState.Nullable],
             };
-        } 
+        }
 
         [Theory]
-        [MemberData(nameof(TestMethodsWithGenericParametersData))]
-        public void TestMethodsWithGenericParameters(Type type, string methodName, Type? genericParameterType, NullabilityState expectedRead, NullabilityState expectedWrite)
+        [MemberData(nameof(TestMethodsWithOpenGenericParametersData))]
+        public void TestMethodsWithOpenGenericParameters([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type,
+            string methodName, NullabilityState expectedRead, NullabilityState expectedWrite)
         {
             var ctx = new NullabilityInfoContext();
 
             MethodInfo method = type.GetMethod(methodName)!;
-            if (genericParameterType is not null)
-                method = method.MakeGenericMethod(genericParameterType);
+
+            ParameterInfo paramInfo = method.GetParameters()[0];
+            NullabilityInfo info = ctx.Create(paramInfo);
+
+            Assert.Equal(expectedRead, info.ReadState);
+            Assert.Equal(expectedWrite, info.WriteState);
+        }
+
+        private delegate void GenericMethod<T>(T value);
+        private delegate void GenericMethodRef<T>([MaybeNull] out T value);
+        private delegate void GenericMethodDisallow<T>([DisallowNull] T value);
+        public static IEnumerable<object[]> TestMethodsWithGenericParametersData() => new object[][]
+        {
+            [(GenericMethod<int>)ClassWithGenericMethods.GenericMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethod<int?>)ClassWithGenericMethods.GenericMethod, NullabilityState.Nullable, NullabilityState.Nullable],
+            [(GenericMethod<object>)ClassWithGenericMethods.GenericMethod, NullabilityState.Nullable, NullabilityState.Nullable],
+
+            [(GenericMethod<int>)ClassWithGenericMethods.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethod<object>)ClassWithGenericMethods.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+
+            [(GenericMethodRef<int>)ClassWithGenericMethods_Maybe.GenericMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethodRef<int?>)ClassWithGenericMethods_Maybe.GenericMethod, NullabilityState.Nullable, NullabilityState.Nullable],
+            [(GenericMethodRef<object>)ClassWithGenericMethods_Maybe.GenericMethod, NullabilityState.Nullable, NullabilityState.Nullable],
+
+            [(GenericMethodRef<int>)ClassWithGenericMethods_Maybe.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethodRef<object>)ClassWithGenericMethods_Maybe.GenericNotNullMethod, NullabilityState.Nullable, NullabilityState.NotNull],
+
+            [(GenericMethod<int>)ClassWithGenericMethods_Allow.GenericMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethod<int?>)ClassWithGenericMethods_Allow.GenericMethod, NullabilityState.Nullable, NullabilityState.Nullable],
+            [(GenericMethod<object>)ClassWithGenericMethods_Allow.GenericMethod, NullabilityState.Nullable, NullabilityState.Nullable],
+
+            [(GenericMethod<int>)ClassWithGenericMethods_Allow.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethod<object>)ClassWithGenericMethods_Allow.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.Nullable],
+
+            // Specialized delegates are required due to CS8622
+
+            [(GenericMethodDisallow<int>)ClassWithGenericMethods_Disallow.GenericMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethodDisallow<int?>)ClassWithGenericMethods_Disallow.GenericMethod, NullabilityState.Nullable, NullabilityState.NotNull],
+            [(GenericMethodDisallow<object>)ClassWithGenericMethods_Disallow.GenericMethod, NullabilityState.Nullable, NullabilityState.NotNull],
+
+            [(GenericMethodDisallow<int>)ClassWithGenericMethods_Disallow.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+            [(GenericMethodDisallow<object>)ClassWithGenericMethods_Disallow.GenericNotNullMethod, NullabilityState.NotNull, NullabilityState.NotNull],
+        };
+
+        [Theory]
+        [MemberData(nameof(TestMethodsWithGenericParametersData))]
+        public void TestMethodsWithGenericParameters(Delegate @delegate, NullabilityState expectedRead, NullabilityState expectedWrite)
+        {
+            var ctx = new NullabilityInfoContext();
+
+            MethodInfo method = @delegate.Method;
 
             ParameterInfo paramInfo = method.GetParameters()[0];
             NullabilityInfo info = ctx.Create(paramInfo);
@@ -1748,22 +1774,22 @@ namespace System.Reflection.Tests
     }
     public class ClassWithGenericMethods
     {
-        public void GenericMethod<T>(T value) => throw new Exception();
-        public void GenericNotNullMethod<T>(T value) where T : notnull => throw new Exception();
+        public static void GenericMethod<T>(T value) => throw new Exception();
+        public static void GenericNotNullMethod<T>(T value) where T : notnull => throw new Exception();
     }
     public class ClassWithGenericMethods_Disallow
     {
-        public void GenericMethod<T>([DisallowNull] T value) => throw new Exception();
-        public void GenericNotNullMethod<T>([DisallowNull] T value) where T : notnull => throw new Exception();
+        public static void GenericMethod<T>([DisallowNull] T value) => throw new Exception();
+        public static void GenericNotNullMethod<T>([DisallowNull] T value) where T : notnull => throw new Exception();
     }
     public class ClassWithGenericMethods_Maybe
     {
-        public void GenericMethod<T>([MaybeNull] out T value) => throw new Exception();
-        public void GenericNotNullMethod<T>([MaybeNull] out T value) where T : notnull => throw new Exception();
+        public static void GenericMethod<T>([MaybeNull] out T value) => throw new Exception();
+        public static void GenericNotNullMethod<T>([MaybeNull] out T value) where T : notnull => throw new Exception();
     }
     public class ClassWithGenericMethods_Allow
     {
-        public void GenericMethod<T>([AllowNull] T value) => throw new Exception();
-        public void GenericNotNullMethod<T>([AllowNull] T value) where T : notnull => throw new Exception();
+        public static void GenericMethod<T>([AllowNull] T value) => throw new Exception();
+        public static void GenericNotNullMethod<T>([AllowNull] T value) where T : notnull => throw new Exception();
     }
 }

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -1317,25 +1317,119 @@ namespace System.Reflection.Tests
             Assert.Equal(expectedGenericArgumentNullability, info.GenericTypeArguments[2].GenericTypeArguments[0].ReadState);
             Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[2].GenericTypeArguments[1].ReadState);
         }
-        public static IEnumerable<object[]> TestCtorWithNullableParametersArgumentsData() => new[]
+
+        public static IEnumerable<object[]> TestCtorParametersData() => new object[][]
         {
-            new object[] { typeof(GenericTypeWithNullableCtor<>), NullabilityState.Nullable },
-            new object[] { typeof(GenericTypeWithNullableCtor<int>), NullabilityState.NotNull },
-            new object[] { typeof(GenericTypeWithNullableCtor<int?>), NullabilityState.Nullable },
-            new object[] { typeof(GenericTypeWithNullableCtor<object>), NullabilityState.Nullable },
+            [typeof(GenericTypeWithCtor<>), NullabilityState.Nullable, NullabilityState.Nullable],
+            [typeof(GenericTypeWithCtor<int>), NullabilityState.NotNull, NullabilityState.NotNull],
+            [typeof(GenericTypeWithCtor<int?>), NullabilityState.Nullable, NullabilityState.Nullable],
+            [typeof(GenericTypeWithCtor<object>), NullabilityState.Nullable, NullabilityState.Nullable],
+
+            [typeof(GenericTypeWithCtor_Disallow<>), NullabilityState.Nullable, NullabilityState.NotNull],
+            [typeof(GenericTypeWithCtor_Disallow<int>), NullabilityState.NotNull, NullabilityState.NotNull],
+            [typeof(GenericTypeWithCtor_Disallow<int?>), NullabilityState.Nullable, NullabilityState.NotNull],
+            [typeof(GenericTypeWithCtor_Disallow<object>), NullabilityState.Nullable, NullabilityState.NotNull],
+
+            [typeof(GenericTypeWithCtor_Maybe<>), NullabilityState.Nullable, NullabilityState.Nullable],
+            [typeof(GenericTypeWithCtor_Maybe<int>), NullabilityState.NotNull, NullabilityState.NotNull],
+            [typeof(GenericTypeWithCtor_Maybe<int?>), NullabilityState.Nullable, NullabilityState.Nullable],
+            [typeof(GenericTypeWithCtor_Maybe<object>), NullabilityState.Nullable, NullabilityState.Nullable],
+
+            [typeof(GenericTypeWithCtor_Allow<>), NullabilityState.Nullable, NullabilityState.Nullable],
+            [typeof(GenericTypeWithCtor_Allow<int>), NullabilityState.NotNull, NullabilityState.NotNull],
+            [typeof(GenericTypeWithCtor_Allow<int?>), NullabilityState.Nullable, NullabilityState.Nullable],
+            [typeof(GenericTypeWithCtor_Allow<object>), NullabilityState.Nullable, NullabilityState.Nullable],
+
+            [typeof(GenericNonNullableTypeWithCtor<>), NullabilityState.NotNull, NullabilityState.NotNull],
+            [typeof(GenericNonNullableTypeWithCtor<int>), NullabilityState.NotNull, NullabilityState.NotNull],
+            [typeof(GenericNonNullableTypeWithCtor<object>), NullabilityState.NotNull, NullabilityState.NotNull],
+
+            [typeof(GenericNonNullableTypeWithCtor_Disallow<>), NullabilityState.NotNull, NullabilityState.NotNull],
+            [typeof(GenericNonNullableTypeWithCtor_Disallow<int>), NullabilityState.NotNull, NullabilityState.NotNull],
+            [typeof(GenericNonNullableTypeWithCtor_Disallow<object>), NullabilityState.NotNull, NullabilityState.NotNull],
+
+            [typeof(GenericNonNullableTypeWithCtor_Maybe<>), NullabilityState.Nullable, NullabilityState.NotNull],
+            [typeof(GenericNonNullableTypeWithCtor_Maybe<int>), NullabilityState.NotNull, NullabilityState.NotNull],
+            [typeof(GenericNonNullableTypeWithCtor_Maybe<object>), NullabilityState.Nullable, NullabilityState.NotNull],
+
+            [typeof(GenericNonNullableTypeWithCtor_Allow<>), NullabilityState.NotNull, NullabilityState.Nullable],
+            [typeof(GenericNonNullableTypeWithCtor_Allow<int>), NullabilityState.NotNull, NullabilityState.NotNull],
+            [typeof(GenericNonNullableTypeWithCtor_Allow<object>), NullabilityState.NotNull, NullabilityState.Nullable],
         };
 
         [Theory]
-        [MemberData(nameof(TestCtorWithNullableParametersArgumentsData))]
-        public void TestCtorWithNullableParameters(Type type, NullabilityState expectedNullability)
+        [MemberData(nameof(TestCtorParametersData))]
+        public void TestCtorParameters(Type type, NullabilityState expectedRead, NullabilityState expectedWrite)
         {
             var ctx = new NullabilityInfoContext();
 
             ParameterInfo param = type.GetConstructors()[0].GetParameters()[0];
             NullabilityInfo info = ctx.Create(param);
 
-            Assert.Equal(expectedNullability, info.ReadState);
-            Assert.Equal(expectedNullability, info.WriteState);
+            Assert.Equal(expectedRead, info.ReadState);
+            Assert.Equal(expectedWrite, info.WriteState);
+        }
+
+        public static IEnumerable<object[]> TestMethodsWithGenericParametersData()
+        {
+            const string MethodNullable = "GenericMethod";
+            const string MethodNonNullable = "GenericNotNullMethod";
+
+            return new object[][]
+            {
+                [typeof(ClassWithGenericMethods), MethodNullable, null, NullabilityState.Nullable, NullabilityState.Nullable],
+                [typeof(ClassWithGenericMethods), MethodNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods), MethodNullable, typeof(int?), NullabilityState.Nullable, NullabilityState.Nullable],
+                [typeof(ClassWithGenericMethods), MethodNullable, typeof(object), NullabilityState.Nullable, NullabilityState.Nullable],
+
+                [typeof(ClassWithGenericMethods), MethodNonNullable, null, NullabilityState.NotNull, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods), MethodNonNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods), MethodNonNullable, typeof(object), NullabilityState.NotNull, NullabilityState.NotNull],
+
+                [typeof(ClassWithGenericMethods_Disallow), MethodNullable, null, NullabilityState.Nullable, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods_Disallow), MethodNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods_Disallow), MethodNullable, typeof(int?), NullabilityState.Nullable, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods_Disallow), MethodNullable, typeof(object), NullabilityState.Nullable, NullabilityState.NotNull],
+
+                [typeof(ClassWithGenericMethods_Disallow), MethodNonNullable, null, NullabilityState.NotNull, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods_Disallow), MethodNonNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods_Disallow), MethodNonNullable, typeof(object), NullabilityState.NotNull, NullabilityState.NotNull],
+
+                [typeof(ClassWithGenericMethods_Maybe), MethodNullable, null, NullabilityState.Nullable, NullabilityState.Nullable],
+                [typeof(ClassWithGenericMethods_Maybe), MethodNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods_Maybe), MethodNullable, typeof(int?), NullabilityState.Nullable, NullabilityState.Nullable],
+                [typeof(ClassWithGenericMethods_Maybe), MethodNullable, typeof(object), NullabilityState.Nullable, NullabilityState.Nullable],
+
+                [typeof(ClassWithGenericMethods_Maybe), MethodNonNullable, null, NullabilityState.Nullable, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods_Maybe), MethodNonNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods_Maybe), MethodNonNullable, typeof(object), NullabilityState.Nullable, NullabilityState.NotNull],
+
+                [typeof(ClassWithGenericMethods_Allow), MethodNullable, null, NullabilityState.Nullable, NullabilityState.Nullable],
+                [typeof(ClassWithGenericMethods_Allow), MethodNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods_Allow), MethodNullable, typeof(int?), NullabilityState.Nullable, NullabilityState.Nullable],
+                [typeof(ClassWithGenericMethods_Allow), MethodNullable, typeof(object), NullabilityState.Nullable, NullabilityState.Nullable],
+
+                [typeof(ClassWithGenericMethods_Allow), MethodNonNullable, null, NullabilityState.NotNull, NullabilityState.Nullable],
+                [typeof(ClassWithGenericMethods_Allow), MethodNonNullable, typeof(int), NullabilityState.NotNull, NullabilityState.NotNull],
+                [typeof(ClassWithGenericMethods_Allow), MethodNonNullable, typeof(object), NullabilityState.NotNull, NullabilityState.Nullable],
+            };
+        } 
+
+        [Theory]
+        [MemberData(nameof(TestMethodsWithGenericParametersData))]
+        public void TestMethodsWithGenericParameters(Type type, string methodName, Type? genericParameterType, NullabilityState expectedRead, NullabilityState expectedWrite)
+        {
+            var ctx = new NullabilityInfoContext();
+
+            MethodInfo method = type.GetMethod(methodName)!;
+            if (genericParameterType is not null)
+                method = method.MakeGenericMethod(genericParameterType);
+
+            ParameterInfo paramInfo = method.GetParameters()[0];
+            NullabilityInfo info = ctx.Create(paramInfo);
+
+            Assert.Equal(expectedRead, info.ReadState);
+            Assert.Equal(expectedWrite, info.WriteState);
         }
     }
 
@@ -1620,8 +1714,56 @@ namespace System.Reflection.Tests
         public Tuple<int, int, Tuple<T, int>?>? Deep5 { get; set; }
     }
 
-    public class GenericTypeWithNullableCtor<T>
+    public class GenericTypeWithCtor<T>
     {
-        public GenericTypeWithNullableCtor(T value) { }
+        public GenericTypeWithCtor(T value) { }
+    }
+    public class GenericTypeWithCtor_Disallow<T>
+    {
+        public GenericTypeWithCtor_Disallow([DisallowNull] T value) { }
+    }
+    public class GenericTypeWithCtor_Maybe<T>
+    {
+        public GenericTypeWithCtor_Maybe([MaybeNull] out T value) { value = default; }
+    }
+    public class GenericTypeWithCtor_Allow<T>
+    {
+        public GenericTypeWithCtor_Allow([AllowNull] T value) { }
+    }
+    public class GenericNonNullableTypeWithCtor<T> where T : notnull
+    {
+        public GenericNonNullableTypeWithCtor(T value) { }
+    }
+    public class GenericNonNullableTypeWithCtor_Disallow<T> where T : notnull
+    {
+        public GenericNonNullableTypeWithCtor_Disallow([DisallowNull] T value) { }
+    }
+    public class GenericNonNullableTypeWithCtor_Maybe<T> where T : notnull
+    {
+        public GenericNonNullableTypeWithCtor_Maybe([MaybeNull] out T value) { value = default; }
+    }
+    public class GenericNonNullableTypeWithCtor_Allow<T> where T : notnull
+    {
+        public GenericNonNullableTypeWithCtor_Allow([AllowNull] T value) { }
+    }
+    public class ClassWithGenericMethods
+    {
+        public void GenericMethod<T>(T value) => throw new Exception();
+        public void GenericNotNullMethod<T>(T value) where T : notnull => throw new Exception();
+    }
+    public class ClassWithGenericMethods_Disallow
+    {
+        public void GenericMethod<T>([DisallowNull] T value) => throw new Exception();
+        public void GenericNotNullMethod<T>([DisallowNull] T value) where T : notnull => throw new Exception();
+    }
+    public class ClassWithGenericMethods_Maybe
+    {
+        public void GenericMethod<T>([MaybeNull] out T value) => throw new Exception();
+        public void GenericNotNullMethod<T>([MaybeNull] out T value) where T : notnull => throw new Exception();
+    }
+    public class ClassWithGenericMethods_Allow
+    {
+        public void GenericMethod<T>([AllowNull] T value) => throw new Exception();
+        public void GenericNotNullMethod<T>([AllowNull] T value) where T : notnull => throw new Exception();
     }
 }

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -1317,6 +1317,26 @@ namespace System.Reflection.Tests
             Assert.Equal(expectedGenericArgumentNullability, info.GenericTypeArguments[2].GenericTypeArguments[0].ReadState);
             Assert.Equal(NullabilityState.NotNull, info.GenericTypeArguments[2].GenericTypeArguments[1].ReadState);
         }
+        public static IEnumerable<object[]> TestCtorWithNullableParametersArgumentsData() => new[]
+        {
+            new object[] { typeof(GenericTypeWithNullableCtor<>), NullabilityState.Nullable },
+            new object[] { typeof(GenericTypeWithNullableCtor<int>), NullabilityState.NotNull },
+            new object[] { typeof(GenericTypeWithNullableCtor<int?>), NullabilityState.Nullable },
+            new object[] { typeof(GenericTypeWithNullableCtor<object>), NullabilityState.Nullable },
+        };
+
+        [Theory]
+        [MemberData(nameof(TestCtorWithNullableParametersArgumentsData))]
+        public void TestCtorWithNullableParameters(Type type, NullabilityState expectedNullability)
+        {
+            var ctx = new NullabilityInfoContext();
+
+            ParameterInfo param = type.GetConstructors()[0].GetParameters()[0];
+            NullabilityInfo info = ctx.Create(param);
+
+            Assert.Equal(expectedNullability, info.ReadState);
+            Assert.Equal(expectedNullability, info.WriteState);
+        }
     }
 
 #pragma warning disable CS0649, CS0067, CS0414
@@ -1598,5 +1618,10 @@ namespace System.Reflection.Tests
         public Tuple<int?, Tuple<T>>? Deep3 { get; set; }
         public Tuple<int, int?, Tuple<T?>>? Deep4 { get; set; }
         public Tuple<int, int, Tuple<T, int>?>? Deep5 { get; set; }
+    }
+
+    public class GenericTypeWithNullableCtor<T>
+    {
+        public GenericTypeWithNullableCtor(T value) { }
     }
 }


### PR DESCRIPTION
Fix #92487 

`NullabilityInfoContext.CheckParameterMetadataType` didn't check for `.ctor` so nullable parameters in `.ctor` was incorrectly reported as `NotNull`.

Is the test sufficient?