### PR TITLE
Reduce some boilerplate in TensorPrimitive's IBinaryOperator

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
@@ -1099,12 +1099,6 @@ namespace System.Numerics.Tensors
 #if NET8_0_OR_GREATER
             public static Vector512<float> Invoke(Vector512<float> x, Vector512<float> y) => x - y;
 #endif
-
-            public static float Invoke(Vector128<float> x) => throw new NotSupportedException();
-            public static float Invoke(Vector256<float> x) => throw new NotSupportedException();
-#if NET8_0_OR_GREATER
-            public static float Invoke(Vector512<float> x) => throw new NotSupportedException();
-#endif
         }
 
         private readonly struct SubtractSquaredOperator : IBinaryOperator
@@ -1133,12 +1127,6 @@ namespace System.Numerics.Tensors
                 Vector512<float> tmp = x - y;
                 return tmp * tmp;
             }
-#endif
-
-            public static float Invoke(Vector128<float> x) => throw new NotSupportedException();
-            public static float Invoke(Vector256<float> x) => throw new NotSupportedException();
-#if NET8_0_OR_GREATER
-            public static float Invoke(Vector512<float> x) => throw new NotSupportedException();
 #endif
         }
 
@@ -1194,12 +1182,6 @@ namespace System.Numerics.Tensors
             public static Vector256<float> Invoke(Vector256<float> x, Vector256<float> y) => x / y;
 #if NET8_0_OR_GREATER
             public static Vector512<float> Invoke(Vector512<float> x, Vector512<float> y) => x / y;
-#endif
-
-            public static float Invoke(Vector128<float> x) => throw new NotSupportedException();
-            public static float Invoke(Vector256<float> x) => throw new NotSupportedException();
-#if NET8_0_OR_GREATER
-            public static float Invoke(Vector512<float> x) => throw new NotSupportedException();
 #endif
         }
 
@@ -1294,14 +1276,18 @@ namespace System.Numerics.Tensors
         private interface IBinaryOperator
         {
             static abstract float Invoke(float x, float y);
-
             static abstract Vector128<float> Invoke(Vector128<float> x, Vector128<float> y);
-            static abstract float Invoke(Vector128<float> x);
             static abstract Vector256<float> Invoke(Vector256<float> x, Vector256<float> y);
-            static abstract float Invoke(Vector256<float> x);
 #if NET8_0_OR_GREATER
             static abstract Vector512<float> Invoke(Vector512<float> x, Vector512<float> y);
-            static abstract float Invoke(Vector512<float> x);
+#endif
+
+            // Operations for aggregating all lanes in a vector into a single value.
+            // These are not supported on most implementations.
+            static virtual float Invoke(Vector128<float> x) => throw new NotSupportedException();
+            static virtual float Invoke(Vector256<float> x) => throw new NotSupportedException();
+#if NET8_0_OR_GREATER
+            static virtual float Invoke(Vector512<float> x) => throw new NotSupportedException();
 #endif
         }
 


### PR DESCRIPTION
Change a few of the static abstract interface methods to be virtual, as most implementations throw from these methods; we can consolidate that throwing to the base.