### PR TITLE
Fix test exclusion for Runtime_91209

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_91209/Runtime_91209.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91209/Runtime_91209.cs
@@ -33,6 +33,12 @@ public class Runtime_91209
     public static int Test1()
     {
         Console.WriteLine("Test1");
+
+        if (!AdvSimd.IsSupported)
+        {
+            return 100;
+        }
+
         Vector64<int> r1 = Problem1();
         return (r1.GetElement(0) + r1.GetElement(1)) == 84 ? 100 : 101;
     }
@@ -56,6 +62,12 @@ public class Runtime_91209
     public static int Test2()
     {
         Console.WriteLine("Test2");
+
+        if (!AdvSimd.IsSupported)
+        {
+            return 100;
+        }
+
         Vector64<sbyte> r1 = Problem2();
         return (r1.GetElement(0) + r1.GetElement(1)) == 12 ? 100 : 101;
     }
@@ -80,6 +92,12 @@ public class Runtime_91209
     public static int Test3()
     {
         Console.WriteLine("Test3");
+
+        if (!AdvSimd.IsSupported)
+        {
+            return 100;
+        }
+
         Vector64<byte> r1 = Problem3();
         return r1.GetElement(2) == 7 ? 100 : 101;
     }
@@ -103,6 +121,12 @@ public class Runtime_91209
     public static int Test4()
     {
         Console.WriteLine("Test4");
+
+        if (!AdvSimd.IsSupported)
+        {
+            return 100;
+        }
+
         Vector64<byte> r1 = Problem4();
         return r1.GetElement(7) == 7 ? 100 : 101;
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91209/Runtime_91209.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91209/Runtime_91209.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Optimize>True</Optimize>
-    <!-- Needed for CLRTestTargetUnsupported -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <CLRTestTargetUnsupported Condition="('$(TargetArchitecture)' != 'arm64') OR ('$(RuntimeFlavor)' != 'coreclr')">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Checking `AdvSimd.IsSupported` dynamically makes the test work for the `DOTNET_EnableHWIntrinsic=0` case.

Fixes #92572
