### PR TITLE
Allow `key#value` for superpmi JIT option specification

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.cpp
@@ -137,12 +137,14 @@ void CommandLine::DumpHelp(const char* program)
     printf(" -jitoption [force] key=value\n");
     printf("     Set the JIT option named \"key\" to \"value\" for JIT 1 if the option was not set.\n");
     printf("     With optional force flag overwrites the existing value if it was already set.\n");
-    printf("     NOTE: do not use a \"DOTNET_\" prefix, \"key\" and \"value\" are case sensitive!\n");
+    printf("     NOTE: do not use a \"DOTNET_\" prefix. \"key\" and \"value\" are case sensitive.\n");
+    printf("     \"key#value\" is also accepted.\n");
     printf("\n");
     printf(" -jit2option [force] key=value\n");
     printf("     Set the JIT option named \"key\" to \"value\" for JIT 2 if the option was not set.\n");
     printf("     With optional force flag overwrites the existing value if it was already set.\n");
-    printf("     NOTE: do not use a \"DOTNET_\" prefix, \"key\" and \"value\" are case sensitive!\n");
+    printf("     NOTE: do not use a \"DOTNET_\" prefix. \"key\" and \"value\" are case sensitive.\n");
+    printf("     \"key#value\" is also accepted.\n");
     printf("\n");
     printf("Inputs are case sensitive.\n");
     printf("\n");
@@ -172,7 +174,7 @@ static bool ParseJitOption(const char* optionString, WCHAR** key, WCHAR** value)
     char tempKey[1024];
 
     unsigned i;
-    for (i = 0; optionString[i] != '='; i++)
+    for (i = 0; (optionString[i] != '=') && (optionString[i] != '#'); i++)
     {
         if ((i >= 1023) || (optionString[i] == '\0'))
         {


### PR DESCRIPTION
superpmi.py will pass this through from the `-jitoption` / `-base_jit_option` / `-diff_jit_option` to superpmi.exe `-jitoption` and `-jit2option`.

Currently, the format is `key=value`. I wrap invocation of superpmi.py with Windows batch file scripting, which has an annoying problem of "eating" the equals size `=`. This works around that problem. I can't think of any case where `#` is needed in a key or value, hence that choice as an additional option.