### PR TITLE
JIT: Allow experimenting with different CSE subsets

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2008,6 +2008,11 @@ void CodeGen::genEmitMachineCode()
                codeSize, prologSize, compiler->info.compPerfScore, instrCount,
                GetEmitter()->emitTotalHotCodeSize + GetEmitter()->emitTotalColdCodeSize);
 
+        if (JitConfig.JitMetrics() > 0)
+        {
+            printf(", num cse %d", compiler->optCSEcount);
+        }
+
 #if TRACK_LSRA_STATS
         if (JitConfig.DisplayLsraStats() == 3)
         {

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2677,6 +2677,13 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         verboseDump = (JitConfig.JitDumpTier0() > 0);
     }
 
+    // Optionally suppress dumping OSR jit requests.
+    //
+    if (verboseDump && jitFlags->IsSet(JitFlags::JIT_FLAG_OSR))
+    {
+        verboseDump = (JitConfig.JitDumpOSR() > 0);
+    }
+
     // Optionally suppress dumping except for a specific OSR jit request.
     //
     const int dumpAtOSROffset = JitConfig.JitDumpAtOSROffset();

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5229,10 +5229,12 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         INDEBUG(sprintf_s(debugPart, 128, ", hash=0x%08x%s", info.compMethodHash(), compGetStressMessage()));
 
         char metricPart[128] = {0};
+#ifdef DEBUG
         if (JitConfig.JitMetrics() > 0)
         {
-            INDEBUG(sprintf_s(metricPart, 128, ", perfScore=%.2f, numCse=%u", info.compPerfScore, optCSEcount));
+            sprintf_s(metricPart, 128, ", perfScore=%.2f, numCse=%u", info.compPerfScore, optCSEcount);
         }
+#endif
 
         const bool hasProf = fgHaveProfileData();
         printf("%4d: JIT compiled %s [%s%s%s%s, IL size=%u, code size=%u%s%s]\n", methodsCompiled, fullName,

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5224,11 +5224,11 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         char metricPart[128] = {0};
         if (JitConfig.JitMetrics() > 0)
         {
-            INDEBUG(sprintf_s(debugPart, 128, ", perfScore=%.2f, numCse=%u", info.compPerfScore, optCSEcount));
+            INDEBUG(sprintf_s(metricPart, 128, ", perfScore=%.2f, numCse=%u", info.compPerfScore, optCSEcount));
         }
 
         const bool hasProf = fgHaveProfileData();
-        printf("%4d: JIT compiled %s [%s%s%s%s, IL size=%u, code size=%u%s,%s]\n", methodsCompiled, fullName,
+        printf("%4d: JIT compiled %s [%s%s%s%s, IL size=%u, code size=%u%s%s]\n", methodsCompiled, fullName,
                compGetTieringName(), osrBuffer, hasProf ? " with " : "", hasProf ? compGetPgoSourceName() : "",
                info.compILCodeSize, *methodCodeSize, debugPart, metricPart);
     }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5221,10 +5221,16 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         char debugPart[128] = {0};
         INDEBUG(sprintf_s(debugPart, 128, ", hash=0x%08x%s", info.compMethodHash(), compGetStressMessage()));
 
+        char metricPart[128] = {0};
+        if (JitConfig.JitMetrics() > 0)
+        {
+            INDEBUG(sprintf_s(debugPart, 128, ", perfScore=%.2f, numCse=%u", info.compPerfScore, optCSEcount));
+        }
+
         const bool hasProf = fgHaveProfileData();
-        printf("%4d: JIT compiled %s [%s%s%s%s, IL size=%u, code size=%u%s]\n", methodsCompiled, fullName,
+        printf("%4d: JIT compiled %s [%s%s%s%s, IL size=%u, code size=%u%s,%s]\n", methodsCompiled, fullName,
                compGetTieringName(), osrBuffer, hasProf ? " with " : "", hasProf ? compGetPgoSourceName() : "",
-               info.compILCodeSize, *methodCodeSize, debugPart);
+               info.compILCodeSize, *methodCodeSize, debugPart, metricPart);
     }
 
     compFunctionTraceEnd(*methodCodePtr, *methodCodeSize, false);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -639,6 +639,8 @@ public:
 
 #ifdef DEBUG
     unsigned char lvClassInfoUpdated : 1; // true if this var has updated class handle or exactness
+    unsigned char lvIsHoist : 1;          // CSE temp for a hoisted tree
+    unsigned char lvIsMultiDefCSE : 1;    // CSE temp for a multi-def CSE
 #endif
 
     unsigned char lvImplicitlyReferenced : 1; // true if there are non-IR references to this local (prolog, epilog, gc,
@@ -6978,9 +6980,10 @@ protected:
 
     bool     optDoCSE;             // True when we have found a duplicate CSE tree
     bool     optValnumCSE_phase;   // True when we are executing the optOptimizeValnumCSEs() phase
-    unsigned optCSECandidateCount; // Count of CSE's candidates
+    unsigned optCSECandidateCount; // Count of CSE candidates
     unsigned optCSEstart;          // The first local variable number that is a CSE
-    unsigned optCSEcount;          // The total count of CSE's introduced.
+    unsigned optCSEattempt;        // The number of CSEs attempted so far.
+    unsigned optCSEcount;          // The total count of CSEs introduced.
     weight_t optCSEweight;         // The weight of the current block when we are doing PerformCSE
 
     bool optIsCSEcandidate(GenTree* tree);

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -7611,7 +7611,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     // emit offsets after the loop with wrong value (for example for GC ref variables).
     unsigned unusedSize = emitTotalCodeSize - actualCodeSize;
 
-    JITDUMP("Allocated method code size = %4u , actual size = %4u, unused size = %4u\n", emitTotalCodeSize,
+    JITDUMP("\n\nAllocated method code size = %4u , actual size = %4u, unused size = %4u\n", emitTotalCodeSize,
             actualCodeSize, unusedSize);
 
     BYTE* cpRW = cp + writeableOffset;

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -398,10 +398,10 @@ CONFIG_INTEGER(JitCSEHash, W("JitCSEHash"), 0)
 // ...etc...
 // FFFFFFFF : do all the CSEs normally done
 CONFIG_INTEGER(JitCSEMask, W("JitCSEMask"), 0)
-#endif
 
 // Enable metric output in jit disasm & elsewhere
 CONFIG_INTEGER(JitMetrics, W("JitMetrics"), 0)
+#endif
 
 ///
 /// JIT

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -376,6 +376,13 @@ CONFIG_INTEGER(JitConstCSE, W("JitConstCSE"), 0)
 #define CONST_CSE_ENABLE_ALL 3
 #define CONST_CSE_ENABLE_ALL_NO_SHARING 4
 
+// Allow fine-grained controls of CSEs done in a particular method
+CONFIG_INTEGER(JitCSEHash, W("JitCSEHash"), 0)
+CONFIG_INTEGER(JitCSEMask, W("JitCSEMask"), 0)
+
+// Enable metric output in jit disasm & elsewhere
+CONFIG_INTEGER(JitMetrics, W("JitMetrics"), 0)
+
 ///
 /// JIT
 ///

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -376,9 +376,28 @@ CONFIG_INTEGER(JitConstCSE, W("JitConstCSE"), 0)
 #define CONST_CSE_ENABLE_ALL 3
 #define CONST_CSE_ENABLE_ALL_NO_SHARING 4
 
+#if defined(DEBUG)
 // Allow fine-grained controls of CSEs done in a particular method
+//
+// Specify method that will respond to the CSEMask.
+// 0 means feature disabled and all methods run CSE normally.
 CONFIG_INTEGER(JitCSEHash, W("JitCSEHash"), 0)
+
+// Bitmask of allowed CSEs in methods specified by JitCSEHash.
+// These bits control the "cse attempts" made by normal jitting,
+// for the first 32 CSEs attempted (Note this is not the same as
+// the CSE candidate number, which reflects the order
+// in which CSEs were discovered).
+//
+// 0: do no CSEs
+// 1: do only the first CSE
+// 2: do only the second CSE
+// C: do only the third and fourth CSEs
+// F: do only the first four CSEs
+// ...etc...
+// FFFFFFFF : do all the CSEs normally done
 CONFIG_INTEGER(JitCSEMask, W("JitCSEMask"), 0)
+#endif
 
 // Enable metric output in jit disasm & elsewhere
 CONFIG_INTEGER(JitMetrics, W("JitMetrics"), 0)

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -191,8 +191,9 @@ CONFIG_INTEGER(JitDisasmWithDebugInfo, W("JitDisasmWithDebugInfo"), 0) // Dump i
                                                                        // disassembled.
 CONFIG_INTEGER(JitDisasmSpilled, W("JitDisasmSpilled"), 0)      // Display native code when any register spilling occurs
 CONFIG_METHODSET(JitDump, W("JitDump"))                         // Dumps trees for specified method
-CONFIG_INTEGER(JitDumpTier0, W("JitDumpTier0"), 1)              // Dump tier0 requests
-CONFIG_INTEGER(JitDumpAtOSROffset, W("JitDumpAtOSROffset"), -1) // Only dump OSR requests for this offset
+CONFIG_INTEGER(JitDumpTier0, W("JitDumpTier0"), 1)              // Dump tier0 jit compilations
+CONFIG_INTEGER(JitDumpOSR, W("JitDumpOSR"), 1)                  // Dump OSR jit compilations
+CONFIG_INTEGER(JitDumpAtOSROffset, W("JitDumpAtOSROffset"), -1) // Dump only OSR jit compilations with this offset
 CONFIG_INTEGER(JitDumpInlinePhases, W("JitDumpInlinePhases"), 1) // Dump inline compiler phases
 CONFIG_METHODSET(JitEHDump, W("JitEHDump")) // Dump the EH table for the method, as reported to the VM
 CONFIG_METHODSET(JitExclude, W("JitExclude"))

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -7570,6 +7570,14 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
     {
         printf(" tier0-frame");
     }
+    if (varDsc->lvIsHoist)
+    {
+        printf(" hoist");
+    }
+    if (varDsc->lvIsMultiDefCSE)
+    {
+        printf(" multi-def");
+    }
 
 #ifndef TARGET_64BIT
     if (varDsc->lvStructDoubleAlign)

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -3330,11 +3330,21 @@ public:
 
                 if (m_pCompiler->info.compMethodHash() == (unsigned)JitConfig.JitCSEHash())
                 {
-                    doCSE = ((1ULL << attempt) & ((unsigned long long)JitConfig.JitCSEMask())) != 0;
-
-                    JITDUMP("CSE " FMT_CSE " attempt %u %s by hash 0x%x mask 0x%0x: %s\n", candidate.CseIndex(),
-                            attempt, doCSE ? "allowed" : "disabled", JitConfig.JitCSEHash(), JitConfig.JitCSEMask(),
-                            m_pCompiler->info.compFullName);
+                    // We can only mask the first 32 CSE attempts, so suppress anything beyond that.
+                    // Note methods with > 32 CSEs are currently quite rare.
+                    //
+                    if (attempt > 32)
+                    {
+                        doCSE = false;
+                        JITDUMP("CSE " FMT_CSE " attempt %u disabled, out side of mask range\n", candidate.CseIndex(),
+                                attempt, doCSE ? "allowed" : "disabled");
+                    }
+                    else
+                    {
+                        doCSE = ((1 << attempt) & ((unsigned)JitConfig.JitCSEMask())) != 0;
+                        JITDUMP("CSE " FMT_CSE " attempt %u %s mask 0x%0x: %s\n", candidate.CseIndex(), attempt,
+                                doCSE ? "allowed" : "disabled", JitConfig.JitCSEMask());
+                    }
                 }
             }
 

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -3331,9 +3331,9 @@ public:
                 if (m_pCompiler->info.compMethodHash() == (unsigned)JitConfig.JitCSEHash())
                 {
                     // We can only mask the first 32 CSE attempts, so suppress anything beyond that.
-                    // Note methods with > 32 CSEs are currently quite rare.
+                    // Note methods with >= 32 CSEs are currently quite rare.
                     //
-                    if (attempt > 32)
+                    if (attempt >= 32)
                     {
                         doCSE = false;
                         JITDUMP(FMT_CSE " attempt %u disabled, out of mask range\n", candidate.CseIndex(), attempt);

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -3336,14 +3336,13 @@ public:
                     if (attempt > 32)
                     {
                         doCSE = false;
-                        JITDUMP("CSE " FMT_CSE " attempt %u disabled, out side of mask range\n", candidate.CseIndex(),
-                                attempt, doCSE ? "allowed" : "disabled");
+                        JITDUMP(FMT_CSE " attempt %u disabled, out of mask range\n", candidate.CseIndex(), attempt);
                     }
                     else
                     {
                         doCSE = ((1 << attempt) & ((unsigned)JitConfig.JitCSEMask())) != 0;
-                        JITDUMP("CSE " FMT_CSE " attempt %u %s mask 0x%0x: %s\n", candidate.CseIndex(), attempt,
-                                doCSE ? "allowed" : "disabled", JitConfig.JitCSEMask());
+                        JITDUMP(FMT_CSE " attempt %u mask 0x%08x: %s\n", candidate.CseIndex(), attempt,
+                                JitConfig.JitCSEMask(), doCSE ? "allowed" : "disabled");
                     }
                 }
             }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -41,6 +41,7 @@ void Compiler::optInit()
     optAssertionDep      = nullptr;
     optCSEstart          = BAD_VAR_NUM;
     optCSEcount          = 0;
+    optCSEattempt        = 0;
 }
 
 DataFlow::DataFlow(Compiler* pCompiler) : m_pCompiler(pCompiler)


### PR DESCRIPTION
Introduce two config vars for experimenting with CSEs:
* `JitCSEHash`: identifies a method for CSE experimentatin
* `JitCSEMask`: specifies a bitmask of allowed CSEs (by "attempt")

When the hash is nonzero, any method whose hash matches will perform only the subset of CSEs specified by the mask (up to 32 CSEs).

Also introduce a config var to dump the total number of CSEs to either the assemby listing footer or the one-liner from the disassembly summary.
* `JitMetrics`

This can perhaps be generalized eventually to report more metrics and perhaps to report them back to SPMI when it is the jit host.

Finally, note CSE lcl vars that represent hoisted trees and or are "multiple-def" CSEs in the local var table.

Contributes to #92915.