### PR TITLE
Revert "Remove Latin1CharSearchValues (#91884)"

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -337,7 +337,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CompareInfo.iOS.cs" Condition="'$(IsiOSLike)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CompareOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.Browser.cs" Condition="'$(TargetsBrowser)' == 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.Browser.cs" Condition="'$(TargetsBrowser)' == 'true'"/>
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.Icu.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.iOS.cs" Condition="'$(IsiOSLike)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.Nls.cs" />
@@ -434,6 +434,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\RangeByteSearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\RangeCharSearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\ProbabilisticCharSearchValues.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\Latin1CharSearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\SearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\SearchValues.T.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\SearchValuesDebugView.cs" />
@@ -1305,7 +1306,7 @@
     <Compile Include="$(CommonPath)Interop\Browser\Interop.CompareInfo.cs" Condition="'$(TargetsBrowser)' == 'true'">
       <Link>Common\Interop\Interop.CompareInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)Interop\Browser\Interop.Calendar.cs" Condition="'$(TargetsBrowser)' == 'true'">
+     <Compile Include="$(CommonPath)Interop\Browser\Interop.Calendar.cs" Condition="'$(TargetsBrowser)' == 'true'">
       <Link>Common\Interop\Interop.Calendar.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)Interop\Browser\Interop.Locale.cs" Condition="'$(TargetsBrowser)' == 'true'">

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -337,7 +337,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CompareInfo.iOS.cs" Condition="'$(IsiOSLike)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CompareOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.Browser.cs" Condition="'$(TargetsBrowser)' == 'true'"/>
+    <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.Browser.cs" Condition="'$(TargetsBrowser)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.Icu.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.iOS.cs" Condition="'$(IsiOSLike)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.Nls.cs" />
@@ -1306,7 +1306,7 @@
     <Compile Include="$(CommonPath)Interop\Browser\Interop.CompareInfo.cs" Condition="'$(TargetsBrowser)' == 'true'">
       <Link>Common\Interop\Interop.CompareInfo.cs</Link>
     </Compile>
-     <Compile Include="$(CommonPath)Interop\Browser\Interop.Calendar.cs" Condition="'$(TargetsBrowser)' == 'true'">
+    <Compile Include="$(CommonPath)Interop\Browser\Interop.Calendar.cs" Condition="'$(TargetsBrowser)' == 'true'">
       <Link>Common\Interop\Interop.Calendar.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)Interop\Browser\Interop.Locale.cs" Condition="'$(TargetsBrowser)' == 'true'">

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/BitVector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/BitVector256.cs
@@ -36,6 +36,10 @@ namespace System.Buffers
             c < 128 && ContainsUnchecked(c);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly bool Contains256(char c) =>
+            c < 256 && ContainsUnchecked(c);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly bool Contains(byte b) =>
             ContainsUnchecked(b);
 

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Latin1CharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Latin1CharSearchValues.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Buffers
+{
+    internal sealed class Latin1CharSearchValues : SearchValues<char>
+    {
+        private readonly BitVector256 _lookup;
+
+        public Latin1CharSearchValues(ReadOnlySpan<char> values)
+        {
+            foreach (char c in values)
+            {
+                if (c > 255)
+                {
+                    // The values were modified concurrent with the call to SearchValues.Create
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+                }
+
+                _lookup.Set(c);
+            }
+        }
+
+        internal override char[] GetValues() => _lookup.GetCharValues();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal override bool ContainsCore(char value) =>
+            _lookup.Contains256(value);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal override int IndexOfAny(ReadOnlySpan<char> span) =>
+            IndexOfAny<IndexOfAnyAsciiSearcher.DontNegate>(ref MemoryMarshal.GetReference(span), span.Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal override int IndexOfAnyExcept(ReadOnlySpan<char> span) =>
+            IndexOfAny<IndexOfAnyAsciiSearcher.Negate>(ref MemoryMarshal.GetReference(span), span.Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal override int LastIndexOfAny(ReadOnlySpan<char> span) =>
+            LastIndexOfAny<IndexOfAnyAsciiSearcher.DontNegate>(ref MemoryMarshal.GetReference(span), span.Length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal override int LastIndexOfAnyExcept(ReadOnlySpan<char> span) =>
+            LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate>(ref MemoryMarshal.GetReference(span), span.Length);
+
+        private int IndexOfAny<TNegator>(ref char searchSpace, int searchSpaceLength)
+            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
+        {
+            ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
+            ref char cur = ref searchSpace;
+
+            while (!Unsafe.AreSame(ref cur, ref searchSpaceEnd))
+            {
+                char c = cur;
+                if (TNegator.NegateIfNeeded(_lookup.Contains256(c)))
+                {
+                    return (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
+                }
+
+                cur = ref Unsafe.Add(ref cur, 1);
+            }
+
+            return -1;
+        }
+
+        private int LastIndexOfAny<TNegator>(ref char searchSpace, int searchSpaceLength)
+            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
+        {
+            for (int i = searchSpaceLength - 1; i >= 0; i--)
+            {
+                char c = Unsafe.Add(ref searchSpace, i);
+                if (TNegator.NegateIfNeeded(_lookup.Contains256(c)))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
@@ -6,6 +6,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 
@@ -152,6 +153,13 @@ namespace System.Buffers
                 return (Ssse3.IsSupported || PackedSimd.IsSupported) && probabilisticValues.Contains('\0')
                     ? new ProbabilisticWithAsciiCharSearchValues<IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle>(probabilisticValues)
                     : new ProbabilisticWithAsciiCharSearchValues<IndexOfAnyAsciiSearcher.Default>(probabilisticValues);
+            }
+
+            // We prefer using the ProbabilisticMap over Latin1CharSearchValues if the former is vectorized.
+            if (!(Sse41.IsSupported || AdvSimd.Arm64.IsSupported) && maxInclusive < 256)
+            {
+                // This will also match ASCII values when IndexOfAnyAsciiSearcher is not supported.
+                return new Latin1CharSearchValues(values);
             }
 
             return new ProbabilisticCharSearchValues(probabilisticValues);


### PR DESCRIPTION
This reverts #91884.
Contributes to https://github.com/dotnet/perf-autofiling-issues/issues/21818
Contributes to https://github.com/dotnet/perf-autofiling-issues/issues/21828


In that PR I measured that the throughput of `IndexOfAny` is practically the same between `Latin1CharSearchValues` and its alternative, `ProbabilisticMap`. While that does seem to be the case, `IndexOfAnyExcept` can be much worse with the prob map, as we currently fall back to an `O(n * m)` loop.

I'm reverting the change until we have better alternatives in place.
Runtimes without explicit ISA support, such as some Mono variants with plain `Vector128`, should benefit from changes like https://github.com/dotnet/runtime/pull/92680 for ASCII search values (assuming optimal codegen).
We can also look into using a faster than `O(n * m)` fallback for the prob map case, but that may come with other downsides like a higher memory footprint (e.g. allocating a bitmap for all values).

cc: @stephentoub 