### PR TITLE
[tests][iOS] Fix iOS.Device.Aot.Test artifacts path

### DIFF
--- a/src/tests/FunctionalTests/iOS/Device/AOT/iOS.Device.Aot.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Device/AOT/iOS.Device.Aot.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="MonoForceInterpreter">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <OutputPath>bin</OutputPath>
     <TestRuntime>true</TestRuntime>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <RuntimeIdentifier>$(TargetOS)-$(TargetArchitecture)</RuntimeIdentifier>


### PR DESCRIPTION
When running the functional test locally, artifacts are placed under the project itself instead of the `artifacts` directory. This leads to `PublishDir` being a relative path `bin/net9.0/ios-arm64/publish/AppleTestRunner.dll` instead of a full path, which eventually causes a problem in the mono aot compiler being unable to find/open assemblies with their relative path.

This PR looks to fix local dev testing by removing the explicit `OutputPath` from this project