### PR TITLE
Fix passing CMAKE_BUILD_TYPE in runtime tests using Ninja

### DIFF
--- a/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshallingNative.cpp
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshallingNative.cpp
@@ -3,6 +3,11 @@
 
 #include <xplatform.h>
 
+// MSVC versions before 19.38 generate incorrect code for this file when compiling with /O2 
+#if defined(_MSC_VER) && (_MSC_VER < 1938)
+#pragma optimize("", off)
+#endif
+
 struct StructWithShortAndBool
 {
     bool b;

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/LPArrayNative/MarshalArrayByValArrayNative.cpp
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsField/LPArrayNative/MarshalArrayByValArrayNative.cpp
@@ -7,6 +7,11 @@
 
 using namespace std;
 
+// MSVC versions before 19.38 generate incorrect code for this file when compiling with /O2 
+#if defined(_MSC_VER) && (_MSC_VER < 1938)
+#pragma optimize("", off)
+#endif
+
 /*----------------------------------------------------------------------------
 macro definition
 ----------------------------------------------------------------------------*/

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/LPArrayNative/MarshalArrayLPArrayNative.cpp
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/LPArrayNative/MarshalArrayLPArrayNative.cpp
@@ -4,6 +4,11 @@
 #include <xplatform.h>
 #include "MarshalArray.h"
 
+// MSVC versions before 19.38 generate incorrect code for this file when compiling with /O2 
+#if defined(_MSC_VER) && (_MSC_VER < 1938)
+#pragma optimize("", off)
+#endif
+
 #if defined(_MSC_VER)
 #define FUNCTIONNAME __FUNCSIG__
 #else

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -279,7 +279,7 @@ echo %__MsgPrefix%Number of processor cores %NumberOfCores%
 set __ExtraCmakeArgs=
 
 if %__Ninja% EQU 1 (
-    set __ExtraCmakeArgs="-DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_BUILD_TYPE=!__BuildType!"
+    set __ExtraCmakeArgs="-DCMAKE_SYSTEM_VERSION=10.0" "-DCMAKE_BUILD_TYPE=!__BuildType!"
 ) else (
     set __ExtraCmakeArgs="-DCMAKE_SYSTEM_VERSION=10.0"
 )


### PR DESCRIPTION
I noticed that we were building the native assets of runtime tests always in Debug mode on Windows when using Ninja, even though we passed CMAKE_BUILD_TYPE=Release.

This results in warnings like this about mismatching debug/release msvc runtime when building with NativeAOT (which uses release msvc runtime in Release config):

> [warning]LIBCMT.lib(initializers.obj)(0,0): warning LNK4098: defaultlib 'libcmtd.lib' conflicts with use of other libs; use /NODEFAULTLIB:library

It turned out that this is because we were accidentally passing CMAKE_SYSTEM_VERSION and CMAKE_BUILD_TYPE as a single string, instead of multiple. This resulted in the CMAKE_SYSTEM_VERSION being set like this in CMakeCache.txt:

```
CMAKE_SYSTEM_VERSION:UNINITIALIZED=10.0 -DCMAKE_BUILD_TYPE=Release
```

CMake then defaulted CMAKE_BUILD_TYPE to Debug.

This uncovered an MSVC bug when compiling some sources with the MSVC version used on CI in /O2 mode. This is fixed in 19.38+, disabled optimization in these files on older versions to workaround.