### PR TITLE
Reduce List indexer getter size

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -144,14 +144,17 @@ namespace System.Collections.Generic
         {
             get
             {
+                T[] items = _items;
+
                 // Following trick can reduce the range check by one
-                if ((uint)index >= (uint)_size)
+                if ((uint)index >= (uint)_size ||
+                    (uint)index >= (uint)items.Length)
                 {
                     ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessException();
                 }
-                return _items[index];
-            }
 
+                return items[index];
+            }
             set
             {
                 if ((uint)index >= (uint)_size)


### PR DESCRIPTION
The idea here is that we're still doing two range checks (`list.Size` and `array.Length`), but both jump into the same `ThrowHelper`, eliminating the need for the `CORINFO_HELP_RNGCHKFAIL` block for callers that don't otherwise need one.
It would mean that some thread-safety misuse exceptions switch from `IndexOutOfRangeException` to `ArgumentOutOfRangeException`, but I don't think we care?

Does a change like this seem worthwhile?

Example diff for ``System.Collections.Generic.List`1[int]:get_Item(int):int:this``:

<details>
<summary>X64</summary>


```diff
 G_M10434_IG01:
        push     rbp
        mov      rbp, rsp
 						;; size=4 bbWeight=1 PerfScore 1.25
 G_M10434_IG02:
+       mov      rax, gword ptr [rdi+0x08]
        cmp      esi, dword ptr [rdi+0x10]
        jae      SHORT G_M10434_IG04
-       mov      rax, gword ptr [rdi+0x08]
-       cmp      esi, dword ptr [rax+0x08]
-       jae      SHORT G_M10434_IG05
+       mov      ecx, dword ptr [rax+0x08]
+       cmp      ecx, esi
+       jbe      SHORT G_M10434_IG04
        mov      ecx, esi
        mov      eax, dword ptr [rax+4*rcx+0x10]
-						;; size=20 bbWeight=1 PerfScore 12.25
+						;; size=22 bbWeight=1 PerfScore 11.50
 G_M10434_IG03:
        pop      rbp
        ret      
 						;; size=2 bbWeight=1 PerfScore 1.50
 G_M10434_IG04:
        mov      rax, 0xD1FFAB1E      ; code for System.ThrowHelper:ThrowArgumentOutOfRange_IndexMustBeLessException()
        call     [rax]System.ThrowHelper:ThrowArgumentOutOfRange_IndexMustBeLessException()
        int3     
 						;; size=13 bbWeight=0 PerfScore 0.00
-G_M10434_IG05:
-       call     CORINFO_HELP_RNGCHKFAIL
-       int3     
-						;; size=6 bbWeight=0 PerfScore 0.00
 
-; Total bytes of code 45, prolog size 4, PerfScore 19.50, instruction count 16, allocated bytes for code 45 (MethodHash=9a7ed73d) for method System.Collections.Generic.List`1[int]:get_Item(int):int:this (FullOpts)
+; Total bytes of code 41, prolog size 4, PerfScore 18.35, instruction count 15, allocated bytes for code 41 (MethodHash=9a7ed73d) for method System.Collections.Generic.List`1[int]:get_Item(int):int:this (FullOpts)
```

</details>

<details>
<summary>Arm64</summary>


```diff
 G_M10434_IG01:
             stp     fp, lr, [sp, #-0x10]!
             mov     fp, sp
 						;; size=8 bbWeight=1 PerfScore 1.50
 G_M10434_IG02:
-            ldr     w2, [x0, #0x10]
-            cmp     w1, w2
+            ldr     x2, [x0, #0x08]
+            ldr     w0, [x0, #0x10]
+            cmp     w1, w0
             bhs     G_M10434_IG04
-            ldr     x0, [x0, #0x08]
-            ldr     w2, [x0, #0x08]
-            cmp     w1, w2
-            bhs     G_M10434_IG05
-            add     x0, x0, #16
+            ldr     w0, [x2, #0x08]
+            cmp     w0, w1
+            bls     G_M10434_IG04
+            add     x0, x2, #16
             ldr     w0, [x0, w1, UXTW #2]
 						;; size=36 bbWeight=1 PerfScore 15.50
 G_M10434_IG03:
             ldp     fp, lr, [sp], #0x10
             ret     lr
 						;; size=8 bbWeight=1 PerfScore 2.00
 G_M10434_IG04:
             movz    x0, #0xD1FFAB1E      // code for System.ThrowHelper:ThrowArgumentOutOfRange_IndexMustBeLessException()
             movk    x0, #0xD1FFAB1E LSL #16
             movk    x0, #0xD1FFAB1E LSL #32
             ldr     x0, [x0]
             blr     x0
             brk_unix #0
 						;; size=24 bbWeight=0 PerfScore 0.00
-G_M10434_IG05:
-            bl      CORINFO_HELP_RNGCHKFAIL
-            brk_unix #0
-						;; size=8 bbWeight=0 PerfScore 0.00
 
-; Total bytes of code 84, prolog size 8, PerfScore 27.40, instruction count 21, allocated bytes for code 84 (MethodHash=9a7ed73d) for method System.Collections.Generic.List`1[int]:get_Item(int):int:this (FullOpts)
+; Total bytes of code 76, prolog size 8, PerfScore 26.60, instruction count 19, allocated bytes for code 76 (MethodHash=9a7ed73d) for method System.Collections.Generic.List`1[int]:get_Item(int):int:this (FullOpts)
```

</details>
