### PR TITLE
Apply sequence equality comparison to the final Regex incremental value.

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
@@ -373,7 +373,28 @@ namespace System.Text.RegularExpressions.Generator
 
         private sealed class ObjectImmutableArraySequenceEqualityComparer : IEqualityComparer<ImmutableArray<object>>
         {
-            public bool Equals(ImmutableArray<object> x, ImmutableArray<object> y) => x.SequenceEqual(y);
+            public bool Equals(ImmutableArray<object> left, ImmutableArray<object> right)
+            {
+                if (left.Length != right.Length)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < left.Length; i++)
+                {
+                    bool areEqual = left[i] is { } leftElem
+                        ? leftElem.Equals(right[i])
+                        : right[i] is null;
+
+                    if (!areEqual)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
             public int GetHashCode([DisallowNull] ImmutableArray<object> obj)
             {
                 int hash = 0;


### PR DESCRIPTION
ImmutableArray uses reference equality semantics, so two arrays containing equal values will always trigger source compilation downstream. Updates the incremental value to use reference equality comparison.