### PR TITLE
[release/8.0] Update dependencies from `dotnet/installer`

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -398,9 +398,9 @@
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>
       <Sha>8fef55f5a55a3b4f2c96cd1a9b5ddc51d4b927f8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-rtm.23477.25">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="8.0.100-rtm.23478.7">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>744d4d634443834750b5c10cc3029123a6fd975e</Sha>
+      <Sha>46a7370763921ded24dcb70c585ee97883c615d4</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -258,7 +258,7 @@
     <MicrosoftExtensionsLoggingVersion>3.1.7</MicrosoftExtensionsLoggingVersion>
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
     <!-- installer version, for testing workloads -->
-    <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23477.25</MicrosoftDotnetSdkInternalVersion>
+    <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23478.7</MicrosoftDotnetSdkInternalVersion>
     <SdkVersionForWorkloadTesting>$(MicrosoftDotnetSdkInternalVersion)</SdkVersionForWorkloadTesting>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Updating 'Microsoft.Dotnet.Sdk.Internal': '8.0.100-rtm.23477.25' => '8.0.100-rtm.23478.7' (from build '20230928.7' of 'https://github.com/dotnet/installer')
