### PR TITLE
JIT: Optimize SequenceEqual to use ccmp on ARM64

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1798,11 +1798,12 @@ GenTree* Lowering::AddrGen(void* addr)
 //
 // Arguments:
 //    tree - GenTreeCall node to replace with STORE_BLK
+//    next - [out] Next node to lower if this function returns true
 //
 // Return Value:
-//    nullptr if no changes were made
+//    false if no changes were made
 //
-GenTree* Lowering::LowerCallMemmove(GenTreeCall* call)
+bool Lowering::LowerCallMemmove(GenTreeCall* call, GenTree** next)
 {
     JITDUMP("Considering Memmove [%06d] for unrolling.. ", comp->dspTreeID(call))
     assert(comp->lookupNamedIntrinsic(call->gtCallMethHnd) == NI_System_Buffer_Memmove);
@@ -1812,7 +1813,7 @@ GenTree* Lowering::LowerCallMemmove(GenTreeCall* call)
     if (comp->info.compHasNextCallRetAddr)
     {
         JITDUMP("compHasNextCallRetAddr=true so we won't be able to remove the call - bail out.\n")
-        return nullptr;
+        return false;
     }
 
     GenTree* lengthArg = call->gtArgs.GetUserArgByIndex(2)->GetNode();
@@ -1857,7 +1858,8 @@ GenTree* Lowering::LowerCallMemmove(GenTreeCall* call)
 
             JITDUMP("\nNew tree:\n")
             DISPTREE(storeBlk);
-            return storeBlk;
+            *next = srcBlk;
+            return true;
         }
         else
         {
@@ -1868,7 +1870,7 @@ GenTree* Lowering::LowerCallMemmove(GenTreeCall* call)
     {
         JITDUMP("size is not a constant.\n")
     }
-    return nullptr;
+    return false;
 }
 
 //------------------------------------------------------------------------
@@ -1877,11 +1879,12 @@ GenTree* Lowering::LowerCallMemmove(GenTreeCall* call)
 //
 // Arguments:
 //    tree - GenTreeCall node to unroll as memcmp
+//    next - [out] Next node to lower if this function returns true
 //
 // Return Value:
-//    nullptr if no changes were made
+//    false if no changes were made
 //
-GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
+bool Lowering::LowerCallMemcmp(GenTreeCall* call, GenTree** next)
 {
     JITDUMP("Considering Memcmp [%06d] for unrolling.. ", comp->dspTreeID(call))
     assert(comp->lookupNamedIntrinsic(call->gtCallMethHnd) == NI_System_SpanHelpers_SequenceEqual);
@@ -1891,13 +1894,13 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
     if (!comp->opts.OptimizationEnabled())
     {
         JITDUMP("Optimizations aren't allowed - bail out.\n")
-        return nullptr;
+        return false;
     }
 
     if (comp->info.compHasNextCallRetAddr)
     {
         JITDUMP("compHasNextCallRetAddr=true so we won't be able to remove the call - bail out.\n")
-        return nullptr;
+        return false;
     }
 
     GenTree* lengthArg = call->gtArgs.GetUserArgByIndex(2)->GetNode();
@@ -2004,9 +2007,8 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
                     GenTree* rIndir = comp->gtNewIndir(loadType, rArg);
                     result          = newBinaryOp(comp, GT_EQ, TYP_INT, lIndir, rIndir);
 
-                    BlockRange().InsertAfter(lArg, lIndir);
-                    BlockRange().InsertAfter(rArg, rIndir);
-                    BlockRange().InsertBefore(call, result);
+                    BlockRange().InsertBefore(call, lIndir, rIndir, result);
+                    *next = lIndir;
                 }
                 else
                 {
@@ -2020,6 +2022,32 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
                     GenTree* rArgClone = comp->gtNewLclvNode(rArgUse.ReplaceWithLclVar(comp), genActualType(rArg));
                     BlockRange().InsertBefore(call, lArgClone, rArgClone);
 
+                    *next = lArgClone;
+
+                    GenTree* l1Indir   = comp->gtNewIndir(loadType, lArgUse.Def());
+                    GenTree* r1Indir   = comp->gtNewIndir(loadType, rArgUse.Def());
+                    GenTree* l2Offs    = comp->gtNewIconNode(cnsSize - loadWidth, TYP_I_IMPL);
+                    GenTree* l2AddOffs = newBinaryOp(comp, GT_ADD, lArg->TypeGet(), lArgClone, l2Offs);
+                    GenTree* l2Indir   = comp->gtNewIndir(loadType, l2AddOffs);
+                    GenTree* r2Offs    = comp->gtNewIconNode(cnsSize - loadWidth, TYP_I_IMPL);
+                    GenTree* r2AddOffs = newBinaryOp(comp, GT_ADD, rArg->TypeGet(), rArgClone, r2Offs);
+                    GenTree* r2Indir   = comp->gtNewIndir(loadType, r2AddOffs);
+
+                    BlockRange().InsertAfter(rArgClone, l1Indir, l2Offs, l2AddOffs, l2Indir);
+                    BlockRange().InsertAfter(l2Indir, r1Indir, r2Offs, r2AddOffs, r2Indir);
+
+#ifdef TARGET_ARM64
+                    // ARM64 will get efficient ccmp codegen if we emit the normal thing:
+                    //
+                    // bool result = (*(int*)leftArg == *(int)rightArg) & (*(int*)(leftArg + 1) == *(int*)(rightArg +
+                    // 1))
+
+                    GenTree* eq1 = newBinaryOp(comp, GT_EQ, actualLoadType, l1Indir, r1Indir);
+                    GenTree* eq2 = newBinaryOp(comp, GT_EQ, actualLoadType, l2Indir, r2Indir);
+                    result       = newBinaryOp(comp, GT_AND, TYP_INT, eq1, eq2);
+
+                    BlockRange().InsertAfter(r2Indir, eq1, eq2, result);
+#else
                     // We're going to emit something like the following:
                     //
                     // bool result = ((*(int*)leftArg ^ *(int*)rightArg) |
@@ -2047,24 +2075,17 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
                     // |           \--*  CNS_INT   int    1
                     // \--*  CNS_INT   int    0
                     //
-                    GenTree* l1Indir   = comp->gtNewIndir(loadType, lArgUse.Def());
-                    GenTree* r1Indir   = comp->gtNewIndir(loadType, rArgUse.Def());
-                    GenTree* lXor      = newBinaryOp(comp, GT_XOR, actualLoadType, l1Indir, r1Indir);
-                    GenTree* l2Offs    = comp->gtNewIconNode(cnsSize - loadWidth, TYP_I_IMPL);
-                    GenTree* l2AddOffs = newBinaryOp(comp, GT_ADD, lArg->TypeGet(), lArgClone, l2Offs);
-                    GenTree* l2Indir   = comp->gtNewIndir(loadType, l2AddOffs);
-                    GenTree* r2Offs    = comp->gtCloneExpr(l2Offs); // offset is the same
-                    GenTree* r2AddOffs = newBinaryOp(comp, GT_ADD, rArg->TypeGet(), rArgClone, r2Offs);
-                    GenTree* r2Indir   = comp->gtNewIndir(loadType, r2AddOffs);
-                    GenTree* rXor      = newBinaryOp(comp, GT_XOR, actualLoadType, l2Indir, r2Indir);
-                    GenTree* resultOr  = newBinaryOp(comp, GT_OR, actualLoadType, lXor, rXor);
-                    GenTree* zeroCns   = comp->gtNewZeroConNode(actualLoadType);
-                    result             = newBinaryOp(comp, GT_EQ, TYP_INT, resultOr, zeroCns);
+                    // TODO-CQ: Do this as a general optimization similar to TryLowerAndOrToCCMP.
 
-                    BlockRange().InsertAfter(rArgClone, l1Indir, l2Offs, l2AddOffs, l2Indir);
-                    BlockRange().InsertAfter(l2Indir, r1Indir, r2Offs, r2AddOffs, r2Indir);
+                    GenTree* lXor     = newBinaryOp(comp, GT_XOR, actualLoadType, l1Indir, r1Indir);
+                    GenTree* rXor     = newBinaryOp(comp, GT_XOR, actualLoadType, l2Indir, r2Indir);
+                    GenTree* resultOr = newBinaryOp(comp, GT_OR, actualLoadType, lXor, rXor);
+                    GenTree* zeroCns  = comp->gtNewZeroConNode(actualLoadType);
+                    result            = newBinaryOp(comp, GT_EQ, TYP_INT, resultOr, zeroCns);
+
                     BlockRange().InsertAfter(r2Indir, lXor, rXor, resultOr, zeroCns);
                     BlockRange().InsertAfter(zeroCns, result);
+#endif
                 }
 
                 JITDUMP("\nUnrolled to:\n");
@@ -2102,7 +2123,7 @@ GenTree* Lowering::LowerCallMemcmp(GenTreeCall* call)
     {
         JITDUMP("size is not a constant.\n")
     }
-    return nullptr;
+    return false;
 }
 
 // do lowering steps for a call
@@ -2133,20 +2154,12 @@ GenTree* Lowering::LowerCall(GenTree* node)
 #if defined(TARGET_AMD64) || defined(TARGET_ARM64)
     if (call->gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC)
     {
-        GenTree*       newNode = nullptr;
-        NamedIntrinsic ni      = comp->lookupNamedIntrinsic(call->gtCallMethHnd);
-        if (ni == NI_System_Buffer_Memmove)
+        GenTree*       nextNode = nullptr;
+        NamedIntrinsic ni       = comp->lookupNamedIntrinsic(call->gtCallMethHnd);
+        if (((ni == NI_System_Buffer_Memmove) && LowerCallMemmove(call, &nextNode)) ||
+            ((ni == NI_System_SpanHelpers_SequenceEqual) && LowerCallMemcmp(call, &nextNode)))
         {
-            newNode = LowerCallMemmove(call);
-        }
-        else if (ni == NI_System_SpanHelpers_SequenceEqual)
-        {
-            newNode = LowerCallMemcmp(call);
-        }
-
-        if (newNode != nullptr)
-        {
-            return newNode->gtNext;
+            return nextNode;
         }
     }
 #endif

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -133,8 +133,8 @@ private:
     // Call Lowering
     // ------------------------------
     GenTree* LowerCall(GenTree* call);
-    GenTree* LowerCallMemmove(GenTreeCall* call);
-    GenTree* LowerCallMemcmp(GenTreeCall* call);
+    bool LowerCallMemmove(GenTreeCall* call, GenTree** next);
+    bool LowerCallMemcmp(GenTreeCall* call, GenTree** next);
     void LowerCFGCall(GenTreeCall* call);
     void MoveCFGCallArg(GenTreeCall* call, GenTree* node);
 #ifndef TARGET_64BIT


### PR DESCRIPTION
In the original PR we could not get this this working due to some conservative interference. This now does the right thing with #92710 merged.

Also change LowerCallMemcmp/LowerCallMemmove to return next node to lower just to align it a bit more with other functions.

```csharp
bool Test1(ReadOnlySpan<byte> data) => "hello world"u8.SequenceEqual(data);
```

Before:
```asm
G_M52062_IG01:  ;; offset=0x0000
            stp     fp, lr, [sp, #-0x10]!
            mov     fp, sp
						;; size=8 bbWeight=1 PerfScore 1.50
G_M52062_IG02:  ;; offset=0x0008
            movz    x2, #0x20D4      // data for <PrivateImplementationDetails>:430646847E70344C09F58739E99D5BC96EAC8D5FE7295CF196B986279876BF9B
            movk    x2, #0xE179 LSL #16
            movk    x2, #554 LSL #32
            cmp     w1, #11
            bne     G_M52062_IG05
						;; size=20 bbWeight=1 PerfScore 3.00
G_M52062_IG03:  ;; offset=0x001C
            ldr     x1, [x2]
            ldr     x2, [x2, #0x03]
            ldr     x3, [x0]
            ldr     x0, [x0, #0x03]
            eor     x1, x1, x3
            eor     x0, x2, x0
            orr     x0, x1, x0
            cmp     x0, #0
            cset    x0, eq
						;; size=36 bbWeight=0.48 PerfScore 6.96
G_M52062_IG04:  ;; offset=0x0040
            ldp     fp, lr, [sp], #0x10
            ret     lr
						;; size=8 bbWeight=1 PerfScore 2.00
G_M52062_IG05:  ;; offset=0x0048
            mov     w0, wzr
            b       G_M52062_IG04
						;; size=8 bbWeight=0 PerfScore 0.00
```

After:
```asm
G_M52062_IG01:  ;; offset=0x0000
            stp     fp, lr, [sp, #-0x10]!
            mov     fp, sp
						;; size=8 bbWeight=1 PerfScore 1.50
G_M52062_IG02:  ;; offset=0x0008
            movz    x2, #0x20D4      // data for <PrivateImplementationDetails>:430646847E70344C09F58739E99D5BC96EAC8D5FE7295CF196B986279876BF9B
            movk    x2, #0x63E LSL #16
            movk    x2, #445 LSL #32
            cmp     w1, #11
            bne     G_M52062_IG05
						;; size=20 bbWeight=1 PerfScore 3.00
G_M52062_IG03:  ;; offset=0x001C
            ldr     x1, [x2]
            ldr     x2, [x2, #0x03]
            ldr     x3, [x0]
            ldr     x0, [x0, #0x03]
            cmp     x1, x3
            ccmp    x2, x0, 0, eq
            cset    x0, eq
						;; size=28 bbWeight=0.48 PerfScore 6.48
G_M52062_IG04:  ;; offset=0x0038
            ldp     fp, lr, [sp], #0x10
            ret     lr
						;; size=8 bbWeight=1 PerfScore 2.00
G_M52062_IG05:  ;; offset=0x0040
            mov     w0, wzr
            b       G_M52062_IG04
						;; size=8 bbWeight=0 PerfScore 0.00
```

Benchmarks from #83945 on my M1:
|       Method |        Job |               Toolchain |      Mean |     Error |    StdDev | Ratio |
|------------- |----------- |------------------------ |----------:|----------:|----------:|------:|
|      TE_Json | Job-RFUZAM |      /Core_Root/corerun | 1.9945 ns | 0.0100 ns | 0.0083 ns |  0.98 |
|      TE_Json | Job-KSXFQI | /Core_Root_base/corerun | 2.0339 ns | 0.0011 ns | 0.0009 ns |  1.00 |
|              |            |                         |           |           |           |       |
| TE_Plaintext | Job-RFUZAM |      /Core_Root/corerun | 0.7460 ns | 0.0086 ns | 0.0080 ns |  0.99 |
| TE_Plaintext | Job-KSXFQI | /Core_Root_base/corerun | 0.7515 ns | 0.0008 ns | 0.0008 ns |  1.00 |
|              |            |                         |           |           |           |       |
|    Equals_15 | Job-RFUZAM |      /Core_Root/corerun | 0.5063 ns | 0.0008 ns | 0.0008 ns |  0.87 |
|    Equals_15 | Job-KSXFQI | /Core_Root_base/corerun | 0.5799 ns | 0.0006 ns | 0.0006 ns |  1.00 |