### PR TITLE
[release/7.0] Fixes not find assembly and pdb if it's not using the default path

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -1528,7 +1528,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         }
                         else
                         {
-                            logger.LogDebug($"Failed to read {step.Url} ({e.Message})");
+                            logger.LogDebug($"Failed to read {step.Url} ({e})");
                         }
                     }
                     catch (Exception ex)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -1533,7 +1533,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
                     catch (Exception ex)
                     {
-                        logger.LogError($"Failed to load {step.Url} ({ex.Message})");
+                        logger.LogError($"Failed to load {step.Url} ({ex})");
                     }
                 }
                 if (assembly == null)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -1523,7 +1523,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         if (tryUseDebuggerProtocol)
                         {
                             string unescapedFileName = Uri.UnescapeDataString(step.Url);
-                            bytes = await context.SdbAgent.GetBytesFromAssemblyAndPdb(Path.GetFileName(unescapedFileName), token);
+                            bytes = await context.SdbAgent.GetBytesFromAssemblyAndPdb(Path.GetFileName(unescapedFileName), token).ConfigureAwait(false);
                             assembly = new AssemblyInfo(monoProxy, id, step.Url, bytes[0], bytes[1], logger, token);
                         }
                         else


### PR DESCRIPTION
## Customer Impact
Fixes https://github.com/dotnet/runtime/issues/93016
When a customer is setting another path for the assets during the Blazor start the debugger is not working.
```
await Blazor.start({
    loadBootResource: function (type: string, name: string, defaultUri: string, integrity: string) {
        return `${defaultUri.replace("_framework", "assets/dotnet")}?${integrity}`;
    }
});
```

## Testing
Manually tested.

## Risk
Low. Only moving the try catch.
