### PR TITLE
Pass /OPT:NOREF for DEBUG VS builds

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -118,7 +118,7 @@ if (MSVC)
     # The Ninja generator doesn't appear to have the default `/INCREMENTAL:ON` that
     # the Visual Studio generator has. Therefore we will override the default for Visual Studio only.
     add_linker_flag(/INCREMENTAL:NO DEBUG)
-    add_linker_flag(/OPT:REF DEBUG)
+    add_linker_flag(/OPT:NOREF DEBUG)
     add_linker_flag(/OPT:NOICF DEBUG)
   endif (CMAKE_GENERATOR MATCHES "^Visual Studio.*$")
 


### PR DESCRIPTION
/OPT:REF will cause the linker to optimize out unused functions/statics, which is not desirable when debugging where you may want to be able to use and inspect those members from the debugger.

See #92993 for some more context.