### PR TITLE
Merged stores: Fix alignment-related issues and enable SIMD where possible

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -487,6 +487,8 @@ enum GenTreeFlags : unsigned int
                                               //           This flag is useful in cases where it is required to generate register
                                               //           indirect addressing mode. One such case is virtual stub calls on xarch.
     GTF_IND_UNALIGNED           = 0x02000000, // OperIsIndir() -- the load or store is unaligned (we assume worst case alignment of 1 byte)
+    GTF_IND_KNOWN_UNALIGNED     = 0x00100000, // GT_IND -- same as GTF_IND_UNALIGNED (it's expected to be set) with a legal allowance
+                                              //           to use wider loads/stores where needed.
     GTF_IND_INVARIANT           = 0x01000000, // GT_IND -- the target is invariant (a prejit indirection)
     GTF_IND_NONNULL             = 0x00400000, // GT_IND -- the indirection never returns null (zero)
     GTF_IND_INITCLASS           = 0x00200000, // OperIsIndir() -- the indirection requires preceding static cctor

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -487,8 +487,7 @@ enum GenTreeFlags : unsigned int
                                               //           This flag is useful in cases where it is required to generate register
                                               //           indirect addressing mode. One such case is virtual stub calls on xarch.
     GTF_IND_UNALIGNED           = 0x02000000, // OperIsIndir() -- the load or store is unaligned (we assume worst case alignment of 1 byte)
-    GTF_IND_KNOWN_UNALIGNED     = 0x00100000, // GT_IND -- same as GTF_IND_UNALIGNED (it's expected to be set) with a legal allowance
-                                              //           to use wider loads/stores where needed.
+    GTF_IND_ALLOW_NON_ATOMIC    = 0x00100000, // GT_IND -- this memory access does not need be atomic
     GTF_IND_INVARIANT           = 0x01000000, // GT_IND -- the target is invariant (a prejit indirection)
     GTF_IND_NONNULL             = 0x00400000, // GT_IND -- the indirection never returns null (zero)
     GTF_IND_INITCLASS           = 0x00200000, // OperIsIndir() -- the indirection requires preceding static cctor

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -487,10 +487,10 @@ enum GenTreeFlags : unsigned int
                                               //           This flag is useful in cases where it is required to generate register
                                               //           indirect addressing mode. One such case is virtual stub calls on xarch.
     GTF_IND_UNALIGNED           = 0x02000000, // OperIsIndir() -- the load or store is unaligned (we assume worst case alignment of 1 byte)
-    GTF_IND_ALLOW_NON_ATOMIC    = 0x00100000, // GT_IND -- this memory access does not need be atomic
     GTF_IND_INVARIANT           = 0x01000000, // GT_IND -- the target is invariant (a prejit indirection)
     GTF_IND_NONNULL             = 0x00400000, // GT_IND -- the indirection never returns null (zero)
     GTF_IND_INITCLASS           = 0x00200000, // OperIsIndir() -- the indirection requires preceding static cctor
+    GTF_IND_ALLOW_NON_ATOMIC    = 0x00100000, // GT_IND -- this memory access does not need to be atomic
 
     GTF_IND_COPYABLE_FLAGS = GTF_IND_VOLATILE | GTF_IND_NONFAULTING | GTF_IND_UNALIGNED | GTF_IND_INITCLASS,
     GTF_IND_FLAGS = GTF_IND_COPYABLE_FLAGS | GTF_IND_NONNULL | GTF_IND_TGT_NOT_HEAP | GTF_IND_TGT_HEAP | GTF_IND_INVARIANT,

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7928,6 +7928,17 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
         return;
     }
 
+    // TODO-ARM64-CQ: revisit TYP_REF if we find a case where it's beneficial.
+    // The algorithm does support TYP_REF (with null value), but it seems to be not worth
+    // it on ARM64 where it's pretty efficient to do "stp xzr, xzr, [addr]" to clear two
+    // items at once. Although, it may be profitable to do "stp q0, q0, [addr]"
+    //
+    // Other types are added for better throughput to early out.
+    if (ind->TypeIs(TYP_REF, TYP_BYREF, TYP_STRUCT, TYP_FLOAT, TYP_DOUBLE))
+    {
+        return;
+    }
+
     // We're going to do it in a loop while we see suitable STOREINDs to coalesce.
     // E.g.: we have the following LIR sequence:
     //

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7943,7 +7943,7 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
     do
     {
         // This check is not really needed, just for better throughput.
-        if (!ind->TypeIs(TYP_BYTE, TYP_UBYTE, TYP_SHORT, TYP_USHORT, TYP_INT) && !varTypeIsSIMD(ind))
+        if (!varTypeIsIntegralOrI(ind) && !varTypeIsSIMD(ind))
         {
             return;
         }
@@ -8133,7 +8133,7 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
                 }
                 return;
 #endif // TARGET_AMD64
-#endif // TARGET_AMD64 && FEATURE_HW_INTRINSICS
+#endif // FEATURE_HW_INTRINSICS
 #endif // TARGET_64BIT
 
             // TYP_FLOAT and TYP_DOUBLE aren't needed here - they're expected to
@@ -8167,6 +8167,8 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
         ind->Data()->gtType = newType;
 
 #if defined(TARGET_AMD64) && defined(FEATURE_HW_INTRINSICS)
+        // Upgrading two SIMD stores to a wider SIMD store.
+        // Only on x64 since ARM64 has no options above SIMD16
         if (varTypeIsSIMD(oldType))
         {
             int8_t* lowerCns = prevData.value->AsVecCon()->gtSimdVal.i8;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7834,7 +7834,7 @@ static bool GetStoreCoalescingData(Compiler* comp, GenTreeStoreInd* ind, StoreCo
     }
 
     // Data has to be INT_CNS, can be also VEC_CNS in future.
-    if (!ind->Data()->IsCnsIntOrI())
+    if (!ind->Data()->IsCnsIntOrI() && !ind->Data()->IsVectorConst())
     {
         return false;
     }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -8114,7 +8114,7 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
 
 #if defined(TARGET_AMD64)
             case TYP_SIMD16:
-                if (comp->getPreferredVectorByteLength() >= 32))
+                if (comp->getPreferredVectorByteLength() >= 32)
                 {
                     newType = TYP_SIMD32;
                     break;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -8114,9 +8114,7 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
 
 #if defined(TARGET_AMD64)
             case TYP_SIMD16:
-                // Check for AVX to present and PreferredVectorByteLength
-                if (comp->compOpportunisticallyDependsOn(InstructionSet_AVX) &&
-                    (comp->getPreferredVectorByteLength() >= 32))
+                if (comp->getPreferredVectorByteLength() >= 32))
                 {
                     newType = TYP_SIMD32;
                     break;
@@ -8124,9 +8122,7 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
                 return;
 
             case TYP_SIMD32:
-                // Same for AVX512
-                if (comp->IsBaselineVector512IsaSupportedOpportunistically() &&
-                    (comp->getPreferredVectorByteLength() >= 64))
+                if (comp->getPreferredVectorByteLength() >= 64)
                 {
                     newType = TYP_SIMD64;
                     break;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -8025,7 +8025,8 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
 
 #if defined(TARGET_AMD64) && defined(FEATURE_HW_INTRINSICS)
             case TYP_SIMD16:
-                if (comp->compOpportunisticallyDependsOn(InstructionSet_AVX))
+                if (comp->compOpportunisticallyDependsOn(InstructionSet_AVX) &&
+                    (comp->getPreferredVectorByteLength() >= 32))
                 {
                     newType = TYP_SIMD32;
                     break;
@@ -8033,7 +8034,8 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
                 return;
 
             case TYP_SIMD32:
-                if (comp->IsBaselineVector512IsaSupportedOpportunistically())
+                if (comp->IsBaselineVector512IsaSupportedOpportunistically() &&
+                    (comp->getPreferredVectorByteLength() >= 64))
                 {
                     newType = TYP_SIMD64;
                     break;


### PR DESCRIPTION
Adjust rules when we can use unaligned stores for merged ones. Also, enable 2xLONG/REF -> SIMD. And 2xSIMD to wider SIMD.

**Wider scalar primitives for naturally aligned data of primitives  (>1B):**

Target memory | Crosses cache-line</br>boundary? | x64* | arm64
-- | -- | -- | --
Global memory | Yes | 🚫 | 🚫
  | No | ✅ | 🚫
Local memory (not exposed) | Yes | ✅ | ✅
  | No | ✅ | ✅

**SIMD for for naturally aligned data of primitives (>1B):**

| Target memory              | Known alignment  | x64*   | arm64 |
|----------------------------|------------------|--------|-------|
| Global memory              | 1B (aka unknown) | 🚫      | 🚫     |
|                            | 8B (most common)              | 🚫      | ✅     |
|                            | 16B (rare**)             | ✅(AVX+) | ✅     |
| Local memory (not exposed) | 1B               | ✅      | ✅     |
|                            | 8B               | ✅      | ✅     |
|                            | 16B              | ✅ | ✅     |

_* both Intel and AMD_
_** it's very unlikely JIT can assume 16-byte alignment currently anyhow_

PS: Merged stores are conservatively disabled on LA64 and RISC-V

Per "Arm Architecture Reference Manual":
```
* Writes from SIMD and floating-point registers of a 128-bit value that is 64-bit aligned in memory
  are treated as a pair of single - copy atomic 64 - bit writes.
```

@tannergooding said that x64 with AVX promises atomicy for 16B for 16B aligned data - so far it seems to be the only thing x64 can guarantee to us.

Related issues: https://github.com/dotnet/runtime/issues/76503, https://github.com/dotnet/runtime/issues/51638, 