### PR TITLE
Don't widen to Int128 in CastCache

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
@@ -250,7 +250,7 @@ namespace System.Runtime.CompilerServices
             TableMask(ref tableData) = size - 1;
 
             // Fibonacci hash reduces the value into desired range by shifting right by the number of leading zeroes in 'size-1'
-            byte shift = (byte)BitOperations.LeadingZeroCount((ulong)(size - 1));
+            byte shift = (byte)BitOperations.LeadingZeroCount((nuint)(size - 1));
             HashShift(ref tableData) = shift;
 
             return table;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
@@ -250,7 +250,7 @@ namespace System.Runtime.CompilerServices
             TableMask(ref tableData) = size - 1;
 
             // Fibonacci hash reduces the value into desired range by shifting right by the number of leading zeroes in 'size-1'
-            byte shift = (byte)BitOperations.LeadingZeroCount(size - 1);
+            byte shift = (byte)BitOperations.LeadingZeroCount((ulong)(size - 1));
             HashShift(ref tableData) = shift;
 
             return table;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericCache.cs
@@ -230,7 +230,7 @@ namespace System.Runtime.CompilerServices
             ref Entry tableData = ref TableData(table);
 
             // Fibonacci hash reduces the value into desired range by shifting right by the number of leading zeroes in 'size-1'
-            byte shift = (byte)BitOperations.LeadingZeroCount(size - 1);
+            byte shift = (byte)BitOperations.LeadingZeroCount((nuint)(size - 1));
             HashShift(table) = shift;
 
             return table;


### PR DESCRIPTION
Leftover change from hackathon. Existing code is widening to Int128 and then counting zeros. It still worked because we only use the number of zeros for bit shifting and bit shifts do wrap around if they're > 64. But this was bringing Int128 into `Runtime.Base` in my hackathon project.

Cc @dotnet/ilc-contrib 