### PR TITLE
[browser] streaming compile wasm bit earlier

### DIFF
--- a/src/mono/wasm/runtime/loader/assets.ts
+++ b/src/mono/wasm/runtime/loader/assets.ts
@@ -5,9 +5,9 @@ import MonoWasmThreads from "consts:monoWasmThreads";
 
 import type { AssetEntryInternal, PromiseAndController } from "../types/internal";
 import type { AssetBehaviors, AssetEntry, LoadingResource, ResourceList, SingleAssetBehaviors as SingleAssetBehaviors, WebAssemblyBootResourceType } from "../types";
-import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, loaderHelpers, mono_assert, runtimeHelpers } from "./globals";
+import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, ENVIRONMENT_IS_WEB, loaderHelpers, mono_assert, runtimeHelpers } from "./globals";
 import { createPromiseController } from "./promise-controller";
-import { mono_log_debug } from "./logging";
+import { mono_log_debug, mono_log_warn } from "./logging";
 import { mono_exit } from "./exit";
 import { addCachedReponse, findCachedResponse } from "./assetsCache";
 import { getIcuResourceName } from "./icu";
@@ -713,4 +713,38 @@ function fileName(name: string) {
         lastIndexOfSlash++;
     }
     return name.substring(lastIndexOfSlash);
+}
+
+export async function streamingCompileWasm() {
+    try {
+        const wasmModuleAsset = resolve_single_asset_path("dotnetwasm");
+        await start_asset_download(wasmModuleAsset);
+        mono_assert(wasmModuleAsset && wasmModuleAsset.pendingDownloadInternal && wasmModuleAsset.pendingDownloadInternal.response, "Can't load dotnet.native.wasm");
+        const response = await wasmModuleAsset.pendingDownloadInternal.response;
+        const contentType = response.headers && response.headers.get ? response.headers.get("Content-Type") : undefined;
+        let compiledModule: WebAssembly.Module;
+        if (typeof WebAssembly.compileStreaming === "function" && contentType === "application/wasm") {
+            compiledModule = await WebAssembly.compileStreaming(response);
+        } else {
+            if (ENVIRONMENT_IS_WEB && contentType !== "application/wasm") {
+                mono_log_warn("WebAssembly resource does not have the expected content type \"application/wasm\", so falling back to slower ArrayBuffer instantiation.");
+            }
+            const arrayBuffer = await response.arrayBuffer();
+            mono_log_debug("instantiate_wasm_module buffered");
+            if (ENVIRONMENT_IS_SHELL) {
+                // workaround for old versions of V8 with https://bugs.chromium.org/p/v8/issues/detail?id=13823
+                compiledModule = await Promise.resolve(new WebAssembly.Module(arrayBuffer));
+            } else {
+                compiledModule = await WebAssembly.compile(arrayBuffer!);
+            }
+        }
+        wasmModuleAsset.pendingDownloadInternal = null as any; // GC
+        wasmModuleAsset.pendingDownload = null as any; // GC
+        wasmModuleAsset.buffer = null as any; // GC
+        wasmModuleAsset.moduleExports = null as any; // GC
+        loaderHelpers.wasmCompilePromise.promise_control.resolve(compiledModule);
+    }
+    catch (err) {
+        loaderHelpers.wasmCompilePromise.promise_control.reject(err);
+    }
 }

--- a/src/mono/wasm/runtime/loader/exit.ts
+++ b/src/mono/wasm/runtime/loader/exit.ts
@@ -120,7 +120,7 @@ async function flush_node_streams() {
 function abort_promises(reason: any) {
     loaderHelpers.allDownloadsQueued.promise_control.reject(reason);
     loaderHelpers.afterConfigLoaded.promise_control.reject(reason);
-    loaderHelpers.wasmDownloadPromise.promise_control.reject(reason);
+    loaderHelpers.wasmCompilePromise.promise_control.reject(reason);
     loaderHelpers.runtimeModuleLoaded.promise_control.reject(reason);
     loaderHelpers.memorySnapshotSkippedOrDone.promise_control.reject(reason);
     if (runtimeHelpers.dotnetReady) {

--- a/src/mono/wasm/runtime/loader/globals.ts
+++ b/src/mono/wasm/runtime/loader/globals.ts
@@ -8,7 +8,7 @@ import { exceptions, simd } from "wasm-feature-detect";
 
 import gitHash from "consts:gitHash";
 
-import type { AssetEntryInternal, DotnetModuleInternal, GlobalObjects, LoaderHelpers, MonoConfigInternal, RuntimeHelpers } from "../types/internal";
+import type { DotnetModuleInternal, GlobalObjects, LoaderHelpers, MonoConfigInternal, RuntimeHelpers } from "../types/internal";
 import type { MonoConfig, RuntimeAPI } from "../types";
 import { assert_runtime_running, is_exited, is_runtime_running, mono_exit } from "./exit";
 import { assertIsControllablePromise, createPromiseController, getPromiseController } from "./promise-controller";
@@ -100,7 +100,7 @@ export function setLoaderGlobals(
 
         afterConfigLoaded: createPromiseController<MonoConfig>(),
         allDownloadsQueued: createPromiseController<void>(),
-        wasmDownloadPromise: createPromiseController<AssetEntryInternal>(),
+        wasmCompilePromise: createPromiseController<WebAssembly.Module>(),
         runtimeModuleLoaded: createPromiseController<void>(),
         memorySnapshotSkippedOrDone: createPromiseController<void>(),
 

--- a/src/mono/wasm/runtime/loader/run.ts
+++ b/src/mono/wasm/runtime/loader/run.ts
@@ -10,7 +10,7 @@ import { ENVIRONMENT_IS_WEB, emscriptenModule, exportedRuntimeAPI, globalObjects
 import { deep_merge_config, deep_merge_module, mono_wasm_load_config } from "./config";
 import { mono_exit } from "./exit";
 import { setup_proxy_console, mono_log_info, mono_log_debug } from "./logging";
-import { mono_download_assets, prepareAssets, prepareAssetsWorker, resolve_single_asset_path, start_asset_download } from "./assets";
+import { mono_download_assets, prepareAssets, prepareAssetsWorker, resolve_single_asset_path, streamingCompileWasm } from "./assets";
 import { detect_features_and_polyfill } from "./polyfills";
 import { runtimeHelpers, loaderHelpers } from "./globals";
 import { init_globalization } from "./icu";
@@ -476,12 +476,7 @@ async function createEmscriptenMain(): Promise<RuntimeAPI> {
 
     await initCacheToUseIfEnabled();
 
-    const wasmModuleAsset = resolve_single_asset_path("dotnetwasm");
-    start_asset_download(wasmModuleAsset).then(asset => {
-        loaderHelpers.wasmDownloadPromise.promise_control.resolve(asset);
-    }).catch(err => {
-        mono_exit(1, err);
-    });
+    streamingCompileWasm(); // intentionally not awaited
 
     setTimeout(async () => {
         try {

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -17,7 +17,7 @@ import { strings_init, utf8ToString } from "./strings";
 import { init_managed_exports } from "./managed-exports";
 import { cwraps_internal } from "./exports-internal";
 import { CharPtr, InstantiateWasmCallBack, InstantiateWasmSuccessCallback } from "./types/emscripten";
-import { instantiate_wasm_asset, wait_for_all_assets } from "./assets";
+import { wait_for_all_assets } from "./assets";
 import { mono_wasm_init_diagnostics } from "./diagnostics";
 import { replace_linker_placeholders } from "./exports-binding";
 import { endMeasure, MeasuredBlock, startMeasure } from "./profiler";
@@ -461,17 +461,12 @@ async function instantiate_wasm_module(
         await runtimeHelpers.beforePreInit.promise;
         Module.addRunDependency("instantiate_wasm_module");
 
-        const wasmFeaturePromise = ensureUsedWasmFeatures();
+        await ensureUsedWasmFeatures();
 
         replace_linker_placeholders(imports);
-        const assetToLoad = await loaderHelpers.wasmDownloadPromise.promise;
-
-        await wasmFeaturePromise;
-        await instantiate_wasm_asset(assetToLoad, imports, successCallback);
-        assetToLoad.pendingDownloadInternal = null as any; // GC
-        assetToLoad.pendingDownload = null as any; // GC
-        assetToLoad.buffer = null as any; // GC
-        assetToLoad.moduleExports = null as any; // GC
+        const compiledModule = await loaderHelpers.wasmCompilePromise.promise;
+        const compiledInstance = await WebAssembly.instantiate(compiledModule, imports);
+        successCallback(compiledInstance, compiledModule);
 
         mono_log_debug("instantiate_wasm_module done");
 

--- a/src/mono/wasm/runtime/types/internal.ts
+++ b/src/mono/wasm/runtime/types/internal.ts
@@ -126,7 +126,7 @@ export type LoaderHelpers = {
 
     afterConfigLoaded: PromiseAndController<MonoConfig>,
     allDownloadsQueued: PromiseAndController<void>,
-    wasmDownloadPromise: PromiseAndController<AssetEntryInternal>,
+    wasmCompilePromise: PromiseAndController<WebAssembly.Module>,
     runtimeModuleLoaded: PromiseAndController<void>,
     memorySnapshotSkippedOrDone: PromiseAndController<void>,
 


### PR DESCRIPTION
This PR moves start of streaming compilation of WASM module into `dotnet.js` loader.
`dotnet.native.wasm` file could start to be compiled even before download and compilation of `dotnet.runtime.js` and `dotnet.native.js` is done.

This brings bit more of the logic (and moves few bytes of download size) into the loader.

Let's measure if this is good idea or not ...