### PR TITLE
Optimize the managed hash implementations.

### DIFF
--- a/src/libraries/Common/src/System/Sha1ForNonSecretPurposes.cs
+++ b/src/libraries/Common/src/System/Sha1ForNonSecretPurposes.cs
@@ -14,18 +14,14 @@ namespace System
     internal struct Sha1ForNonSecretPurposes
     {
         private long _length; // Total message length in bits
-        private uint[] _w; // Workspace
+        private HashState _w; // Workspace
         private int _pos; // Length of current chunk in bytes
 
         /// <summary>
-        /// Call Start() to initialize the hash object.
+        /// Call the default constructor to initialize the hash object.
         /// </summary>
-        public void Start()
+        public Sha1ForNonSecretPurposes()
         {
-            _w ??= new uint[85];
-
-            _length = 0;
-            _pos = 0;
             _w[80] = 0x67452301;
             _w[81] = 0xEFCDAB89;
             _w[82] = 0x98BADCFE;
@@ -154,6 +150,12 @@ namespace System
 
             _length += 512; // 64 bytes == 512 bits
             _pos = 0;
+        }
+
+        [InlineArray(85)]
+        private struct HashState
+        {
+            uint _x;
         }
     }
 }

--- a/src/libraries/Common/src/System/Sha1ForNonSecretPurposes.cs
+++ b/src/libraries/Common/src/System/Sha1ForNonSecretPurposes.cs
@@ -156,7 +156,7 @@ namespace System
         [InlineArray(85)]
         private struct HashState
         {
-            uint _x;
+            private uint _x;
         }
     }
 }

--- a/src/libraries/Common/src/System/Sha1ForNonSecretPurposes.cs
+++ b/src/libraries/Common/src/System/Sha1ForNonSecretPurposes.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace System
 {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1695,16 +1695,14 @@ namespace System.Diagnostics.Tracing
                 0x87, 0xF8, 0x1A, 0x15, 0xBF, 0xC1, 0x30, 0xFB,
             };
 
-            byte[] bytes = Encoding.BigEndianUnicode.GetBytes(name);
-            Sha1ForNonSecretPurposes hash = default;
-            hash.Start();
+            Sha1ForNonSecretPurposes hash = new();
             hash.Append(namespaceBytes);
-            hash.Append(bytes);
-            Array.Resize(ref bytes, 16);
-            hash.Finish(bytes);
+            hash.Append(Encoding.BigEndianUnicode.GetBytes(name));
+            Span<byte> output = stackalloc byte[16];
+            hash.Finish(output);
 
-            bytes[7] = unchecked((byte)((bytes[7] & 0x0F) | 0x50));    // Set high 4 bits of octet 7 to 5, as per RFC 4122
-            return new Guid(bytes);
+            output[7] = unchecked((byte)((output[7] & 0x0F) | 0x50));    // Set high 4 bits of octet 7 to 5, as per RFC 4122
+            return new Guid(output);
         }
 
         private static unsafe void DecodeObjects(object?[] decodedObjects, Type[] parameterTypes, EventData* data)
@@ -5282,7 +5280,7 @@ namespace System.Diagnostics.Tracing
         }
 
         /// <summary>
-        /// <term>Will NOT build a manifest!</term> If the intention is to build a manifest don’t use this constructor.
+        /// <term>Will NOT build a manifest!</term> If the intention is to build a manifest donï¿½t use this constructor.
         ///'resources, is a resource manager.  If specified all messages are localized using that manager.
         /// </summary>
         internal ManifestBuilder(ResourceManager? resources, EventManifestOptions flags)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -5280,7 +5280,7 @@ namespace System.Diagnostics.Tracing
         }
 
         /// <summary>
-        /// <term>Will NOT build a manifest!</term> If the intention is to build a manifest don�t use this constructor.
+        /// <term>Will NOT build a manifest!</term> If the intention is to build a manifest don't use this constructor.
         ///'resources, is a resource manager.  If specified all messages are localized using that manager.
         /// </summary>
         internal ManifestBuilder(ResourceManager? resources, EventManifestOptions flags)

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameHelpers.StrongName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameHelpers.StrongName.cs
@@ -21,8 +21,7 @@ namespace System.Reflection
 
             Span<byte> hash = stackalloc byte[20];
 
-            Sha1ForNonSecretPurposes sha1 = default;
-            sha1.Start();
+            Sha1ForNonSecretPurposes sha1 = new();
             sha1.Append(publicKey);
             sha1.Finish(hash);
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Browser.cs
@@ -53,9 +53,15 @@ namespace System.Security.Cryptography
 
             public static int HashData(string hashAlgorithmId, ReadOnlySpan<byte> source, Span<byte> destination)
             {
-                HashProvider provider = CreateHashProvider(hashAlgorithmId);
-                provider.AppendHashData(source);
-                return provider.FinalizeHashAndReset(destination);
+                switch (hashAlgorithmId)
+                {
+                    case HashAlgorithmNames.SHA1:
+                    case HashAlgorithmNames.SHA256:
+                    case HashAlgorithmNames.SHA384:
+                    case HashAlgorithmNames.SHA512:
+                        return SHAManagedHashProvider.HashData(hashAlgorithmId, source, destination);
+                }
+                throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
             }
 
             public static void HashDataXof(string hashAlgorithmId, ReadOnlySpan<byte> source, Span<byte> destination)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
@@ -97,8 +97,7 @@ namespace System.Security.Cryptography
 
             public override void Initialize()
             {
-                _state = default;
-                _state.Start();
+                _state = new();
             }
 
             public override void HashCore(byte[] partIn, int ibStart, int cbSize)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
@@ -186,27 +186,26 @@ namespace System.Security.Cryptography
             */
             public override byte[] HashFinal()
             {
-                byte[] pad;
-                int padLen;
                 byte[] hash = new byte[32]; // HashSizeValue = 256
 
                 /* Compute padding: 80 00 00 ... 00 00 <bit count>
                 */
 
-                padLen = 64 - (int)(_count & 0x3f);
+                int padLen = 64 - (int)(_count & 0x3f);
                 if (padLen <= 8)
                     padLen += 64;
 
-                pad = new byte[padLen];
+                Span<byte> pad = stackalloc byte[64 + 16];
                 pad[0] = 0x80;
+                pad[1..padLen - 1].Clear();
 
                 //  Convert count to bit count
                 ulong bitCount = _count * 8;
 
-                BinaryPrimitives.WriteUInt64BigEndian(pad[..^sizeof(ulong)], bitCount);
+                BinaryPrimitives.WriteUInt64BigEndian(pad[..padLen - sizeof(ulong)], bitCount);
 
                 /* Digest padding */
-                HashCore(pad);
+                HashCore(pad[..padLen]);
 
                 /* Store digest */
                 SHAUtils.DWORDToBigEndian(hash, _stateSHA256[..8]);
@@ -422,27 +421,26 @@ namespace System.Security.Cryptography
             */
             public override byte[] HashFinal()
             {
-                byte[] pad;
-                int padLen;
                 byte[] hash = new byte[48]; // HashSizeValue = 384
 
                 /* Compute padding: 80 00 00 ... 00 00 <bit count>
                 */
 
-                padLen = 128 - (int)(_count & 0x7f);
+                int padLen = 128 - (int)(_count & 0x7f);
                 if (padLen <= 16)
                     padLen += 128;
 
-                pad = new byte[padLen];
+                Span<byte> pad = stackalloc byte[128 + 16];
                 pad[0] = 0x80;
+                pad[1..padLen - 1].Clear();
 
                 //  Convert count to bit count
                 ulong bitCount = _count * 8;
 
-                BinaryPrimitives.WriteUInt64BigEndian(pad[..^sizeof(ulong)], bitCount);
+                BinaryPrimitives.WriteUInt64BigEndian(pad[..padLen - sizeof(ulong)], bitCount);
 
                 /* Digest padding */
-                HashCore(pad);
+                HashCore(pad[..padLen]);
 
                 /* Store digest */
                 SHAUtils.QuadWordToBigEndian(hash, _stateSHA384[..6]);
@@ -662,27 +660,26 @@ namespace System.Security.Cryptography
             */
             public override byte[] HashFinal()
             {
-                byte[] pad;
-                int padLen;
                 byte[] hash = new byte[64]; // HashSizeValue = 512
 
                 /* Compute padding: 80 00 00 ... 00 00 <bit count>
                 */
 
-                padLen = 128 - (int)(_count & 0x7f);
+                int padLen = 128 - (int)(_count & 0x7f);
                 if (padLen <= 16)
                     padLen += 128;
 
-                pad = new byte[padLen];
+                Span<byte> pad = stackalloc byte[128 + 16];
                 pad[0] = 0x80;
+                pad[1..padLen - 1].Clear();
 
                 //  Convert count to bit count
                 ulong bitCount = _count * 8;
 
-                BinaryPrimitives.WriteUInt64BigEndian(pad[..^sizeof(ulong)], bitCount);
+                BinaryPrimitives.WriteUInt64BigEndian(pad[..padLen - sizeof(ulong)], bitCount);
 
                 /* Digest padding */
-                HashCore(pad);
+                HashCore(pad[..padLen]);
 
                 /* Store digest */
                 SHAUtils.QuadWordToBigEndian(hash, _stateSHA512[..8]);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
@@ -61,9 +61,11 @@ namespace System.Security.Cryptography
                     throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
             }
 
-            static void Hash<T>(ReadOnlySpan<byte> source, Span<byte> destination) where T : struct, new(), ISHAManagedImplementation
+            static void Hash<T>(ReadOnlySpan<byte> source, Span<byte> destination) where T : struct, ISHAManagedImplementation
             {
+                #pragma warning disable SA1129 // Do not use default value type constructor
                 T impl = new();
+                #pragma warning restore SA1129 // Do not use default value type constructor
                 impl.AppendHashData(source);
                 impl.FinalizeHashAndReset(destination);
             }
@@ -187,7 +189,7 @@ namespace System.Security.Cryptography
 
                 if ((bufferLen > 0) && (bufferLen + partIn.Length >= 64))
                 {
-                    partIn[..64 - bufferLen].CopyTo(_buffer[bufferLen..]);
+                    partIn[..(64 - bufferLen)].CopyTo(_buffer[bufferLen..]);
                     SHATransform(ref _W, ref _stateSHA256, _buffer);
                     bufferLen = 0;
                 }
@@ -215,12 +217,12 @@ namespace System.Security.Cryptography
 
                 Span<byte> pad = stackalloc byte[64 + 16];
                 pad[0] = 0x80;
-                pad[1..padLen - 1].Clear();
+                pad[1..(padLen - 1)].Clear();
 
                 //  Convert count to bit count
-                ulong bitCount = _count * 8;
+                ulong bitCount = (ulong)_count * 8;
 
-                BinaryPrimitives.WriteUInt64BigEndian(pad[..padLen - sizeof(ulong)], bitCount);
+                BinaryPrimitives.WriteUInt64BigEndian(pad[..(padLen - sizeof(ulong))], bitCount);
 
                 /* Digest padding */
                 AppendHashData(pad[..padLen]);
@@ -273,7 +275,7 @@ namespace System.Security.Cryptography
 
                 // fill in the first 16 bytes of W.
                 SHAUtils.DWORDFromBigEndian(expandedBuffer[..16], block);
-                SHA256Expand(expandedBuffer);
+                SHA256Expand(ref expandedBuffer);
 
                 /* Apply the SHA256 compression function */
                 // We are trying to be smart here and avoid as many copies as we can
@@ -413,7 +415,7 @@ namespace System.Security.Cryptography
 
                 if ((bufferLen > 0) && (bufferLen + partIn.Length >= 128))
                 {
-                    partIn[..128 - bufferLen].CopyTo(_buffer[bufferLen..]);
+                    partIn[..(128 - bufferLen)].CopyTo(_buffer[bufferLen..]);
                     SHATransform(ref _W, ref _stateSHA384, _buffer);
                     bufferLen = 0;
                 }
@@ -441,12 +443,12 @@ namespace System.Security.Cryptography
 
                 Span<byte> pad = stackalloc byte[128 + 16];
                 pad[0] = 0x80;
-                pad[1..padLen - 1].Clear();
+                pad[1..(padLen - 1)].Clear();
 
                 //  Convert count to bit count
-                ulong bitCount = _count * 8;
+                ulong bitCount = (ulong)_count * 8;
 
-                BinaryPrimitives.WriteUInt64BigEndian(pad[..padLen - sizeof(ulong)], bitCount);
+                BinaryPrimitives.WriteUInt64BigEndian(pad[..(padLen - sizeof(ulong))], bitCount);
 
                 /* Digest padding */
                 AppendHashData(pad[..padLen]);
@@ -503,7 +505,7 @@ namespace System.Security.Cryptography
 
                 // fill in the first 16 blocks of W.
                 SHAUtils.QuadWordFromBigEndian(expandedBuffer[..16], block);
-                SHA384Expand(expandedBuffer);
+                SHA384Expand(ref expandedBuffer);
 
                 /* Apply the SHA384 compression function */
                 // We are trying to be smart here and avoid as many copies as we can
@@ -643,7 +645,7 @@ namespace System.Security.Cryptography
 
                 if ((bufferLen > 0) && (bufferLen + partIn.Length >= 128))
                 {
-                    partIn[..128 - bufferLen].CopyTo(_buffer[bufferLen..]);
+                    partIn[..(128 - bufferLen)].CopyTo(_buffer[bufferLen..]);
                     SHATransform(ref _W, ref _stateSHA512, _buffer);
                     bufferLen = 0;
                 }
@@ -671,12 +673,12 @@ namespace System.Security.Cryptography
 
                 Span<byte> pad = stackalloc byte[128 + 16];
                 pad[0] = 0x80;
-                pad[1..padLen - 1].Clear();
+                pad[1..(padLen - 1)].Clear();
 
                 //  Convert count to bit count
-                ulong bitCount = _count * 8;
+                ulong bitCount = (ulong)_count * 8;
 
-                BinaryPrimitives.WriteUInt64BigEndian(pad[..padLen - sizeof(ulong)], bitCount);
+                BinaryPrimitives.WriteUInt64BigEndian(pad[..(padLen - sizeof(ulong))], bitCount);
 
                 /* Digest padding */
                 AppendHashData(pad[..padLen]);
@@ -733,7 +735,7 @@ namespace System.Security.Cryptography
 
                 // fill in the first 16 blocks of W.
                 SHAUtils.QuadWordFromBigEndian(expandedBuffer[..16], block);
-                SHA512Expand(expandedBuffer);
+                SHA512Expand(ref expandedBuffer);
 
                 /* Apply the SHA512 compression function */
                 // We are trying to be smart here and avoid as many copies as we can
@@ -865,7 +867,7 @@ namespace System.Security.Cryptography
             {
                 for (int i = 0; i < x.Length; i++)
                 {
-                    x[i] = BinaryPrimitives.ReadUInt64BigEndian(block[i * sizeof(uint)..]);
+                    x[i] = BinaryPrimitives.ReadUInt32BigEndian(block[(i * sizeof(uint))..]);
                 }
             }
 
@@ -874,7 +876,7 @@ namespace System.Security.Cryptography
             {
                 for (int i = 0; i < x.Length; i++)
                 {
-                    BinaryPrimitives.WriteUInt32BigEndian(block[i * sizeof(uint)..], x[i]);
+                    BinaryPrimitives.WriteUInt32BigEndian(block[(i * sizeof(uint))..], x[i]);
                 }
             }
 
@@ -882,7 +884,7 @@ namespace System.Security.Cryptography
             {
                 for (int i = 0; i < x.Length; i++)
                 {
-                    x[i] = BinaryPrimitives.ReadUInt64BigEndian(block[i * sizeof(ulong)..]);
+                    x[i] = BinaryPrimitives.ReadUInt64BigEndian(block[(i * sizeof(ulong))..]);
                 }
             }
 
@@ -891,7 +893,7 @@ namespace System.Security.Cryptography
             {
                 for (int i = 0; i < x.Length; i++)
                 {
-                    BinaryPrimitives.WriteUInt64BigEndian(block[i * sizeof(ulong)..], x[i]);
+                    BinaryPrimitives.WriteUInt64BigEndian(block[(i * sizeof(ulong))..], x[i]);
                 }
             }
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
@@ -41,6 +41,34 @@ namespace System.Security.Cryptography
             }
         }
 
+        public static int HashData(string hashAlgorithmId, ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            switch (hashAlgorithmId)
+            {
+                case HashAlgorithmNames.SHA1:
+                    Hash<SHA1ManagedImplementation>(source, destination);
+                    return 20;
+                case HashAlgorithmNames.SHA256:
+                    Hash<SHA256ManagedImplementation>(source, destination);
+                    return 32;
+                case HashAlgorithmNames.SHA384:
+                    Hash<SHA384ManagedImplementation>(source, destination);
+                    return 48;
+                case HashAlgorithmNames.SHA512:
+                    Hash<SHA512ManagedImplementation>(source, destination);
+                    return 64;
+                default:
+                    throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
+            }
+
+            static void Hash<T>(ReadOnlySpan<byte> source, Span<byte> destination) where T : struct, new(), ISHAManagedImplementation
+            {
+                T impl = new();
+                impl.AppendHashData(source);
+                impl.FinalizeHashAndReset(destination);
+            }
+        }
+
         public override void AppendHashData(ReadOnlySpan<byte> data)
         {
             impl.AppendHashData(data);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
@@ -576,11 +576,6 @@ namespace System.Security.Cryptography
                 state[7] += h;
             }
 
-            private static ulong RotateRight(ulong x, int n)
-            {
-                return (((x) >> (n)) | ((x) << (64 - (n))));
-            }
-
             private static ulong Ch(ulong x, ulong y, ulong z)
             {
                 return ((x & y) ^ ((x ^ 0xffffffffffffffff) & z));

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
@@ -91,9 +91,14 @@ namespace System.Security.Cryptography
             // about our crypto primitives in wasm environments.
             private Sha1ForNonSecretPurposes _state; // mutable struct - don't make readonly
 
-            public void Initialize()
+            public SHA1ManagedImplementation()
             {
                 _state = new();
+            }
+
+            public void Initialize()
+            {
+                this = new();
             }
 
             public void AppendHashData(ReadOnlySpan<byte> partIn)
@@ -125,22 +130,6 @@ namespace System.Security.Cryptography
 
             public SHA256ManagedImplementation()
             {
-                InitializeState();
-            }
-
-            public void Initialize()
-            {
-                InitializeState();
-
-                // Zeroize potentially sensitive information.
-                _buffer = default;
-                _W = default;
-            }
-
-            private void InitializeState()
-            {
-                _count = 0;
-
                 _stateSHA256[0] = 0x6a09e667;
                 _stateSHA256[1] = 0xbb67ae85;
                 _stateSHA256[2] = 0x3c6ef372;
@@ -149,6 +138,11 @@ namespace System.Security.Cryptography
                 _stateSHA256[5] = 0x9b05688c;
                 _stateSHA256[6] = 0x1f83d9ab;
                 _stateSHA256[7] = 0x5be0cd19;
+            }
+
+            public void Initialize()
+            {
+                this = new();
             }
 
             /* SHA256 block update operation. Continues an SHA message-digest
@@ -362,22 +356,6 @@ namespace System.Security.Cryptography
 
             public SHA384ManagedImplementation()
             {
-                InitializeState();
-            }
-
-            public void Initialize()
-            {
-                InitializeState();
-
-                // Zeroize potentially sensitive information.
-                _buffer = default;
-                _W = default;
-            }
-
-            private void InitializeState()
-            {
-                _count = 0;
-
                 _stateSHA384[0] = 0xcbbb9d5dc1059ed8;
                 _stateSHA384[1] = 0x629a292a367cd507;
                 _stateSHA384[2] = 0x9159015a3070dd17;
@@ -386,6 +364,11 @@ namespace System.Security.Cryptography
                 _stateSHA384[5] = 0x8eb44a8768581511;
                 _stateSHA384[6] = 0xdb0c2e0d64f98fa7;
                 _stateSHA384[7] = 0x47b5481dbefa4fa4;
+            }
+
+            public void Initialize()
+            {
+                this = new();
             }
 
             /* SHA384 block update operation. Continues an SHA message-digest
@@ -603,22 +586,6 @@ namespace System.Security.Cryptography
 
             public SHA512ManagedImplementation()
             {
-                InitializeState();
-            }
-
-            public void Initialize()
-            {
-                InitializeState();
-
-                // Zeroize potentially sensitive information.
-                _buffer = default;
-                _W = default;
-            }
-
-            private void InitializeState()
-            {
-                _count = 0;
-
                 _stateSHA512[0] = 0x6a09e667f3bcc908;
                 _stateSHA512[1] = 0xbb67ae8584caa73b;
                 _stateSHA512[2] = 0x3c6ef372fe94f82b;
@@ -627,6 +594,11 @@ namespace System.Security.Cryptography
                 _stateSHA512[5] = 0x9b05688c2b3e6c1f;
                 _stateSHA512[6] = 0x1f83d9abfb41bd6b;
                 _stateSHA512[7] = 0x5be0cd19137e2179;
+            }
+
+            public void Initialize()
+            {
+                this = new();
             }
 
             /* SHA512 block update operation. Continues an SHA message-digest

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
@@ -118,15 +118,13 @@ namespace System.Security.Cryptography
         // ported from https://github.com/microsoft/referencesource/blob/a48449cb48a9a693903668a71449ac719b76867c/mscorlib/system/security/cryptography/sha256managed.cs
         private sealed class SHA256ManagedImplementation : SHAManagedImplementationBase
         {
-            private byte[] _buffer;
+            private HashBuffer64 _buffer;
             private long _count; // Number of bytes in the hashed message
             private HashState<uint> _stateSHA256;
             private ExpandedBuffer<uint> _W;
 
             public SHA256ManagedImplementation()
             {
-                _buffer = new byte[64];
-
                 InitializeState();
             }
 
@@ -135,7 +133,7 @@ namespace System.Security.Cryptography
                 InitializeState();
 
                 // Zeroize potentially sensitive information.
-                Array.Clear(_buffer, 0, _buffer.Length);
+                _buffer = default;
                 _W = default;
             }
 
@@ -167,7 +165,7 @@ namespace System.Security.Cryptography
 
                 if ((bufferLen > 0) && (bufferLen + partIn.Length >= 64))
                 {
-                    partIn[..64 - bufferLen].CopyTo(_buffer.AsSpan(bufferLen));
+                    partIn[..64 - bufferLen].CopyTo(_buffer[bufferLen..]);
                     SHATransform(ref _W, ref _stateSHA256, _buffer);
                     bufferLen = 0;
                 }
@@ -178,7 +176,7 @@ namespace System.Security.Cryptography
                     partIn = partIn[64..];
                 }
 
-                partIn.CopyTo(_buffer.AsSpan(bufferLen));
+                partIn.CopyTo(_buffer[bufferLen..]);
             }
 
             /* SHA256 finalization. Ends an SHA256 message-digest operation, writing
@@ -353,15 +351,13 @@ namespace System.Security.Cryptography
         // ported from https://github.com/microsoft/referencesource/blob/a48449cb48a9a693903668a71449ac719b76867c/mscorlib/system/security/cryptography/sha384managed.cs
         private sealed class SHA384ManagedImplementation : SHAManagedImplementationBase
         {
-            private byte[] _buffer;
+            private HashBuffer128 _buffer;
             private ulong _count; // Number of bytes in the hashed message
             private HashState<ulong> _stateSHA384;
             private ExpandedBuffer<ulong> _W;
 
             public SHA384ManagedImplementation()
             {
-                _buffer = new byte[128];
-
                 InitializeState();
             }
 
@@ -370,7 +366,7 @@ namespace System.Security.Cryptography
                 InitializeState();
 
                 // Zeroize potentially sensitive information.
-                Array.Clear(_buffer, 0, _buffer.Length);
+                _buffer = default;
                 _W = default;
             }
 
@@ -402,7 +398,7 @@ namespace System.Security.Cryptography
 
                 if ((bufferLen > 0) && (bufferLen + partIn.Length >= 128))
                 {
-                    partIn[..128 - bufferLen].CopyTo(_buffer.AsSpan(bufferLen));
+                    partIn[..128 - bufferLen].CopyTo(_buffer[bufferLen..]);
                     SHATransform(ref _W, ref _stateSHA384, _buffer);
                     bufferLen = 0;
                 }
@@ -413,7 +409,7 @@ namespace System.Security.Cryptography
                     partIn = partIn[128..];
                 }
 
-                partIn.CopyTo(_buffer.AsSpan(bufferLen));
+                partIn.CopyTo(_buffer[bufferLen..]);
             }
 
             /* SHA384 finalization. Ends an SHA384 message-digest operation, writing
@@ -592,15 +588,13 @@ namespace System.Security.Cryptography
         // ported from https://github.com/microsoft/referencesource/blob/a48449cb48a9a693903668a71449ac719b76867c/mscorlib/system/security/cryptography/sha512managed.cs
         private sealed class SHA512ManagedImplementation : SHAManagedImplementationBase
         {
-            private byte[] _buffer;
+            private HashBuffer128 _buffer;
             private ulong _count; // Number of bytes in the hashed message
             private HashState<ulong> _stateSHA512;
             private ExpandedBuffer<ulong> _W;
 
             public SHA512ManagedImplementation()
             {
-                _buffer = new byte[128];
-
                 InitializeState();
             }
 
@@ -609,7 +603,7 @@ namespace System.Security.Cryptography
                 InitializeState();
 
                 // Zeroize potentially sensitive information.
-                Array.Clear(_buffer, 0, _buffer.Length);
+                _buffer = default;
                 _W = default;
             }
 
@@ -641,7 +635,7 @@ namespace System.Security.Cryptography
 
                 if ((bufferLen > 0) && (bufferLen + partIn.Length >= 128))
                 {
-                    partIn[..128 - bufferLen].CopyTo(_buffer.AsSpan(bufferLen));
+                    partIn[..128 - bufferLen].CopyTo(_buffer[bufferLen..]);
                     SHATransform(ref _W, ref _stateSHA512, _buffer);
                     bufferLen = 0;
                 }
@@ -652,7 +646,7 @@ namespace System.Security.Cryptography
                     partIn = partIn[128..];
                 }
 
-                partIn.CopyTo(_buffer.AsSpan(bufferLen));
+                partIn.CopyTo(_buffer[bufferLen..]);
             }
 
             /* SHA512 finalization. Ends an SHA512 message-digest operation, writing
@@ -838,6 +832,18 @@ namespace System.Security.Cryptography
         private struct ExpandedBuffer<T>
         {
             public T Data;
+        }
+
+        [InlineArray(64)]
+        private struct HashBuffer64
+        {
+            public byte Data;
+        }
+
+        [InlineArray(128)]
+        private struct HashBuffer128
+        {
+            public byte Data;
         }
 
         // ported from https://github.com/microsoft/referencesource/blob/a48449cb48a9a693903668a71449ac719b76867c/mscorlib/system/security/cryptography/utils.cs

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHAHashProvider.Browser.Managed.cs
@@ -188,7 +188,6 @@ namespace System.Security.Cryptography
             {
                 byte[] pad;
                 int padLen;
-                long bitCount;
                 byte[] hash = new byte[32]; // HashSizeValue = 256
 
                 /* Compute padding: 80 00 00 ... 00 00 <bit count>
@@ -202,16 +201,9 @@ namespace System.Security.Cryptography
                 pad[0] = 0x80;
 
                 //  Convert count to bit count
-                bitCount = _count * 8;
+                ulong bitCount = _count * 8;
 
-                pad[padLen - 8] = (byte)((bitCount >> 56) & 0xff);
-                pad[padLen - 7] = (byte)((bitCount >> 48) & 0xff);
-                pad[padLen - 6] = (byte)((bitCount >> 40) & 0xff);
-                pad[padLen - 5] = (byte)((bitCount >> 32) & 0xff);
-                pad[padLen - 4] = (byte)((bitCount >> 24) & 0xff);
-                pad[padLen - 3] = (byte)((bitCount >> 16) & 0xff);
-                pad[padLen - 2] = (byte)((bitCount >> 8) & 0xff);
-                pad[padLen - 1] = (byte)((bitCount >> 0) & 0xff);
+                BinaryPrimitives.WriteUInt64BigEndian(pad[..^sizeof(ulong)], bitCount);
 
                 /* Digest padding */
                 HashCore(pad);
@@ -432,7 +424,6 @@ namespace System.Security.Cryptography
             {
                 byte[] pad;
                 int padLen;
-                ulong bitCount;
                 byte[] hash = new byte[48]; // HashSizeValue = 384
 
                 /* Compute padding: 80 00 00 ... 00 00 <bit count>
@@ -446,27 +437,9 @@ namespace System.Security.Cryptography
                 pad[0] = 0x80;
 
                 //  Convert count to bit count
-                bitCount = _count * 8;
+                ulong bitCount = _count * 8;
 
-                // bitCount is at most 8 * 128 = 1024. Its representation as a 128-bit number has all bits set to zero
-                // except eventually the 11 lower bits
-
-                //pad[padLen-16] = (byte) ((bitCount >> 120) & 0xff);
-                //pad[padLen-15] = (byte) ((bitCount >> 112) & 0xff);
-                //pad[padLen-14] = (byte) ((bitCount >> 104) & 0xff);
-                //pad[padLen-13] = (byte) ((bitCount >> 96) & 0xff);
-                //pad[padLen-12] = (byte) ((bitCount >> 88) & 0xff);
-                //pad[padLen-11] = (byte) ((bitCount >> 80) & 0xff);
-                //pad[padLen-10] = (byte) ((bitCount >> 72) & 0xff);
-                //pad[padLen-9] = (byte) ((bitCount >> 64) & 0xff);
-                pad[padLen - 8] = (byte)((bitCount >> 56) & 0xff);
-                pad[padLen - 7] = (byte)((bitCount >> 48) & 0xff);
-                pad[padLen - 6] = (byte)((bitCount >> 40) & 0xff);
-                pad[padLen - 5] = (byte)((bitCount >> 32) & 0xff);
-                pad[padLen - 4] = (byte)((bitCount >> 24) & 0xff);
-                pad[padLen - 3] = (byte)((bitCount >> 16) & 0xff);
-                pad[padLen - 2] = (byte)((bitCount >> 8) & 0xff);
-                pad[padLen - 1] = (byte)((bitCount >> 0) & 0xff);
+                BinaryPrimitives.WriteUInt64BigEndian(pad[..^sizeof(ulong)], bitCount);
 
                 /* Digest padding */
                 HashCore(pad);
@@ -691,7 +664,6 @@ namespace System.Security.Cryptography
             {
                 byte[] pad;
                 int padLen;
-                ulong bitCount;
                 byte[] hash = new byte[64]; // HashSizeValue = 512
 
                 /* Compute padding: 80 00 00 ... 00 00 <bit count>
@@ -705,28 +677,9 @@ namespace System.Security.Cryptography
                 pad[0] = 0x80;
 
                 //  Convert count to bit count
-                bitCount = _count * 8;
+                ulong bitCount = _count * 8;
 
-                // If we ever have UInt128 for bitCount, then these need to be uncommented.
-                // Note that C# only looks at the low 6 bits of the shift value for ulongs,
-                // so >>0 and >>64 are equal!
-
-                //pad[padLen-16] = (byte) ((bitCount >> 120) & 0xff);
-                //pad[padLen-15] = (byte) ((bitCount >> 112) & 0xff);
-                //pad[padLen-14] = (byte) ((bitCount >> 104) & 0xff);
-                //pad[padLen-13] = (byte) ((bitCount >> 96) & 0xff);
-                //pad[padLen-12] = (byte) ((bitCount >> 88) & 0xff);
-                //pad[padLen-11] = (byte) ((bitCount >> 80) & 0xff);
-                //pad[padLen-10] = (byte) ((bitCount >> 72) & 0xff);
-                //pad[padLen-9] = (byte) ((bitCount >> 64) & 0xff);
-                pad[padLen - 8] = (byte)((bitCount >> 56) & 0xff);
-                pad[padLen - 7] = (byte)((bitCount >> 48) & 0xff);
-                pad[padLen - 6] = (byte)((bitCount >> 40) & 0xff);
-                pad[padLen - 5] = (byte)((bitCount >> 32) & 0xff);
-                pad[padLen - 4] = (byte)((bitCount >> 24) & 0xff);
-                pad[padLen - 3] = (byte)((bitCount >> 16) & 0xff);
-                pad[padLen - 2] = (byte)((bitCount >> 8) & 0xff);
-                pad[padLen - 1] = (byte)((bitCount >> 0) & 0xff);
+                BinaryPrimitives.WriteUInt64BigEndian(pad[..^sizeof(ulong)], bitCount);
 
                 /* Digest padding */
                 HashCore(pad);


### PR DESCRIPTION
This PR optimizes the managed hash implementations (`Sha1ForNonSecretPurposes` and SHA-2 which is used by browser) to reduce allocations and data copying. We make use of `InlineArray` to store the hash's state, and the SHA-2 classes were more significantly overhauled, to remove unsafe code, and support hashing the provided input directly without buffering it to a `MemoryStream`. Also on browser, one-shot hashing became allocation-free.

Let's see what CI thinks.