### PR TITLE
[PERF] Update perf-job MonoProduct__ name to match new name

### DIFF
--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -169,8 +169,8 @@ jobs:
         parameters:
           unpackFolder: $(librariesDownloadDir)/bin/mono/$(osGroup).$(archType).$(buildConfigUpper)
           cleanUnpackFolder: false
-          artifactFileName: 'MonoProduct__${{ parameters.runtimeVariant }}_$(osGroup)_$(archType)_$(buildConfig)$(archiveExtension)'
-          artifactName: 'MonoProduct__${{ parameters.runtimeVariant }}_$(osGroup)_$(archType)_$(buildConfig)'
+          artifactFileName: 'MonoProduct_${{ parameters.runtimeVariant }}_$(osGroup)_$(archType)_$(buildConfig)$(archiveExtension)'
+          artifactName: 'MonoProduct_${{ parameters.runtimeVariant }}_$(osGroup)_$(archType)_$(buildConfig)'
           displayName: 'Mono runtime'
 
     # Download wasm


### PR DESCRIPTION
Update perf-job MonoProduct__ name to match new name per change made: https://github.com/dotnet/runtime/commit/493a702b5ce0ac3c98cea5797f74e34e87c2ce26#diff-ef17aa4ba5069df7ab344cb6bdd121032a667b899762be670997df540a4313bdL61-R61.

This should fix the two failing micro_mono jobs.