### PR TITLE
Add plain Vector128 support to IndexOfAnyAsciiSearcher

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
@@ -233,7 +233,7 @@ namespace System.Buffers
         {
             var valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
 
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported &&
+            if (Vector128.IsHardwareAccelerated &&
                 !ShouldUseSimpleLoop(searchSpaceLength, valuesLength) &&
                 IndexOfAnyAsciiSearcher.TryIndexOfAnyExcept(ref searchSpace, searchSpaceLength, valuesSpan, out int index))
             {
@@ -265,7 +265,7 @@ namespace System.Buffers
         {
             var valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
 
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported &&
+            if (Vector128.IsHardwareAccelerated &&
                 !ShouldUseSimpleLoop(searchSpaceLength, valuesLength) &&
                 IndexOfAnyAsciiSearcher.TryLastIndexOfAnyExcept(ref searchSpace, searchSpaceLength, valuesSpan, out int index))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
@@ -20,7 +20,7 @@ namespace System.Buffers
 
         public ProbabilisticWithAsciiCharSearchValues(scoped ReadOnlySpan<char> values)
         {
-            Debug.Assert(IndexOfAnyAsciiSearcher.IsVectorizationSupported);
+            Debug.Assert(Vector128.IsHardwareAccelerated);
             Debug.Assert(values.ContainsAnyInRange((char)0, (char)127));
 
             IndexOfAnyAsciiSearcher.ComputeAsciiState(values, out _asciiState);
@@ -42,7 +42,7 @@ namespace System.Buffers
 
             // We check whether the first character is ASCII before calling into IndexOfAnyAsciiSearcher
             // in order to minimize the overhead this fast-path has on non-ASCII texts.
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count && char.IsAscii(span[0]))
+            if (span.Length >= Vector128<short>.Count && char.IsAscii(span[0]))
             {
                 // We are using IndexOfAnyAsciiSearcher to search for the first ASCII character in the set, or any non-ASCII character.
                 // We do this by inverting the bitmap and using the opposite search function (Negate instead of DontNegate).
@@ -104,7 +104,7 @@ namespace System.Buffers
 
             // We check whether the first character is ASCII before calling into IndexOfAnyAsciiSearcher
             // in order to minimize the overhead this fast-path has on non-ASCII texts.
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count && char.IsAscii(span[0]))
+            if (span.Length >= Vector128<short>.Count && char.IsAscii(span[0]))
             {
                 // Do a regular IndexOfAnyExcept for the ASCII characters. The search will stop if we encounter a non-ASCII char.
                 offset = IndexOfAnyAsciiSearcher.IndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, TOptimizations>(
@@ -140,7 +140,7 @@ namespace System.Buffers
         {
             // We check whether the last character is ASCII before calling into IndexOfAnyAsciiSearcher
             // in order to minimize the overhead this fast-path has on non-ASCII texts.
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count && char.IsAscii(span[^1]))
+            if (span.Length >= Vector128<short>.Count && char.IsAscii(span[^1]))
             {
                 // We are using IndexOfAnyAsciiSearcher to search for the last ASCII character in the set, or any non-ASCII character.
                 // We do this by inverting the bitmap and using the opposite search function (Negate instead of DontNegate).
@@ -194,7 +194,7 @@ namespace System.Buffers
         {
             // We check whether the last character is ASCII before calling into IndexOfAnyAsciiSearcher
             // in order to minimize the overhead this fast-path has on non-ASCII texts.
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count && char.IsAscii(span[^1]))
+            if (span.Length >= Vector128<short>.Count && char.IsAscii(span[^1]))
             {
                 // Do a regular LastIndexOfAnyExcept for the ASCII characters. The search will stop if we encounter a non-ASCII char.
                 int offset = IndexOfAnyAsciiSearcher.LastIndexOfAnyVectorized<IndexOfAnyAsciiSearcher.Negate, TOptimizations>(

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
@@ -54,7 +54,7 @@ namespace System.Buffers
                 };
             }
 
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && maxInclusive < 128)
+            if (Vector128.IsHardwareAccelerated && maxInclusive < 128)
             {
                 return new AsciiByteSearchValues(values);
             }
@@ -110,7 +110,7 @@ namespace System.Buffers
             }
 
             // IndexOfAnyAsciiSearcher for chars is slower than Any3CharSearchValues, but faster than Any4SearchValues
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && maxInclusive < 128)
+            if (Vector128.IsHardwareAccelerated && maxInclusive < 128)
             {
                 return (Ssse3.IsSupported || PackedSimd.IsSupported) && minInclusive == 0
                     ? new AsciiCharSearchValues<IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle>(values)
@@ -144,7 +144,7 @@ namespace System.Buffers
                 probabilisticValues = newValues;
             }
 
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && minInclusive < 128)
+            if (Vector128.IsHardwareAccelerated && minInclusive < 128)
             {
                 // If we have both ASCII and non-ASCII characters, use an implementation that
                 // does an optimistic ASCII fast-path and then falls back to the ProbabilisticMap.

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasick.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasick.cs
@@ -30,7 +30,7 @@ namespace System.Buffers
         {
             get
             {
-                if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && _startingAsciiChars.Bitmap != default)
+                if (Vector128.IsHardwareAccelerated && _startingAsciiChars.Bitmap != default)
                 {
                     // If there are a lot of starting characters such that we often find one early,
                     // the ASCII fast scan may end up performing worse than checking one character at a time.
@@ -87,7 +87,7 @@ namespace System.Buffers
             Debug.Assert(nodeIndex == 0);
             // We are currently in the root node and trying to find the next position of any starting character.
             // If all the values start with an ASCII character, use a vectorized helper to quickly skip over characters that can't start a match.
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && typeof(TFastScanVariant) == typeof(IndexOfAnyAsciiFastScan))
+            if (Vector128.IsHardwareAccelerated && typeof(TFastScanVariant) == typeof(IndexOfAnyAsciiFastScan))
             {
                 int remainingLength = span.Length - i;
 
@@ -192,7 +192,7 @@ namespace System.Buffers
         FastScan:
             // We are currently in the root node and trying to find the next position of any starting character.
             // If all the values start with an ASCII character, use a vectorized helper to quickly skip over characters that can't start a match.
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && typeof(TFastScanVariant) == typeof(IndexOfAnyAsciiFastScan))
+            if (Vector128.IsHardwareAccelerated && typeof(TFastScanVariant) == typeof(IndexOfAnyAsciiFastScan))
             {
                 if (lowSurrogateUpper != LowSurrogateNotSet)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasickBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasickBuilder.cs
@@ -48,7 +48,7 @@ namespace System.Buffers
                 _nodes[i].OptimizeChildren();
             }
 
-            if (IndexOfAnyAsciiSearcher.IsVectorizationSupported)
+            if (Vector128.IsHardwareAccelerated)
             {
                 GenerateStartingAsciiCharsBitmap();
             }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/perf-autofiling-issues/issues/21818

I believe this should be an okay implementation correctness-wise, but it's up to Mono implementations how efficiently they can handle the `Vector128` paths (e.g. efficiently handing `Vector128.Shuffle` with non-const indices).

@fanyang-mono could you please check how this impacts Mono perf?
We shouldn't merge this without good validation as it will affect most uses of `SearchValues`.