### PR TITLE
[wasm] Set InstallV8ForTests=true only for windows/linux

### DIFF
--- a/eng/testing/tests.browser.targets
+++ b/eng/testing/tests.browser.targets
@@ -29,8 +29,9 @@
                                         ('$(ContinuousIntegrationBuild)' != 'true' or Exists('/.dockerenv')) and
                                         '$(Scenario)' == 'WasmTestOnBrowser'">true</InstallChromeForTests>
     <InstallV8ForTests Condition="'$(InstallV8ForTests)' == '' and
-                                        ('$(ContinuousIntegrationBuild)' != 'true' or Exists('/.dockerenv')) and
-                                        ('$(Scenario)' == 'normal' or '$(Scenario)' == '')">true</InstallV8ForTests>
+                                        ('$(ContinuousIntegrationBuild)' == 'true' or Exists('/.dockerenv')) and
+                                        ($([MSBuild]::IsOSPlatform('windows')) or $([MSBuild]::IsOSPlatform('linux')))"
+                                    >true</InstallV8ForTests>
 
     <GetNuGetsToBuildForWorkloadTestingDependsOn>_GetRuntimePackNuGetsToBuild;_GetNugetsForAOT;$(GetNuGetsToBuildForWorkloadTestingDependsOn)</GetNuGetsToBuildForWorkloadTestingDependsOn>
     <_BundleAOTTestWasmAppForHelixDependsOn>$(_BundleAOTTestWasmAppForHelixDependsOn);PrepareForWasmBuildApp;_PrepareForAOTOnHelix</_BundleAOTTestWasmAppForHelixDependsOn>


### PR DESCRIPTION
.. on CI, or in a container (like codespaces).
Without this it would be `true` on macOS by default, and then fail with:
`error : V8 provisioning only supported on Linux, and windows.`
