### PR TITLE
Remove slipped debugging message in jitinterface.cpp

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -140,14 +140,7 @@ FCIMPLEND
 FCIMPL1(INT64, GetCompiledMethodCount, CLR_BOOL currentThread)
 {
     FCALL_CONTRACT;
-    // WIP-DEBUG-ONLY change: Windows is causing problems in the CI, but can't
-    // be replicated locally. Using this for some logging there to try to figure
-    // it out.
-    printf("\nENTERING GETCOMPILEDMETHODCOUNT:");
-    printf("%d\n", currentThread ? 1 : 0);
-    printf("%ld\n", (long) t_cMethodsJittedForThread);
-    printf("%ld\n", (long) AtomicLoad64WithoutTearing(&g_cMethodsJitted));
-    printf(":EXITING GETCOMPILEDMETHODCOUNT\n");
+
     return currentThread ? t_cMethodsJittedForThread : AtomicLoad64WithoutTearing(&g_cMethodsJitted);
 }
 FCIMPLEND


### PR DESCRIPTION
When PR #91235 was merged, some debugging messages slipped. This PR removes them.