### PR TITLE
Minimal ILGenerator implementation for new AssemblyBuilder.Save

### DIFF
--- a/src/libraries/System.Reflection.Emit/src/Resources/Strings.resx
+++ b/src/libraries/System.Reflection.Emit/src/Resources/Strings.resx
@@ -183,4 +183,7 @@
   <data name="InvalidOperation_NoUnderlyingTypeOnEnum" xml:space="preserve">
     <value>Underlying type information on enumeration is not specified.</value>
   </data>
+  <data name="InvalidOperation_ShouldNotHaveMethodBody" xml:space="preserve">
+    <value>Method body should not exist.</value>
+  </data>
 </root>

--- a/src/libraries/System.Reflection.Emit/src/System.Reflection.Emit.csproj
+++ b/src/libraries/System.Reflection.Emit/src/System.Reflection.Emit.csproj
@@ -11,6 +11,7 @@
     <Compile Include="System\Reflection\Emit\EnumBuilderImpl.cs" />
     <Compile Include="System\Reflection\Emit\FieldBuilderImpl.cs" />
     <Compile Include="System\Reflection\Emit\GenericTypeParameterBuilderImpl.cs" />
+    <Compile Include="System\Reflection\Emit\ILGeneratorImpl.cs" />
     <Compile Include="System\Reflection\Emit\MethodBuilderImpl.cs" />
     <Compile Include="System\Reflection\Emit\ModuleBuilderImpl.cs" />
     <Compile Include="System\Reflection\Emit\ParameterBuilderImpl.cs" />

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/AssemblyBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/AssemblyBuilderImpl.cs
@@ -86,12 +86,12 @@ namespace System.Reflection.Emit
                hashAlgorithm: (AssemblyHashAlgorithm)_assemblyName.HashAlgorithm
 #pragma warning restore SYSLIB0037
                );
-
             _module.WriteCustomAttributes(_customAttributes, assemblyHandle);
-            // Add module's metadata
-            _module.AppendMetadata();
 
             var ilBuilder = new BlobBuilder();
+            MethodBodyStreamEncoder methodBodyEncoder = new MethodBodyStreamEncoder(ilBuilder);
+            _module.AppendMetadata(methodBodyEncoder);
+
             WritePEImage(stream, ilBuilder);
             _previouslySaved = true;
         }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
@@ -20,6 +20,7 @@ namespace System.Reflection.Emit
         internal ILGeneratorImpl(MethodBuilder methodBuilder, int size)
         {
             _methodBuilder = methodBuilder;
+            // For compat, runtime implementation doesn't throw for negative or zero value.
             _builder = new BlobBuilder(Math.Max(size, DefaultSize));
             _il = new InstructionEncoder(_builder, new ControlFlowBuilder());
         }
@@ -177,7 +178,6 @@ namespace System.Reflection.Emit
         {
             // Puts the opcode onto the IL stream followed by the metadata token
             // represented by str.
-
             ModuleBuilder modBuilder = (ModuleBuilder)_methodBuilder.Module;
             int tempVal = modBuilder.GetStringMetadataToken(str);
             _il.OpCode((ILOpCode)opcode.Value);

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
@@ -1,0 +1,203 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Reflection.Emit
+{
+    internal sealed class ILGeneratorImpl : ILGenerator
+    {
+        private const int DefaultSize = 16;
+        private readonly MethodBuilder _methodBuilder;
+        private readonly BlobBuilder _builder;
+        private readonly InstructionEncoder _il;
+        private bool _hasDynamicStackAllocation;
+
+        internal ILGeneratorImpl(MethodBuilder methodBuilder, int size)
+        {
+            _methodBuilder = methodBuilder;
+            _builder = new BlobBuilder(Math.Max(size, DefaultSize));
+            _il = new InstructionEncoder(_builder, new ControlFlowBuilder());
+        }
+
+        internal InstructionEncoder Instructions => _il;
+        internal bool HasDynamicStackAllocation => _hasDynamicStackAllocation;
+
+        public override int ILOffset => _il.Offset;
+
+        public override void BeginCatchBlock(Type? exceptionType) => throw new NotImplementedException();
+        public override void BeginExceptFilterBlock() => throw new NotImplementedException();
+        public override Label BeginExceptionBlock() => throw new NotImplementedException();
+        public override void BeginFaultBlock() => throw new NotImplementedException();
+        public override void BeginFinallyBlock() => throw new NotImplementedException();
+        public override void BeginScope() => throw new NotImplementedException();
+        public override LocalBuilder DeclareLocal(Type localType, bool pinned) => throw new NotImplementedException();
+        public override Label DefineLabel() => throw new NotImplementedException();
+
+        public override void Emit(OpCode opcode)
+        {
+            if (opcode == OpCodes.Localloc)
+            {
+                _hasDynamicStackAllocation = true;
+            }
+            _il.OpCode((ILOpCode)opcode.Value);
+        }
+
+        public override void Emit(OpCode opcode, byte arg)
+        {
+            _il.OpCode((ILOpCode)opcode.Value);
+            _builder.WriteByte(arg);
+        }
+
+        public override void Emit(OpCode opcode, double arg)
+        {
+            _il.OpCode((ILOpCode)opcode.Value);
+            _builder.WriteDouble(arg);
+        }
+
+        public override void Emit(OpCode opcode, float arg)
+        {
+            _il.OpCode((ILOpCode)opcode.Value);
+            _builder.WriteSingle(arg);
+        }
+
+        public override void Emit(OpCode opcode, short arg)
+        {
+            _il.OpCode((ILOpCode)opcode.Value);
+            _builder.WriteInt16(arg);
+        }
+
+        public override void Emit(OpCode opcode, int arg)
+        {
+            // Special-case several opcodes that have shorter variants for common values.
+            if (opcode.Equals(OpCodes.Ldc_I4))
+            {
+                if (arg >= -1 && arg <= 8)
+                {
+                    _il.OpCode(arg switch
+                    {
+                        -1 => ILOpCode.Ldc_i4_m1,
+                        0 => ILOpCode.Ldc_i4_0,
+                        1 => ILOpCode.Ldc_i4_1,
+                        2 => ILOpCode.Ldc_i4_2,
+                        3 => ILOpCode.Ldc_i4_3,
+                        4 => ILOpCode.Ldc_i4_4,
+                        5 => ILOpCode.Ldc_i4_5,
+                        6 => ILOpCode.Ldc_i4_6,
+                        7 => ILOpCode.Ldc_i4_7,
+                        _ => ILOpCode.Ldc_i4_8,
+                    });
+                    return;
+                }
+
+                if (arg >= -128 && arg <= 127)
+                {
+                    _il.OpCode(ILOpCode.Ldc_i4_s);
+                    _builder.WriteSByte((sbyte)arg) ;
+                    return;
+                }
+            }
+            else if (opcode.Equals(OpCodes.Ldarg))
+            {
+                if ((uint)arg <= 3)
+                {
+                    _il.OpCode(arg switch
+                    {
+                        0 => ILOpCode.Ldarg_0,
+                        1 => ILOpCode.Ldarg_1,
+                        2 => ILOpCode.Ldarg_2,
+                        _ => ILOpCode.Ldarg_3,
+                    });
+                    return;
+                }
+
+                if ((uint)arg <= byte.MaxValue)
+                {
+                    _il.OpCode(ILOpCode.Ldarg_s);
+                    _builder.WriteByte((byte)arg);
+                    return;
+                }
+
+                if ((uint)arg <= ushort.MaxValue) // this will be true except on misuse of the opcode
+                {
+                    _il.OpCode(ILOpCode.Ldarg);
+                    _builder.WriteInt16((short)arg);
+                    return;
+                }
+            }
+            else if (opcode.Equals(OpCodes.Ldarga))
+            {
+                if ((uint)arg <= byte.MaxValue)
+                {
+                    _il.OpCode(ILOpCode.Ldarga_s);
+                    _builder.WriteByte((byte)arg);
+                    return;
+                }
+
+                if ((uint)arg <= ushort.MaxValue) // this will be true except on misuse of the opcode
+                {
+                    _il.OpCode(ILOpCode.Ldarga);
+                    _builder.WriteInt16((short)arg);
+                    return;
+                }
+            }
+            else if (opcode.Equals(OpCodes.Starg))
+            {
+                if ((uint)arg <= byte.MaxValue)
+                {
+                    _il.OpCode(ILOpCode.Starg_s);
+                    _builder.WriteByte((byte)arg);
+                    return;
+                }
+
+                if ((uint)arg <= ushort.MaxValue) // this will be true except on misuse of the opcode
+                {
+                    _il.OpCode(ILOpCode.Starg);
+                    _builder.WriteInt16((short)arg);
+                    return;
+                }
+            }
+
+            // For everything else, put the opcode followed by the arg onto the stream of instructions.
+            _il.OpCode((ILOpCode)opcode.Value);
+            _builder.WriteInt32(arg);
+        }
+
+        public override void Emit(OpCode opcode, long arg)
+        {
+            _il.OpCode((ILOpCode)opcode.Value);
+            _il.CodeBuilder.WriteInt64(arg);
+        }
+
+        public override void Emit(OpCode opcode, string str)
+        {
+            // Puts the opcode onto the IL stream followed by the metadata token
+            // represented by str.
+
+            ModuleBuilder modBuilder = (ModuleBuilder)_methodBuilder.Module;
+            int tempVal = modBuilder.GetStringMetadataToken(str);
+            _il.OpCode((ILOpCode)opcode.Value);
+            _il.Token(tempVal);
+        }
+
+        public override void Emit(OpCode opcode, ConstructorInfo con) => throw new NotImplementedException();
+        public override void Emit(OpCode opcode, Label label) => throw new NotImplementedException();
+        public override void Emit(OpCode opcode, Label[] labels) => throw new NotImplementedException();
+        public override void Emit(OpCode opcode, LocalBuilder local) => throw new NotImplementedException();
+        public override void Emit(OpCode opcode, SignatureHelper signature) => throw new NotImplementedException();
+        public override void Emit(OpCode opcode, FieldInfo field) => throw new NotImplementedException();
+        public override void Emit(OpCode opcode, MethodInfo meth) => throw new NotImplementedException();
+        public override void Emit(OpCode opcode, Type cls) => throw new NotImplementedException();
+        public override void EmitCall(OpCode opcode, MethodInfo methodInfo, Type[]? optionalParameterTypes) => throw new NotImplementedException();
+        public override void EmitCalli(OpCode opcode, CallingConventions callingConvention, Type? returnType, Type[]? parameterTypes, Type[]? optionalParameterTypes) => throw new NotImplementedException();
+        public override void EmitCalli(OpCode opcode, CallingConvention unmanagedCallConv, Type? returnType, Type[]? parameterTypes) => throw new NotImplementedException();
+        public override void EndExceptionBlock() => throw new NotImplementedException();
+        public override void EndScope() => throw new NotImplementedException();
+        public override void MarkLabel(Label loc) => throw new NotImplementedException();
+        public override void UsingNamespace(string usingNamespace) => throw new NotImplementedException();
+    }
+}

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
@@ -16,6 +16,7 @@ namespace System.Reflection.Emit
         private readonly BlobBuilder _builder;
         private readonly InstructionEncoder _il;
         private bool _hasDynamicStackAllocation;
+        private int _maxStackSize;
 
         internal ILGeneratorImpl(MethodBuilder methodBuilder, int size)
         {
@@ -24,6 +25,8 @@ namespace System.Reflection.Emit
             _builder = new BlobBuilder(Math.Max(size, DefaultSize));
             _il = new InstructionEncoder(_builder, new ControlFlowBuilder());
         }
+
+        internal int GetMaxStackSize() => _maxStackSize;
 
         internal InstructionEncoder Instructions => _il;
         internal bool HasDynamicStackAllocation => _hasDynamicStackAllocation;
@@ -46,6 +49,10 @@ namespace System.Reflection.Emit
                 _hasDynamicStackAllocation = true;
             }
             _il.OpCode((ILOpCode)opcode.Value);
+
+            // TODO for now only count the Opcodes emitted, in order to correctly we might need to make below API public
+            // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/Opcode.cs#L48
+            _maxStackSize++;
         }
 
         public override void Emit(OpCode opcode, byte arg)

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
@@ -50,7 +50,7 @@ namespace System.Reflection.Emit
             }
             _il.OpCode((ILOpCode)opcode.Value);
 
-            // TODO for now only count the Opcodes emitted, in order to correctly we might need to make below API public
+            // TODO: for now only count the Opcodes emitted, in order to calculate it correctly we might need to make internal Opcode APIs public
             // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/Opcode.cs#L48
             _maxStackSize++;
         }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Emit
 {
@@ -20,6 +21,8 @@ namespace System.Reflection.Emit
         private MethodAttributes _attributes;
         private MethodImplAttributes _methodImplFlags;
         private GenericTypeParameterBuilderImpl[]? _typeParameters;
+        private ILGeneratorImpl? _ilGenerator;
+        private bool _initLocals;
 
         internal DllImportData? _dllImportData;
         internal List<CustomAttributeWrapper>? _customAttributes;
@@ -46,7 +49,10 @@ namespace System.Reflection.Emit
             }
 
             _methodImplFlags = MethodImplAttributes.IL;
+            _initLocals = true;
         }
+
+        internal ILGeneratorImpl? ILGeneratorImpl => _ilGenerator;
 
         internal BlobBuilder GetMethodSignatureBlob() => MetadataSignatureHelper.MethodSignatureEncoder(_module,
             _parameterTypes, ReturnType, GetSignatureConvention(_callingConventions), GetGenericArguments().Length, !IsStatic);
@@ -68,7 +74,14 @@ namespace System.Reflection.Emit
 
             return convention;
         }
-        protected override bool InitLocalsCore { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        protected override bool InitLocalsCore
+        {
+            get { ThrowIfGeneric(); return _initLocals; }
+            set { ThrowIfGeneric(); _initLocals = value; }
+        }
+
+        private void ThrowIfGeneric() { if (IsGenericMethod && !IsGenericMethodDefinition) throw new InvalidOperationException(); }
+
         protected override GenericTypeParameterBuilder[] DefineGenericParametersCore(params string[] names)
         {
             if (_typeParameters != null)
@@ -98,7 +111,23 @@ namespace System.Reflection.Emit
             return parameter;
         }
 
-        protected override ILGenerator GetILGeneratorCore(int size) => throw new NotImplementedException();
+        protected override ILGenerator GetILGeneratorCore(int size)
+        {
+            if (IsGenericMethod && !IsGenericMethodDefinition)
+            {
+                throw new InvalidOperationException();
+            }
+
+            if ((_methodImplFlags & MethodImplAttributes.CodeTypeMask) != MethodImplAttributes.IL ||
+                (_methodImplFlags & MethodImplAttributes.Unmanaged) != 0 ||
+                (_attributes & MethodAttributes.PinvokeImpl) != 0)
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_ShouldNotHaveMethodBody);
+            }
+
+            return _ilGenerator ??= new ILGeneratorImpl(this, size);
+        }
+
         protected override void SetCustomAttributeCore(ConstructorInfo con, ReadOnlySpan<byte> binaryAttribute)
         {
             // Handle pseudo custom attributes
@@ -199,8 +228,8 @@ namespace System.Reflection.Emit
         public override bool IsDefined(Type attributeType, bool inherit) => throw new NotSupportedException(SR.NotSupported_DynamicModule);
 
         [RequiresDynamicCode("The native code for this instantiation might not be available at runtime.")]
-        [RequiresUnreferencedCodeAttribute("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
-        public override MethodInfo MakeGenericMethod(params System.Type[] typeArguments)
+        [RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
+        public override MethodInfo MakeGenericMethod(params Type[] typeArguments)
             => throw new NotImplementedException();
     }
 }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
@@ -125,6 +125,11 @@ namespace System.Reflection.Emit
                 throw new InvalidOperationException(SR.InvalidOperation_ShouldNotHaveMethodBody);
             }
 
+            if ((_attributes & MethodAttributes.Abstract) != 0)
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_ShouldNotHaveMethodBody);
+            }
+
             return _ilGenerator ??= new ILGeneratorImpl(this, size);
         }
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -240,7 +240,7 @@ namespace System.Reflection.Emit
         private static int AddMethodBody(MethodBuilderImpl method, ILGeneratorImpl il, MethodBodyStreamEncoder methodBodyEncoder) =>
             methodBodyEncoder.AddMethodBody(
                 instructionEncoder: il.Instructions,
-                maxStack: 8, // TODO
+                maxStack: il.GetMaxStackSize(),
                 localVariablesSignature: default, // TODO
                 attributes: method.InitLocals ? MethodBodyAttributes.InitLocals : MethodBodyAttributes.None,
                 hasDynamicStackAllocation: il.HasDynamicStackAllocation);

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -186,7 +186,7 @@ namespace System.Reflection.Emit
             {
                 int offset = -1;
                 ILGeneratorImpl? il = method.ILGeneratorImpl;
-                if (!method.IsAbstract && il != null)
+                if (il != null)
                 {
                     offset = AddMethodBody(method, il, methodBodyEncoder);
                 }
@@ -451,7 +451,9 @@ namespace System.Reflection.Emit
         public override int GetFieldMetadataToken(FieldInfo field) => throw new NotImplementedException();
         public override int GetMethodMetadataToken(ConstructorInfo constructor) => throw new NotImplementedException();
         public override int GetMethodMetadataToken(MethodInfo method) => throw new NotImplementedException();
-        public override int GetStringMetadataToken(string stringConstant) => throw new NotImplementedException();
+
+        public override int GetStringMetadataToken(string stringConstant) => MetadataTokens.GetToken(_metadataBuilder.GetOrAddUserString(stringConstant));
+
         public override int GetTypeMetadataToken(Type type) => throw new NotImplementedException();
         protected override void CreateGlobalFunctionsCore() => throw new NotImplementedException();
 

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace System.Reflection.Emit.Tests
+{
+    public class AssemblySaveILGeneratorTests
+    {
+        [Fact]
+        public void MethodWithEmptyBody()
+        {
+            using (TempFile file = TempFile.Create())
+            {
+                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndSaveMethod(out MethodInfo saveMethod);
+                TypeBuilder type = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public);
+
+                var methodBuilder = type.DefineMethod("EmptyMethod", MethodAttributes.Public, typeof(void), new[] { typeof(Version) });
+                var il = methodBuilder.GetILGenerator();
+                il.Emit(OpCodes.Ret);
+                saveMethod.Invoke(ab, new object[] { file.Path });
+
+                Assembly assemblyFromDisk = AssemblySaveTools.LoadAssemblyFromPath(file.Path);
+                Type typeFromDisk = assemblyFromDisk.Modules.First().GetType("MyType");
+                MethodInfo method = typeFromDisk.GetMethod("EmptyMethod");
+                MethodBody body = method.GetMethodBody();
+                Assert.Empty(body.LocalVariables);
+                Assert.Empty(body.ExceptionHandlingClauses);
+                byte[]? bodyBytes = body.GetILAsByteArray();
+                Assert.NotNull(bodyBytes);
+                Assert.Equal(OpCodes.Ret.Value, bodyBytes[0]);
+
+            }
+        }
+
+        [Theory]
+        [InlineData(20)]
+        [InlineData(-10)]
+        public void MethodReturning_Int(int size)
+        {
+            using (TempFile file = TempFile.Create())
+            {
+                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndSaveMethod(out MethodInfo saveMethod);
+                TypeBuilder type = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public);
+                MethodBuilder method = type.DefineMethod("TestMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(int), Type.EmptyTypes);
+
+                ILGenerator ilGenerator = method.GetILGenerator(size);
+                int expectedReturn = 5;
+                ilGenerator.Emit(OpCodes.Ldc_I4, expectedReturn);
+                ilGenerator.Emit(OpCodes.Ret);
+                saveMethod.Invoke(ab, new object[] { file.Path });
+
+                Assembly assemblyFromDisk = AssemblySaveTools.LoadAssemblyFromPath(file.Path);
+                Type typeFromDisk = assemblyFromDisk.Modules.First().GetType("MyType");
+                MethodInfo methodFromFile = typeFromDisk.GetMethod("TestMethod");
+                MethodBody body = methodFromFile.GetMethodBody();
+                byte[]? bodyBytes = body.GetILAsByteArray();
+                Assert.NotNull(bodyBytes);
+                Assert.Equal(OpCodes.Ldc_I4_5.Value, bodyBytes[0]);
+                Assert.Equal(OpCodes.Ret.Value, bodyBytes[1]);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -36,7 +36,7 @@ namespace System.Reflection.Emit.Tests
 
         [Theory]
         [InlineData(20)]
-        [InlineData(-10)]
+        [InlineData(-10)] // For compat, runtime implementation doesn't throw for negative value.
         public void MethodReturning_Int(int size)
         {
             using (TempFile file = TempFile.Create())
@@ -103,6 +103,69 @@ namespace System.Reflection.Emit.Tests
                 Assert.Equal(OpCodes.Ldarg_0.Value, addBody[0]);
                 Assert.Equal(OpCodes.Ldarg_1.Value, addBody[1]);
                 Assert.Equal(OpCodes.Add.Value, addBody[2]);
+            }
+        }
+
+        [Fact]
+        public void MultipleTypesWithMultipleMethods()
+        {
+            using (TempFile file = TempFile.Create())
+            {
+                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderTypeBuilderAndSaveMethod(out TypeBuilder type, out MethodInfo saveMethod);
+                MethodBuilder multiplyMethod = type.DefineMethod("MultiplyMethod", MethodAttributes.Public, typeof(short), new Type[] { typeof(short) });
+                MethodBuilder addMethod = type.DefineMethod("AddMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(double), new Type[] { typeof(double) });
+
+                ILGenerator multiplyMethodIL = multiplyMethod.GetILGenerator();
+                multiplyMethodIL.Emit(OpCodes.Ldarg, 1);
+                multiplyMethodIL.Emit(OpCodes.Ldc_I4_S, (short)11);
+                multiplyMethodIL.Emit(OpCodes.Mul);
+                multiplyMethodIL.Emit(OpCodes.Ret);
+                ILGenerator addMethodIL = addMethod.GetILGenerator();
+                addMethodIL.Emit(OpCodes.Ldarg_0);
+                addMethodIL.Emit(OpCodes.Ldc_R8, (double)123456.123);
+                addMethodIL.Emit(OpCodes.Add);
+                addMethodIL.Emit(OpCodes.Ret);
+
+                TypeBuilder anotherType = ab.GetDynamicModule("MyModule").DefineType("AnotherType", TypeAttributes.NotPublic);
+                MethodBuilder stringMethod = anotherType.DefineMethod("StringMethod", MethodAttributes.FamORAssem, typeof(string), Type.EmptyTypes);
+                MethodBuilder floatMethod = anotherType.DefineMethod("FloatMethod", MethodAttributes.Family, typeof(float), Type.EmptyTypes);
+                MethodBuilder longMethod = anotherType.DefineMethod("LongMethod", MethodAttributes.Static, typeof(long), Type.EmptyTypes);
+
+                ILGenerator stringMethodIL = stringMethod.GetILGenerator();
+                stringMethodIL.Emit(OpCodes.Ldstr, "Hello world!");
+                stringMethodIL.Emit(OpCodes.Ret);
+                ILGenerator floatMethodIL = floatMethod.GetILGenerator();
+                floatMethodIL.Emit(OpCodes.Ldc_R4, (float)123456.123);
+                floatMethodIL.Emit(OpCodes.Ret);
+                ILGenerator longMethodIL = longMethod.GetILGenerator();
+                longMethodIL.Emit(OpCodes.Ldc_I8, (long)1234567);
+                longMethodIL.Emit(OpCodes.Ret);
+
+                saveMethod.Invoke(ab, new object[] { file.Path });
+
+                Assembly assemblyFromDisk = AssemblySaveTools.LoadAssemblyFromPath(file.Path);
+                Module moduleFromFile = assemblyFromDisk.Modules.First();
+                Type typeFromDisk = moduleFromFile.GetType("MyType");
+                Type anotherTypeFromDisk = moduleFromFile.GetType("AnotherType");
+                byte[]? multiplyBody = typeFromDisk.GetMethod("MultiplyMethod").GetMethodBody().GetILAsByteArray();
+                byte[]? addBody = typeFromDisk.GetMethod("AddMethod").GetMethodBody().GetILAsByteArray();
+                byte[]? stringBody = anotherTypeFromDisk.GetMethod("StringMethod", BindingFlags.NonPublic | BindingFlags.Instance).GetMethodBody().GetILAsByteArray();
+                byte[]? floatBody = anotherTypeFromDisk.GetMethod("FloatMethod", BindingFlags.NonPublic | BindingFlags.Instance).GetMethodBody().GetILAsByteArray();
+                byte[]? longBody = anotherTypeFromDisk.GetMethod("LongMethod", BindingFlags.NonPublic | BindingFlags.Static).GetMethodBody().GetILAsByteArray();
+
+                Assert.NotNull(multiplyBody);
+                Assert.Equal(OpCodes.Ldarg_1.Value, multiplyBody[0]);
+                Assert.Equal(OpCodes.Ldc_I4_S.Value, multiplyBody[1]);
+                Assert.Equal(11, multiplyBody[2]);
+                Assert.NotNull(addBody);
+                Assert.Equal(OpCodes.Ldarg_0.Value, addBody[0]);
+                Assert.Equal(OpCodes.Ldc_R8.Value, addBody[1]);
+                Assert.NotNull(stringBody);
+                Assert.Equal(OpCodes.Ldstr.Value, stringBody[0]);
+                Assert.NotNull(floatBody);
+                Assert.Equal(OpCodes.Ldc_R4.Value, floatBody[0]);
+                Assert.NotNull(longBody);
+                Assert.Equal(OpCodes.Ldc_I8.Value, longBody[0]);
             }
         }
     }

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.Reflection.Emit.Tests
 {
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
     public class AssemblySaveILGeneratorTests
     {
         [Fact]
@@ -14,11 +15,9 @@ namespace System.Reflection.Emit.Tests
         {
             using (TempFile file = TempFile.Create())
             {
-                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndSaveMethod(out MethodInfo saveMethod);
-                TypeBuilder type = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public);
-
-                var methodBuilder = type.DefineMethod("EmptyMethod", MethodAttributes.Public, typeof(void), new[] { typeof(Version) });
-                var il = methodBuilder.GetILGenerator();
+                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderTypeBuilderAndSaveMethod(out TypeBuilder type, out MethodInfo saveMethod);
+                MethodBuilder methodBuilder = type.DefineMethod("EmptyMethod", MethodAttributes.Public, typeof(void), new[] { typeof(Version) });
+                ILGenerator il = methodBuilder.GetILGenerator();
                 il.Emit(OpCodes.Ret);
                 saveMethod.Invoke(ab, new object[] { file.Path });
 
@@ -42,8 +41,7 @@ namespace System.Reflection.Emit.Tests
         {
             using (TempFile file = TempFile.Create())
             {
-                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndSaveMethod(out MethodInfo saveMethod);
-                TypeBuilder type = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public);
+                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderTypeBuilderAndSaveMethod(out TypeBuilder type, out MethodInfo saveMethod);
                 MethodBuilder method = type.DefineMethod("TestMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(int), Type.EmptyTypes);
 
                 ILGenerator ilGenerator = method.GetILGenerator(size);
@@ -60,6 +58,51 @@ namespace System.Reflection.Emit.Tests
                 Assert.NotNull(bodyBytes);
                 Assert.Equal(OpCodes.Ldc_I4_5.Value, bodyBytes[0]);
                 Assert.Equal(OpCodes.Ret.Value, bodyBytes[1]);
+            }
+        }
+
+        [Theory]
+        [InlineData(20)]
+        [InlineData(11)]
+        public void TypeWithTwoMethod_ReferenceMethodArguments(int multiplier)
+        {
+            using (TempFile file = TempFile.Create())
+            {
+                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderTypeBuilderAndSaveMethod(out TypeBuilder type, out MethodInfo saveMethod);
+                MethodBuilder multiplyMethod = type.DefineMethod("MultiplyMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(int), new Type[] { typeof(int) });
+                multiplyMethod.DefineParameter(1, ParameterAttributes.None, "myParam");
+                MethodBuilder addMethod = type.DefineMethod("AddMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(int), new Type[] { typeof(int), typeof(int) });
+                addMethod.DefineParameter(1, ParameterAttributes.None, "firsParam");
+                addMethod.DefineParameter(2, ParameterAttributes.None, "secondParam");
+
+                ILGenerator multiplyMethodIL = multiplyMethod.GetILGenerator();
+                multiplyMethodIL.Emit(OpCodes.Ldarg_0);
+                multiplyMethodIL.Emit(OpCodes.Ldc_I4, multiplier);
+                multiplyMethodIL.Emit(OpCodes.Mul);
+                multiplyMethodIL.Emit(OpCodes.Ret);
+
+                ILGenerator addMethodIL = addMethod.GetILGenerator();
+                addMethodIL.Emit(OpCodes.Ldarg_0);
+                addMethodIL.Emit(OpCodes.Ldarg_1);
+                addMethodIL.Emit(OpCodes.Add);
+                addMethodIL.Emit(OpCodes.Ret);
+
+                saveMethod.Invoke(ab, new object[] { file.Path });
+
+                Assembly assemblyFromDisk = AssemblySaveTools.LoadAssemblyFromPath(file.Path);
+                Type typeFromDisk = assemblyFromDisk.Modules.First().GetType("MyType");
+                byte[]? multiplyBody = typeFromDisk.GetMethod("MultiplyMethod").GetMethodBody().GetILAsByteArray();
+                byte[]? addBody = typeFromDisk.GetMethod("AddMethod").GetMethodBody().GetILAsByteArray();
+
+                Assert.NotNull(multiplyBody);
+                Assert.Equal(OpCodes.Ldarg_0.Value, multiplyBody[0]);
+                Assert.Equal(OpCodes.Ldc_I4_S.Value, multiplyBody[1]);
+                Assert.Equal(multiplier, multiplyBody[2]);
+                Assert.Equal(OpCodes.Mul.Value, multiplyBody[3]);
+                Assert.NotNull(addBody);
+                Assert.Equal(OpCodes.Ldarg_0.Value, addBody[0]);
+                Assert.Equal(OpCodes.Ldarg_1.Value, addBody[1]);
+                Assert.Equal(OpCodes.Add.Value, addBody[2]);
             }
         }
     }

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTools.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTools.cs
@@ -11,6 +11,11 @@ namespace System.Reflection.Emit.Tests
 {
     internal static class AssemblySaveTools
     {
+        private static readonly AssemblyName s_assemblyName = new AssemblyName("MyDynamicAssembly")
+        {
+            Version = new Version("1.2.3.4"),
+        };
+
         internal static void WriteAssemblyToDisk(AssemblyName assemblyName, Type[] types, string fileLocation)
         {
             AssemblyBuilder assemblyBuilder = PopulateAssemblyBuilderAndSaveMethod(
@@ -56,6 +61,9 @@ namespace System.Reflection.Emit.Tests
 
             saveMethod.Invoke(assemblyBuilder, new object[] { stream });
         }
+
+        internal static AssemblyBuilder PopulateAssemblyBuilderAndSaveMethod(out MethodInfo saveMethod) =>
+            PopulateAssemblyBuilderAndSaveMethod(s_assemblyName, null, typeof(string), out saveMethod);
 
         internal static AssemblyBuilder PopulateAssemblyBuilderAndSaveMethod(AssemblyName assemblyName,
             List<CustomAttributeBuilder>? assemblyAttributes, Type parameterType, out MethodInfo saveMethod)

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTools.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTools.cs
@@ -62,8 +62,13 @@ namespace System.Reflection.Emit.Tests
             saveMethod.Invoke(assemblyBuilder, new object[] { stream });
         }
 
-        internal static AssemblyBuilder PopulateAssemblyBuilderAndSaveMethod(out MethodInfo saveMethod) =>
-            PopulateAssemblyBuilderAndSaveMethod(s_assemblyName, null, typeof(string), out saveMethod);
+        internal static AssemblyBuilder PopulateAssemblyBuilderTypeBuilderAndSaveMethod(out TypeBuilder typeBuilder, out MethodInfo saveMethod)
+        {
+            AssemblyBuilder ab = PopulateAssemblyBuilderAndSaveMethod(s_assemblyName, null, typeof(string), out saveMethod);
+            typeBuilder = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public);
+            return ab;
+        }
+            
 
         internal static AssemblyBuilder PopulateAssemblyBuilderAndSaveMethod(AssemblyName assemblyName,
             List<CustomAttributeBuilder>? assemblyAttributes, Type parameterType, out MethodInfo saveMethod)

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTools.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTools.cs
@@ -68,8 +68,7 @@ namespace System.Reflection.Emit.Tests
             typeBuilder = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public);
             return ab;
         }
-            
-
+        
         internal static AssemblyBuilder PopulateAssemblyBuilderAndSaveMethod(AssemblyName assemblyName,
             List<CustomAttributeBuilder>? assemblyAttributes, Type parameterType, out MethodInfo saveMethod)
         {

--- a/src/libraries/System.Reflection.Emit/tests/System.Reflection.Emit.Tests.csproj
+++ b/src/libraries/System.Reflection.Emit/tests/System.Reflection.Emit.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="ParameterBuilder\ParameterBuilderSetConstant.cs" />
     <Compile Include="PersistableAssemblyBuilder\AssemblySaveCustomAttributeTests.cs" />
     <Compile Include="PersistableAssemblyBuilder\AssemblySaveEnumBuilderTests.cs" />
+    <Compile Include="PersistableAssemblyBuilder\AssemblySaveILGeneratorTests.cs" />
     <Compile Include="PersistableAssemblyBuilder\AssemblySaveTools.cs" />
     <Compile Include="PersistableAssemblyBuilder\AssemblySaveTypeBuilderTests.cs" />
     <Compile Include="PropertyBuilder\PropertyBuilderAddOtherMethod.cs" />


### PR DESCRIPTION
Basically, replacing the ILGenerator.Emit overloads implementaiton with `InstructionEncoder` which will be written into the file when saving the methods in a type using [MethodBodyStreamEncoder](https://learn.microsoft.com/dotnet/api/system.reflection.metadata.ecma335.methodbodystreamencoder)

Contributes to https://github.com/dotnet/runtime/issues/83988