### PR TITLE
Do not nop-out SSA definitions in block morphing

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3504,6 +3504,11 @@ public:
         return m_ssaNum.IsComposite();
     }
 
+    bool HasSsaIdentity() const
+    {
+        return !m_ssaNum.IsInvalid();
+    }
+
 #if DEBUGGABLE_GENTREE
     GenTreeLclVarCommon() : GenTreeUnOp()
     {

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -750,9 +750,10 @@ void MorphCopyBlockHelper::MorphStructCases()
         }
     }
 
-    // Check to see if we are doing a copy to/from the same local block.
-    // If so, morph it to a nop.
-    if ((m_dstVarDsc != nullptr) && (m_srcVarDsc == m_dstVarDsc) && (m_dstLclOffset == m_srcLclOffset))
+    // Check to see if we are doing a copy to/from the same local block. If so, morph it to a nop.
+    // Don't do this for SSA definitions as we have no way to update downstream uses.
+    if ((m_dstVarDsc != nullptr) && (m_srcVarDsc == m_dstVarDsc) && (m_dstLclOffset == m_srcLclOffset) &&
+        !m_store->AsLclVarCommon()->HasSsaIdentity())
     {
         JITDUMP("Self-copy; replaced with a NOP.\n");
         m_transformationDecision = BlockTransformation::Nop;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91839/Runtime_91839.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91839/Runtime_91839.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+public class Runtime_91839
+{
+    public static I0[] s_1;
+    public static I2 s_5;
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        S1 vr2 = new S1(new S0(0));
+        if (vr2.F5)
+        {
+            s_5 = s_5;
+        }
+
+        S1 vr3 = vr2;
+        vr3.F4 = vr3.F4;
+        for (int vr4 = 0; vr4 < 1; vr4++)
+        {
+            var vr5 = vr3.F4;
+            M2(vr5);
+        }
+
+        Assert.True(vr3.F4.F2 == 0);
+    }
+
+    private static void M2(S0 arg0)
+    {
+        s_1 = new I0[] { new C0() };
+    }
+
+    public interface I0
+    {
+    }
+
+    public interface I2
+    {
+    }
+
+    public struct S0
+    {
+        public ulong F0;
+        public long F2;
+        public short F3;
+        public S0(long f2) : this()
+        {
+            F2 = f2;
+        }
+    }
+
+    public class C0 : I0
+    {
+    }
+
+    public struct S1
+    {
+        public S0 F4;
+        public bool F5;
+        public S1(S0 f4) : this()
+        {
+            F4 = f4;
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_91839/Runtime_91839.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_91839/Runtime_91839.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_NO_OLD_PROMOTION" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
SSA definitions cannot be removed as there is no way to update downstream uses.

Fixes #91839.