### PR TITLE
Make it possible to preinitialize HW intrinsic IsSupported

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/HardwareIntrinsicILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/HardwareIntrinsicILProvider.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.IL;
+using Internal.IL.Stubs;
+using Internal.JitInterface;
+using Internal.TypeSystem;
+
+namespace ILCompiler
+{
+    public sealed class HardwareIntrinsicILProvider : ILProvider
+    {
+        private readonly InstructionSetSupport _isaSupport;
+        private readonly TypeSystemContext _context;
+        private readonly FieldDesc _isSupportedField;
+        private readonly ILProvider _nestedProvider;
+        private readonly Dictionary<string, InstructionSet> _instructionSetMap;
+
+        public HardwareIntrinsicILProvider(InstructionSetSupport isaSupport, FieldDesc isSupportedField, ILProvider nestedProvider)
+        {
+            _isaSupport = isaSupport;
+            _context = isSupportedField.Context;
+            _isSupportedField = isSupportedField;
+            _nestedProvider = nestedProvider;
+
+            _instructionSetMap = new Dictionary<string, InstructionSet>();
+            foreach (var instructionSetInfo in InstructionSetFlags.ArchitectureToValidInstructionSets(_context.Target.Architecture))
+            {
+                if (instructionSetInfo.ManagedName != "")
+                    _instructionSetMap.Add(instructionSetInfo.ManagedName, instructionSetInfo.InstructionSet);
+            }
+        }
+
+        public override MethodIL GetMethodIL(MethodDesc method)
+        {
+            TypeDesc owningType = method.OwningType;
+            string intrinsicId = InstructionSetSupport.GetHardwareIntrinsicId(_context.Target.Architecture, owningType);
+            if (!string.IsNullOrEmpty(intrinsicId)
+                && HardwareIntrinsicHelpers.IsIsSupportedMethod(method))
+            {
+                InstructionSet instructionSet = _instructionSetMap[intrinsicId];
+
+                bool isSupported = _isaSupport.IsInstructionSetSupported(instructionSet);
+                bool isOptimisticallySupported = _isaSupport.OptimisticFlags.HasInstructionSet(instructionSet);
+
+                // If this is an instruction set that is optimistically supported, but is not one of the
+                // intrinsics that are known to be always available, emit IL that checks the support level
+                // at runtime.
+                if (!isSupported && isOptimisticallySupported)
+                {
+                    return HardwareIntrinsicHelpers.EmitIsSupportedIL(method, _isSupportedField, instructionSet);
+                }
+                else
+                {
+                    ILOpcode flag = isSupported ? ILOpcode.ldc_i4_1 : ILOpcode.ldc_i4_0;
+                    return new ILStubMethodIL(method,
+                        new byte[] { (byte)flag, (byte)ILOpcode.ret },
+                        Array.Empty<LocalVariableDefinition>(),
+                        null);
+                }
+            }
+
+            return _nestedProvider.GetMethodIL(method);
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -451,6 +451,7 @@
     <Compile Include="Compiler\GeneratingMetadataManager.cs" />
     <Compile Include="Compiler\GenericRootProvider.cs" />
     <Compile Include="Compiler\HardwareIntrinsicHelpers.Aot.cs" />
+    <Compile Include="Compiler\HardwareIntrinsicILProvider.cs" />
     <Compile Include="Compiler\IInliningPolicy.cs" />
     <Compile Include="Compiler\Logging\NativeAotFatalErrorException.cs" />
     <Compile Include="Compiler\ManifestResourceBlockingPolicy.cs" />

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -20,6 +20,7 @@ using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
 using ILCompiler.Dataflow;
+using ILCompiler.DependencyAnalysis;
 using ILLink.Shared;
 
 using Debug = System.Diagnostics.Debug;
@@ -142,6 +143,11 @@ namespace ILCompiler
 
             if (typeSystemContext.InputFilePaths.Count == 0)
                 throw new CommandLineException("No input files specified");
+
+            ilProvider = new HardwareIntrinsicILProvider(
+                instructionSetSupport,
+                new ExternSymbolMappedField(typeSystemContext.GetWellKnownType(WellKnownType.Int32), "g_cpuFeatures"),
+                ilProvider);
 
             SecurityMitigationOptions securityMitigationOptions = 0;
             string guard = Get(_command.Guard);

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
 
 using BindingFlags = System.Reflection.BindingFlags;
 
@@ -14,6 +15,7 @@ internal class Program
     private static int Main()
     {
 #if !MULTIMODULE_BUILD
+        TestHardwareIntrinsics.Run();
         TestLdstr.Run();
         TestException.Run();
         TestThreadStaticNotInitialized.Run();
@@ -55,6 +57,39 @@ internal class Program
 #endif
 
         return 100;
+    }
+}
+
+class TestHardwareIntrinsics
+{
+    class Simple1
+    {
+        public static bool IsSseSupported = Sse.IsSupported;
+    }
+
+    class Simple2
+    {
+        public static bool IsAvxVnniSupported = AvxVnni.IsSupported;
+    }
+
+    class Complex
+    {
+        public static bool IsPopcntSupported = Popcnt.IsSupported;
+    }
+
+    public static void Run()
+    {
+        Assert.IsPreinitialized(typeof(Simple1));
+        Assert.AreEqual(Sse.IsSupported, Simple1.IsSseSupported);
+
+        Assert.IsPreinitialized(typeof(Simple2));
+        Assert.AreEqual(AvxVnni.IsSupported, Simple2.IsAvxVnniSupported);
+
+        if (RuntimeInformation.ProcessArchitecture is Architecture.X86 or Architecture.X64)
+            Assert.IsLazyInitialized(typeof(Complex));
+        else
+            Assert.IsPreinitialized(typeof(Complex));
+        Assert.AreEqual(Popcnt.IsSupported, Complex.IsPopcntSupported);
     }
 }
 


### PR DESCRIPTION
* Move the IL rewriting for HW intrinsice `IsSuported` calls to `ILProvider` from `RyuJitCompilation`
* Also rewrite constant true/false

Cc @dotnet/ilc-contrib 