### PR TITLE
Add tests for `UnsafeAccessor` on fields on generic types

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/UnsafeAccessors.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/UnsafeAccessors.cs
@@ -71,13 +71,12 @@ namespace Internal.IL
                         return GenerateAccessorBadImageFailure(method);
                     }
 
-                    const string ctorName = ".ctor";
-                    context.TargetType = ValidateTargetType(retType);
-                    if (context.TargetType == null)
+                    if (!ValidateTargetType(retType, out context.TargetType))
                     {
                         return GenerateAccessorBadImageFailure(method);
                     }
 
+                    const string ctorName = ".ctor";
                     if (!TrySetTargetMethod(ref context, ctorName, out isAmbiguous))
                     {
                         return GenerateAccessorSpecificFailure(ref context, ctorName, isAmbiguous);
@@ -100,8 +99,7 @@ namespace Internal.IL
                         return GenerateAccessorBadImageFailure(method);
                     }
 
-                    context.TargetType = ValidateTargetType(firstArgType);
-                    if (context.TargetType == null)
+                    if (!ValidateTargetType(firstArgType, out context.TargetType))
                     {
                         return GenerateAccessorBadImageFailure(method);
                     }
@@ -132,8 +130,7 @@ namespace Internal.IL
                         return GenerateAccessorBadImageFailure(method);
                     }
 
-                    context.TargetType = ValidateTargetType(firstArgType);
-                    if (context.TargetType == null)
+                    if (!ValidateTargetType(firstArgType, out context.TargetType))
                     {
                         return GenerateAccessorBadImageFailure(method);
                     }
@@ -221,7 +218,7 @@ namespace Internal.IL
             public FieldDesc TargetField;
         }
 
-        private static TypeDesc ValidateTargetType(TypeDesc targetTypeMaybe)
+        private static bool ValidateTargetType(TypeDesc targetTypeMaybe, out TypeDesc validated)
         {
             TypeDesc targetType = targetTypeMaybe.IsByRef
                 ? ((ParameterizedType)targetTypeMaybe).ParameterType
@@ -232,10 +229,11 @@ namespace Internal.IL
             if ((targetType.IsParameterizedType && !targetType.IsArray)
                 || targetType.IsFunctionPointer)
             {
-                ThrowHelper.ThrowBadImageFormatException();
+                targetType = null;
             }
 
-            return targetType;
+            validated = targetType;
+            return validated != null;
         }
 
         private static bool DoesMethodMatchUnsafeAccessorDeclaration(ref GenerationContext context, MethodDesc method, bool ignoreCustomModifiers)

--- a/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.cs
+++ b/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.cs
@@ -43,7 +43,7 @@ static unsafe class UnsafeAccessorsTests
         private void _mvv() {}
 
         // The "init" is important to have here - custom modifier test.
-        // The signature of set_Prop is 
+        // The signature of set_Prop is
         // instance void modreq([System.Runtime]System.Runtime.CompilerServices.IsExternalInit) set_Prop ( string 'value')
         private string Prop { get; init; }
 
@@ -83,6 +83,33 @@ static unsafe class UnsafeAccessorsTests
         private string _m(string s, ref string sr, in string si) => s;
 
         public string GetFieldValue() => _f;
+    }
+
+    class UserDataGenericClass<T>
+    {
+        public const string StaticGenericFieldName = nameof(_GF);
+        public const string GenericFieldName = nameof(_gf);
+        public const string StaticGenericMethodName = nameof(_GM);
+        public const string GenericMethodName = nameof(_gm);
+
+        public const string StaticFieldName = nameof(_F);
+        public const string FieldName = nameof(_f);
+        public const string StaticMethodName = nameof(_M);
+        public const string MethodName = nameof(_m);
+
+        private static T _GF;
+        private T _gf;
+
+        private static string _F = PrivateStatic;
+        private string _f;
+
+        public UserDataGenericClass() { _f = Private; }
+
+        private static string _GM(T s, ref T sr, in T si) => typeof(T).ToString();
+        private string _gm(T s, ref T sr, in T si) => typeof(T).ToString();
+
+        private static string _M(string s, ref string sr, in string si) => s;
+        private string _m(string s, ref string sr, in string si) => s;
     }
 
     [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
@@ -189,6 +216,23 @@ static unsafe class UnsafeAccessorsTests
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/92633")]
+    public static void Verify_AccessStaticFieldGenericClass()
+    {
+        Console.WriteLine($"Running {nameof(Verify_AccessStaticFieldGenericClass)}");
+
+        Assert.Equal(PrivateStatic, GetPrivateStaticFieldInt((UserDataGenericClass<int>)null));
+
+        Assert.Equal(PrivateStatic, GetPrivateStaticFieldString((UserDataGenericClass<string>)null));
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=UserDataGenericClass<int>.StaticFieldName)]
+        extern static ref string GetPrivateStaticFieldInt(UserDataGenericClass<int> d);
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=UserDataGenericClass<string>.StaticFieldName)]
+        extern static ref string GetPrivateStaticFieldString(UserDataGenericClass<string> d);
+    }
+
+    [Fact]
     public static void Verify_AccessStaticFieldValue()
     {
         Console.WriteLine($"Running {nameof(Verify_AccessStaticFieldValue)}");
@@ -213,6 +257,23 @@ static unsafe class UnsafeAccessorsTests
 
         [UnsafeAccessor(UnsafeAccessorKind.Field, Name=UserDataValue.FieldName)]
         extern static ref string GetPrivateField(ref UserDataValue d);
+    }
+
+    [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/92633")]
+    public static void Verify_AccessFieldGenericClass()
+    {
+        Console.WriteLine($"Running {nameof(Verify_AccessFieldGenericClass)}");
+
+        Assert.Equal(Private, GetPrivateFieldInt(new UserDataGenericClass<int>()));
+
+        Assert.Equal(Private, GetPrivateFieldString(new UserDataGenericClass<string>()));
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name=UserDataGenericClass<int>.FieldName)]
+        extern static ref string GetPrivateFieldInt(UserDataGenericClass<int> d);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name=UserDataGenericClass<string>.FieldName)]
+        extern static ref string GetPrivateFieldString(UserDataGenericClass<string> d);
     }
 
     [Fact]


### PR DESCRIPTION
Add tests for the currently unsupported scenario described in https://github.com/dotnet/runtime/issues/92633.

Fix ILC to handle compiling `UnsafeAccessorsTests`.

The `UnsafeAccessorsTests` project now compiles and passes on CoreCLR and NAOT.