### PR TITLE
Account port number already included within server string

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Linux.cs
@@ -60,8 +60,11 @@ namespace System.DirectoryServices.Protocols
                     }
                     temp.Append(scheme);
                     temp.Append(servers[i]);
-                    temp.Append(':');
-                    temp.Append(directoryIdentifier.PortNumber);
+                    if (!servers[i].Contains(':'))
+                    {
+                        temp.Append(':');
+                        temp.Append(directoryIdentifier.PortNumber);
+                    }
                 }
                 if (temp.Length != 0)
                 {

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -75,31 +75,10 @@ namespace System.DirectoryServices.Protocols.Tests
             // Does not throw
         }
 
-
-        private LdapConnection GetConnectionWithServerNameAndPort()
-        {
-            LdapDirectoryIdentifier directoryIdentifier = new LdapDirectoryIdentifier($"{LdapConfiguration.Configuration.ServerName}:{LdapConfiguration.Configuration.Port}", true, false);
-            NetworkCredential credential = new NetworkCredential(LdapConfiguration.Configuration.UserName, LdapConfiguration.Configuration.Password);
-
-            LdapConnection connection = new LdapConnection(directoryIdentifier, credential)
-            {
-                AuthType = AuthType.Basic
-            };
-
-            // Set server protocol before bind; OpenLDAP servers default
-            // to LDAP v2, which we do not support, and will return LDAP_PROTOCOL_ERROR
-            connection.SessionOptions.ProtocolVersion = 3;
-            connection.SessionOptions.SecureSocketLayer = LdapConfiguration.Configuration.UseTls;
-            connection.Bind();
-
-            connection.Timeout = new TimeSpan(0, 3, 0);
-            return connection;
-        }
-
         [ConditionalFact(nameof(IsLdapConfigurationExist))]
         public void TestServerWithPortNumber()
         {
-            using LdapConnection connection = GetConnectionWithServerNameAndPort();
+            using LdapConnection connection = GetConnection($"{LdapConfiguration.Configuration.ServerName}:{LdapConfiguration.Configuration.Port}");
 
             var searchRequest = new SearchRequest(LdapConfiguration.Configuration.SearchDn, "(objectClass=*)", SearchScope.Subtree);
 
@@ -807,6 +786,13 @@ namespace System.DirectoryServices.Protocols.Tests
             return null;
         }
 
+        private LdapConnection GetConnection(string server)
+        {
+            LdapDirectoryIdentifier directoryIdentifier = new LdapDirectoryIdentifier(server, true, false);
+
+            return GetConnection(directoryIdentifier);
+        }
+
         private LdapConnection GetConnection()
         {
             LdapDirectoryIdentifier directoryIdentifier = string.IsNullOrEmpty(LdapConfiguration.Configuration.Port) ?
@@ -814,6 +800,11 @@ namespace System.DirectoryServices.Protocols.Tests
                                         new LdapDirectoryIdentifier(LdapConfiguration.Configuration.ServerName,
                                                                     int.Parse(LdapConfiguration.Configuration.Port, NumberStyles.None, CultureInfo.InvariantCulture),
                                                                     true, false);
+            return GetConnection(directoryIdentifier);
+        }
+
+        private static LdapConnection GetConnection(LdapDirectoryIdentifier directoryIdentifier)
+        {
             NetworkCredential credential = new NetworkCredential(LdapConfiguration.Configuration.UserName, LdapConfiguration.Configuration.Password);
 
             LdapConnection connection = new LdapConnection(directoryIdentifier, credential)

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -14,12 +14,12 @@ namespace System.DirectoryServices.Protocols.Tests
 {
     public partial class DirectoryServicesProtocolsTests
     {
-        internal static bool IsLdapConfigurationExist => LdapConfiguration.Configuration != null;
-        internal static bool IsActiveDirectoryServer => IsLdapConfigurationExist && LdapConfiguration.Configuration.IsActiveDirectoryServer;
+        internal static bool LdapConfigurationExists => LdapConfiguration.Configuration != null;
+        internal static bool IsActiveDirectoryServer => LdapConfigurationExists && LdapConfiguration.Configuration.IsActiveDirectoryServer;
 
-        internal static bool IsServerSideSortSupported => IsLdapConfigurationExist && LdapConfiguration.Configuration.SupportsServerSideSort;
+        internal static bool IsServerSideSortSupported => LdapConfigurationExists && LdapConfiguration.Configuration.SupportsServerSideSort;
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestInvalidFilter()
         {
             using LdapConnection connection = GetConnection();
@@ -33,7 +33,7 @@ namespace System.DirectoryServices.Protocols.Tests
             Assert.Equal(/* LdapError.FilterError */ 0x57, ex.ErrorCode);
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestInvalidSearchDn()
         {
             using LdapConnection connection = GetConnection();
@@ -47,7 +47,7 @@ namespace System.DirectoryServices.Protocols.Tests
             Assert.Equal(ResultCode.InvalidDNSyntax, ex.Response.ResultCode);
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestUnavailableCriticalExtension()
         {
             using LdapConnection connection = GetConnection();
@@ -63,7 +63,7 @@ namespace System.DirectoryServices.Protocols.Tests
             Assert.Equal(ResultCode.UnavailableCriticalExtension, ex.Response.ResultCode);
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestUnavailableNonCriticalExtension()
         {
             using LdapConnection connection = GetConnection();
@@ -75,7 +75,7 @@ namespace System.DirectoryServices.Protocols.Tests
             // Does not throw
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestServerWithPortNumber()
         {
             using LdapConnection connection = GetConnection($"{LdapConfiguration.Configuration.ServerName}:{LdapConfiguration.Configuration.Port}");
@@ -89,7 +89,7 @@ namespace System.DirectoryServices.Protocols.Tests
         [InlineData(60)]
         [InlineData(0)]
         [InlineData(-60)]
-        [ConditionalTheory(nameof(IsLdapConfigurationExist))]
+        [ConditionalTheory(nameof(LdapConfigurationExists))]
         public void TestSearchWithTimeLimit(int timeLimit)
         {
             using LdapConnection connection = GetConnection();
@@ -107,7 +107,7 @@ namespace System.DirectoryServices.Protocols.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestAddingOU()
         {
             using (LdapConnection connection = GetConnection())
@@ -129,7 +129,7 @@ namespace System.DirectoryServices.Protocols.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestDeleteOU()
         {
             using (LdapConnection connection = GetConnection())
@@ -154,7 +154,7 @@ namespace System.DirectoryServices.Protocols.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestAddAndModifyAttribute()
         {
             using (LdapConnection connection = GetConnection())
@@ -189,7 +189,7 @@ namespace System.DirectoryServices.Protocols.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestNestedOUs()
         {
             using (LdapConnection connection = GetConnection())
@@ -220,7 +220,7 @@ namespace System.DirectoryServices.Protocols.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestAddUser()
         {
             using (LdapConnection connection = GetConnection())
@@ -272,7 +272,7 @@ namespace System.DirectoryServices.Protocols.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestAddingMultipleAttributes()
         {
             using (LdapConnection connection = GetConnection())
@@ -355,7 +355,7 @@ namespace System.DirectoryServices.Protocols.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestMoveAndRenameUser()
         {
             using (LdapConnection connection = GetConnection())
@@ -414,7 +414,7 @@ namespace System.DirectoryServices.Protocols.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestAsyncSearch()
         {
             using (LdapConnection connection = GetConnection())
@@ -525,7 +525,7 @@ namespace System.DirectoryServices.Protocols.Tests
             yield return new object[] { "http://example.com/", "http://false/"u8.ToArray(), ResultCode.CompareFalse };
         }
 
-        [ConditionalTheory(nameof(IsLdapConfigurationExist))]
+        [ConditionalTheory(nameof(LdapConfigurationExists))]
         [MemberData(nameof(TestCompareRequestTheory_TestData))]
         public void TestCompareRequestTheory(object value, object assertion, ResultCode compareResult)
         {
@@ -558,7 +558,7 @@ namespace System.DirectoryServices.Protocols.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestCompareRequest()
         {
             using (LdapConnection connection = GetConnection())
@@ -682,7 +682,7 @@ namespace System.DirectoryServices.Protocols.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsLdapConfigurationExist))]
+        [ConditionalFact(nameof(LdapConfigurationExists))]
         public void TestMultipleServerBind()
         {
             LdapDirectoryIdentifier directoryIdentifier = string.IsNullOrEmpty(LdapConfiguration.Configuration.Port) ?
@@ -788,7 +788,7 @@ namespace System.DirectoryServices.Protocols.Tests
 
         private LdapConnection GetConnection(string server)
         {
-            LdapDirectoryIdentifier directoryIdentifier = new LdapDirectoryIdentifier(server, true, false);
+            LdapDirectoryIdentifier directoryIdentifier = new LdapDirectoryIdentifier(server, fullyQualifiedDnsHostName: true, connectionless: false);
 
             return GetConnection(directoryIdentifier);
         }
@@ -796,10 +796,10 @@ namespace System.DirectoryServices.Protocols.Tests
         private LdapConnection GetConnection()
         {
             LdapDirectoryIdentifier directoryIdentifier = string.IsNullOrEmpty(LdapConfiguration.Configuration.Port) ?
-                                        new LdapDirectoryIdentifier(LdapConfiguration.Configuration.ServerName, true, false) :
+                                        new LdapDirectoryIdentifier(LdapConfiguration.Configuration.ServerName, fullyQualifiedDnsHostName: true, connectionless: false) :
                                         new LdapDirectoryIdentifier(LdapConfiguration.Configuration.ServerName,
                                                                     int.Parse(LdapConfiguration.Configuration.Port, NumberStyles.None, CultureInfo.InvariantCulture),
-                                                                    true, false);
+                                                                    fullyQualifiedDnsHostName: true, connectionless: false);
             return GetConnection(directoryIdentifier);
         }
 


### PR DESCRIPTION
On Linux: Instantiating a LdapConnection with a server string including a port number throws exception when call `LdapConnection.SendRequest(...)`, this works fine on Windows. Turns out on Linux it always appends the port number to the server string when populating the uri string, fixed this issue

Fixes https://github.com/dotnet/runtime/issues/59701