### PR TITLE
[mono][jit] Fuse SIMD extract and insert on arm64

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -12643,12 +12643,14 @@ mono_op_no_side_effects (int opcode)
 	case OP_NOT_NULL:
 	case OP_IL_SEQ_POINT:
 	case OP_RTTYPE:
+#if defined(TARGET_X86) || defined(TARGET_AMD64) || defined(TARGET_WASM) || defined(TARGET_ARM64)
 	case OP_EXTRACT_I1:
 	case OP_EXTRACT_I2:
 	case OP_EXTRACT_I4:
 	case OP_EXTRACT_I8:
 	case OP_EXTRACT_R4:
 	case OP_EXTRACT_R8:
+#endif
 		return TRUE;
 	default:
 		return FALSE;

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -12643,6 +12643,12 @@ mono_op_no_side_effects (int opcode)
 	case OP_NOT_NULL:
 	case OP_IL_SEQ_POINT:
 	case OP_RTTYPE:
+	case OP_EXTRACT_I1:
+	case OP_EXTRACT_I2:
+	case OP_EXTRACT_I4:
+	case OP_EXTRACT_I8:
+	case OP_EXTRACT_R4:
+	case OP_EXTRACT_R8:
 		return TRUE;
 	default:
 		return FALSE;

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -4065,18 +4065,20 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				break;
 			}
 
+			int idx_to = GTMREG_TO_UINT32 (ins->inst_c0) & 0xff;
+			int idx_from = GTMREG_TO_UINT32 (ins->inst_c0) >> 8;
 			if (dreg != sreg1) {
 				if (dreg != sreg2) {
 					arm_neon_mov (code, dreg, sreg1);
-					arm_neon_ins_e(code, t, dreg, sreg2, GTMREG_TO_UINT32 (ins->inst_c0), 0);
+					arm_neon_ins_e(code, t, dreg, sreg2, idx_to, idx_from);
 				} else {
 					arm_neon_mov (code, NEON_TMP_REG, sreg1);
-					arm_neon_ins_e(code, t, NEON_TMP_REG, sreg2, GTMREG_TO_UINT32 (ins->inst_c0), 0);
+					arm_neon_ins_e(code, t, NEON_TMP_REG, sreg2, idx_to, idx_from);
 					arm_neon_mov (code, dreg, NEON_TMP_REG);
 				}
 			} else {
 				g_assert (dreg != sreg2);
-				arm_neon_ins_e(code, t, dreg, sreg2, GTMREG_TO_UINT32 (ins->inst_c0), 0);
+				arm_neon_ins_e(code, t, dreg, sreg2, idx_to, idx_from);
 			}
 			break;
 		}

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1068,41 +1068,42 @@ support_probe_complete:
 	return custom_emit (cfg, fsig, args, klass, intrin_group, info, id, arg0_type, is_64bit);
 }
 
-#ifdef TARGET_ARM64
-static int
-arm64_make_ins_index (int destidx, int srcidx, int numelems)
+static MonoInst*
+emit_vector_insert_element (
+	MonoCompile* cfg, MonoClass* vklass, MonoInst* ins, MonoTypeEnum type, MonoInst* element, 
+	int index, gboolean is_zero_inited)
 {
-	g_assert (destidx < numelems);
-	g_assert (srcidx < numelems);
-	return destidx | (srcidx << 8);
-}
+	int op = type_to_insert_op (type);
+
+	if (is_zero_inited && is_zero_const (element)) {
+			// element already set to zero
+#ifdef TARGET_ARM64
+	} else if (!COMPILE_LLVM (cfg) && element->opcode == type_to_extract_op (type) && 
+		(type == MONO_TYPE_R4 || type == MONO_TYPE_R8)) {
+		// OP_INSERT_Ix inserts from GP reg, not SIMD. Cannot optimize for int types.
+		ins = emit_simd_ins (cfg, vklass, op, ins->dreg, element->sreg1);
+		ins->inst_c0 = index | ((element->inst_c0) << 8);
+		ins->inst_c1 = type;
 #endif
+	} else {
+		ins = emit_simd_ins (cfg, vklass, op, ins->dreg, element->dreg);
+		ins->inst_c0 = index;
+		ins->inst_c1 = type;
+	}
+
+	return ins;
+}
 
 static MonoInst *
 emit_vector_create_elementwise (
 	MonoCompile *cfg, MonoMethodSignature *fsig, MonoType *vtype,
 	MonoTypeEnum type, MonoInst **args)
 {
-	int op = type_to_insert_op (type);
 	MonoClass *vklass = mono_class_from_mono_type_internal (vtype);
 	MonoInst *ins = emit_xzero (cfg, vklass);
-	for (int i = 0; i < fsig->param_count; ++i) {
-		if (is_zero_const (args [i])) {
-			// element already set to zero
-#ifdef TARGET_ARM64
-		} else if (!COMPILE_LLVM (cfg) && args [i]->opcode == type_to_extract_op (type) && 
-			(type == MONO_TYPE_R4 || type == MONO_TYPE_R8)) {
-			// OP_INSERT_Ix inserts from GP reg, not SIMD. Cannot optimize for int types.
-			ins = emit_simd_ins (cfg, vklass, op, ins->dreg, args [i]->sreg1);
-			ins->inst_c0 = arm64_make_ins_index (i, args [i]->inst_c0, fsig->param_count);
-			ins->inst_c1 = type;
-#endif
-		} else {
-			ins = emit_simd_ins (cfg, vklass, op, ins->dreg, args [i]->dreg);
-			ins->inst_c0 = i;
-			ins->inst_c1 = type;
-		}
-	}
+	for (int i = 0; i < fsig->param_count; ++i)
+		emit_vector_insert_element (cfg, vklass, ins, type, args[i], i, TRUE);
+
 	return ins;
 }
 
@@ -2300,31 +2301,12 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 		if (args [1]->opcode == OP_ICONST) {
 			// If the index is provably a constant, we can generate vastly better code.
 			int index = GTMREG_TO_INT (args[1]->inst_c0);
-
 			if (index < 0 || index >= elems) {
 					MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, args [1]->dreg, elems);
 					MONO_EMIT_NEW_COND_EXC (cfg, GE_UN, "ArgumentOutOfRangeException");
 			}
 
-			int insert_op = type_to_insert_op (arg0_type);
-
-#ifdef TARGET_ARM64
-			if (!COMPILE_LLVM (cfg) && args [2]->opcode == type_to_extract_op (arg0_type) && (arg0_type == MONO_TYPE_R4 || arg0_type == MONO_TYPE_R8)) {
-				// Optimize WithElement(GetElement(x, const_1), const_2) into one ins instruction on arm64
-				// OP_INSERT_Ix inserts from GP reg, not SIMD. Cannot optimize for int types.
-				MonoInst* ins = emit_simd_ins (cfg, klass, insert_op, args [0]->dreg, args [2]->sreg1);
-				ins->inst_c0 = arm64_make_ins_index (index, args [2]->inst_c0, elems);
-				ins->inst_c1 = arg0_type;
-				return ins;
-			} 
-			else 
-#endif
-			{
-				MonoInst *ins = emit_simd_ins (cfg, klass, insert_op, args [0]->dreg, args [2]->dreg);
-				ins->inst_c0 = index;
-				ins->inst_c1 = arg0_type;
-				return ins;
-			}
+			return emit_vector_insert_element (cfg, klass, args [0], arg0_type, args [2], index, FALSE);
 		} 
 
 		if (!COMPILE_LLVM (cfg) && fsig->params [0]->type != MONO_TYPE_GENERICINST)
@@ -2725,11 +2707,9 @@ emit_vector_2_3_4 (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *f
 			ins->dreg = dreg;
 			ins->inst_c1 = MONO_TYPE_R4;
 
-			for (int i = 1; i < fsig->param_count; ++i) {
-				ins = emit_simd_ins (cfg, klass, OP_INSERT_R4, ins->dreg, args [i + 1]->dreg);
-				ins->inst_c0 = i;
-				ins->inst_c1 = MONO_TYPE_R4;
-			}
+			for (int i = 1; i < fsig->param_count; ++i)
+				ins = emit_vector_insert_element (cfg, klass, ins, MONO_TYPE_R4, args [i + 1], i, FALSE);
+
 			ins->dreg = dreg;
 
 			if (indirect) {
@@ -2870,19 +2850,9 @@ emit_vector_2_3_4 (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *f
 				MONO_EMIT_NEW_COND_EXC (cfg, GE_UN, "ArgumentOutOfRangeException");
 			}
 
-#ifdef TARGET_ARM64
-			if (!COMPILE_LLVM (cfg) && args [2]->opcode == OP_EXTRACT_R4) {
-				// Optimize x[const_1] = y[const_2] into one ins instruction on arm64
-				// OP_INSERT_Ix inserts from GP reg, not SIMD. Cannot optimize for int types.
-				ins = emit_simd_ins (cfg, klass, OP_INSERT_R4, dreg, args [2]->sreg1);
-				ins->inst_c0 = arm64_make_ins_index (index, args [2]->inst_c0, fsig->param_count);
-				ins->inst_c1 = MONO_TYPE_R4;
-				ins->dreg = dreg;
-				return ins;
-			} 
-			else 
-#endif
-			{
+			if (args [0]->dreg == dreg) {
+				ins = emit_vector_insert_element (cfg, klass, args [0], MONO_TYPE_R4, args [2], index, FALSE);
+			} else {
 				ins = emit_simd_ins (cfg, klass, OP_INSERT_R4, dreg, args [2]->dreg);
 				ins->inst_c0 = index;
 				ins->inst_c1 = MONO_TYPE_R4;

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1102,7 +1102,7 @@ emit_vector_create_elementwise (
 	MonoClass *vklass = mono_class_from_mono_type_internal (vtype);
 	MonoInst *ins = emit_xzero (cfg, vklass);
 	for (int i = 0; i < fsig->param_count; ++i)
-		emit_vector_insert_element (cfg, vklass, ins, type, args[i], i, TRUE);
+		ins = emit_vector_insert_element (cfg, vklass, ins, type, args[i], i, TRUE);
 
 	return ins;
 }


### PR DESCRIPTION
Arm64 has the `ins` instruction which is capable of inserting from a specific lane into another lane. This PR takes advantage of this and fuses constant extract with constant insert (or elementwise constructor). Only `float` and `double` vectors are affected, as the appropriate mono operations for int types are missing. This change affects only mini, not LLVM.

This code:
```cs
private static Vector128<float> DUT1(Vector128<float> x)
{
    return Vector128.Create(
        Vector128.GetElement(x, 1),
        Vector128.GetElement(x, 2),
        Vector128.GetElement(x, 3),
        Vector128.GetElement(x, 0)); 
}
```

Would compile into:
```
0000000000000000        stp     x29, x30, [sp, #-0x30]!
0000000000000004        mov     x29, sp
0000000000000008        stp     x0, x1, [x29, #0x20]
000000000000000c        ldr     q0, [x29, #0x20]
0000000000000010        dup.4s  v4, v0[1]
0000000000000014        dup.4s  v3, v0[2]
0000000000000018        dup.4s  v2, v0[3]
000000000000001c        dup.4s  v1, v0[0]
0000000000000020        eor.16b v0, v0, v0
0000000000000024        mov.s   v0[0], v4[0]
0000000000000028        mov.s   v0[1], v3[0]
000000000000002c        mov.s   v0[2], v2[0]
0000000000000030        mov.s   v0[3], v1[0]
0000000000000034        str     q0, [x29, #0x10]
0000000000000038        ldp     x0, x1, [x29, #0x10]
000000000000003c        mov     sp, x29
0000000000000040        ldp     x29, x30, [sp], #0x30
0000000000000044        ret
```

Current codegen is:
```
0000000000000000        stp     x29, x30, [sp, #-0x30]!
0000000000000004        mov     x29, sp
0000000000000008        stp     x0, x1, [x29, #0x20]
000000000000000c        eor.16b v0, v0, v0
0000000000000010        ldr     q1, [x29, #0x20]
0000000000000014        mov.s   v0[0], v1[1]
0000000000000018        mov.s   v0[1], v1[2]
000000000000001c        mov.s   v0[2], v1[3]
0000000000000020        mov.s   v0[3], v1[0]
0000000000000024        str     q0, [x29, #0x10]
0000000000000028        ldp     x0, x1, [x29, #0x10]
000000000000002c        mov     sp, x29
0000000000000030        ldp     x29, x30, [sp], #0x30
0000000000000034        ret
```
Addresses https://github.com/dotnet/runtime/issues/85166.