### PR TITLE
Reenable pragma suppressions for config binder gen (+ JSON)

### DIFF
--- a/src/libraries/Common/src/SourceGenerators/DiagnosticInfo.cs
+++ b/src/libraries/Common/src/SourceGenerators/DiagnosticInfo.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Linq;
 using System.Numerics.Hashing;
+using System.Reflection;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace SourceGenerators;
 
@@ -14,6 +16,9 @@ namespace SourceGenerators;
 /// </summary>
 internal readonly struct DiagnosticInfo : IEquatable<DiagnosticInfo>
 {
+    private static readonly Lazy<CSharpSyntaxTree?> s_dummySyntaxTree = new Lazy<CSharpSyntaxTree?>(GetDummySyntaxTree);
+    private static readonly Lazy<FieldInfo?> s_sourceTreeBackingFieldInfo = new Lazy<FieldInfo?>(GetSourceTreeBackingFieldInfo);
+
     public DiagnosticDescriptor Descriptor { get; private init; }
     public object?[] MessageArgs { get; private init; }
     public Location? Location { get; private init; }
@@ -30,8 +35,35 @@ internal readonly struct DiagnosticInfo : IEquatable<DiagnosticInfo>
         };
 
         // Creates a copy of the Location instance that does not capture a reference to Compilation.
-        static Location GetTrimmedLocation(Location location)
-            => Location.Create(location.SourceTree?.FilePath ?? "", location.SourceSpan, location.GetLineSpan().Span);
+        static Location? GetTrimmedLocation(Location? sourceLocation)
+        {
+            if (sourceLocation is null)
+            {
+                return null;
+            }
+
+            Location trimmedLocation = Location.Create(sourceLocation.SourceTree?.FilePath ?? "", sourceLocation.SourceSpan, sourceLocation.GetLineSpan().Span);
+
+            if (sourceLocation.IsInSource &&
+                !trimmedLocation.IsInSource &&
+                s_sourceTreeBackingFieldInfo.Value is FieldInfo sourceTreeField &&
+                s_dummySyntaxTree.Value is CSharpSyntaxTree syntaxTree)
+            {
+                // Attempt to mark this as a source location, so that it is suppressible with #pragma.
+                try
+                {
+                    sourceTreeField.SetValue(trimmedLocation, syntaxTree);
+
+                    if (!trimmedLocation.IsInSource)
+                    {
+                        sourceTreeField.SetValue(trimmedLocation, null);
+                    }
+                }
+                catch { }
+            }
+
+            return trimmedLocation;
+        }
     }
 
     public Diagnostic CreateDiagnostic()
@@ -56,5 +88,35 @@ internal readonly struct DiagnosticInfo : IEquatable<DiagnosticInfo>
 
         hashCode = HashHelpers.Combine(hashCode, Location?.GetHashCode() ?? 0);
         return hashCode;
+    }
+
+    private static FieldInfo? GetSourceTreeBackingFieldInfo()
+    {
+        FieldInfo? info;
+
+        try
+        {
+            FieldInfo[] fields = typeof(Location).GetFields(BindingFlags.NonPublic);
+            info = typeof(Location).GetField("<SourceTree>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance);
+        }
+        catch
+        {
+            info = null;
+        }
+
+        return info;
+    }
+
+    private static CSharpSyntaxTree? GetDummySyntaxTree()
+    {
+        try
+        {
+            Type? dummySyntaxTree = typeof(CSharpSyntaxTree).Assembly.GetType("Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.DummySyntaxTree", throwOnError: false);
+            return dummySyntaxTree is null ? null : (CSharpSyntaxTree?)Activator.CreateInstance(dummySyntaxTree);
+        }
+        catch
+        {
+            return null;
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj
@@ -4,8 +4,6 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <!-- Type not supported; property on type not supported -->
     <NoWarn>$(NoWarn);SYSLIB1100,SYSLIB1101</NoWarn>
-    <!-- Logic not generated for unknown/unsupported type. -->
-    <NoWarn>$(NoWarn);SYSLIB1103,SYSLIB1104</NoWarn>
     <Features>$(Features);InterceptorsPreview</Features>
     <!-- TODO: Remove InterceptorsPreview feature after 8.0 RC2 SDK is used for build -->
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Extensions.Configuration.Binder.SourceGeneration</InterceptorsPreviewNamespaces>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
@@ -11,8 +11,6 @@
     <!-- TODO: Remove InterceptorsPreview feature after 8.0 RC2 SDK is used for build -->
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Extensions.Configuration.Binder.SourceGeneration</InterceptorsPreviewNamespaces>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
-    <!-- TODO: reinstate pragma suppressions for config binding diagnostics: https://github.com/dotnet/runtime/issues/92509. -->
-    <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101</NoWarn>
     <PackageDescription>Console logger provider implementation for Microsoft.Extensions.Logging.</PackageDescription>
   </PropertyGroup>
 


### PR DESCRIPTION
- Prototyping a fix. They were disabled in https://github.com/dotnet/runtime/pull/89587, which (temporarily, hopefully) sacrificed the UX over favor of incremental generation.
- Workaround till we implement a separate analyzer to handle diagnostics (https://github.com/dotnet/runtime/issues/92509).
- Proposing to address in 8.0 for config binder since all diagnostics are issued in source.