### PR TITLE
Remove some nullchecks for frozen objects

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1635,7 +1635,7 @@ bool ValueNumStore::IsKnownNonNull(ValueNum vn)
         return false;
     }
 
-    if (IsVNObjHandle(vn))
+    if (IsVNHandle(vn))
     {
         assert(CoercedConstantValue<size_t>(vn) != 0);
         return true;

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1634,6 +1634,13 @@ bool ValueNumStore::IsKnownNonNull(ValueNum vn)
     {
         return false;
     }
+
+    if (IsVNObjHandle(vn))
+    {
+        assert(CoercedConstantValue<size_t>(vn) != 0);
+        return true;
+    }
+
     VNFuncApp funcAttr;
     return GetVNFunc(vn, &funcAttr) && (s_vnfOpAttribs[funcAttr.m_func] & VNFOA_KnownNonNull) != 0;
 }


### PR DESCRIPTION
This PR drops redundant nullchecks on top of frozen objects, e.g.:
```cs
bool Test() => typeof(int).IsInterface;
```

```diff
; Method Program:Test():ubyte:this (FullOpts)
       sub      rsp, 40
       mov      rcx, 0x2BC000053F0      ; 'System.Int32'
-      cmp      dword ptr [rcx], ecx
       call     [System.RuntimeType:get_IsInterface():ubyte:this]
       nop      
       add      rsp, 40
       ret      
-; Total bytes of code: 28
+; Total bytes of code: 26
```