### PR TITLE
Fixed wrong comment in Marshalling/*Marshaller.cs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
@@ -109,7 +109,7 @@ namespace System.Runtime.InteropServices.Marshalling
             /// <remarks>
             /// This property represents a potential optimization for the marshaller.
             /// </remarks>
-            // We'll keep the buffer size at a maximum of 200 bytes to avoid overflowing the stack.
+            // We'll keep the buffer size at a maximum of 512 bytes to avoid overflowing the stack.
             public static int BufferSize { get; } = 0x200 / sizeof(TUnmanagedElement);
 
             private T[]? _managedArray;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/PointerArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/PointerArrayMarshaller.cs
@@ -110,7 +110,7 @@ namespace System.Runtime.InteropServices.Marshalling
             /// <remarks>
             /// This property represents a potential optimization for the marshaller.
             /// </remarks>
-            // We'll keep the buffer size at a maximum of 200 bytes to avoid overflowing the stack.
+            // We'll keep the buffer size at a maximum of 512 bytes to avoid overflowing the stack.
             public static int BufferSize => 0x200 / sizeof(TUnmanagedElement);
 
             private T*[]? _managedArray;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ReadOnlySpanMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ReadOnlySpanMarshaller.cs
@@ -79,7 +79,7 @@ namespace System.Runtime.InteropServices.Marshalling
             /// <summary>
             /// Gets the size of the caller-allocated buffer to allocate.
             /// </summary>
-            // We'll keep the buffer size at a maximum of 200 bytes to avoid overflowing the stack.
+            // We'll keep the buffer size at a maximum of 512 bytes to avoid overflowing the stack.
             public static int BufferSize { get; } = 0x200 / sizeof(TUnmanagedElement);
 
             private ReadOnlySpan<T> _managedArray;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/SpanMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/SpanMarshaller.cs
@@ -108,7 +108,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         public ref struct ManagedToUnmanagedIn
         {
-            // We'll keep the buffer size at a maximum of 200 bytes to avoid overflowing the stack.
+            // We'll keep the buffer size at a maximum of 512 bytes to avoid overflowing the stack.
             public static int BufferSize { get; } = 0x200 / sizeof(TUnmanagedElement);
 
             private Span<T> _managedArray;


### PR DESCRIPTION
For the BufferSize 0x200 the maximum size is 512 (dec). That was presumable copy & pasta...