### PR TITLE
Reduce 1 possible string allocation in `System.RuntimeType.SplitName`

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2033,6 +2033,7 @@ namespace System
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void SplitName(string? fullname, out string? name, out ReadOnlySpan<char> ns)
         {
             name = null;
@@ -2045,18 +2046,22 @@ namespace System
             int nsDelimiter = fullname.LastIndexOf('.');
             if (nsDelimiter >= 0)
             {
-                ns = fullname.AsSpan(0, nsDelimiter);
-                int nameLength = fullname.Length - ns.Length - 1;
-                if (nameLength != 0)
-                    name = fullname.Substring(nsDelimiter + 1, nameLength);
-                else
-                    name = "";
-                Debug.Assert(fullname.Equals(ns.ToString() + "." + name));
+                SplitFullName(fullname, nsDelimiter, out name, out ns);
             }
             else
             {
                 name = fullname;
             }
+        }
+        private static void SplitFullName(string fullname, int nsDelimiter, out string name, out ReadOnlySpan<char> ns)
+        {
+            ns = fullname.AsSpan(0, nsDelimiter);
+            int nameLength = fullname.Length - ns.Length - 1;
+            if (nameLength != 0)
+                name = fullname.Substring(nsDelimiter + 1, nameLength);
+            else
+                name = "";
+            Debug.Assert(fullname.Equals(ns.ToString() + "." + name));
         }
         #endregion
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2045,7 +2045,7 @@ namespace System
             int nsDelimiter = fullname.LastIndexOf('.');
             if (nsDelimiter >= 0)
             {
-                ns = fullname.AsSpan().Slice(0, nsDelimiter);
+                ns = fullname.AsSpan(0, nsDelimiter);
                 int nameLength = fullname.Length - ns.Length - 1;
                 if (nameLength != 0)
                     name = fullname.Substring(nsDelimiter + 1, nameLength);
@@ -2242,7 +2242,7 @@ namespace System
             if (!FilterApplyBase(type, bindingFlags, isPublic, type.IsNestedAssembly, isStatic: false, name, prefixLookup))
                 return false;
 
-            if (ns != default && !ns.SequenceEqual(type.Namespace))
+            if (!ns.IsEmpty && !ns.SequenceEqual(type.Namespace))
                 return false;
 
             return true;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2046,11 +2046,7 @@ namespace System
             if (nsDelimiter >= 0)
             {
                 ns = fullname.AsSpan(0, nsDelimiter);
-                int nameLength = fullname.Length - ns.Length - 1;
-                if (nameLength != 0)
-                    name = fullname.Substring(nsDelimiter + 1, nameLength);
-                else
-                    name = "";
+                name = fullname.Substring(nsDelimiter + 1);
                 Debug.Assert(fullname == $"{ns}.{name}");
             }
             else

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2051,7 +2051,7 @@ namespace System
                     name = fullname.Substring(nsDelimiter + 1, nameLength);
                 else
                     name = "";
-                Debug.Assert(fullname.Equals(ns.ToString() + "." + name));
+                Debug.Assert(fullname == $"{ns}.{name}");
             }
             else
             {
@@ -2242,7 +2242,7 @@ namespace System
             if (!FilterApplyBase(type, bindingFlags, isPublic, type.IsNestedAssembly, isStatic: false, name, prefixLookup))
                 return false;
 
-            if (!ns.IsEmpty && !ns.SequenceEqual(type.Namespace))
+            if (!Unsafe.IsNullRef(ref ns._reference) && !ns.SequenceEqual(type.Namespace))
                 return false;
 
             return true;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2033,7 +2033,6 @@ namespace System
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void SplitName(string? fullname, out string? name, out ReadOnlySpan<char> ns)
         {
             name = null;
@@ -2046,22 +2045,18 @@ namespace System
             int nsDelimiter = fullname.LastIndexOf('.');
             if (nsDelimiter >= 0)
             {
-                SplitFullName(fullname, nsDelimiter, out name, out ns);
+                ns = fullname.AsSpan(0, nsDelimiter);
+                int nameLength = fullname.Length - ns.Length - 1;
+                if (nameLength != 0)
+                    name = fullname.Substring(nsDelimiter + 1, nameLength);
+                else
+                    name = "";
+                Debug.Assert(fullname.Equals(ns.ToString() + "." + name));
             }
             else
             {
                 name = fullname;
             }
-        }
-        private static void SplitFullName(string fullname, int nsDelimiter, out string name, out ReadOnlySpan<char> ns)
-        {
-            ns = fullname.AsSpan(0, nsDelimiter);
-            int nameLength = fullname.Length - ns.Length - 1;
-            if (nameLength != 0)
-                name = fullname.Substring(nsDelimiter + 1, nameLength);
-            else
-                name = "";
-            Debug.Assert(fullname.Equals(ns.ToString() + "." + name));
         }
         #endregion
 


### PR DESCRIPTION
### Summary

`System.RuntimeType.SplitName`, mainly used by `GetInterface`, allocates an unnecessary string for namespace. This PR improves performance by addressing that, which can be beneficial to [some codebases](https://github.com/search?q=.GetInterface%28+language%3AC%23&type=code&ref=advsearch).

### Changes

* `fullName.Substring` is replaced with `fullName.AsSpan` to avoid unnecessary allocation. The method of `FilterApplyType` is adjusted accordingly.

### Risk

For simple names without namespace, `GetInterface` and `GetNestedType` can be 1-2 nanoseconds slower.

### Benchmark
```
BenchmarkDotNet v0.13.8, Windows 10 (10.0.19045.2546/22H2/2022Update)
Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK 8.0.100-rc.1.23463.5
  [Host]     : .NET 8.0.0 (8.0.23.41904), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.0 (8.0.23.41904), X64 RyuJIT AVX2
  Job-LDKVHW : .NET 9.0.0 (42.42.42.42424), X64 RyuJIT AVX2
```
| Method                        | Toolchain | Mean     | Error    | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
|------------------------------ |---------- |---------:|---------:|---------:|------:|-------:|----------:|------------:|
| UnambiguousInterface_Name     | Default   | 28.93 ns | 0.133 ns | 0.111 ns |  1.00 |      - |         - |          NA |
| UnambiguousInterface_Name     | PR        | 30.21 ns | 0.139 ns | 0.108 ns |  1.04 |      - |         - |          NA |
|                               |           |          |          |          |       |        |           |             |
| UnambiguousInterface_FullName | Default   | 48.99 ns | 0.184 ns | 0.153 ns |  1.00 | 0.0089 |      56 B |        1.00 |
| UnambiguousInterface_FullName | PR        | 43.81 ns | 0.127 ns | 0.112 ns |  0.89 | 0.0038 |      24 B |        0.43 |
|                               |           |          |          |          |       |        |           |             |
| PickOneInterface_FullName     | Default   | 69.92 ns | 0.224 ns | 0.187 ns |  1.00 | 0.0088 |      56 B |        1.00 |
| PickOneInterface_FullName     | PR        | 67.47 ns | 0.163 ns | 0.145 ns |  0.96 | 0.0038 |      24 B |        0.43 |
|                               |           |          |          |          |       |        |           |             |
| GetNestedType_Name            | Default   | 41.71 ns | 0.141 ns | 0.132 ns |  1.00 |      - |         - |          NA |
| GetNestedType_Name            | PR        | 42.63 ns | 0.233 ns | 0.182 ns |  1.02 |      - |         - |          NA |
|                               |           |          |          |          |       |        |           |             |
| GetNestedTypes_Name           | Default   | 48.90 ns | 0.134 ns | 0.125 ns |  1.00 | 0.0051 |      32 B |        1.00 |
| GetNestedTypes_Name           | PR        | 51.17 ns | 0.186 ns | 0.165 ns |  1.05 | 0.0051 |      32 B |        1.00 |

<details>
<summary>Benchmark code</summary>
<pre>
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Columns;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Jobs;
using BenchmarkDotNet.Running;
using BenchmarkDotNet.Toolchains.CoreRun;
using System.Reflection;
using TestNs;

namespace PerfBm
{
    internal class Program
    {
        static void Main(string[] args)
        {
            const string coreRunPath = @"D:\repos\karakasa\runtime\artifacts\bin\testhost\net9.0-windows-Release-x64\shared\Microsoft.NETCore.App\9.0.0\CoreRun.exe";
            var config = ManualConfig
            .Create(DefaultConfig.Instance)
            .AddJob(Job.Default.WithBaseline(true))
            .AddJob(Job.Default.WithToolchain(new CoreRunToolchain(new FileInfo(coreRunPath), targetFrameworkMoniker: "net8.0", displayName: "PR")))
            .HideColumns(new ColumnHidingByNameRule(Column.Job));

            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
        }
    }

    //[SimpleJob(RuntimeMoniker.HostProcess)]
    [MemoryDiagnoser]
    public class BenchmarkClass
    {
        [Benchmark]
        public Type? UnambiguousInterface_Name()
        {
            return typeof(TestOne).GetInterface("I");
        }
        [Benchmark]
        public Type? UnambiguousInterface_FullName()
        {
            return typeof(TestOne).GetInterface("Ns1.I");
        }
        [Benchmark]
        public Type? PickOneInterface_FullName()
        {
            return typeof(TestTwo).GetInterface("Ns1.I");
        }
        [Benchmark]
        public Type? GetNestedType_Name()
        {
            return typeof(NestedType).GetNestedType("NestedType2");
        }
        [Benchmark]
        public Type[] GetNestedTypes_Name()
        {
            return typeof(NestedType).GetNestedTypes();
        }
    }
}

namespace TestNs
{
    public class NestedType
    {
        public class NestedType2
        {
        }
    }
    public class TestOne : Ns1.I
    {
        public void M1() { }
    }
    public class TestTwo : Ns1.I, Ns2.I
    {
        public void M1() { }
        public void M2() { }
    }
}

namespace Ns1
{
    public interface I
    {
        public void M1();
    }
}
namespace Ns2
{
    public interface I
    {
        public void M2();
    }
}
</pre>
</details>