### PR TITLE
JIT: Promote size-wise improvements in physical promotion

### DIFF
--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -802,14 +802,27 @@ public:
         if ((cycleImprovementPerInvoc > 0) &&
             ((cycleImprovementPerInvoc * ALLOWED_SIZE_REGRESSION_PER_CYCLE_IMPROVEMENT) >= -sizeImprovement))
         {
-            JITDUMP("  Promoting replacement\n\n");
+            JITDUMP("  Promoting replacement (cycle improvement)\n\n");
+            return true;
+        }
+
+        // Similarly, even for a cycle-wise regression, if we see a large size
+        // wise improvement we may want to promote. The main case is where all
+        // uses are in blocks with bbWeight=0, but we still estimate a
+        // size-wise improvement.
+        const weight_t ALLOWED_CYCLE_REGRESSION_PER_SIZE_IMPROVEMENT = 0.01;
+
+        if ((sizeImprovement > 0) &&
+            ((sizeImprovement * ALLOWED_CYCLE_REGRESSION_PER_SIZE_IMPROVEMENT) >= -cycleImprovementPerInvoc))
+        {
+            JITDUMP("  Promoting replacement (size improvement)\n\n");
             return true;
         }
 
 #ifdef DEBUG
         if (comp->compStressCompile(Compiler::STRESS_PHYSICAL_PROMOTION_COST, 25))
         {
-            JITDUMP("  Promoting replacement due to stress\n\n");
+            JITDUMP("  Promoting replacement (stress)\n\n");
             return true;
         }
 #endif


### PR DESCRIPTION
I hit the following case:
```
Evaluating access byref @000
  Single write-back cost: 3
  Write backs: 0
  Read backs: 0
  Estimated cycle improvement: 0 cycles per invocation
  Estimated size improvement: 2 bytes
Disqualifying replacement
```

These cases happen when the blocks that have candidates for promotion in them have bbWeight equal to 0.

If we estimate a size improvement without a cycle improvement it still makes sense to promote a replacement. More generally, a large size improvement can make up for a small cycle regression, so add a heuristic similar to the existing one for this. I've set it to be quite conservative: we require 100 bytes of size improvement before we allow 1 cycle of regression. This is enough to handle the common case where the cycle improvement is 0 due to the bbWeight = 0.