### PR TITLE
Add catch for ConnectionAborted in Http3

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -388,6 +388,13 @@ namespace System.Net.Http
 
                 await _clientControl.WriteAsync(_pool.Settings.Http3SettingsFrame, CancellationToken.None).ConfigureAwait(false);
             }
+            catch (QuicException ex) when (ex.QuicError == QuicError.ConnectionAborted)
+            {
+                Debug.Assert(ex.ApplicationErrorCode.HasValue);
+                Http3ErrorCode code = (Http3ErrorCode)ex.ApplicationErrorCode.Value;
+
+                Abort(HttpProtocolException.CreateHttp3ConnectionException(code, SR.net_http_http3_connection_close));
+            }
             catch (Exception ex)
             {
                 Abort(ex);
@@ -576,6 +583,13 @@ namespace System.Net.Http
             catch (QuicException ex) when (ex.QuicError == QuicError.OperationAborted)
             {
                 // ignore the exception, we have already closed the connection
+            }
+            catch (QuicException ex) when (ex.QuicError == QuicError.ConnectionAborted)
+            {
+                Debug.Assert(ex.ApplicationErrorCode.HasValue);
+                Http3ErrorCode code = (Http3ErrorCode)ex.ApplicationErrorCode.Value;
+
+                Abort(HttpProtocolException.CreateHttp3ConnectionException(code, SR.net_http_http3_connection_close));
             }
             catch (Exception ex)
             {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -319,15 +319,12 @@ namespace System.Net.Http.Functional.Tests
 
             using Http3LoopbackServer server = CreateHttp3LoopbackServer();
 
-            TaskCompletionSource<bool> taskCompletionSource = new TaskCompletionSource<bool>(TaskContinuationOptions.RunContinuationsAsynchronously);
-
             Task serverTask = Task.Run(async () =>
             {
                 await using Http3LoopbackConnection connection = (Http3LoopbackConnection)await server.EstablishGenericConnectionAsync();
                 await using Http3LoopbackStream stream = await connection.AcceptRequestStreamAsync();
 
                 await connection.CloseAsync(GeneralProtocolError);
-                await taskCompletionSource.Task;
             });
 
             Task clientTask = Task.Run(async () =>
@@ -342,7 +339,6 @@ namespace System.Net.Http.Functional.Tests
                 };
 
                 await AssertProtocolErrorAsync(GeneralProtocolError, () => client.SendAsync(request));
-                taskCompletionSource.SetResult(true);
             });
 
             await new[] { clientTask, serverTask }.WhenAllOrAnyFailed(20_000);


### PR DESCRIPTION
It wasn't actually a race between, closing, etc. Since we're keeping the first exception in _abortException, we're returning that and in some cases, we weren't actually wrapping `ConnectionAbort` with `HttpProtocolException`, and it was resulting in throwing a `QuicException`.

Fixes #92359