### PR TITLE
Remove Unwrap flag from UniqueComInterfaceMarshaller

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/UniqueComInterfaceMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/UniqueComInterfaceMarshaller.cs
@@ -55,7 +55,7 @@ namespace System.Runtime.InteropServices.Marshalling
             {
                 return default;
             }
-            return (T)StrategyBasedComWrappers.DefaultMarshallingInstance.GetOrCreateObjectForComInstance((nint)unmanaged, CreateObjectFlags.Unwrap | CreateObjectFlags.UniqueInstance);
+            return (T)StrategyBasedComWrappers.DefaultMarshallingInstance.GetOrCreateObjectForComInstance((nint)unmanaged, CreateObjectFlags.UniqueInstance);
         }
 
 

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -9,6 +9,7 @@ namespace ComWrappersTests
     using System.Diagnostics;
     using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
+    using System.Runtime.InteropServices.Marshalling;
 
     using ComWrappersTests.Common;
     using TestLibrary;
@@ -188,14 +189,14 @@ namespace ComWrappersTests
             var testObjUnwrapped = wrappers.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.Unwrap);
             Assert.Same(testObj, testObjUnwrapped);
 
-            // UniqueInstance and Unwrap should always be a new ComObject, never unwrapped
+            // UniqueInstance and Unwrap should always be a new com object, never unwrapped
             var testObjUniqueUnwrapped = wrappers.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.Unwrap | CreateObjectFlags.UniqueInstance);
-            Assert.True(testObjUniqueUnwrapped is ComObject)
             Assert.NotSame(testObj, testObjUniqueUnwrapped);
 
             // Release the wrapper
             int count = Marshal.Release(comWrapper);
-            Assert.Equal(0, count);
+            // Expect 1 reference remaining from UniqueInstance
+            Assert.Equal(1, count);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -190,13 +190,13 @@ namespace ComWrappersTests
             Assert.Same(testObj, testObjUnwrapped);
 
             // UniqueInstance and Unwrap should always be a new com object, never unwrapped
-            var testObjUniqueUnwrapped = wrappers.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.Unwrap | CreateObjectFlags.UniqueInstance);
+            var testObjUniqueUnwrapped = (ITestObjectWrapper)wrappers.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.Unwrap | CreateObjectFlags.UniqueInstance);
             Assert.NotSame(testObj, testObjUniqueUnwrapped);
+            testObjUniqueUnwrapped.FinalRelease();
 
             // Release the wrapper
             int count = Marshal.Release(comWrapper);
-            // Expect 1 reference remaining from UniqueInstance
-            Assert.Equal(1, count);
+            Assert.Equal(0, count);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -188,6 +188,11 @@ namespace ComWrappersTests
             var testObjUnwrapped = wrappers.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.Unwrap);
             Assert.Same(testObj, testObjUnwrapped);
 
+            // UniqueInstance and Unwrap should always be a new ComObject, never unwrapped
+            var testObjUniqueUnwrapped = wrappers.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.Unwrap | CreateObjectFlags.UniqueInstance);
+            Assert.True(testObjUniqueUnwrapped is ComObject)
+            Assert.NotSame(testObj, testObjUniqueUnwrapped);
+
             // Release the wrapper
             int count = Marshal.Release(comWrapper);
             Assert.Equal(0, count);

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -97,6 +97,7 @@ namespace ComWrappersTests.Common
     {
         private readonly ITestVtbl._SetValue _setValue;
         private readonly IntPtr _ptr;
+        private bool _released;
 
         public ITestObjectWrapper(IntPtr ptr)
         {
@@ -104,11 +105,19 @@ namespace ComWrappersTests.Common
             VtblPtr inst = Marshal.PtrToStructure<VtblPtr>(ptr);
             ITestVtbl _vtbl = Marshal.PtrToStructure<ITestVtbl>(inst.Vtbl);
             _setValue = Marshal.GetDelegateForFunctionPointer<ITestVtbl._SetValue>(_vtbl.SetValue);
+            _released = false;
+        }
+
+        public int FinalRelease()
+        {
+            int count = Marshal.Release(_ptr);
+            _released = true;
+            return count;
         }
 
         ~ITestObjectWrapper()
         {
-            if (_ptr != IntPtr.Zero)
+            if (_ptr != IntPtr.Zero && !_released)
             {
                 Marshal.Release(_ptr);
             }

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -110,6 +110,7 @@ namespace ComWrappersTests.Common
 
         public int FinalRelease()
         {
+            Debug.Assert(!_released);
             int count = Marshal.Release(_ptr);
             _released = true;
             return count;

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -4,6 +4,7 @@
 namespace ComWrappersTests.Common
 {
     using System;
+    using System.Diagnostics;
     using System.Threading;
     using System.Runtime.InteropServices;
 


### PR DESCRIPTION
The Unwrap flag only has effect when UniqueInstance is not set. To avoid confusion from anyone referencing this code, we should remove it here.

See [here](https://github.com/dotnet/runtime/blob/eb4c875340cb3647d43df53eca1d42f50df5fda5/src/coreclr/vm/interoplibinterface_comwrappers.cpp#L863) for the code that unwraps a ComObject, which is guarded by a check to ensure UniqueInstance is not set.

NativeAOT needed to move the Unwrap code to inside the `!UniqueInstance` to match behavior of CoreCLR. This should only be noticeable when using ComWrappers to wrap an unwrap the same object in the same NativeAOT instance. In-Proc COM with different servers and clients won't hit this behavior, so I'm not sure it's worth backporting to 8.