### PR TITLE
Fix build of IJW test after VS upgrade

### DIFF
--- a/eng/native/ijw/IJW.cmake
+++ b/eng/native/ijw/IJW.cmake
@@ -45,7 +45,7 @@ if (CLR_CMAKE_HOST_WIN32)
 
   # 4365 - signed/unsigned mismatch
   # 4679 - Could not import member. This is an issue with IJW and static abstract methods in interfaces.
-  add_compile_options(/wd4365 /wd4679)
+  add_compile_options(/wd4365 /wd4679 /wd5271)
 
   # IJW
   add_compile_options(/clr:netcore)


### PR DESCRIPTION
The latest build of VS carries a C/C++ compiler which produces warning C5271:
```
src\native\corehost\test\ijw\ijw.cpp(6): warning C5271: consider replacing #using <System.Console.dll>  with command line argument /FU "F:\dotnet\runtime2\.dotnet\packs\Microsoft.NETCore.App.Ref\8.0.0-rc.1.23414.4\ref\net8.0\System.Console.dll"
src\native\corehost\test\ijw\ijw.cpp(7): warning C5271: consider replacing #using <System.Runtime.Loader.dll>  with command line argument /FU "F:\dotnet\runtime2\.dotnet\packs\Microsoft.NETCore.App.Ref\8.0.0-rc.1.23414.4\ref\net8.0\System.Runtime.Loader.dll"
```

This breaks the build on Windows. For now I'm disabling the warning as the real fix is more complex (we would need to calculate the path to the required assemblies in CMake somehow).

I created https://github.com/dotnet/runtime/issues/92879 to track implementing a real fix.