### PR TITLE
Remove base type rooting for types in rooted assemblies

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingHelpers.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingHelpers.cs
@@ -40,15 +40,6 @@ namespace ILCompiler
                 rootProvider.AddReflectionRoot(type, reason);
             }
 
-            // Also root base types. This is so that we make methods on the base types callable.
-            // This helps in cases like "class Foo : Bar<int> { }" where we discover new
-            // generic instantiations.
-            TypeDesc baseType = type.BaseType;
-            if (baseType != null)
-            {
-                RootType(rootProvider, baseType.NormalizeInstantiation(), reason);
-            }
-
             if (type.IsDefType)
             {
                 foreach (var method in type.ConvertToCanonForm(CanonicalFormKind.Specific).GetMethods())

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingHelpers.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingHelpers.cs
@@ -11,11 +11,11 @@ namespace ILCompiler
 {
     public class RootingHelpers
     {
-        public static bool TryRootType(IRootingServiceProvider rootProvider, TypeDesc type, string reason)
+        public static bool TryRootType(IRootingServiceProvider rootProvider, TypeDesc type, bool rootBaseTypes, string reason)
         {
             try
             {
-                RootType(rootProvider, type, reason);
+                RootType(rootProvider, type, rootBaseTypes, reason);
                 return true;
             }
             catch (TypeSystemException)
@@ -24,7 +24,7 @@ namespace ILCompiler
             }
         }
 
-        public static void RootType(IRootingServiceProvider rootProvider, TypeDesc type, string reason)
+        public static void RootType(IRootingServiceProvider rootProvider, TypeDesc type, bool rootBaseTypes, string reason)
         {
             rootProvider.AddReflectionRoot(type, reason);
 
@@ -38,6 +38,15 @@ namespace ILCompiler
                 type = ((MetadataType)type).MakeInstantiatedType(inst);
 
                 rootProvider.AddReflectionRoot(type, reason);
+            }
+
+            if (rootBaseTypes)
+            {
+                TypeDesc baseType = type.BaseType;
+                if (baseType != null)
+                {
+                    RootType(rootProvider, baseType.NormalizeInstantiation(), rootBaseTypes, reason);
+                }
             }
 
             if (type.IsDefType)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -351,7 +351,7 @@ namespace ILCompiler
                     var rootProvider = new RootingServiceProvider(factory, dependencies.Add);
                     foreach (TypeDesc t in mdType.Module.GetAllTypes())
                     {
-                        RootingHelpers.TryRootType(rootProvider, t, reason);
+                        RootingHelpers.TryRootType(rootProvider, t, rootBaseTypes: false, reason);
                     }
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCases/TestDatabase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCases/TestDatabase.cs
@@ -34,7 +34,12 @@ namespace Mono.Linker.Tests.TestCases
 			return TestNamesBySuiteName();
 		}
 
-		public static IEnumerable<object[]> LinkXml()
+        public static IEnumerable<object[]> Libraries()
+        {
+            return TestNamesBySuiteName();
+        }
+
+        public static IEnumerable<object[]> LinkXml()
 		{
 			return TestNamesBySuiteName();
 		}

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCases/TestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCases/TestSuites.cs
@@ -37,7 +37,14 @@ namespace Mono.Linker.Tests.TestCases
 			Run(t);
 		}
 
-		[Theory]
+        [Theory]
+        [MemberData(nameof(TestDatabase.Libraries), MemberType = typeof(TestDatabase))]
+        public void Libraries(string t)
+        {
+            Run(t);
+        }
+
+        [Theory]
 		[MemberData (nameof (TestDatabase.LinkXml), MemberType = typeof (TestDatabase))]
 		public void LinkXml (string t)
 		{

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ResultChecker.cs
@@ -14,7 +14,6 @@ using Internal.TypeSystem;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
-using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Extensions;
 using Xunit;
 

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
@@ -103,7 +103,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				new ManifestResourceBlockingPolicy (logger, options.FeatureSwitches, new Dictionary<ModuleDesc, IReadOnlySet<string>>()),
 				logFile: null,
 				new NoStackTraceEmissionPolicy (),
-				new NoDynamicInvokeThunkGenerationPolicy (),
+				new DefaultDynamicInvokeThunkGenerationPolicy (),
 				new FlowAnnotations (logger, ilProvider, compilerGeneratedState),
 				UsageBasedMetadataGenerationOptions.ReflectionILScanning,
 				options: default,

--- a/src/coreclr/tools/aot/ILCompiler/RdXmlRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler/RdXmlRootProvider.cs
@@ -71,7 +71,7 @@ namespace ILCompiler
 
                 foreach (TypeDesc type in ((EcmaModule)assembly).GetAllTypes())
                 {
-                    RootingHelpers.TryRootType(rootProvider, type, "RD.XML root");
+                    RootingHelpers.TryRootType(rootProvider, type, rootBaseTypes: true, "RD.XML root");
                 }
             }
 
@@ -103,7 +103,7 @@ namespace ILCompiler
                 if (dynamicDegreeAttribute.Value != "Required All")
                     throw new NotSupportedException($"\"{dynamicDegreeAttribute.Value}\" is not a supported value for the \"Dynamic\" attribute of the \"Type\" Runtime Directive. Supported values are \"Required All\".");
 
-                RootingHelpers.RootType(rootProvider, type, "RD.XML root");
+                RootingHelpers.RootType(rootProvider, type, rootBaseTypes: true, "RD.XML root");
             }
 
             var marshalStructureDegreeAttribute = typeElement.Attribute("MarshalStructure");

--- a/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/PriorityQueue/PriorityQueue.Tests.cs
@@ -287,7 +287,7 @@ namespace System.Collections.Tests
 
         private static int GetUnderlyingBufferCapacity<TPriority, TElement>(PriorityQueue<TPriority, TElement> queue)
         {
-            FieldInfo nodesField = queue.GetType().GetField("_nodes", BindingFlags.NonPublic | BindingFlags.Instance);
+            FieldInfo nodesField = typeof(PriorityQueue<TPriority, TElement>).GetField("_nodes", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.NotNull(nodesField);
             var nodes = ((TElement Element, TPriority Priority)[])nodesField.GetValue(queue);
             return nodes.Length;

--- a/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.EncodingTests.cs
+++ b/src/libraries/System.IO/tests/BinaryWriter/BinaryWriter.EncodingTests.cs
@@ -190,7 +190,7 @@ namespace System.IO.Tests
 
         private static bool IsUsingFastUtf8(BinaryWriter writer)
         {
-            return (bool)writer.GetType().GetField("_useFastUtf8", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(writer);
+            return (bool)typeof(BinaryWriter).GetField("_useFastUtf8", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(writer);
         }
 
         private static string GenerateLargeUnicodeString(int charCount)

--- a/src/libraries/System.Security.Cryptography/tests/DSATests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DSATests.cs
@@ -171,7 +171,7 @@ namespace System.Security.Cryptography.Tests
             public override void ImportParameters(DSAParameters parameters) => _dsa.ImportParameters(parameters);
             public override bool VerifySignature(byte[] rgbHash, byte[] rgbSignature) => _dsa.VerifySignature(rgbHash, rgbSignature);
             protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
-                (byte[])_dsa.GetType().GetMethod(
+                (byte[])typeof(DSA).GetMethod(
                     nameof(HashData),
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                     null,
@@ -179,7 +179,7 @@ namespace System.Security.Cryptography.Tests
                     null)
                 .Invoke(_dsa, new object[] { data, hashAlgorithm });
             protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
-                (byte[])_dsa.GetType().GetMethod(
+                (byte[])typeof(DSA).GetMethod(
                     nameof(HashData),
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                     null,

--- a/src/libraries/System.Security.Cryptography/tests/ECDsaTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/ECDsaTests.cs
@@ -169,7 +169,7 @@ namespace System.Security.Cryptography.Tests
                 base.HashData(data, offset, count, hashAlgorithm);
 
             protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
-                (byte[])_ecdsa.GetType().GetMethod(
+                (byte[])typeof(ECDsa).GetMethod(
                     nameof(HashData),
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                     null,
@@ -178,7 +178,7 @@ namespace System.Security.Cryptography.Tests
                 .Invoke(_ecdsa, new object[] { data, hashAlgorithm });
 
             protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
-                (byte[])_ecdsa.GetType().GetMethod(
+                (byte[])typeof(ECDsa).GetMethod(
                     nameof(HashData),
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                     null,

--- a/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.cs
+++ b/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.cs
@@ -1913,69 +1913,81 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public static class ReflectionExtensions
+    {
+#if NET6_0_OR_GREATER
+        [return: System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        public static Type WithConstructors(
+            [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+            this Type type) => type;
+#else
+        public static Type WithConstructors(this Type type) => type;
+#endif
+    }
+
     public static class CollectionTestTypes
     {
         public static IEnumerable<Type> EnumerableTypes<TElement>()
         {
-            yield return typeof(TElement[]); // ArrayConverter
-            yield return typeof(ConcurrentQueue<TElement>); // ConcurrentQueueOfTConverter
-            yield return typeof(GenericICollectionWrapper<TElement>); // ICollectionOfTConverter
-            yield return typeof(WrapperForIEnumerable); // IEnumerableConverter
-            yield return typeof(WrapperForIReadOnlyCollectionOfT<TElement>); // IEnumerableOfTConverter
-            yield return typeof(Queue); // IEnumerableWithAddMethodConverter
-            yield return typeof(WrapperForIList); // IListConverter
-            yield return typeof(Collection<TElement>); // IListOfTConverter
-            yield return typeof(ImmutableList<TElement>); // ImmutableEnumerableOfTConverter
-            yield return typeof(HashSet<TElement>); // ISetOfTConverter
-            yield return typeof(List<TElement>); // ListOfTConverter
-            yield return typeof(Queue<TElement>); // QueueOfTConverter
+            yield return typeof(TElement[]).WithConstructors(); // ArrayConverter
+            yield return typeof(ConcurrentQueue<TElement>).WithConstructors(); // ConcurrentQueueOfTConverter
+            yield return typeof(GenericICollectionWrapper<TElement>).WithConstructors(); // ICollectionOfTConverter
+            yield return typeof(WrapperForIEnumerable).WithConstructors(); // IEnumerableConverter
+            yield return typeof(WrapperForIReadOnlyCollectionOfT<TElement>).WithConstructors(); // IEnumerableOfTConverter
+            yield return typeof(Queue).WithConstructors(); // IEnumerableWithAddMethodConverter
+            yield return typeof(WrapperForIList).WithConstructors(); // IListConverter
+            yield return typeof(Collection<TElement>).WithConstructors(); // IListOfTConverter
+            yield return typeof(ImmutableList<TElement>).WithConstructors(); // ImmutableEnumerableOfTConverter
+            yield return typeof(HashSet<TElement>).WithConstructors(); // ISetOfTConverter
+            yield return typeof(List<TElement>).WithConstructors(); // ListOfTConverter
+            yield return typeof(Queue<TElement>).WithConstructors(); // QueueOfTConverter
         }
 
         public static IEnumerable<Type> DeserializableGenericEnumerableTypes<TElement>()
         {
-            yield return typeof(TElement[]); // ArrayConverter
-            yield return typeof(ConcurrentQueue<TElement>); // ConcurrentQueueOfTConverter
-            yield return typeof(GenericICollectionWrapper<TElement>); // ICollectionOfTConverter
-            yield return typeof(IEnumerable<TElement>); // IEnumerableConverter
-            yield return typeof(Collection<TElement>); // IListOfTConverter
-            yield return typeof(ImmutableList<TElement>); // ImmutableEnumerableOfTConverter
-            yield return typeof(HashSet<TElement>); // ISetOfTConverter
-            yield return typeof(List<TElement>); // ListOfTConverter
-            yield return typeof(Queue<TElement>); // QueueOfTConverter
+            yield return typeof(TElement[]).WithConstructors(); // ArrayConverter
+            yield return typeof(ConcurrentQueue<TElement>).WithConstructors(); // ConcurrentQueueOfTConverter
+            yield return typeof(GenericICollectionWrapper<TElement>).WithConstructors(); // ICollectionOfTConverter
+            yield return typeof(IEnumerable<TElement>).WithConstructors(); // IEnumerableConverter
+            yield return typeof(Collection<TElement>).WithConstructors(); // IListOfTConverter
+            yield return typeof(ImmutableList<TElement>).WithConstructors(); // ImmutableEnumerableOfTConverter
+            yield return typeof(HashSet<TElement>).WithConstructors(); // ISetOfTConverter
+            yield return typeof(List<TElement>).WithConstructors(); // ListOfTConverter
+            yield return typeof(Queue<TElement>).WithConstructors(); // QueueOfTConverter
         }
 
         public static IEnumerable<Type> DeserializableNonGenericEnumerableTypes()
         {
-            yield return typeof(Queue); // IEnumerableWithAddMethodConverter
-            yield return typeof(WrapperForIList); // IListConverter
+            yield return typeof(Queue).WithConstructors(); // IEnumerableWithAddMethodConverter
+            yield return typeof(WrapperForIList).WithConstructors(); // IListConverter
         }
 
         public static IEnumerable<Type> DictionaryTypes<TElement>()
         {
-            yield return typeof(Dictionary<string, TElement>); // DictionaryOfStringTValueConverter
-            yield return typeof(Hashtable); // IDictionaryConverter
-            yield return typeof(ConcurrentDictionary<string, TElement>); // IDictionaryOfStringTValueConverter
-            yield return typeof(GenericIDictionaryWrapper<string, TElement>); // IDictionaryOfStringTValueConverter
-            yield return typeof(ImmutableDictionary<string, TElement>); // ImmutableDictionaryOfStringTValueConverter
-            yield return typeof(GenericIReadOnlyDictionaryWrapper<string, TElement>); // IReadOnlyDictionaryOfStringTValueConverter
+            yield return typeof(Dictionary<string, TElement>).WithConstructors(); // DictionaryOfStringTValueConverter
+            yield return typeof(Hashtable).WithConstructors(); // IDictionaryConverter
+            yield return typeof(ConcurrentDictionary<string, TElement>).WithConstructors(); // IDictionaryOfStringTValueConverter
+            yield return typeof(GenericIDictionaryWrapper<string, TElement>).WithConstructors(); // IDictionaryOfStringTValueConverter
+            yield return typeof(ImmutableDictionary<string, TElement>).WithConstructors(); // ImmutableDictionaryOfStringTValueConverter
+            yield return typeof(GenericIReadOnlyDictionaryWrapper<string, TElement>).WithConstructors(); // IReadOnlyDictionaryOfStringTValueConverter
         }
 
         public static IEnumerable<Type> DeserializableDictionaryTypes<TKey, TValue>()
         {
-            yield return typeof(Dictionary<TKey, TValue>); // DictionaryOfStringTValueConverter
-            yield return typeof(Hashtable); // IDictionaryConverter
-            yield return typeof(IDictionary); // IDictionaryConverter
-            yield return typeof(ConcurrentDictionary<TKey, TValue>); // IDictionaryOfStringTValueConverter
-            yield return typeof(IDictionary<TKey, TValue>); // IDictionaryOfStringTValueConverter
-            yield return typeof(GenericIDictionaryWrapper<TKey, TValue>); // IDictionaryOfStringTValueConverter
-            yield return typeof(ImmutableDictionary<TKey, TValue>); // ImmutableDictionaryOfStringTValueConverter
-            yield return typeof(IReadOnlyDictionary<TKey, TValue>); // IReadOnlyDictionaryOfStringTValueConverter
+            yield return typeof(Dictionary<TKey, TValue>).WithConstructors(); // DictionaryOfStringTValueConverter
+            yield return typeof(Hashtable).WithConstructors(); // IDictionaryConverter
+            yield return typeof(IDictionary).WithConstructors(); // IDictionaryConverter
+            yield return typeof(ConcurrentDictionary<TKey, TValue>).WithConstructors(); // IDictionaryOfStringTValueConverter
+            yield return typeof(IDictionary<TKey, TValue>).WithConstructors(); // IDictionaryOfStringTValueConverter
+            yield return typeof(GenericIDictionaryWrapper<TKey, TValue>).WithConstructors(); // IDictionaryOfStringTValueConverter
+            yield return typeof(ImmutableDictionary<TKey, TValue>).WithConstructors(); // ImmutableDictionaryOfStringTValueConverter
+            yield return typeof(IReadOnlyDictionary<TKey, TValue>).WithConstructors(); // IReadOnlyDictionaryOfStringTValueConverter
         }
 
         public static IEnumerable<Type> DeserializableNonGenericDictionaryTypes()
         {
-            yield return typeof(Hashtable); // IDictionaryConverter
-            yield return typeof(SortedList); // IDictionaryConverter
+            yield return typeof(Hashtable).WithConstructors(); // IDictionaryConverter
+            yield return typeof(SortedList).WithConstructors(); // IDictionaryConverter
         }
     }
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/BaseInAssemblyAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/BaseInAssemblyAttribute.cs
@@ -5,5 +5,11 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
 {
 	public abstract class BaseInAssemblyAttribute : BaseExpectedLinkedBehaviorAttribute
 	{
+		/// <summary>
+		/// By default the behavior should be preserved by all platforms
+		/// This property can override that by setting only the platforms
+		/// which are expected to preserve the desired behavior.
+		/// </summary>
+		public Tool Tool { get; set; } = Tool.TrimmerAnalyzerAndNativeAot;
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/CanLinkPublicApisOfLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/CanLinkPublicApisOfLibrary.cs
@@ -3,6 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Libraries
 {
+	[IgnoreTestCase("NativeAOT doesn't implement library trimming the same way", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
 	[SetupLinkerLinkPublicAndFamily]
 	[SetupCompileAsLibrary]
 	[Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/CopyUsedAssemblyWithMainEntryRoot.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/CopyUsedAssemblyWithMainEntryRoot.cs
@@ -4,6 +4,8 @@ using Mono.Linker.Tests.Cases.Libraries.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Libraries
 {
+	[IgnoreTestCase ("NativeAOT doesn't implement copy used behavior", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
 	[Kept]
 	[KeptMember (".ctor()")]
 	[SetupLinkerAction ("copyused", "test")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/CopyUsedAssemblyWithPublicRoots.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/CopyUsedAssemblyWithPublicRoots.cs
@@ -3,6 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Libraries
 {
+	[IgnoreTestCase ("NativeAOT doesn't implement copy used behavior", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
 	[Kept]
 	[KeptMember (".ctor()")]
 	[SetupLinkerAction ("copyused", "test")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/DefaultLibraryLinkBehavior.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/DefaultLibraryLinkBehavior.cs
@@ -3,6 +3,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Libraries
 {
+	[IgnoreTestCase ("NativeAOT doesn't implement library trimming the same way", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
 	[SetupCompileAsLibrary]
 	[SetupLinkerArgument ("-a", "test.dll")]
 	[Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/UserAssemblyActionWorks_ChildLib.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/UserAssemblyActionWorks_ChildLib.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mono.Linker.Tests.Cases.Libraries.Dependencies
+{
+	public abstract class UserAssemblyActionWorks_ChildLib
+	{
+		public abstract void MustOverride ();
+
+		public static void ChildUnusedMethod (InputType input) { }
+
+		private static void ChildUnusedPrivateMethod () { }
+
+		public void ChildUnusedInstanceMethod () { }
+
+		public int UnusedProperty { get; set; }
+
+		public static int UnusedField;
+	}
+
+	public class InputType { }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/UserAssemblyActionWorks_Lib.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/Dependencies/UserAssemblyActionWorks_Lib.cs
@@ -1,7 +1,9 @@
 namespace Mono.Linker.Tests.Cases.Libraries.Dependencies
 {
-	public class UserAssemblyActionWorks_Lib
+	public class UserAssemblyActionWorks_Lib : UserAssemblyActionWorks_ChildLib
 	{
+		public override void MustOverride () { }
+
 		public static void Used ()
 		{
 		}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/LibraryWithUnresolvedInterfaces.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/LibraryWithUnresolvedInterfaces.cs
@@ -7,6 +7,8 @@ using Mono.Linker.Tests.Cases.Libraries.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Libraries
 {
+	[IgnoreTestCase ("NativeAOT doesn't implement library trimming the same way", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
 	[SetupCompileBefore ("copylibrary.dll", new[] { "Dependencies/CopyLibrary.cs" }, removeFromLinkerInput: true)]
 	[SetupLinkerArgument ("--skip-unresolved", "true")]
 	[SetupLinkerArgument ("-a", "test.exe", "library")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/RootLibrary.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/RootLibrary.cs
@@ -11,6 +11,8 @@ using Mono.Linker.Tests.Cases.Libraries.Dependencies;
 
 namespace Mono.Linker.Tests.Cases.Libraries
 {
+	[IgnoreTestCase ("NativeAOT doesn't implement library trimming the same way", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
 	[SetupCompileBefore ("copylibrary.dll", new[] { "Dependencies/CopyLibrary.cs" })]
 	[SetupLinkerAction ("copy", "copylibrary")]
 	[SetupLinkerArgument ("-a", "test.exe", "library")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryInternalsWithIVT.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryInternalsWithIVT.cs
@@ -10,6 +10,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Libraries
 {
+	[IgnoreTestCase ("NativeAOT doesn't implement library trimming the same way", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
 	[Kept]
 	[KeptMember (".ctor()")]
 	[SetupLinkerLinkPublicAndFamily]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryVisibleAndDescriptor.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryVisibleAndDescriptor.cs
@@ -4,6 +4,8 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Libraries
 {
+	[IgnoreTestCase ("NativeAOT doesn't implement library trimming the same way", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
 	[Kept]
 	[KeptMember (".ctor()")]
 	[SetupLinkerLinkPublicAndFamily]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryVisibleForwarders.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryVisibleForwarders.cs
@@ -8,6 +8,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Libraries
 {
+	[IgnoreTestCase ("NativeAOT doesn't implement library trimming the same way", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
+
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/RootLibraryVisibleForwarders_Lib.cs" })]
 	[SetupLinkerLinkPublicAndFamily]
 	[Define ("RootLibraryVisibleForwarders")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryVisibleForwardersWithoutReference.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/RootLibraryVisibleForwardersWithoutReference.cs
@@ -8,6 +8,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Libraries
 {
+	[IgnoreTestCase ("NativeAOT doesn't implement library trimming the same way", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
+
 	[SetupCompileBefore ("library.dll", new[] { "Dependencies/RootLibraryVisibleForwarders_Lib.cs" }, outputSubFolder: "isolated")]
 	[SetupLinkerLinkPublicAndFamily]
 	[SetupLinkerArgument ("-a", "isolated/library.dll", "visible")] // Checks for no-eager exported type resolving

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/UserAssemblyActionWorks.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/UserAssemblyActionWorks.cs
@@ -7,10 +7,23 @@ namespace Mono.Linker.Tests.Cases.Libraries
 	/// <summary>
 	/// We have to check another assembly because the test exe is included with -a and that will cause it to be linked
 	/// </summary>
-	[SetupLinkerDefaultAction ("copy")]
-	[SetupCompileBefore ("lib.dll", new[] { "Dependencies/UserAssemblyActionWorks_Lib.cs" })]
-	[KeptAllTypesAndMembersInAssembly ("lib.dll")]
+	[SetupCompileBefore ("childlib.dll", new[] { "Dependencies/UserAssemblyActionWorks_ChildLib.cs" })]
+	[SetupCompileBefore ("lib.dll", new[] { "Dependencies/UserAssemblyActionWorks_Lib.cs" }, new[] { "childlib.dll" })]
+	[SetupLinkerAction ("link", "childlib")]
+	[SetupLinkerAction ("copy", "lib")]
 	[SetupLinkerAction ("link", "test")]
+
+	[KeptAllTypesAndMembersInAssembly ("lib.dll")]
+	[KeptTypeInAssembly("childlib", "Mono.Linker.Tests.Cases.Libraries.Dependencies.UserAssemblyActionWorks_ChildLib")]
+
+	[KeptMemberInAssembly ("childlib", "Mono.Linker.Tests.Cases.Libraries.Dependencies.UserAssemblyActionWorks_ChildLib", "MustOverride()")]
+
+	[RemovedMemberInAssembly ("childlib", "Mono.Linker.Tests.Cases.Libraries.Dependencies.UserAssemblyActionWorks_ChildLib", "ChildUnusedMethod(Mono.Linker.Tests.Cases.Libraries.Dependencies.InputType)")]
+	[RemovedMemberInAssembly ("childlib", "Mono.Linker.Tests.Cases.Libraries.Dependencies.UserAssemblyActionWorks_ChildLib", "ChildUnusedPrivateMethod()")]
+	[RemovedMemberInAssembly ("childlib", "Mono.Linker.Tests.Cases.Libraries.Dependencies.UserAssemblyActionWorks_ChildLib", "ChildUnusedInstanceMethod()")]
+	[RemovedMemberInAssembly ("childlib", "Mono.Linker.Tests.Cases.Libraries.Dependencies.UserAssemblyActionWorks_ChildLib", "UnusedProperty")]
+	[RemovedMemberInAssembly ("childlib", "Mono.Linker.Tests.Cases.Libraries.Dependencies.UserAssemblyActionWorks_ChildLib", "UnusedField")]
+	[RemovedTypeInAssembly ("childlib", "Mono.Linker.Tests.Cases.Libraries.Dependencies.InputType")]
 	public class UserAssemblyActionWorks
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveAnExportedType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveAnExportedType.cs
@@ -8,9 +8,10 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 	// Add another assembly in that uses the forwarder just to make things a little more complex
 	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/CanPreserveAnExportedType_Forwarder.cs" }, references: new[] { "Library.dll" })]
 
-	[KeptMemberInAssembly ("Library.dll", typeof (CanPreserveAnExportedType_Library), "Field1", "Method()", ".ctor()")]
+	// NativeAOT doesn't have a concept of type forwarders in the compiled app, everything is fully resolved
+	[KeptMemberInAssembly ("Library.dll", typeof (CanPreserveAnExportedType_Library), "Field1", "Method()", ".ctor()", Tool = Tool.Trimmer)]
+	[KeptTypeInAssembly ("Forwarder.dll", typeof (CanPreserveAnExportedType_Library), Tool = Tool.Trimmer)]
 	[SetupLinkerDescriptorFile ("CanPreserveAnExportedType.xml")]
-	[KeptTypeInAssembly ("Forwarder.dll", typeof (CanPreserveAnExportedType_Library))]
 	class CanPreserveAnExportedType
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExportedTypesUsingRegex.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/CanPreserveExportedTypesUsingRegex.cs
@@ -8,9 +8,10 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 	// Add another assembly in that uses the forwarder just to make things a little more complex
 	[SetupCompileBefore ("Forwarder.dll", new[] { "Dependencies/CanPreserveAnExportedType_Forwarder.cs" }, references: new[] { "Library.dll" })]
 
-	[KeptMemberInAssembly ("Library.dll", typeof (CanPreserveAnExportedType_Library), "Field1", "Method()", ".ctor()")]
+	// NativeAOT doesn't have a concept of type forwarders in the compiled app, everything is fully resolved
+	[KeptMemberInAssembly ("Library.dll", typeof (CanPreserveAnExportedType_Library), "Field1", "Method()", ".ctor()", Tool = Tool.Trimmer)]
+	[KeptTypeInAssembly ("Forwarder.dll", typeof (CanPreserveAnExportedType_Library), Tool = Tool.Trimmer)]
 	[SetupLinkerDescriptorFile ("CanPreserveExportedTypesUsingRegex.xml")]
-	[KeptTypeInAssembly ("Forwarder.dll", typeof (CanPreserveAnExportedType_Library))]
 	class CanPreserveExportedTypesUsingRegex
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlFromCopyAssemblyIsProcessed.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/EmbeddedLinkXmlFromCopyAssemblyIsProcessed.cs
@@ -12,8 +12,10 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 	[IgnoreDescriptors (false)]
 	[SetupLinkerAction ("copy", "CopyLibrary")]
 
-	[KeptTypeInAssembly ("CopyLibrary.dll", typeof (CopyLibrary))]
-	[KeptTypeInAssembly ("Library.dll", typeof (OtherLibrary))]
+	// NativeAOT doesn't support reading embedded descriptors from a resource called "AssemblyName"
+	// It only supports "ILLink.Descriptor.xml" name
+	[KeptTypeInAssembly ("CopyLibrary.dll", typeof (CopyLibrary), Tool = Tool.Trimmer)]
+	[KeptTypeInAssembly ("Library.dll", typeof (OtherLibrary), Tool = Tool.Trimmer)]
 	public class EmbeddedLinkXmlFromCopyAssemblyIsProcessed
 	{
 		public static void Main ()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKeptWhenRooted.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/UsedNonRequiredExportedTypeIsKeptWhenRooted.cs
@@ -3,6 +3,9 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.LinkXml
 {
+	[IgnoreTestCase ("NativeAOT doesn't implement 'visible' rooting behavior", IgnoredBy = Tool.NativeAot)]
+	[KeptAttributeAttribute (typeof (IgnoreTestCaseAttribute), By = Tool.Trimmer)]
+
 	[SetupLinkerDescriptorFile ("UsedNonRequiredExportedTypeIsKeptWhenRooted.xml")]
 	[SetupLinkerArgument ("-a", "libfwd.dll", "visible")]
 

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -933,7 +933,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 				foreach (var additionalExpectedAttributesFromFixedField in GetCustomAttributeCtorValues<object> (fixedField, nameof (KeptAttributeOnFixedBufferTypeAttribute)))
 					yield return additionalExpectedAttributesFromFixedField.ToString ();
-
 			}
 		}
 

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -718,7 +718,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 			var missingInLinked = originalTypes.Keys.Except (linkedTypes.Keys);
 
-			Assert.That (missingInLinked, Is.Empty, $"Expected all types to exist in the linked assembly, but one or more were missing");
+			Assert.That (missingInLinked, Is.Empty, $"Expected all types to exist in the linked assembly {linked.Name}, but one or more were missing");
 
 			foreach (var originalKvp in originalTypes) {
 				var linkedType = linkedTypes[originalKvp.Key];
@@ -1136,6 +1136,11 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			foreach (var typeWithRemoveInAssembly in original.AllDefinedTypes ()) {
 				foreach (var attr in typeWithRemoveInAssembly.CustomAttributes.Where (IsTypeInOtherAssemblyAssertion)) {
 					var assemblyName = (string) attr.ConstructorArguments[0].Value;
+
+					Tool? toolTarget = (Tool?) (int?) attr.GetPropertyValue ("Tool");
+					if (toolTarget is not null && !toolTarget.Value.HasFlag (Tool.Trimmer))
+						continue;
+
 					if (!checks.TryGetValue (assemblyName, out List<CustomAttribute> checksForAssembly))
 						checks[assemblyName] = checksForAssembly = new List<CustomAttribute> ();
 


### PR DESCRIPTION
When rooting entire assemblies NativeAOT also roots all base types of all the types in such assembly. Regardless of which assembly the base type comes from. Historically this was necessary to make certain combinations of generic instantiations to work, but that's no longer the case. The compiler has better mechanism of tracking necessary things for generics now.

This rooting behavior brings in more code than necessary. This is specifically problematic when using the assembly rooting as a mechanism to test library trim/AOT compatibility. If the tested library depends on another library which has some incompatible code in it, but it's not used, ideally the compiler should remove the unused code and thus not see the incompatibilities. Rooting entire base types sometimes breaks that behavior and produces unnecessary warnings.

The product change is really just "don't root the base type", all of the rest of the change is tests. Modified existing test to validate more things around rooting behavior across assemblies. And then infrastructure changes to make it possible to use this test from NativeAOT.

This brings the behavior of NativeAOT and trimmer much closer with regard to assembly rooting.

Fixes https://github.com/dotnet/runtime/issues/92271.