### PR TITLE
runtime-wasm-perf: add triggers for PRs

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -58,6 +58,7 @@ parameters:
         eng/pipelines/coreclr/templates/perf-job.yml
         eng/pipelines/coreclr/templates/*-perf-*
         eng/pipelines/coreclr/templates/run-perf*
+        eng/pipelines/coreclr/templates/run-scenarios-job.yml
         eng/testing/performance/*
     ]
 

--- a/eng/pipelines/runtime-wasm-perf.yml
+++ b/eng/pipelines/runtime-wasm-perf.yml
@@ -4,6 +4,20 @@
 
 trigger: none
 
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - eng/pipelines/runtime-wasm-perf.yml
+    - eng/pipelines/coreclr/perf*.yml
+    - eng/pipelines/coreclr/templates/perf-job.yml
+    - eng/pipelines/coreclr/templates/run-perf*
+    - eng/pipelines/coreclr/templates/run-scenarios-job.yml
+    - eng/testing/performance/*
+    - eng/testing/ChromeVersions.props
+
 variables:
   - template: /eng/pipelines/common/variables.yml
 


### PR DESCRIPTION
This is useful to prevent perf pipeline from breaking when changes are
made in `dotnet/runtime`.