### PR TITLE
Simplify TensorPrimitive's AbsoluteOperator

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
@@ -1256,28 +1256,10 @@ namespace System.Numerics.Tensors
         private readonly struct AbsoluteOperator : IUnaryOperator
         {
             public static float Invoke(float x) => MathF.Abs(x);
-
-            public static Vector128<float> Invoke(Vector128<float> x)
-            {
-                Vector128<uint> raw = x.AsUInt32();
-                Vector128<uint> mask = Vector128.Create((uint)0x7FFFFFFF);
-                return (raw & mask).AsSingle();
-            }
-
-            public static Vector256<float> Invoke(Vector256<float> x)
-            {
-                Vector256<uint> raw = x.AsUInt32();
-                Vector256<uint> mask = Vector256.Create((uint)0x7FFFFFFF);
-                return (raw & mask).AsSingle();
-            }
-
+            public static Vector128<float> Invoke(Vector128<float> x) => Vector128.Abs(x);
+            public static Vector256<float> Invoke(Vector256<float> x) => Vector256.Abs(x);
 #if NET8_0_OR_GREATER
-            public static Vector512<float> Invoke(Vector512<float> x)
-            {
-                Vector512<uint> raw = x.AsUInt32();
-                Vector512<uint> mask = Vector512.Create((uint)0x7FFFFFFF);
-                return (raw & mask).AsSingle();
-            }
+            public static Vector512<float> Invoke(Vector512<float> x) => Vector512.Abs(x);
 #endif
         }
 

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netstandard.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netstandard.cs
@@ -572,13 +572,7 @@ namespace System.Numerics.Tensors
         private readonly struct AbsoluteOperator : IUnaryOperator
         {
             public float Invoke(float x) => MathF.Abs(x);
-
-            public Vector<float> Invoke(Vector<float> x)
-            {
-                Vector<uint> raw = Vector.AsVectorUInt32(x);
-                Vector<uint> mask = new Vector<uint>(0x7FFFFFFF);
-                return Vector.AsVectorSingle(raw & mask);
-            }
+            public Vector<float> Invoke(Vector<float> x) => Vector.Abs(x);
         }
 
         private interface IUnaryOperator


### PR DESCRIPTION
Vector{128/256/512} all provide Abs; no need to do this manually.