### PR TITLE
[release/7.0-staging] CI: runtime-wasm-perf: disable for PRs

### DIFF
--- a/eng/pipelines/runtime-wasm-perf.yml
+++ b/eng/pipelines/runtime-wasm-perf.yml
@@ -3,6 +3,7 @@
 # UI to this, and thus avoid any scheduled triggers
 
 trigger: none
+pr: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml


### PR DESCRIPTION
Since we have `runtime-wasm-perf` enabled for PRs now, it needs a corresponding `pr: none` in the yml to disable it for this branch.