### PR TITLE
[release/8.0][wasm] Fix regressed file sizes for blazor

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/WasmNativeDefaultsTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmNativeDefaultsTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,6 +13,7 @@ namespace Wasm.Build.Tests
 {
     public class WasmNativeDefaultsTests : TestMainJsTestBase
     {
+        private static Regex s_regex = new("\\*\\* WasmBuildNative:.*");
         public WasmNativeDefaultsTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext)
             : base(output, buildContext)
         {
@@ -39,19 +41,20 @@ namespace Wasm.Build.Tests
                     // Config=Release always causes relinking when publishing
                     bool publishValue = forPublish && config == "Release" ? true : false;
                     // Setting the default value from the runtime pack shouldn't trigger relinking
-                    data.Add(config, $"<{defaultPair.propertyName}>{defaultPair.defaultValueInRuntimePack}</{defaultPair.propertyName}>",
+                    data.Add(config, $"<{defaultPair.propertyName}>{defaultPair.defaultValueInRuntimePack.ToString().ToLower()}</{defaultPair.propertyName}>",
                                         /*aot*/ false, /*build*/ false, /*publish*/ publishValue);
                     // Leaving the property unset, so checking the default
                     data.Add(config, "", /*aot*/ false, /*build*/ false, /*publish*/ publishValue);
 
                     // Setting the !default value should trigger relinking
-                    data.Add(config, $"<{defaultPair.propertyName}>{!defaultPair.defaultValueInRuntimePack}</{defaultPair.propertyName}>",
+                    data.Add(config, $"<{defaultPair.propertyName}>{(!defaultPair.defaultValueInRuntimePack).ToString().ToLower()}</{defaultPair.propertyName}>",
                                         /*aot*/ false, /*build*/ true, /*publish*/ true);
                 }
             }
 
             return data;
         }
+
         public static TheoryData<string, string, bool, bool, bool> DefaultsTestData(bool forPublish)
         {
             TheoryData<string, string, bool, bool, bool> data = new()
@@ -93,45 +96,34 @@ namespace Wasm.Build.Tests
             return data;
         }
 
+#pragma warning disable xUnit1026 // For unused *buildValue*, and *publishValue* parameters
         [Theory]
         [MemberData(nameof(DefaultsTestData), parameters: false)]
         [MemberData(nameof(SettingDifferentFromValuesInRuntimePack), parameters: false)]
         public void DefaultsWithBuild(string config, string extraProperties, bool aot, bool expectWasmBuildNativeForBuild, bool expectWasmBuildNativeForPublish)
         {
-            string output = CheckWasmNativeDefaultValue("native_defaults_build", config, extraProperties, aot, dotnetWasmFromRuntimePack: !expectWasmBuildNativeForPublish, publish: false);
+            (string output, string? line) = CheckWasmNativeDefaultValue("native_defaults_build", config, extraProperties, aot, dotnetWasmFromRuntimePack: !expectWasmBuildNativeForBuild, publish: false);
 
-            bool expectedWasmNativeStripValue = true;
-            if (/*isBuild && */ expectWasmBuildNativeForBuild && config == "Debug")
-                expectedWasmNativeStripValue = false;
-
-            // bool expectedWasmNativeStripValue = !(wasmBuildNativeForBuild && config == "Debug");
-            // for build
-            Assert.Contains($"** WasmBuildNative: '{expectWasmBuildNativeForBuild.ToString().ToLower()}', WasmNativeStrip: '{expectedWasmNativeStripValue.ToString().ToLower()}', WasmBuildingForNestedPublish: ''", output);
-            Assert.Contains("Stopping the build", output);
+            InferAndCheckPropertyValues(line, isPublish: false, wasmBuildNative: expectWasmBuildNativeForBuild, config: config);
         }
 
-#pragma warning disable xUnit1026 // For unused *buildValue* parameter
         [Theory]
         [MemberData(nameof(DefaultsTestData), parameters: true)]
         [MemberData(nameof(SettingDifferentFromValuesInRuntimePack), parameters: true)]
         public void DefaultsWithPublish(string config, string extraProperties, bool aot, bool expectWasmBuildNativeForBuild, bool expectWasmBuildNativeForPublish)
         {
-            string output = CheckWasmNativeDefaultValue("native_defaults_publish", config, extraProperties, aot, dotnetWasmFromRuntimePack: !expectWasmBuildNativeForPublish, publish: true);
+            (string output, string? line) = CheckWasmNativeDefaultValue("native_defaults_publish", config, extraProperties, aot, dotnetWasmFromRuntimePack: !expectWasmBuildNativeForPublish, publish: true);
 
-            // for build
-            // Assert.DoesNotContain($"** WasmBuildNative: '{buildValue.ToString().ToLower()}', WasmNativeStrip: 'true', WasmBuildingForNestedPublish: ''", output);
-            // for publish
-            Assert.Contains($"** WasmBuildNative: '{expectWasmBuildNativeForPublish.ToString().ToLower()}', WasmNativeStrip: 'true', WasmBuildingForNestedPublish: 'true'", output);
-            Assert.Contains("Stopping the build", output);
+            InferAndCheckPropertyValues(line, isPublish: true, wasmBuildNative: expectWasmBuildNativeForPublish, config: config);
         }
 #pragma warning restore xunit1026
 
         public static TheoryData<string, string, bool, bool> SetWasmNativeStripExplicitlyTestData(bool publish) => new()
         {
-            {"Debug", "<WasmNativeStrip>true</WasmNativeStrip>", false, true },
-            {"Release", "<WasmNativeStrip>true</WasmNativeStrip>", publish, true },
-            {"Debug", "<WasmNativeStrip>false</WasmNativeStrip>", true, false },
-            {"Release", "<WasmNativeStrip>false</WasmNativeStrip>", true, false }
+            {"Debug", "<WasmNativeStrip>true</WasmNativeStrip>",    /*wasmBuildNative*/ false,   /*wasmNativeStrip*/ true },
+            {"Release", "<WasmNativeStrip>true</WasmNativeStrip>",  /*wasmBuildNative*/ publish, /*wasmNativeStrip*/ true },
+            {"Debug", "<WasmNativeStrip>false</WasmNativeStrip>",   /*wasmBuildNative*/ true,    /*wasmNativeStrip*/ false },
+            {"Release", "<WasmNativeStrip>false</WasmNativeStrip>", /*wasmBuildNative*/ true,    /*wasmNativeStrip*/ false }
         };
 
         public static TheoryData<string, string, bool, bool> SetWasmNativeStripExplicitlyWithWasmBuildNativeTestData() => new()
@@ -147,10 +139,13 @@ namespace Wasm.Build.Tests
         [MemberData(nameof(SetWasmNativeStripExplicitlyWithWasmBuildNativeTestData))]
         public void WasmNativeStripDefaultWithBuild(string config, string extraProperties, bool expectedWasmBuildNativeValue, bool expectedWasmNativeStripValue)
         {
-            string output = CheckWasmNativeDefaultValue("native_strip_defaults", config, extraProperties, aot: false, dotnetWasmFromRuntimePack: !expectedWasmBuildNativeValue, publish: false);
+            (string output, string? line) = CheckWasmNativeDefaultValue("native_strip_defaults", config, extraProperties, aot: false, dotnetWasmFromRuntimePack: !expectedWasmBuildNativeValue, publish: false);
 
-            Assert.Contains($"** WasmBuildNative: '{expectedWasmBuildNativeValue.ToString().ToLower()}', WasmNativeStrip: '{expectedWasmNativeStripValue.ToString().ToLower()}', WasmBuildingForNestedPublish: ''", output);
-            Assert.Contains("Stopping the build", output);
+            CheckPropertyValues(line,
+                                wasmBuildNative: expectedWasmBuildNativeValue,
+                                wasmNativeStrip: expectedWasmNativeStripValue,
+                                wasmNativeDebugSymbols: true,
+                                wasmBuildingForNestedPublish: null);
         }
 
         [Theory]
@@ -158,37 +153,38 @@ namespace Wasm.Build.Tests
         [MemberData(nameof(SetWasmNativeStripExplicitlyWithWasmBuildNativeTestData))]
         public void WasmNativeStripDefaultWithPublish(string config, string extraProperties, bool expectedWasmBuildNativeValue, bool expectedWasmNativeStripValue)
         {
-            string output = CheckWasmNativeDefaultValue("native_strip_defaults", config, extraProperties, aot: false, dotnetWasmFromRuntimePack: !expectedWasmBuildNativeValue, publish: true);
+            (string output, string? line) = CheckWasmNativeDefaultValue("native_strip_defaults", config, extraProperties, aot: false, dotnetWasmFromRuntimePack: !expectedWasmBuildNativeValue, publish: true);
 
-            Assert.Contains($"** WasmBuildNative: '{expectedWasmBuildNativeValue.ToString().ToLower()}', WasmNativeStrip: '{expectedWasmNativeStripValue.ToString().ToLower()}', WasmBuildingForNestedPublish: 'true'", output);
-            Assert.Contains("Stopping the build", output);
+            CheckPropertyValues(line,
+                                wasmBuildNative: expectedWasmBuildNativeValue,
+                                wasmNativeStrip: expectedWasmNativeStripValue,
+                                wasmNativeDebugSymbols: true,
+                                wasmBuildingForNestedPublish: true);
         }
 
         [Theory]
         /* always relink */
-        [InlineData("Debug",   "",   /*build*/ true, /*publish*/ true)]
-        [InlineData("Release", "",   /*build*/ true, /*publish*/ true)]
-        [InlineData("Release", "<PublishTrimmed>false</PublishTrimmed>", /*build*/ true, /*publish*/ true)]
-        public void WithNativeReference(string config, string extraProperties, bool buildValue, bool publishValue)
+        [InlineData("Debug",   "",   /*publish*/ false)]
+        [InlineData("Debug",   "",   /*publish*/ true)]
+        [InlineData("Release", "",   /*publish*/ false)]
+        [InlineData("Release", "",   /*publish*/ true)]
+        [InlineData("Release", "<PublishTrimmed>false</PublishTrimmed>", /*publish*/ true)]
+        public void WithNativeReference(string config, string extraProperties, bool publish)
         {
             string nativeLibPath = Path.Combine(BuildEnvironment.TestAssetsPath, "native-libs", "native-lib.o");
             string nativeRefItem = @$"<NativeFileReference Include=""{nativeLibPath}"" />";
-            string output = CheckWasmNativeDefaultValue("native_defaults_publish",
+            (string output, string? line) = CheckWasmNativeDefaultValue("native_defaults_publish",
                                                         config,
                                                         extraProperties,
                                                         aot: false,
-                                                        dotnetWasmFromRuntimePack: !publishValue,
-                                                        publish: true,
+                                                        dotnetWasmFromRuntimePack: !publish,
+                                                        publish: publish,
                                                         extraItems: nativeRefItem);
 
-            // for build - FIXME:
-             Assert.DoesNotContain($"** WasmBuildNative: '{buildValue.ToString().ToLower()}', WasmBuildingForNestedPublish: ''", output);
-            // for publish
-            Assert.Contains($"** WasmBuildNative: '{publishValue.ToString().ToLower()}', WasmNativeStrip: 'true', WasmBuildingForNestedPublish: 'true'", output);
-            Assert.Contains("Stopping the build", output);
+            InferAndCheckPropertyValues(line, isPublish: publish, wasmBuildNative: true, config: config);
         }
 
-        private string CheckWasmNativeDefaultValue(string projectName,
+        private (string, string?) CheckWasmNativeDefaultValue(string projectName,
                                                    string config,
                                                    string extraProperties,
                                                    bool aot,
@@ -201,7 +197,7 @@ namespace Wasm.Build.Tests
 
             string printValueTarget = @"
                 <Target Name=""PrintWasmBuildNative"" AfterTargets=""_BeforeWasmBuildApp"">
-                    <Message Text=""** WasmBuildNative: '$(WasmBuildNative)', WasmNativeStrip: '$(WasmNativeStrip)', WasmBuildingForNestedPublish: '$(WasmBuildingForNestedPublish)'"" Importance=""High"" />
+                    <Message Text=""** WasmBuildNative: '$(WasmBuildNative)', WasmNativeStrip: '$(WasmNativeStrip)', WasmNativeDebugSymbols: '$(WasmNativeDebugSymbols)', WasmBuildingForNestedPublish: '$(WasmBuildingForNestedPublish)'"" Importance=""High"" />
                 " + (publish
                         ? @"<Error Text=""Stopping the build"" Condition=""$(WasmBuildingForNestedPublish) == 'true'"" />"
                         : @"<Error Text=""Stopping the build"" />")
@@ -223,7 +219,32 @@ namespace Wasm.Build.Tests
                                                     BuildOnlyAfterPublish: false,
                                                     Publish: publish));
 
-            return output;
+            Assert.Contains("Stopping the build", output);
+
+            Match m = s_regex.Match(output);
+            Assert.Equal(1, m.Groups.Count);
+            return (output, m.Success ? m.Groups[0]?.ToString() : null);
+        }
+
+        private void InferAndCheckPropertyValues(string? line, bool isPublish, bool wasmBuildNative, string config)
+        {
+            bool expectedWasmNativeStripValue;
+            if (!isPublish && wasmBuildNative && config == "Debug")
+                expectedWasmNativeStripValue = false;
+            else
+                expectedWasmNativeStripValue = true;
+
+            CheckPropertyValues(line, wasmBuildNative, expectedWasmNativeStripValue, /*wasmNativeDebugSymbols*/true, isPublish);
+        }
+
+        private void CheckPropertyValues(string? line, bool wasmBuildNative, bool wasmNativeStrip, bool wasmNativeDebugSymbols, bool? wasmBuildingForNestedPublish)
+        {
+            Assert.NotNull(line);
+            Assert.Contains($"** WasmBuildNative: '{wasmBuildNative.ToString().ToLower()}', " +
+                            $"WasmNativeStrip: '{wasmNativeStrip.ToString().ToLower()}', " +
+                            $"WasmNativeDebugSymbols: '{wasmNativeDebugSymbols.ToString().ToLower()}', " +
+                            $"WasmBuildingForNestedPublish: '{(wasmBuildingForNestedPublish.HasValue && wasmBuildingForNestedPublish == true ? "true" : "")}'",
+                        line);
         }
     }
 }

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -22,7 +22,6 @@
       $(_BeforeWasmBuildAppDependsOn);
       _SetupEmscripten;
       _SetWasmBuildNativeDefaults;
-      _SetWasmNativeStripDefault;
       _ReadEmccProps
     </_BeforeWasmBuildAppDependsOn>
 
@@ -119,6 +118,7 @@
       <_BoolPropertiesThatTriggerRelinking Include="InvariantTimezone" DefaultValueInRuntimePack="false" />
       <_BoolPropertiesThatTriggerRelinking Include="InvariantGlobalization" DefaultValueInRuntimePack="false" />
       <_BoolPropertiesThatTriggerRelinking Include="WasmNativeStrip" DefaultValueInRuntimePack="true" />
+      <!--<_BoolPropertiesThatTriggerRelinking Include="WasmNativeDebugSymbols" DefaultValueInRuntimePack="true" />-->
     </ItemGroup>
 
     <PropertyGroup>
@@ -133,7 +133,6 @@
       <WasmBuildNative Condition="'$(RunAOTCompilation)' == 'true' and '$(RunAOTCompilationAfterBuild)' == 'true'">true</WasmBuildNative>
 
       <WasmBuildNative Condition="'$(WasmBuildNative)' == '' and @(NativeFileReference->Count()) > 0" >true</WasmBuildNative>
-      <WasmBuildNative Condition="'$(WasmBuildNative)' == ''">false</WasmBuildNative>
     </PropertyGroup>
 
     <!-- When Publishing -->
@@ -147,8 +146,21 @@
 
       <!-- default to relinking in Release config -->
       <WasmBuildNative Condition="'$(WasmBuildNative)' == '' and '$(Configuration)' == 'Release'">true</WasmBuildNative>
+    </PropertyGroup>
 
+    <PropertyGroup>
       <WasmBuildNative Condition="'$(WasmBuildNative)' == ''">false</WasmBuildNative>
+    </PropertyGroup>
+
+    <!-- Default with nothing set: Build+relink+config=debug -->
+    <PropertyGroup Condition="'$(WasmNativeDebugSymbols)' == '' and '$(WasmNativeStrip)' == '' and '$(WasmBuildingForNestedPublish)' != 'true' and '$(WasmBuildNative)' == 'true' and '$(Configuration)' == 'Debug'">
+      <WasmNativeDebugSymbols>true</WasmNativeDebugSymbols>
+      <WasmNativeStrip>false</WasmNativeStrip>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <WasmNativeDebugSymbols Condition="'$(WasmNativeDebugSymbols)' == ''">true</WasmNativeDebugSymbols>
+      <WasmNativeStrip Condition="'$(WasmNativeStrip)' == ''">true</WasmNativeStrip>
     </PropertyGroup>
 
     <!-- If we want to default to true, and sdk is missing, then just warn, and set it to false -->
@@ -157,14 +169,6 @@
 
     <PropertyGroup>
       <WasmBuildNative Condition="'$(WasmBuildNative)' == 'true' and '$(_IsEMSDKMissing)' == 'true'">false</WasmBuildNative>
-    </PropertyGroup>
-  </Target>
-
-  <Target Name="_SetWasmNativeStripDefault" Condition="'$(WasmNativeStrip)' == ''">
-    <PropertyGroup>
-      <!-- Build+relink+config=debug -->
-      <WasmNativeStrip Condition="'$(WasmBuildingForNestedPublish)' != 'true' and '$(WasmBuildNative)' == 'true' and '$(Configuration)' == 'Debug'">false</WasmNativeStrip>
-      <WasmNativeStrip Condition="'$(WasmNativeStrip)' == ''">true</WasmNativeStrip>
     </PropertyGroup>
   </Target>
 
@@ -178,7 +182,6 @@
       <_MonoAotCrossCompilerPath>@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier','browser-wasm'))</_MonoAotCrossCompilerPath>
       <_EmccDefaultFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'emcc-default.rsp'))</_EmccDefaultFlagsRsp>
       <_EmccDefaultLinkFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'emcc-link.rsp'))</_EmccDefaultLinkFlagsRsp>
-      <WasmNativeDebugSymbols Condition="'$(WasmNativeDebugSymbols)' == ''">true</WasmNativeDebugSymbols>
       <WasmLinkIcalls Condition="'$(WasmLinkIcalls)' == ''">$(WasmBuildNative)</WasmLinkIcalls>
 
       <_WasmICallTablePath>$(_WasmIntermediateOutputPath)icall-table.h</_WasmICallTablePath>
@@ -221,7 +224,7 @@
 
       <_EmccCommonFlags Include="$(_DefaultEmccFlags)" />
       <_EmccCommonFlags Include="$(EmccFlags)" />
-      <_EmccCommonFlags Include="-g"                                       Condition="'$(WasmNativeDebugSymbols)' == 'true'" />
+      <_EmccCommonFlags Include="-g"                                       Condition="'$(WasmNativeStrip)' == 'false'" />
       <_EmccCommonFlags Include="-v"                                       Condition="'$(EmccVerbose)' != 'false'" />
       <_EmccCommonFlags Include="-s DISABLE_EXCEPTION_CATCHING=0"          Condition="'$(WasmEnableExceptionHandling)' == 'false'" />
       <_EmccCommonFlags Include="-fwasm-exceptions"                        Condition="'$(WasmEnableExceptionHandling)' == 'true'" />
@@ -249,6 +252,7 @@
       <_EmccCFlags Include="-emit-llvm" />
 
       <_EmccCFlags Include="&quot;-I%(_EmccIncludePaths.Identity)&quot;" />
+      <_EmccCFlags Include="-g"                                Condition="'$(WasmNativeDebugSymbols)' == 'true'" />
 
       <!-- Adding optimization flag at the top, so it gets precedence -->
       <_EmccLDFlags Include="$(EmccLinkOptimizationFlag)" />

--- a/src/mono/wasm/runtime/es6/dotnet.es6.pre.js
+++ b/src/mono/wasm/runtime/es6/dotnet.es6.pre.js
@@ -1,3 +1,5 @@
 if (_nativeModuleLoaded) throw new Error("Native module already loaded");
 _nativeModuleLoaded = true;
 createDotnetRuntime = Module = createDotnetRuntime(Module);
+Module["getWasmIndirectFunctionTable"] = function () { return wasmTable; }
+Module["getMemory"] = function () { return wasmMemory; }

--- a/src/mono/wasm/runtime/jiterpreter-jit-call.ts
+++ b/src/mono/wasm/runtime/jiterpreter-jit-call.ts
@@ -281,7 +281,7 @@ export function mono_jiterp_do_jit_call_indirect(
                     jit_call_cb: jitCallCb,
                 },
                 m: {
-                    h: (<any>Module).asm.memory
+                    h: (<any>Module).getMemory()
                 },
             });
             const impl = instance.exports.do_jit_call_indirect;

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -239,9 +239,12 @@ export class WasmBuilder {
     }
 
     getWasmImports(): WebAssembly.Imports {
+        const memory = (<any>Module).getMemory();
+        mono_assert(memory instanceof WebAssembly.Memory, () => `expected heap import to be WebAssembly.Memory but was ${memory}`);
+
         const result: any = {
             c: <any>this.getConstants(),
-            m: { h: (<any>Module).asm.memory },
+            m: { h: memory },
             // f: { f: getWasmFunctionTable() },
         };
 
@@ -1589,7 +1592,7 @@ export function copyIntoScratchBuffer(src: NativePointer, size: number): NativeP
 
 export function getWasmFunctionTable() {
     if (!wasmTable)
-        wasmTable = (<any>Module)["asm"]["__indirect_function_table"];
+        wasmTable = Module.getWasmIndirectFunctionTable();
     if (!wasmTable)
         throw new Error("Module did not export the indirect function table");
     return wasmTable;

--- a/src/mono/wasm/runtime/types/internal.ts
+++ b/src/mono/wasm/runtime/types/internal.ts
@@ -454,6 +454,8 @@ export declare interface EmscriptenModuleInternal {
     ready: Promise<unknown>;
     asm: { memory?: WebAssembly.Memory };
     wasmMemory?: WebAssembly.Memory;
+    getWasmIndirectFunctionTable: any;
+    getMemory: WebAssembly.Memory;
     getWasmTableEntry(index: number): any;
     removeRunDependency(id: string): void;
     addRunDependency(id: string): void;

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -33,7 +33,6 @@
     <_EmccDefaultsRspPath>$(NativeBinDir)src\emcc-default.rsp</_EmccDefaultsRspPath>
     <_EmccCompileRspPath>$(NativeBinDir)src\emcc-compile.rsp</_EmccCompileRspPath>
     <_EmccLinkRspPath>$(NativeBinDir)src\emcc-link.rsp</_EmccLinkRspPath>
-    <WasmNativeStrip Condition="'$(ContinuousIntegrationBuild)' == 'true'">false</WasmNativeStrip>
     <EmSdkLLVMAr>$(EMSDK_PATH)\upstream\bin\llvm-ar</EmSdkLLVMAr>
     <EmSdkLLVMAr Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(EmSdkLLVMAr).exe</EmSdkLLVMAr>
   </PropertyGroup>


### PR DESCRIPTION
[wasm] build: Revert to older behavior for WasmNativeStrip

The earlier change was done in 26ae09784c16dfa6707cd73eca2aeb00a28741d0,
which changed to pass `-g` to the link step also. But that resulted in
increased native file sizes.

Changed sizes for the `minimum blazor template - publish` scenario:


---------------------------------------------------------- | Last rc1 run     | With the change
----------------------------------------------------------|----------------- |------------------
SOD - Minimum Blazor Template - Publish                   |8590723.000 bytes |7889806.000 bytes
Total Uncompressed _framework                             |4304274.000 bytes |4202273.000 bytes
pub/wwwroot/_framework/dotnet.js                          |35722.000 bytes   |35838.000 bytes
pub/wwwroot/_framework/dotnet.native.8.0.0-VERSION.js     |239307.000 bytes  |134566.000 bytes
pub/wwwroot/_framework/dotnet.native.wasm                 |1174394.000 bytes |1148841.000 bytes
pub/wwwroot/_framework/dotnet.runtime.8.0.0-VERSION.js    |221356.000 bytes  |221712.000 bytes


- [wasm] Add getters for __indirect_function_table, and wasmMemory
- [wasm] cleanup corresponding tests
- [wasm] Remove WasmNativeStrip from wasm.proj as it will have no effect

Issue: https://github.com/dotnet/perf-autofiling-issues/issues/20642