### PR TITLE
Add analyzer support for inline array access

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/CapturedReferenceValue.cs
@@ -20,6 +20,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			case OperationKind.FieldReference:
 			case OperationKind.ParameterReference:
 			case OperationKind.ArrayElementReference:
+			case OperationKind.InlineArrayAccess:
 			case OperationKind.ImplicitIndexerReference:
 				break;
 			case OperationKind.None:

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DynamicallyAccessedMembersCodeFixTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DynamicallyAccessedMembersCodeFixTests.cs
@@ -25,7 +25,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			var test = new VerifyCS.Test {
 				TestCode = source,
 				FixedCode = fixedSource,
-				ReferenceAssemblies = TestCaseUtils.Net6PreviewAssemblies
+				ReferenceAssemblies = TestCaseUtils.NetCoreAppReferencessemblies
 			};
 			test.ExpectedDiagnostics.AddRange (baselineExpected);
 			test.TestState.AnalyzerConfigFiles.Add (

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresAssemblyFilesAnalyzerTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresAssemblyFilesAnalyzerTests.cs
@@ -46,7 +46,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			var test = new VerifyCS.Test {
 				TestCode = source,
 				FixedCode = fixedSource,
-				ReferenceAssemblies = TestCaseUtils.Net6PreviewAssemblies
+				ReferenceAssemblies = TestCaseUtils.NetCoreAppReferencessemblies
 			};
 			test.ExpectedDiagnostics.AddRange (baselineExpected);
 			test.TestState.AnalyzerConfigFiles.Add (

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresDynamicCodeAnalyzerTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresDynamicCodeAnalyzerTests.cs
@@ -44,7 +44,7 @@ namespace System.Diagnostics.CodeAnalysis
 			var test = new VerifyCS.Test {
 				TestCode = source + dynamicCodeAttribute,
 				FixedCode = fixedSource + dynamicCodeAttribute,
-				ReferenceAssemblies = TestCaseUtils.Net6PreviewAssemblies
+				ReferenceAssemblies = TestCaseUtils.NetCoreAppReferencessemblies
 			};
 			test.ExpectedDiagnostics.AddRange (baselineExpected);
 			test.TestState.AnalyzerConfigFiles.Add (

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresUnreferencedCodeAnalyzerTests.cs
@@ -40,7 +40,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 			var test = new VerifyCS.Test {
 				TestCode = source,
 				FixedCode = fixedSource,
-				ReferenceAssemblies = TestCaseUtils.Net6PreviewAssemblies
+				ReferenceAssemblies = TestCaseUtils.NetCoreAppReferencessemblies
 			};
 			test.ExpectedDiagnostics.AddRange (baselineExpected);
 			test.TestState.AnalyzerConfigFiles.Add (

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TestCaseUtils.cs
@@ -24,21 +24,21 @@ namespace ILLink.RoslynAnalyzer.Tests
 	{
 		private static readonly string MonoLinkerTestsCases = "Mono.Linker.Tests.Cases";
 
-		public static readonly ReferenceAssemblies Net6PreviewAssemblies =
+		public static readonly ReferenceAssemblies NetCoreAppReferencessemblies =
 		new ReferenceAssemblies (
 				"net8.0",
-				new PackageIdentity ("Microsoft.NETCore.App.Ref", "8.0.0-alpha.1.23060.19"),
+				new PackageIdentity ("Microsoft.NETCore.App.Ref", "8.0.0-rc.1.23419.4"),
 				Path.Combine ("ref", "net8.0"))
 			.WithNuGetConfigFilePath (Path.Combine (TestCaseUtils.GetRepoRoot (), "NuGet.config"));
 
-		private static ImmutableArray<MetadataReference> s_net6Refs;
+		private static ImmutableArray<MetadataReference> s_netcoreappRefs;
 		public static async ValueTask<ImmutableArray<MetadataReference>> GetNet6References ()
 		{
-			if (s_net6Refs.IsDefault) {
-				var refs = await Net6PreviewAssemblies.ResolveAsync (null, default);
-				ImmutableInterlocked.InterlockedInitialize (ref s_net6Refs, refs);
+			if (s_netcoreappRefs.IsDefault) {
+				var refs = await NetCoreAppReferencessemblies.ResolveAsync (null, default);
+				ImmutableInterlocked.InterlockedInitialize (ref s_netcoreappRefs, refs);
 			}
-			return s_net6Refs;
+			return s_netcoreappRefs;
 		}
 
 		public static string FindTestSuiteDir (string rootDir, string suiteName)

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/UnconditionalSuppressMessageCodeFixTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/UnconditionalSuppressMessageCodeFixTests.cs
@@ -49,7 +49,7 @@ namespace System.Diagnostics.CodeAnalysis
 			var test = new VerifyCSUSMwithRUC.Test {
 				TestCode = source,
 				FixedCode = fixedSource,
-				ReferenceAssemblies = TestCaseUtils.Net6PreviewAssemblies
+				ReferenceAssemblies = TestCaseUtils.NetCoreAppReferencessemblies
 			};
 			test.ExpectedDiagnostics.AddRange (baselineExpected);
 			test.TestState.AnalyzerConfigFiles.Add (
@@ -69,7 +69,7 @@ build_property.{MSBuildPropertyOptionNames.EnableTrimAnalyzer} = true")));
 			var test = new VerifyCSUSMwithRAF.Test {
 				TestCode = source,
 				FixedCode = fixedSource,
-				ReferenceAssemblies = TestCaseUtils.Net6PreviewAssemblies
+				ReferenceAssemblies = TestCaseUtils.NetCoreAppReferencessemblies
 			};
 			test.ExpectedDiagnostics.AddRange (baselineExpected);
 			test.TestState.AnalyzerConfigFiles.Add (
@@ -89,7 +89,7 @@ build_property.{MSBuildPropertyOptionNames.EnableSingleFileAnalyzer} = true")));
 			var test = new VerifyCSUSMwithRDC.Test {
 				TestCode = source + dynamicCodeAttribute,
 				FixedCode = fixedSource + dynamicCodeAttribute,
-				ReferenceAssemblies = TestCaseUtils.Net6PreviewAssemblies
+				ReferenceAssemblies = TestCaseUtils.NetCoreAppReferencessemblies
 			};
 			test.ExpectedDiagnostics.AddRange (baselineExpected);
 			test.TestState.AnalyzerConfigFiles.Add (

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
@@ -274,6 +277,41 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			[Kept]
+			[KeptAttributeAttribute (typeof (InlineArrayAttribute))]
+			[InlineArray (8)]
+			public struct InlineTypeArray
+			{
+				[Kept]
+				public Type t;
+			}
+
+			[Kept]
+			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll))]
+			static void TestInlineArrayElementReferenceAssignment (bool b = true)
+			{
+				var arr1 = new InlineTypeArray ();
+				arr1[0] = GetUnknownType ();
+				var arr2 = new InlineTypeArray ();
+				arr2[0] = GetTypeWithPublicConstructors ();
+				(b ? ref arr1[0] : ref arr2[0]) = GetTypeWithPublicFields ();
+				arr1[0].RequiresAll ();
+				arr2[0].RequiresAll ();
+			}
+
+			// Inline array references are not allowed in conditionals, unlike array references.
+			// static void TestInlineArrayElementAssignment (bool b = true)
+			// {
+			// 	var arr1 = new InlineTypeArray ();
+			// 	arr1[0] = GetUnknownType ();
+			// 	var arr2 = new InlineTypeArray ();
+			// 	arr2[0] = GetTypeWithPublicConstructors ();
+			// 	(b ? arr1 : arr2)[0] = GetTypeWithPublicFields ();
+			// 	arr1[0].RequiresAll ();
+			// 	arr2[0].RequiresAll ();
+			// }
+
+			[Kept]
 			[ExpectedWarning ("IL2074", nameof (_publicMethodsField), nameof (GetUnknownType))]
 			[ExpectedWarning ("IL2074", nameof (_publicPropertiesField), nameof (GetUnknownType))]
 			static void TestNullCoalescingAssignment (bool b = true)
@@ -321,6 +359,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestLocalAssignment ();
 				TestArrayElementReferenceAssignment ();
 				TestArrayElementAssignment ();
+				TestInlineArrayElementReferenceAssignment ();
+				// TestInlineArrayElementAssignment ();
 				TestNullCoalescingAssignment ();
 				TestNullCoalescingAssignmentComplex ();
 				TestDataFlowOnRightHandOfAssignment ();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/InlineArrayDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/InlineArrayDataflow.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -45,8 +45,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public Type value;
 		}
 
-		// Analyzer doesn't understand inline arrays currently - so it doesn't produce a warning here
-		[ExpectedWarning ("IL2065", "GetProperty", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+		[ExpectedWarning ("IL2065", "GetProperty")]
 		static void AccessUnannotatedTypeArray ()
 		{
 			UnannotatedTypeArray a = new UnannotatedTypeArray ();
@@ -64,7 +63,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		}
 
 		// Currently tracking of annotations on inline array values is not implemented
-		[ExpectedWarning("IL2065", "GetProperty", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+		[ExpectedWarning("IL2065", "GetProperty")]
 		static void AccessAnnotatedTypeArray ()
 		{
 			AnnotatedTypeArray a = new AnnotatedTypeArray ();


### PR DESCRIPTION
This allows analysis of inline array access operations, by treating them similarly to array access. However, like ILLink/ILCompiler it doesn't understand inline array creation, so doesn't track them as arrays. The result is that values read out of an inline array are unknown, so this produces dataflow warnings when such a value is passed to a location with dataflow requirements, matching the ILLink/ILCompiler behavior.

Using `InlineArray` required referencing a more recent of the .NET 8 reference assemblies.

Fixes https://github.com/dotnet/runtime/issues/88684