### PR TITLE
[mono] Reenable MSVC warnings

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -17,17 +17,13 @@ if (MSVC)
     add_link_options("/sourcelink:${CLR_SOURCELINK_FILE_PATH}")
   endif()
 
-  # FIXME This is all questionable but the logs are flooded and nothing else is fixing them.
-  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4090>) # W1: const problem
   add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4100>) # W4: unreferenced formal parameter
-  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4152>) # W4: nonstandard extension, function/data pointer conversion in expression
-  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4201>) # W4: nonstandard extension used: nameless struct/union
-  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4210>) # W4: nonstandard extension used: function given file scope
-  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4245>) # W4: signed/unsigned mismatch
-  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4389>) # W4: signed/unsigned mismatch
-  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4505>) # W4: unreferenced function with internal linkage has been removed
   add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4702>) # W4: unreachable code
   add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4706>) # W4: assignment within conditional expression
+
+  # FIXME we should investigate these mismatches at some point
+  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4245>) # W4: signed/unsigned mismatch
+  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/wd4389>) # W4: signed/unsigned mismatch
 endif(MSVC)
 
 set(CROSS_ROOTFS $ENV{ROOTFS_DIR})

--- a/src/mono/mono/arch/arm64/arm64-codegen.h
+++ b/src/mono/mono/arch/arm64/arm64-codegen.h
@@ -247,12 +247,14 @@ arm_get_disp15 (void *p, void *target)
 
 #define arm_is_pimm12_scaled(pimm,size) ((pimm) >= 0 && (pimm) / (size) <= 0xfff && ((pimm) % (size)) == 0)
 
+MONO_DISABLE_WARNING(4505) // unreferenced function with internal linkage has been removed
 static G_GNUC_UNUSED unsigned int
 arm_encode_pimm12 (int pimm, int size)
 {
 	g_assert (arm_is_pimm12_scaled (pimm, size));
 	return ((unsigned int)(pimm / size)) & 0xfff;
 }
+MONO_RESTORE_WARNING
 
 #define arm_is_strb_imm(pimm) arm_is_pimm12_scaled((pimm), 1)
 #define arm_is_strh_imm(pimm) arm_is_pimm12_scaled((pimm), 2)
@@ -287,12 +289,14 @@ arm_encode_pimm12 (int pimm, int size)
 #define arm_strb(p, rt, rn, pimm) arm_format_mem_imm (p, ARMSIZE_B, 0x0, (rt), (rn), (pimm), 1)
 
 /* C3.3.9 Load/store register (immediate post-indexed) */
+MONO_DISABLE_WARNING(4505) // unreferenced function with internal linkage has been removed
 static G_GNUC_UNUSED unsigned int
 arm_encode_simm9 (int simm)
 {
 	g_assert (simm >= -256 && simm <= 255);
 	return ((unsigned int)simm) & 0x1ff;
 }
+MONO_RESTORE_WARNING
 
 #define arm_format_mem_imm_post(p, size, V, opc, rt, rn, simm) arm_emit ((p), ((size) << 30) | (0x7 << 27) | ((V) << 26) | (0x0 << 24) | ((opc) << 22) | (arm_encode_simm9 ((simm)) << 12) | (0x1 << 10) | ((rn) << 5) | ((rt) << 0))
 
@@ -354,12 +358,14 @@ arm_encode_simm9 (int simm)
 
 /* Load/Store Pair */
 
+MONO_DISABLE_WARNING(4505) // unreferenced function with internal linkage has been removed
 static G_GNUC_UNUSED unsigned int
 arm_encode_imm7 (int imm, int size)
 {
 	g_assert (imm / size >= -64 && imm / size <= 63 && (imm % size) == 0);
 	return ((unsigned int)(imm / size)) & 0x7f;
 }
+MONO_RESTORE_WARNING
 
 #define arm_is_imm7_scaled(imm, size) ((imm) / (size) >= -64 && (imm) / (size) <= 63 && ((imm) % (size)) == 0)
 

--- a/src/mono/mono/eglib/garray.c
+++ b/src/mono/mono/eglib/garray.c
@@ -226,7 +226,7 @@ g_array_set_size (GArray *array, gint length)
 	g_return_if_fail (array != NULL);
 	g_return_if_fail (length >= 0);
 
-	if (length == priv->capacity)
+	if (GINT_TO_UINT(length) == priv->capacity)
 		return; // nothing to be done
 
 	if (GINT_TO_UINT(length) > priv->capacity) {

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1062,7 +1062,7 @@ mono_register_jit_icall_info (MonoJitICallInfo *info, T func, const char *name, 
 }
 #endif // __cplusplus
 
-#define mono_register_jit_icall(func, sig, no_wrapper) (mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, func, #func, (sig), (no_wrapper), NULL))
+#define mono_register_jit_icall(func, sig, no_wrapper) (mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, (gconstpointer)func, #func, (sig), (no_wrapper), NULL))
 
 MonoException*
 mono_class_get_exception_for_failure (MonoClass *klass);

--- a/src/mono/mono/metadata/cominterop.c
+++ b/src/mono/mono/metadata/cominterop.c
@@ -95,11 +95,11 @@ Code shared between the DISABLE_COM and !DISABLE_COM
 // must be extern "C".
 #ifndef DISABLE_JIT
 #define register_icall(func, sig, no_wrapper) \
-	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, func, #func, (sig), (no_wrapper), #func))
+	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, (gconstpointer)func, #func, (sig), (no_wrapper), #func))
 #else
 /* No need for the name/C symbol */
 #define register_icall(func, sig, no_wrapper) \
-	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, func, NULL, (sig), (no_wrapper), NULL))
+	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, (gconstpointer)func, NULL, (sig), (no_wrapper), NULL))
 #endif
 
 mono_bstr

--- a/src/mono/mono/metadata/icall-eventpipe.c
+++ b/src/mono/mono/metadata/icall-eventpipe.c
@@ -23,7 +23,7 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_CreateProvider (
 
 	char *provider_name_utf8 = mono_string_handle_to_utf8 (provider_name, error);
 	if (is_ok (error) && provider_name_utf8) {
-		provider = mono_component_event_pipe ()->create_provider (provider_name_utf8, callback_func, callback_context);
+		provider = mono_component_event_pipe ()->create_provider (provider_name_utf8, (EventPipeCallback)callback_func, callback_context);
 	}
 
 	g_free (provider_name_utf8);

--- a/src/mono/mono/metadata/jit-icall-reg.h
+++ b/src/mono/mono/metadata/jit-icall-reg.h
@@ -356,6 +356,7 @@ MONO_JIT_ICALLS
 #undef MONO_JIT_ICALL
 } MonoJitICallId;
 
+MONO_DISABLE_WARNING(4201) // nonstandard extension used: nameless struct/union
 typedef union MonoJitICallInfos {
 	struct {
 #define MONO_JIT_ICALL(x) MonoJitICallInfo x;
@@ -364,6 +365,7 @@ MONO_JIT_ICALLS
 	};
 	MonoJitICallInfo array [MONO_JIT_ICALL_count];
 } MonoJitICallInfos;
+MONO_RESTORE_WARNING
 
 extern MonoJitICallInfos mono_jit_icall_info;
 

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -205,11 +205,11 @@ get_method_image (MonoMethod *method)
 // must be extern "C".
 #ifndef DISABLE_JIT
 #define register_icall(func, sig, no_wrapper) \
-	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, func, #func, (sig), (no_wrapper), #func))
+	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, (gconstpointer)func, #func, (sig), (no_wrapper), #func))
 #else
 /* No need for the name/C symbol */
 #define register_icall(func, sig, no_wrapper) \
-	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, func, NULL, (sig), (no_wrapper), NULL))
+	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, (gconstpointer)func, NULL, (sig), (no_wrapper), NULL))
 #endif
 
 MonoMethodSignature*

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -7672,9 +7672,9 @@ mono_arch_register_lowlevel_calls (void)
 
 #if defined(TARGET_WIN32) || defined(HOST_WIN32)
 #if _MSC_VER
-	mono_register_jit_icall_info (&mono_get_jit_icall_info ()->mono_chkstk_win64, __chkstk, "mono_chkstk_win64", NULL, TRUE, "__chkstk");
+	mono_register_jit_icall_info (&mono_get_jit_icall_info ()->mono_chkstk_win64, (gconstpointer)__chkstk, "mono_chkstk_win64", NULL, TRUE, "__chkstk");
 #else
-	mono_register_jit_icall_info (&mono_get_jit_icall_info ()->mono_chkstk_win64, ___chkstk_ms, "mono_chkstk_win64", NULL, TRUE, "___chkstk_ms");
+	mono_register_jit_icall_info (&mono_get_jit_icall_info ()->mono_chkstk_win64, (gconstpointer)___chkstk_ms, "mono_chkstk_win64", NULL, TRUE, "___chkstk_ms");
 #endif
 #endif
 }

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -723,7 +723,7 @@ register_opcode_emulation (int opcode, MonoJitICallInfo *jit_icall_info, const c
 }
 
 #define register_opcode_emulation(opcode, name, sig, func, no_wrapper) \
-	(register_opcode_emulation ((opcode), &mono_get_jit_icall_info ()->name, #name, (sig), func, #func, (no_wrapper)))
+	(register_opcode_emulation ((opcode), &mono_get_jit_icall_info ()->name, #name, (sig), (gpointer)func, #func, (no_wrapper)))
 
 /*
  * For JIT icalls implemented in C.
@@ -740,10 +740,10 @@ register_opcode_emulation (int opcode, MonoJitICallInfo *jit_icall_info, const c
  */
 #ifdef DISABLE_JIT
 #define register_icall(func, sig, avoid_wrapper) \
-	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, func, NULL, (sig), (avoid_wrapper), NULL))
+	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, (gconstpointer)func, NULL, (sig), (avoid_wrapper), NULL))
 #else
 #define register_icall(func, sig, avoid_wrapper) \
-	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, func, #func, (sig), (avoid_wrapper), #func))
+	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, (gconstpointer)func, #func, (sig), (avoid_wrapper), #func))
 #endif
 
 #define register_icall_no_wrapper(func, sig) register_icall (func, sig, TRUE)
@@ -761,7 +761,7 @@ register_opcode_emulation (int opcode, MonoJitICallInfo *jit_icall_info, const c
  * This also passes last parameter c_symbol=NULL since there is not a directly linkable symbol.
  */
 #define register_dyn_icall(func, name, sig, save) \
-	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->name, (func), #name, (sig), (save), NULL))
+	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->name, (gconstpointer)func, #name, (sig), (save), NULL))
 
 MonoLMF *
 mono_get_lmf (void)

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -362,6 +362,7 @@ enum {
 	MONO_INST_MAX = 6
 };
 
+MONO_DISABLE_WARNING(4201) // nonstandard extension used: nameless struct/union
 typedef union MonoInstSpec { // instruction specification
 	struct {
 		char dest;
@@ -383,6 +384,7 @@ typedef union MonoInstSpec { // instruction specification
 	};
 	char bytes[MONO_INST_MAX];
 } MonoInstSpec;
+MONO_RESTORE_WARNING
 
 extern const char mini_ins_info[];
 extern const gint8 mini_ins_sreg_counts [];

--- a/src/mono/mono/profiler/aot.c
+++ b/src/mono/mono/profiler/aot.c
@@ -334,7 +334,7 @@ start_helper_thread (void)
 
 	MonoNativeThreadId thread_id;
 
-	if (!mono_native_thread_create (&thread_id, helper_thread, NULL)) {
+	if (!mono_native_thread_create (&thread_id, (gpointer)helper_thread, NULL)) {
 		mono_profiler_printf_err ("Could not start aot profiler helper thread");
 		exit (1);
 	}

--- a/src/mono/mono/profiler/log.c
+++ b/src/mono/mono/profiler/log.c
@@ -2902,7 +2902,7 @@ start_helper_thread (void)
 
 	mono_profhelper_setup_command_server (&log_profiler.server_socket, &log_profiler.command_port, "log");
 
-	if (!mono_native_thread_create (&log_profiler.helper_thread, helper_thread, NULL)) {
+	if (!mono_native_thread_create (&log_profiler.helper_thread, (gpointer)helper_thread, NULL)) {
 		mono_profiler_printf_err ("Could not start log profiler helper thread");
 		mono_profhelper_close_socket_fd (log_profiler.server_socket);
 		exit (1);
@@ -3038,7 +3038,7 @@ start_writer_thread (void)
 {
 	mono_atomic_store_i32 (&log_profiler.run_writer_thread, 1);
 
-	if (!mono_native_thread_create (&log_profiler.writer_thread, writer_thread, NULL)) {
+	if (!mono_native_thread_create (&log_profiler.writer_thread, (gpointer)writer_thread, NULL)) {
 		mono_profiler_printf_err ("Could not start log profiler writer thread");
 		exit (1);
 	}
@@ -3161,7 +3161,7 @@ start_dumper_thread (void)
 {
 	mono_atomic_store_i32 (&log_profiler.run_dumper_thread, 1);
 
-	if (!mono_native_thread_create (&log_profiler.dumper_thread, dumper_thread, NULL)) {
+	if (!mono_native_thread_create (&log_profiler.dumper_thread, (gpointer)dumper_thread, NULL)) {
 		mono_profiler_printf_err ("Could not start log profiler dumper thread");
 		exit (1);
 	}

--- a/src/mono/mono/utils/mono-error-internals.h
+++ b/src/mono/mono/utils/mono-error-internals.h
@@ -9,6 +9,7 @@
 #include <mono/utils/mono-forward.h>
 #include "mono/utils/mono-compiler.h"
 
+MONO_DISABLE_WARNING(4201) // nonstandard extension used: nameless struct/union
 /*Keep in sync with MonoError*/
 typedef union _MonoErrorInternal {
 	// Merge two uint16 into one uint32 so it can be initialized
@@ -43,6 +44,7 @@ typedef union _MonoErrorInternal {
 		//void *padding [3];
 	};
 } MonoErrorInternal;
+MONO_RESTORE_WARNING
 
 /* Invariant: the error strings are allocated in the mempool of the given image */
 struct _MonoErrorBoxed {

--- a/src/mono/mono/utils/mono-logger-internals.h
+++ b/src/mono/mono/utils/mono-logger-internals.h
@@ -64,6 +64,8 @@ mono_trace_is_traced (GLogLevelFlags level, MonoTraceMask mask);
 #define MONO_TRACE_IS_TRACED(level, mask) \
 	G_UNLIKELY ((level) <= mono_internal_current_level && ((mask) & mono_internal_current_mask))
 
+MONO_DISABLE_WARNING(4505) // unreferenced function with internal linkage has been removed
+
 G_GNUC_UNUSED static void
 mono_tracev (GLogLevelFlags level, MonoTraceMask mask, const char *format, va_list args)
 {
@@ -90,6 +92,8 @@ mono_trace (GLogLevelFlags level, MonoTraceMask mask, const char *format, ...)
 		va_end (args);
 	}
 }
+
+MONO_RESTORE_WARNING
 
 // __VA_ARGS__ is never empty, so a comma before it is always correct.
 #define mono_trace_error(...)	(mono_trace (G_LOG_LEVEL_ERROR, __VA_ARGS__))

--- a/src/mono/mono/utils/mono-threads.h
+++ b/src/mono/mono/utils/mono-threads.h
@@ -168,6 +168,7 @@ enum {
 	ASYNC_SUSPEND_STATE_INDEX = 1,
 };
 
+MONO_DISABLE_WARNING(4201) // nonstandard extension used: nameless struct/union
 typedef union {
 	int32_t raw;
 	struct {
@@ -176,6 +177,7 @@ typedef union {
 		int32_t suspend_count : 8;
 	};
 } MonoThreadStateMachine;
+MONO_RESTORE_WARNING
 
 /*
  * These flags control how the rest of the runtime will see and interact with

--- a/src/mono/mono/utils/mono-utility-thread.c
+++ b/src/mono/mono/utils/mono-utility-thread.c
@@ -95,7 +95,7 @@ mono_utility_thread_launch (size_t payload_size, MonoUtilityThreadCallbacks *cal
 	mono_os_sem_init (&thread->work_queue_sem, 0);
 	mono_atomic_store_i32 (&thread->run_thread, 1);
 
-	if (!mono_native_thread_create (&thread->thread_id, utility_thread, thread))
+	if (!mono_native_thread_create (&thread->thread_id, (gpointer)utility_thread, thread))
 		g_error ("Could not create utility thread");
 
 	return thread;


### PR DESCRIPTION
This reenables most MSVC warnings, only the signed/unsigned mismatch ones are left (and warnings which we deem OK like unreachable code or unused params).