### PR TITLE
Ensure HW intrinsics enabled when running arm64 longmul tests.

### DIFF
--- a/src/tests/JIT/opt/Multiply/MultiplyLongOps.csproj
+++ b/src/tests/JIT/opt/Multiply/MultiplyLongOps.csproj
@@ -14,5 +14,6 @@
 
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
     <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_EnableHWIntrinsic" Value="1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Currently, when jitstress runs the HWIntrinsics disabled environment for JIT opts, arm64 longmul tests will fall over as it must have hardware intrinsics enabled to detect the correct assembly output (as per #92571).

This patch simply forces on DOTNET_EnableHWIntrinsic to ensure the test will always function correctly. I'm not sure this is a complete solution to the problem (not sure what category this test should be in, and I'm not familiar enough with the `HWIntrinsics` test templating to move it to there quickly if need be), but this should work.

Let me know what you think.
cc: @kunalspathak

Fixes: https://github.com/dotnet/runtime/issues/92571