### PR TITLE
Update package description used types for System.IO.Hashing

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
+++ b/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
@@ -8,7 +8,11 @@
 
 Commonly Used Types:
 System.IO.Hashing.Crc32
-System.IO.Hashing.XxHash32</PackageDescription>
+System.IO.Hashing.Crc64
+System.IO.Hashing.XxHash128
+System.IO.Hashing.XxHash3
+System.IO.Hashing.XxHash32
+System.IO.Hashing.XxHash64</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
While installing the NuGet package, the recently added types were not added to the csproj/NuGet description. This PR fixes this.

Should be probably backported to .NET 8 branch?