### PR TITLE
Make `TypeDescriptor` thread safe with custom providers and minimize lock use

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -1456,7 +1456,7 @@ namespace System.ComponentModel
             while (node == null)
             {
                 node = (TypeDescriptionNode?)s_providerTypeTable[searchType] ??
-                    (TypeDescriptionNode?)s_providerTable[searchType];
+                       (TypeDescriptionNode?)s_providerTable[searchType];
 
                 if (node == null)
                 {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -1447,7 +1447,7 @@ namespace System.ComponentModel
         {
             Debug.Assert(type != null, "Caller should validate");
 
-            lock (s_internalSyncObject)
+            lock (s_providerTable)
             {
                 CheckDefaultProvider(type);
 
@@ -1564,8 +1564,7 @@ namespace System.ComponentModel
                 }
                 else
                 {
-                    //lock (s_internalSyncObject)
-                        node = NodeFor(type);
+                    node = NodeFor(type);
                 }
             }
 

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/ConcurrentTypeDescriptorTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/ConcurrentTypeDescriptorTests.cs
@@ -20,6 +20,7 @@ namespace System.ComponentModel.Tests
             get => Interlocked.Read(ref _error) == 1;
             set => Interlocked.Exchange(ref _error, value ? 1 : 0);
         }
+
         private void ConcurrentTest(SomeType instance)
         {
             var properties = TypeDescriptor.GetProperties(instance);
@@ -65,7 +66,8 @@ namespace System.ComponentModel.Tests
                 Assert.False(Error, "Fallback type descriptor is used.");
             }
         }
-        internal class SomeTypeProvider : TypeDescriptionProvider
+
+        private class SomeTypeProvider : TypeDescriptionProvider
         {
             public static ThreadLocal<bool> Constructed = new ThreadLocal<bool>();
             public static ThreadLocal<bool> GetPropertiesCalled = new ThreadLocal<bool>();
@@ -102,7 +104,7 @@ namespace System.ComponentModel.Tests
         }
 
         [TypeDescriptionProvider(typeof(SomeTypeProvider))]
-        internal sealed class SomeType
+        private sealed class SomeType
         {
             public int SomeProperty { get; set; }
         }

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/ConcurrentTypeDescriptorTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/ConcurrentTypeDescriptorTests.cs
@@ -1,0 +1,110 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.ComponentModel.Tests
+{
+    [Collection(nameof(DisableParallelization))] // manipulates cache
+    public class ConcurrentTypeDescriptorTests
+    {
+        private long _error = 0;
+        private bool Error
+        {
+            get => Interlocked.Read(ref _error) == 1;
+            set => Interlocked.Exchange(ref _error, value ? 1 : 0);
+        }
+        private void ConcurrentTest(SomeType instance)
+        {
+            var properties = TypeDescriptor.GetProperties(instance);
+            Thread.Sleep(10);
+            if (properties.Count > 0)
+            {
+                Error = true;
+            }
+        }
+
+        [Fact]
+        public void GetProperties_ReturnsExpected()
+        {
+            const int Timeout = 60000;
+            int concurrentCount = Environment.ProcessorCount * 2;
+
+            using var finished = new CountdownEvent(concurrentCount);
+
+            var instances = new SomeType[concurrentCount];
+            for (int i = 0; i < concurrentCount; i++)
+            {
+                instances[i] = new SomeType();
+            }
+
+            for (int i = 0; i < concurrentCount; i++)
+            {
+                int i2 = i;
+                new Thread(() =>
+                {
+                    ConcurrentTest(instances[i2]);
+                    finished.Signal();
+                }).Start();
+            }
+
+            finished.Wait(Timeout);
+
+            if (finished.CurrentCount != 0)
+            {
+                Assert.Fail("Timeout. Possible deadlock.");
+            }
+            else
+            {
+                Assert.False(Error, "Fallback type descriptor is used.");
+            }
+        }
+        internal class SomeTypeProvider : TypeDescriptionProvider
+        {
+            public static ThreadLocal<bool> Constructed = new ThreadLocal<bool>();
+            public static ThreadLocal<bool> GetPropertiesCalled = new ThreadLocal<bool>();
+            private class CTD : ICustomTypeDescriptor
+            {
+                public AttributeCollection GetAttributes() => AttributeCollection.Empty;
+                public string? GetClassName() => null;
+                public string? GetComponentName() => null;
+                public TypeConverter GetConverter() => new TypeConverter();
+                public EventDescriptor? GetDefaultEvent() => null;
+                public PropertyDescriptor? GetDefaultProperty() => null;
+                public object? GetEditor(Type editorBaseType) => null;
+                public EventDescriptorCollection GetEvents() => EventDescriptorCollection.Empty;
+                public EventDescriptorCollection GetEvents(Attribute[]? attributes) => EventDescriptorCollection.Empty;
+
+                public PropertyDescriptorCollection GetProperties()
+                {
+                    GetPropertiesCalled.Value = true;
+                    return PropertyDescriptorCollection.Empty;
+                }
+
+                public PropertyDescriptorCollection GetProperties(Attribute[]? attributes)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public object? GetPropertyOwner(PropertyDescriptor? pd) => null;
+            }
+            public override ICustomTypeDescriptor GetTypeDescriptor(Type objectType, object? instance)
+            {
+                Constructed.Value = true;
+                return new CTD();
+            }
+        }
+
+        [TypeDescriptionProvider(typeof(SomeTypeProvider))]
+        internal sealed class SomeType
+        {
+            public int SomeProperty { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Fix #92394 

Similar to #92521 but the PR takes a more aggressive approach. The PR creates specialized versions of `AddProvider` and `NodeFor(Type)` for use in `CheckDefaultProvider` to minimize lock. Though the side effects are not fully reviewed due to control flow change.

### Risk

The performance should be close to, or better than, the before-PR implementation because the `lock` statement doesn't change.

The PR might introduce bugs as it puts `s_defaultProviders[type] = null` **after** `AddProvider`.