### PR TITLE
[mono][hotreload] Generate seq_points if we don't have pdb information from HotReload

### DIFF
--- a/src/mono/mono/metadata/debug-internals.h
+++ b/src/mono/mono/metadata/debug-internals.h
@@ -112,4 +112,6 @@ mono_debug_lookup_source_location_by_il (MonoMethod *method, guint32 il_offset, 
 MONO_COMPONENT_API char*
 mono_debug_image_get_sourcelink (MonoImage *image);
 
+mono_bool
+mono_debug_generate_enc_seq_points_without_debug_info (MonoDebugMethodInfo *minfo);
 #endif /* __DEBUG_INTERNALS_H__ */

--- a/src/mono/mono/metadata/mono-debug.c
+++ b/src/mono/mono/metadata/mono-debug.c
@@ -1127,6 +1127,21 @@ mono_debug_enabled (void)
 	return mono_debug_format != MONO_DEBUG_FORMAT_NONE;
 }
 
+
+//Returns true if the method has updates but doesn't have ppdb information then we should generate the seq points using the coreclr rules
+mono_bool
+mono_debug_generate_enc_seq_points_without_debug_info (MonoDebugMethodInfo *minfo)
+{
+	MonoImage* img = m_class_get_image (minfo->method->klass);
+	if (img->has_updates) {
+		guint32 idx = mono_metadata_token_index (minfo->method->token);
+		MonoDebugInformationEnc *mdie = (MonoDebugInformationEnc *) mono_metadata_update_get_updated_method_ppdb (img, idx);
+		if (mdie == NULL)
+			return TRUE;
+	}
+	return FALSE;
+}
+
 void
 mono_debug_get_seq_points (MonoDebugMethodInfo *minfo, char **source_file, GPtrArray **source_file_list, int **source_files, MonoSymSeqPoint **seq_points, int *n_seq_points)
 {

--- a/src/mono/mono/metadata/mono-debug.c
+++ b/src/mono/mono/metadata/mono-debug.c
@@ -1133,7 +1133,7 @@ mono_bool
 mono_debug_generate_enc_seq_points_without_debug_info (MonoDebugMethodInfo *minfo)
 {
 	MonoImage* img = m_class_get_image (minfo->method->klass);
-	if (img->has_updates) {
+	if (G_UNLIKELY (img->has_updates)) {
 		guint32 idx = mono_metadata_token_index (minfo->method->token);
 		MonoDebugInformationEnc *mdie = (MonoDebugInformationEnc *) mono_metadata_update_get_updated_method_ppdb (img, idx);
 		if (mdie == NULL)

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4813,6 +4813,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 	gboolean save_last_error = FALSE;
 	gboolean link_bblocks = TRUE;
 	gboolean inlining = td->method != method;
+	gboolean generate_enc_seq_points_without_debug_info = FALSE;
 	InterpBasicBlock *exit_bb = NULL;
 
 	original_bb = bb = mono_basic_block_split (method, error, header);
@@ -4859,6 +4860,8 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			int n_il_offsets;
 
 			mono_debug_get_seq_points (minfo, NULL, NULL, NULL, &sps, &n_il_offsets);
+			if (n_il_offsets == 0)
+				generate_enc_seq_points_without_debug_info = mono_debug_generate_enc_seq_points_without_debug_info (minfo);
 			// FIXME: Free
 			seq_point_locs = mono_bitset_mem_new (mono_mempool_alloc0 (td->mempool, mono_bitset_alloc_size (header->code_size, 0)), header->code_size, 0);
 			sym_seq_points = TRUE;
@@ -5084,6 +5087,15 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			WRITE64_INS (td->last_ins, 0, &counter);
 		}
 
+		if (generate_enc_seq_points_without_debug_info)
+		{
+			if ((*td->ip == CEE_NOP) ||
+				(*td->ip == CEE_CALLVIRT) ||
+				(*td->ip == CEE_CALLI) ||
+				(*td->ip == CEE_CALL) ||
+				(GPTRDIFF_TO_INT (td->sp - td->stack) == 0))
+			last_seq_point = interp_add_ins (td, MINT_SDB_SEQ_POINT);
+		}
 		switch (*td->ip) {
 		case CEE_NOP:
 			/* lose it */
@@ -5353,7 +5365,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			if (!interp_transform_call (td, method, NULL, generic_context, constrained_class, readonly, error, TRUE, save_last_error, tailcall))
 				goto exit;
 
-			if (need_seq_point) {
+			if (need_seq_point && !generate_seq_points_without_debug_info) {
 				// check if it is a nested call and remove the MONO_INST_NONEMPTY_STACK of the last breakpoint, only for non native methods
 				if (!(method->flags & METHOD_IMPL_ATTRIBUTE_NATIVE)) {
 					if (emitted_funccall_seq_point)	{

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -5087,7 +5087,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			WRITE64_INS (td->last_ins, 0, &counter);
 		}
 
-		if (generate_enc_seq_points_without_debug_info)
+		if (G_UNLIKELY (generate_enc_seq_points_without_debug_info))
 		{
 			if ((*td->ip == CEE_NOP) ||
 				(*td->ip == CEE_CALLVIRT) ||

--- a/src/native/public/mono/metadata/details/mono-debug-functions.h
+++ b/src/native/public/mono/metadata/details/mono-debug-functions.h
@@ -7,6 +7,7 @@
 #endif
 
 MONO_API_FUNCTION(mono_bool, mono_debug_enabled, (void))
+MONO_API_FUNCTION(mono_bool, mono_debug_generate_enc_seq_points_without_debug_info, (MonoDebugMethodInfo* minfo))
 
 MONO_API_FUNCTION(void, mono_debug_init, (MonoDebugFormat format))
 MONO_API_FUNCTION(void, mono_debug_open_image_from_memory, (MonoImage *image, const mono_byte *raw_contents, int size))

--- a/src/native/public/mono/metadata/details/mono-debug-functions.h
+++ b/src/native/public/mono/metadata/details/mono-debug-functions.h
@@ -7,7 +7,6 @@
 #endif
 
 MONO_API_FUNCTION(mono_bool, mono_debug_enabled, (void))
-MONO_API_FUNCTION(mono_bool, mono_debug_generate_enc_seq_points_without_debug_info, (MonoDebugMethodInfo* minfo))
 
 MONO_API_FUNCTION(void, mono_debug_init, (MonoDebugFormat format))
 MONO_API_FUNCTION(void, mono_debug_open_image_from_memory, (MonoImage *image, const mono_byte *raw_contents, int size))


### PR DESCRIPTION
Sometimes when we apply changes on runtime side we don't receive the PDB information, so we should try to generate the seq points using the same rules used by coreclr.

Maybe in the future we can use these rules always and then avoid runtime loading the PDB information???