### PR TITLE
Port SpinWait(int iterations) to C#

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -145,18 +145,16 @@ namespace System.Threading
             // void YieldProcessorNormalized(const YieldProcessorNormalizationInfo &normalizationInfo, unsigned int count)
 
             // Prevent overflow on the multiply below on 32bit
-            if (IntPtr.Size == 4)
+#if TARGET_32BIT
+            // Copied from YieldProcessorNormalization (yieldprocessornormalized.h)
+            const int targetNsPerNormalizedYield = 37;
+            const int maxYieldsPerNormalizedYield = targetNsPerNormalizedYield * 10;
+            const int maxCount = int.MaxValue / maxYieldsPerNormalizedYield;
+            if (iterations > maxCount)
             {
-                // Copied from YieldProcessorNormalization (yieldprocessornormalized.h)
-                const int targetNsPerNormalizedYield = 37;
-                const int maxYieldsPerNormalizedYield = targetNsPerNormalizedYield * 10;
-
-                const int maxCount = int.MaxValue / maxYieldsPerNormalizedYield;
-                if (iterations > maxCount)
-                {
-                    iterations = maxCount;
-                }
+                iterations = maxCount;
             }
+#endif
 
             nint n = (nint)iterations * GetYieldsPerNormalizedYield;
             Debug.Assert(n != 0);

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -377,8 +377,7 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Max value to be passed into <see cref="SpinWait(int)"/> for optimal delaying. This value is normalized to be
-        /// appropriate for the processor.
+        /// Number of yields required to span the duration of a normalized yield.
         /// </summary>
         internal static int GetYieldsPerNormalizedYield
         {

--- a/src/coreclr/inc/yieldprocessornormalized.h
+++ b/src/coreclr/inc/yieldprocessornormalized.h
@@ -53,6 +53,12 @@ public:
     {
         return s_optimalMaxNormalizedYieldsPerSpinIteration;
     }
+    static unsigned int GetYieldsPerNormalizedYield()
+    {
+        // Schedule measurement if necessary
+        YieldProcessorNormalization::ScheduleMeasurementIfNecessary();
+        return s_yieldsPerNormalizedYield;
+    }
 
     static void FireMeasurementEvents();
 

--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -1035,6 +1035,15 @@ FCIMPL0(INT32, ThreadNative::GetOptimalMaxSpinWaitsPerSpinIteration)
 }
 FCIMPLEND
 
+FCIMPL0(INT32, ThreadNative::GetYieldsPerNormalizedYield)
+{
+    FCALL_CONTRACT;
+
+    // Schedule measurements if needed
+    return (INT32)YieldProcessorNormalization::GetYieldsPerNormalizedYield();
+}
+FCIMPLEND
+
 FCIMPL1(void, ThreadNative::SpinWait, int iterations)
 {
     FCALL_CONTRACT;

--- a/src/coreclr/vm/comsynchronizable.h
+++ b/src/coreclr/vm/comsynchronizable.h
@@ -70,6 +70,7 @@ public:
 
 
     static FCDECL0(INT32,   GetOptimalMaxSpinWaitsPerSpinIteration);
+    static FCDECL0(INT32,   GetYieldsPerNormalizedYield);
     static FCDECL1(void,    SpinWait,                       int iterations);
     static FCDECL0(Object*, GetCurrentThread);
     static FCDECL1(void,    Finalize,                       ThreadBaseObject* pThis);

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -386,6 +386,7 @@ FCFuncStart(gThreadFuncs)
 #endif // FEATURE_COMINTEROP
     FCFuncElement("Interrupt", ThreadNative::Interrupt)
     FCFuncElement("Join", ThreadNative::Join)
+    FCFuncElement("get_GetYieldsPerNormalizedYield", ThreadNative::GetYieldsPerNormalizedYield)
     FCFuncElement("get_OptimalMaxSpinWaitsPerSpinIteration", ThreadNative::GetOptimalMaxSpinWaitsPerSpinIteration)
 FCFuncEnd()
 


### PR DESCRIPTION
It seems to be simple unless I am missing something. Presumably, it should allow gc to interrupt at any point while previously we had to enter preemptive mode for too many iterations and could slightly stall gc in coop.

Also, I heard modern ARM cpus should use ISB instead of Yield 