### PR TITLE
Enable all interop generators if any are enabled

### DIFF
--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -56,13 +56,15 @@
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\LibraryImportGenerator\LibraryImportGenerator.csproj"
                       ReferenceOutputAssembly="false"
                       OutputItemType="Analyzer"
-                      SetConfiguration="Configuration=$(LibrariesConfiguration)"
-                      Condition="@(EnabledGenerators->AnyHaveMetadataValue('Identity', 'LibraryImportGenerator'))" />
+                      SetConfiguration="Configuration=$(LibrariesConfiguration)" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\ComInterfaceGenerator\ComInterfaceGenerator.csproj"
                       ReferenceOutputAssembly="false"
                       OutputItemType="Analyzer"
-                      SetConfiguration="Configuration=$(LibrariesConfiguration)"
-                      Condition="@(EnabledGenerators->AnyHaveMetadataValue('Identity', 'ComInterfaceGenerator'))" />
+                      SetConfiguration="Configuration=$(LibrariesConfiguration)" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer"
+                      SetConfiguration="Configuration=$(LibrariesConfiguration)" />
   </ItemGroup>
 
   <Target Name="ConfigureGenerators"


### PR DESCRIPTION
It looks like we enable only a few of the live generators at a time when we should enable all if there are any that reference Microsoft.Interop.SourceGeneration

Fixes https://github.com/dotnet/runtime/issues/92655 on my machine