### PR TITLE
Use P256 for PCP X.509 test

### DIFF
--- a/src/libraries/System.Security.Cryptography.Cng/tests/ECDiffieHellmanCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/ECDiffieHellmanCngTests.cs
@@ -189,7 +189,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
             Assert.Equal(key1, key2);
         }
 
-        [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
+        [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctionalP256))]
         [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void PlatformCryptoProvider_DeriveKeyMaterial()
         {

--- a/src/libraries/System.Security.Cryptography.Cng/tests/PropertyTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/PropertyTests.cs
@@ -9,23 +9,35 @@ namespace System.Security.Cryptography.Cng.Tests
 {
     public static class PropertyTests
     {
-        [ConditionalTheory(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
-        [InlineData("ECDH_P256", 256)]
-        [InlineData("ECDH_P384", 384)]
-        [InlineData("ECDSA_P256", 256)]
-        [InlineData("ECDSA_P384", 384)]
+        [ConditionalTheory(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctionalP256))]
+        [InlineData("ECDH_P256")]
+        [InlineData("ECDSA_P256")]
         [OuterLoop("Hardware backed key generation takes several seconds.")]
-        public static void CreatePersisted_PlatformEccKeyHasKeySize(string algorithm, int expectedKeySize)
+        public static void CreatePersisted_PlatformEccKeyHasKeySize_P256(string algorithm)
         {
             CngAlgorithm cngAlgorithm = new CngAlgorithm(algorithm);
 
             using (CngPlatformProviderKey platformKey = new CngPlatformProviderKey(cngAlgorithm))
             {
-                Assert.Equal(expectedKeySize, platformKey.Key.KeySize);
+                Assert.Equal(256, platformKey.Key.KeySize);
             }
         }
 
-        [ConditionalTheory(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
+        [ConditionalTheory(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctionalP384))]
+        [InlineData("ECDH_P384")]
+        [InlineData("ECDSA_P384")]
+        [OuterLoop("Hardware backed key generation takes several seconds.")]
+        public static void CreatePersisted_PlatformEccKeyHasKeySize_P384(string algorithm)
+        {
+            CngAlgorithm cngAlgorithm = new CngAlgorithm(algorithm);
+
+            using (CngPlatformProviderKey platformKey = new CngPlatformProviderKey(cngAlgorithm))
+            {
+                Assert.Equal(384, platformKey.Key.KeySize);
+            }
+        }
+
+        [ConditionalTheory(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctionalRsa))]
         [InlineData(1024)]
         [InlineData(2048)]
         [OuterLoop("Hardware backed key generation takes several seconds.")]

--- a/src/libraries/System.Security.Cryptography.Cng/tests/RsaCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/RsaCngTests.cs
@@ -127,7 +127,7 @@ namespace System.Security.Cryptography.Cng.Tests
             RSACng_Ctor_UnusualKeysize(ExpectedKeySize, keyBlob, expected);
         }
 
-        [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
+        [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctionalRsa))]
         [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void RSACng_PlatformCryptoProvider_SignHash_Roundtrip()
         {
@@ -173,7 +173,7 @@ namespace System.Security.Cryptography.Cng.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
+        [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctionalRsa))]
         [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void RSACng_PlatformCryptoProvider_EncryptDecrypt_Roundtrip()
         {

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
@@ -601,7 +601,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
+        [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctionalP256))]
         [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void CreateCertificate_MicrosoftPlatformCryptoProvider_EcdsaKey()
         {
@@ -622,7 +622,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
+        [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctionalRsa))]
         [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void CreateCertificate_MicrosoftPlatformCryptoProvider_RsaKey()
         {

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
@@ -605,7 +605,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void CreateCertificate_MicrosoftPlatformCryptoProvider_EcdsaKey()
         {
-            using (CngPlatformProviderKey platformKey = new CngPlatformProviderKey(CngAlgorithm.ECDsaP384))
+            using (CngPlatformProviderKey platformKey = new CngPlatformProviderKey(CngAlgorithm.ECDsaP256))
             using (ECDsaCng ecdsa = new ECDsaCng(platformKey.Key))
             {
                 CertificateRequest req = new CertificateRequest("CN=potato", ecdsa, HashAlgorithmName.SHA256);


### PR DESCRIPTION
The `ConditionalFact` tests for a functional TPM using P-256. Tests assumed that if the TPM supported P-256, then P-384 is supported as well. This is not always the case - some TPMs implement 256 without support for 384.

This test changes the TPM conditional facts to be per-algorithm.

Fixes #92623 