### PR TITLE
[wasm][debugger] Support passing identifiers to methods

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/EvaluateExpression.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/EvaluateExpression.cs
@@ -201,7 +201,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         string node_str = ies.ToString();
                         if (!methodCallToParamName.TryGetValue(node_str, out string id_name))
                         {
-                            throw new Exception($"BUG: Expected to find an id name for the member access string: {node_str}");
+                            throw new Exception($"BUG: Expected to find an id name for the invokation expression string: {node_str}");
                         }
                         AddLocalVariableWithValue(id_name, value);
                     }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -754,7 +754,15 @@ namespace Microsoft.WebAssembly.Diagnostics
                         }
                         else if (arg.Expression is IdentifierNameSyntax identifierName)
                         {
-                            if (!await commandParamsObjWriter.WriteJsonValue(memberAccessValues[identifierName.Identifier.Text], context.SdbAgent, methodParamsInfo[argIndex].TypeCode, token))
+                            if (!memberAccessValues.TryGetValue(identifierName.Identifier.Text, out JObject argValue))
+                                argValue = await Resolve(identifierName.Identifier.Text, token);
+                            if (!await commandParamsObjWriter.WriteJsonValue(argValue, context.SdbAgent, methodParamsInfo[argIndex].TypeCode, token))
+                                throw new InternalErrorException($"Unable to evaluate method '{methodName}'. Unable to write IdentifierNameSyntax into binary writer.");
+                        }
+                        else if (arg.Expression is MemberAccessExpressionSyntax memberAccess)
+                        {
+                            JObject argValue = await Resolve(memberAccess.ToString(), token);
+                            if (!await commandParamsObjWriter.WriteJsonValue(argValue, context.SdbAgent, methodParamsInfo[argIndex].TypeCode, token))
                                 throw new InternalErrorException($"Unable to evaluate method '{methodName}'. Unable to write IdentifierNameSyntax into binary writer.");
                         }
                         else

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -451,7 +451,7 @@ namespace DebuggerTests
 
         [ConditionalFact(nameof(RunningOnChrome))]
         public async Task EvaluateMethodWithDefaultParam() => await CheckInspectLocalsAtBreakpointSite(
-            $"DebuggerTests.DefaultParamMethods", "Evaluate", 5, "DebuggerTests.DefaultParamMethods.Evaluate",
+            $"DebuggerTests.DefaultParamMethods", "Evaluate", 2, "DebuggerTests.DefaultParamMethods.Evaluate",
             $"window.setTimeout(function() {{ invoke_static_method ('[debugger-test] DebuggerTests.DefaultParamMethods:Evaluate'); 1 }})",
             wait_for_event_fn: async (pause_location) =>
             {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -451,55 +451,56 @@ namespace DebuggerTests
 
         [ConditionalFact(nameof(RunningOnChrome))]
         public async Task EvaluateMethodWithDefaultParam() => await CheckInspectLocalsAtBreakpointSite(
-            $"DebuggerTests.DefaultParamMethods", "Evaluate", 2, "DebuggerTests.DefaultParamMethods.Evaluate",
+            $"DebuggerTests.DefaultParamMethods", "Evaluate", 3, "DebuggerTests.DefaultParamMethods.Evaluate",
             $"window.setTimeout(function() {{ invoke_static_method ('[debugger-test] DebuggerTests.DefaultParamMethods:Evaluate'); 1 }})",
             wait_for_event_fn: async (pause_location) =>
             {
                 var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
                 await EvaluateOnCallFrameAndCheck(id,
-                   ("test.GetByte()", TNumber(1)),
-                   ("test.GetSByte()", TNumber(1)),
-                   ("test.GetByteNullable()", TNumber(1)),
-                   ("test.GetSByteNullable()", TNumber(1)),
+                    ("test.GetByte()", TNumber(1)),
+                    ("test.GetSByte()", TNumber(1)),
+                    ("test.GetByteNullable()", TNumber(1)),
+                    ("test.GetSByteNullable()", TNumber(1)),
 
-                   ("test.GetInt16()", TNumber(1)),
-                   ("test.GetUInt16()", TNumber(1)),
-                   ("test.GetInt16Nullable()", TNumber(1)),
-                   ("test.GetUInt16Nullable()", TNumber(1)),
+                    ("test.GetInt16()", TNumber(1)),
+                    ("test.GetUInt16()", TNumber(1)),
+                    ("test.GetInt16Nullable()", TNumber(1)),
+                    ("test.GetUInt16Nullable()", TNumber(1)),
 
-                   ("test.GetInt32()", TNumber(1)),
-                   ("test.GetUInt32()", TNumber(1)),
-                   ("test.GetInt32Nullable()", TNumber(1)),
-                   ("test.GetUInt32Nullable()", TNumber(1)),
+                    ("test.GetInt32()", TNumber(1)),
+                    ("test.GetUInt32()", TNumber(1)),
+                    ("test.GetInt32Nullable()", TNumber(1)),
+                    ("test.GetUInt32Nullable()", TNumber(1)),
 
-                   ("test.GetInt64()", TNumber(1)),
-                   ("test.GetUInt64()", TNumber(1)),
-                   ("test.GetInt64Nullable()", TNumber(1)),
-                   ("test.GetUInt64Nullable()", TNumber(1)),
+                    ("test.GetInt64()", TNumber(1)),
+                    ("test.GetUInt64()", TNumber(1)),
+                    ("test.GetInt64Nullable()", TNumber(1)),
+                    ("test.GetUInt64Nullable()", TNumber(1)),
 
-                   ("test.GetChar()", TChar('T')),
-                   ("test.GetCharNullable()", TChar('T')),
-                   ("test.GetUnicodeChar()", TChar('\u0105')),
+                    ("test.GetChar()", TChar('T')),
+                    ("test.GetCharNullable()", TChar('T')),
+                    ("test.GetUnicodeChar()", TChar('\u0105')),
 
-                   ("test.GetString()", TString("1.23")),
-                   ("test.GetUnicodeString()", TString("\u017C\u00F3\u0142\u0107")),
-                   ("test.GetString(null)", TString(null)),
-                   ("test.GetStringNullable()", TString("1.23")),
+                    ("test.GetString()", TString("1.23")),
+                    ("test.GetUnicodeString()", TString("\u017C\u00F3\u0142\u0107")),
+                    ("test.GetString(null)", TString(null)),
+                    ("test.GetStringNullable()", TString("1.23")),
 
-                   ("test.GetSingle()", TNumber("1.23", isDecimal: true)),
-                   ("test.GetDouble()",  TNumber("1.23", isDecimal: true)),
-                   ("test.GetSingleNullable()",  TNumber("1.23", isDecimal: true)),
-                   ("test.GetDoubleNullable()",  TNumber("1.23", isDecimal: true)),
+                    ("test.GetSingle()", TNumber("1.23", isDecimal: true)),
+                    ("test.GetDouble()",  TNumber("1.23", isDecimal: true)),
+                    ("test.GetSingleNullable()",  TNumber("1.23", isDecimal: true)),
+                    ("test.GetDoubleNullable()",  TNumber("1.23", isDecimal: true)),
 
-                   ("test.GetBool()", TBool(true)),
-                   ("test.GetBoolNullable()", TBool(true)),
-                   ("test.GetNull()", TBool(true)),
+                    ("test.GetBool()", TBool(true)),
+                    ("test.GetBoolNullable()", TBool(true)),
+                    ("test.GetNull()", TBool(true)),
 
-                   ("test.GetDefaultAndRequiredParam(2)", TNumber(5)),
-                   ("test.GetDefaultAndRequiredParam(3, 2)", TNumber(5)),
-                   ("test.GetDefaultAndRequiredParamMixedTypes(\"a\")", TString("a; -1; False")),
-                   ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23)", TString("a; 23; False")),
-                   ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23, true)", TString("a; 23; True"))
+                    ("test.GetDefaultAndRequiredParam(2)", TNumber(5)),
+                    ("test.GetDefaultAndRequiredParam(3, 2)", TNumber(5)),
+                    ("test.GetDefaultAndRequiredParam(number)", TNumber(126)),
+                    ("test.GetDefaultAndRequiredParamMixedTypes(\"a\")", TString("a; -1; False")),
+                    ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23)", TString("a; 23; False")),
+                    ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23, true)", TString("a; 23; True"))
                    );
 
                 var (_, res) = await EvaluateOnCallFrame(id, "test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23, true, 1.23f)", expect_ok: false);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -451,7 +451,7 @@ namespace DebuggerTests
 
         [ConditionalFact(nameof(RunningOnChrome))]
         public async Task EvaluateMethodWithDefaultParam() => await CheckInspectLocalsAtBreakpointSite(
-            $"DebuggerTests.DefaultParamMethods", "Evaluate", 3, "DebuggerTests.DefaultParamMethods.Evaluate",
+            $"DebuggerTests.DefaultParamMethods", "Evaluate", 5, "DebuggerTests.DefaultParamMethods.Evaluate",
             $"window.setTimeout(function() {{ invoke_static_method ('[debugger-test] DebuggerTests.DefaultParamMethods:Evaluate'); 1 }})",
             wait_for_event_fn: async (pause_location) =>
             {
@@ -498,6 +498,10 @@ namespace DebuggerTests
                     ("test.GetDefaultAndRequiredParam(2)", TNumber(5)),
                     ("test.GetDefaultAndRequiredParam(3, 2)", TNumber(5)),
                     ("test.GetDefaultAndRequiredParam(number)", TNumber(126)),
+                    ("test.GetDefaultAndRequiredParam(DebuggerTestsV2.EvaluateStaticFieldsInStaticClass.StaticField)", TNumber(23)),
+                    ("test.GetDefaultAndRequiredParam(EvaluateStaticFieldsInInstanceClass.StaticField)", TNumber(73)),
+                    ("test.GetDefaultAndRequiredParam(instance.StaticField)", TNumber(73)),
+                    ("test.GetDefaultAndRequiredParam(instance2.propInt)", TNumber(15)),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\")", TString("a; -1; False")),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23)", TString("a; 23; False")),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23, true)", TString("a; 23; True"))

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -497,11 +497,6 @@ namespace DebuggerTests
 
                     ("test.GetDefaultAndRequiredParam(2)", TNumber(5)),
                     ("test.GetDefaultAndRequiredParam(3, 2)", TNumber(5)),
-                    ("test.GetDefaultAndRequiredParam(number)", TNumber(126)),
-                    ("test.GetDefaultAndRequiredParam(DebuggerTestsV2.EvaluateStaticFieldsInStaticClass.StaticField)", TNumber(23)),
-                    ("test.GetDefaultAndRequiredParam(EvaluateStaticFieldsInInstanceClass.StaticField)", TNumber(73)),
-                    ("test.GetDefaultAndRequiredParam(instance.StaticField)", TNumber(73)),
-                    ("test.GetDefaultAndRequiredParam(instance2.propInt)", TNumber(15)),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\")", TString("a; -1; False")),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23)", TString("a; 23; False")),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23, true)", TString("a; 23; True"))
@@ -747,7 +742,7 @@ namespace DebuggerTests
                 await EvaluateOnCallFrameAndCheck(id,
                    ("s_valueTypeEnum.ToString()", TString("no")),
                    ("mc.valueTypeEnum.ToString()", TString("yes"))
-                   // ("mc.valueTypeEnum.HasFlag(SampleEnum.no)", TBool(true)) // ToDo: https://github.com/dotnet/runtime/issues/92262
+                //    ("mc.valueTypeEnum.HasFlag(SampleEnum.no)", TBool(true)) // ToDo: https://github.com/dotnet/runtime/issues/92262
                 );
            });
 
@@ -767,6 +762,25 @@ namespace DebuggerTests
                    ("f[f.numArray[j], f.numArray[0]]", TNumber("3")), //multiple ElementAccessExpressionSyntaxes
                    ("f[f.numArray[f.numList[0]], f.numArray[i]]", TNumber("3")),
                    ("f[f.numArray[f.numList[0]], f.numArray[f.numArray[i]]]", TNumber("4"))
+                ); 
+           });
+
+        
+        [Fact]
+        public async Task EvaluateMethodsWithObjectParams() => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTests.FastCheck", "run", 6, "DebuggerTests.FastCheck.run",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.FastCheck:run'); })",
+            wait_for_event_fn: async (pause_location) =>
+            {
+                var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("mc.Method(number)", TNumber(-123)),
+                    ("mc.Method(ic)", TNumber(123)),
+                    ("mc.Method(ic.number)", TNumber(123)),
+                    ("mc.Method(DebuggerTestsV2.EvaluateStaticFieldsInStaticClass.StaticField)", TNumber(20)),
+                    ("mc.Method(EvaluateStaticFieldsInInstanceClass.StaticField)", TNumber(70)),
+                    ("mc.Method(instance.StaticField)", TNumber(70)),
+                    ("mc.Method(instance2.propInt)", TNumber(12))
                 ); 
            });
     }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -1980,6 +1980,8 @@ namespace DebuggerTests
         {
             var test = new TestClass();
             int number = 123;
+            EvaluateStaticFieldsInInstanceClass instance = new();
+            PrimitiveTypeMethods.TestClass instance2 = new();
         }
     }
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -1933,6 +1933,29 @@ namespace DebuggerTests
         }
     }
 
+    public static class FastCheck
+    {
+        public class InstanceClass
+        {
+            public int number = 123;
+        }
+
+        public class MemberClass
+        {
+            public int Method(InstanceClass ic) => ic.number;
+            public int Method(int num) => num;
+        }
+
+        public static void run()
+        {
+            int number = -123;
+            InstanceClass ic = new();
+            MemberClass mc = new();
+            EvaluateStaticFieldsInInstanceClass instance = new();
+            PrimitiveTypeMethods.TestClass instance2 = new();
+        }
+    }
+
     public static class DefaultParamMethods
     {
         public class TestClass
@@ -1979,9 +2002,6 @@ namespace DebuggerTests
         public static void Evaluate()
         {
             var test = new TestClass();
-            int number = 123;
-            EvaluateStaticFieldsInInstanceClass instance = new();
-            PrimitiveTypeMethods.TestClass instance2 = new();
         }
     }
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -1979,6 +1979,7 @@ namespace DebuggerTests
         public static void Evaluate()
         {
             var test = new TestClass();
+            int number = 123;
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/92262.
We supported methods with literals as params, e.g. `Method(2)` or with static members, e.g. `S*T*R".Split('*', 3, System.StringSplitOptions.TrimEntries)`.
Now we can support local variables passing e.g. `int n = 2; Method(n);` and object members passing.

Out of scope:
Failing case from `EvaluateMethodsOnEnum` can be fixed only when we use enum cast to double mechanism (working on it in https://github.com/dotnet/runtime/pull/92334).