### PR TITLE
Use invariant culture for CBOR

### DIFF
--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Tag.cs
@@ -74,7 +74,7 @@ namespace System.Formats.Cbor
                 // TODO determine if conformance modes should allow inexact date sting parsing
                 if (!DateTimeOffset.TryParseExact(dateString, CborWriter.Rfc3339FormatString, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTimeOffset result))
                 {
-                    throw new CborContentException(SR.Cbor_Reader_InvalidDateTimeEncoding + " " + dateString);
+                    throw new CborContentException(SR.Cbor_Reader_InvalidDateTimeEncoding);
                 }
 
                 return result;

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Tag.cs
@@ -72,9 +72,9 @@ namespace System.Formats.Cbor
                 string dateString = ReadTextString();
 
                 // TODO determine if conformance modes should allow inexact date sting parsing
-                if (!DateTimeOffset.TryParseExact(dateString, CborWriter.Rfc3339FormatString, null, DateTimeStyles.RoundtripKind, out DateTimeOffset result))
+                if (!DateTimeOffset.TryParseExact(dateString, CborWriter.Rfc3339FormatString, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTimeOffset result))
                 {
-                    throw new CborContentException(SR.Cbor_Reader_InvalidDateTimeEncoding);
+                    throw new CborContentException(SR.Cbor_Reader_InvalidDateTimeEncoding + " " + dateString);
                 }
 
                 return result;

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Tag.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Numerics;
 
 namespace System.Formats.Cbor
@@ -42,8 +43,8 @@ namespace System.Formats.Cbor
 #else
                 value.Offset == TimeSpan.Zero ?
 #endif // NET8_0_OR_GREATER
-                value.UtcDateTime.ToString(Rfc3339FormatString) : // prefer 'Z' over '+00:00'
-                value.ToString(Rfc3339FormatString);
+                value.UtcDateTime.ToString(Rfc3339FormatString, CultureInfo.InvariantCulture) : // prefer 'Z' over '+00:00'
+                value.ToString(Rfc3339FormatString, CultureInfo.InvariantCulture);
 
             WriteTag(CborTag.DateTimeString);
             WriteTextString(dateString);


### PR DESCRIPTION
The tests fail otherwise on my macOS Sonoma machine in English / Czech / Saudi Arabia culture settings:

<img width="502" alt="image" src="https://github.com/dotnet/runtime/assets/1764393/0189fb24-3d79-41d3-907d-5d2d9081d5bb">

cc @vcsjones 