### PR TITLE
[wasm] Fix Wasm.Build.Tests on `main`

### DIFF
--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -270,8 +270,6 @@
     <ItemGroup Condition="'$(NeedsWorkload)' == 'true'">
       <HelixCorrelationPayload Include="$(SdkWithWorkloadForTestingPath)"     Destination="$(SdkForWorkloadTestingDirName)" Condition="'$(TestUsingWorkloads)' == 'true'" />
       <HelixCorrelationPayload Include="$(SdkWithNoWorkloadForTestingPath)"   Destination="$(SdkForWorkloadTestingDirName)" Condition="'$(TestUsingWorkloads)' != 'true'" />
-
-      <HelixCorrelationPayload Include="$(MicrosoftNetCoreAppRefPackDir)"     Destination="microsoft.netcore.app.ref" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -599,8 +599,8 @@ namespace Wasm.Build.Tests
         }
 
         protected static string GetSkiaSharpReferenceItems()
-            => @"<PackageReference Include=""SkiaSharp"" Version=""2.88.4-preview.76"" />
-                <PackageReference Include=""SkiaSharp.NativeAssets.WebAssembly"" Version=""2.88.4-preview.76"" />
+            => @"<PackageReference Include=""SkiaSharp"" Version=""2.88.6"" />
+                <PackageReference Include=""SkiaSharp.NativeAssets.WebAssembly"" Version=""2.88.6"" />
                 <NativeFileReference Include=""$(SkiaSharpStaticLibraryPath)\3.1.34\st\*.a"" />";
 
         protected static string s_mainReturns42 = @"


### PR DESCRIPTION
## CI: Don't include ref pack when the tests need workload
.. as it already includes it.

https://github.com/dotnet/runtime/issues/92732 broke this as a side-effect which caused the `microsoft.netcore.app.ref` directory to not be created.

Fixes https://github.com/dotnet/runtime/issues/92732 .

## Fixes tests failing with `Package 'SkiaSharp' 2.88.4-preview.76 has a known high severity vulnerability`

Fixes https://github.com/dotnet/runtime/issues/92743