### PR TITLE
[linux-bionic] Skip failing NTLM tests

### DIFF
--- a/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/NegotiateAuthenticationTests.cs
@@ -32,6 +32,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "The test is specific to GSSAPI / Managed implementations of NegotiateAuthentication")]
         public void RemoteIdentity_ThrowsOnUnauthenticated()
         {
             NegotiateAuthenticationClientOptions clientOptions = new NegotiateAuthenticationClientOptions { Credential = s_testCredentialRight, TargetName = "HTTP/foo" };
@@ -65,6 +66,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "The test is specific to GSSAPI / Managed implementations of NegotiateAuthentication")]
         public void Package_Unsupported()
         {
             NegotiateAuthenticationClientOptions clientOptions = new NegotiateAuthenticationClientOptions { Package = "INVALID", Credential = s_testCredentialRight, TargetName = "HTTP/foo" };
@@ -96,6 +98,7 @@ namespace System.Net.Security.Tests
 
         [Fact]
         [SkipOnPlatform(TestPlatforms.Windows, "The test is specific to GSSAPI / Managed implementations of NegotiateAuthentication")]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "The test is specific to GSSAPI / Managed implementations of NegotiateAuthentication")]
         public void DefaultNetworkCredentials_NTLM_DoesNotThrow()
         {
             NegotiateAuthenticationClientOptions clientOptions = new NegotiateAuthenticationClientOptions { Package = "NTLM", Credential = CredentialCache.DefaultNetworkCredentials, TargetName = "HTTP/foo" };


### PR DESCRIPTION
Some NTLM tests are still running and failing even though libSystem.Net.Security.Native isn't being built for linux-bionic. This PR skips them all.