### PR TITLE
[wasi] Fix wasi.build.test instructions

### DIFF
--- a/src/mono/wasi/Wasi.Build.Tests/README.md
+++ b/src/mono/wasi/Wasi.Build.Tests/README.md
@@ -13,7 +13,7 @@ being generated.
 - Running:
 
 Linux/macOS: `$ make -C src/mono/wasi run-build-tests`
-Windows: `.\dotnet.cmd build .\src\mono\wasi\Wasi.Build.Tests\Wasi.Build.Tests.csproj -c Release -t:Test -p:TargetOS=Browser -p:TargetArchitecture=wasi`
+Windows: `.\dotnet.cmd build .\src\mono\wasi\Wasi.Build.Tests\Wasi.Build.Tests.csproj -c Release -t:Test -p:TargetOS=wasi -p:TargetArchitecture=wasm`
 
 - Specific tests can be run via `XUnitClassName`, and `XUnitMethodName`
   - eg. `XUnitClassName=Wasm.Build.Tests.BlazorWasmTests`


### PR DESCRIPTION
This could stand to include instructions on accessing the binlogs and rebuilding the sdk after changing the manifests