### PR TITLE
Adding Log2 tests covering some special values

### DIFF
--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
@@ -1058,6 +1058,41 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(TensorLengths))]
+        public static void Log2_SpecialValues(int tensorLength)
+        {
+            using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);
+            using BoundedMemory<float> destination = CreateTensor(tensorLength);
+
+            // NaN
+            x[s_random.Next(x.Length)] = float.NaN;
+
+            // +Infinity
+            x[s_random.Next(x.Length)] = float.PositiveInfinity;
+
+            // -Infinity
+            x[s_random.Next(x.Length)] = float.NegativeInfinity;
+
+            // +Zero
+            x[s_random.Next(x.Length)] = +0.0f;
+
+            // -Zero
+            x[s_random.Next(x.Length)] = -0.0f;
+
+            // +Epsilon
+            x[s_random.Next(x.Length)] = +float.Epsilon;
+
+            // -Epsilon
+            x[s_random.Next(x.Length)] = -float.Epsilon;
+
+            TensorPrimitives.Log2(x, destination);
+            for (int i = 0; i < tensorLength; i++)
+            {
+                Assert.Equal(MathF.Log(x[i], 2), destination[i], Tolerance);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TensorLengths))]
         public static void Log2_ThrowsForTooShortDestination(int tensorLength)
         {
             using BoundedMemory<float> x = CreateAndFillTensor(tensorLength);


### PR DESCRIPTION
Adds tests covering explicit edge case values, such as `NaN`, `+/-Infinity`, `+/-0`, and `+/-Epsilon`