### PR TITLE
[wasm] Use intended ports when running DevServer

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -249,6 +249,7 @@ jobs:
       - src/mono/tools/*
       - src/mono/wasi/*
       - src/mono/wasm/debugger/*
+      - src/mono/wasm/host/*
       - src/mono/wasm/Wasm.Build.Tests/*
       - ${{ parameters._const_paths._wasm_pipelines }}
       - ${{ parameters._const_paths._always_exclude }}

--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -266,6 +266,7 @@ jobs:
       - eng/testing/workloads-testing.targets
       - src/mono/mono/component/mini-wasm-debugger.c
       - src/mono/wasm/debugger/*
+      - src/mono/wasm/host/*
       - src/mono/wasm/Wasm.Build.Tests/*
       - src/mono/nuget/Microsoft.NET.Runtime*
         src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/*

--- a/src/mono/wasm/host/BrowserHost.cs
+++ b/src/mono/wasm/host/BrowserHost.cs
@@ -74,7 +74,7 @@ internal sealed class BrowserHost
                                                debugging: _args.CommonConfig.Debugging);
         runArgsJson.Save(Path.Combine(_args.CommonConfig.AppPath, "runArgs.json"));
 
-        string[] urls = envVars.TryGetValue("ASPNETCORE_URLS", out string? aspnetUrls)
+        string[] urls = (envVars.TryGetValue("ASPNETCORE_URLS", out string? aspnetUrls) && aspnetUrls.Length > 0)
                             ? aspnetUrls.Split(';', StringSplitOptions.RemoveEmptyEntries)
                             : new string[] { $"http://127.0.0.1:{_args.CommonConfig.HostProperties.WebServerPort}", "https://127.0.0.1:0" };
 

--- a/src/mono/wasm/host/DevServer/DevServer.cs
+++ b/src/mono/wasm/host/DevServer/DevServer.cs
@@ -46,7 +46,8 @@ internal static class DevServer
                 services.AddSingleton(Options.Create(options));
                 services.AddSingleton(realUrlsAvailableTcs);
                 services.AddRouting();
-            });
+            })
+            .UseUrls(options.Urls);
 
 
         IWebHost? host = builder.Build();


### PR DESCRIPTION
- [wasm] Ignore empty `$ASPNETCORE_URLS`
- [wasm] DevServer: honor urls specified in the options
- [wasm] CI: Don't trigger non-wbt jobs on wasm-app-host changes
- CI: don't trigger wasm runtime tests on wasm-app-host changes
