### PR TITLE
Minor code cleanup in TensorPrimitives tests

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.cs
@@ -6,6 +6,14 @@ namespace System.Numerics.Tensors
     /// <summary>Performs primitive tensor operations over spans of memory.</summary>
     public static partial class TensorPrimitives
     {
+        /// <summary>Computes the element-wise result of: <c>MathF.Abs(<paramref name="x" />)</c>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = MathF.Abs(<paramref name="x" />[i])</c>.</remarks>
+        public static void Abs(ReadOnlySpan<float> x, Span<float> destination) =>
+            InvokeSpanIntoSpan<AbsoluteOperator>(x, destination);
+
         /// <summary>Computes the element-wise result of: <c><paramref name="x" /> + <paramref name="y" /></c>.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
         /// <param name="y">The second tensor, represented as a span.</param>
@@ -24,82 +32,6 @@ namespace System.Numerics.Tensors
         /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] + <paramref name="y" /></c>.</remarks>
         public static void Add(ReadOnlySpan<float> x, float y, Span<float> destination) =>
             InvokeSpanScalarIntoSpan<AddOperator>(x, y, destination);
-
-        /// <summary>Computes the element-wise result of: <c><paramref name="x" /> - <paramref name="y" /></c>.</summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="y">The second tensor, represented as a scalar.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] - <paramref name="y" />[i]</c>.</remarks>
-        public static void Subtract(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<float> destination) =>
-            InvokeSpanSpanIntoSpan<SubtractOperator>(x, y, destination);
-
-        /// <summary>Computes the element-wise result of: <c><paramref name="x" /> - <paramref name="y" /></c>.</summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="y">The second tensor, represented as a scalar.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] - <paramref name="y" /></c>.</remarks>
-        public static void Subtract(ReadOnlySpan<float> x, float y, Span<float> destination) =>
-            InvokeSpanScalarIntoSpan<SubtractOperator>(x, y, destination);
-
-        /// <summary>Computes the element-wise result of: <c><paramref name="x" /> * <paramref name="y" /></c>.</summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="y">The second tensor, represented as a span.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] * <paramref name="y" /></c>.</remarks>
-        public static void Multiply(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<float> destination) =>
-            InvokeSpanSpanIntoSpan<MultiplyOperator>(x, y, destination);
-
-        /// <summary>Computes the element-wise result of: <c><paramref name="x" /> * <paramref name="y" /></c>.</summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="y">The second tensor, represented as a scalar.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>
-        ///     <para>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] * <paramref name="y" /></c>.</para>
-        ///     <para>This method corresponds to the <c>scal</c> method defined by <c>BLAS1</c>.</para>
-        /// </remarks>
-        public static void Multiply(ReadOnlySpan<float> x, float y, Span<float> destination) =>
-            InvokeSpanScalarIntoSpan<MultiplyOperator>(x, y, destination);
-
-        /// <summary>Computes the element-wise result of: <c><paramref name="x" /> / <paramref name="y" /></c>.</summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="y">The second tensor, represented as a span.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] / <paramref name="y" /></c>.</remarks>
-        public static void Divide(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<float> destination) =>
-            InvokeSpanSpanIntoSpan<DivideOperator>(x, y, destination);
-
-        /// <summary>Computes the element-wise result of: <c><paramref name="x" /> / <paramref name="y" /></c>.</summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="y">The second tensor, represented as a scalar.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] / <paramref name="y" /></c>.</remarks>
-        public static void Divide(ReadOnlySpan<float> x, float y, Span<float> destination) =>
-            InvokeSpanScalarIntoSpan<DivideOperator>(x, y, destination);
-
-        /// <summary>Computes the element-wise result of: <c>-<paramref name="x" /></c>.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = -<paramref name="x" />[i]</c>.</remarks>
-        public static void Negate(ReadOnlySpan<float> x, Span<float> destination) =>
-            InvokeSpanIntoSpan<NegateOperator>(x, destination);
-
-        /// <summary>Computes the element-wise result of: <c>MathF.Abs(<paramref name="x" />)</c>.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = MathF.Abs(<paramref name="x" />[i])</c>.</remarks>
-        public static void Abs(ReadOnlySpan<float> x, Span<float> destination) =>
-            InvokeSpanIntoSpan<AbsoluteOperator>(x, destination);
 
         /// <summary>Computes the element-wise result of: <c>(<paramref name="x" /> + <paramref name="y" />) * <paramref name="multiplier" /></c>.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -135,42 +67,103 @@ namespace System.Numerics.Tensors
         public static void AddMultiply(ReadOnlySpan<float> x, float y, ReadOnlySpan<float> multiplier, Span<float> destination) =>
             InvokeSpanScalarSpanIntoSpan<AddMultiplyOperator>(x, y, multiplier, destination);
 
-        /// <summary>Computes the element-wise result of: <c>(<paramref name="x" /> * <paramref name="y" />) + <paramref name="addend" /></c>.</summary>
+        /// <summary>Computes the element-wise result of: <c>cosh(<paramref name="x" />)</c>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <see cref="MathF" />.Cosh(<paramref name="x" />[i])</c>.</remarks>
+        public static void Cosh(ReadOnlySpan<float> x, Span<float> destination)
+        {
+            if (x.Length > destination.Length)
+            {
+                ThrowHelper.ThrowArgument_DestinationTooShort();
+            }
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                destination[i] = MathF.Cosh(x[i]);
+            }
+        }
+
+        /// <summary>Computes the cosine similarity between two non-zero vectors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
         /// <param name="y">The second tensor, represented as a span.</param>
-        /// <param name="addend">The third tensor, represented as a span.</param>
+        /// <returns>The cosine similarity between the two vectors.</returns>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
+        /// <exception cref="ArgumentException">'<paramref name="x" />' and '<paramref name="y" />' must not be empty.</exception>
+        public static float CosineSimilarity(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            if (x.Length != y.Length)
+            {
+                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+            }
+
+            return CosineSimilarityCore(x, y);
+        }
+
+        /// <summary>
+        /// Compute the distance between two points in Euclidean space.
+        /// </summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <returns>The Euclidean distance.</returns>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
+        /// <exception cref="ArgumentException">'<paramref name="x" />' and '<paramref name="y" />' must not be empty.</exception>
+        public static float Distance(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            if (x.Length != y.Length)
+            {
+                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+            }
+
+            return MathF.Sqrt(Aggregate<SubtractSquaredOperator, AddOperator>(0f, x, y));
+        }
+
+        /// <summary>Computes the element-wise result of: <c><paramref name="x" /> / <paramref name="y" /></c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
         /// <param name="destination">The destination tensor, represented as a span.</param>
         /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
-        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="addend" />'.</exception>
         /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = (<paramref name="x" />[i] * <paramref name="y" />[i]) + <paramref name="addend" />[i]</c>.</remarks>
-        public static void MultiplyAdd(ReadOnlySpan<float> x, ReadOnlySpan<float> y, ReadOnlySpan<float> addend, Span<float> destination) =>
-            InvokeSpanSpanSpanIntoSpan<MultiplyAddOperator>(x, y, addend, destination);
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] / <paramref name="y" /></c>.</remarks>
+        public static void Divide(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<float> destination) =>
+            InvokeSpanSpanIntoSpan<DivideOperator>(x, y, destination);
 
-        /// <summary>Computes the element-wise result of: <c>(<paramref name="x" /> * <paramref name="y" />) + <paramref name="addend" /></c>.</summary>
+        /// <summary>Computes the element-wise result of: <c><paramref name="x" /> / <paramref name="y" /></c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a scalar.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] / <paramref name="y" /></c>.</remarks>
+        public static void Divide(ReadOnlySpan<float> x, float y, Span<float> destination) =>
+            InvokeSpanScalarIntoSpan<DivideOperator>(x, y, destination);
+
+        /// <summary>
+        /// A mathematical operation that takes two vectors and returns a scalar.
+        /// </summary>
         /// <param name="x">The first tensor, represented as a span.</param>
         /// <param name="y">The second tensor, represented as a span.</param>
-        /// <param name="addend">The third tensor, represented as a span.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <returns>The dot product.</returns>
         /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>
-        ///     <para>This method effectively does <c><paramref name="destination" />[i] = (<paramref name="x" />[i] * <paramref name="y" />[i]) + <paramref name="addend" /></c>.</para>
-        ///     <para>This method corresponds to the <c>axpy</c> method defined by <c>BLAS1</c>.</para>
-        /// </remarks>
-        public static void MultiplyAdd(ReadOnlySpan<float> x, ReadOnlySpan<float> y, float addend, Span<float> destination) =>
-            InvokeSpanSpanScalarIntoSpan<MultiplyAddOperator>(x, y, addend, destination);
+        public static float Dot(ReadOnlySpan<float> x, ReadOnlySpan<float> y) // BLAS1: dot
+        {
+            if (x.Length != y.Length)
+            {
+                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+            }
 
-        /// <summary>Computes the element-wise result of: <c>(<paramref name="x" /> * <paramref name="y" />) + <paramref name="addend" /></c>.</summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="y">The second tensor, represented as a span.</param>
-        /// <param name="addend">The third tensor, represented as a span.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="addend" />'.</exception>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = (<paramref name="x" />[i] * <paramref name="y" />) + <paramref name="addend" />[i]</c>.</remarks>
-        public static void MultiplyAdd(ReadOnlySpan<float> x, float y, ReadOnlySpan<float> addend, Span<float> destination) =>
-            InvokeSpanScalarSpanIntoSpan<MultiplyAddOperator>(x, y, addend, destination);
+            return Aggregate<MultiplyOperator, AddOperator>(0f, x, y);
+        }
 
         /// <summary>Computes the element-wise result of: <c>pow(e, <paramref name="x" />)</c>.</summary>
         /// <param name="x">The tensor, represented as a span.</param>
@@ -188,6 +181,191 @@ namespace System.Numerics.Tensors
             {
                 destination[i] = MathF.Exp(x[i]);
             }
+        }
+
+        /// <summary>Computes the index of the maximum element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The index of the maximum element in <paramref name="x"/>, or -1 if <paramref name="x"/> is empty.</returns>
+        public static unsafe int IndexOfMax(ReadOnlySpan<float> x)
+        {
+            int result = -1;
+
+            if (!x.IsEmpty)
+            {
+                float max = float.NegativeInfinity;
+
+                for (int i = 0; i < x.Length; i++)
+                {
+                    // This matches the IEEE 754:2019 `maximum` function.
+                    // It propagates NaN inputs back to the caller and
+                    // otherwise returns the greater of the inputs.
+                    // It treats +0 as greater than -0 as per the specification.
+
+                    float current = x[i];
+
+                    if (current != max)
+                    {
+                        if (float.IsNaN(current))
+                        {
+                            return i;
+                        }
+
+                        if (max < current)
+                        {
+                            result = i;
+                            max = current;
+                        }
+                    }
+                    else if (IsNegative(max) && !IsNegative(current))
+                    {
+                        result = i;
+                        max = current;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Computes the index of the element in <paramref name="x"/> with the maximum magnitude.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The index of the element with the maximum magnitude, or -1 if <paramref name="x"/> is empty.</returns>
+        /// <remarks>This method corresponds to the <c>iamax</c> method defined by <c>BLAS1</c>.</remarks>
+        public static unsafe int IndexOfMaxMagnitude(ReadOnlySpan<float> x)
+        {
+            int result = -1;
+
+            if (!x.IsEmpty)
+            {
+                float max = float.NegativeInfinity;
+                float maxMag = float.NegativeInfinity;
+
+                for (int i = 0; i < x.Length; i++)
+                {
+                    // This matches the IEEE 754:2019 `maximumMagnitude` function.
+                    // It propagates NaN inputs back to the caller and
+                    // otherwise returns the input with a greater magnitude.
+                    // It treats +0 as greater than -0 as per the specification.
+
+                    float current = x[i];
+                    float currentMag = Math.Abs(current);
+
+                    if (currentMag != maxMag)
+                    {
+                        if (float.IsNaN(currentMag))
+                        {
+                            return i;
+                        }
+
+                        if (maxMag < currentMag)
+                        {
+                            result = i;
+                            max = current;
+                            maxMag = currentMag;
+                        }
+                    }
+                    else if (IsNegative(max) && !IsNegative(current))
+                    {
+                        result = i;
+                        max = current;
+                        maxMag = currentMag;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Computes the index of the minimum element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The index of the minimum element in <paramref name="x"/>, or -1 if <paramref name="x"/> is empty.</returns>
+        public static unsafe int IndexOfMin(ReadOnlySpan<float> x)
+        {
+            int result = -1;
+
+            if (!x.IsEmpty)
+            {
+                float min = float.PositiveInfinity;
+
+                for (int i = 0; i < x.Length; i++)
+                {
+                    // This matches the IEEE 754:2019 `minimum` function.
+                    // It propagates NaN inputs back to the caller and
+                    // otherwise returns the lesser of the inputs.
+                    // It treats +0 as greater than -0 as per the specification.
+
+                    float current = x[i];
+
+                    if (current != min)
+                    {
+                        if (float.IsNaN(current))
+                        {
+                            return i;
+                        }
+
+                        if (current < min)
+                        {
+                            result = i;
+                            min = current;
+                        }
+                    }
+                    else if (IsNegative(current) && !IsNegative(min))
+                    {
+                        result = i;
+                        min = current;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Computes the index of the element in <paramref name="x"/> with the minimum magnitude.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The index of the element with the minimum magnitude, or -1 if <paramref name="x"/> is empty.</returns>
+        public static unsafe int IndexOfMinMagnitude(ReadOnlySpan<float> x)
+        {
+            int result = -1;
+
+            if (!x.IsEmpty)
+            {
+                float min = float.PositiveInfinity;
+                float minMag = float.PositiveInfinity;
+
+                for (int i = 0; i < x.Length; i++)
+                {
+                    // This matches the IEEE 754:2019 `minimumMagnitude` function
+                    // It propagates NaN inputs back to the caller and
+                    // otherwise returns the input with a lesser magnitude.
+                    // It treats +0 as greater than -0 as per the specification.
+
+                    float current = x[i];
+                    float currentMag = Math.Abs(current);
+
+                    if (currentMag != minMag)
+                    {
+                        if (float.IsNaN(currentMag))
+                        {
+                            return i;
+                        }
+
+                        if (currentMag < minMag)
+                        {
+                            result = i;
+                            min = current;
+                            minMag = currentMag;
+                        }
+                    }
+                    else if (IsNegative(current) && !IsNegative(min))
+                    {
+                        result = i;
+                        min = current;
+                        minMag = currentMag;
+                    }
+                }
+            }
+
+            return result;
         }
 
         /// <summary>Computes the element-wise result of: <c>ln(<paramref name="x" />)</c>.</summary>
@@ -223,184 +401,6 @@ namespace System.Numerics.Tensors
             for (int i = 0; i < x.Length; i++)
             {
                 destination[i] = Log2(x[i]);
-            }
-        }
-
-        /// <summary>Computes the element-wise result of: <c>cosh(<paramref name="x" />)</c>.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <see cref="MathF" />.Cosh(<paramref name="x" />[i])</c>.</remarks>
-        public static void Cosh(ReadOnlySpan<float> x, Span<float> destination)
-        {
-            if (x.Length > destination.Length)
-            {
-                ThrowHelper.ThrowArgument_DestinationTooShort();
-            }
-
-            for (int i = 0; i < x.Length; i++)
-            {
-                destination[i] = MathF.Cosh(x[i]);
-            }
-        }
-
-        /// <summary>Computes the element-wise result of: <c>sinh(<paramref name="x" />)</c>.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <see cref="MathF" />.Sinh(<paramref name="x" />[i])</c>.</remarks>
-        public static void Sinh(ReadOnlySpan<float> x, Span<float> destination)
-        {
-            if (x.Length > destination.Length)
-            {
-                ThrowHelper.ThrowArgument_DestinationTooShort();
-            }
-
-            for (int i = 0; i < x.Length; i++)
-            {
-                destination[i] = MathF.Sinh(x[i]);
-            }
-        }
-
-        /// <summary>Computes the element-wise result of: <c>tanh(<paramref name="x" />)</c>.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <see cref="MathF" />.Tanh(<paramref name="x" />[i])</c>.</remarks>
-        public static void Tanh(ReadOnlySpan<float> x, Span<float> destination)
-        {
-            if (x.Length > destination.Length)
-            {
-                ThrowHelper.ThrowArgument_DestinationTooShort();
-            }
-
-            for (int i = 0; i < x.Length; i++)
-            {
-                destination[i] = MathF.Tanh(x[i]);
-            }
-        }
-
-        /// <summary>Computes the cosine similarity between two non-zero vectors.</summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="y">The second tensor, represented as a span.</param>
-        /// <returns>The cosine similarity between the two vectors.</returns>
-        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
-        /// <exception cref="ArgumentException">'<paramref name="x" />' and '<paramref name="y" />' must not be empty.</exception>
-        public static float CosineSimilarity(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
-        {
-            if (x.IsEmpty)
-            {
-                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
-            }
-            if (x.Length != y.Length)
-            {
-                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
-            }
-
-            return CosineSimilarityCore(x, y);
-        }
-
-        /// <summary>
-        /// Compute the distance between two points in Euclidean space.
-        /// </summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="y">The second tensor, represented as a span.</param>
-        /// <returns>The Euclidean distance.</returns>
-        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
-        /// <exception cref="ArgumentException">'<paramref name="x" />' and '<paramref name="y" />' must not be empty.</exception>
-        public static float Distance(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
-        {
-            if (x.IsEmpty)
-            {
-                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
-            }
-            if (x.Length != y.Length)
-            {
-                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
-            }
-
-            return MathF.Sqrt(Aggregate<SubtractSquaredOperator, AddOperator>(0f, x, y));
-        }
-
-        /// <summary>
-        /// A mathematical operation that takes two vectors and returns a scalar.
-        /// </summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="y">The second tensor, represented as a span.</param>
-        /// <returns>The dot product.</returns>
-        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
-        public static float Dot(ReadOnlySpan<float> x, ReadOnlySpan<float> y) // BLAS1: dot
-        {
-            if (x.Length != y.Length)
-            {
-                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
-            }
-
-            return Aggregate<MultiplyOperator, AddOperator>(0f, x, y);
-        }
-
-        /// <summary>
-        /// A mathematical operation that takes a vector and returns the L2 norm.
-        /// </summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <returns>The L2 norm.</returns>
-        public static float Norm(ReadOnlySpan<float> x) // BLAS1: nrm2
-        {
-            return MathF.Sqrt(Aggregate<SquaredOperator, AddOperator>(0f, x));
-        }
-
-        /// <summary>
-        /// A function that takes a collection of real numbers and returns a probability distribution.
-        /// </summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="destination">The destination tensor.</param>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <exception cref="ArgumentException">'<paramref name="x" />' must not be empty.</exception>
-        public static void SoftMax(ReadOnlySpan<float> x, Span<float> destination)
-        {
-            if (x.IsEmpty)
-            {
-                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
-            }
-            if (x.Length > destination.Length)
-            {
-                ThrowHelper.ThrowArgument_DestinationTooShort();
-            }
-
-            float expSum = 0f;
-
-            for (int i = 0; i < x.Length; i++)
-            {
-                expSum += MathF.Exp(x[i]);
-            }
-
-            for (int i = 0; i < x.Length; i++)
-            {
-                destination[i] = MathF.Exp(x[i]) / expSum;
-            }
-        }
-
-        /// <summary>
-        /// A function that takes a real number and returns a value between 0 and 1.
-        /// </summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="destination">The destination tensor.</param>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <exception cref="ArgumentException">'<paramref name="x" />' must not be empty.</exception>
-        public static void Sigmoid(ReadOnlySpan<float> x, Span<float> destination)
-        {
-            if (x.IsEmpty)
-            {
-                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
-            }
-            if (x.Length > destination.Length)
-            {
-                ThrowHelper.ThrowArgument_DestinationTooShort();
-            }
-
-            for (int i = 0; i < x.Length; i++)
-            {
-                destination[i] = 1f / (1 + MathF.Exp(-x[i]));
             }
         }
 
@@ -469,74 +469,6 @@ namespace System.Numerics.Tensors
             for (int i = 0; i < x.Length; i++)
             {
                 destination[i] = MathF.Max(x[i], y[i]);
-            }
-        }
-
-        /// <summary>Computes the minimum element in <paramref name="x"/>.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <returns>The minimum element in <paramref name="x"/>.</returns>
-        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be greater than zero.</exception>
-        public static float Min(ReadOnlySpan<float> x)
-        {
-            if (x.IsEmpty)
-            {
-                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
-            }
-
-            float result = float.PositiveInfinity;
-
-            for (int i = 0; i < x.Length; i++)
-            {
-                // This matches the IEEE 754:2019 `minimum` function
-                // It propagates NaN inputs back to the caller and
-                // otherwise returns the lesser of the inputs.
-                // It treats +0 as greater than -0 as per the specification.
-
-                float current = x[i];
-
-                if (current != result)
-                {
-                    if (float.IsNaN(current))
-                    {
-                        return current;
-                    }
-
-                    if (current < result)
-                    {
-                        result = current;
-                    }
-                }
-                else if (IsNegative(current))
-                {
-                    result = current;
-                }
-            }
-
-            return result;
-        }
-
-        /// <summary>Computes the element-wise result of: <c>MathF.Min(<paramref name="x" />, <paramref name="y" />)</c>.</summary>
-        /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="y">The second tensor, represented as a span.</param>
-        /// <param name="destination">The destination tensor, represented as a span.</param>
-        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
-        /// <exception cref="ArgumentException">Destination is too short.</exception>
-        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = MathF.Min(<paramref name="x" />[i], <paramref name="y" />[i])</c>.</remarks>
-        public static void Min(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<float> destination)
-        {
-            if (x.Length != y.Length)
-            {
-                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
-            }
-
-            if (x.Length > destination.Length)
-            {
-                ThrowHelper.ThrowArgument_DestinationTooShort();
-            }
-
-            for (int i = 0; i < x.Length; i++)
-            {
-                destination[i] = MathF.Min(x[i], y[i]);
             }
         }
 
@@ -612,6 +544,74 @@ namespace System.Numerics.Tensors
             }
         }
 
+        /// <summary>Computes the minimum element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The minimum element in <paramref name="x"/>.</returns>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be greater than zero.</exception>
+        public static float Min(ReadOnlySpan<float> x)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            float result = float.PositiveInfinity;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                // This matches the IEEE 754:2019 `minimum` function
+                // It propagates NaN inputs back to the caller and
+                // otherwise returns the lesser of the inputs.
+                // It treats +0 as greater than -0 as per the specification.
+
+                float current = x[i];
+
+                if (current != result)
+                {
+                    if (float.IsNaN(current))
+                    {
+                        return current;
+                    }
+
+                    if (current < result)
+                    {
+                        result = current;
+                    }
+                }
+                else if (IsNegative(current))
+                {
+                    result = current;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Computes the element-wise result of: <c>MathF.Min(<paramref name="x" />, <paramref name="y" />)</c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = MathF.Min(<paramref name="x" />[i], <paramref name="y" />[i])</c>.</remarks>
+        public static void Min(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<float> destination)
+        {
+            if (x.Length != y.Length)
+            {
+                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+            }
+
+            if (x.Length > destination.Length)
+            {
+                ThrowHelper.ThrowArgument_DestinationTooShort();
+            }
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                destination[i] = MathF.Min(x[i], y[i]);
+            }
+        }
+
         /// <summary>Computes the minimum magnitude of any element in <paramref name="x"/>.</summary>
         /// <param name="x">The tensor, represented as a span.</param>
         /// <returns>The minimum magnitude of any element in <paramref name="x"/>.</returns>
@@ -684,213 +684,80 @@ namespace System.Numerics.Tensors
             }
         }
 
-        /// <summary>Computes the index of the maximum element in <paramref name="x"/>.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <returns>The index of the maximum element in <paramref name="x"/>, or -1 if <paramref name="x"/> is empty.</returns>
-        public static unsafe int IndexOfMax(ReadOnlySpan<float> x)
-        {
-            int result = -1;
+        /// <summary>Computes the element-wise result of: <c><paramref name="x" /> * <paramref name="y" /></c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] * <paramref name="y" /></c>.</remarks>
+        public static void Multiply(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<float> destination) =>
+            InvokeSpanSpanIntoSpan<MultiplyOperator>(x, y, destination);
 
-            if (!x.IsEmpty)
-            {
-                float max = float.NegativeInfinity;
-
-                for (int i = 0; i < x.Length; i++)
-                {
-                    // This matches the IEEE 754:2019 `maximum` function.
-                    // It propagates NaN inputs back to the caller and
-                    // otherwise returns the greater of the inputs.
-                    // It treats +0 as greater than -0 as per the specification.
-
-                    float current = x[i];
-
-                    if (current != max)
-                    {
-                        if (float.IsNaN(current))
-                        {
-                            return i;
-                        }
-
-                        if (max < current)
-                        {
-                            result = i;
-                            max = current;
-                        }
-                    }
-                    else if (IsNegative(max) && !IsNegative(current))
-                    {
-                        result = i;
-                        max = current;
-                    }
-                }
-            }
-
-            return result;
-        }
-
-        /// <summary>Computes the index of the minimum element in <paramref name="x"/>.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <returns>The index of the minimum element in <paramref name="x"/>, or -1 if <paramref name="x"/> is empty.</returns>
-        public static unsafe int IndexOfMin(ReadOnlySpan<float> x)
-        {
-            int result = -1;
-
-            if (!x.IsEmpty)
-            {
-                float min = float.PositiveInfinity;
-
-                for (int i = 0; i < x.Length; i++)
-                {
-                    // This matches the IEEE 754:2019 `minimum` function.
-                    // It propagates NaN inputs back to the caller and
-                    // otherwise returns the lesser of the inputs.
-                    // It treats +0 as greater than -0 as per the specification.
-
-                    float current = x[i];
-
-                    if (current != min)
-                    {
-                        if (float.IsNaN(current))
-                        {
-                            return i;
-                        }
-
-                        if (current < min)
-                        {
-                            result = i;
-                            min = current;
-                        }
-                    }
-                    else if (IsNegative(current) && !IsNegative(min))
-                    {
-                        result = i;
-                        min = current;
-                    }
-                }
-            }
-
-            return result;
-        }
-
-        /// <summary>Computes the index of the element in <paramref name="x"/> with the maximum magnitude.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <returns>The index of the element with the maximum magnitude, or -1 if <paramref name="x"/> is empty.</returns>
-        /// <remarks>This method corresponds to the <c>iamax</c> method defined by <c>BLAS1</c>.</remarks>
-        public static unsafe int IndexOfMaxMagnitude(ReadOnlySpan<float> x)
-        {
-            int result = -1;
-
-            if (!x.IsEmpty)
-            {
-                float max = float.NegativeInfinity;
-                float maxMag = float.NegativeInfinity;
-
-                for (int i = 0; i < x.Length; i++)
-                {
-                    // This matches the IEEE 754:2019 `maximumMagnitude` function.
-                    // It propagates NaN inputs back to the caller and
-                    // otherwise returns the input with a greater magnitude.
-                    // It treats +0 as greater than -0 as per the specification.
-
-                    float current = x[i];
-                    float currentMag = Math.Abs(current);
-
-                    if (currentMag != maxMag)
-                    {
-                        if (float.IsNaN(currentMag))
-                        {
-                            return i;
-                        }
-
-                        if (maxMag < currentMag)
-                        {
-                            result = i;
-                            max = current;
-                            maxMag = currentMag;
-                        }
-                    }
-                    else if (IsNegative(max) && !IsNegative(current))
-                    {
-                        result = i;
-                        max = current;
-                        maxMag = currentMag;
-                    }
-                }
-            }
-
-            return result;
-        }
-
-        /// <summary>Computes the index of the element in <paramref name="x"/> with the minimum magnitude.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <returns>The index of the element with the minimum magnitude, or -1 if <paramref name="x"/> is empty.</returns>
-        public static unsafe int IndexOfMinMagnitude(ReadOnlySpan<float> x)
-        {
-            int result = -1;
-
-            if (!x.IsEmpty)
-            {
-                float min = float.PositiveInfinity;
-                float minMag = float.PositiveInfinity;
-
-                for (int i = 0; i < x.Length; i++)
-                {
-                    // This matches the IEEE 754:2019 `minimumMagnitude` function
-                    // It propagates NaN inputs back to the caller and
-                    // otherwise returns the input with a lesser magnitude.
-                    // It treats +0 as greater than -0 as per the specification.
-
-                    float current = x[i];
-                    float currentMag = Math.Abs(current);
-
-                    if (currentMag != minMag)
-                    {
-                        if (float.IsNaN(currentMag))
-                        {
-                            return i;
-                        }
-
-                        if (currentMag < minMag)
-                        {
-                            result = i;
-                            min = current;
-                            minMag = currentMag;
-                        }
-                    }
-                    else if (IsNegative(current) && !IsNegative(min))
-                    {
-                        result = i;
-                        min = current;
-                        minMag = currentMag;
-                    }
-                }
-            }
-
-            return result;
-        }
-
-        /// <summary>Computes the sum of all elements in <paramref name="x"/>.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <returns>The result of adding all elements in <paramref name="x"/>, or zero if <paramref name="x"/> is empty.</returns>
-        public static float Sum(ReadOnlySpan<float> x) =>
-            Aggregate<IdentityOperator, AddOperator>(0f, x);
-
-        /// <summary>Computes the sum of the squares of every element in <paramref name="x"/>.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <returns>The result of adding every element in <paramref name="x"/> multiplied by itself, or zero if <paramref name="x"/> is empty.</returns>
-        /// <remarks>This method effectively does <c><see cref="TensorPrimitives" />.Sum(<see cref="TensorPrimitives" />.Multiply(<paramref name="x" />, <paramref name="x" />))</c>.</remarks>
-        public static float SumOfSquares(ReadOnlySpan<float> x) =>
-            Aggregate<SquaredOperator, AddOperator>(0f, x);
-
-        /// <summary>Computes the sum of the absolute values of every element in <paramref name="x"/>.</summary>
-        /// <param name="x">The tensor, represented as a span.</param>
-        /// <returns>The result of adding the absolute value of every element in <paramref name="x"/>, or zero if <paramref name="x"/> is empty.</returns>
+        /// <summary>Computes the element-wise result of: <c><paramref name="x" /> * <paramref name="y" /></c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a scalar.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
         /// <remarks>
-        ///     <para>This method effectively does <c><see cref="TensorPrimitives" />.Sum(<see cref="TensorPrimitives" />.Abs(<paramref name="x" />))</c>.</para>
-        ///     <para>This method corresponds to the <c>asum</c> method defined by <c>BLAS1</c>.</para>
+        ///     <para>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] * <paramref name="y" /></c>.</para>
+        ///     <para>This method corresponds to the <c>scal</c> method defined by <c>BLAS1</c>.</para>
         /// </remarks>
-        public static float SumOfMagnitudes(ReadOnlySpan<float> x) =>
-            Aggregate<AbsoluteOperator, AddOperator>(0f, x);
+        public static void Multiply(ReadOnlySpan<float> x, float y, Span<float> destination) =>
+            InvokeSpanScalarIntoSpan<MultiplyOperator>(x, y, destination);
+
+        /// <summary>Computes the element-wise result of: <c>(<paramref name="x" /> * <paramref name="y" />) + <paramref name="addend" /></c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <param name="addend">The third tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="addend" />'.</exception>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = (<paramref name="x" />[i] * <paramref name="y" />[i]) + <paramref name="addend" />[i]</c>.</remarks>
+        public static void MultiplyAdd(ReadOnlySpan<float> x, ReadOnlySpan<float> y, ReadOnlySpan<float> addend, Span<float> destination) =>
+            InvokeSpanSpanSpanIntoSpan<MultiplyAddOperator>(x, y, addend, destination);
+
+        /// <summary>Computes the element-wise result of: <c>(<paramref name="x" /> * <paramref name="y" />) + <paramref name="addend" /></c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <param name="addend">The third tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>
+        ///     <para>This method effectively does <c><paramref name="destination" />[i] = (<paramref name="x" />[i] * <paramref name="y" />[i]) + <paramref name="addend" /></c>.</para>
+        ///     <para>This method corresponds to the <c>axpy</c> method defined by <c>BLAS1</c>.</para>
+        /// </remarks>
+        public static void MultiplyAdd(ReadOnlySpan<float> x, ReadOnlySpan<float> y, float addend, Span<float> destination) =>
+            InvokeSpanSpanScalarIntoSpan<MultiplyAddOperator>(x, y, addend, destination);
+
+        /// <summary>Computes the element-wise result of: <c>(<paramref name="x" /> * <paramref name="y" />) + <paramref name="addend" /></c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <param name="addend">The third tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="addend" />'.</exception>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = (<paramref name="x" />[i] * <paramref name="y" />) + <paramref name="addend" />[i]</c>.</remarks>
+        public static void MultiplyAdd(ReadOnlySpan<float> x, float y, ReadOnlySpan<float> addend, Span<float> destination) =>
+            InvokeSpanScalarSpanIntoSpan<MultiplyAddOperator>(x, y, addend, destination);
+
+        /// <summary>Computes the element-wise result of: <c>-<paramref name="x" /></c>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = -<paramref name="x" />[i]</c>.</remarks>
+        public static void Negate(ReadOnlySpan<float> x, Span<float> destination) =>
+            InvokeSpanIntoSpan<NegateOperator>(x, destination);
+
+        /// <summary>
+        /// A mathematical operation that takes a vector and returns the L2 norm.
+        /// </summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <returns>The L2 norm.</returns>
+        public static float Norm(ReadOnlySpan<float> x) => // BLAS1: nrm2
+            MathF.Sqrt(Aggregate<SquaredOperator, AddOperator>(0f, x));
 
         /// <summary>Computes the product of all elements in <paramref name="x"/>.</summary>
         /// <param name="x">The tensor, represented as a span.</param>
@@ -904,6 +771,28 @@ namespace System.Numerics.Tensors
             }
 
             return Aggregate<IdentityOperator, MultiplyOperator>(1.0f, x);
+        }
+
+        /// <summary>Computes the product of the element-wise result of: <c><paramref name="x" /> - <paramref name="y" /></c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <returns>The result of multiplying the element-wise subtraction of the elements in the second tensor from the first tensor.</returns>
+        /// <exception cref="ArgumentException">Length of both input spans must be greater than zero.</exception>
+        /// <exception cref="ArgumentException"><paramref name="x"/> and <paramref name="y"/> must have the same length.</exception>
+        /// <remarks>This method effectively does <c><see cref="TensorPrimitives" />.Product(<see cref="TensorPrimitives" />.Subtract(<paramref name="x" />, <paramref name="y" />))</c>.</remarks>
+        public static float ProductOfDifferences(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            if (x.Length != y.Length)
+            {
+                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+            }
+
+            return Aggregate<SubtractOperator, MultiplyOperator>(1.0f, x, y);
         }
 
         /// <summary>Computes the product of the element-wise result of: <c><paramref name="x" /> + <paramref name="y" /></c>.</summary>
@@ -928,26 +817,139 @@ namespace System.Numerics.Tensors
             return Aggregate<AddOperator, MultiplyOperator>(1.0f, x, y);
         }
 
-        /// <summary>Computes the product of the element-wise result of: <c><paramref name="x" /> - <paramref name="y" /></c>.</summary>
+        /// <summary>
+        /// A function that takes a real number and returns a value between 0 and 1.
+        /// </summary>
         /// <param name="x">The first tensor, represented as a span.</param>
-        /// <param name="y">The second tensor, represented as a span.</param>
-        /// <returns>The result of multiplying the element-wise subtraction of the elements in the second tensor from the first tensor.</returns>
-        /// <exception cref="ArgumentException">Length of both input spans must be greater than zero.</exception>
-        /// <exception cref="ArgumentException"><paramref name="x"/> and <paramref name="y"/> must have the same length.</exception>
-        /// <remarks>This method effectively does <c><see cref="TensorPrimitives" />.Product(<see cref="TensorPrimitives" />.Subtract(<paramref name="x" />, <paramref name="y" />))</c>.</remarks>
-        public static float ProductOfDifferences(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
+        /// <param name="destination">The destination tensor.</param>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <exception cref="ArgumentException">'<paramref name="x" />' must not be empty.</exception>
+        public static void Sigmoid(ReadOnlySpan<float> x, Span<float> destination)
         {
             if (x.IsEmpty)
             {
                 ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
             }
 
-            if (x.Length != y.Length)
+            if (x.Length > destination.Length)
             {
-                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+                ThrowHelper.ThrowArgument_DestinationTooShort();
             }
 
-            return Aggregate<SubtractOperator, MultiplyOperator>(1.0f, x, y);
+            for (int i = 0; i < x.Length; i++)
+            {
+                destination[i] = 1f / (1 + MathF.Exp(-x[i]));
+            }
+        }
+
+        /// <summary>Computes the element-wise result of: <c>sinh(<paramref name="x" />)</c>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <see cref="MathF" />.Sinh(<paramref name="x" />[i])</c>.</remarks>
+        public static void Sinh(ReadOnlySpan<float> x, Span<float> destination)
+        {
+            if (x.Length > destination.Length)
+            {
+                ThrowHelper.ThrowArgument_DestinationTooShort();
+            }
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                destination[i] = MathF.Sinh(x[i]);
+            }
+        }
+
+        /// <summary>
+        /// A function that takes a collection of real numbers and returns a probability distribution.
+        /// </summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor.</param>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <exception cref="ArgumentException">'<paramref name="x" />' must not be empty.</exception>
+        public static void SoftMax(ReadOnlySpan<float> x, Span<float> destination)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            if (x.Length > destination.Length)
+            {
+                ThrowHelper.ThrowArgument_DestinationTooShort();
+            }
+
+            float expSum = 0f;
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                expSum += MathF.Exp(x[i]);
+            }
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                destination[i] = MathF.Exp(x[i]) / expSum;
+            }
+        }
+
+        /// <summary>Computes the element-wise result of: <c><paramref name="x" /> - <paramref name="y" /></c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a scalar.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Length of '<paramref name="x" />' must be same as length of '<paramref name="y" />'.</exception>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] - <paramref name="y" />[i]</c>.</remarks>
+        public static void Subtract(ReadOnlySpan<float> x, ReadOnlySpan<float> y, Span<float> destination) =>
+            InvokeSpanSpanIntoSpan<SubtractOperator>(x, y, destination);
+
+        /// <summary>Computes the element-wise result of: <c><paramref name="x" /> - <paramref name="y" /></c>.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a scalar.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <paramref name="x" />[i] - <paramref name="y" /></c>.</remarks>
+        public static void Subtract(ReadOnlySpan<float> x, float y, Span<float> destination) =>
+            InvokeSpanScalarIntoSpan<SubtractOperator>(x, y, destination);
+
+        /// <summary>Computes the sum of all elements in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The result of adding all elements in <paramref name="x"/>, or zero if <paramref name="x"/> is empty.</returns>
+        public static float Sum(ReadOnlySpan<float> x) =>
+            Aggregate<IdentityOperator, AddOperator>(0f, x);
+
+        /// <summary>Computes the sum of the absolute values of every element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The result of adding the absolute value of every element in <paramref name="x"/>, or zero if <paramref name="x"/> is empty.</returns>
+        /// <remarks>
+        ///     <para>This method effectively does <c><see cref="TensorPrimitives" />.Sum(<see cref="TensorPrimitives" />.Abs(<paramref name="x" />))</c>.</para>
+        ///     <para>This method corresponds to the <c>asum</c> method defined by <c>BLAS1</c>.</para>
+        /// </remarks>
+        public static float SumOfMagnitudes(ReadOnlySpan<float> x) =>
+            Aggregate<AbsoluteOperator, AddOperator>(0f, x);
+
+        /// <summary>Computes the sum of the squares of every element in <paramref name="x"/>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <returns>The result of adding every element in <paramref name="x"/> multiplied by itself, or zero if <paramref name="x"/> is empty.</returns>
+        /// <remarks>This method effectively does <c><see cref="TensorPrimitives" />.Sum(<see cref="TensorPrimitives" />.Multiply(<paramref name="x" />, <paramref name="x" />))</c>.</remarks>
+        public static float SumOfSquares(ReadOnlySpan<float> x) =>
+            Aggregate<SquaredOperator, AddOperator>(0f, x);
+
+        /// <summary>Computes the element-wise result of: <c>tanh(<paramref name="x" />)</c>.</summary>
+        /// <param name="x">The tensor, represented as a span.</param>
+        /// <param name="destination">The destination tensor, represented as a span.</param>
+        /// <exception cref="ArgumentException">Destination is too short.</exception>
+        /// <remarks>This method effectively does <c><paramref name="destination" />[i] = <see cref="MathF" />.Tanh(<paramref name="x" />[i])</c>.</remarks>
+        public static void Tanh(ReadOnlySpan<float> x, Span<float> destination)
+        {
+            if (x.Length > destination.Length)
+            {
+                ThrowHelper.ThrowArgument_DestinationTooShort();
+            }
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                destination[i] = MathF.Tanh(x[i]);
+            }
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
@@ -49,7 +49,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void AddTwoTensors(int tensorLength)
+        public static void Add_TwoTensors(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -65,7 +65,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void AddTwoTensors_ThrowsForMismatchedLengths(int tensorLength)
+        public static void Add_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
@@ -76,7 +76,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void AddTwoTensors_ThrowsForTooShortDestination(int tensorLength)
+        public static void Add_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -87,7 +87,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void AddTensorAndScalar(int tensorLength)
+        public static void Add_TensorScalar(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -103,7 +103,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void AddTensorAndScalar_ThrowsForTooShortDestination(int tensorLength)
+        public static void Add_TensorScalar_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -114,7 +114,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void SubtractTwoTensors(int tensorLength)
+        public static void Subtract_TwoTensors(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -130,7 +130,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void SubtractTwoTensors_ThrowsForMismatchedLengths(int tensorLength)
+        public static void Subtract_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
@@ -141,7 +141,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void SubtractTwoTensors_ThrowsForTooShortDestination(int tensorLength)
+        public static void Subtract_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -152,7 +152,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void SubtractTensorAndScalar(int tensorLength)
+        public static void Subtract_TensorScalar(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -168,7 +168,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void SubtractTensorAndScalar_ThrowsForTooShortDestination(int tensorLength)
+        public static void Subtract_TensorScalar_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -179,7 +179,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void MultiplyTwoTensors(int tensorLength)
+        public static void Multiply_TwoTensors(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -195,7 +195,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MultiplyTwoTensors_ThrowsForMismatchedLengths(int tensorLength)
+        public static void Multiply_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
@@ -206,7 +206,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MultiplyTwoTensors_ThrowsForTooShortDestination(int tensorLength)
+        public static void Multiply_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -217,7 +217,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void MultiplyTensorAndScalar(int tensorLength)
+        public static void Multiply_TensorScalar(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -233,7 +233,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MultiplyTensorAndScalar_ThrowsForTooShortDestination(int tensorLength)
+        public static void Multiply_TensorScalar_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -244,7 +244,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void DivideTwoTensors(int tensorLength)
+        public static void Divide_TwoTensors(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -260,7 +260,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void DivideTwoTensors_ThrowsForMismatchedLengths(int tensorLength)
+        public static void Divide_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
@@ -271,7 +271,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void DivideTwoTensors_ThrowsForTooShortDestination(int tensorLength)
+        public static void Divide_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -282,7 +282,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void DivideTensorAndScalar(int tensorLength)
+        public static void Divide_TensorScalar(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -298,7 +298,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void DivideTensorAndScalar_ThrowsForTooShortDestination(int tensorLength)
+        public static void Divide_TensorScalar_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -309,7 +309,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void NegateTensor(int tensorLength)
+        public static void Negate(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
@@ -324,7 +324,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void NegateTensor_ThrowsForTooShortDestination(int tensorLength)
+        public static void Negate_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
@@ -334,7 +334,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void AddTwoTensorsAndMultiplyWithThirdTensor(int tensorLength)
+        public static void AddMultiply_ThreeTensors(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -351,7 +351,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void AddTwoTensorsAndMultiplyWithThirdTensor_ThrowsForMismatchedLengths_x_y(int tensorLength)
+        public static void AddMultiply_ThreeTensors_ThrowsForMismatchedLengths_x_y(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
@@ -363,7 +363,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void AddTwoTensorsAndMultiplyWithThirdTensor_ThrowsForMismatchedLengths_x_multiplier(int tensorLength)
+        public static void AddMultiply_ThreeTensors_ThrowsForMismatchedLengths_x_multiplier(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -375,7 +375,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void AddTwoTensorsAndMultiplyWithThirdTensor_ThrowsForTooShortDestination(int tensorLength)
+        public static void AddMultiply_ThreeTensors_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -387,7 +387,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void AddTwoTensorsAndMultiplyWithScalar(int tensorLength)
+        public static void AddMultiply_TensorTensorScalar(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -404,7 +404,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void AddTwoTensorsAndMultiplyWithScalar_ThrowsForMismatchedLengths_x_y(int tensorLength)
+        public static void AddMultiply_TensorTensorScalar_ThrowsForMismatchedLengths_x_y(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
@@ -416,7 +416,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void AddTwoTensorsAndMultiplyWithScalar_ThrowsForTooShortDestination(int tensorLength)
+        public static void AddMultiply_TensorTensorScalar_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -428,7 +428,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void AddTensorAndScalarAndMultiplyWithTensor(int tensorLength)
+        public static void AddMultiply_TensorScalarTensor(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -445,7 +445,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void AddTensorAndScalarAndMultiplyWithTensor_ThrowsForMismatchedLengths_x_z(int tensorLength)
+        public static void AddMultiply_TensorScalarTensor_ThrowsForMismatchedLengths_x_z(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -457,7 +457,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void AddTensorAndScalarAndMultiplyWithTensor_ThrowsForTooShortDestination(int tensorLength)
+        public static void AddMultiply_TensorScalarTensor_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -469,7 +469,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void MultiplyTwoTensorsAndAddWithThirdTensor(int tensorLength)
+        public static void MultiplyAdd_ThreeTensors(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -486,7 +486,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MultiplyTwoTensorsAndAddWithThirdTensor_ThrowsForMismatchedLengths_x_y(int tensorLength)
+        public static void MultiplyAdd_ThreeTensors_ThrowsForMismatchedLengths_x_y(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
@@ -498,7 +498,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MultiplyTwoTensorsAndAddWithThirdTensor_ThrowsForMismatchedLengths_x_multiplier(int tensorLength)
+        public static void MultiplyAdd_ThreeTensors_ThrowsForMismatchedLengths_x_multiplier(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -510,7 +510,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MultiplyTwoTensorsAndAddWithThirdTensor_ThrowsForTooShortDestination(int tensorLength)
+        public static void MultiplyAdd_ThreeTensors_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -522,7 +522,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void MultiplyTwoTensorsAndAddWithScalar(int tensorLength)
+        public static void MultiplyAdd_TensorTensorScalar(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -539,7 +539,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MultiplyTwoTensorsAndAddWithScalar_ThrowsForTooShortDestination(int tensorLength)
+        public static void MultiplyAdd_TensorTensorScalar_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
@@ -551,7 +551,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void MultiplyTensorAndScalarAndAddWithTensor(int tensorLength)
+        public static void MultiplyAdd_TensorScalarTensor(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -568,7 +568,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MultiplyTensorAndScalarAndAddWithTensor_ThrowsForTooShortDestination(int tensorLength)
+        public static void MultiplyAdd_TensorScalarTensor_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
@@ -580,7 +580,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void ExpTensor(int tensorLength)
+        public static void Exp(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
@@ -595,7 +595,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void ExpTensor_ThrowsForTooShortDestination(int tensorLength)
+        public static void Exp_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
@@ -605,7 +605,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void LogTensor(int tensorLength)
+        public static void Log(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
@@ -620,7 +620,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void LogTensor_ThrowsForTooShortDestination(int tensorLength)
+        public static void Log_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
@@ -655,7 +655,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void CoshTensor(int tensorLength)
+        public static void Cosh(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
@@ -670,7 +670,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void CoshTensor_ThrowsForTooShortDestination(int tensorLength)
+        public static void Cosh_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
@@ -680,7 +680,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void SinhTensor(int tensorLength)
+        public static void Sinh(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
@@ -695,7 +695,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void SinhTensor_ThrowsForTooShortDestination(int tensorLength)
+        public static void Sinh_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
@@ -705,7 +705,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void TanhTensor(int tensorLength)
+        public static void Tanh(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
@@ -720,7 +720,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void TanhTensor_ThrowsForTooShortDestination(int tensorLength)
+        public static void Tanh_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
@@ -773,7 +773,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public static void Distance_ThrowsForEmpty_x_y()
+        public static void Distance_ThrowsForEmpty()
         {
             Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(ReadOnlySpan<float>.Empty, ReadOnlySpan<float>.Empty));
             Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(ReadOnlySpan<float>.Empty, CreateTensor(1)));
@@ -782,7 +782,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void Distance_ThrowsForMismatchedLengths_x_y(int tensorLength)
+        public static void Distance_ThrowsForMismatchedLengths(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
@@ -1146,14 +1146,14 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public static void Max_ThrowsForEmpty()
+        public static void Max_Tensor_ThrowsForEmpty()
         {
             Assert.Throws<ArgumentException>(() => TensorPrimitives.Max(ReadOnlySpan<float>.Empty));
         }
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void Max(int tensorLength)
+        public static void Max_Tensor(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
 
@@ -1169,7 +1169,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void Max_NanReturned(int tensorLength)
+        public static void Max_Tensor_NanReturned(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
@@ -1180,7 +1180,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public static void Max_Negative0LesserThanPositive0()
+        public static void Max_Tensor_Negative0LesserThanPositive0()
         {
             Assert.Equal(+0f, TensorPrimitives.Max([-0f, +0f]));
             Assert.Equal(+0f, TensorPrimitives.Max([+0f, -0f]));
@@ -1227,14 +1227,14 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public static void MaxMagnitude_ThrowsForEmpty()
+        public static void MaxMagnitude_Tensor_ThrowsForEmpty()
         {
             Assert.Throws<ArgumentException>(() => TensorPrimitives.MaxMagnitude(ReadOnlySpan<float>.Empty));
         }
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MaxMagnitude(int tensorLength)
+        public static void MaxMagnitude_Tensor(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
 
@@ -1252,7 +1252,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MaxMagnitude_NanReturned(int tensorLength)
+        public static void MaxMagnitude_Tensor_NanReturned(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
@@ -1263,7 +1263,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public static void MaxMagnitude_Negative0LesserThanPositive0()
+        public static void MaxMagnitude_Tensor_Negative0LesserThanPositive0()
         {
             Assert.Equal(+0f, TensorPrimitives.MaxMagnitude([-0f, +0f]));
             Assert.Equal(+0f, TensorPrimitives.MaxMagnitude([+0f, -0f]));
@@ -1312,14 +1312,14 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public static void Min_ThrowsForEmpty()
+        public static void Min_Tensor_ThrowsForEmpty()
         {
             Assert.Throws<ArgumentException>(() => TensorPrimitives.Min(ReadOnlySpan<float>.Empty));
         }
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void Min(int tensorLength)
+        public static void Min_Tensor(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
 
@@ -1335,7 +1335,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void Min_NanReturned(int tensorLength)
+        public static void Min_Tensor_NanReturned(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
@@ -1346,7 +1346,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public static void Min_Negative0LesserThanPositive0()
+        public static void Min_Tensor_Negative0LesserThanPositive0()
         {
             Assert.Equal(-0f, TensorPrimitives.Min([-0f, +0f]));
             Assert.Equal(-0f, TensorPrimitives.Min([+0f, -0f]));
@@ -1393,14 +1393,14 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public static void MinMagnitude_ThrowsForEmpty()
+        public static void MinMagnitude_Tensor_ThrowsForEmpty()
         {
             Assert.Throws<ArgumentException>(() => TensorPrimitives.MinMagnitude(ReadOnlySpan<float>.Empty));
         }
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MinMagnitude(int tensorLength)
+        public static void MinMagnitude_Tensor(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
 
@@ -1418,7 +1418,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MinMagnitude_NanReturned(int tensorLength)
+        public static void MinMagnitude_Tensor_NanReturned(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
@@ -1429,7 +1429,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Fact]
-        public static void MinMagnitude_Negative0LesserThanPositive0()
+        public static void MinMagnitude_Tensor_Negative0LesserThanPositive0()
         {
             Assert.Equal(0, TensorPrimitives.MinMagnitude([-0f, +0f]));
             Assert.Equal(0, TensorPrimitives.MinMagnitude([+0f, -0f]));

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
@@ -102,6 +102,7 @@ namespace System.Numerics.Tensors.Tests
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
             Assert.Throws<ArgumentException>(() => TensorPrimitives.Add(x, y, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Add(y, x, destination));
         }
 
         [Theory]
@@ -163,26 +164,16 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void AddMultiply_ThreeTensors_ThrowsForMismatchedLengths_x_y(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
-            using BoundedMemory<float> multiplier = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.AddMultiply(x, y, multiplier, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void AddMultiply_ThreeTensors_ThrowsForMismatchedLengths_x_multiplier(int tensorLength)
+        public static void AddMultiply_ThreeTensors_ThrowsForMismatchedLengths(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> multiplier = CreateAndFillTensor(tensorLength - 1);
+            using BoundedMemory<float> z = CreateAndFillTensor(tensorLength - 1);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.AddMultiply(x, y, multiplier, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.AddMultiply(x, y, z, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.AddMultiply(x, z, y, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.AddMultiply(z, x, y, destination));
         }
 
         [Theory]
@@ -224,6 +215,7 @@ namespace System.Numerics.Tensors.Tests
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
             Assert.Throws<ArgumentException>(() => TensorPrimitives.AddMultiply(x, y, multiplier, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.AddMultiply(y, x, multiplier, destination));
         }
 
         [Theory]
@@ -261,10 +253,11 @@ namespace System.Numerics.Tensors.Tests
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             float y = NextSingle();
-            using BoundedMemory<float> multiplier = CreateAndFillTensor(tensorLength - 1);
+            using BoundedMemory<float> z = CreateAndFillTensor(tensorLength - 1);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.AddMultiply(x, y, multiplier, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.AddMultiply(x, y, z, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.AddMultiply(z, y, x, destination));
         }
 
         [Theory]
@@ -316,6 +309,7 @@ namespace System.Numerics.Tensors.Tests
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
 
             Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(x, y));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(y, x));
         }
 
         [Fact]
@@ -370,6 +364,7 @@ namespace System.Numerics.Tensors.Tests
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
 
             Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(x, y));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(y, x));
         }
 
         [Theory]
@@ -425,6 +420,7 @@ namespace System.Numerics.Tensors.Tests
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
             Assert.Throws<ArgumentException>(() => TensorPrimitives.Divide(x, y, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Divide(y, x, destination));
         }
 
         [Theory]
@@ -475,6 +471,7 @@ namespace System.Numerics.Tensors.Tests
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
 
             Assert.Throws<ArgumentException>(() => TensorPrimitives.Dot(x, y));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Dot(y, x));
         }
 
         [Theory]
@@ -835,6 +832,7 @@ namespace System.Numerics.Tensors.Tests
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
             Assert.Throws<ArgumentException>(() => TensorPrimitives.Max(x, y, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Max(y, x, destination));
         }
 
         [Theory]
@@ -922,6 +920,7 @@ namespace System.Numerics.Tensors.Tests
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
             Assert.Throws<ArgumentException>(() => TensorPrimitives.MaxMagnitude(x, y, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.MaxMagnitude(y, x, destination));
         }
 
         [Theory]
@@ -1005,6 +1004,7 @@ namespace System.Numerics.Tensors.Tests
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
             Assert.Throws<ArgumentException>(() => TensorPrimitives.Min(x, y, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Min(y, x, destination));
         }
 
         [Theory]
@@ -1090,6 +1090,7 @@ namespace System.Numerics.Tensors.Tests
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
             Assert.Throws<ArgumentException>(() => TensorPrimitives.MinMagnitude(x, y, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.MinMagnitude(y, x, destination));
         }
 
         [Theory]
@@ -1130,6 +1131,7 @@ namespace System.Numerics.Tensors.Tests
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
             Assert.Throws<ArgumentException>(() => TensorPrimitives.Multiply(x, y, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Multiply(y, x, destination));
         }
 
         [Theory]
@@ -1194,23 +1196,13 @@ namespace System.Numerics.Tensors.Tests
         public static void MultiplyAdd_ThreeTensors_ThrowsForMismatchedLengths_x_y(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
-            using BoundedMemory<float> addend = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.MultiplyAdd(x, y, addend, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void MultiplyAdd_ThreeTensors_ThrowsForMismatchedLengths_x_multiplier(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> addend = CreateAndFillTensor(tensorLength - 1);
+            using BoundedMemory<float> z = CreateAndFillTensor(tensorLength - 1);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.MultiplyAdd(x, y, addend, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.MultiplyAdd(x, y, z, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.MultiplyAdd(x, z, y, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.MultiplyAdd(z, x, y, destination));
         }
 
         [Theory]
@@ -1608,6 +1600,7 @@ namespace System.Numerics.Tensors.Tests
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
             Assert.Throws<ArgumentException>(() => TensorPrimitives.Subtract(x, y, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Subtract(y, x, destination));
         }
 
         [Theory]

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
@@ -13,6 +13,7 @@ namespace System.Numerics.Tensors.Tests
 {
     public static partial class TensorPrimitivesTests
     {
+        #region Test Utilities
         private const double Tolerance = 0.0001;
 
         public static IEnumerable<object[]> TensorLengthsIncluding0 =>
@@ -46,7 +47,36 @@ namespace System.Numerics.Tensors.Tests
             // For testing purposes, get a mix of negative and positive values.
             return (float)((s_random.NextDouble() * 2) - 1);
         }
+        #endregion
 
+        #region Abs
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Abs(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.Abs(x, destination);
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                Assert.Equal(MathF.Abs(x[i]), destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Abs_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Abs(x, destination));
+        }
+        #endregion
+
+        #region Add
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
         public static void Add_TwoTensors(int tensorLength)
@@ -111,227 +141,9 @@ namespace System.Numerics.Tensors.Tests
 
             AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Add(x, y, destination));
         }
+        #endregion
 
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Subtract_TwoTensors(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Subtract(x, y, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(x[i] - y[i], destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Subtract_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Subtract(x, y, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Subtract_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Subtract(x, y, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Subtract_TensorScalar(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            float y = NextSingle();
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Subtract(x, y, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(x[i] - y, destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Subtract_TensorScalar_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            float y = NextSingle();
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Subtract(x, y, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Multiply_TwoTensors(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Multiply(x, y, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(x[i] * y[i], destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Multiply_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Multiply(x, y, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Multiply_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Multiply(x, y, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Multiply_TensorScalar(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            float y = NextSingle();
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Multiply(x, y, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(x[i] * y, destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Multiply_TensorScalar_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            float y = NextSingle();
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Multiply(x, y, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Divide_TwoTensors(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Divide(x, y, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(x[i] / y[i], destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Divide_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Divide(x, y, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Divide_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Divide(x, y, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Divide_TensorScalar(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            float y = NextSingle();
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Divide(x, y, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(x[i] / y, destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Divide_TensorScalar_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            float y = NextSingle();
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Divide(x, y, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Negate(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Negate(x, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(-x[i], destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Negate_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Negate(x, destination));
-        }
-
+        #region AddMultiply
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
         public static void AddMultiply_ThreeTensors(int tensorLength)
@@ -466,7 +278,900 @@ namespace System.Numerics.Tensors.Tests
 
             AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.AddMultiply(x, y, multiplier, destination));
         }
+        #endregion
 
+        #region Cosh
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Cosh(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.Cosh(x, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(MathF.Cosh(x[i]), destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Cosh_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Cosh(x, destination));
+        }
+        #endregion
+
+        #region CosineSimilarity
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void CosineSimilarity_ThrowsForMismatchedLengths(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(x, y));
+        }
+
+        [Fact]
+        public static void CosineSimilarity_ThrowsForEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(ReadOnlySpan<float>.Empty, ReadOnlySpan<float>.Empty));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(ReadOnlySpan<float>.Empty, CreateTensor(1)));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(CreateTensor(1), ReadOnlySpan<float>.Empty));
+        }
+
+        [Theory]
+        [InlineData(new float[] { 3, 2, 0, 5 }, new float[] { 1, 0, 0, 0 }, 0.48666f)]
+        [InlineData(new float[] { 1, 1, 1, 1, 1, 0 }, new float[] { 1, 1, 1, 1, 0, 1 }, 0.80f)]
+        public static void CosineSimilarity_KnownValues(float[] x, float[] y, float expectedResult)
+        {
+            Assert.Equal(expectedResult, TensorPrimitives.CosineSimilarity(x, y), Tolerance);
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void CosineSimilarity(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+
+            float dot = 0f, squareX = 0f, squareY = 0f;
+            for (int i = 0; i < x.Length; i++)
+            {
+                dot += x[i] * y[i];
+                squareX += x[i] * x[i];
+                squareY += y[i] * y[i];
+            }
+
+            Assert.Equal(dot / (Math.Sqrt(squareX) * Math.Sqrt(squareY)), TensorPrimitives.CosineSimilarity(x, y), Tolerance);
+        }
+        #endregion
+
+        #region Distance
+        [Fact]
+        public static void Distance_ThrowsForEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(ReadOnlySpan<float>.Empty, ReadOnlySpan<float>.Empty));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(ReadOnlySpan<float>.Empty, CreateTensor(1)));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(CreateTensor(1), ReadOnlySpan<float>.Empty));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Distance_ThrowsForMismatchedLengths(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(x, y));
+        }
+
+        [Theory]
+        [InlineData(new float[] { 3, 2 }, new float[] { 4, 1 }, 1.4142f)]
+        [InlineData(new float[] { 0, 4 }, new float[] { 6, 2 }, 6.3245f)]
+        [InlineData(new float[] { 1, 2, 3 }, new float[] { 4, 5, 6 }, 5.1961f)]
+        [InlineData(new float[] { 5, 1, 6, 10 }, new float[] { 7, 2, 8, 4 }, 6.7082f)]
+        public static void Distance_KnownValues(float[] x, float[] y, float expectedResult)
+        {
+            Assert.Equal(expectedResult, TensorPrimitives.Distance(x, y), Tolerance);
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Distance(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+
+            float distance = 0f;
+            for (int i = 0; i < x.Length; i++)
+            {
+                distance += (x[i] - y[i]) * (x[i] - y[i]);
+            }
+
+            Assert.Equal(Math.Sqrt(distance), TensorPrimitives.Distance(x, y), Tolerance);
+        }
+        #endregion
+
+        #region Divide
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Divide_TwoTensors(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.Divide(x, y, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(x[i] / y[i], destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Divide_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Divide(x, y, destination));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Divide_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Divide(x, y, destination));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Divide_TensorScalar(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            float y = NextSingle();
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.Divide(x, y, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(x[i] / y, destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Divide_TensorScalar_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            float y = NextSingle();
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Divide(x, y, destination));
+        }
+        #endregion
+
+        #region Dot
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Dot_ThrowsForMismatchedLengths_x_y(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Dot(x, y));
+        }
+
+        [Theory]
+        [InlineData(new float[] { 1, 3, -5 }, new float[] { 4, -2, -1 }, 3)]
+        [InlineData(new float[] { 1, 2, 3 }, new float[] { 4, 5, 6 }, 32)]
+        [InlineData(new float[] { 1, 2, 3, 10, 8 }, new float[] { 4, 5, 6, -2, 7 }, 68)]
+        [InlineData(new float[] { }, new float[] { }, 0)]
+        public static void Dot_KnownValues(float[] x, float[] y, float expectedResult)
+        {
+            Assert.Equal(expectedResult, TensorPrimitives.Dot(x, y), Tolerance);
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Dot(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+
+            float dot = 0f;
+            for (int i = 0; i < x.Length; i++)
+            {
+                dot += x[i] * y[i];
+            }
+
+            Assert.Equal(dot, TensorPrimitives.Dot(x, y), Tolerance);
+        }
+        #endregion
+
+        #region Exp
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Exp(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.Exp(x, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(MathF.Exp(x[i]), destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Exp_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Exp(x, destination));
+        }
+        #endregion
+
+        #region IndexOfMax
+        [Fact]
+        public static void IndexOfMax_ReturnsNegative1OnEmpty()
+        {
+            Assert.Equal(-1, TensorPrimitives.IndexOfMax(ReadOnlySpan<float>.Empty));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void IndexOfMax(int tensorLength)
+        {
+            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
+            {
+                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+                x[expected] = Enumerable.Max(MemoryMarshal.ToEnumerable<float>(x.Memory)) + 1;
+                Assert.Equal(expected, TensorPrimitives.IndexOfMax(x));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void IndexOfMax_FirstNaNReturned(int tensorLength)
+        {
+            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
+            {
+                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+                x[expected] = float.NaN;
+                x[tensorLength - 1] = float.NaN;
+                Assert.Equal(expected, TensorPrimitives.IndexOfMax(x));
+            }
+        }
+
+        [Fact]
+        public static void IndexOfMax_Negative0LesserThanPositive0()
+        {
+            Assert.Equal(1, TensorPrimitives.IndexOfMax([-0f, +0f]));
+            Assert.Equal(0, TensorPrimitives.IndexOfMax([-0f, -0f, -0f, -0f]));
+            Assert.Equal(4, TensorPrimitives.IndexOfMax([-0f, -0f, -0f, -0f, +0f, +0f, +0f]));
+            Assert.Equal(0, TensorPrimitives.IndexOfMax([+0f, -0f]));
+            Assert.Equal(1, TensorPrimitives.IndexOfMax([-1, -0f]));
+            Assert.Equal(2, TensorPrimitives.IndexOfMax([-1, -0f, 1]));
+        }
+        #endregion
+
+        #region IndexOfMaxMagnitude
+        [Fact]
+        public static void IndexOfMaxMagnitude_ReturnsNegative1OnEmpty()
+        {
+            Assert.Equal(-1, TensorPrimitives.IndexOfMaxMagnitude(ReadOnlySpan<float>.Empty));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void IndexOfMaxMagnitude(int tensorLength)
+        {
+            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
+            {
+                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+                x[expected] = Enumerable.Max(MemoryMarshal.ToEnumerable<float>(x.Memory), Math.Abs) + 1;
+                Assert.Equal(expected, TensorPrimitives.IndexOfMaxMagnitude(x));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void IndexOfMaxMagnitude_FirstNaNReturned(int tensorLength)
+        {
+            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
+            {
+                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+                x[expected] = float.NaN;
+                x[tensorLength - 1] = float.NaN;
+                Assert.Equal(expected, TensorPrimitives.IndexOfMaxMagnitude(x));
+            }
+        }
+
+        [Fact]
+        public static void IndexOfMaxMagnitude_Negative0LesserThanPositive0()
+        {
+            Assert.Equal(0, TensorPrimitives.IndexOfMaxMagnitude([-0f, -0f, -0f, -0f]));
+            Assert.Equal(1, TensorPrimitives.IndexOfMaxMagnitude([-0f, +0f]));
+            Assert.Equal(1, TensorPrimitives.IndexOfMaxMagnitude([-0f, +0f, +0f, +0f]));
+            Assert.Equal(0, TensorPrimitives.IndexOfMaxMagnitude([+0f, -0f]));
+            Assert.Equal(0, TensorPrimitives.IndexOfMaxMagnitude([-1, -0f]));
+            Assert.Equal(2, TensorPrimitives.IndexOfMaxMagnitude([-1, -0f, 1]));
+        }
+        #endregion
+
+        #region IndexOfMin
+        [Fact]
+        public static void IndexOfMin_ReturnsNegative1OnEmpty()
+        {
+            Assert.Equal(-1, TensorPrimitives.IndexOfMin(ReadOnlySpan<float>.Empty));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void IndexOfMin(int tensorLength)
+        {
+            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
+            {
+                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+                x[expected] = Enumerable.Min(MemoryMarshal.ToEnumerable<float>(x.Memory)) - 1;
+                Assert.Equal(expected, TensorPrimitives.IndexOfMin(x));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void IndexOfMin_FirstNaNReturned(int tensorLength)
+        {
+            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
+            {
+                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+                x[expected] = float.NaN;
+                x[tensorLength - 1] = float.NaN;
+                Assert.Equal(expected, TensorPrimitives.IndexOfMin(x));
+            }
+        }
+
+        [Fact]
+        public static void IndexOfMin_Negative0LesserThanPositive0()
+        {
+            Assert.Equal(0, TensorPrimitives.IndexOfMin([-0f, +0f]));
+            Assert.Equal(1, TensorPrimitives.IndexOfMin([+0f, -0f]));
+            Assert.Equal(1, TensorPrimitives.IndexOfMin([+0f, -0f, -0f, -0f, -0f]));
+            Assert.Equal(0, TensorPrimitives.IndexOfMin([-1, -0f]));
+            Assert.Equal(0, TensorPrimitives.IndexOfMin([-1, -0f, 1]));
+        }
+        #endregion
+
+        #region IndexOfMinMagnitude
+        [Fact]
+        public static void IndexOfMinMagnitude_ReturnsNegative1OnEmpty()
+        {
+            Assert.Equal(-1, TensorPrimitives.IndexOfMinMagnitude(ReadOnlySpan<float>.Empty));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void IndexOfMinMagnitude(int tensorLength)
+        {
+            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
+            {
+                using BoundedMemory<float> x = CreateTensor(tensorLength);
+                for (int i = 0; i < x.Length; i++)
+                {
+                    x[i] = i % 2 == 0 ? 42 : -42;
+                }
+
+                x[expected] = -41;
+
+                Assert.Equal(expected, TensorPrimitives.IndexOfMinMagnitude(x));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void IndexOfMinMagnitude_FirstNaNReturned(int tensorLength)
+        {
+            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
+            {
+                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+                x[expected] = float.NaN;
+                x[tensorLength - 1] = float.NaN;
+                Assert.Equal(expected, TensorPrimitives.IndexOfMinMagnitude(x));
+            }
+        }
+
+        [Fact]
+        public static void IndexOfMinMagnitude_Negative0LesserThanPositive0()
+        {
+            Assert.Equal(0, TensorPrimitives.IndexOfMinMagnitude([-0f, -0f, -0f, -0f]));
+            Assert.Equal(0, TensorPrimitives.IndexOfMinMagnitude([-0f, +0f]));
+            Assert.Equal(1, TensorPrimitives.IndexOfMinMagnitude([+0f, -0f]));
+            Assert.Equal(1, TensorPrimitives.IndexOfMinMagnitude([+0f, -0f, -0f, -0f]));
+            Assert.Equal(1, TensorPrimitives.IndexOfMinMagnitude([-1, -0f]));
+            Assert.Equal(1, TensorPrimitives.IndexOfMinMagnitude([-1, -0f, 1]));
+        }
+        #endregion
+
+        #region Log
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Log(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.Log(x, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(MathF.Log(x[i]), destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Log_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Log(x, destination));
+        }
+        #endregion
+
+        #region Log2
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Log2(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.Log2(x, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(MathF.Log(x[i], 2), destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Log2_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Log2(x, destination));
+        }
+        #endregion
+
+        #region Max
+        [Fact]
+        public static void Max_Tensor_ThrowsForEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Max(ReadOnlySpan<float>.Empty));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Max_Tensor(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+
+            Assert.Equal(Enumerable.Max(MemoryMarshal.ToEnumerable<float>(x.Memory)), TensorPrimitives.Max(x));
+
+            float max = float.NegativeInfinity;
+            foreach (float f in x.Span)
+            {
+                max = Math.Max(max, f);
+            }
+            Assert.Equal(max, TensorPrimitives.Max(x));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Max_Tensor_NanReturned(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
+            {
+                x[expected] = float.NaN;
+                Assert.Equal(float.NaN, TensorPrimitives.Max(x));
+            }
+        }
+
+        [Fact]
+        public static void Max_Tensor_Negative0LesserThanPositive0()
+        {
+            Assert.Equal(+0f, TensorPrimitives.Max([-0f, +0f]));
+            Assert.Equal(+0f, TensorPrimitives.Max([+0f, -0f]));
+            Assert.Equal(-0f, TensorPrimitives.Max([-1, -0f]));
+            Assert.Equal(1, TensorPrimitives.Max([-1, -0f, 1]));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Max_TwoTensors(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.Max(x, y, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(MathF.Max(x[i], y[i]), destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Max_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Max(x, y, destination));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Max_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Max(x, y, destination));
+        }
+        #endregion
+
+        #region MaxMagnitude
+        [Fact]
+        public static void MaxMagnitude_Tensor_ThrowsForEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.MaxMagnitude(ReadOnlySpan<float>.Empty));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void MaxMagnitude_Tensor(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+
+            int index = 0;
+            for (int i = 0; i < x.Length; i++)
+            {
+                if (MathF.Abs(x[i]) >= MathF.Abs(x[index]))
+                {
+                    index = i;
+                }
+            }
+
+            Assert.Equal(x[index], TensorPrimitives.MaxMagnitude(x), Tolerance);
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void MaxMagnitude_Tensor_NanReturned(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
+            {
+                x[expected] = float.NaN;
+                Assert.Equal(float.NaN, TensorPrimitives.MaxMagnitude(x));
+            }
+        }
+
+        [Fact]
+        public static void MaxMagnitude_Tensor_Negative0LesserThanPositive0()
+        {
+            Assert.Equal(+0f, TensorPrimitives.MaxMagnitude([-0f, +0f]));
+            Assert.Equal(+0f, TensorPrimitives.MaxMagnitude([+0f, -0f]));
+            Assert.Equal(-1, TensorPrimitives.MaxMagnitude([-1, -0f]));
+            Assert.Equal(1, TensorPrimitives.MaxMagnitude([-1, -0f, 1]));
+            Assert.Equal(0f, TensorPrimitives.MaxMagnitude([-0f, -0f, -0f, -0f, -0f, 0f]));
+            Assert.Equal(1, TensorPrimitives.MaxMagnitude([-0f, -0f, -0f, -0f, -1, -0f, 0f, 1]));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void MaxMagnitude_TwoTensors(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.MaxMagnitude(x, y, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(MathF.Abs(x[i]) >= MathF.Abs(y[i]) ? x[i] : y[i], destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void MaxMagnitude_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.MaxMagnitude(x, y, destination));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void MaxMagnitude_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.MaxMagnitude(x, y, destination));
+        }
+        #endregion
+
+        #region Min
+        [Fact]
+        public static void Min_Tensor_ThrowsForEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Min(ReadOnlySpan<float>.Empty));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Min_Tensor(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+
+            Assert.Equal(Enumerable.Min(MemoryMarshal.ToEnumerable<float>(x.Memory)), TensorPrimitives.Min(x));
+
+            float min = float.PositiveInfinity;
+            foreach (float f in x.Span)
+            {
+                min = Math.Min(min, f);
+            }
+            Assert.Equal(min, TensorPrimitives.Min(x));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Min_Tensor_NanReturned(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
+            {
+                x[expected] = float.NaN;
+                Assert.Equal(float.NaN, TensorPrimitives.Min(x));
+            }
+        }
+
+        [Fact]
+        public static void Min_Tensor_Negative0LesserThanPositive0()
+        {
+            Assert.Equal(-0f, TensorPrimitives.Min([-0f, +0f]));
+            Assert.Equal(-0f, TensorPrimitives.Min([+0f, -0f]));
+            Assert.Equal(-1, TensorPrimitives.Min([-1, -0f]));
+            Assert.Equal(-1, TensorPrimitives.Min([-1, -0f, 1]));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Min_TwoTensors(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.Min(x, y, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(MathF.Min(x[i], y[i]), destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Min_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Min(x, y, destination));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Min_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Min(x, y, destination));
+        }
+        #endregion
+
+        #region MinMagnitude
+        [Fact]
+        public static void MinMagnitude_Tensor_ThrowsForEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.MinMagnitude(ReadOnlySpan<float>.Empty));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void MinMagnitude_Tensor(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+
+            int index = 0;
+            for (int i = 0; i < x.Length; i++)
+            {
+                if (MathF.Abs(x[i]) < MathF.Abs(x[index]))
+                {
+                    index = i;
+                }
+            }
+
+            Assert.Equal(x[index], TensorPrimitives.MinMagnitude(x), Tolerance);
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void MinMagnitude_Tensor_NanReturned(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
+            {
+                x[expected] = float.NaN;
+                Assert.Equal(float.NaN, TensorPrimitives.MinMagnitude(x));
+            }
+        }
+
+        [Fact]
+        public static void MinMagnitude_Tensor_Negative0LesserThanPositive0()
+        {
+            Assert.Equal(0, TensorPrimitives.MinMagnitude([-0f, +0f]));
+            Assert.Equal(0, TensorPrimitives.MinMagnitude([+0f, -0f]));
+            Assert.Equal(0, TensorPrimitives.MinMagnitude([-1, -0f]));
+            Assert.Equal(0, TensorPrimitives.MinMagnitude([-1, -0f, 1]));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void MinMagnitude_TwoTensors(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.MinMagnitude(x, y, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(MathF.Abs(x[i]) < MathF.Abs(y[i]) ? x[i] : y[i], destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void MinMagnitude_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.MinMagnitude(x, y, destination));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void MinMagnitude_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.MinMagnitude(x, y, destination));
+        }
+        #endregion
+
+        #region Multiply
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Multiply_TwoTensors(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.Multiply(x, y, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(x[i] * y[i], destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Multiply_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Multiply(x, y, destination));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Multiply_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Multiply(x, y, destination));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Multiply_TensorScalar(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            float y = NextSingle();
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.Multiply(x, y, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(x[i] * y, destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void Multiply_TensorScalar_ThrowsForTooShortDestination(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            float y = NextSingle();
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Multiply(x, y, destination));
+        }
+        #endregion
+
+        #region MultiplyAdd
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
         public static void MultiplyAdd_ThreeTensors(int tensorLength)
@@ -577,281 +1282,36 @@ namespace System.Numerics.Tensors.Tests
 
             AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.MultiplyAdd(x, y, addend, destination));
         }
+        #endregion
 
+        #region Negate
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Exp(int tensorLength)
+        public static void Negate(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
-            TensorPrimitives.Exp(x, destination);
+            TensorPrimitives.Negate(x, destination);
 
             for (int i = 0; i < tensorLength; i++)
             {
-                Assert.Equal(MathF.Exp(x[i]), destination[i], Tolerance);
+                Assert.Equal(-x[i], destination[i], Tolerance);
             }
         }
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void Exp_ThrowsForTooShortDestination(int tensorLength)
+        public static void Negate_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
 
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Exp(x, destination));
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Negate(x, destination));
         }
+        #endregion
 
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Log(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Log(x, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(MathF.Log(x[i]), destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Log_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Log(x, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Log2(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Log2(x, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(MathF.Log(x[i], 2), destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Log2_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Log2(x, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Cosh(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Cosh(x, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(MathF.Cosh(x[i]), destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Cosh_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Cosh(x, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Sinh(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Sinh(x, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(MathF.Sinh(x[i]), destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Sinh_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Sinh(x, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Tanh(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Tanh(x, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(MathF.Tanh(x[i]), destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Tanh_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Tanh(x, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void CosineSimilarity_ThrowsForMismatchedLengths_x_y(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
-
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(x, y));
-        }
-
-        [Fact]
-        public static void CosineSimilarity_ThrowsForEmpty_x_y()
-        {
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(ReadOnlySpan<float>.Empty, ReadOnlySpan<float>.Empty));
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(ReadOnlySpan<float>.Empty, CreateTensor(1)));
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.CosineSimilarity(CreateTensor(1), ReadOnlySpan<float>.Empty));
-        }
-
-        [Theory]
-        [InlineData(new float[] { 3, 2, 0, 5 }, new float[] { 1, 0, 0, 0 }, 0.48666f)]
-        [InlineData(new float[] { 1, 1, 1, 1, 1, 0 }, new float[] { 1, 1, 1, 1, 0, 1 }, 0.80f)]
-        public static void CosineSimilarity_KnownValues(float[] x, float[] y, float expectedResult)
-        {
-            Assert.Equal(expectedResult, TensorPrimitives.CosineSimilarity(x, y), Tolerance);
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void CosineSimilarity(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-
-            float dot = 0f, squareX = 0f, squareY = 0f;
-            for (int i = 0; i < x.Length; i++)
-            {
-                dot += x[i] * y[i];
-                squareX += x[i] * x[i];
-                squareY += y[i] * y[i];
-            }
-
-            Assert.Equal(dot / (Math.Sqrt(squareX) * Math.Sqrt(squareY)), TensorPrimitives.CosineSimilarity(x, y), Tolerance);
-        }
-
-        [Fact]
-        public static void Distance_ThrowsForEmpty()
-        {
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(ReadOnlySpan<float>.Empty, ReadOnlySpan<float>.Empty));
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(ReadOnlySpan<float>.Empty, CreateTensor(1)));
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(CreateTensor(1), ReadOnlySpan<float>.Empty));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Distance_ThrowsForMismatchedLengths(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
-
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Distance(x, y));
-        }
-
-        [Theory]
-        [InlineData(new float[] { 3, 2 }, new float[] { 4, 1 }, 1.4142f)]
-        [InlineData(new float[] { 0, 4 }, new float[] { 6, 2 }, 6.3245f)]
-        [InlineData(new float[] { 1, 2, 3 }, new float[] { 4, 5, 6 }, 5.1961f)]
-        [InlineData(new float[] { 5, 1, 6, 10 }, new float[] { 7, 2, 8, 4 }, 6.7082f)]
-        public static void Distance_KnownValues(float[] x, float[] y, float expectedResult)
-        {
-            Assert.Equal(expectedResult, TensorPrimitives.Distance(x, y), Tolerance);
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Distance(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-
-            float distance = 0f;
-            for (int i = 0; i < x.Length; i++)
-            {
-                distance += (x[i] - y[i]) * (x[i] - y[i]);
-            }
-
-            Assert.Equal(Math.Sqrt(distance), TensorPrimitives.Distance(x, y), Tolerance);
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Dot_ThrowsForMismatchedLengths_x_y(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
-
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Dot(x, y));
-        }
-
-        [Theory]
-        [InlineData(new float[] { 1, 3, -5 }, new float[] { 4, -2, -1 }, 3)]
-        [InlineData(new float[] { 1, 2, 3 }, new float[] { 4, 5, 6 }, 32)]
-        [InlineData(new float[] { 1, 2, 3, 10, 8 }, new float[] { 4, 5, 6, -2, 7 }, 68)]
-        [InlineData(new float[] { }, new float[] { }, 0)]
-        public static void Dot_KnownValues(float[] x, float[] y, float expectedResult)
-        {
-            Assert.Equal(expectedResult, TensorPrimitives.Dot(x, y), Tolerance);
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Dot(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-
-            float dot = 0f;
-            for (int i = 0; i < x.Length; i++)
-            {
-                dot += x[i] * y[i];
-            }
-
-            Assert.Equal(dot, TensorPrimitives.Dot(x, y), Tolerance);
-        }
-
+        #region Norm
         [Theory]
         [InlineData(new float[] { 1, 2, 3 }, 3.7416575f)]
         [InlineData(new float[] { 3, 4 }, 5)]
@@ -877,53 +1337,127 @@ namespace System.Numerics.Tensors.Tests
 
             Assert.Equal(Math.Sqrt(sumOfSquares), TensorPrimitives.Norm(x), Tolerance);
         }
+        #endregion
+
+        #region Product
+        [Fact]
+        public static void Product_ThrowsForEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Product(ReadOnlySpan<float>.Empty));
+        }
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void SoftMax_ThrowsForTooShortDestination(int tensorLength)
+        public static void Product(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
 
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.SoftMax(x, destination));
+            float f = x[0];
+            for (int i = 1; i < x.Length; i++)
+            {
+                f *= x[i];
+            }
+
+            Assert.Equal(f, TensorPrimitives.Product(x), Tolerance);
+        }
+
+        [Fact]
+        public static void Product_KnownValues()
+        {
+            Assert.Equal(1, TensorPrimitives.Product([1]));
+            Assert.Equal(-2, TensorPrimitives.Product([1, -2]));
+            Assert.Equal(-6, TensorPrimitives.Product([1, -2, 3]));
+            Assert.Equal(24, TensorPrimitives.Product([1, -2, 3, -4]));
+            Assert.Equal(120, TensorPrimitives.Product([1, -2, 3, -4, 5]));
+            Assert.Equal(-720, TensorPrimitives.Product([1, -2, 3, -4, 5, -6]));
+            Assert.Equal(0, TensorPrimitives.Product([1, -2, 3, -4, 5, -6, 0]));
+            Assert.Equal(0, TensorPrimitives.Product([0, 1, -2, 3, -4, 5, -6]));
+            Assert.Equal(0, TensorPrimitives.Product([1, -2, 3, 0, -4, 5, -6]));
+            Assert.Equal(float.NaN, TensorPrimitives.Product([1, -2, 3, float.NaN, -4, 5, -6]));
+        }
+        #endregion
+
+        #region ProductOfDifferences
+        [Fact]
+        public static void ProductOfDifferences_ThrowsForEmptyAndMismatchedLengths()
+        {
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfDifferences(ReadOnlySpan<float>.Empty, ReadOnlySpan<float>.Empty));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfDifferences(ReadOnlySpan<float>.Empty, CreateTensor(1)));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfDifferences(CreateTensor(1), ReadOnlySpan<float>.Empty));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfDifferences(CreateTensor(44), CreateTensor(43)));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfDifferences(CreateTensor(43), CreateTensor(44)));
         }
 
         [Theory]
-        [InlineData(new float[] { 3, 1, .2f }, new float[] { 0.8360188f, 0.11314284f, 0.05083836f })]
-        [InlineData(new float[] { 3, 4, 1 }, new float[] { 0.2594f, 0.705384f, 0.0351f })]
-        [InlineData(new float[] { 5, 3 }, new float[] { 0.8807f, 0.1192f })]
-        [InlineData(new float[] { 4, 2, 1, 9 }, new float[] { 0.0066f, 9.04658e-4f, 3.32805e-4f, 0.9920f})]
-        public static void SoftMax(float[] x, float[] expectedResult)
+        [MemberData(nameof(TensorLengths))]
+        public static void ProductOfDifferences(int tensorLength)
         {
-            using BoundedMemory<float> dest = CreateTensor(x.Length);
-            TensorPrimitives.SoftMax(x, dest);
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
 
-            for (int i = 0; i < x.Length; i++)
+            float f = x[0] - y[0];
+            for (int i = 1; i < x.Length; i++)
             {
-                Assert.Equal(expectedResult[i], dest[i], Tolerance);
+                f *= x[i] - y[i];
             }
+            Assert.Equal(f, TensorPrimitives.ProductOfDifferences(x, y), Tolerance);
         }
 
         [Fact]
-        public static void SoftMax_DestinationLongerThanSource()
+        public static void ProductOfDifferences_KnownValues()
         {
-            float[] x = [3, 1, .2f];
-            float[] expectedResult = [0.8360188f, 0.11314284f, 0.05083836f];
-            using BoundedMemory<float> dest = CreateTensor(x.Length + 1);
-            TensorPrimitives.SoftMax(x, dest);
+            Assert.Equal(0, TensorPrimitives.ProductOfDifferences([0], [0]));
+            Assert.Equal(0, TensorPrimitives.ProductOfDifferences([1], [1]));
+            Assert.Equal(1, TensorPrimitives.ProductOfDifferences([1], [0]));
+            Assert.Equal(-1, TensorPrimitives.ProductOfDifferences([0], [1]));
+            Assert.Equal(-1, TensorPrimitives.ProductOfDifferences([1, 2, 3, 4, 5], [2, 3, 4, 5, 6]));
+            Assert.Equal(120, TensorPrimitives.ProductOfDifferences([1, 2, 3, 4, 5], [0, 0, 0, 0, 0]));
+            Assert.Equal(-120, TensorPrimitives.ProductOfDifferences([0, 0, 0, 0, 0], [1, 2, 3, 4, 5]));
+            Assert.Equal(float.NaN, TensorPrimitives.ProductOfDifferences([1, 2, float.NaN, 4, 5], [0, 0, 0, 0, 0]));
+        }
+        #endregion
 
-            for (int i = 0; i < x.Length; i++)
+        #region ProductOfSums
+        [Fact]
+        public static void ProductOfSums_ThrowsForEmptyAndMismatchedLengths()
+        {
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfSums(ReadOnlySpan<float>.Empty, ReadOnlySpan<float>.Empty));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfSums(ReadOnlySpan<float>.Empty, CreateTensor(1)));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfSums(CreateTensor(1), ReadOnlySpan<float>.Empty));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfSums(CreateTensor(44), CreateTensor(43)));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfSums(CreateTensor(43), CreateTensor(44)));
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void ProductOfSums(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
+
+            float f = x[0] + y[0];
+            for (int i = 1; i < x.Length; i++)
             {
-                Assert.Equal(expectedResult[i], dest[i], Tolerance);
+                f *= x[i] + y[i];
             }
+            Assert.Equal(f, TensorPrimitives.ProductOfSums(x, y), Tolerance);
         }
 
         [Fact]
-        public static void SoftMax_ThrowsForEmptyInput()
+        public static void ProductOfSums_KnownValues()
         {
-            AssertExtensions.Throws<ArgumentException>(() => TensorPrimitives.SoftMax(ReadOnlySpan<float>.Empty, CreateTensor(1)));
+            Assert.Equal(0, TensorPrimitives.ProductOfSums([0], [0]));
+            Assert.Equal(1, TensorPrimitives.ProductOfSums([0], [1]));
+            Assert.Equal(1, TensorPrimitives.ProductOfSums([1], [0]));
+            Assert.Equal(2, TensorPrimitives.ProductOfSums([1], [1]));
+            Assert.Equal(10395, TensorPrimitives.ProductOfSums([1, 2, 3, 4, 5], [2, 3, 4, 5, 6]));
+            Assert.Equal(120, TensorPrimitives.ProductOfSums([1, 2, 3, 4, 5], [0, 0, 0, 0, 0]));
+            Assert.Equal(120, TensorPrimitives.ProductOfSums([0, 0, 0, 0, 0], [1, 2, 3, 4, 5]));
+            Assert.Equal(float.NaN, TensorPrimitives.ProductOfSums([1, 2, float.NaN, 4, 5], [0, 0, 0, 0, 0]));
         }
+        #endregion
 
+        #region Sigmoid
         [Theory]
         [MemberData(nameof(TensorLengths))]
         public static void Sigmoid_ThrowsForTooShortDestination(int tensorLength)
@@ -971,622 +1505,151 @@ namespace System.Numerics.Tensors.Tests
         {
             AssertExtensions.Throws<ArgumentException>(() => TensorPrimitives.Sigmoid(ReadOnlySpan<float>.Empty, CreateTensor(1)));
         }
+        #endregion
 
-        [Fact]
-        public static void IndexOfMax_ReturnsNegative1OnEmpty()
-        {
-            Assert.Equal(-1, TensorPrimitives.IndexOfMax(ReadOnlySpan<float>.Empty));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void IndexOfMax(int tensorLength)
-        {
-            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
-            {
-                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-                x[expected] = Enumerable.Max(MemoryMarshal.ToEnumerable<float>(x.Memory)) + 1;
-                Assert.Equal(expected, TensorPrimitives.IndexOfMax(x));
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void IndexOfMax_FirstNaNReturned(int tensorLength)
-        {
-            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
-            {
-                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-                x[expected] = float.NaN;
-                x[tensorLength - 1] = float.NaN;
-                Assert.Equal(expected, TensorPrimitives.IndexOfMax(x));
-            }
-        }
-
-        [Fact]
-        public static void IndexOfMax_Negative0LesserThanPositive0()
-        {
-            Assert.Equal(1, TensorPrimitives.IndexOfMax([-0f, +0f]));
-            Assert.Equal(0, TensorPrimitives.IndexOfMax([-0f, -0f, -0f, -0f]));
-            Assert.Equal(4, TensorPrimitives.IndexOfMax([-0f, -0f, -0f, -0f, +0f, +0f, +0f]));
-            Assert.Equal(0, TensorPrimitives.IndexOfMax([+0f, -0f]));
-            Assert.Equal(1, TensorPrimitives.IndexOfMax([-1, -0f]));
-            Assert.Equal(2, TensorPrimitives.IndexOfMax([-1, -0f, 1]));
-        }
-
-        [Fact]
-        public static void IndexOfMin_ReturnsNegative1OnEmpty()
-        {
-            Assert.Equal(-1, TensorPrimitives.IndexOfMin(ReadOnlySpan<float>.Empty));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void IndexOfMin(int tensorLength)
-        {
-            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
-            {
-                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-                x[expected] = Enumerable.Min(MemoryMarshal.ToEnumerable<float>(x.Memory)) - 1;
-                Assert.Equal(expected, TensorPrimitives.IndexOfMin(x));
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void IndexOfMin_FirstNaNReturned(int tensorLength)
-        {
-            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
-            {
-                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-                x[expected] = float.NaN;
-                x[tensorLength - 1] = float.NaN;
-                Assert.Equal(expected, TensorPrimitives.IndexOfMin(x));
-            }
-        }
-
-        [Fact]
-        public static void IndexOfMin_Negative0LesserThanPositive0()
-        {
-            Assert.Equal(0, TensorPrimitives.IndexOfMin([-0f, +0f]));
-            Assert.Equal(1, TensorPrimitives.IndexOfMin([+0f, -0f]));
-            Assert.Equal(1, TensorPrimitives.IndexOfMin([+0f, -0f, -0f, -0f, -0f]));
-            Assert.Equal(0, TensorPrimitives.IndexOfMin([-1, -0f]));
-            Assert.Equal(0, TensorPrimitives.IndexOfMin([-1, -0f, 1]));
-        }
-
-        [Fact]
-        public static void IndexOfMaxMagnitude_ReturnsNegative1OnEmpty()
-        {
-            Assert.Equal(-1, TensorPrimitives.IndexOfMaxMagnitude(ReadOnlySpan<float>.Empty));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void IndexOfMaxMagnitude(int tensorLength)
-        {
-            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
-            {
-                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-                x[expected] = Enumerable.Max(MemoryMarshal.ToEnumerable<float>(x.Memory), Math.Abs) + 1;
-                Assert.Equal(expected, TensorPrimitives.IndexOfMaxMagnitude(x));
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void IndexOfMaxMagnitude_FirstNaNReturned(int tensorLength)
-        {
-            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
-            {
-                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-                x[expected] = float.NaN;
-                x[tensorLength - 1] = float.NaN;
-                Assert.Equal(expected, TensorPrimitives.IndexOfMaxMagnitude(x));
-            }
-        }
-
-        [Fact]
-        public static void IndexOfMaxMagnitude_Negative0LesserThanPositive0()
-        {
-            Assert.Equal(0, TensorPrimitives.IndexOfMaxMagnitude([-0f, -0f, -0f, -0f]));
-            Assert.Equal(1, TensorPrimitives.IndexOfMaxMagnitude([-0f, +0f]));
-            Assert.Equal(1, TensorPrimitives.IndexOfMaxMagnitude([-0f, +0f, +0f, +0f]));
-            Assert.Equal(0, TensorPrimitives.IndexOfMaxMagnitude([+0f, -0f]));
-            Assert.Equal(0, TensorPrimitives.IndexOfMaxMagnitude([-1, -0f]));
-            Assert.Equal(2, TensorPrimitives.IndexOfMaxMagnitude([-1, -0f, 1]));
-        }
-
-        [Fact]
-        public static void IndexOfMinMagnitude_ReturnsNegative1OnEmpty()
-        {
-            Assert.Equal(-1, TensorPrimitives.IndexOfMinMagnitude(ReadOnlySpan<float>.Empty));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void IndexOfMinMagnitude(int tensorLength)
-        {
-            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
-            {
-                using BoundedMemory<float> x = CreateTensor(tensorLength);
-                for (int i = 0; i < x.Length; i++)
-                {
-                    x[i] = i % 2 == 0 ? 42 : -42;
-                }
-
-                x[expected] = -41;
-
-                Assert.Equal(expected, TensorPrimitives.IndexOfMinMagnitude(x));
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void IndexOfMinMagnitude_FirstNaNReturned(int tensorLength)
-        {
-            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
-            {
-                using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-                x[expected] = float.NaN;
-                x[tensorLength - 1] = float.NaN;
-                Assert.Equal(expected, TensorPrimitives.IndexOfMinMagnitude(x));
-            }
-        }
-
-        [Fact]
-        public static void IndexOfMinMagnitude_Negative0LesserThanPositive0()
-        {
-            Assert.Equal(0, TensorPrimitives.IndexOfMinMagnitude([-0f, -0f, -0f, -0f]));
-            Assert.Equal(0, TensorPrimitives.IndexOfMinMagnitude([-0f, +0f]));
-            Assert.Equal(1, TensorPrimitives.IndexOfMinMagnitude([+0f, -0f]));
-            Assert.Equal(1, TensorPrimitives.IndexOfMinMagnitude([+0f, -0f, -0f, -0f]));
-            Assert.Equal(1, TensorPrimitives.IndexOfMinMagnitude([-1, -0f]));
-            Assert.Equal(1, TensorPrimitives.IndexOfMinMagnitude([-1, -0f, 1]));
-        }
-
-        [Fact]
-        public static void Max_Tensor_ThrowsForEmpty()
-        {
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Max(ReadOnlySpan<float>.Empty));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Max_Tensor(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-
-            Assert.Equal(Enumerable.Max(MemoryMarshal.ToEnumerable<float>(x.Memory)), TensorPrimitives.Max(x));
-
-            float max = float.NegativeInfinity;
-            foreach (float f in x.Span)
-            {
-                max = Math.Max(max, f);
-            }
-            Assert.Equal(max, TensorPrimitives.Max(x));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Max_Tensor_NanReturned(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
-            {
-                x[expected] = float.NaN;
-                Assert.Equal(float.NaN, TensorPrimitives.Max(x));
-            }
-        }
-
-        [Fact]
-        public static void Max_Tensor_Negative0LesserThanPositive0()
-        {
-            Assert.Equal(+0f, TensorPrimitives.Max([-0f, +0f]));
-            Assert.Equal(+0f, TensorPrimitives.Max([+0f, -0f]));
-            Assert.Equal(-0f, TensorPrimitives.Max([-1, -0f]));
-            Assert.Equal(1, TensorPrimitives.Max([-1, -0f, 1]));
-        }
-
+        #region Sinh
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Max_TwoTensors(int tensorLength)
+        public static void Sinh(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
-            TensorPrimitives.Max(x, y, destination);
+            TensorPrimitives.Sinh(x, destination);
 
             for (int i = 0; i < tensorLength; i++)
             {
-                Assert.Equal(MathF.Max(x[i], y[i]), destination[i], Tolerance);
+                Assert.Equal(MathF.Sinh(x[i]), destination[i], Tolerance);
             }
         }
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void Max_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
+        public static void Sinh_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Max(x, y, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Max_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
 
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Max(x, y, destination));
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Sinh(x, destination));
         }
+        #endregion
 
-        [Fact]
-        public static void MaxMagnitude_Tensor_ThrowsForEmpty()
+        #region SoftMax
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void SoftMax_ThrowsForTooShortDestination(int tensorLength)
         {
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.MaxMagnitude(ReadOnlySpan<float>.Empty));
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
+
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.SoftMax(x, destination));
         }
 
         [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void MaxMagnitude_Tensor(int tensorLength)
+        [InlineData(new float[] { 3, 1, .2f }, new float[] { 0.8360188f, 0.11314284f, 0.05083836f })]
+        [InlineData(new float[] { 3, 4, 1 }, new float[] { 0.2594f, 0.705384f, 0.0351f })]
+        [InlineData(new float[] { 5, 3 }, new float[] { 0.8807f, 0.1192f })]
+        [InlineData(new float[] { 4, 2, 1, 9 }, new float[] { 0.0066f, 9.04658e-4f, 3.32805e-4f, 0.9920f })]
+        public static void SoftMax(float[] x, float[] expectedResult)
         {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> dest = CreateTensor(x.Length);
+            TensorPrimitives.SoftMax(x, dest);
 
-            int index = 0;
             for (int i = 0; i < x.Length; i++)
             {
-                if (MathF.Abs(x[i]) >= MathF.Abs(x[index]))
-                {
-                    index = i;
-                }
-            }
-
-            Assert.Equal(x[index], TensorPrimitives.MaxMagnitude(x), Tolerance);
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void MaxMagnitude_Tensor_NanReturned(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
-            {
-                x[expected] = float.NaN;
-                Assert.Equal(float.NaN, TensorPrimitives.MaxMagnitude(x));
+                Assert.Equal(expectedResult[i], dest[i], Tolerance);
             }
         }
 
         [Fact]
-        public static void MaxMagnitude_Tensor_Negative0LesserThanPositive0()
+        public static void SoftMax_DestinationLongerThanSource()
         {
-            Assert.Equal(+0f, TensorPrimitives.MaxMagnitude([-0f, +0f]));
-            Assert.Equal(+0f, TensorPrimitives.MaxMagnitude([+0f, -0f]));
-            Assert.Equal(-1, TensorPrimitives.MaxMagnitude([-1, -0f]));
-            Assert.Equal(1, TensorPrimitives.MaxMagnitude([-1, -0f, 1]));
-            Assert.Equal(0f, TensorPrimitives.MaxMagnitude([-0f, -0f, -0f, -0f, -0f, 0f]));
-            Assert.Equal(1, TensorPrimitives.MaxMagnitude([-0f, -0f, -0f, -0f, -1, -0f, 0f, 1]));
-        }
+            float[] x = [3, 1, .2f];
+            float[] expectedResult = [0.8360188f, 0.11314284f, 0.05083836f];
+            using BoundedMemory<float> dest = CreateTensor(x.Length + 1);
+            TensorPrimitives.SoftMax(x, dest);
 
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void MaxMagnitude_TwoTensors(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.MaxMagnitude(x, y, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(MathF.Abs(x[i]) >= MathF.Abs(y[i]) ? x[i] : y[i], destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void MaxMagnitude_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.MaxMagnitude(x, y, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void MaxMagnitude_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.MaxMagnitude(x, y, destination));
-        }
-
-        [Fact]
-        public static void Min_Tensor_ThrowsForEmpty()
-        {
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Min(ReadOnlySpan<float>.Empty));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Min_Tensor(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-
-            Assert.Equal(Enumerable.Min(MemoryMarshal.ToEnumerable<float>(x.Memory)), TensorPrimitives.Min(x));
-
-            float min = float.PositiveInfinity;
-            foreach (float f in x.Span)
-            {
-                min = Math.Min(min, f);
-            }
-            Assert.Equal(min, TensorPrimitives.Min(x));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Min_Tensor_NanReturned(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
-            {
-                x[expected] = float.NaN;
-                Assert.Equal(float.NaN, TensorPrimitives.Min(x));
-            }
-        }
-
-        [Fact]
-        public static void Min_Tensor_Negative0LesserThanPositive0()
-        {
-            Assert.Equal(-0f, TensorPrimitives.Min([-0f, +0f]));
-            Assert.Equal(-0f, TensorPrimitives.Min([+0f, -0f]));
-            Assert.Equal(-1, TensorPrimitives.Min([-1, -0f]));
-            Assert.Equal(-1, TensorPrimitives.Min([-1, -0f, 1]));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Min_TwoTensors(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            TensorPrimitives.Min(x, y, destination);
-
-            for (int i = 0; i < tensorLength; i++)
-            {
-                Assert.Equal(MathF.Min(x[i], y[i]), destination[i], Tolerance);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Min_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength);
-
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Min(x, y, destination));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void Min_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
-
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Min(x, y, destination));
-        }
-
-        [Fact]
-        public static void MinMagnitude_Tensor_ThrowsForEmpty()
-        {
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.MinMagnitude(ReadOnlySpan<float>.Empty));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void MinMagnitude_Tensor(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-
-            int index = 0;
             for (int i = 0; i < x.Length; i++)
             {
-                if (MathF.Abs(x[i]) < MathF.Abs(x[index]))
-                {
-                    index = i;
-                }
-            }
-
-            Assert.Equal(x[index], TensorPrimitives.MinMagnitude(x), Tolerance);
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void MinMagnitude_Tensor_NanReturned(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            foreach (int expected in new[] { 0, tensorLength / 2, tensorLength - 1 })
-            {
-                x[expected] = float.NaN;
-                Assert.Equal(float.NaN, TensorPrimitives.MinMagnitude(x));
+                Assert.Equal(expectedResult[i], dest[i], Tolerance);
             }
         }
 
         [Fact]
-        public static void MinMagnitude_Tensor_Negative0LesserThanPositive0()
+        public static void SoftMax_ThrowsForEmptyInput()
         {
-            Assert.Equal(0, TensorPrimitives.MinMagnitude([-0f, +0f]));
-            Assert.Equal(0, TensorPrimitives.MinMagnitude([+0f, -0f]));
-            Assert.Equal(0, TensorPrimitives.MinMagnitude([-1, -0f]));
-            Assert.Equal(0, TensorPrimitives.MinMagnitude([-1, -0f, 1]));
+            AssertExtensions.Throws<ArgumentException>(() => TensorPrimitives.SoftMax(ReadOnlySpan<float>.Empty, CreateTensor(1)));
         }
+        #endregion
 
+        #region Subtract
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void MinMagnitude_TwoTensors(int tensorLength)
+        public static void Subtract_TwoTensors(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
-            TensorPrimitives.MinMagnitude(x, y, destination);
+            TensorPrimitives.Subtract(x, y, destination);
 
             for (int i = 0; i < tensorLength; i++)
             {
-                Assert.Equal(MathF.Abs(x[i]) < MathF.Abs(y[i]) ? x[i] : y[i], destination[i], Tolerance);
+                Assert.Equal(x[i] - y[i], destination[i], Tolerance);
             }
         }
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MinMagnitude_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
+        public static void Subtract_TwoTensors_ThrowsForMismatchedLengths(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength - 1);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.MinMagnitude(x, y, destination));
+            Assert.Throws<ArgumentException>(() => TensorPrimitives.Subtract(x, y, destination));
         }
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void MinMagnitude_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
+        public static void Subtract_TwoTensors_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
 
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.MinMagnitude(x, y, destination));
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Subtract(x, y, destination));
         }
 
-        [Fact]
-        public static void Product_ThrowsForEmpty()
+        [Theory]
+        [MemberData(nameof(TensorLengthsIncluding0))]
+        public static void Subtract_TensorScalar(int tensorLength)
         {
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.Product(ReadOnlySpan<float>.Empty));
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            float y = NextSingle();
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            TensorPrimitives.Subtract(x, y, destination);
+
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(x[i] - y, destination[i], Tolerance);
+            }
         }
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void Product(int tensorLength)
+        public static void Subtract_TensorScalar_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            float y = NextSingle();
+            using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
 
-            float f = x[0];
-            for (int i = 1; i < x.Length; i++)
-            {
-                f *= x[i];
-            }
-
-            Assert.Equal(f, TensorPrimitives.Product(x), Tolerance);
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Subtract(x, y, destination));
         }
+        #endregion
 
-        [Fact]
-        public static void Product_KnownValues()
-        {
-            Assert.Equal(1, TensorPrimitives.Product([1]));
-            Assert.Equal(-2, TensorPrimitives.Product([1, -2]));
-            Assert.Equal(-6, TensorPrimitives.Product([1, -2, 3]));
-            Assert.Equal(24, TensorPrimitives.Product([1, -2, 3, -4]));
-            Assert.Equal(120, TensorPrimitives.Product([1, -2, 3, -4, 5]));
-            Assert.Equal(-720, TensorPrimitives.Product([1, -2, 3, -4, 5, -6]));
-            Assert.Equal(0, TensorPrimitives.Product([1, -2, 3, -4, 5, -6, 0]));
-            Assert.Equal(0, TensorPrimitives.Product([0, 1, -2, 3, -4, 5, -6]));
-            Assert.Equal(0, TensorPrimitives.Product([1, -2, 3, 0, -4, 5, -6]));
-            Assert.Equal(float.NaN, TensorPrimitives.Product([1, -2, 3, float.NaN, -4, 5, -6]));
-        }
-
-        [Fact]
-        public static void ProductOfDifferences_ThrowsForEmptyAndMismatchedLengths()
-        {
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfDifferences(ReadOnlySpan<float>.Empty, ReadOnlySpan<float>.Empty));
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfDifferences(ReadOnlySpan<float>.Empty, CreateTensor(1)));
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfDifferences(CreateTensor(1), ReadOnlySpan<float>.Empty));
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfDifferences(CreateTensor(44), CreateTensor(43)));
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfDifferences(CreateTensor(43), CreateTensor(44)));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void ProductOfDifferences(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-
-            float f = x[0] - y[0];
-            for (int i = 1; i < x.Length; i++)
-            {
-                f *= x[i] - y[i];
-            }
-            Assert.Equal(f, TensorPrimitives.ProductOfDifferences(x, y), Tolerance);
-        }
-
-        [Fact]
-        public static void ProductOfDifferences_KnownValues()
-        {
-            Assert.Equal(0, TensorPrimitives.ProductOfDifferences([0], [0]));
-            Assert.Equal(0, TensorPrimitives.ProductOfDifferences([1], [1]));
-            Assert.Equal(1, TensorPrimitives.ProductOfDifferences([1], [0]));
-            Assert.Equal(-1, TensorPrimitives.ProductOfDifferences([0], [1]));
-            Assert.Equal(-1, TensorPrimitives.ProductOfDifferences([1, 2, 3, 4, 5], [2, 3, 4, 5, 6]));
-            Assert.Equal(120, TensorPrimitives.ProductOfDifferences([1, 2, 3, 4, 5], [0, 0, 0, 0, 0]));
-            Assert.Equal(-120, TensorPrimitives.ProductOfDifferences([0, 0, 0, 0, 0], [1, 2, 3, 4, 5]));
-            Assert.Equal(float.NaN, TensorPrimitives.ProductOfDifferences([1, 2, float.NaN, 4, 5], [0, 0, 0, 0, 0]));
-        }
-
-        [Fact]
-        public static void ProductOfSums_ThrowsForEmptyAndMismatchedLengths()
-        {
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfSums(ReadOnlySpan<float>.Empty, ReadOnlySpan<float>.Empty));
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfSums(ReadOnlySpan<float>.Empty, CreateTensor(1)));
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfSums(CreateTensor(1), ReadOnlySpan<float>.Empty));
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfSums(CreateTensor(44), CreateTensor(43)));
-            Assert.Throws<ArgumentException>(() => TensorPrimitives.ProductOfSums(CreateTensor(43), CreateTensor(44)));
-        }
-
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void ProductOfSums(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-            using BoundedMemory<float> y = CreateAndFillTensor(tensorLength);
-
-            float f = x[0] + y[0];
-            for (int i = 1; i < x.Length; i++)
-            {
-                f *= x[i] + y[i];
-            }
-            Assert.Equal(f, TensorPrimitives.ProductOfSums(x, y), Tolerance);
-        }
-
-        [Fact]
-        public static void ProductOfSums_KnownValues()
-        {
-            Assert.Equal(0, TensorPrimitives.ProductOfSums([0], [0]));
-            Assert.Equal(1, TensorPrimitives.ProductOfSums([0], [1]));
-            Assert.Equal(1, TensorPrimitives.ProductOfSums([1], [0]));
-            Assert.Equal(2, TensorPrimitives.ProductOfSums([1], [1]));
-            Assert.Equal(10395, TensorPrimitives.ProductOfSums([1, 2, 3, 4, 5], [2, 3, 4, 5, 6]));
-            Assert.Equal(120, TensorPrimitives.ProductOfSums([1, 2, 3, 4, 5], [0, 0, 0, 0, 0]));
-            Assert.Equal(120, TensorPrimitives.ProductOfSums([0, 0, 0, 0, 0], [1, 2, 3, 4, 5]));
-            Assert.Equal(float.NaN, TensorPrimitives.ProductOfSums([1, 2, float.NaN, 4, 5], [0, 0, 0, 0, 0]));
-        }
-
+        #region Sum
         [Theory]
         [MemberData(nameof(TensorLengths))]
         public static void Sum(int tensorLength)
@@ -1612,33 +1675,9 @@ namespace System.Numerics.Tensors.Tests
             Assert.Equal(0, TensorPrimitives.Sum([-3, 0, 3]));
             Assert.Equal(float.NaN, TensorPrimitives.Sum([-3, float.NaN, 3]));
         }
+        #endregion
 
-        [Theory]
-        [MemberData(nameof(TensorLengths))]
-        public static void SumOfSquares(int tensorLength)
-        {
-            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
-
-            Assert.Equal(Enumerable.Sum(MemoryMarshal.ToEnumerable<float>(x.Memory), v => v * v), TensorPrimitives.SumOfSquares(x), Tolerance);
-
-            float sum = 0;
-            foreach (float f in x.Span)
-            {
-                sum += f * f;
-            }
-            Assert.Equal(sum, TensorPrimitives.SumOfSquares(x), Tolerance);
-        }
-
-        [Fact]
-        public static void SumOfSquares_KnownValues()
-        {
-            Assert.Equal(0, TensorPrimitives.SumOfSquares([0]));
-            Assert.Equal(1, TensorPrimitives.SumOfSquares([0, 1]));
-            Assert.Equal(14, TensorPrimitives.SumOfSquares([1, 2, 3]));
-            Assert.Equal(18, TensorPrimitives.SumOfSquares([-3, 0, 3]));
-            Assert.Equal(float.NaN, TensorPrimitives.SumOfSquares([-3, float.NaN, 3]));
-        }
-
+        #region SumOfMagnitudes
         [Theory]
         [MemberData(nameof(TensorLengths))]
         public static void SumOfMagnitudes(int tensorLength)
@@ -1664,30 +1703,61 @@ namespace System.Numerics.Tensors.Tests
             Assert.Equal(6, TensorPrimitives.SumOfMagnitudes([-3, 0, 3]));
             Assert.Equal(float.NaN, TensorPrimitives.SumOfMagnitudes([-3, float.NaN, 3]));
         }
+        #endregion
 
+        #region SumOfSquares
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
+        public static void SumOfSquares(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+
+            Assert.Equal(Enumerable.Sum(MemoryMarshal.ToEnumerable<float>(x.Memory), v => v * v), TensorPrimitives.SumOfSquares(x), Tolerance);
+
+            float sum = 0;
+            foreach (float f in x.Span)
+            {
+                sum += f * f;
+            }
+            Assert.Equal(sum, TensorPrimitives.SumOfSquares(x), Tolerance);
+        }
+
+        [Fact]
+        public static void SumOfSquares_KnownValues()
+        {
+            Assert.Equal(0, TensorPrimitives.SumOfSquares([0]));
+            Assert.Equal(1, TensorPrimitives.SumOfSquares([0, 1]));
+            Assert.Equal(14, TensorPrimitives.SumOfSquares([1, 2, 3]));
+            Assert.Equal(18, TensorPrimitives.SumOfSquares([-3, 0, 3]));
+            Assert.Equal(float.NaN, TensorPrimitives.SumOfSquares([-3, float.NaN, 3]));
+        }
+        #endregion
+
+        #region Tanh
         [Theory]
         [MemberData(nameof(TensorLengthsIncluding0))]
-        public static void Abs(int tensorLength)
+        public static void Tanh(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength);
 
-            TensorPrimitives.Abs(x, destination);
+            TensorPrimitives.Tanh(x, destination);
 
-            for (int i = 0; i < x.Length; i++)
+            for (int i = 0; i < tensorLength; i++)
             {
-                Assert.Equal(MathF.Abs(x[i]), destination[i], Tolerance);
+                Assert.Equal(MathF.Tanh(x[i]), destination[i], Tolerance);
             }
         }
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
-        public static void Abs_ThrowsForTooShortDestination(int tensorLength)
+        public static void Tanh_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
             using BoundedMemory<float> destination = CreateTensor(tensorLength - 1);
 
-            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Abs(x, destination));
+            AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.Tanh(x, destination));
         }
+        #endregion
     }
 }

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.netcore.cs
@@ -8,6 +8,7 @@ namespace System.Numerics.Tensors.Tests
 {
     public static partial class TensorPrimitivesTests
     {
+        #region ConvertToHalf
         [Theory]
         [InlineData(0)]
         [MemberData(nameof(TensorLengths))]
@@ -44,7 +45,9 @@ namespace System.Numerics.Tensors.Tests
 
             AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.ConvertToHalf(source, destination));
         }
+        #endregion
 
+        #region ConvertToSingle
         [Theory]
         [InlineData(0)]
         [MemberData(nameof(TensorLengths))]
@@ -87,5 +90,6 @@ namespace System.Numerics.Tensors.Tests
 
             AssertExtensions.Throws<ArgumentException>("destination", () => TensorPrimitives.ConvertToSingle(source, destination));
         }
+        #endregion
     }
 }

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.netcore.cs
@@ -10,8 +10,7 @@ namespace System.Numerics.Tensors.Tests
     {
         #region ConvertToHalf
         [Theory]
-        [InlineData(0)]
-        [MemberData(nameof(TensorLengths))]
+        [MemberData(nameof(TensorLengthsIncluding0))]
         public static void ConvertToHalf(int tensorLength)
         {
             using BoundedMemory<float> source = CreateAndFillTensor(tensorLength);
@@ -49,8 +48,7 @@ namespace System.Numerics.Tensors.Tests
 
         #region ConvertToSingle
         [Theory]
-        [InlineData(0)]
-        [MemberData(nameof(TensorLengths))]
+        [MemberData(nameof(TensorLengthsIncluding0))]
         public static void ConvertToSingle(int tensorLength)
         {
             Half[] source = new Half[tensorLength];


### PR DESCRIPTION
- Normalizes the naming of some tests
- Alphabetizes the tests by tested function name
- Adds a few test cases when validating mismatched input tensor lengths
- Alphabetizes the src methods in TensorPrimitives.cs, just to make them easier to find and to know the "right place" to put new ones. Zero code changes other than moving the cheese around.