### PR TITLE
Removes redundant code from `JsonCamelCaseNamingPolicy.cs`

### DIFF
--- a/src/libraries/System.Text.Json/Common/JsonCamelCaseNamingPolicy.cs
+++ b/src/libraries/System.Text.Json/Common/JsonCamelCaseNamingPolicy.cs
@@ -15,11 +15,7 @@ namespace System.Text.Json
 #if NETCOREAPP
             return string.Create(name.Length, name, (chars, name) =>
             {
-                name
-#if !NETCOREAPP
-                .AsSpan()
-#endif
-                .CopyTo(chars);
+                name.CopyTo(chars);
                 FixCasing(chars);
             });
 #else


### PR DESCRIPTION
The current code contains a redundant compiler directive.

This section of the code was altered in the following commit: https://github.com/dotnet/runtime/commit/e18a77feff92fe6cdf8b891aa3b44fb1acb972d1

Given that:
> "The minimum supported .NETCoreApp version in the repository is 6.0, hence both defines can be replaced with the versionless NETCOREAPP one. There is no need to version APIs below the minimum supported .NETCoreApp version."

I believe the entire inner check can be removed.
