### PR TITLE
Always emit jump from hot finally block to cold target

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2180,7 +2180,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         GetEmitter()->emitDisableGC();
 
         // Now go to where the finally funclet needs to return to.
-        if (block->bbNext->bbJumpDest == block->bbNext->bbNext)
+        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext)
+            && !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
         {
             // Fall-through.
             // TODO-ARM64-CQ: Can we get rid of this instruction, and just have the call return directly

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2160,6 +2160,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     }
     GetEmitter()->emitIns_J(INS_bl_local, block->bbJumpDest);
 
+    BasicBlock* const nextBlock = block->bbNext;
+
     if (block->bbFlags & BBF_RETLESS_CALL)
     {
         // We have a retless call, and the last instruction generated was a call.
@@ -2167,7 +2169,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // block), then we need to generate a breakpoint here (since it will never
         // get executed) to get proper unwind behavior.
 
-        if ((block->bbNext == nullptr) || !BasicBlock::sameEHRegion(block, block->bbNext))
+        if ((nextBlock == nullptr) || !BasicBlock::sameEHRegion(block, nextBlock))
         {
             instGen(INS_BREAKPOINT); // This should never get executed
         }
@@ -2179,9 +2181,10 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // handler.  So turn off GC reporting for this single instruction.
         GetEmitter()->emitDisableGC();
 
+        BasicBlock* const jumpDest = nextBlock->bbJumpDest;
+
         // Now go to where the finally funclet needs to return to.
-        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext) &&
-            !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
+        if ((jumpDest == nextBlock->bbNext) && !compiler->fgInDifferentRegions(nextBlock, jumpDest))
         {
             // Fall-through.
             // TODO-ARM64-CQ: Can we get rid of this instruction, and just have the call return directly
@@ -2191,7 +2194,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         }
         else
         {
-            inst_JMP(EJ_jmp, block->bbNext->bbJumpDest);
+            inst_JMP(EJ_jmp, jumpDest);
         }
 
         GetEmitter()->emitEnableGC();
@@ -2204,7 +2207,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     if (!(block->bbFlags & BBF_RETLESS_CALL))
     {
         assert(block->isBBCallAlwaysPair());
-        block = block->bbNext;
+        block = nextBlock;
     }
     return block;
 }

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2180,8 +2180,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         GetEmitter()->emitDisableGC();
 
         // Now go to where the finally funclet needs to return to.
-        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext)
-            && !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
+        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext) &&
+            !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
         {
             // Fall-through.
             // TODO-ARM64-CQ: Can we get rid of this instruction, and just have the call return directly

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -1540,7 +1540,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         GetEmitter()->emitDisableGC();
 
         // Now go to where the finally funclet needs to return to.
-        if (block->bbNext->bbJumpDest == block->bbNext->bbNext)
+        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext)
+            && !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
         {
             // Fall-through.
             // TODO-LOONGARCH64-CQ: Can we get rid of this instruction, and just have the call return directly

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -1540,8 +1540,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         GetEmitter()->emitDisableGC();
 
         // Now go to where the finally funclet needs to return to.
-        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext)
-            && !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
+        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext) &&
+            !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
         {
             // Fall-through.
             // TODO-LOONGARCH64-CQ: Can we get rid of this instruction, and just have the call return directly

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -1520,6 +1520,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     }
     GetEmitter()->emitIns_J(INS_bl, block->bbJumpDest);
 
+    BasicBlock* const nextBlock = block->bbNext;
+
     if (block->bbFlags & BBF_RETLESS_CALL)
     {
         // We have a retless call, and the last instruction generated was a call.
@@ -1527,7 +1529,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // block), then we need to generate a breakpoint here (since it will never
         // get executed) to get proper unwind behavior.
 
-        if ((block->bbNext == nullptr) || !BasicBlock::sameEHRegion(block, block->bbNext))
+        if ((nextBlock == nullptr) || !BasicBlock::sameEHRegion(block, nextBlock))
         {
             instGen(INS_break); // This should never get executed
         }
@@ -1539,9 +1541,10 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // handler.  So turn off GC reporting for this single instruction.
         GetEmitter()->emitDisableGC();
 
+        BasicBlock* const jumpDest = nextBlock->bbJumpDest;
+
         // Now go to where the finally funclet needs to return to.
-        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext) &&
-            !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
+        if ((jumpDest == nextBlock->bbNext) && !compiler->fgInDifferentRegions(nextBlock, jumpDest))
         {
             // Fall-through.
             // TODO-LOONGARCH64-CQ: Can we get rid of this instruction, and just have the call return directly
@@ -1551,7 +1554,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         }
         else
         {
-            inst_JMP(EJ_jmp, block->bbNext->bbJumpDest);
+            inst_JMP(EJ_jmp, jumpDest);
         }
 
         GetEmitter()->emitEnableGC();
@@ -1564,7 +1567,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     if (!(block->bbFlags & BBF_RETLESS_CALL))
     {
         assert(block->isBBCallAlwaysPair());
-        block = block->bbNext;
+        block = nextBlock;
     }
     return block;
 }

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1178,7 +1178,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         GetEmitter()->emitDisableGC();
 
         // Now go to where the finally funclet needs to return to.
-        if (block->bbNext->bbJumpDest == block->bbNext->bbNext)
+        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext)
+            && !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
         {
             // Fall-through.
             // TODO-RISCV64-CQ: Can we get rid of this instruction, and just have the call return directly

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1158,6 +1158,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     }
     GetEmitter()->emitIns_J(INS_jal, block->bbJumpDest);
 
+    BasicBlock* const nextBlock = block->bbNext;
+
     if (block->bbFlags & BBF_RETLESS_CALL)
     {
         // We have a retless call, and the last instruction generated was a call.
@@ -1165,7 +1167,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // block), then we need to generate a breakpoint here (since it will never
         // get executed) to get proper unwind behavior.
 
-        if ((block->bbNext == nullptr) || !BasicBlock::sameEHRegion(block, block->bbNext))
+        if ((nextBlock == nullptr) || !BasicBlock::sameEHRegion(block, nextBlock))
         {
             instGen(INS_ebreak); // This should never get executed
         }
@@ -1177,9 +1179,10 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // handler.  So turn off GC reporting for this single instruction.
         GetEmitter()->emitDisableGC();
 
+        BasicBlock* const jumpDest = nextBlock->bbJumpDest;
+
         // Now go to where the finally funclet needs to return to.
-        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext) &&
-            !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
+        if ((jumpDest == nextBlock->bbNext) && !compiler->fgInDifferentRegions(nextBlock, jumpDest))
         {
             // Fall-through.
             // TODO-RISCV64-CQ: Can we get rid of this instruction, and just have the call return directly
@@ -1189,7 +1192,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         }
         else
         {
-            inst_JMP(EJ_jmp, block->bbNext->bbJumpDest);
+            inst_JMP(EJ_jmp, jumpDest);
         }
 
         GetEmitter()->emitEnableGC();
@@ -1202,7 +1205,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     if (!(block->bbFlags & BBF_RETLESS_CALL))
     {
         assert(block->isBBCallAlwaysPair());
-        block = block->bbNext;
+        block = nextBlock;
     }
     return block;
 }

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1178,8 +1178,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         GetEmitter()->emitDisableGC();
 
         // Now go to where the finally funclet needs to return to.
-        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext)
-            && !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
+        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext) &&
+            !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
         {
             // Fall-through.
             // TODO-RISCV64-CQ: Can we get rid of this instruction, and just have the call return directly

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -252,7 +252,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 #endif // JIT32_GCENCODER
 
         // Now go to where the finally funclet needs to return to.
-        if (block->bbNext->bbJumpDest == block->bbNext->bbNext)
+        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext)
+            && !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
         {
             // Fall-through.
             // TODO-XArch-CQ: Can we get rid of this instruction, and just have the call return directly

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -252,8 +252,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 #endif // JIT32_GCENCODER
 
         // Now go to where the finally funclet needs to return to.
-        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext)
-            && !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
+        if ((block->bbNext->bbJumpDest == block->bbNext->bbNext) &&
+            !compiler->fgInDifferentRegions(block->bbNext, block->bbNext->bbJumpDest))
         {
             // Fall-through.
             // TODO-XArch-CQ: Can we get rid of this instruction, and just have the call return directly

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -206,7 +206,6 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
 BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 {
     BasicBlock* const nextBlock = block->bbNext;
-    BasicBlock* const jumpDest  = nextBlock->bbJumpDest;
 
 #if defined(FEATURE_EH_FUNCLETS)
     // Generate a call to the finally, like this:
@@ -253,6 +252,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // handler.  So turn off GC reporting for this single instruction.
         GetEmitter()->emitDisableGC();
 #endif // JIT32_GCENCODER
+
+        BasicBlock* const jumpDest = nextBlock->bbJumpDest;
 
         // Now go to where the finally funclet needs to return to.
         if ((jumpDest == nextBlock->bbNext) && !compiler->fgInDifferentRegions(nextBlock, jumpDest))
@@ -315,7 +316,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     if (!(block->bbFlags & BBF_RETLESS_CALL))
     {
         assert(block->isBBCallAlwaysPair());
-        GetEmitter()->emitIns_J(INS_push_hide, jumpDest);
+        GetEmitter()->emitIns_J(INS_push_hide, nextBlock->bbJumpDest);
     }
     else
     {

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -205,6 +205,9 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
 
 BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 {
+    BasicBlock* const nextBlock = block->bbNext;
+    BasicBlock* const jumpDest  = nextBlock->bbJumpDest;
+
 #if defined(FEATURE_EH_FUNCLETS)
     // Generate a call to the finally, like this:
     //      mov         rcx,qword ptr [rbp + 20H]       // Load rcx with PSPSym
@@ -227,9 +230,6 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         GetEmitter()->emitIns_R_S(ins_Load(TYP_I_IMPL), EA_PTRSIZE, REG_ARG_0, compiler->lvaPSPSym, 0);
     }
     GetEmitter()->emitIns_J(INS_call, block->bbJumpDest);
-
-    BasicBlock* const nextBlock = block->bbNext;
-    BasicBlock* const jumpDest  = nextBlock->bbJumpDest;
 
     if (block->bbFlags & BBF_RETLESS_CALL)
     {


### PR DESCRIPTION
On some platforms, `CodeGen::genCallFinally()` will remove the jump between a finally block in a call-finally pair to its jump target if the target is its immediate successor in the block list (in other words, we just fall through). However, if we are doing hot/cold splitting, it is possible for the finally block to be the last hot block, and its target the first cold block. Thus, if the two are contiguous in the block list but in separate regions, we must always emit a jump.