### PR TITLE
Define bool as Interop.BOOL to prevent upper bytes setting native bool

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -62,12 +62,12 @@ namespace System.Runtime
         [RuntimeExport("RhCollect")]
         internal static void RhCollect(int generation, InternalGCCollectionMode mode, bool lowMemoryP = false)
         {
-            RhpCollect(generation, mode, lowMemoryP);
+            RhpCollect(generation, mode, lowMemoryP ? Interop.BOOL.TRUE : Interop.BOOL.FALSE);
         }
 
         [DllImport(Redhawk.BaseName)]
         [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
-        private static extern void RhpCollect(int generation, InternalGCCollectionMode mode, bool lowMemoryP);
+        private static extern void RhpCollect(int generation, InternalGCCollectionMode mode, Interop.BOOL lowMemoryP);
 
         [RuntimeExport("RhGetGcTotalMemory")]
         internal static long RhGetGcTotalMemory()


### PR DESCRIPTION
This PR fixes an issue with NativeAOT-LLVM and possibly other native AOT targets where the bool passed to `RhpCollect` was not passed as `Interop.BOOL` leading to the upper bytes being observed as part of the native bool.

cc @SingleAccretion 
cc @AaronRobinsonMSFT 
cc @jkotas