### PR TITLE
[Mono] Disabled failing tests on Mono Android and interpreter lanes to keep CI green

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2849,7 +2849,6 @@
             <Issue>https://github.com/dotnet/runtime/issues/92727</Issue>
         </ExcludeList>
     </ItemGroup>
-    </ItemGroup>
 
 
     <ItemGroup Condition="'$(TargetArchitecture)' == 'wasm' or '$(TargetsAppleMobile)' == 'true'">

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2845,6 +2845,10 @@
         <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventpipe/pauseonstart/**">
             <Issue> needs triage </Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/tracing/runtimeeventsource/nativeruntimeeventsource/**">
+            <Issue>https://github.com/dotnet/runtime/issues/92727</Issue>
+        </ExcludeList>
+    </ItemGroup>
     </ItemGroup>
 
 
@@ -3463,6 +3467,9 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/DllImportSearchPaths/DllImportSearchPathsTest/**">
             <Issue>https://github.com/dotnet/runtime/issues/91388</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/unhandled/unhandled/**">
+            <Issue>https://github.com/dotnet/runtime/issues/92723</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
Trying to make `runtime-extra-platforms` greener