### PR TITLE
Fix Common.Tests.GetPrettyName_CannotRead_ReturnsNull test for root user

### DIFF
--- a/src/libraries/Common/tests/Tests/Interop/OSReleaseTests.cs
+++ b/src/libraries/Common/tests/Tests/Interop/OSReleaseTests.cs
@@ -53,7 +53,7 @@ namespace Common.Tests
             string path = CreateTestFile();
             File.SetUnixFileMode(path, UnixFileMode.None);
 
-            // If user have root permissions, kernel doesn't care about access priviliges,
+            // If user have root permissions, kernel doesn't care about access privileges,
             // so there is no point in expecting System.Exception
             if (!Environment.IsPrivilegedProcess)
             {

--- a/src/libraries/Common/tests/Tests/Interop/OSReleaseTests.cs
+++ b/src/libraries/Common/tests/Tests/Interop/OSReleaseTests.cs
@@ -47,15 +47,9 @@ namespace Common.Tests
             Assert.Null(name);
         }
 
-        [Fact, PlatformSpecific(TestPlatforms.Linux)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotPrivilegedProcess)), PlatformSpecific(TestPlatforms.Linux)]
         public void GetPrettyName_CannotRead_ReturnsNull()
         {
-            // This test only applies for non-root users.
-            if (Environment.IsPrivilegedProcess)
-            {
-                return;
-            }
-
             string path = CreateTestFile();
             File.SetUnixFileMode(path, UnixFileMode.None);
 
@@ -65,15 +59,9 @@ namespace Common.Tests
             Assert.Null(name);
         }
 
-        [Fact, PlatformSpecific(TestPlatforms.Linux)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess)), PlatformSpecific(TestPlatforms.Linux)]
         public void GetPrettyName_NonePrivileges_CanRead_ReturnsNull()
         {
-            // This test only applies for root users.
-            if (!Environment.IsPrivilegedProcess)
-            {
-                return;
-            }
-
             string path = CreateTestFile();
             File.SetUnixFileMode(path, UnixFileMode.None);
 

--- a/src/libraries/Common/tests/Tests/Interop/OSReleaseTests.cs
+++ b/src/libraries/Common/tests/Tests/Interop/OSReleaseTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Text;
 using Xunit;
-using System.Runtime.InteropServices;
 
 namespace Common.Tests
 {
@@ -48,10 +47,6 @@ namespace Common.Tests
             Assert.Null(name);
         }
 
-        [PlatformSpecific(TestPlatforms.Linux)]
-        [DllImport("libc")]
-        private static extern uint getuid();
-
         [Fact, PlatformSpecific(TestPlatforms.Linux)]
         public void GetPrettyName_CannotRead_ReturnsNull()
         {
@@ -60,7 +55,7 @@ namespace Common.Tests
 
             // If user have root permissions, kernel doesn't care about access priviliges,
             // so there is no point in expecting System.Exception
-            if (getuid() != 0)
+            if (!Environment.IsPrivilegedProcess)
             {
                 Assert.ThrowsAny<Exception>(() => File.ReadAllText(path)); 
             }


### PR DESCRIPTION
That test was meant to change privileges of file to `0` and then try to read file, which should resolve in System.Exception, but instead it reads file normally.

I modified test, so it will just check whether file permissions has been set to `None` if user have root permissions, because in that case kernel would ignore privileges check, so the test would fail.

Of course there is an option to change code in corelib instead of test, but I'm not sure if root should be artificially restricted.

Part of https://github.com/dotnet/runtime/issues/84834
cc @tomeksowi @wscho77 @HJLeee @JongHeonChoi @t-mustafin @gbalykov @clamp03 @yurai007 @jkotas 