### PR TITLE
Add illink analyzer support for field/property initializers

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ResultChecker.cs
@@ -303,18 +303,19 @@ namespace Mono.Linker.Tests.TestCasesRunner
 											loggedMessages.Remove (loggedMessage);
 											break;
 										}
-										if (actualName?.StartsWith (expectedTypeName) == true &&
-											actualName?.Contains (".cctor") == true &&
-											(expectedMember is FieldDefinition || expectedMember is PropertyDefinition)) {
-											expectedWarningFound = true;
-											loggedMessages.Remove (loggedMessage);
-											break;
-										}
-										if (methodDesc.IsConstructor &&
-											(expectedMember is FieldDefinition || expectedMember is PropertyDefinition || new AssemblyQualifiedToken (methodDesc.OwningType).Equals(new AssemblyQualifiedToken (expectedMember)))) {
-											expectedWarningFound = true;
-											loggedMessages.Remove (loggedMessage);
-											break;
+										if (actualName?.StartsWith (expectedTypeName) == true) {
+											if (actualName?.Contains (".cctor") == true &&
+												(expectedMember is FieldDefinition || expectedMember is PropertyDefinition)) {
+												expectedWarningFound = true;
+												loggedMessages.Remove (loggedMessage);
+												break;
+											}
+											if (methodDesc.IsConstructor &&
+												(expectedMember is FieldDefinition || expectedMember is PropertyDefinition || new AssemblyQualifiedToken (methodDesc.OwningType).Equals(new AssemblyQualifiedToken (expectedMember)))) {
+												expectedWarningFound = true;
+												loggedMessages.Remove (loggedMessage);
+												break;
+											}
 										}
 									} else if (attrProvider is AssemblyDefinition expectedAssembly) {
 										// Allow assembly-level attributes to match warnings from compiler-generated Main

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ResultChecker.cs
@@ -311,7 +311,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 											break;
 										}
 										if (methodDesc.IsConstructor &&
-											new AssemblyQualifiedToken (methodDesc.OwningType).Equals(new AssemblyQualifiedToken (expectedMember))) {
+											(expectedMember is FieldDefinition || expectedMember is PropertyDefinition || new AssemblyQualifiedToken (methodDesc.OwningType).Equals(new AssemblyQualifiedToken (expectedMember)))) {
 											expectedWarningFound = true;
 											loggedMessages.Remove (loggedMessage);
 											break;

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowAnalysis.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowAnalysis.cs
@@ -58,18 +58,17 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 				return;
 			}
 
-			if (Context.OwningSymbol is not IMethodSymbol owningMethod)
-				return;
 
-			Debug.Assert (owningMethod.MethodKind is not (MethodKind.LambdaMethod or MethodKind.LocalFunction));
-			var startMethod = new MethodBodyValue (owningMethod, Context.GetControlFlowGraph (OperationBlock));
+			Debug.Assert (Context.OwningSymbol is not IMethodSymbol methodSymbol ||
+				methodSymbol.MethodKind is not (MethodKind.LambdaMethod or MethodKind.LocalFunction));
+			var startMethod = new MethodBodyValue (Context.OwningSymbol, Context.GetControlFlowGraph (OperationBlock));
 			interproceduralState.TrackMethod (startMethod);
 
 			while (!interproceduralState.Equals (oldInterproceduralState)) {
 				oldInterproceduralState = interproceduralState.Clone ();
 
 				foreach (var method in oldInterproceduralState.Methods) {
-					if (method.Method.IsInRequiresUnreferencedCodeAttributeScope (out _))
+					if (method.OwningSymbol.IsInRequiresUnreferencedCodeAttributeScope (out _))
 						continue;
 
 					AnalyzeMethod (method, ref interproceduralState);
@@ -89,7 +88,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		{
 			var cfg = method.ControlFlowGraph;
 			var lValueFlowCaptures = LValueFlowCapturesProvider.CreateLValueFlowCaptures (cfg);
-			var visitor = GetVisitor (method.Method, cfg, lValueFlowCaptures, interproceduralState);
+			var visitor = GetVisitor (method.OwningSymbol, cfg, lValueFlowCaptures, interproceduralState);
 			Fixpoint (new ControlFlowGraphProxy (cfg), Lattice, visitor);
 
 			// The interprocedural state struct is stored as a field of the visitor and modified

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -505,6 +505,9 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		public override TValue VisitFlowAnonymousFunction (IFlowAnonymousFunctionOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
 		{
+			// The containing symbol of a lambda is either another method, or a field (for field initializers).
+			// For property initializers, the containing symbol is the compiler-generated backing field.
+			// For property accessors, the containing symbol is the accessor method.
 			Debug.Assert (operation.Symbol.ContainingSymbol is IMethodSymbol or IFieldSymbol);
 			var lambda = operation.Symbol;
 			Debug.Assert (lambda.MethodKind == MethodKind.LambdaMethod);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -76,6 +76,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			// If not, the BranchValue represents a return or throw value associated with the FallThroughSuccessor of this block.
 			// (ConditionalSuccessor == null iff ConditionKind == None).
 			// If we get here, we should be analyzing a method body, not an attribute instance since attributes can't have throws or return statements
+			// Field/property initializers also can't have throws or return statements.
 			Debug.Assert (OwningSymbol is IMethodSymbol);
 
 			// The BranchValue for a thrown value is not involved in dataflow tracking.
@@ -504,7 +505,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		public override TValue VisitFlowAnonymousFunction (IFlowAnonymousFunctionOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
 		{
-			Debug.Assert (operation.Symbol.ContainingSymbol is IMethodSymbol);
+			Debug.Assert (operation.Symbol.ContainingSymbol is IMethodSymbol or IFieldSymbol);
 			var lambda = operation.Symbol;
 			Debug.Assert (lambda.MethodKind == MethodKind.LambdaMethod);
 			var lambdaCFG = ControlFlowGraph.GetAnonymousFunctionControlFlowGraphInScope (operation);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/MethodBodyValue.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/MethodBodyValue.cs
@@ -12,19 +12,22 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 	// along with its control flow graph. It implements IEquatable for the method.
 	public readonly struct MethodBodyValue : IEquatable<MethodBodyValue>
 	{
-		public IMethodSymbol Method { get; }
+		// Usually an IMethodSymbol, but may also be an IFieldSymbol or IPropertySymbol
+		// for field initializers.
+		public ISymbol OwningSymbol { get; }
 
 		public ControlFlowGraph ControlFlowGraph { get; }
 
-		public MethodBodyValue (IMethodSymbol method, ControlFlowGraph cfg)
+		public MethodBodyValue (ISymbol owningSymbol, ControlFlowGraph cfg)
 		{
-			Method = method;
+			Debug.Assert (owningSymbol is (IMethodSymbol or IFieldSymbol or IPropertySymbol));
+			OwningSymbol = owningSymbol;
 			ControlFlowGraph = cfg;
 		}
 
 		public bool Equals (MethodBodyValue other)
 		{
-			if (!ReferenceEquals (Method, other.Method))
+			if (!ReferenceEquals (OwningSymbol, other.OwningSymbol))
 				return false;
 
 			Debug.Assert (ControlFlowGraph == other.ControlFlowGraph);
@@ -34,6 +37,6 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		public override bool Equals (object obj)
 			=> obj is MethodBodyValue inst && Equals (inst);
 
-		public override int GetHashCode () => SymbolEqualityComparer.Default.GetHashCode (Method);
+		public override int GetHashCode () => SymbolEqualityComparer.Default.GetHashCode (OwningSymbol);
 	}
 }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -114,6 +114,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			// The instance reference operation represents a 'this' or 'base' reference to the containing type,
 			// so we get the annotation from the containing method.
 			if (instanceRef.Type != null && instanceRef.Type.IsTypeInterestingForDataflow ()) {
+				// 'this' is not allowed in field/property initializers, so the owning symbol should be a method.
 				Debug.Assert (OwningSymbol is IMethodSymbol);
 				if (OwningSymbol is IMethodSymbol method)
 					return new MethodParameterValue (method, (ParameterIndex) 0, method.GetDynamicallyAccessedMemberTypes ());
@@ -297,6 +298,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 		public override void HandleReturnValue (MultiValue returnValue, IOperation operation)
 		{
+			// Return statements should only happen inside of method bodies.
 			Debug.Assert (OwningSymbol is IMethodSymbol);
 			if (OwningSymbol is not IMethodSymbol method)
 				return;

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -113,6 +113,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task ConstructorDataFlow ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task DynamicDependencyDataflow ()
 		{
 			return RunTest (nameof (DynamicDependencyDataflow));

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructorDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructorDataFlow.cs
@@ -46,11 +46,27 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 					return RequireAll (GetUnknown ());
 				});
 
+			// When analyzer visits the lambda, its containing symbol is the compiler-generated
+			// backing field of the property, not the property itself.
+			Func<int> PropertyWithReturnStatementInInitializer { get; } =
+			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
+			() => {
+				return RequireAll (GetUnknown ());
+			};
+
+			// For property accessors, the containing symbol is the accessor method.
+			Func<int> PropertyWithReturnStatementInGetter =>
+			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
+			() => {
+				return RequireAll (GetUnknown ());
+			};
+
 			static int Execute(Func<int> f) => f();
 
 			public static void Test ()
 			{
-				new DataFlowInConstructor ();
+				var instance = new DataFlowInConstructor ();
+				var _ = instance.PropertyWithReturnStatementInGetter;
 			}
 		}
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructorDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructorDataFlow.cs
@@ -29,11 +29,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				RequireAll (GetUnknown ());
 			}
 
-			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
+			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll), CompilerGeneratedCode = true)]
 			int field = RequireAll (GetUnknown ());
 
-			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
-			int Propertty { get; } = RequireAll (GetUnknown ());
+			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll), CompilerGeneratedCode = true)]
+			int Property { get; } = RequireAll (GetUnknown ());
 
 			// The analyzer dataflow visitor asserts that we only see a return value
 			// inside of an IMethodSymbol. This testcase checks that we don't hit asserts
@@ -62,11 +62,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				RequireAll (GetUnknown ());
 			}
 
-			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
+			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll), CompilerGeneratedCode = true)]
 			static int field = RequireAll (GetUnknown ());
 
-			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
-			static int Propertty { get; } = RequireAll (GetUnknown ());
+			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll), CompilerGeneratedCode = true)]
+			static int Property { get; } = RequireAll (GetUnknown ());
 
 			public static void Test ()
 			{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructorDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructorDataFlow.cs
@@ -35,6 +35,19 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
 			int Propertty { get; } = RequireAll (GetUnknown ());
 
+			// The analyzer dataflow visitor asserts that we only see a return value
+			// inside of an IMethodSymbol. This testcase checks that we don't hit asserts
+			// in case the return statement is in a lambda owned by a field.
+			// When the lambda is analyzed, the OwningSymbol is still an IMethodSymbol
+			// (the symbol representing the lambda, not the field).
+			int fieldWithReturnStatementInInitializer = Execute(
+				[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
+				() => {
+					return RequireAll (GetUnknown ());
+				});
+
+			static int Execute(Func<int> f) => f();
+
 			public static void Test ()
 			{
 				new DataFlowInConstructor ();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructorDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructorDataFlow.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SkipKeptItemsValidation]
+	[ExpectedNoWarnings]
+	public class ConstructorDataFlow
+	{
+		public static void Main ()
+		{
+			DataFlowInConstructor.Test ();
+			DataFlowInStaticConstructor.Test ();
+		}
+
+		class DataFlowInConstructor
+		{
+			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
+			public DataFlowInConstructor ()
+			{
+				RequireAll (GetUnknown ());
+			}
+
+			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
+			int field = RequireAll (GetUnknown ());
+
+			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
+			int Propertty { get; } = RequireAll (GetUnknown ());
+
+			public static void Test ()
+			{
+				new DataFlowInConstructor ();
+			}
+		}
+
+		class DataFlowInStaticConstructor
+		{
+			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
+			static DataFlowInStaticConstructor ()
+			{
+				RequireAll (GetUnknown ());
+			}
+
+			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
+			static int field = RequireAll (GetUnknown ());
+
+			[ExpectedWarning ("IL2072", nameof (GetUnknown), nameof (RequireAll))]
+			static int Propertty { get; } = RequireAll (GetUnknown ());
+
+			public static void Test ()
+			{
+			}
+		}
+
+		static Type GetUnknown () => null;
+
+		static int RequireAll ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] Type type) => 0;
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -873,17 +873,19 @@ namespace Mono.Linker.Tests.TestCasesRunner
 										}
 										if (memberDefinition is not MethodDefinition)
 											continue;
-										if (actualName.StartsWith (expectedMember.DeclaringType.FullName) &&
-											actualName.Contains (".cctor") && (expectedMember is FieldDefinition || expectedMember is PropertyDefinition)) {
-											expectedWarningFound = true;
-											loggedMessages.Remove (loggedMessage);
-											break;
-										}
-										if (memberDefinition.Name == ".ctor" &&
-											(expectedMember is FieldDefinition || expectedMember is PropertyDefinition || memberDefinition.DeclaringType.FullName == expectedMember.FullName)) {
-											expectedWarningFound = true;
-											loggedMessages.Remove (loggedMessage);
-											break;
+										if (actualName.StartsWith (expectedMember.DeclaringType.FullName)) {
+											if (memberDefinition.Name == ".cctor" &&
+												(expectedMember is FieldDefinition || expectedMember is PropertyDefinition)) {
+												expectedWarningFound = true;
+												loggedMessages.Remove (loggedMessage);
+												break;
+											}
+											if (memberDefinition.Name == ".ctor" &&
+												(expectedMember is FieldDefinition || expectedMember is PropertyDefinition || memberDefinition.DeclaringType.FullName == expectedMember.FullName)) {
+												expectedWarningFound = true;
+												loggedMessages.Remove (loggedMessage);
+												break;
+											}
 										}
 									} else if (attrProvider is AssemblyDefinition expectedAssembly) {
 										// Allow assembly-level attributes to match warnings from compiler-generated Main

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -880,7 +880,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 											break;
 										}
 										if (memberDefinition.Name == ".ctor" &&
-											memberDefinition.DeclaringType.FullName == expectedMember.FullName) {
+											(expectedMember is FieldDefinition || expectedMember is PropertyDefinition || memberDefinition.DeclaringType.FullName == expectedMember.FullName)) {
 											expectedWarningFound = true;
 											loggedMessages.Remove (loggedMessage);
 											break;


### PR DESCRIPTION
The dataflow analyzer was exiting early for cases where the owning symbol was not an `IMethodSymbol`. This meant we weren't running dataflow analysis for field and property initializers.

This fixes it by allowing through cases where the owning symbol is not an `IMethodSymbol`, and adding testcases to validate that we don't hit asserts in the code paths that only light up for methods.