### PR TITLE
`readonly`-ify fields based on whole program view

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
@@ -125,7 +125,7 @@ namespace ILCompiler
         protected PreinitializationManager GetPreinitializationManager()
         {
             if (_preinitializationManager == null)
-                return new PreinitializationManager(_context, _compilationGroup, GetILProvider(), new TypePreinit.DisabledPreinitializationPolicy());
+                return new PreinitializationManager(_context, _compilationGroup, GetILProvider(), new TypePreinit.DisabledPreinitializationPolicy(), new ReadOnlyFieldPolicy());
             return _preinitializationManager;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
@@ -19,6 +19,7 @@ namespace ILCompiler
         protected DevirtualizationManager _devirtualizationManager = new DevirtualizationManager();
         protected InlinedThreadStatics _inlinedThreadStatics = new InlinedThreadStatics();
         protected MethodImportationErrorProvider _methodImportationErrorProvider = new MethodImportationErrorProvider();
+        protected ReadOnlyFieldPolicy _readOnlyFieldPolicy = new ReadOnlyFieldPolicy();
         protected IInliningPolicy _inliningPolicy;
         protected bool _methodBodyFolding;
         protected InstructionSetSupport _instructionSetSupport;
@@ -110,6 +111,12 @@ namespace ILCompiler
             return this;
         }
 
+        public CompilationBuilder UseReadOnlyFieldPolicy(ReadOnlyFieldPolicy policy)
+        {
+            _readOnlyFieldPolicy = policy;
+            return this;
+        }
+
         public CompilationBuilder UseInlinedThreadStatics(InlinedThreadStatics inlinedThreadStatics)
         {
             _inlinedThreadStatics = inlinedThreadStatics;
@@ -125,7 +132,7 @@ namespace ILCompiler
         protected PreinitializationManager GetPreinitializationManager()
         {
             if (_preinitializationManager == null)
-                return new PreinitializationManager(_context, _compilationGroup, GetILProvider(), new TypePreinit.DisabledPreinitializationPolicy(), new ReadOnlyFieldPolicy());
+                return new PreinitializationManager(_context, _compilationGroup, GetILProvider(), new TypePreinit.DisabledPreinitializationPolicy(), new StaticReadOnlyFieldPolicy());
             return _preinitializationManager;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -319,6 +319,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new ReflectedTypeNode(type);
             });
 
+            _notReadOnlyFields = new NodeCache<FieldDesc, NotReadOnlyFieldNode>(field =>
+            {
+                return new NotReadOnlyFieldNode(field);
+            });
+
             _genericStaticBaseInfos = new NodeCache<MetadataType, GenericStaticBaseInfoNode>(type =>
             {
                 return new GenericStaticBaseInfoNode(type);
@@ -996,6 +1001,12 @@ namespace ILCompiler.DependencyAnalysis
         public ReflectedTypeNode ReflectedType(TypeDesc type)
         {
             return _reflectedTypes.GetOrAdd(type);
+        }
+
+        private NodeCache<FieldDesc, NotReadOnlyFieldNode> _notReadOnlyFields;
+        public NotReadOnlyFieldNode NotReadOnlyField(FieldDesc field)
+        {
+            return _notReadOnlyFields.GetOrAdd(field);
         }
 
         private NodeCache<MetadataType, GenericStaticBaseInfoNode> _genericStaticBaseInfos;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NotReadOnlyFieldNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NotReadOnlyFieldNode.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a field that cannot be optimized to `readonly`.
+    /// </summary>
+    public class NotReadOnlyFieldNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly FieldDesc _field;
+
+        public NotReadOnlyFieldNode(FieldDesc field)
+        {
+            Debug.Assert(!field.OwningType.IsCanonicalSubtype(CanonicalFormKind.Any)
+                || field.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific) == field.OwningType);
+            _field = field;
+        }
+
+        public FieldDesc Field => _field;
+
+        protected override string GetName(NodeFactory factory)
+        {
+            return "Field written outside initializer: " + _field.ToString();
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedFieldNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedFieldNode.cs
@@ -43,6 +43,10 @@ namespace ILCompiler.DependencyAnalysis
                 return dependencies;
             }
 
+            // readonly static fields are not reflection settable, the rest are
+            if (!_field.IsInitOnly || !_field.IsStatic)
+                dependencies.Add(factory.NotReadOnlyField(_field), "Reflection writable field");
+
             FieldDesc typicalField = _field.GetTypicalFieldDefinition();
             if (typicalField != _field)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/PreinitializationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/PreinitializationManager.cs
@@ -14,10 +14,10 @@ namespace ILCompiler
     {
         private readonly bool _supportsLazyCctors;
 
-        public PreinitializationManager(TypeSystemContext context, CompilationModuleGroup compilationGroup, ILProvider ilprovider, TypePreinit.TypePreinitializationPolicy policy)
+        public PreinitializationManager(TypeSystemContext context, CompilationModuleGroup compilationGroup, ILProvider ilprovider, TypePreinit.TypePreinitializationPolicy policy, ReadOnlyFieldPolicy readOnlyPolicy)
         {
             _supportsLazyCctors = context.SystemModule.GetType("System.Runtime.CompilerServices", "ClassConstructorRunner", throwIfNotFound: false) != null;
-            _preinitHashTable = new PreinitializationInfoHashtable(compilationGroup, ilprovider, policy);
+            _preinitHashTable = new PreinitializationInfoHashtable(compilationGroup, ilprovider, policy, readOnlyPolicy);
         }
 
         /// <summary>
@@ -136,12 +136,14 @@ namespace ILCompiler
             private readonly CompilationModuleGroup _compilationGroup;
             private readonly ILProvider _ilProvider;
             internal readonly TypePreinit.TypePreinitializationPolicy _policy;
+            private readonly ReadOnlyFieldPolicy _readOnlyPolicy;
 
-            public PreinitializationInfoHashtable(CompilationModuleGroup compilationGroup, ILProvider ilProvider, TypePreinit.TypePreinitializationPolicy policy)
+            public PreinitializationInfoHashtable(CompilationModuleGroup compilationGroup, ILProvider ilProvider, TypePreinit.TypePreinitializationPolicy policy, ReadOnlyFieldPolicy readOnlyPolicy)
             {
                 _compilationGroup = compilationGroup;
                 _ilProvider = ilProvider;
                 _policy = policy;
+                _readOnlyPolicy = readOnlyPolicy;
             }
 
             protected override bool CompareKeyToValue(MetadataType key, TypePreinit.PreinitializationInfo value) => key == value.Type;
@@ -151,7 +153,7 @@ namespace ILCompiler
 
             protected override TypePreinit.PreinitializationInfo CreateValueFromKey(MetadataType key)
             {
-                var info = TypePreinit.ScanType(_compilationGroup, _ilProvider, _policy, key);
+                var info = TypePreinit.ScanType(_compilationGroup, _ilProvider, _policy, _readOnlyPolicy, key);
 
                 // We either successfully preinitialized or
                 // the type doesn't have a canonical form or

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReadOnlyFieldPolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReadOnlyFieldPolicy.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.TypeSystem;
+
+namespace ILCompiler
+{
+    public class ReadOnlyFieldPolicy
+    {
+        public virtual bool IsReadOnly(FieldDesc field) => field.IsStatic && field.IsInitOnly;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReadOnlyFieldPolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReadOnlyFieldPolicy.cs
@@ -7,6 +7,11 @@ namespace ILCompiler
 {
     public class ReadOnlyFieldPolicy
     {
-        public virtual bool IsReadOnly(FieldDesc field) => field.IsStatic && field.IsInitOnly;
+        public virtual bool IsReadOnly(FieldDesc field) => field.IsInitOnly;
+    }
+
+    public sealed class StaticReadOnlyFieldPolicy : ReadOnlyFieldPolicy
+    {
+        public override bool IsReadOnly(FieldDesc field) => field.IsStatic && field.IsInitOnly;
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -35,16 +35,18 @@ namespace ILCompiler
         private readonly CompilationModuleGroup _compilationGroup;
         private readonly ILProvider _ilProvider;
         private readonly TypePreinitializationPolicy _policy;
+        private readonly ReadOnlyFieldPolicy _readOnlyPolicy;
         private readonly Dictionary<FieldDesc, Value> _fieldValues = new Dictionary<FieldDesc, Value>();
         private readonly Dictionary<string, StringInstance> _internedStrings = new Dictionary<string, StringInstance>();
         private readonly Dictionary<TypeDesc, RuntimeTypeValue> _internedTypes = new Dictionary<TypeDesc, RuntimeTypeValue>();
 
-        private TypePreinit(MetadataType owningType, CompilationModuleGroup compilationGroup, ILProvider ilProvider, TypePreinitializationPolicy policy)
+        private TypePreinit(MetadataType owningType, CompilationModuleGroup compilationGroup, ILProvider ilProvider, TypePreinitializationPolicy policy, ReadOnlyFieldPolicy readOnlyPolicy)
         {
             _type = owningType;
             _compilationGroup = compilationGroup;
             _ilProvider = ilProvider;
             _policy = policy;
+            _readOnlyPolicy = readOnlyPolicy;
 
             // Zero initialize all fields we model.
             foreach (var field in owningType.GetFields())
@@ -56,7 +58,7 @@ namespace ILCompiler
             }
         }
 
-        public static PreinitializationInfo ScanType(CompilationModuleGroup compilationGroup, ILProvider ilProvider, TypePreinitializationPolicy policy, MetadataType type)
+        public static PreinitializationInfo ScanType(CompilationModuleGroup compilationGroup, ILProvider ilProvider, TypePreinitializationPolicy policy, ReadOnlyFieldPolicy readOnlyPolicy, MetadataType type)
         {
             Debug.Assert(type.HasStaticConstructor);
             Debug.Assert(!type.IsGenericDefinition);
@@ -83,7 +85,7 @@ namespace ILCompiler
             Status status;
             try
             {
-                preinit = new TypePreinit(type, compilationGroup, ilProvider, policy);
+                preinit = new TypePreinit(type, compilationGroup, ilProvider, policy, readOnlyPolicy);
                 int instructions = 0;
                 status = preinit.TryScanMethod(type.GetStaticConstructor(), null, null, ref instructions, out _);
             }
@@ -345,11 +347,11 @@ namespace ILCompiler
                             {
                                 stack.PushFromLocation(field.FieldType, _fieldValues[field]);
                             }
-                            else if (field.IsInitOnly
+                            else if (_readOnlyPolicy.IsReadOnly(field)
                                 && field.OwningType.HasStaticConstructor
                                 && _policy.CanPreinitialize(field.OwningType))
                             {
-                                TypePreinit nestedPreinit = new TypePreinit((MetadataType)field.OwningType, _compilationGroup, _ilProvider, _policy);
+                                TypePreinit nestedPreinit = new TypePreinit((MetadataType)field.OwningType, _compilationGroup, _ilProvider, _policy, _readOnlyPolicy);
                                 recursionProtect ??= new Stack<MethodDesc>();
                                 recursionProtect.Push(methodIL.OwningMethod);
 
@@ -597,7 +599,7 @@ namespace ILCompiler
                                             TypeDesc fieldType = field.FieldType;
                                             if (fieldType.IsGCPointer)
                                             {
-                                                if (!field.IsInitOnly)
+                                                if (!_readOnlyPolicy.IsReadOnly(field))
                                                 {
                                                     allGcPointersAreReadonly = false;
                                                     break;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -379,6 +379,12 @@ namespace ILCompiler
                                 else
                                     return Status.Fail(methodIL.OwningMethod, opcode);
                             }
+                            else if (_readOnlyPolicy.IsReadOnly(field)
+                                && !field.OwningType.HasStaticConstructor)
+                            {
+                                // (Effectively) read only field but no static constructor to set it: the value is default-initialized.
+                                stack.PushFromLocation(field.FieldType, NewUninitializedLocationValue(field.FieldType));
+                            }
                             else
                             {
                                 return Status.Fail(methodIL.OwningMethod, opcode, "Load from other non-initonly static");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -974,12 +974,33 @@ namespace Internal.IL
             _isReadOnly = true;
         }
 
-        private void ImportFieldAccess(int token, bool isStatic, string reason)
+        private void ImportFieldAccess(int token, bool isStatic, bool write, string reason)
         {
             var field = (FieldDesc)_methodIL.GetObject(token);
             var canonField = (FieldDesc)_canonMethodIL.GetObject(token);
 
             _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _compilation.NodeFactory, _canonMethodIL, canonField);
+
+            if (write)
+            {
+                bool isInitOnlyWrite = field.OwningType == _methodIL.OwningMethod.OwningType
+                    && ((field.IsStatic && _methodIL.OwningMethod.IsStaticConstructor)
+                        || (!field.IsStatic && _methodIL.OwningMethod.IsConstructor));
+
+                // Consider initonly statics always safe; Roslyn does generate ldflda for these.
+                isInitOnlyWrite |= field.IsStatic && field.IsInitOnly;
+
+                if (!isInitOnlyWrite)
+                {
+                    FieldDesc fieldToReport = canonField;
+                    DefType fieldOwningType = canonField.OwningType;
+                    TypeDesc canonFieldOwningType = fieldOwningType.ConvertToCanonForm(CanonicalFormKind.Specific);
+                    if (fieldOwningType != canonFieldOwningType)
+                        fieldToReport = _factory.TypeSystemContext.GetFieldForInstantiatedType(fieldToReport.GetTypicalFieldDefinition(), (InstantiatedType)canonFieldOwningType);
+
+                    _dependencies.Add(_factory.NotReadOnlyField(fieldToReport), "Field written outside initializer");
+                }
+            }
 
             // Covers both ldsfld/ldsflda and ldfld/ldflda with a static field
             if (isStatic || field.IsStatic)
@@ -1034,17 +1055,17 @@ namespace Internal.IL
 
         private void ImportLoadField(int token, bool isStatic)
         {
-            ImportFieldAccess(token, isStatic, isStatic ? "ldsfld" : "ldfld");
+            ImportFieldAccess(token, isStatic, write: false, isStatic ? "ldsfld" : "ldfld");
         }
 
         private void ImportAddressOfField(int token, bool isStatic)
         {
-            ImportFieldAccess(token, isStatic, isStatic ? "ldsflda" : "ldflda");
+            ImportFieldAccess(token, isStatic, write: true, isStatic ? "ldsflda" : "ldflda");
         }
 
         private void ImportStoreField(int token, bool isStatic)
         {
-            ImportFieldAccess(token, isStatic, isStatic ? "stsfld" : "stfld");
+            ImportFieldAccess(token, isStatic, write: true, isStatic ? "stsfld" : "stfld");
         }
 
         private void ImportLoadString(int token)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -981,9 +981,9 @@ namespace Internal.IL
 
             _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _compilation.NodeFactory, _canonMethodIL, canonField);
 
-            // Write will be null for ld(s)flda. Consider address loads write unless they were
-            // for initonly fields. We'll trust the initonly that this is not a write.
-            write ??= !field.IsInitOnly;
+            // `write` will be null for ld(s)flda. Consider address loads write unless they were
+            // for initonly static fields. We'll trust the initonly that this is not a write.
+            write ??= !field.IsInitOnly || !field.IsStatic;
 
             if (write.Value)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -983,8 +983,7 @@ namespace Internal.IL
 
             // Write will be null for ld(s)flda. Consider address loads write unless they were
             // for initonly fields. We'll trust the initonly that this is not a write.
-            if (write == null)
-                write = !field.IsInitOnly;
+            write ??= !field.IsInitOnly;
 
             if (write.Value)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -421,6 +421,7 @@
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchCellSectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MethodExceptionHandlingInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ModuleInitializerListNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\NotReadOnlyFieldNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ObjectGetTypeFlowDependenciesNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\PointerTypeMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectedFieldNode.cs" />
@@ -585,6 +586,7 @@
     <Compile Include="Compiler\DependencyAnalysis\Target_LoongArch64\LoongArch64ReadyToRunHelperNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_LoongArch64\LoongArch64ReadyToRunGenericHelperNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_LoongArch64\LoongArch64UnboxingStubNode.cs" />
+    <Compile Include="Compiler\ReadOnlyFieldPolicy.cs" />
     <Compile Include="Compiler\UnmanagedEntryPointsRootProvider.cs" />
     <Compile Include="Compiler\GenericDictionaryLookup.cs" />
     <Compile Include="Compiler\IRootingServiceProvider.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -24,6 +24,7 @@ namespace ILCompiler
         internal readonly RyuJitCompilationOptions _compilationOptions;
         private readonly ProfileDataManager _profileDataManager;
         private readonly MethodImportationErrorProvider _methodImportationErrorProvider;
+        private readonly ReadOnlyFieldPolicy _readOnlyFieldPolicy;
         private readonly int _parallelism;
 
         public InstructionSetSupport InstructionSetSupport { get; }
@@ -40,6 +41,7 @@ namespace ILCompiler
             InstructionSetSupport instructionSetSupport,
             ProfileDataManager profileDataManager,
             MethodImportationErrorProvider errorProvider,
+            ReadOnlyFieldPolicy readOnlyFieldPolicy,
             RyuJitCompilationOptions options,
             int parallelism)
             : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, devirtualizationManager, inliningPolicy, logger)
@@ -51,10 +53,14 @@ namespace ILCompiler
 
             _methodImportationErrorProvider = errorProvider;
 
+            _readOnlyFieldPolicy = readOnlyFieldPolicy;
+
             _parallelism = parallelism;
         }
 
         public ProfileDataManager ProfileData => _profileDataManager;
+
+        public bool IsInitOnly(FieldDesc field) => _readOnlyFieldPolicy.IsReadOnly(field);
 
         public override IEETypeNode NecessaryTypeSymbolIfPossible(TypeDesc type)
         {

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
@@ -127,7 +127,7 @@ namespace ILCompiler
 
             JitConfigProvider.Initialize(_context.Target, jitFlagBuilder.ToArray(), _ryujitOptions, _jitPath);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(CompilerComparer.Instance));
-            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _devirtualizationManager, _inliningPolicy ?? _compilationGroup, _instructionSetSupport, _profileDataManager, _methodImportationErrorProvider, options, _parallelism);
+            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _devirtualizationManager, _inliningPolicy ?? _compilationGroup, _instructionSetSupport, _profileDataManager, _methodImportationErrorProvider, _readOnlyFieldPolicy, options, _parallelism);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2274,6 +2274,7 @@ namespace Internal.JitInterface
                 }
                 else if (!owningType.HasStaticConstructor)
                 {
+                    // (Effectively) read only field but no static constructor to set it: the value is default-initialized.
                     int size = field.FieldType.GetElementSize().AsInt;
                     if (size >= bufferSize && valueOffset <= size - bufferSize)
                     {

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2168,7 +2168,7 @@ namespace Internal.JitInterface
                 fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_INSTANCE;
             }
 
-            if (field.IsInitOnly)
+            if (_compilation.IsInitOnly(field))
                 fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_FINAL;
 
             pResult->fieldAccessor = fieldAccessor;
@@ -2224,7 +2224,7 @@ namespace Internal.JitInterface
             Debug.Assert(field.IsStatic);
 
 
-            if (!field.IsThreadStatic && field.IsInitOnly && field.OwningType is MetadataType owningType)
+            if (!field.IsThreadStatic && _compilation.IsInitOnly(field) && field.OwningType is MetadataType owningType)
             {
                 if (field.HasRva)
                 {

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2231,13 +2231,13 @@ namespace Internal.JitInterface
                     return TryReadRvaFieldData(field, buffer, bufferSize, valueOffset);
                 }
 
-                int targetPtrSize = _compilation.TypeSystemContext.Target.PointerSize;
-
                 PreinitializationManager preinitManager = _compilation.NodeFactory.PreinitializationManager;
                 if (preinitManager.IsPreinitialized(owningType))
                 {
                     TypePreinit.ISerializableValue value = preinitManager
                         .GetPreinitializationInfo(owningType).GetFieldValue(field);
+
+                    int targetPtrSize = _compilation.TypeSystemContext.Target.PointerSize;
 
                     if (value == null)
                     {

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -436,7 +436,7 @@ namespace ILCompiler
             TypePreinit.TypePreinitializationPolicy preinitPolicy = preinitStatics ?
                 new TypePreinit.TypeLoaderAwarePreinitializationPolicy() : new TypePreinit.DisabledPreinitializationPolicy();
 
-            var preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, preinitPolicy, new ReadOnlyFieldPolicy());
+            var preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, preinitPolicy, new StaticReadOnlyFieldPolicy());
             builder
                 .UseILProvider(ilProvider)
                 .UsePreinitializationManager(preinitManager);
@@ -513,9 +513,11 @@ namespace ILCompiler
                 // has the whole program view.
                 if (preinitStatics)
                 {
+                    var readOnlyFieldPolicy = scanResults.GetReadOnlyFieldPolicy();
                     preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, scanResults.GetPreinitializationPolicy(),
-                        scanResults.GetReadOnlyFieldPolicy());
-                    builder.UsePreinitializationManager(preinitManager);
+                        readOnlyFieldPolicy);
+                    builder.UsePreinitializationManager(preinitManager)
+                        .UseReadOnlyFieldPolicy(readOnlyFieldPolicy);
                 }
 
                 // If we have a scanner, we can inline threadstatics storage using the information we collected at scanning time.

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -436,7 +436,7 @@ namespace ILCompiler
             TypePreinit.TypePreinitializationPolicy preinitPolicy = preinitStatics ?
                 new TypePreinit.TypeLoaderAwarePreinitializationPolicy() : new TypePreinit.DisabledPreinitializationPolicy();
 
-            var preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, preinitPolicy);
+            var preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, preinitPolicy, new ReadOnlyFieldPolicy());
             builder
                 .UseILProvider(ilProvider)
                 .UsePreinitializationManager(preinitManager);
@@ -513,7 +513,8 @@ namespace ILCompiler
                 // has the whole program view.
                 if (preinitStatics)
                 {
-                    preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, scanResults.GetPreinitializationPolicy());
+                    preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, scanResults.GetPreinitializationPolicy(),
+                        scanResults.GetReadOnlyFieldPolicy());
                     builder.UsePreinitializationManager(preinitManager);
                 }
 

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -31,7 +31,6 @@ internal class Program
         TestCctorCycle.Run();
         TestReferenceTypeAllocation.Run();
         TestReferenceTypeWithGCPointerAllocation.Run();
-        TestReferenceTypeWithReadonlyNullGCPointerAllocation.Run();
         TestRelationalOperators.Run();
         TestTryFinally.Run();
         TestTryCatch.Run();
@@ -428,34 +427,6 @@ class TestReferenceTypeWithGCPointerAllocation
     {
         Assert.IsLazyInitialized(typeof(TestReferenceTypeWithGCPointerAllocation));
         Assert.AreSame("hi", s_referenceType.StringValue);
-    }
-}
-
-class TestReferenceTypeWithReadonlyNullGCPointerAllocation
-{
-    class ReferenceType
-    {
-        // Can't actually access this from anywhere because the test is compiled
-        // with IlcTrimMetadata=false and accessing the field would make it reflection-visible.
-        public readonly string StringValue;
-
-        public ReferenceType()
-        {
-        }
-    }
-
-    static ReferenceType s_referenceType = new ReferenceType();
-
-    public static void Run()
-    {
-#if DEBUG
-        // ReferenceType.StringValue is considered maybe reflection-accessed in this test
-        // without the whole program analysis done in RELEASE configuration.
-        Assert.IsLazyInitialized(typeof(TestReferenceTypeWithReadonlyNullGCPointerAllocation));
-#else
-        Assert.IsPreinitialized(typeof(TestReferenceTypeWithReadonlyNullGCPointerAllocation));
-#endif
-        s_referenceType.ToString();
     }
 }
 

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -435,20 +435,27 @@ class TestReferenceTypeWithReadonlyNullGCPointerAllocation
 {
     class ReferenceType
     {
+        // Can't actually access this from anywhere because the test is compiled
+        // with IlcTrimMetadata=false and accessing the field would make it reflection-visible.
         public readonly string StringValue;
 
-        public ReferenceType(string stringvalue)
+        public ReferenceType()
         {
-            StringValue = stringvalue;
         }
     }
 
-    static ReferenceType s_referenceType = new ReferenceType(null);
+    static ReferenceType s_referenceType = new ReferenceType();
 
     public static void Run()
     {
+#if DEBUG
+        // ReferenceType.StringValue is considered maybe reflection-accessed in this test
+        // without the whole program analysis done in RELEASE configuration.
+        Assert.IsLazyInitialized(typeof(TestReferenceTypeWithReadonlyNullGCPointerAllocation));
+#else
         Assert.IsPreinitialized(typeof(TestReferenceTypeWithReadonlyNullGCPointerAllocation));
-        Assert.AreSame(null, s_referenceType.StringValue);
+#endif
+        s_referenceType.ToString();
     }
 }
 

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -410,7 +410,9 @@ class DeadCodeElimination
             // We're testing the optimizations mentioned above work by inspecting the side effect
             // (that is only visible to trim-unsafe code).
             Console.WriteLine($"Testing we were able to make non-readonly field read-only: {ClassThatShouldBePreinited.Value}");
+#if !DEBUG
             ThrowIfPresentWithUsableMethodTable(typeof(TestUnmodifiableStaticFieldOptimization), nameof(Unimportant));
+#endif
         }
     }
 
@@ -464,7 +466,9 @@ class DeadCodeElimination
             IsModified.Instance.Field = new object();
             typeof(IsReflectedOn).GetFields();
 
+#if !DEBUG
             ThrowIfPresentWithUsableMethodTable(typeof(TestUnmodifiableInstanceFieldOptimization), nameof(Canary1));
+#endif
             ThrowIfNotPresent(typeof(TestUnmodifiableInstanceFieldOptimization), nameof(Canary2));
             ThrowIfNotPresent(typeof(TestUnmodifiableInstanceFieldOptimization), nameof(Canary3));
         }


### PR DESCRIPTION
Marking fields `readonly` has a couple benefits:

* Codegen can assume the value doesn't change and can inline the values into code.
* In the static constructor interpreter, we allow reading readonly fields of other classes. So `class A { public static int X = 123 } class B { static int Y = A.X }` - `A` can be preinitialized at compile time, but `B` cannot. However: `class A { public static readonly int X = 123 } class B { static int Y = A.X }` both `A` and `B` can preinitialize at compile time.

In this PR, I'm adding infrastructure to collect information about field writes during whole program analysis. This collects information about fields that are effectively read-only. Then during compilation, we use this data instead of the `IsInitOnly` metadata. The big advantage of this approach (as opposed to e.g. a Roslyn analyzer) is that we look at the app after trimming - some fields might be writable, but if we discarded the code that writes them, they're read only.

This is also a correctness fix - the compiler would previously assume preinitializing instances of classes with all-readonly instance fields is safe, but one can set them with reflection and this would lead to a crash in the write barrier. Not that anyone should be reflection-setting readonly fields outside of deserialization scenarios.

Cc @dotnet/ilc-contrib 