### PR TITLE
[wasm] WBT: Avoid using `-O0` in tests

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildPublishTests.cs
@@ -79,7 +79,7 @@ namespace Wasm.Build.Tests
                 prefix: "build_publish", config: buildArgs.Config, appendUnicode: testUnicode);
 
             buildArgs = buildArgs with { ProjectName = projectName };
-            buildArgs = ExpandBuildArgs(buildArgs, extraProperties: "<_WasmDevel>true</_WasmDevel>");
+            buildArgs = ExpandBuildArgs(buildArgs);
 
             // no relinking for build
             bool relinked = false;

--- a/src/mono/wasm/Wasm.Build.Tests/NativeRebuildTests/OptimizationFlagChangeTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NativeRebuildTests/OptimizationFlagChangeTests.cs
@@ -23,7 +23,7 @@ public class OptimizationFlagChangeTests : NativeRebuildTestsBase
     public static IEnumerable<object?[]> FlagsOnlyChangeData(bool aot)
         => ConfigWithAOTData(aot, config: "Release").Multiply(
                     new object[] { /*cflags*/ "/p:EmccCompileOptimizationFlag=-O1", /*ldflags*/ "" },
-                    new object[] { /*cflags*/ "",                                   /*ldflags*/ "/p:EmccLinkOptimizationFlag=-O0" }
+                    new object[] { /*cflags*/ "",                                   /*ldflags*/ "/p:EmccLinkOptimizationFlag=-O1" }
         ).WithRunHosts(RunHost.Chrome).UnwrapItemsAsArrays();
 
     [Theory]

--- a/src/mono/wasm/Wasm.Build.Tests/SatelliteAssembliesTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/SatelliteAssembliesTests.cs
@@ -136,7 +136,8 @@ namespace Wasm.Build.Tests
                                         projectTemplate: s_resourcesProjectTemplate,
                                         extraProperties: $@"
                                             <EmccCompileOptimizationFlag>-O0</EmccCompileOptimizationFlag>
-                                            <EmccLinkOptimizationFlag>-O0</EmccLinkOptimizationFlag>",
+                                            <EmccLinkOptimizationFlag>-O0</EmccLinkOptimizationFlag>
+                                            <WasmDedup>false</WasmDedup>", // -O0 can cause aot-instances.dll to blow up, and fail to compile, and it is not really needed here
                                         extraItems: $"<EmbeddedResource Include=\"{BuildEnvironment.RelativeTestAssetsPath}resx\\*\" />");
 
             BuildProject(buildArgs,

--- a/src/mono/wasm/Wasm.Build.Tests/SatelliteAssembliesTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/SatelliteAssembliesTests.cs
@@ -135,8 +135,8 @@ namespace Wasm.Build.Tests
             buildArgs = ExpandBuildArgs(buildArgs,
                                         projectTemplate: s_resourcesProjectTemplate,
                                         extraProperties: $@"
-                                            <EmccCompileOptimizationFlag>-O0</EmccCompileOptimizationFlag>
-                                            <EmccLinkOptimizationFlag>-O0</EmccLinkOptimizationFlag>
+                                            <EmccCompileOptimizationFlag>-O1</EmccCompileOptimizationFlag>
+                                            <EmccLinkOptimizationFlag>-O1</EmccLinkOptimizationFlag>
                                             <WasmDedup>false</WasmDedup>", // -O0 can cause aot-instances.dll to blow up, and fail to compile, and it is not really needed here
                                         extraItems: $"<EmbeddedResource Include=\"{BuildEnvironment.RelativeTestAssetsPath}resx\\*\" />");
 


### PR DESCRIPTION
Some WBT tests started failing while compiling `aot-instances.dll.bc`
when compiled with `-O0`. So, we avoid using that where possible.

Fixes issue: https://github.com/dotnet/runtime/issues/93023