### PR TITLE
JIT: Handle remainder accesses more precisely in physical promotion liveness

### DIFF
--- a/src/coreclr/jit/jitstd/vector.h
+++ b/src/coreclr/jit/jitstd/vector.h
@@ -145,6 +145,7 @@ public:
 
     // cctors
     vector(const vector& vec);
+    vector(vector&& vec);
 
     template <typename Alt, typename AltAllocator>
     explicit vector(const vector<Alt, AltAllocator>& vec);
@@ -194,6 +195,8 @@ public:
     vector& operator=(const vector& vec);
     template <typename Alt, typename AltAllocator>
     vector<T, Allocator>& operator=(const vector<Alt, AltAllocator>& vec);
+
+    vector& operator=(vector&& vec);
 
     reference operator[](size_type n);
     const_reference operator[](size_type n) const;
@@ -326,6 +329,18 @@ vector<T, Allocator>::vector(const vector<T, Allocator>& vec)
     {
         new (m_pArray + i, placement_t()) T(vec.m_pArray[i]);
     }
+}
+
+template <typename T, typename Allocator>
+vector<T, Allocator>::vector(vector<T, Allocator>&& vec)
+    : m_allocator(vec.m_allocator)
+    , m_pArray(vec.m_pArray)
+    , m_nSize(vec.m_nSize)
+    , m_nCapacity(vec.m_nCapacity)
+{
+    vec.m_pArray = nullptr;
+    vec.m_nSize = 0;
+    vec.m_nCapacity = 0;
 }
 
 template <typename T, typename Allocator>
@@ -578,6 +593,20 @@ vector<T, Allocator>& vector<T, Allocator>::operator=(const vector<T, Allocator>
     return *this;
 }
 
+template <typename T, typename Allocator>
+vector<T, Allocator>& vector<T, Allocator>::operator=(vector<T, Allocator>&& vec)
+{
+    m_allocator = vec.m_allocator;
+    m_pArray = vec.m_pArray;
+    m_nSize = vec.m_nSize;
+    m_nCapacity = vec.m_nCapacity;
+
+    vec.m_pArray = nullptr;
+    vec.m_nSize = 0;
+    vec.m_nCapacity = 0;
+
+    return *this;
+}
 
 template <typename T, typename Allocator>
 typename vector<T, Allocator>::reference vector<T, Allocator>::operator[](size_type n)

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -1229,19 +1229,18 @@ public:
             }
 #endif
 
-            StructSegments unpromotedParts =
-                m_prom->SignificantSegments(m_compiler->lvaGetDesc(agg->LclNum)->GetLayout());
+            agg->Unpromoted = m_prom->SignificantSegments(m_compiler->lvaGetDesc(agg->LclNum)->GetLayout());
             for (Replacement& rep : reps)
             {
-                unpromotedParts.Subtract(StructSegments::Segment(rep.Offset, rep.Offset + genTypeSize(rep.AccessType)));
+                agg->Unpromoted.Subtract(StructSegments::Segment(rep.Offset, rep.Offset + genTypeSize(rep.AccessType)));
             }
 
             JITDUMP("  Unpromoted remainder: ");
-            DBEXEC(m_compiler->verbose, unpromotedParts.Dump());
+            DBEXEC(m_compiler->verbose, agg->Unpromoted.Dump());
             JITDUMP("\n\n");
 
             StructSegments::Segment unpromotedSegment;
-            if (unpromotedParts.CoveringSegment(&unpromotedSegment))
+            if (agg->Unpromoted.CoveringSegment(&unpromotedSegment))
             {
                 agg->UnpromotedMin = unpromotedSegment.Start;
                 agg->UnpromotedMax = unpromotedSegment.End;
@@ -1496,6 +1495,31 @@ bool StructSegments::Segment::IntersectsOrAdjacent(const Segment& other) const
 }
 
 //------------------------------------------------------------------------
+// Intersects:
+//   Check if this segment intersects another segment.
+//
+// Parameters:
+//   other - The other segment.
+//
+// Returns:
+//    True if so.
+//
+bool StructSegments::Segment::Intersects(const Segment& other) const
+{
+    if (End <= other.Start)
+    {
+        return false;
+    }
+
+    if (other.End <= Start)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+//------------------------------------------------------------------------
 // Contains:
 //   Check if this segment contains another segment.
 //
@@ -1586,7 +1610,7 @@ void StructSegments::Subtract(const Segment& segment)
         return;
     }
 
-    assert(m_segments[index].IntersectsOrAdjacent(segment));
+    assert(m_segments[index].Intersects(segment));
 
     if (m_segments[index].Contains(segment))
     {
@@ -1676,6 +1700,46 @@ bool StructSegments::CoveringSegment(Segment* result)
 
     result->Start = m_segments[0].Start;
     result->End   = m_segments[m_segments.size() - 1].End;
+    return true;
+}
+
+//------------------------------------------------------------------------
+// Intersects:
+//   Check if a segment intersects with any segment in this segment tree.
+//
+// Parameters:
+//   segment - The segment.
+//
+// Returns:
+//   True if the input segment intersects with any segment in the tree;
+//   otherwise false.
+//
+bool StructSegments::Intersects(const Segment& segment)
+{
+    size_t index = Promotion::BinarySearch<Segment, &Segment::End>(m_segments, segment.Start);
+    if ((ssize_t)index < 0)
+    {
+        index = ~index;
+    }
+    else
+    {
+        // Start == segment[index].End, which makes it non-interesting.
+        index++;
+    }
+
+    if (index >= m_segments.size())
+    {
+        return false;
+    }
+
+    // Here we know Start < segment[index].End. Do they not intersect at all?
+    if (m_segments[index].Start >= segment.End)
+    {
+        // Does not intersect any segment.
+        return false;
+    }
+
+    assert(m_segments[index].Intersects(segment));
     return true;
 }
 

--- a/src/coreclr/jit/promotion.h
+++ b/src/coreclr/jit/promotion.h
@@ -60,6 +60,7 @@ public:
         }
 
         bool IntersectsOrAdjacent(const Segment& other) const;
+        bool Intersects(const Segment& other) const;
         bool Contains(const Segment& other) const;
         void Merge(const Segment& other);
     };
@@ -68,7 +69,7 @@ private:
     jitstd::vector<Segment> m_segments;
 
 public:
-    StructSegments(CompAllocator allocator) : m_segments(allocator)
+    explicit StructSegments(CompAllocator allocator) : m_segments(allocator)
     {
     }
 
@@ -76,6 +77,7 @@ public:
     void Subtract(const Segment& segment);
     bool IsEmpty();
     bool CoveringSegment(Segment* result);
+    bool Intersects(const Segment& segment);
 
 #ifdef DEBUG
     void Dump();
@@ -87,12 +89,14 @@ struct AggregateInfo
 {
     jitstd::vector<Replacement> Replacements;
     unsigned                    LclNum;
+    // Unpromoted parts of the struct local.
+    StructSegments Unpromoted;
     // Min offset in the struct local of the unpromoted part.
     unsigned UnpromotedMin = 0;
     // Max offset in the struct local of the unpromoted part.
     unsigned UnpromotedMax = 0;
 
-    AggregateInfo(CompAllocator alloc, unsigned lclNum) : Replacements(alloc), LclNum(lclNum)
+    AggregateInfo(CompAllocator alloc, unsigned lclNum) : Replacements(alloc), LclNum(lclNum), Unpromoted(alloc)
     {
     }
 

--- a/src/coreclr/jit/promotionliveness.cpp
+++ b/src/coreclr/jit/promotionliveness.cpp
@@ -242,7 +242,7 @@ void PromotionLiveness::MarkUseDef(GenTreeLclVarCommon* lcl, BitVec& useSet, Bit
             }
 
             bool isFullDefOfRemainder = isDef && (agg->UnpromotedMin >= offs) && (agg->UnpromotedMax <= (offs + size));
-            bool isUseOfRemainder = isUse && agg->Unpromoted.Intersects(StructSegments::Segment(offs, offs + size));
+            bool isUseOfRemainder     = isUse && agg->Unpromoted.Intersects(StructSegments::Segment(offs, offs + size));
             MarkIndex(baseIndex, isUseOfRemainder, isFullDefOfRemainder, useSet, defSet);
         }
     }

--- a/src/coreclr/jit/promotionliveness.cpp
+++ b/src/coreclr/jit/promotionliveness.cpp
@@ -242,9 +242,10 @@ void PromotionLiveness::MarkUseDef(GenTreeLclVarCommon* lcl, BitVec& useSet, Bit
             }
 
             bool isFullDefOfRemainder = isDef && (agg->UnpromotedMin >= offs) && (agg->UnpromotedMax <= (offs + size));
+            bool isUseOfRemainder = isUse && agg->Unpromoted.Intersects(StructSegments::Segment(offs, offs + size));
             // TODO-CQ: We could also try to figure out if a use actually touches the remainder, e.g. in some cases
             // a struct use may consist only of promoted fields and does not actually use the remainder.
-            MarkIndex(baseIndex, isUse, isFullDefOfRemainder, useSet, defSet);
+            MarkIndex(baseIndex, isUseOfRemainder, isFullDefOfRemainder, useSet, defSet);
         }
     }
     else
@@ -609,11 +610,9 @@ void PromotionLiveness::FillInLiveness(BitVec& life, BitVec volatileVars, GenTre
             }
             else
             {
-                // TODO-CQ: We could also try to figure out if a use actually touches the remainder, e.g. in some cases
-                // a struct use may consist only of promoted fields and does not actually use the remainder.
                 BitVecOps::AddElemD(&aggTraits, aggDeaths, 0);
 
-                if (isUse)
+                if (isUse && agg->Unpromoted.Intersects(StructSegments::Segment(offs, offs + size)))
                 {
                     BitVecOps::AddElemD(m_bvTraits, life, baseIndex);
                 }

--- a/src/coreclr/jit/promotionliveness.cpp
+++ b/src/coreclr/jit/promotionliveness.cpp
@@ -243,8 +243,6 @@ void PromotionLiveness::MarkUseDef(GenTreeLclVarCommon* lcl, BitVec& useSet, Bit
 
             bool isFullDefOfRemainder = isDef && (agg->UnpromotedMin >= offs) && (agg->UnpromotedMax <= (offs + size));
             bool isUseOfRemainder = isUse && agg->Unpromoted.Intersects(StructSegments::Segment(offs, offs + size));
-            // TODO-CQ: We could also try to figure out if a use actually touches the remainder, e.g. in some cases
-            // a struct use may consist only of promoted fields and does not actually use the remainder.
             MarkIndex(baseIndex, isUseOfRemainder, isFullDefOfRemainder, useSet, defSet);
         }
     }


### PR DESCRIPTION
The liveness pass in physical promotion will currently handle any struct
LCL_FLD access of a physically promoted struct as accessing the
remainder. However, if the LCL_FLD only touches promoted fields then the
remainder is not actually used. There was a TODO around this which this
PR fixes as I stumbled upon a case this would improve.