### PR TITLE
Disable TargetingPack Analyzers

### DIFF
--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -172,9 +172,12 @@
     </ItemGroup>
   </Target>
 
-  <!-- Don't use the TargetingPack Analyzers unless explicitly enabled -->
+  <!-- Don't use the TargetingPack Analyzers for current .NET version unless explicitly enabled -->
   <Target Name="RemoveTargetingPackAnalyzers"
-          Condition="'$(UseLocalTargetingRuntimePack)' != 'true' AND '$(UseTargetingPackAnalyzers)' != 'true'"
+          Condition="'$(UseLocalTargetingRuntimePack)' != 'true' and
+                     '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
+                     '$(TargetFrameworkVersion)' == 'v$(NetCoreAppCurrentVersion)' and
+                     '$(UseTargetingPackAnalyzers)' != 'true'"
           AfterTargets="ResolveTargetingPackAssets">
     <ItemGroup>
       <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.FrameworkReferenceName)' != ''" />

--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -172,6 +172,15 @@
     </ItemGroup>
   </Target>
 
+  <!-- Don't use the TargetingPack Analyzers unless explicitly enabled -->
+  <Target Name="RemoveTargetingPackAnalyzers"
+          Condition="'$(UseLocalTargetingRuntimePack)' != 'true' AND '$(UseTargetingPackAnalyzers)' != 'true'"
+          AfterTargets="ResolveTargetingPackAssets">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.FrameworkReferenceName)' != ''" />
+    </ItemGroup>
+  </Target>
+
   <!-- Update the local targeting pack's version as it's written into the runtimeconfig.json file to select the right framework. -->
   <Target Name="UpdateRuntimeFrameworkVersion"
           Condition="'$(UseLocalTargetingRuntimePack)' == 'true'"


### PR DESCRIPTION
Fix issue introduced in https://github.com/dotnet/runtime/pull/92301

This makes it the default to remove all analyzers that come from the TargetingPack unless specified.

This is important so that we don't mix the LKG binaries in the same process that will later load the live-built binaries.  Doing so can result in the live built binaries being ignored since they have the same assembly name as those already loaded in process.

I considered making this opt-in instead of opt-out, but I don't think we want anything in the repo loading the LKG binaries in the compiler process.