### PR TITLE
Light up String.Manipulation APIs with Vector512 codepath

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1249,12 +1249,11 @@ namespace System
                     do
                     {
                         Vector512<ushort> vector = Vector512.LoadUnsafe(ref source, offset);
-                        Vector512<byte> cmp = (Vector512.Equals(vector, v1)).AsByte();
 
-                        if (!Vector512.EqualsAll(cmp, Vector512<byte>.Zero))
+                        if (Vector512.EqualsAny(vector, v1))
                         {
                             // Skip every other bit
-                            ulong mask = cmp.ExtractMostSignificantBits() & 0x5555555555555555;
+                            ulong mask = (Vector512.Equals(vector, v1)).AsByte().ExtractMostSignificantBits() & 0x5555555555555555;
                             do
                             {
                                 uint bitPos = (uint)BitOperations.TrailingZeroCount(mask) / sizeof(char);

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1274,7 +1274,7 @@ namespace System
                         Vector256<ushort> vector = Vector256.LoadUnsafe(ref source, offset);
                         Vector256<byte> cmp = (Vector256.Equals(vector, v1)).AsByte();
 
-                        if (!Vector256.EqualsAll(cmp, Vector256<byte>.Zero))
+                        if (cmp != Vector256<byte>.Zero)
                         {
                             // Skip every other bit
                             uint mask = cmp.ExtractMostSignificantBits() & 0x55555555;
@@ -1298,7 +1298,7 @@ namespace System
                         Vector128<ushort> vector = Vector128.LoadUnsafe(ref source, offset);
                         Vector128<byte> cmp = (Vector128.Equals(vector, v1)).AsByte();
 
-                        if (!Vector128.EqualsAll(cmp, Vector128<byte>.Zero))
+                        if (cmp != Vector128<byte>.Zero)
                         {
                             // Skip every other bit
                             uint mask = cmp.ExtractMostSignificantBits() & 0x5555;
@@ -2005,7 +2005,7 @@ namespace System
                     Vector512<ushort> v3Eq = Vector512.Equals(vector, v3);
                     Vector512<byte> cmp = (v1Eq | v2Eq | v3Eq).AsByte();
 
-                    if (!Vector512.EqualsAll(cmp, Vector512<byte>.Zero))
+                    if (cmp != Vector512<byte>.Zero)
                     {
                         // Skip every other bit
                         ulong mask = cmp.ExtractMostSignificantBits() & 0x5555555555555555;
@@ -2034,7 +2034,7 @@ namespace System
                     Vector256<ushort> v3Eq = Vector256.Equals(vector, v3);
                     Vector256<byte> cmp = (v1Eq | v2Eq | v3Eq).AsByte();
 
-                    if (!Vector256.EqualsAll(cmp, Vector256<byte>.Zero))
+                    if (cmp != Vector256<byte>.Zero)
                     {
                         // Skip every other bit
                         uint mask = cmp.ExtractMostSignificantBits() & 0x55555555;
@@ -2063,7 +2063,7 @@ namespace System
                     Vector128<ushort> v3Eq = Vector128.Equals(vector, v3);
                     Vector128<byte> cmp = (v1Eq | v2Eq | v3Eq).AsByte();
 
-                    if (!Vector128.EqualsAll(cmp, Vector128<byte>.Zero))
+                    if (cmp != Vector128<byte>.Zero)
                     {
                         // Skip every other bit
                         uint mask = cmp.ExtractMostSignificantBits() & 0x5555;

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1244,7 +1244,6 @@ namespace System
 
                 if (Vector512.IsHardwareAccelerated && this.Length >= (uint)Vector512<ushort>.Count*2)
                 {
-                    // Internal.Console.WriteLine("Vector512");
                     ref char source = ref MemoryMarshal.GetReference(this.AsSpan());
                     Vector512<ushort> v1 = Vector512.Create((ushort)c);
                     do
@@ -1260,8 +1259,6 @@ namespace System
                             {
                                 uint bitPos = (uint)BitOperations.TrailingZeroCount(mask) / sizeof(char);
                                 replacementIndices.Append((int)(offset + bitPos));
-                                // Internal.Console.Write("" + ((int)(offset + bitPos)));
-                                // Internal.Console.Write(", ");
                                 mask = BitOperations.ResetLowestSetBit(mask);
                             } while (mask != 0);
                         }
@@ -1271,7 +1268,6 @@ namespace System
                 }
                 else if (Vector256.IsHardwareAccelerated && this.Length >= (uint)Vector256<ushort>.Count*2)
                 {
-                    // Internal.Console.WriteLine("Vector256");
                     ref char source = ref MemoryMarshal.GetReference(this.AsSpan());
                     Vector256<ushort> v1 = Vector256.Create((ushort)c);
                     do
@@ -1287,8 +1283,6 @@ namespace System
                             {
                                 uint bitPos = (uint)BitOperations.TrailingZeroCount(mask) / sizeof(char);
                                 replacementIndices.Append((int)(offset + bitPos));
-                                // Internal.Console.Write("" + ((int)(offset + bitPos)));
-                                // Internal.Console.Write(", ");
                                 mask = BitOperations.ResetLowestSetBit(mask);
                             } while (mask != 0);
                         }
@@ -1298,7 +1292,6 @@ namespace System
                 }
                 else if (Vector128.IsHardwareAccelerated && this.Length >= (uint)Vector128<ushort>.Count*2)
                 {
-                    // Internal.Console.WriteLine("Vector128");
                     ref char source = ref MemoryMarshal.GetReference(this.AsSpan());
                     Vector128<ushort> v1 = Vector128.Create((ushort)c);
                     do
@@ -1314,8 +1307,6 @@ namespace System
                             {
                                 uint bitPos = (uint)BitOperations.TrailingZeroCount(mask) / sizeof(char);
                                 replacementIndices.Append((int)(offset + bitPos));
-                                // Internal.Console.Write("" + ((int)(offset + bitPos)));
-                                // Internal.Console.Write(", ");
                                 mask = BitOperations.ResetLowestSetBit(mask);
                             } while (mask != 0);
                         }
@@ -1326,7 +1317,6 @@ namespace System
                 int i = (int)offset;
                 if (PackedSpanHelpers.PackedIndexOfIsSupported && PackedSpanHelpers.CanUsePackedIndexOf(c))
                 {
-                    // Internal.Console.WriteLine("PackedSpanHelpers");
                     while (true)
                     {
                         int pos = PackedSpanHelpers.IndexOf(ref Unsafe.Add(ref _firstChar, i), c, Length - i);
@@ -1335,14 +1325,11 @@ namespace System
                             break;
                         }
                         replacementIndices.Append(i + pos);
-                        // Internal.Console.Write("" + ((int)(i + pos)));
-                        // Internal.Console.Write(", ");
                         i += pos + 1;
                     }
                 }
                 else
                 {
-                    // Internal.Console.WriteLine("Else");
                     while (true)
                     {
                         int pos = SpanHelpers.NonPackedIndexOfChar(ref Unsafe.Add(ref _firstChar, i), c, Length - i);
@@ -1351,8 +1338,6 @@ namespace System
                             break;
                         }
                         replacementIndices.Append(i + pos);
-                        // Internal.Console.Write("" + ((int)(i + pos)));
-                        // Internal.Console.Write(", ");
                         i += pos + 1;
                     }
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1188,7 +1188,14 @@ namespace System
             // process the remaining elements vectorized too.
             // Thus we adjust the pointers so that at least one full vector from the end can be processed.
             nuint length = (uint)Length;
-            if (Vector128.IsHardwareAccelerated && length >= (uint)Vector128<ushort>.Count)
+            if (Vector512.IsHardwareAccelerated && length >= (uint)Vector512<ushort>.Count)
+            {
+                nuint adjust = (length - remainingLength) & ((uint)Vector512<ushort>.Count - 1);
+                pSrc = ref Unsafe.Subtract(ref pSrc, adjust);
+                pDst = ref Unsafe.Subtract(ref pDst, adjust);
+                remainingLength += adjust;
+            }
+            else if (Vector128.IsHardwareAccelerated && length >= (uint)Vector128<ushort>.Count)
             {
                 nuint adjust = (length - remainingLength) & ((uint)Vector128<ushort>.Count - 1);
                 pSrc = ref Unsafe.Subtract(ref pSrc, adjust);
@@ -1227,7 +1234,33 @@ namespace System
                 char c = oldValue[0];
                 int i = 0;
 
-                if (PackedSpanHelpers.PackedIndexOfIsSupported && PackedSpanHelpers.CanUsePackedIndexOf(c))
+                if (Vector512.IsHardwareAccelerated && this.Length >= (uint)Vector512<ushort>.Count*2)
+                {
+                    nuint lengthToExamine = (uint)this.Length;
+                    nuint offset = 0;
+                    ref char source = ref MemoryMarshal.GetReference(this.AsSpan());
+                    Vector512<ushort> v1 = Vector512.Create((ushort)c);
+                    do
+                    {
+                        Vector512<ushort> vector = Vector512.LoadUnsafe(ref source, offset);
+                        Vector512<byte> cmp = (Vector512.Equals(vector, v1)).AsByte();
+
+                        if (cmp != Vector512<byte>.Zero)
+                        {
+                            // Skip every other bit
+                            ulong mask = cmp.ExtractMostSignificantBits() & 0x5555555555555555;
+                            do
+                            {
+                                uint bitPos = (uint)BitOperations.TrailingZeroCount(mask) / sizeof(char);
+                                replacementIndices.Append((int)(offset + bitPos));
+                                mask = BitOperations.ResetLowestSetBit(mask);
+                            } while (mask != 0);
+                        }
+
+                        offset += (nuint)Vector512<ushort>.Count;
+                    } while (offset <= lengthToExamine - (nuint)Vector512<ushort>.Count);
+                }
+                else if (PackedSpanHelpers.PackedIndexOfIsSupported && PackedSpanHelpers.CanUsePackedIndexOf(c))
                 {
                     while (true)
                     {
@@ -1899,46 +1932,69 @@ namespace System
 
         private static void MakeSeparatorListVectorized(ReadOnlySpan<char> sourceSpan, ref ValueListBuilder<int> sepListBuilder, char c, char c2, char c3)
         {
-            // Redundant test so we won't prejit remainder of this method
-            // on platforms where it is not supported
-            if (!Vector128.IsHardwareAccelerated)
-            {
-                throw new PlatformNotSupportedException();
-            }
-
             Debug.Assert(sourceSpan.Length >= Vector128<ushort>.Count);
-
-            nuint offset = 0;
             nuint lengthToExamine = (uint)sourceSpan.Length;
-
+            nuint offset = 0;
             ref char source = ref MemoryMarshal.GetReference(sourceSpan);
 
-            Vector128<ushort> v1 = Vector128.Create((ushort)c);
-            Vector128<ushort> v2 = Vector128.Create((ushort)c2);
-            Vector128<ushort> v3 = Vector128.Create((ushort)c3);
-
-            do
+            if (Vector512.IsHardwareAccelerated && lengthToExamine >= (uint)Vector512<ushort>.Count*2)
             {
-                Vector128<ushort> vector = Vector128.LoadUnsafe(ref source, offset);
-                Vector128<ushort> v1Eq = Vector128.Equals(vector, v1);
-                Vector128<ushort> v2Eq = Vector128.Equals(vector, v2);
-                Vector128<ushort> v3Eq = Vector128.Equals(vector, v3);
-                Vector128<byte> cmp = (v1Eq | v2Eq | v3Eq).AsByte();
+                Vector512<ushort> v1 = Vector512.Create((ushort)c);
+                Vector512<ushort> v2 = Vector512.Create((ushort)c2);
+                Vector512<ushort> v3 = Vector512.Create((ushort)c3);
 
-                if (cmp != Vector128<byte>.Zero)
+                do
                 {
-                    // Skip every other bit
-                    uint mask = cmp.ExtractMostSignificantBits() & 0x5555;
-                    do
-                    {
-                        uint bitPos = (uint)BitOperations.TrailingZeroCount(mask) / sizeof(char);
-                        sepListBuilder.Append((int)(offset + bitPos));
-                        mask = BitOperations.ResetLowestSetBit(mask);
-                    } while (mask != 0);
-                }
+                    Vector512<ushort> vector = Vector512.LoadUnsafe(ref source, offset);
+                    Vector512<ushort> v1Eq = Vector512.Equals(vector, v1);
+                    Vector512<ushort> v2Eq = Vector512.Equals(vector, v2);
+                    Vector512<ushort> v3Eq = Vector512.Equals(vector, v3);
+                    Vector512<byte> cmp = (v1Eq | v2Eq | v3Eq).AsByte();
 
-                offset += (nuint)Vector128<ushort>.Count;
-            } while (offset <= lengthToExamine - (nuint)Vector128<ushort>.Count);
+                    if (cmp != Vector512<byte>.Zero)
+                    {
+                        // Skip every other bit
+                        ulong mask = cmp.ExtractMostSignificantBits() & 0x5555555555555555;
+                        do
+                        {
+                            uint bitPos = (uint)BitOperations.TrailingZeroCount(mask) / sizeof(char);
+                            sepListBuilder.Append((int)(offset + bitPos));
+                            mask = BitOperations.ResetLowestSetBit(mask);
+                        } while (mask != 0);
+                    }
+
+                    offset += (nuint)Vector512<ushort>.Count;
+                } while (offset <= lengthToExamine - (nuint)Vector512<ushort>.Count);
+            }
+            else if (Vector128.IsHardwareAccelerated)
+            {
+                Vector128<ushort> v1 = Vector128.Create((ushort)c);
+                Vector128<ushort> v2 = Vector128.Create((ushort)c2);
+                Vector128<ushort> v3 = Vector128.Create((ushort)c3);
+
+                do
+                {
+                    Vector128<ushort> vector = Vector128.LoadUnsafe(ref source, offset);
+                    Vector128<ushort> v1Eq = Vector128.Equals(vector, v1);
+                    Vector128<ushort> v2Eq = Vector128.Equals(vector, v2);
+                    Vector128<ushort> v3Eq = Vector128.Equals(vector, v3);
+                    Vector128<byte> cmp = (v1Eq | v2Eq | v3Eq).AsByte();
+
+                    if (cmp != Vector128<byte>.Zero)
+                    {
+                        // Skip every other bit
+                        uint mask = cmp.ExtractMostSignificantBits() & 0x5555;
+                        do
+                        {
+                            uint bitPos = (uint)BitOperations.TrailingZeroCount(mask) / sizeof(char);
+                            sepListBuilder.Append((int)(offset + bitPos));
+                            mask = BitOperations.ResetLowestSetBit(mask);
+                        } while (mask != 0);
+                    }
+
+                    offset += (nuint)Vector128<ushort>.Count;
+                } while (offset <= lengthToExamine - (nuint)Vector128<ushort>.Count);
+            }
 
             while (offset < lengthToExamine)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1240,11 +1240,11 @@ namespace System
                 // Find all occurrences of the oldValue character.
                 char c = oldValue[0];
                 int i = 0;
+                nuint offset = 0;
 
                 if (Vector512.IsHardwareAccelerated && this.Length >= (uint)Vector512<ushort>.Count*2)
                 {
                     nuint lengthToExamine = (uint)this.Length;
-                    nuint offset = 0;
                     ref char source = ref MemoryMarshal.GetReference(this.AsSpan());
                     Vector512<ushort> v1 = Vector512.Create((ushort)c);
                     do
@@ -1270,7 +1270,6 @@ namespace System
                 else if (Vector256.IsHardwareAccelerated && this.Length >= (uint)Vector256<ushort>.Count*2)
                 {
                     nuint lengthToExamine = (uint)this.Length;
-                    nuint offset = 0;
                     ref char source = ref MemoryMarshal.GetReference(this.AsSpan());
                     Vector256<ushort> v1 = Vector256.Create((ushort)c);
                     do
@@ -1296,7 +1295,6 @@ namespace System
                 else if (Vector128.IsHardwareAccelerated && this.Length >= (uint)Vector128<ushort>.Count*2)
                 {
                     nuint lengthToExamine = (uint)this.Length;
-                    nuint offset = 0;
                     ref char source = ref MemoryMarshal.GetReference(this.AsSpan());
                     Vector128<ushort> v1 = Vector128.Create((ushort)c);
                     do
@@ -1321,6 +1319,7 @@ namespace System
                 }
                 else if (PackedSpanHelpers.PackedIndexOfIsSupported && PackedSpanHelpers.CanUsePackedIndexOf(c))
                 {
+                    i = (int)offset;
                     while (true)
                     {
                         int pos = PackedSpanHelpers.IndexOf(ref Unsafe.Add(ref _firstChar, i), c, Length - i);
@@ -1334,6 +1333,7 @@ namespace System
                 }
                 else
                 {
+                    i = (int)offset;
                     while (true)
                     {
                         int pos = SpanHelpers.NonPackedIndexOfChar(ref Unsafe.Add(ref _firstChar, i), c, Length - i);


### PR DESCRIPTION
### **NO NEED FOR REVIEW AT THIS TIME. STILL A WIP**

Optimizing the following String APIs

1. String.Replace(string old, string replacer) --> Optimization done for cases where oldValue.Length ==1 and newValue.Length != 1
2. String.Split --> Optimizing MakeSeparatorListVectorized
3. String.Replace(char oldChar, char newChar) --> Optimizing for first iteration