### PR TITLE
Light up String.Manipulation APIs with Vector512 codepath

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1913,6 +1913,12 @@ namespace System
 
         private static void MakeSeparatorListVectorized(ReadOnlySpan<char> sourceSpan, ref ValueListBuilder<int> sepListBuilder, char c, char c2, char c3)
         {
+            // Redundant test so we won't prejit remainder of this method
+            // on platforms where it is not supported
+            if (!Vector128.IsHardwareAccelerated)
+            {
+                throw new PlatformNotSupportedException();
+            }
             Debug.Assert(sourceSpan.Length >= Vector128<ushort>.Count);
             nuint lengthToExamine = (uint)sourceSpan.Length;
             nuint offset = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1188,7 +1188,21 @@ namespace System
             // process the remaining elements vectorized too.
             // Thus we adjust the pointers so that at least one full vector from the end can be processed.
             nuint length = (uint)Length;
-            if (Vector128.IsHardwareAccelerated && length >= (uint)Vector128<ushort>.Count)
+            if (Vector512.IsHardwareAccelerated && length >= (uint)Vector512<ushort>.Count)
+            {
+                nuint adjust = (length - remainingLength) & ((uint)Vector512<ushort>.Count - 1);
+                pSrc = ref Unsafe.Subtract(ref pSrc, adjust);
+                pDst = ref Unsafe.Subtract(ref pDst, adjust);
+                remainingLength += adjust;
+            }
+            else if (Vector256.IsHardwareAccelerated && length >= (uint)Vector256<ushort>.Count)
+            {
+                nuint adjust = (length - remainingLength) & ((uint)Vector256<ushort>.Count - 1);
+                pSrc = ref Unsafe.Subtract(ref pSrc, adjust);
+                pDst = ref Unsafe.Subtract(ref pDst, adjust);
+                remainingLength += adjust;
+            }
+            else if (Vector128.IsHardwareAccelerated && length >= (uint)Vector128<ushort>.Count)
             {
                 nuint adjust = (length - remainingLength) & ((uint)Vector128<ushort>.Count - 1);
                 pSrc = ref Unsafe.Subtract(ref pSrc, adjust);
@@ -1899,46 +1913,98 @@ namespace System
 
         private static void MakeSeparatorListVectorized(ReadOnlySpan<char> sourceSpan, ref ValueListBuilder<int> sepListBuilder, char c, char c2, char c3)
         {
-            // Redundant test so we won't prejit remainder of this method
-            // on platforms where it is not supported
-            if (!Vector128.IsHardwareAccelerated)
-            {
-                throw new PlatformNotSupportedException();
-            }
-
             Debug.Assert(sourceSpan.Length >= Vector128<ushort>.Count);
-
-            nuint offset = 0;
             nuint lengthToExamine = (uint)sourceSpan.Length;
-
+            nuint offset = 0;
             ref char source = ref MemoryMarshal.GetReference(sourceSpan);
 
-            Vector128<ushort> v1 = Vector128.Create((ushort)c);
-            Vector128<ushort> v2 = Vector128.Create((ushort)c2);
-            Vector128<ushort> v3 = Vector128.Create((ushort)c3);
-
-            do
+            if (Vector512.IsHardwareAccelerated && lengthToExamine >= (uint)Vector512<ushort>.Count*2)
             {
-                Vector128<ushort> vector = Vector128.LoadUnsafe(ref source, offset);
-                Vector128<ushort> v1Eq = Vector128.Equals(vector, v1);
-                Vector128<ushort> v2Eq = Vector128.Equals(vector, v2);
-                Vector128<ushort> v3Eq = Vector128.Equals(vector, v3);
-                Vector128<byte> cmp = (v1Eq | v2Eq | v3Eq).AsByte();
+                Vector512<ushort> v1 = Vector512.Create((ushort)c);
+                Vector512<ushort> v2 = Vector512.Create((ushort)c2);
+                Vector512<ushort> v3 = Vector512.Create((ushort)c3);
 
-                if (cmp != Vector128<byte>.Zero)
+                do
                 {
-                    // Skip every other bit
-                    uint mask = cmp.ExtractMostSignificantBits() & 0x5555;
-                    do
-                    {
-                        uint bitPos = (uint)BitOperations.TrailingZeroCount(mask) / sizeof(char);
-                        sepListBuilder.Append((int)(offset + bitPos));
-                        mask = BitOperations.ResetLowestSetBit(mask);
-                    } while (mask != 0);
-                }
+                    Vector512<ushort> vector = Vector512.LoadUnsafe(ref source, offset);
+                    Vector512<ushort> v1Eq = Vector512.Equals(vector, v1);
+                    Vector512<ushort> v2Eq = Vector512.Equals(vector, v2);
+                    Vector512<ushort> v3Eq = Vector512.Equals(vector, v3);
+                    Vector512<byte> cmp = (v1Eq | v2Eq | v3Eq).AsByte();
 
-                offset += (nuint)Vector128<ushort>.Count;
-            } while (offset <= lengthToExamine - (nuint)Vector128<ushort>.Count);
+                    if (cmp != Vector512<byte>.Zero)
+                    {
+                        // Skip every other bit
+                        ulong mask = cmp.ExtractMostSignificantBits() & 0x5555555555555555;
+                        do
+                        {
+                            uint bitPos = (uint)BitOperations.TrailingZeroCount(mask) / sizeof(char);
+                            sepListBuilder.Append((int)(offset + bitPos));
+                            mask = BitOperations.ResetLowestSetBit(mask);
+                        } while (mask != 0);
+                    }
+
+                    offset += (nuint)Vector512<ushort>.Count;
+                } while (offset <= lengthToExamine - (nuint)Vector512<ushort>.Count);
+            }
+            else if (Vector256.IsHardwareAccelerated && lengthToExamine >= (uint)Vector256<ushort>.Count*2)
+            {
+                Vector256<ushort> v1 = Vector256.Create((ushort)c);
+                Vector256<ushort> v2 = Vector256.Create((ushort)c2);
+                Vector256<ushort> v3 = Vector256.Create((ushort)c3);
+
+                do
+                {
+                    Vector256<ushort> vector = Vector256.LoadUnsafe(ref source, offset);
+                    Vector256<ushort> v1Eq = Vector256.Equals(vector, v1);
+                    Vector256<ushort> v2Eq = Vector256.Equals(vector, v2);
+                    Vector256<ushort> v3Eq = Vector256.Equals(vector, v3);
+                    Vector256<byte> cmp = (v1Eq | v2Eq | v3Eq).AsByte();
+
+                    if (cmp != Vector256<byte>.Zero)
+                    {
+                        // Skip every other bit
+                        uint mask = cmp.ExtractMostSignificantBits() & 0x55555555;
+                        do
+                        {
+                            uint bitPos = (uint)BitOperations.TrailingZeroCount(mask) / sizeof(char);
+                            sepListBuilder.Append((int)(offset + bitPos));
+                            mask = BitOperations.ResetLowestSetBit(mask);
+                        } while (mask != 0);
+                    }
+
+                    offset += (nuint)Vector256<ushort>.Count;
+                } while (offset <= lengthToExamine - (nuint)Vector256<ushort>.Count);
+            }
+            else if (Vector128.IsHardwareAccelerated)
+            {
+                Vector128<ushort> v1 = Vector128.Create((ushort)c);
+                Vector128<ushort> v2 = Vector128.Create((ushort)c2);
+                Vector128<ushort> v3 = Vector128.Create((ushort)c3);
+
+                do
+                {
+                    Vector128<ushort> vector = Vector128.LoadUnsafe(ref source, offset);
+                    Vector128<ushort> v1Eq = Vector128.Equals(vector, v1);
+                    Vector128<ushort> v2Eq = Vector128.Equals(vector, v2);
+                    Vector128<ushort> v3Eq = Vector128.Equals(vector, v3);
+                    Vector128<byte> cmp = (v1Eq | v2Eq | v3Eq).AsByte();
+
+                    if (cmp != Vector128<byte>.Zero)
+                    {
+                        // Skip every other bit
+                        uint mask = cmp.ExtractMostSignificantBits() & 0x5555;
+                        do
+                        {
+                            uint bitPos = (uint)BitOperations.TrailingZeroCount(mask) / sizeof(char);
+                            sepListBuilder.Append((int)(offset + bitPos));
+                            mask = BitOperations.ResetLowestSetBit(mask);
+                        } while (mask != 0);
+                    }
+
+                    offset += (nuint)Vector128<ushort>.Count;
+                } while (offset <= lengthToExamine - (nuint)Vector128<ushort>.Count);
+            }
 
             while (offset < lengthToExamine)
             {


### PR DESCRIPTION
Optimizing the following String APIs

1. String.Split --> Optimizing MakeSeparatorListVectorized
3. String.Replace(char oldChar, char newChar) --> Optimizing for a single iteration. Although we have measured perf on this API, it just represents optimizing a single iteration and not all.

### PERF on ICX
______________

Below tables show a result comparison output by ResultComparer in the performance repo.

Base = No changes
Diff = With the PR changes

### **1. Split**
______
A Vector128 code path already exists for this API. We are adding a similar Vector256 and Vector512 code path.

base = ```Diff Vector256 code path``` vs diff = ```Diff Vector512 code path```
| Slower                                                                           | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.09 |         25083.88 |         27315.47 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.07 |           216.23 |           231.68 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.06 |           527.11 |           561.25 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.06 |         21021.31 |         22223.51 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.04 |           292.20 |           304.67 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.04 |          5308.70 |          5499.70 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.02 |           663.91 |           678.31 |         |

| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.43 |           100.27 |            69.98 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.37 |            99.78 |            72.70 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.06 |         47539.44 |         44884.05 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.03 |          2787.30 |          2701.91 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.03 |         38497.32 |         37374.38 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.02 |          1089.85 |          1073.03 |         |

base = ```Base Vector128 code path``` vs diff = ```Diff Vector256 code path```
| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.77 |           176.76 |            99.78 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.76 |           176.33 |           100.27 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.47 |         56625.27 |         38497.32 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.43 |         67789.59 |         47539.44 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.27 |          1151.90 |           908.21 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.20 |          6348.06 |          5308.70 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.19 |          5407.90 |          4549.70 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.19 |          1293.97 |          1089.85 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.18 |          2753.15 |          2337.50 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.16 |         24393.60 |         21021.31 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.16 |           609.65 |           527.11 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.16 |         28984.70 |         25083.88 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.15 |          3213.50 |          2787.30 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.11 |           239.76 |           216.23 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.10 |           320.35 |           292.20 |         |
| System.Tests.Perf_String.Split(s: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgblu3at20nfab |      1.09 |           721.48 |           663.91 |         |


This is one of the issues where Avx512 is not that performance because of the issue with using multiple ```Vector512.Equals()```. I ran a couple of iterations using StopWatch method and below are the results.

![15](https://github.com/dotnet/runtime/assets/13829923/5f52a10f-f119-4fda-8d0d-183d433630ae)

As you can see, for each iteration, ```Vector512``` is almost the same as ```Vector256```.  Let me know if there are any suggestions for further optimizing ```Vector512``` code path. We have to decide whether this can ne merged or not since there are already ```Vector128``` code path for both the APIs. Also, the Vector256 and Vector512 code path provide a significant speed up over Vector128 code path.

### **2. Replace_Char**
_______
A Vector128 code path already exists for this API. We are just adding a single iteration of Vector512 or Vector256.

base = ```Diff, Vector256 code path``` vs diff = ```Diff Vector512 code path```

| Slower                                                                           | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Tests.Perf_String.Replace_Char(text: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgbl |      1.12 |            24.74 |            27.63 |         |
| System.Tests.Perf_String.Replace_Char(text: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgbl |      1.06 |          4003.77 |          4246.22 |         |
| System.Tests.Perf_String.Replace_Char(text: "This is a very nice sentence", oldC |      1.03 |            18.05 |            18.56 |         |

| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Tests.Perf_String.Replace_Char(text: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgbl |      1.25 |           173.57 |           139.21 |         |
| System.Tests.Perf_String.Replace_Char(text: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgbl |      1.15 |          1486.21 |          1292.79 |         |
| System.Tests.Perf_String.Replace_Char(text: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgbl |      1.15 |           722.97 |           630.87 |         |
| System.Tests.Perf_String.Replace_Char(text: "This is a very nice sentence", oldC |      1.09 |             3.90 |             3.57 |         |
| System.Tests.Perf_String.Replace_Char(text: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgbl |      1.09 |          2216.98 |          2029.28 |         |

base = ```Base Vector128 code path``` vs diff = ```Diff Vector256 code path```
| Slower                                                                           | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Tests.Perf_String.Replace_Char(text: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgbl |      1.12 |            24.74 |            27.63 |         |
| System.Tests.Perf_String.Replace_Char(text: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgbl |      1.06 |          4003.77 |          4246.22 |         |
| System.Tests.Perf_String.Replace_Char(text: "This is a very nice sentence", oldC |      1.03 |            18.05 |            18.56 |         |

| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Tests.Perf_String.Replace_Char(text: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgbl |      1.25 |           173.57 |           139.21 |         |
| System.Tests.Perf_String.Replace_Char(text: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgbl |      1.15 |          1486.21 |          1292.79 |         |
| System.Tests.Perf_String.Replace_Char(text: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgbl |      1.15 |           722.97 |           630.87 |         |
| System.Tests.Perf_String.Replace_Char(text: "This is a very nice sentence", oldC |      1.09 |             3.90 |             3.57 |         |
| System.Tests.Perf_String.Replace_Char(text: "yfesgj0sg1ijslnjsb3uofdz3tbzf6ysgbl |      1.09 |          2216.98 |          2029.28 |         |