### PR TITLE
Fix conflicting test assembly name in classloader tests

### DIFF
--- a/src/tests/Loader/classloader/regressions/dd52/dd52.csproj
+++ b/src/tests/Loader/classloader/regressions/dd52/dd52.csproj
@@ -9,6 +9,6 @@
     <Compile Include="runtest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="test.ilproj" />
+    <ProjectReference Include="test_dd52.ilproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Loader/classloader/regressions/dd52/test_dd52.il
+++ b/src/tests/Loader/classloader/regressions/dd52/test_dd52.il
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 .assembly extern System.Console { }
-.assembly test {}
+.assembly test_dd52 {}
 .assembly extern mscorlib {}
 
 

--- a/src/tests/Loader/classloader/regressions/dd52/test_dd52.ilproj
+++ b/src/tests/Loader/classloader/regressions/dd52/test_dd52.ilproj
@@ -3,6 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="test.il" />
+    <Compile Include="test_dd52.il" />
   </ItemGroup>
 </Project>

--- a/src/tests/Loader/classloader/regressions/dev10_897464/Test_dev10_897464.il
+++ b/src/tests/Loader/classloader/regressions/dev10_897464/Test_dev10_897464.il
@@ -6,7 +6,7 @@
 {
 }
 
-.assembly Test
+.assembly Test_dev10_897464
 {
   .hash algorithm 0x00008004
   .ver 1:0:0:0

--- a/src/tests/Loader/classloader/regressions/dev10_897464/Test_dev10_897464.ilproj
+++ b/src/tests/Loader/classloader/regressions/dev10_897464/Test_dev10_897464.ilproj
@@ -3,6 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Test.il" />
+    <Compile Include="Test_dev10_897464.il" />
   </ItemGroup>
 </Project>

--- a/src/tests/Loader/classloader/regressions/dev10_897464/dev10_897464.csproj
+++ b/src/tests/Loader/classloader/regressions/dev10_897464/dev10_897464.csproj
@@ -9,6 +9,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="Test.ilproj" />
+    <ProjectReference Include="Test_dev10_897464.ilproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
dd52 was building test.dll and dev10_897464 was building Test.dll which caused assembly resolving conflicts:

> warning MSB3243: No way to resolve conflict between "Test, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" and "test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null". Choosing "Test, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" arbitrarily.

Fixed by making the test assembly names unique for each test.