### PR TITLE
Add stress mode for arm/arm64 function fragment splitting

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9897,6 +9897,7 @@ public:
         STRESS_MODE(NO_OLD_PROMOTION) /* Do not use old promotion */                            \
         STRESS_MODE(PHYSICAL_PROMOTION) /* Use physical promotion */                            \
         STRESS_MODE(PHYSICAL_PROMOTION_COST)                                                    \
+        STRESS_MODE(UNWIND) /* stress unwind info; e.g., create function fragments */           \
                                                                                                 \
         /* After COUNT_VARN, stress level 2 does all of these all the time */                   \
                                                                                                 \

--- a/src/coreclr/jit/unwindarmarch.cpp
+++ b/src/coreclr/jit/unwindarmarch.cpp
@@ -1834,6 +1834,22 @@ void UnwindInfo::Split()
 #ifdef DEBUG
     // Consider DOTNET_JitSplitFunctionSize
     unsigned splitFunctionSize = (unsigned)JitConfig.JitSplitFunctionSize();
+    if (splitFunctionSize == 0)
+    {
+        // If the split configuration is not set, then sometimes set it during stress.
+        // Use two stress modes: a split size of 4 (extreme) and a split size of 200 (reasonable).
+        if (uwiComp->compStressCompile(Compiler::STRESS_UNWIND, 10))
+        {
+            if (uwiComp->compStressCompile(Compiler::STRESS_UNWIND, 5))
+            {
+                splitFunctionSize = 4;
+            }
+            else
+            {
+                splitFunctionSize = 200;
+            }
+        }
+    }
 
     if (splitFunctionSize != 0)
         if (splitFunctionSize < maxFragmentSize)


### PR DESCRIPTION
Set JitSplitFunctionSize to either 4 or 200 under new STRESS_UNWIND mode.