### PR TITLE
fixed the order of WASI_AFTER_RUNTIME_LOADED_CALLS

### DIFF
--- a/src/mono/wasi/runtime/main.c
+++ b/src/mono/wasi/runtime/main.c
@@ -12,15 +12,16 @@ WASI_AFTER_RUNTIME_LOADED_DECLARATIONS
 
 int main(int argc, char * argv[]) {
 
-#ifdef WASI_AFTER_RUNTIME_LOADED_CALLS
-	// This is supplied from the MSBuild itemgroup @(WasiAfterRuntimeLoaded)
-	WASI_AFTER_RUNTIME_LOADED_CALLS
-#endif
 #ifndef WASM_SINGLE_FILE
 	mono_set_assemblies_path("managed");
 #endif
 	mono_wasm_load_runtime("", 0);
 
+#ifdef WASI_AFTER_RUNTIME_LOADED_CALLS
+	// This is supplied from the MSBuild itemgroup @(WasiAfterRuntimeLoaded)
+	WASI_AFTER_RUNTIME_LOADED_CALLS
+#endif
+    
 	int arg_ofs = 0;
 #ifdef WASM_SINGLE_FILE
 	/*


### PR DESCRIPTION
`WASI_AFTER_RUNTIME_LOADED_CALLS` are included in the wrong place.
As the name indicates, they should be included after Mono is loaded.

It used to work like this in the old [experimental SDK from Steve](https://github.com/SteveSandersonMS/dotnet-wasi-sdk/blob/main/src/Wasi.Sdk/native/main.c#L25-L28)

Tested with `Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk`, version `8.0.0-rc.1.23419.4`.

Note that just fixing this does not actually make the `WASI_AFTER_RUNTIME_LOADED_CALLS` behave correctly due to https://github.com/dotnet/runtime/issues/92551, which prevents them from being passed from MsBuild to Clang compiler in the first place.
 
However the MsBuild workaround code that I described there is not that good so I explicitly did not include it in this PR.