### PR TITLE
Start new per-host queue when an async over sync Dns call is cancelled

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -666,8 +666,8 @@ namespace System.Net
                     {
                         using (cancellationToken.UnsafeRegister(static s =>
                         {
-                            // In case a request is cancelled, make sure we start queue for this key.
-                            // This helps avoiding congestion on stalled or long running requests.
+                            // In case a request is cancelled, start a new queue for this key.
+                            // This helps avoiding congestion when a getaddrinfo call runs for too long.
                             lock (s_tasks)
                             {
                                 s_tasks.Remove(s!);

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -666,7 +666,16 @@ namespace System.Net
                     Debug.Assert(!Monitor.IsEntered(s_tasks));
                     try
                     {
-                        return func(key, startingTimestamp);
+                        using (cancellationToken.UnsafeRegister(static s =>
+                        {
+                            lock (s_tasks)
+                            {
+                                s_tasks.Remove(s!);
+                            }
+                        }, key))
+                        {
+                            return func(key, startingTimestamp);
+                        }
                     }
                     finally
                     {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -97,7 +97,7 @@ namespace System.Net.Sockets
 
             saea.RemoteEndPoint = remoteEP;
 
-            ValueTask connectTask = saea.ConnectAsync(this);
+            ValueTask connectTask = saea.ConnectAsync(this, saeaCancelable: cancellationToken.CanBeCanceled);
             if (connectTask.IsCompleted || !cancellationToken.CanBeCanceled)
             {
                 // Avoid async invocation overhead
@@ -1202,11 +1202,11 @@ namespace System.Net.Sockets
                     ValueTask.FromException<int>(CreateException(error));
             }
 
-            public ValueTask ConnectAsync(Socket socket)
+            public ValueTask ConnectAsync(Socket socket, bool saeaCancelable)
             {
                 try
                 {
-                    if (socket.ConnectAsync(this, userSocket: true, saeaCancelable: false))
+                    if (socket.ConnectAsync(this, userSocket: true, saeaCancelable: saeaCancelable))
                     {
                         return new ValueTask(this, _mrvtsc.Version);
                     }


### PR DESCRIPTION
We had several customer reports of #81023 -- long running `getaddrinfo` lookups stalling `Dns.*Async` calls as a result of #49171. This is a simple mitigation of the problem by starting a new per-hostname Task queue in case a cancellation fires and also fixing #92054 to make sure the `CancellationToken` flows down to `GetHostAddressesAsync`.

The downside of this mitigation is that it actually needs a cancellation (~`ConnectTimeout`) to work. IMO this is still better than not having a solution to the problem at .NET level at all. We could implement a more sophisticated fix (see #92863), but I'm assuming that we are looking for a low-risk change to service .NET 8 and maybe earlier versions.

Fixes #92054
Fixes #92045
Mitigates #81023 (doesn't fully fix the issue)