### PR TITLE
[wasm] Perf pipeline - fix blazor_scenarios run for hybrid globalization

### DIFF
--- a/eng/pipelines/coreclr/perf-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-wasm-jobs.yml
@@ -191,6 +191,8 @@ jobs:
         projectFile: blazor_perf.proj
         runKind: blazor_scenarios
         runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+        additionalSetupParameters: '--dotnetversions 8.0.0' # passed to performance-setup.sh
         logicalmachine: 'perftiger'
         downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
         perfForkToUse: ${{ parameters.perfForkToUse }}

--- a/eng/pipelines/coreclr/perf-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-wasm-jobs.yml
@@ -174,7 +174,7 @@ jobs:
         downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
         perfForkToUse: ${{ parameters.perfForkToUse }}
 
-- ${{if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+- ${{if or(and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')), in(variables['Build.DefinitionName'], 'runtime-wasm-perf')) }}:
   # run mono wasm blazor perf job
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:


### PR DESCRIPTION
Fails with:
```
Traceback (most recent call last):
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/ci_setup.py", line 487, in <module>
    __main(sys.argv[1:])
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/ci_setup.py", line 483, in __main
    main(CiSetupArgs(**vars(args)))
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/ci_setup.py", line 411, in main
    dotnet_version = dotnet.get_dotnet_version(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
  File "/mnt/vss/_work/1/s/Payload/performance/scripts/dotnet.py", line 581, in get_dotnet_version
    raise RuntimeError(
RuntimeError: Unable to determine the .NET SDK used for net8.0
```

This is because the new definition didn't copy over the `--dotnet-versions
8.0.0` workaround needed for now. And this runs only once a week, so it
was discovered on Oct 2(Monday) even though it was merged on Sep
26(Friday).- [wasm] Perf pipeline - fix blazor_scenarios run for hybrid globalization

- [wasm] Perf: run the hybrid-globalization job on runtime-wasm-perf also, for validation

This was added in https://github.com/dotnet/runtime/pull/89825 .