### PR TITLE
[wasm][debugger] Support passing negative/positive numbers to methods.

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -752,6 +752,11 @@ namespace Microsoft.WebAssembly.Diagnostics
                             if (!await commandParamsObjWriter.WriteConst(literal, context.SdbAgent, token))
                                 throw new InternalErrorException($"Unable to evaluate method '{methodName}'. Unable to write LiteralExpressionSyntax into binary writer.");
                         }
+                        else if (arg.Expression is PrefixUnaryExpressionSyntax negativeLiteral)
+                        {
+                            if (!commandParamsObjWriter.WriteConst(negativeLiteral))
+                                throw new InternalErrorException($"Unable to evaluate method '{methodName}'. Unable to write PrefixUnaryExpressionSyntax into binary writer.");
+                        }
                         else if (arg.Expression is IdentifierNameSyntax identifierName)
                         {
                             if (!await commandParamsObjWriter.WriteJsonValue(memberAccessValues[identifierName.Identifier.Text], context.SdbAgent, methodParamsInfo[argIndex].TypeCode, token))

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -757,7 +757,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     Write(ElementType.U2, (int)us);
                     break;
                 case short s:
-                    Write(ElementType.I2, (uint)s);
+                    Write(ElementType.I2, (uint)s  * coeff);
                     break;
                 case uint ui:
                     Write(ElementType.U4, ui);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -650,51 +650,37 @@ namespace Microsoft.WebAssembly.Diagnostics
             return false;
         }
 
+        public bool WriteConst(PrefixUnaryExpressionSyntax constValue)
+        {
+            switch (constValue.Kind())
+            {
+                case SyntaxKind.UnaryMinusExpression:
+                {
+                    switch (constValue.Operand)
+                    {
+                        case LiteralExpressionSyntax les:
+                        {
+                            return WriteNumber(les.Token.Value, convertToNegative: true);
+                        }
+                        default:
+                        {
+                            // not supported yet
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+            return false;
+        }
+
         public async Task<bool> WriteConst(LiteralExpressionSyntax constValue, MonoSDBHelper SdbHelper, CancellationToken token)
         {
             switch (constValue.Kind())
             {
                 case SyntaxKind.NumericLiteralExpression:
                 {
-                    switch (constValue.Token.Value) {
-                        case double d:
-                            Write(ElementType.R8, d);
-                            break;
-                        case float f:
-                            Write(ElementType.R4, f);
-                            break;
-                        case long l:
-                            Write(ElementType.I8, l);
-                            break;
-                        case ulong ul:
-                            Write(ElementType.U8, ul);
-                            break;
-                        case byte b:
-                            Write(ElementType.U1, (int)b);
-                            break;
-                        case sbyte sb:
-                            Write(ElementType.I1, (uint)sb);
-                            break;
-                        case ushort us:
-                            Write(ElementType.U2, (int)us);
-                            break;
-                        case short s:
-                            Write(ElementType.I2, (uint)s);
-                            break;
-                        case uint ui:
-                            Write(ElementType.U4, ui);
-                            break;
-                        case IntPtr ip:
-                            Write(ElementType.I, (int)ip);
-                            break;
-                        case UIntPtr up:
-                            Write(ElementType.U, (uint)up);
-                            break;
-                        default:
-                            Write(ElementType.I4, (int)constValue.Token.Value);
-                            break;
-                    }
-                    return true;
+                    return WriteNumber(constValue.Token.Value);
                 }
                 case SyntaxKind.StringLiteralExpression:
                 {
@@ -726,6 +712,51 @@ namespace Microsoft.WebAssembly.Diagnostics
                 }
             }
             return false;
+        }
+
+        public bool WriteNumber(object number, bool convertToNegative=false)
+        {
+            int coeff = convertToNegative ? -1 : 1;
+            switch (number)
+            {
+                case double d:
+                    Write(ElementType.R8, d * coeff);
+                    break;
+                case float f:
+                    Write(ElementType.R4, f * coeff);
+                    break;
+                case long l:
+                    Write(ElementType.I8, l * coeff);
+                    break;
+                case ulong ul:
+                    Write(ElementType.U8, ul);
+                    break;
+                case byte b:
+                    Write(ElementType.U1, (int)b);
+                    break;
+                case sbyte sb:
+                    Write(ElementType.I1, (uint)sb);
+                    break;
+                case ushort us:
+                    Write(ElementType.U2, (int)us);
+                    break;
+                case short s:
+                    Write(ElementType.I2, (uint)s);
+                    break;
+                case uint ui:
+                    Write(ElementType.U4, ui);
+                    break;
+                case IntPtr ip:
+                    Write(ElementType.I, (int)ip);
+                    break;
+                case UIntPtr up:
+                    Write(ElementType.U, (uint)up);
+                    break;
+                default:
+                    Write(ElementType.I4, (int)number * coeff);
+                    break;
+            }
+            return true;
         }
 
         public async Task<bool> WriteJsonValue(JObject objValue, MonoSDBHelper SdbHelper, ElementType? expectedType, CancellationToken token)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -670,6 +670,22 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
                     break;
                 }
+                case SyntaxKind.UnaryPlusExpression:
+                {
+                    switch (constValue.Operand)
+                    {
+                        case LiteralExpressionSyntax les:
+                        {
+                            return WriteNumber(les.Token.Value, convertToNegative: false);
+                        }
+                        default:
+                        {
+                            // not supported yet
+                            break;
+                        }
+                    }
+                    break;
+                }
             }
             return false;
         }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -499,6 +499,8 @@ namespace DebuggerTests
                     ("test.GetDefaultAndRequiredParam(3, 2)", TNumber(5)),
                     ("test.GetDefaultAndRequiredParam(3, +2)", TNumber(5)),
                     ("test.GetDefaultAndRequiredParam(3, -2)", TNumber(1)),
+                    ("test.GetDefaultAndRequiredParam(-123l, -1.1f)", TNumber("-124.1", isDecimal: true)), // long, float
+                    ("test.GetDefaultAndRequiredParam(-0.23)", TNumber("-32768.23", isDecimal: true)), // double, short
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\")", TString("a; -1; False")),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23)", TString("a; 23; False")),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23, true)", TString("a; 23; True"))

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -497,6 +497,7 @@ namespace DebuggerTests
 
                    ("test.GetDefaultAndRequiredParam(2)", TNumber(5)),
                    ("test.GetDefaultAndRequiredParam(3, 2)", TNumber(5)),
+                   ("test.GetDefaultAndRequiredParam(3, +2)", TNumber(5)),
                    ("test.GetDefaultAndRequiredParam(3, -2)", TNumber(1)),
                    ("test.GetDefaultAndRequiredParamMixedTypes(\"a\")", TString("a; -1; False")),
                    ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23)", TString("a; 23; False")),

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -497,6 +497,7 @@ namespace DebuggerTests
 
                    ("test.GetDefaultAndRequiredParam(2)", TNumber(5)),
                    ("test.GetDefaultAndRequiredParam(3, 2)", TNumber(5)),
+                   ("test.GetDefaultAndRequiredParam(3, -2)", TNumber(1)),
                    ("test.GetDefaultAndRequiredParamMixedTypes(\"a\")", TString("a; -1; False")),
                    ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23)", TString("a; 23; False")),
                    ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23, true)", TString("a; 23; True"))

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -1996,6 +1996,8 @@ namespace DebuggerTests
 
             public bool GetNull(object param = null) => param == null ? true : false;
             public int GetDefaultAndRequiredParam(int requiredParam, int optionalParam = 3) => requiredParam + optionalParam;
+            public float GetDefaultAndRequiredParam(long requiredParam, float optionalParam = 3.3f) => requiredParam + optionalParam;
+            public double GetDefaultAndRequiredParam(double requiredParam, short optionalParam = -32768) => requiredParam + optionalParam;
             public string GetDefaultAndRequiredParamMixedTypes(string requiredParam, int optionalParamFirst = -1, bool optionalParamSecond = false) => $"{requiredParam}; {optionalParamFirst}; {optionalParamSecond}";
         }
 


### PR DESCRIPTION
Passing negative number generates different `ExpressionSyntax` type than passing a positive number. Because we classify method arguments by casting them to Syntax types, we were not handling negative case at all (throwing `Unable to evaluate method 'GetDefaultAndRequiredParam'. Unable to write into binary writer, not recognized expression type: PrefixUnaryExpressionSyntax"`).
Same with positive numbers, passing `+2` should behave the same as passing `2`.
`SyntaxKind` has a lot of possible values (https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.csharp.syntaxkind) and we probably are not handling all of them yet. Logging this into https://github.com/dotnet/runtime/issues/65864.