### PR TITLE
[mono][wasm] Add linux-arm64 net8 workload definitions

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net8.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net8.Manifest/WorkloadManifest.json.in
@@ -12,7 +12,7 @@
         "Microsoft.NETCore.App.Runtime.AOT.Cross.net8.browser-wasm"
       ],
       "extends": [ "microsoft-net-runtime-mono-tooling-net8", "microsoft-net-sdk-emscripten-net8" ],
-      "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ]
+      "platforms": [ "win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64" ]
     },
     "wasm-experimental-net8": {
       "description": ".NET WebAssembly experimental tooling for net8.0",
@@ -21,7 +21,7 @@
         "Microsoft.NETCore.App.Runtime.Mono.multithread.net8.browser-wasm"
       ],
       "extends": [ "wasm-tools-net8" ],
-      "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ]
+      "platforms": [ "win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64" ]
     },
     "wasi-experimental-net8": {
       "description": ".NET WASI experimental",
@@ -440,6 +440,7 @@
         "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm",
         "win-arm64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm",
         "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.browser-wasm",
+        "linux-arm64": "Microsoft.NETCore.App.Runtime.AOT.linux-arm64.Cross.browser-wasm",
         "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm",
         "osx-arm64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm"
       }


### PR DESCRIPTION
There are probably more missing (android) but this was for testing