### PR TITLE
Remove ActiveIssue on HostFactoryResolver tests

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
@@ -108,7 +108,6 @@ namespace Microsoft.Extensions.Hosting.Tests
         [Fact]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(CreateHostBuilderPatternTestSite.Program))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Host))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73420", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void CreateHostBuilderPattern_CanFindServiceProvider()
         {
             var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(CreateHostBuilderPatternTestSite.Program).Assembly);
@@ -138,7 +137,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPattern.Program))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73420", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void NoSpecialEntryPointPattern()
         {
             var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPattern.Program).Assembly, s_WaitTimeout);
@@ -237,7 +235,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPatternMainNoArgs.Program))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73420", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void NoSpecialEntryPointPatternMainNoArgs()
         {
             var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPatternMainNoArgs.Program).Assembly, s_WaitTimeout);
@@ -248,7 +245,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Program", "TopLevelStatements")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73420", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void TopLevelStatements()
         {
             var assembly = Assembly.Load("TopLevelStatements");
@@ -270,7 +266,6 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73420", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Program", "ApplicationNameSetFromArgument")]
         public void ApplicationNameSetFromArgument()
         {
@@ -284,7 +279,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPattern.Program))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73420", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void NoSpecialEntryPointPatternCanRunInParallel()
         {

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -433,6 +433,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\RefEmitLoadContext\System.Runtime.Loader.RefEmitLoadContext.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\System.Runtime.Loader.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection\tests\CoreCLR\System.Reflection.CoreCLR.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.HostFactoryResolver\tests\Microsoft.Extensions.HostFactoryResolver.Tests.csproj" />
 
     <!-- Most of these need tagging as "requires Ref.Emit". Not much interesting things left to run. Low priority. -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.Emit.Lightweight\tests\System.Reflection.Emit.Lightweight.Tests.csproj" />


### PR DESCRIPTION
This whole thing is not applicable to NativeAOT, don't even build it.

Resolves #73420.

Cc @dotnet/ilc-contrib 