### PR TITLE
[release/6.0-staging] Fix JsonDocument thread safety.

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -9,8 +9,8 @@
     <Nullable>enable</Nullable>
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
     <IsPackable>true</IsPackable>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <ServicingVersion>8</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>9</ServicingVersion>
     <PackageDescription>Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.
 
 Commonly Used Types:

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
@@ -14,6 +14,7 @@ using System.IO.Tests;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace System.Text.Json.Tests
 {
@@ -2719,11 +2720,9 @@ namespace System.Text.Json.Tests
                     Assert.Equal(test, property.Value.GetInt32());
                     test++;
 
-                    // Subsequent read of the same JsonProperty doesn't allocate a new string
-                    // (if another property is inspected from the same document that guarantee
-                    // doesn't hold).
+                    // Subsequent read of the same JsonProperty should return an equal string
                     string propertyName2 = property.Name;
-                    Assert.Same(propertyName, propertyName2);
+                    Assert.Equal(propertyName, propertyName2);
                 }
 
                 test = 0;
@@ -3579,6 +3578,41 @@ namespace System.Text.Json.Tests
                 AssertExtensions.Throws<InvalidOperationException>(() => jElement.ValueEquals(ThrowsAnyway), ErrorMessage);
                 AssertExtensions.Throws<InvalidOperationException>(() => jElement.ValueEquals(ThrowsAnyway.AsSpan()), ErrorMessage);
                 AssertExtensions.Throws<InvalidOperationException>(() => jElement.ValueEquals(Encoding.UTF8.GetBytes(ThrowsAnyway)), ErrorMessage);
+            }
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [OuterLoop] // thread-safety / stress test
+        public static async Task GetString_ConcurrentUse_ThreadSafe()
+        {
+            using (JsonDocument doc = JsonDocument.Parse(SR.SimpleObjectJson))
+            {
+                JsonElement first = doc.RootElement.GetProperty("first");
+                JsonElement last = doc.RootElement.GetProperty("last");
+
+                const int Iters = 10_000;
+                using (var gate = new Barrier(2))
+                {
+                    await Task.WhenAll(
+                        Task.Factory.StartNew(() =>
+                        {
+                            gate.SignalAndWait();
+                            for (int i = 0; i < Iters; i++)
+                            {
+                                Assert.Equal("John", first.GetString());
+                                Assert.True(first.ValueEquals("John"));
+                            }
+                        }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default),
+                        Task.Factory.StartNew(() =>
+                        {
+                            gate.SignalAndWait();
+                            for (int i = 0; i < Iters; i++)
+                            {
+                                Assert.Equal("Smith", last.GetString());
+                                Assert.True(last.ValueEquals("Smith"));
+                            }
+                        }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default));
+                }
             }
         }
 


### PR DESCRIPTION
Backport of #76716 to release/6.0-staging

/cc @eiriktsarpalis

## Customer Impact

Even though the `JsonDocument`/`JsonElement` types are documented as immutable/thread safe values, the current implementation suffers from a concurrency bug that can result in incorrect strings being returned when multiple threads attempt to call the `GetString()` method on the same document. This can result in nondeterministic bugs including potential privacy or security problems.

## Testing

Added an OuterLoop test validating the absence of the problem.

## Risk

Low. This PR removes the cache that was causing the issue. [We have concluded](https://github.com/dotnet/runtime/pull/76450#issuecomment-1265968074) that the removal of the cache should not contribute to any perf regressions in real-life scenaria.

