### PR TITLE
[wasm] Disable `TensorPrimitivesTests.ConvertToHalf_SpecialValues`

### DIFF
--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.netcore.cs
@@ -37,6 +37,7 @@ namespace System.Numerics.Tensors.Tests
         }
 
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/92885", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         [MemberData(nameof(TensorLengths))]
         public static void ConvertToHalf_SpecialValues(int tensorLength)
         {


### PR DESCRIPTION
Failing test: `System.Numerics.Tensors.Tests.TensorPrimitivesTests.ConvertToHalf_SpecialValues`

Issue: https://github.com/dotnet/runtime/issues/92885
