### PR TITLE
[wasm] Interpreter automatic PGO

### DIFF
--- a/eng/testing/scenarios/BuildWasmAppsJobsList.txt
+++ b/eng/testing/scenarios/BuildWasmAppsJobsList.txt
@@ -3,6 +3,7 @@ Wasm.Build.NativeRebuild.Tests.NoopNativeRebuildTest
 Wasm.Build.NativeRebuild.Tests.OptimizationFlagChangeTests
 Wasm.Build.NativeRebuild.Tests.ReferenceNewAssemblyRebuildTest
 Wasm.Build.NativeRebuild.Tests.SimpleSourceChangeRebuildTest
+Wasm.Build.Templates.Tests.InterpPgoTests
 Wasm.Build.Templates.Tests.NativeBuildTests
 Wasm.Build.Tests.Blazor.AppsettingsTests
 Wasm.Build.Tests.Blazor.BuildPublishTests

--- a/src/mono/mono/mini/CMakeLists.txt
+++ b/src/mono/mono/mini/CMakeLists.txt
@@ -299,7 +299,8 @@ set(interp_sources
     interp/transform.c
     interp/tiering.h
     interp/tiering.c
-    interp/jiterpreter.c)
+    interp/jiterpreter.c
+    interp/interp-pgo.c)
 set(interp_simd_sources
     interp/interp-simd.c)
 set(interp_stub_sources

--- a/src/mono/mono/mini/interp/interp-pgo.c
+++ b/src/mono/mono/mini/interp/interp-pgo.c
@@ -1,0 +1,368 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// This file contains icalls used in jitted interpreter traces and wrappers,
+//  along with infrastructure to support code generration
+
+// This file implements most of interpreter automatic PGO.
+// Loading/saving the actual table is your responsibility via mono_interp_pgo_(load|save)_table
+
+#ifndef __USE_ISOC99
+#define __USE_ISOC99
+#endif
+#include "config.h"
+
+// We start with a fixed-size table and then grow it by a given ratio when we run out of space
+// Generally speaking size doubling is suboptimal so we use a 1.5x ratio
+#define TABLE_MINIMUM_SIZE 4096
+#define TABLE_GROWTH_FACTOR 150
+#define INTERP_PGO_LOG_INTERVAL_MS 10
+
+#include <mono/metadata/mono-config.h>
+#include <mono/utils/mono-threads.h>
+#include <mono/utils/mono-time.h>
+#include <mono/utils/bsearch.h>
+
+#include "interp.h"
+#include "interp-internals.h"
+#include "transform.h"
+#include "interp-intrins.h"
+#include "tiering.h"
+
+#include "interp-pgo.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <mono/utils/options.h>
+#include <mono/utils/atomic.h>
+
+
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+//
+// Implementation was copied from https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
+// with changes around strict-aliasing/unaligned reads
+
+#define MM3_HASH_BYTE_SIZE 16   // MurMurHash3 is 128-bit, so we need 16 bytes to store it
+#define MM3_HASH_BUFFER_SIZE 33 // MurMurHash3 is 128-bit, so we need 32 chars + 1 char to store null-terminator
+
+inline static uint64_t ROTL64(uint64_t x, int8_t r)
+{
+    return (x << r) | (x >> (64 - r));
+}
+
+inline static uint64_t getblock64(const uint8_t* ptr)
+{
+    uint64_t val = 0;
+    memcpy(&val, ptr, sizeof(uint64_t));
+    return val;
+}
+
+inline static void setblock64(uint8_t* ptr, uint64_t val)
+{
+    memcpy(ptr, &val, sizeof(uint64_t));
+}
+
+// Finalization mix - force all bits of a hash block to avalanche
+inline static uint64_t fmix64(uint64_t k)
+{
+    k ^= k >> 33;
+    k *= 0xff51afd7ed558ccdLLU;
+    k ^= k >> 33;
+    k *= 0xc4ceb9fe1a85ec53LLU;
+    k ^= k >> 33;
+    return k;
+}
+
+static void MurmurHash3_128(const void* key, const size_t len, const uint32_t seed, uint8_t out[MM3_HASH_BYTE_SIZE])
+{
+    const uint8_t* data = (const uint8_t*)key;
+    const size_t nblocks = len / MM3_HASH_BYTE_SIZE;
+    uint64_t h1 = seed;
+    uint64_t h2 = seed;
+    const uint64_t c1 = 0x87c37b91114253d5LLU;
+    const uint64_t c2 = 0x4cf5ad432745937fLLU;
+
+    // body
+    for (size_t i = 0; i < nblocks; i++)
+    {
+        uint64_t k1 = getblock64(data + (i * 2 + 0) * sizeof(uint64_t));
+        uint64_t k2 = getblock64(data + (i * 2 + 1) * sizeof(uint64_t));
+
+        k1 *= c1; k1 = ROTL64(k1, 31); k1 *= c2; h1 ^= k1;
+        h1 = ROTL64(h1, 27); h1 += h2; h1 = h1 * 5 + 0x52dce729;
+        k2 *= c2; k2 = ROTL64(k2, 33); k2 *= c1; h2 ^= k2;
+        h2 = ROTL64(h2, 31); h2 += h1; h2 = h2 * 5 + 0x38495ab5;
+    }
+
+    // tail
+    const uint8_t* tail = data + nblocks * MM3_HASH_BYTE_SIZE;
+    uint64_t k1 = 0;
+    uint64_t k2 = 0;
+
+    switch (len & 15)
+    {
+        case 15: k2 ^= (uint64_t)(tail[14]) << 48;
+        case 14: k2 ^= (uint64_t)(tail[13]) << 40;
+        case 13: k2 ^= (uint64_t)(tail[12]) << 32;
+        case 12: k2 ^= (uint64_t)(tail[11]) << 24;
+        case 11: k2 ^= (uint64_t)(tail[10]) << 16;
+        case 10: k2 ^= (uint64_t)(tail[9]) << 8;
+        case 9:  k2 ^= (uint64_t)(tail[8]) << 0;
+            k2 *= c2; k2 = ROTL64(k2, 33); k2 *= c1; h2 ^= k2;
+
+        case 8: k1 ^= (uint64_t)(tail[7]) << 56;
+        case 7: k1 ^= (uint64_t)(tail[6]) << 48;
+        case 6: k1 ^= (uint64_t)(tail[5]) << 40;
+        case 5: k1 ^= (uint64_t)(tail[4]) << 32;
+        case 4: k1 ^= (uint64_t)(tail[3]) << 24;
+        case 3: k1 ^= (uint64_t)(tail[2]) << 16;
+        case 2: k1 ^= (uint64_t)(tail[1]) << 8;
+        case 1: k1 ^= (uint64_t)(tail[0]) << 0;
+            k1 *= c1; k1 = ROTL64(k1, 31); k1 *= c2; h1 ^= k1;
+            break;
+    }
+
+    // finalization
+    h1 ^= len;
+    h2 ^= len;
+    h1 += h2;
+    h2 += h1;
+    h1 = fmix64(h1);
+    h2 = fmix64(h2);
+    h1 += h2;
+    h2 += h1;
+
+    setblock64((uint8_t*)(out), h1);
+    setblock64((uint8_t*)(out) + sizeof(uint64_t), h2);
+}
+
+// end of murmurhash
+
+
+static gint64 generate_started, generate_total_time;
+static gint32 generate_depth;
+
+static gint32
+ms_from_100ns_ticks (gint64 ticks) {
+	return (int)((ticks + 500) / 1000);
+}
+
+void
+mono_interp_pgo_generate_start (void) {
+	if (!mono_opt_interp_codegen_timing)
+		return;
+
+	if (mono_atomic_inc_i32 (&generate_depth) == 1)
+		generate_started = mono_100ns_ticks ();
+}
+
+void
+mono_interp_pgo_generate_end (void) {
+	if (!mono_opt_interp_codegen_timing)
+		return;
+	if (mono_atomic_dec_i32 (&generate_depth) != 0)
+		return;
+
+	gint64 elapsed = mono_100ns_ticks () - generate_started,
+		new_total = mono_atomic_add_i64 (&generate_total_time, elapsed);
+	gint32 total_ms = ms_from_100ns_ticks (new_total),
+		prior_total_ms = ms_from_100ns_ticks (new_total - elapsed);
+
+	if ((total_ms / INTERP_PGO_LOG_INTERVAL_MS) != (prior_total_ms / INTERP_PGO_LOG_INTERVAL_MS))
+		g_printf ("generate_code elapsed time: %dms\n", total_ms);
+}
+
+
+typedef struct {
+	uint8_t *data;
+	uint32_t size, capacity;
+} interp_pgo_table;
+
+// loaded_table is the table we loaded from persistent storage at startup (if any),
+//  while building_table is the table we built during the current run. we store these
+//  separately so that we don't have to maintain a sorted table (for bsearch) on an
+//  ongoing basis.
+static interp_pgo_table *loaded_table, *building_table;
+// Loaded_table is immutable once loaded, so it has no mutex. Any access to building_table
+//  needs to be performed while holding this mutex.
+static mono_mutex_t building_table_lock;
+
+static int
+hash_comparer (const void *needle, const void *haystack)
+{
+	return memcmp (needle, haystack, MM3_HASH_BYTE_SIZE);
+}
+
+static gboolean
+table_lookup (interp_pgo_table *table, uint8_t hash[MM3_HASH_BYTE_SIZE]) {
+	// Early out if no table is loaded or the table is empty.
+	if (!table || !table->size)
+		return FALSE;
+
+	g_assert (table->size <= table->capacity);
+
+	void * result = mono_binary_search (hash, table->data, table->size / MM3_HASH_BYTE_SIZE, MM3_HASH_BYTE_SIZE, hash_comparer);
+	return (result != NULL);
+}
+
+static void
+table_add_locked (interp_pgo_table **table_variable, uint8_t hash[MM3_HASH_BYTE_SIZE]) {
+	interp_pgo_table *table = *table_variable;
+	// If we don't have a table yet, allocate one
+	if (!table)
+		*table_variable = table = g_malloc0 (sizeof (interp_pgo_table));
+
+	const uint32_t required_size = table->size + MM3_HASH_BYTE_SIZE,
+		required_capacity = MAX (required_size, TABLE_MINIMUM_SIZE);
+
+	// If we're out of space or haven't yet allocated a buffer for this table, calculate
+	//  an appropriate larger size and grow/allocate the buffer. We start at a fixed size,
+	//  then after that grow the current size by a set ratio per step.
+	while (required_capacity >= table->capacity) {
+		uint32_t new_capacity = MAX (required_capacity, (table->capacity * TABLE_GROWTH_FACTOR / 100));
+		if (table->data)
+			table->data = g_realloc (table->data, new_capacity);
+		else
+			table->data = g_malloc0 (new_capacity);
+		table->capacity = new_capacity;
+	}
+
+	// Copy the whole hash into the table at the end and update the size of the data
+	memcpy (table->data + table->size, hash, MM3_HASH_BYTE_SIZE);
+	table->size = required_size;
+}
+
+static void
+table_sort_locked (interp_pgo_table *table) {
+	mono_qsort (table->data, table->size / MM3_HASH_BYTE_SIZE, MM3_HASH_BYTE_SIZE, hash_comparer);
+}
+
+static void
+compute_method_hash (MonoMethod *method, uint8_t outbuf[MM3_HASH_BYTE_SIZE]) {
+	// method token + image guid
+	size_t size = sizeof(uint32_t) + 16;
+	uint32_t *inbuf = alloca (size);
+	// method tokens are globally unique within a given assembly
+	inbuf[0] = mono_method_get_token (method);
+	// use the assembly guid as a unique id for the assembly
+	MonoImage *image = m_class_get_image (mono_method_get_class (method));
+	memcpy (inbuf + 1, mono_image_get_guid (image), 16);
+
+	MurmurHash3_128 (inbuf, size, 0x43219876, (uint8_t *)outbuf);
+}
+
+gboolean
+mono_interp_pgo_should_tier_method (MonoMethod *method) {
+	// If we didn't load a table, don't bother hashing the method.
+	if (!loaded_table)
+		return FALSE;
+
+	uint8_t hash[MM3_HASH_BYTE_SIZE];
+	compute_method_hash (method, hash);
+
+	if (table_lookup (loaded_table, hash)) {
+		if (mono_opt_interp_pgo_logging) {
+			char * name = mono_method_full_name (method, TRUE);
+			g_print ("Tiering %s because it was in the interp_pgo table\n", name);
+			g_free (name);
+		}
+
+		return TRUE;
+	}
+
+	return FALSE;
+}
+
+void
+mono_interp_pgo_method_was_tiered (MonoMethod *method) {
+	if (!mono_opt_interp_pgo_recording)
+		return;
+
+	// Wrappers are already tiered automatically, so we don't put them in the table
+	if (method->wrapper_type != MONO_WRAPPER_NONE)
+		return;
+
+	uint8_t hash[MM3_HASH_BYTE_SIZE] = {0};
+	compute_method_hash (method, hash);
+
+	mono_os_mutex_lock (&building_table_lock);
+	table_add_locked (&building_table, hash);
+	mono_os_mutex_unlock (&building_table_lock);
+
+	if (mono_opt_interp_pgo_logging) {
+		char * name = mono_method_full_name (method, TRUE);
+		g_print ("added %s to table\n", name);
+		g_free (name);
+	}
+}
+
+#if HOST_BROWSER
+
+#include <emscripten.h>
+
+// We disable this diagnostic because EMSCRIPTEN_KEEPALIVE makes it a false alarm, the keepalive
+//  functions are being used externally. Having a bunch of prototypes is pointless since these
+//  functions are not consumed by C anywhere else
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
+EMSCRIPTEN_KEEPALIVE int
+mono_interp_pgo_load_table (uint8_t * data, int data_size) {
+	// Early-out if a table is already loaded.
+	if (loaded_table)
+		return 1;
+	// If the data we were passed is too small then early out
+	if (data_size < sizeof(uint32_t))
+		return 3;
+
+	interp_pgo_table *result = g_malloc0 (sizeof (interp_pgo_table));
+	// The table storage format is [uint32 size] [data...]
+	uint32_t size = *(uint32_t *)data;
+
+	if (mono_opt_interp_pgo_logging)
+		g_print ("Loading %d bytes of interp_pgo data (table size == %zu)\n", data_size, size);
+
+	result->data = g_malloc0 (data_size);
+	g_assert ((int64_t)size < (int64_t)data_size);
+	result->size = size;
+	result->capacity = data_size;
+	memcpy (result->data, data + sizeof (uint32_t), result->size);
+
+	// Atomically swap the new table in
+	interp_pgo_table *old_table = mono_atomic_cas_ptr ((volatile gpointer*)&loaded_table, result, NULL);
+
+	if (old_table) {
+		// We lost a race with another thread that also loaded a table, so destroy ours and leave
+		//  theirs in place.
+		if (result->data)
+			g_free (result->data);
+		g_free (result);
+
+		return 2;
+	}
+
+	return 0;
+}
+
+EMSCRIPTEN_KEEPALIVE int
+mono_interp_pgo_save_table (uint8_t * data, int data_size) {
+	if (!building_table)
+		return 0;
+
+	mono_os_mutex_lock (&building_table_lock);
+	interp_pgo_table *table = building_table;
+	int expected_size = table->size + sizeof (uint32_t);
+	if (data_size != expected_size) {
+		mono_os_mutex_unlock (&building_table_lock);
+		return expected_size;
+	}
+	table_sort_locked (table);
+	// The table storage format is [uint32 size] [data...]
+	memcpy (data, &table->size, sizeof (uint32_t));
+	memcpy (data + sizeof (uint32_t), table->data, table->size);
+	mono_os_mutex_unlock (&building_table_lock);
+	return 0;
+}
+
+#endif // HOST_BROWSER

--- a/src/mono/mono/mini/interp/interp-pgo.h
+++ b/src/mono/mono/mini/interp/interp-pgo.h
@@ -1,0 +1,16 @@
+#ifndef __MONO_MINI_INTERP_PGO_H__
+#define __MONO_MINI_INTERP_PGO_H__
+
+gboolean
+mono_interp_pgo_should_tier_method (MonoMethod *method);
+
+void
+mono_interp_pgo_method_was_tiered (MonoMethod *method);
+
+void
+mono_interp_pgo_generate_start (void);
+
+void
+mono_interp_pgo_generate_end (void);
+
+#endif // __MONO_MINI_INTERP_PGO_H__

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -87,6 +87,8 @@
 #endif
 #include <mono/metadata/icall-decl.h>
 
+#include "interp-pgo.h"
+
 #ifdef HOST_BROWSER
 #include "jiterpreter.h"
 #include <emscripten.h>
@@ -513,6 +515,9 @@ mono_interp_get_imethod (MonoMethod *method)
 		imethod->param_types = (MonoType**)m_method_alloc0 (method, sizeof (MonoType*) * sig->param_count);
 	for (i = 0; i < sig->param_count; ++i)
 		imethod->param_types [i] = mini_get_underlying_type (sig->params [i]);
+
+	if (!imethod->optimized && mono_interp_pgo_should_tier_method (method))
+		imethod->optimized = TRUE;
 
 	jit_mm_lock (jit_mm);
 	InterpMethod *old_imethod;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4832,8 +4832,6 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 	gboolean generate_enc_seq_points_without_debug_info = FALSE;
 	InterpBasicBlock *exit_bb = NULL;
 
-	mono_interp_pgo_generate_start ();
-
 	original_bb = bb = mono_basic_block_split (method, error, header);
 	goto_if_nok (error, exit);
 	g_assert (bb);
@@ -8260,8 +8258,6 @@ exit_ret:
 	mono_basic_block_free (original_bb);
 	td->dont_inline = g_list_remove (td->dont_inline, method);
 
-	mono_interp_pgo_generate_end ();
-
 	return ret;
 exit:
 	ret = FALSE;
@@ -11135,6 +11131,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, MonoG
 	}
 
 retry:
+	mono_interp_pgo_generate_start ();
 	memset (&transform_data, 0, sizeof(transform_data));
 	td = &transform_data;
 
@@ -11339,6 +11336,7 @@ exit:
 		g_array_free (td->line_numbers, TRUE);
 	g_slist_free (td->imethod_items);
 	mono_mempool_destroy (td->mempool);
+	mono_interp_pgo_generate_end ();
 	if (retry_compilation)
 		goto retry;
 }

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -62,6 +62,14 @@ DEFINE_BOOL(wasm_gc_safepoints, "wasm-gc-safepoints", FALSE, "Use GC safepoints 
 DEFINE_BOOL(aot_lazy_assembly_load, "aot-lazy-assembly-load", FALSE, "Load assemblies referenced by AOT images lazily")
 
 #if HOST_BROWSER
+DEFINE_BOOL(interp_pgo_recording, "interp-pgo-recording", TRUE, "Record interpreter tiering information for automatic PGO")
+#else
+DEFINE_BOOL(interp_pgo_recording, "interp-pgo-recording", FALSE, "Record interpreter tiering information for automatic PGO")
+#endif
+DEFINE_BOOL(interp_pgo_logging, "interp-pgo-logging", FALSE, "Log messages when interpreter PGO optimizes a method or updates its table")
+DEFINE_BOOL(interp_codegen_timing, "interp-codegen-timing", FALSE, "Measure time spent generating interpreter code and log it periodically")
+
+#if HOST_BROWSER
 
 // jiterpreter AOT optimizations aren't thread safe yet
 #ifdef DISABLE_THREADS

--- a/src/mono/sample/wasm/browser-bench/main.js
+++ b/src/mono/sample/wasm/browser-bench/main.js
@@ -13,7 +13,7 @@ let legacyExportTargetInt;
 let jsExportTargetInt;
 let legacyExportTargetString;
 let jsExportTargetString;
-let _jiterpreter_dump_stats;
+let _jiterpreter_dump_stats, _interp_pgo_save_data;
 
 function runLegacyExportInt(count) {
     for (let i = 0; i < count; i++) {
@@ -63,10 +63,9 @@ function importTargetThrows(value) {
 class MainApp {
     async init({ getAssemblyExports, setModuleImports, BINDING, INTERNAL }) {
         const exports = await getAssemblyExports("Wasm.Browser.Bench.Sample.dll");
-        INTERNAL.jiterpreter_apply_options({
-            enableStats: true
-        });
+        // Capture these two internal APIs for use at the end of the benchmark run
         _jiterpreter_dump_stats = INTERNAL.jiterpreter_dump_stats.bind(INTERNAL);
+        _interp_pgo_save_data = INTERNAL.interp_pgo_save_data.bind(INTERNAL);
         runBenchmark = exports.Sample.Test.RunBenchmark;
         setTasks = exports.Sample.Test.SetTasks;
         setExclusions = exports.Sample.Test.SetExclusions;
@@ -117,7 +116,6 @@ class MainApp {
             console.log(resultString);
         }
 
-        _jiterpreter_dump_stats();
         document.getElementById("out").innerHTML += "Finished";
         const r1 = await fetch("/results.json", {
             method: 'POST',
@@ -129,6 +127,21 @@ class MainApp {
             body: document.getElementById("out").innerHTML
         });
         console.log("post request complete, response: ", r2);
+
+        // If the jiterpreter's statistics are enabled, make sure we dump them at the
+        //  end of the benchmark run to have a definitive version of them that captures
+        //  everything, since the automatic ones are triggered at a basically random
+        //  interval
+        if (_jiterpreter_dump_stats)
+            _jiterpreter_dump_stats();
+
+        // We explicitly save the interpreter PGO table after a run is complete
+        //  in order to capture all the methods that were tiered while running benchmarks
+        // The normal automatic save-on-startup-timeout behavior is insufficient for
+        //  scenarios like this since we can't predict how long the benchmarks will
+        //  take, and "startup" is spread over the whole run instead of the beginning
+        if (_interp_pgo_save_data)
+            await _interp_pgo_save_data(true);
     }
 
     yieldBench() {
@@ -179,11 +192,27 @@ class MainApp {
                 ? 'unique/' + guid + '/' + page
                 : page;
 
+            let resolved = false;
             promise = new Promise(resolve => { promiseResolve = resolve; })
             window.resolveAppStartEvent = function (event) {
-                if (!eventName || event == eventName)
+                if (!eventName || event == eventName) {
+                    resolved = true;
                     promiseResolve();
+                }
             }
+
+            // The appstart event may never fire if something goes wrong, in that case
+            //  we want to time out within a reasonable period of time so that the run
+            //  of browser-bench will eventually complete instead of just freezing.
+            setTimeout(function () {
+                if (resolved)
+                    return;
+                console.error(`waitFor ${eventName} timed out`);
+                promiseResolve();
+            // Make sure this timeout is big enough that it won't cause measurements
+            //  to be truncated! i.e. "Blazor Reach managed cold" is nearly 10k in some
+            //  configurations right now
+            }, 20000);
 
             document.body.appendChild(this._frame);
             await promise;
@@ -208,7 +237,15 @@ try {
     globalThis.mainApp.SetFramePage = globalThis.mainApp.setFramePage.bind(globalThis.mainApp);
 
     const runtime = await dotnet
+        // We enable jiterpreter stats so that in local runs you can open the devtools
+        //  console to see statistics on how much code it generated and whether any new opcodes
+        //  are causing traces to fail to compile
         .withRuntimeOptions(["--jiterpreter-stats-enabled"])
+        // We enable interpreter PGO so that you can exercise it in local tests, i.e.
+        //  run browser-bench one, then refresh the tab to measure the performance improvement
+        //  on the second run of browser-bench. The overall speed of the benchmarks won't
+        //  improve much, but the time spent generating code during the run will go down
+        .withInterpreterPgo(true, 30)
         .withElementOnExit()
         .withExitCodeLogging()
         .create();

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -34,22 +34,18 @@ internal class BrowserRunner : IAsyncDisposable
 
     public BrowserRunner(ITestOutputHelper testOutput) => _testOutput = testOutput;
 
-    // FIXME: options
-    public async Task<IPage> RunAsync(
+    public async Task<string> StartServerAndGetUrlAsync(
         ToolCommand cmd,
-        string args,
-        bool headless = true,
-        Action<IConsoleMessage>? onConsoleMessage = null,
-        Action<string>? onError = null,
-        Func<string, string>? modifyBrowserUrl = null)
-    {
+        string args
+    ) {
         TaskCompletionSource<string> urlAvailable = new();
         Action<string?> outputHandler = msg =>
         {
             if (string.IsNullOrEmpty(msg))
                 return;
 
-            OutputLines.Add(msg);
+            lock (OutputLines)
+                OutputLines.Add(msg);
 
             Match m = s_appHostUrlRegex.Match(msg);
             if (!m.Success)
@@ -66,7 +62,7 @@ internal class BrowserRunner : IAsyncDisposable
             m = s_exitRegex.Match(msg);
             if (m.Success)
             {
-                _exited.SetResult(int.Parse(m.Groups["exitCode"].Value));
+                _exited.TrySetResult(int.Parse(m.Groups["exitCode"].Value));
                 return;
             }
         };
@@ -85,21 +81,56 @@ internal class BrowserRunner : IAsyncDisposable
         if (!urlAvailable.Task.IsCompleted)
             throw new Exception("Timed out waiting for the web server url");
 
-        var url = new Uri(urlAvailable.Task.Result);
+        RunTask = runTask;
+        return urlAvailable.Task.Result;
+    }
+
+    public async Task<IBrowser> SpawnBrowserAsync(
+        string browserUrl,
+        bool headless = true
+    ) {
+        var url = new Uri(browserUrl);
         Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
         string[] chromeArgs = new[] { $"--explicitly-allowed-ports={url.Port}" };
         _testOutput.WriteLine($"Launching chrome ('{s_chromePath.Value}') via playwright with args = {string.Join(',', chromeArgs)}");
-        Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions{
+        return Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions{
             ExecutablePath = s_chromePath.Value,
             Headless = headless,
             Args = chromeArgs
         });
+    }
 
-        string browserUrl = urlAvailable.Task.Result;
+    // FIXME: options
+    public async Task<IPage> RunAsync(
+        ToolCommand cmd,
+        string args,
+        bool headless = true,
+        Action<IConsoleMessage>? onConsoleMessage = null,
+        Action<string>? onError = null,
+        Func<string, string>? modifyBrowserUrl = null)
+    {
+        var urlString = await StartServerAndGetUrl(cmd, args);
+        var browser = await SpawnBrowserAsync(urlString, headless);
+        var context = await browser.NewContextAsync();
+        return await RunAsync(context, urlString, headless, onConsoleMessage, onError, modifyBrowserUrl);
+    }
+
+    public async Task<IPage> RunAsync(
+        IBrowserContext context,
+        string browserUrl,
+        bool headless = true,
+        Action<IConsoleMessage>? onConsoleMessage = null,
+        Action<string>? onError = null,
+        Func<string, string>? modifyBrowserUrl = null,
+        bool resetExitedState = false
+    ) {
+        if (resetExitedState)
+            _exited = new ();
+
         if (modifyBrowserUrl != null)
             browserUrl = modifyBrowserUrl(browserUrl);
 
-        IPage page = await Browser.NewPageAsync();
+        IPage page = await context.NewPageAsync();
         if (onConsoleMessage is not null)
             page.Console += (_, msg) => onConsoleMessage(msg);
 
@@ -112,7 +143,6 @@ internal class BrowserRunner : IAsyncDisposable
         }
 
         await page.GotoAsync(browserUrl);
-        RunTask = runTask;
         return page;
     }
 

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -109,7 +109,7 @@ internal class BrowserRunner : IAsyncDisposable
         Action<string>? onError = null,
         Func<string, string>? modifyBrowserUrl = null)
     {
-        var urlString = await StartServerAndGetUrl(cmd, args);
+        var urlString = await StartServerAndGetUrlAsync(cmd, args);
         var browser = await SpawnBrowserAsync(urlString, headless);
         var context = await browser.NewContextAsync();
         return await RunAsync(context, urlString, headless, onConsoleMessage, onError, modifyBrowserUrl);

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/InterpPgoTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/InterpPgoTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System;
 using System.Diagnostics;
+using Microsoft.Playwright;
 
 #nullable enable
 
@@ -72,7 +73,7 @@ public class InterpPgoTests : WasmTemplateTestBase
         using var runCommand = new RunCommand(s_buildEnv, _testOutput)
                                     .WithWorkingDirectory(_projectDir!);
         await using var runner = new BrowserRunner(_testOutput);
-        var url = await runner.StartServerAndGetUrl(runCommand, $"run --no-silent -c {config} --no-build --project {projectFile} --forward-console");
+        var url = await runner.StartServerAndGetUrlAsync(runCommand, $"run --no-silent -c {config} --no-build --project {projectFile} --forward-console");
         IBrowser browser = await runner.SpawnBrowserAsync(url);
         IBrowserContext context = await browser.NewContextAsync();
 

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/InterpPgoTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/InterpPgoTests.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Wasm.Build.Tests;
+using Xunit;
+using Xunit.Abstractions;
+using System.Threading;
+using System.Threading.Tasks;
+using System;
+using System.Diagnostics;
+
+#nullable enable
+
+namespace Wasm.Build.Templates.Tests;
+
+public class InterpPgoTests : WasmTemplateTestBase
+{
+    public InterpPgoTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext)
+        : base(output, buildContext)
+    {
+    }
+
+    [Theory]
+    // Interpreter PGO is not meaningful to enable in debug builds - tiering is inactive there so all methods
+    //  would get added to the PGO table instead of just hot ones.
+    [InlineData("Release")]
+    public async Task FirstRunGeneratesTableAndSecondRunLoadsIt(string config)
+    {
+        // We need to invoke Greeting enough times to cause BCL code to tier so we can exercise interpreter PGO
+        // Invoking it too many times makes the test meaningfully slower.
+        const int iterationCount = 70;
+
+        string id = $"browser_{config}_{GetRandomId()}";
+        _testOutput.WriteLine("/// Creating project");
+        string projectFile = CreateWasmTemplateProject(id, "wasmbrowser");
+
+        _testOutput.WriteLine("/// Updating JS");
+        UpdateBrowserMainJs((js) => {
+            // We need to capture INTERNAL so we can explicitly save the PGO table
+            js = js.Replace(
+                "const { setModuleImports, getAssemblyExports, getConfig } = await dotnet",
+                "const { setModuleImports, getAssemblyExports, getConfig, INTERNAL } = await dotnet"
+            );
+            // Enable interpreter PGO + interpreter PGO logging + console output capturing
+            js = js.Replace(
+                ".create()",
+                ".withConsoleForwarding().withElementOnExit().withExitCodeLogging().withExitOnUnhandledError().withRuntimeOptions(['--interp-pgo-logging']).withInterpreterPgo(true).create()"
+            );
+            // Call Greeting in a loop to exercise enough code to cause something to tier,
+            //  then call INTERNAL.interp_pgo_save_data() to save the interp PGO table
+            js = js.Replace(
+                "const text = exports.MyClass.Greeting();",
+                "let text = '';\n" +
+                $"for (let i = 0; i < {iterationCount}; i++) {{ text = exports.MyClass.Greeting(); }};\n" +
+                "await INTERNAL.interp_pgo_save_data();"
+            );
+            return js;
+        }, DefaultTargetFramework);
+
+        _testOutput.WriteLine("/// Building");
+
+        new DotNetCommand(s_buildEnv, _testOutput)
+                .WithWorkingDirectory(_projectDir!)
+                .Execute($"build -c {config} -bl:{Path.Combine(s_buildEnv.LogRootPath, $"{id}.binlog")}")
+                .EnsureSuccessful();
+
+        _testOutput.WriteLine("/// Starting server");
+
+        // Create a single browser instance and single context to host all our pages.
+        // If we don't do this, each page will have its own unique cache and the table won't be loaded.
+        using var runCommand = new RunCommand(s_buildEnv, _testOutput)
+                                    .WithWorkingDirectory(_projectDir!);
+        await using var runner = new BrowserRunner(_testOutput);
+        var url = await runner.StartServerAndGetUrl(runCommand, $"run --no-silent -c {config} --no-build --project {projectFile} --forward-console");
+        IBrowser browser = await runner.SpawnBrowserAsync(url);
+        IBrowserContext context = await browser.NewContextAsync();
+
+        string output;
+        {
+            _testOutput.WriteLine("/// First run");
+            var page = await runner.RunAsync(context, url);
+            await runner.WaitForExitMessageAsync(TimeSpan.FromSeconds(30));
+            lock (runner.OutputLines)
+                output = string.Join(Environment.NewLine, runner.OutputLines);
+
+            Assert.Contains("Hello, Browser!", output);
+            // Verify that no PGO table was located in cache
+            Assert.Contains("Failed to load interp_pgo table", output);
+            // Verify that the table was saved after the app ran
+            Assert.Contains("Saved interp_pgo table", output);
+            // Verify that a specific method was tiered by the Greeting calls and recorded by PGO
+            Assert.Contains("added System.Runtime.CompilerServices.Unsafe:Add<byte> (byte&,int) to table", output);
+        }
+
+        {
+            _testOutput.WriteLine("/// Second run");
+            // Clear the shared output lines buffer so it's empty for the next run.
+            lock (runner.OutputLines)
+                runner.OutputLines.Clear();
+            // resetExitedState is necessary for WaitForExitMessageAsync to work correctly
+            var page = await runner.RunAsync(context, url, resetExitedState: true);
+            await runner.WaitForExitMessageAsync(TimeSpan.FromSeconds(30));
+            lock (runner.OutputLines)
+                output = string.Join(Environment.NewLine, runner.OutputLines);
+
+            Assert.Contains("Hello, Browser!", output);
+            // Verify that table data was loaded from cache
+            Assert.Contains(" bytes of interp_pgo data (table size == ", output);
+            // Verify that the table was saved after the app ran
+            Assert.Contains("Saved interp_pgo table", output);
+            // Verify that method(s) were found in the table and eagerly tiered
+            Assert.Contains("because it was in the interp_pgo table", output);
+            // Verify that a specific method was tiered by the Greeting calls and recorded by PGO
+            Assert.Contains("added System.Runtime.CompilerServices.Unsafe:Add<byte> (byte&,int) to table", output);
+        }
+
+        _testOutput.WriteLine("/// Done");
+
+        (context as IDisposable)?.Dispose();
+        (browser as IDisposable)?.Dispose();
+    }
+}

--- a/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTestBase.cs
@@ -137,4 +137,16 @@ public abstract class WasmTemplateTestBase : BuildTestBase
         else
             projectProvider.AssertBundle(buildArgs, buildProjectOptions);
     }
+
+    protected const string DefaultRuntimeAssetsRelativePath = "./_framework/";
+
+    protected void UpdateBrowserMainJs(Func<string, string> transform, string targetFramework, string runtimeAssetsRelativePath = DefaultRuntimeAssetsRelativePath)
+    {
+        string mainJsPath = Path.Combine(_projectDir!, "wwwroot", "main.js");
+        string mainJsContent = File.ReadAllText(mainJsPath);
+
+        mainJsContent = transform(mainJsContent);
+
+        File.WriteAllText(mainJsPath, mainJsContent);
+    }
 }

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -148,9 +148,11 @@ const fn_signatures: SigLine[] = [
     [true, "mono_jiterp_tlqueue_clear", "void", ["number"]],
     [true, "mono_jiterp_begin_catch", "void", ["number"]],
     [true, "mono_jiterp_end_catch", "void", []],
+    [true, "mono_interp_pgo_load_table", "number", ["number", "number"]],
+    [true, "mono_interp_pgo_save_table", "number", ["number", "number"]],
 
     ...diagnostics_cwraps,
-    ...legacy_interop_cwraps
+    ...legacy_interop_cwraps,
 ];
 
 export interface t_LegacyCwraps {
@@ -293,6 +295,8 @@ export interface t_Cwraps {
     mono_jiterp_tlqueue_clear(queue: number): void;
     mono_jiterp_begin_catch(ptr: number): void;
     mono_jiterp_end_catch(): void;
+    mono_interp_pgo_load_table(buffer: VoidPtr, bufferSize: number): number;
+    mono_interp_pgo_save_table(buffer: VoidPtr, bufferSize: number): number;
 }
 
 const wrapped_c_functions: t_Cwraps = <any>{};

--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -160,6 +160,16 @@ type MonoConfig = {
      */
     startupMemoryCache?: boolean;
     /**
+     * If true, a list of the methods optimized by the interpreter will be saved and used for faster startup
+     *  on future runs of the application
+     */
+    interpreterPgo?: boolean;
+    /**
+     * Configures how long to wait before saving the interpreter PGO list. If your application takes
+     *  a while to start you should adjust this value.
+     */
+    interpreterPgoSaveDelay?: number;
+    /**
      * application environment
      */
     applicationEnvironment?: string;

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -11,6 +11,7 @@ import { mono_wasm_stringify_as_error_with_stack } from "./logging";
 import { ws_wasm_create, ws_wasm_open, ws_wasm_send, ws_wasm_receive, ws_wasm_close, ws_wasm_abort } from "./web-socket";
 import { mono_wasm_get_loaded_files } from "./assets";
 import { jiterpreter_dump_stats } from "./jiterpreter";
+import { interp_pgo_load_data, interp_pgo_save_data } from "./interp-pgo";
 import { getOptions, applyOptions } from "./jiterpreter-support";
 import { mono_wasm_gc_lock, mono_wasm_gc_unlock } from "./gc-lock";
 import { loadLazyAssembly } from "./lazyLoading";
@@ -86,6 +87,10 @@ export function export_internal(): any {
         jiterpreter_dump_stats,
         jiterpreter_apply_options: applyOptions,
         jiterpreter_get_options: getOptions,
+
+        // interpreter pgo
+        interp_pgo_load_data,
+        interp_pgo_save_data,
 
         // Blazor GC Lock support
         mono_wasm_gc_lock,

--- a/src/mono/wasm/runtime/interp-pgo.ts
+++ b/src/mono/wasm/runtime/interp-pgo.ts
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+import { Module } from "./globals";
+import { getCacheKey, cleanupCache, getCacheEntry, storeCacheEntry } from "./snapshot";
+import { mono_log_info, mono_log_error } from "./logging";
+import { localHeapViewU8 } from "./memory";
+import cwraps from "./cwraps";
+
+export const tablePrefix = "https://dotnet.generated.invalid/interp_pgo";
+
+export async function getInterpPgoTable(): Promise<ArrayBuffer | undefined> {
+    const cacheKey = await getCacheKey(tablePrefix);
+    if (!cacheKey)
+        return undefined;
+    return await getCacheEntry(cacheKey);
+}
+
+async function storeInterpPgoTable(memory: ArrayBuffer) {
+    const cacheKey = await getCacheKey(tablePrefix);
+    if (!cacheKey)
+        return;
+
+    await storeCacheEntry(cacheKey, memory, "application/octet-stream");
+
+    cleanupCache(tablePrefix, cacheKey); // no await
+}
+
+export async function interp_pgo_save_data () {
+    const cacheKey = await getCacheKey(tablePrefix);
+    if (!cacheKey) {
+        mono_log_error("Failed to save interp_pgo table (No cache key)");
+        return;
+    }
+
+    try {
+        const expectedSize = cwraps.mono_interp_pgo_save_table(<any>0, 0);
+        // If save_table returned 0 despite not being passed a buffer, that means there is no
+        //  table data to save, either because interp_pgo is disabled or no methods were tiered yet
+        if (expectedSize <= 0) {
+            mono_log_error("Failed to save interp_pgo table (No data to save)");
+            return;
+        }
+
+        const pData = <any>Module._malloc(expectedSize);
+        const saved = cwraps.mono_interp_pgo_save_table(pData, expectedSize) === 0;
+        if (!saved) {
+            mono_log_error("Failed to save interp_pgo table (Unknown error)");
+            return;
+        }
+
+        const u8 = localHeapViewU8();
+        const data = u8.slice(pData, pData + expectedSize);
+
+        await storeInterpPgoTable(data);
+
+        mono_log_info("Saved interp_pgo table to cache");
+        Module._free(pData);
+    } catch (exc) {
+        mono_log_error(`Failed to save interp_pgo table: ${exc}`);
+    }
+}
+
+export async function interp_pgo_load_data () {
+    const data = await getInterpPgoTable();
+    if (!data) {
+        mono_log_error("Failed to load interp_pgo table (No table found in cache)");
+        return;
+    }
+
+    const pData = <any>Module._malloc(data.byteLength);
+    const u8 = localHeapViewU8();
+    u8.set(new Uint8Array(data), pData);
+
+    if (cwraps.mono_interp_pgo_load_table(pData, data.byteLength))
+        mono_log_error("Failed to load interp_pgo table (Unknown error)");
+
+    Module._free(pData);
+}

--- a/src/mono/wasm/runtime/loader/run.ts
+++ b/src/mono/wasm/runtime/loader/run.ts
@@ -173,6 +173,19 @@ export class HostBuilder implements DotnetHostBuilder {
         }
     }
 
+    withInterpreterPgo(value: boolean, autoSaveDelay?: number): DotnetHostBuilder {
+        try {
+            deep_merge_config(monoConfig, {
+                interpreterPgo: value,
+                interpreterPgoSaveDelay: autoSaveDelay
+            });
+            return this;
+        } catch (err) {
+            mono_exit(1, err);
+            throw err;
+        }
+    }
+
     withConfig(config: MonoConfig): DotnetHostBuilder {
         try {
             deep_merge_config(monoConfig, config);

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -22,6 +22,7 @@ import { mono_wasm_init_diagnostics } from "./diagnostics";
 import { replace_linker_placeholders } from "./exports-binding";
 import { endMeasure, MeasuredBlock, startMeasure } from "./profiler";
 import { checkMemorySnapshotSize, getMemorySnapshot, storeMemorySnapshot } from "./snapshot";
+import { interp_pgo_load_data, interp_pgo_save_data } from "./interp-pgo";
 import { mono_log_debug, mono_log_error, mono_log_warn, mono_set_thread_id } from "./logging";
 
 // threads
@@ -256,6 +257,10 @@ async function onRuntimeInitializedAsync(userOnRuntimeInitialized: () => void) {
 
         // load runtime and apply environment settings (if necessary)
         await mono_wasm_before_memory_snapshot();
+
+        if (runtimeHelpers.config.interpreterPgo) {
+            await interp_pgo_load_data();
+        }
 
         if (runtimeHelpers.config.exitAfterSnapshot) {
             const reason = runtimeHelpers.ExitStatus
@@ -557,7 +562,21 @@ async function mono_wasm_before_memory_snapshot() {
         runtimeHelpers.storeMemorySnapshotPending = false;
     }
 
+    if (runtimeHelpers.config.interpreterPgo)
+        setTimeout(maybeSaveInterpPgoTable, (runtimeHelpers.config.interpreterPgoSaveDelay || 15) * 1000);
+
     endMeasure(mark, MeasuredBlock.memorySnapshot);
+}
+
+async function maybeSaveInterpPgoTable () {
+    // If the application exited abnormally, don't save the table. It probably doesn't contain useful data,
+    //  and saving would overwrite any existing table from a previous successful run.
+    // We treat exiting with a code of 0 as equivalent to if the app is still running - it's perfectly fine
+    //  to save the table once main has returned, since the table can still make future runs faster.
+    if ((loaderHelpers.exitCode !== undefined) && (loaderHelpers.exitCode !== 0))
+        return;
+
+    await interp_pgo_save_data();
 }
 
 export function mono_wasm_load_runtime(unused?: string, debugLevel?: number): void {

--- a/src/mono/wasm/runtime/types/index.ts
+++ b/src/mono/wasm/runtime/types/index.ts
@@ -94,6 +94,16 @@ export type MonoConfig = {
      */
     startupMemoryCache?: boolean,
     /**
+     * If true, a list of the methods optimized by the interpreter will be saved and used for faster startup
+     *  on future runs of the application
+     */
+    interpreterPgo?: boolean,
+    /**
+     * Configures how long to wait before saving the interpreter PGO list. If your application takes
+     *  a while to start you should adjust this value.
+     */
+    interpreterPgoSaveDelay?: number,
+    /**
      * application environment
      */
     applicationEnvironment?: string,
@@ -167,7 +177,7 @@ export type ResourceList = { [name: string]: string | null | "" };
  * @param defaultUri The URI from which the framework would fetch the resource by default. The URI may be relative or absolute.
  * @param integrity The integrity string representing the expected content in the response.
  * @param behavior The detailed behavior/type of the resource to be loaded.
- * @returns A URI string or a Response promise to override the loading process, or null/undefined to allow the default loading behavior. 
+ * @returns A URI string or a Response promise to override the loading process, or null/undefined to allow the default loading behavior.
  * When returned string is not qualified with `./` or absolute URL, it will be resolved against the application base URI.
  */
 export type LoadBootResourceCallback = (type: WebAssemblyBootResourceType, name: string, defaultUri: string, integrity: string, behavior: AssetBehaviors) => string | Promise<Response> | null | undefined;
@@ -195,7 +205,7 @@ export interface AssetEntry {
     /**
      * the integrity hash of the asset (if any)
      */
-    hash?: string | null | ""; // 
+    hash?: string | null | "";
     /**
      * If specified, overrides the path of the asset in the virtual filesystem and similar data structures once downloaded.
      */
@@ -207,13 +217,13 @@ export interface AssetEntry {
     /**
      * If true, an attempt will be made to load the asset from each location in MonoConfig.remoteSources.
      */
-    loadRemote?: boolean, // 
+    loadRemote?: boolean,
     /**
      * If true, the runtime startup would not fail if the asset download was not successful.
      */
     isOptional?: boolean
     /**
-     * If provided, runtime doesn't have to fetch the data. 
+     * If provided, runtime doesn't have to fetch the data.
      * Runtime would set the buffer to null after instantiation to free the memory.
      */
     buffer?: ArrayBuffer | Promise<ArrayBuffer>,

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -113,6 +113,7 @@ function initRunArgs(runArgs) {
     // default'ing to true for tests, unless debugging
     runArgs.forwardConsole = runArgs.forwardConsole === undefined ? !runArgs.debugging : runArgs.forwardConsole;
     runArgs.memorySnapshot = runArgs.memorySnapshot === undefined ? true : runArgs.memorySnapshot;
+    runArgs.interpreterPgo = runArgs.interpreterPgo === undefined ? true : runArgs.interpreterPgo;
 
     return runArgs;
 }
@@ -146,6 +147,8 @@ function processArguments(incomingArguments, runArgs) {
             runArgs.forwardConsole = false;
         } else if (currentArg == "--no-memory-snapshot") {
             runArgs.memorySnapshot = false;
+        } else if (currentArg == "--no-interpreter-pgo") {
+            runArgs.interpreterPgo = false;
         } else if (currentArg.startsWith("--fetch-random-delay=")) {
             const arg = currentArg.substring("--fetch-random-delay=".length);
             if (ENVIRONMENT_IS_WEB) {
@@ -290,9 +293,10 @@ function configureRuntime(dotnet, runArgs) {
         }
     }
     if (ENVIRONMENT_IS_WEB) {
-        if (runArgs.memorySnapshot) {
+        if (runArgs.memorySnapshot)
             dotnet.withStartupMemoryCache(true);
-        }
+        if (runArgs.interpreterPgo)
+            dotnet.withInterpreterPgo(true);
         dotnet.withEnvironmentVariable("IsWebSocketSupported", "true");
     }
     if (runArgs.runtimeArgs.length > 0) {
@@ -321,7 +325,7 @@ async function dry_run(runArgs) {
             logExitCode: false,
             virtualWorkingDirectory: undefined,
             pthreadPoolSize: 0,
-            // this just means to not continue startup after the snapshot is taken. 
+            // this just means to not continue startup after the snapshot is taken.
             // If there was previously a matching snapshot, it will be used.
             exitAfterSnapshot: true
         }).create();
@@ -349,7 +353,7 @@ async function run() {
             }
         }
 
-        // this is subsequent run with the actual tests. It will use whatever was cached in the previous run. 
+        // this is subsequent run with the actual tests. It will use whatever was cached in the previous run.
         // This way, we are testing that the cached version works.
         mono_exit = exit;
 


### PR DESCRIPTION
This PR adds automatic PGO for interpreter tiering. The idea is that by maintaining a list of which interpreter methods were tiered during execution, we can skip directly to generating optimized code on future runs. This will get the application into a steady high-performance state faster on future runs, while also reducing the amount of time/memory we spend on code generation (since normally we generate unoptimized code, then generate optimized code).

The infrastructure for this feature is not platform gated, but the only platform that has an implementation for loading/saving the PGO data right now is the browser, and the runtime option controlling it is only default-on for the browser.

Web application code can either use `INTERNAL.interpgo_load_data` and `INTERNAL.interpgo_save_data` to manually control the loading/saving of the data, or can use the new `withInterpreterPgo(true, autoSaveDelay)` builder method to turn on automatic mode. Automatic mode will attempt to load the data during startup, and will automatically save it after a delay (at which point your application should be in something approximating a steady-state and critical code has already tiered.) The current web implementation repurposes the cache storage code from pavel's memory snapshot feature to store the pgo table in the cache next to the snapshot(s).

This PR also adds basic (controlled by a `#define` and off by default) timing instrumentation for generate_code, because in my testing the browser's profiler was producing wildly incorrect timing data for interpreter codegen. This should make it easy to evaluate how well the feature is working since you can just look at the output.

One interesting finding: The list of method hashes generated on a first run is bigger than the list generated on future runs - I believe this is because once a full set of methods is tiered, we no longer need the tiered version of some of them because the hottest methods have gotten inlined into their callers. So on a second run the list of hashes stabilizes into a smaller list.

In a couple local test runs of browser-bench with this active and without, the time spent in generate_code was 3600ms without interpgo and 3209ms with interpgo, so the improvement over the course of a full run of an application with lots of generated code should be worthwhile. For smaller applications it's below the noise floor, I haven't been able to measure it successfully at that scale.