### PR TITLE
Fix tvOS builds.

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -39,7 +39,6 @@
     <ProjectReference Condition="'$(TargetOS)' != 'ios' and '$(TargetOS)' != 'tvos'" Include="System.Runtime.Loader.Test.Assembly2\System.Runtime.Loader.Test.Assembly2.csproj" ReferenceOutputAssembly="false" OutputItemType="EmbeddedResource" />
     <ProjectReference Condition="'$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvos'" Include="System.Runtime.Loader.Test.Assembly\System.Runtime.Loader.Test.Assembly.csproj" />
     <ProjectReference Condition="'$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvos'" Include="System.Runtime.Loader.Test.Assembly2\System.Runtime.Loader.Test.Assembly2.csproj" />
-    <ProjectReference Condition="'$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvos'" Include="System.Runtime.Loader.Test.AssemblyNotSupported\System.Runtime.Loader.Test.AssemblyNotSupported.csproj" />
     <ProjectReference Include="ContextualReflectionDependency\System.Runtime.Loader.Test.ContextualReflectionDependency.csproj" />
     <ProjectReference Include="ReferencedClassLib\ReferencedClassLib.csproj" />
     <ProjectReference Include="ReferencedClassLibNeutralIsSatellite\ReferencedClassLibNeutralIsSatellite.csproj" />


### PR DESCRIPTION
#89895 removed a test project for a formerly unsupported scenario, but left a project reference to it, causing tvOS builds to fail. This PR removes this project reference.

Fixes #92522.