### PR TITLE
CI: Don't run runtime.yml on perf pipeline specific changes

### DIFF
--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -22,6 +22,7 @@ trigger:
     - eng/pipelines/coreclr/templates/build-perf*
     - eng/pipelines/coreclr/templates/perf-job.yml
     - eng/pipelines/coreclr/templates/run-perf*
+    - eng/testing/performance/*
 
 schedules:
   - cron: "0 7,19 * * *" # run at 7:00 and 19:00 (UTC) which is 23:00 and 11:00 (PST).

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -18,6 +18,10 @@ trigger:
     - LICENSE.TXT
     - PATENTS.TXT
     - THIRD-PARTY-NOTICES.TXT
+    - eng/pipelines/coreclr/perf*yml
+    - eng/pipelines/coreclr/templates/build-perf*
+    - eng/pipelines/coreclr/templates/perf-job.yml
+    - eng/pipelines/coreclr/templates/run-perf*
 
 schedules:
   - cron: "0 7,19 * * *" # run at 7:00 and 19:00 (UTC) which is 23:00 and 11:00 (PST).

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -19,6 +19,10 @@ trigger:
     - LICENSE.TXT
     - PATENTS.TXT
     - THIRD-PARTY-NOTICES.TXT
+    - eng/pipelines/coreclr/perf*yml
+    - eng/pipelines/coreclr/templates/build-perf*
+    - eng/pipelines/coreclr/templates/perf-job.yml
+    - eng/pipelines/coreclr/templates/run-perf*
 
 schedules:
   - cron: "0 8,20 * * *" # run at 8:00 and 20:00 (UTC) which is 00:00 and 12:00 (PST).

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -23,6 +23,7 @@ trigger:
     - eng/pipelines/coreclr/templates/build-perf*
     - eng/pipelines/coreclr/templates/perf-job.yml
     - eng/pipelines/coreclr/templates/run-perf*
+    - eng/testing/performance/*
 
 schedules:
   - cron: "0 8,20 * * *" # run at 8:00 and 20:00 (UTC) which is 00:00 and 12:00 (PST).


### PR DESCRIPTION
.. and the same for `dotnet-linker-tests` pipeline. The perf pipeline
specific files are used only by `dotnet-runtime-perf`, and
`runtime-wasm-perf` which currently do not run on PRs.
