### PR TITLE
[release/8.0][wasm] Use intended ports when running `DevServer`

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -241,6 +241,7 @@ jobs:
       - src/mono/tools/*
       - src/mono/wasi/*
       - src/mono/wasm/debugger/*
+      - src/mono/wasm/host/*
       - src/mono/wasm/Wasm.Build.Tests/*
       - ${{ parameters._const_paths._wasm_pipelines }}
       - ${{ parameters._const_paths._always_exclude }}

--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -258,6 +258,7 @@ jobs:
       - eng/testing/workloads-testing.targets
       - src/mono/mono/component/mini-wasm-debugger.c
       - src/mono/wasm/debugger/*
+      - src/mono/wasm/host/*
       - src/mono/wasm/Wasm.Build.Tests/*
       - src/mono/nuget/Microsoft.NET.Runtime*
         src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/*

--- a/src/mono/wasm/host/BrowserHost.cs
+++ b/src/mono/wasm/host/BrowserHost.cs
@@ -74,7 +74,7 @@ internal sealed class BrowserHost
                                                debugging: _args.CommonConfig.Debugging);
         runArgsJson.Save(Path.Combine(_args.CommonConfig.AppPath, "runArgs.json"));
 
-        string[] urls = envVars.TryGetValue("ASPNETCORE_URLS", out string? aspnetUrls)
+        string[] urls = (envVars.TryGetValue("ASPNETCORE_URLS", out string? aspnetUrls) && aspnetUrls.Length > 0)
                             ? aspnetUrls.Split(';', StringSplitOptions.RemoveEmptyEntries)
                             : new string[] { $"http://127.0.0.1:{_args.CommonConfig.HostProperties.WebServerPort}", "https://127.0.0.1:0" };
 

--- a/src/mono/wasm/host/DevServer/DevServer.cs
+++ b/src/mono/wasm/host/DevServer/DevServer.cs
@@ -46,7 +46,8 @@ internal static class DevServer
                 services.AddSingleton(Options.Create(options));
                 services.AddSingleton(realUrlsAvailableTcs);
                 services.AddRouting();
-            });
+            })
+            .UseUrls(options.Urls);
 
 
         IWebHost? host = builder.Build();

--- a/src/mono/wasm/host/RuntimeConfigJson.cs
+++ b/src/mono/wasm/host/RuntimeConfigJson.cs
@@ -24,7 +24,7 @@ internal sealed record WasmHostProperties(
      int? FirefoxDebuggingPort,
      int? ChromeProxyPort,
      int? ChromeDebuggingPort,
-     int WebServerPort = 9000)
+     int WebServerPort = 0)
 {
     // using an explicit property because the deserializer doesn't like
     // extension data in the record constructor


### PR DESCRIPTION
For running a wasm-browser application `DevServer` is used, but it always started the webserver on port `5000`, because the selected ports weren't used by the `DevServer`, and thus used the defaults.

```
...
      [] Unhandled exception. System.IO.IOException: Failed to bind to address http://127.0.0.1:5000: address already in use.
...
```

- Also, ignore empty `ASPNETCORE_URLS=''` in the environment.

Fixes https://github.com/dotnet/runtime/issues/91143 .

## Customer impact

Every run for a `wasmbrowser` template (which is still only in the `wasm-experimental` workload) will use a random port for the webserver, instead of a fixed `5000`, as intended.

## Testing

Automated testing.

## Impact

Low. This affects an experimental feature.