### PR TITLE
Fix memory leak in MemoryCache

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -389,10 +389,9 @@ namespace Microsoft.Extensions.Caching.Memory
             {
                 for (int i = 0; i < _allStats.Count; i++)
                 {
-                    if (_allStats[i].TryGetTarget(out Stats? stats) && stats == current)
+                    if (_allStats[i].TryGetTarget(out Stats? stats))
                     {
                         _allStats.RemoveAt(i);
-                        break;
                     }
                 }
 

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -392,6 +392,7 @@ namespace Microsoft.Extensions.Caching.Memory
                     if (!_allStats[i].TryGetTarget(out Stats? stats))
                     {
                         _allStats.RemoveAt(i);
+                        i--;
                     }
                 }
 

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -389,7 +389,7 @@ namespace Microsoft.Extensions.Caching.Memory
             {
                 for (int i = 0; i < _allStats.Count; i++)
                 {
-                    if (_allStats[i].TryGetTarget(out Stats? stats))
+                    if (!_allStats[i].TryGetTarget(out Stats? stats))
                     {
                         _allStats.RemoveAt(i);
                     }


### PR DESCRIPTION
`WeakReference<T>.TryGetTarget` apparently returns false in the target object's finalizer. Here is an example demonstrating that:
```cs
CreateTest();
GC.Collect(GC.MaxGeneration);
GC.WaitForPendingFinalizers();

void CreateTest() => _ = new Test();

class Test
{
    private readonly WeakReference<Test> _wr;

    public Test()
    {
        _wr = new WeakReference<Test>(this);
        Console.WriteLine(_wr.TryGetTarget(out _)); // True
    }

    ~Test()
    {
        Console.WriteLine(_wr.TryGetTarget(out _)); // False
    }
}
```

In MemoryCache that would cause the Stats in the _allStats list to never be cleaned out.
```cs
MemoryCache c = new(new MemoryCacheOptions { TrackStatistics = true });
for (int i = 0; i < 100; i += 1)
{
    CreateThread();
}

for (int i = 0; i < 10; i += 1)
{
    Thread.Sleep(100);
    GC.Collect(GC.MaxGeneration);
    GC.WaitForPendingFinalizers();
}

Console.WriteLine(c.GetCurrentStatistics());

void CreateThread()
{
    Thread t = new(() => { c.Get(""); });
    t.Start();
    t.Join();
}
```
At the end of this program, `c._allStats.Count == 100`.