### PR TITLE
Fold GC.KeepAlive for frozen objects

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5824,9 +5824,15 @@ Compiler::fgWalkResult Compiler::optVNConstantPropCurStmt(BasicBlock* block,
 //
 Compiler::fgWalkResult Compiler::optVNGenericPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree)
 {
-    if (tree->OperIs(GT_KEEPALIVE) && vnStore->IsVNObjHandle(tree->gtGetOp1()->gtVNPair.GetConservative()))
+    if (tree->OperIs(GT_KEEPALIVE))
     {
-        optAssertionProp_Update(gtNewNothingNode(), tree, stmt);
+        const ValueNumPair opVnp = tree->gtGetOp1()->gtVNPair;
+        if (opVnp.BothEqual() && vnStore->IsVNObjHandle(tree->gtGetOp1()->gtVNPair.GetLiberal()))
+        {
+            tree->gtBashToNOP();
+            optAssertionPropagated            = true;
+            optAssertionPropagatedCurrentStmt = true;
+        }
     }
     return WALK_CONTINUE;
 }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7621,7 +7621,7 @@ protected:
 public:
     void optVnNonNullPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
     fgWalkResult optVNConstantPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree, bool* changed);
-    fgWalkResult optVNGenericPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree, bool* changed);
+    fgWalkResult optVNGenericPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
     GenTree* optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test);
     GenTree* optVNConstantPropOnTree(BasicBlock* block, GenTree* tree);
     GenTree* optExtractSideEffListFromConst(GenTree* tree);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7620,7 +7620,8 @@ protected:
 
 public:
     void optVnNonNullPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
-    fgWalkResult optVNConstantPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
+    fgWalkResult optVNConstantPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree, bool* changed);
+    fgWalkResult optVNGenericPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree, bool* changed);
     GenTree* optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test);
     GenTree* optVNConstantPropOnTree(BasicBlock* block, GenTree* tree);
     GenTree* optExtractSideEffListFromConst(GenTree* tree);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -6023,7 +6023,18 @@ bool ValueNumStore::IsVNHandle(ValueNum vn)
 
 bool ValueNumStore::IsVNObjHandle(ValueNum vn)
 {
-    return IsVNHandle(vn) && GetHandleFlags(vn) == GTF_ICON_OBJ_HDL;
+    if (vn == NoVN)
+    {
+        return false;
+    }
+
+    Chunk* c = m_chunks.GetNoExpand(GetChunkNum(vn));
+    if (c->m_attribs == CEA_Handle)
+    {
+        VNHandle* handle = &reinterpret_cast<VNHandle*>(c->m_defs)[ChunkOffset(vn)];
+        return handle->m_flags == GTF_ICON_OBJ_HDL;
+    }
+    return false;
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
Basically, remove `GC.KeepAlive` used for frozen(nongc) objects if JIT can see it.
```cs
void Test()
{
    string s = "hello world";
    GC.KeepAlive(s);
}
```
Codegen diff:
```diff
; Method Runtime_90508:Test():this (FullOpts)
-      mov      rax, 0x22800008D58      ; 'hello world'
       ret    
```

This is mainly needed for code paths in RuntimeType e.g. https://github.com/dotnet/runtime/blob/main/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs#L3381 (where `this` could be a frozen object)