### PR TITLE
[wasm][debugger] Add tests for all possible types of negative arguments

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -506,8 +506,8 @@ namespace DebuggerTests
                     ("test.SumDefaultNegativeAndRequiredParamFloats(-1.1f)", TNumber("-4.4", isDecimal: true)), // default: -3.3f
                     ("test.SumDefaultNegativeAndRequiredParamDoubles(-0.1, -0.2)", TNumber("-0.30000000000000004", isDecimal: true)), // expected result for doubles copied from coreclr response
                     ("test.SumDefaultNegativeAndRequiredParamDoubles(-0.1)", TNumber("-3.3000000000000003", isDecimal: true)), // default: -3.2
-                    // ("test.SumDefaultNegativeAndRequiredParamShortInts(-1, -123)", TNumber(-124)), // we have no way of testing it, debugger recognizes passed literals as integers and does not find the correct overload. We would need to cast to short and we don't support passing parameters with a cast.
-                    // ("test.SumDefaultNegativeAndRequiredParamShortInts(-10000)", TNumber(-42769)), // default: -32768
+                    // ("test.SumDefaultNegativeAndRequiredParamShortInts(-1, -120)", TNumber(-121)), // we have no way of testing it, debugger recognizes passed literals as integers and does not find the correct overload. We would need to cast to short and we don't support passing parameters with a cast.
+                    // ("test.SumDefaultNegativeAndRequiredParamShortInts(-1)", TNumber(-124)), // default: -123
                     // ("test.GetDefaultNegativeShortInt(-123)", TNumber(-123)),
                     ("test.GetDefaultNegativeShortInt()", TNumber(-32768)), // default: -32768
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\")", TString("a; -1; False")),

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -495,12 +495,20 @@ namespace DebuggerTests
                     ("test.GetBoolNullable()", TBool(true)),
                     ("test.GetNull()", TBool(true)),
 
-                    ("test.GetDefaultAndRequiredParam(2)", TNumber(5)),
-                    ("test.GetDefaultAndRequiredParam(3, 2)", TNumber(5)),
-                    ("test.GetDefaultAndRequiredParam(3, +2)", TNumber(5)),
-                    ("test.GetDefaultAndRequiredParam(3, -2)", TNumber(1)),
-                    ("test.GetDefaultAndRequiredParam(-123l, -1.1f)", TNumber("-124.1", isDecimal: true)), // long, float
-                    ("test.GetDefaultAndRequiredParam(-0.23)", TNumber("-32768.23", isDecimal: true)), // double, short
+                    ("test.SumDefaultAndRequiredParam(2)", TNumber(5)),
+                    ("test.SumDefaultAndRequiredParam(3, 2)", TNumber(5)),
+                    ("test.SumDefaultNegativeAndRequiredParamInts(3, +2)", TNumber(5)),
+                    ("test.SumDefaultNegativeAndRequiredParamInts(-3, -2)", TNumber(-5)),
+                    ("test.SumDefaultNegativeAndRequiredParamInts(-3)", TNumber(-6)), // default: -3
+                    ("test.SumDefaultNegativeAndRequiredParamLongInts(-1l, -2l)", TNumber(-3)),
+                    ("test.SumDefaultNegativeAndRequiredParamLongInts(-1l)", TNumber(-124)), // default: -123l
+                    ("test.SumDefaultNegativeAndRequiredParamFloats(-1.1f, -1.1f)", TNumber("-2.2", isDecimal: true)),
+                    ("test.SumDefaultNegativeAndRequiredParamFloats(-1.1f)", TNumber("-4.4", isDecimal: true)), // default: -3.3f
+                    // ("test.SumDefaultNegativeAndRequiredParamDoubles(-0.1, -0.2)", TNumber("-0.3", isDecimal: true)), // precision in double operations fails, received -0.30000000000000004
+                    // ("test.SumDefaultNegativeAndRequiredParamDoubles(-0.1)", TNumber("-3.3", isDecimal: true)), // default: -3.2, precision fails, received -3.3000000000000003
+                    // ("test.SumDefaultNegativeAndRequiredParamDoubles(0.1, 0.2)", TNumber("0.3", isDecimal: true)), // positive double precision is wrong too: received 0.30000000000000004
+                    // ("test.SumDefaultNegativeAndRequiredParamShortInts(-0.111, -0.456)", TNumber("-0.567", isDecimal: true)), // we have no way of testing it, debugger recognizes passed literals as integers and does not find the correct overload. We would need to cast to short and we don't support passing parameters with a cast.
+                    // ("test.SumDefaultNegativeAndRequiredParamShortInts(-0.111)", TNumber("-3.567", isDecimal: true)), // default: -32768
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\")", TString("a; -1; False")),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23)", TString("a; 23; False")),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23, true)", TString("a; 23; True"))

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -506,8 +506,10 @@ namespace DebuggerTests
                     ("test.SumDefaultNegativeAndRequiredParamFloats(-1.1f)", TNumber("-4.4", isDecimal: true)), // default: -3.3f
                     ("test.SumDefaultNegativeAndRequiredParamDoubles(-0.1, -0.2)", TNumber("-0.30000000000000004", isDecimal: true)), // expected result for doubles copied from coreclr response
                     ("test.SumDefaultNegativeAndRequiredParamDoubles(-0.1)", TNumber("-3.3000000000000003", isDecimal: true)), // default: -3.2
-                    // ("test.SumDefaultNegativeAndRequiredParamShortInts(-0.111, -0.456)", TNumber("-0.567", isDecimal: true)), // we have no way of testing it, debugger recognizes passed literals as integers and does not find the correct overload. We would need to cast to short and we don't support passing parameters with a cast.
-                    // ("test.SumDefaultNegativeAndRequiredParamShortInts(-0.111)", TNumber("-3.567", isDecimal: true)), // default: -32768
+                    // ("test.SumDefaultNegativeAndRequiredParamShortInts(-1, -123)", TNumber(-124)), // we have no way of testing it, debugger recognizes passed literals as integers and does not find the correct overload. We would need to cast to short and we don't support passing parameters with a cast.
+                    // ("test.SumDefaultNegativeAndRequiredParamShortInts(-10000)", TNumber(-42769)), // default: -32768
+                    // ("test.GetDefaultNegativeShortInt(-123)", TNumber(-123)),
+                    ("test.GetDefaultNegativeShortInt()", TNumber(-32768)), // default: -32768
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\")", TString("a; -1; False")),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23)", TString("a; 23; False")),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23, true)", TString("a; 23; True"))

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -506,6 +506,7 @@ namespace DebuggerTests
                     ("test.SumDefaultNegativeAndRequiredParamFloats(-1.1f)", TNumber("-4.4", isDecimal: true)), // default: -3.3f
                     ("test.SumDefaultNegativeAndRequiredParamDoubles(-0.1, -0.2)", TNumber("-0.30000000000000004", isDecimal: true)), // expected result for doubles copied from coreclr response
                     ("test.SumDefaultNegativeAndRequiredParamDoubles(-0.1)", TNumber("-3.3000000000000003", isDecimal: true)), // default: -3.2
+                    // https://github.com/dotnet/runtime/issues/93057
                     // ("test.SumDefaultNegativeAndRequiredParamShortInts(-1, -120)", TNumber(-121)), // we have no way of testing it, debugger recognizes passed literals as integers and does not find the correct overload. We would need to cast to short and we don't support passing parameters with a cast.
                     // ("test.SumDefaultNegativeAndRequiredParamShortInts(-1)", TNumber(-124)), // default: -123
                     // ("test.GetDefaultNegativeShortInt(-123)", TNumber(-123)),

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -504,9 +504,8 @@ namespace DebuggerTests
                     ("test.SumDefaultNegativeAndRequiredParamLongInts(-1l)", TNumber(-124)), // default: -123l
                     ("test.SumDefaultNegativeAndRequiredParamFloats(-1.1f, -1.1f)", TNumber("-2.2", isDecimal: true)),
                     ("test.SumDefaultNegativeAndRequiredParamFloats(-1.1f)", TNumber("-4.4", isDecimal: true)), // default: -3.3f
-                    // ("test.SumDefaultNegativeAndRequiredParamDoubles(-0.1, -0.2)", TNumber("-0.3", isDecimal: true)), // precision in double operations fails, received -0.30000000000000004
-                    // ("test.SumDefaultNegativeAndRequiredParamDoubles(-0.1)", TNumber("-3.3", isDecimal: true)), // default: -3.2, precision fails, received -3.3000000000000003
-                    // ("test.SumDefaultNegativeAndRequiredParamDoubles(0.1, 0.2)", TNumber("0.3", isDecimal: true)), // positive double precision is wrong too: received 0.30000000000000004
+                    ("test.SumDefaultNegativeAndRequiredParamDoubles(-0.1, -0.2)", TNumber("-0.30000000000000004", isDecimal: true)), // expected result for doubles copied from coreclr response
+                    ("test.SumDefaultNegativeAndRequiredParamDoubles(-0.1)", TNumber("-3.3000000000000003", isDecimal: true)), // default: -3.2
                     // ("test.SumDefaultNegativeAndRequiredParamShortInts(-0.111, -0.456)", TNumber("-0.567", isDecimal: true)), // we have no way of testing it, debugger recognizes passed literals as integers and does not find the correct overload. We would need to cast to short and we don't support passing parameters with a cast.
                     // ("test.SumDefaultNegativeAndRequiredParamShortInts(-0.111)", TNumber("-3.567", isDecimal: true)), // default: -32768
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\")", TString("a; -1; False")),

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -510,7 +510,7 @@ namespace DebuggerTests
                     // ("test.SumDefaultNegativeAndRequiredParamShortInts(-1, -120)", TNumber(-121)), // we have no way of testing it, debugger recognizes passed literals as integers and does not find the correct overload. We would need to cast to short and we don't support passing parameters with a cast.
                     // ("test.SumDefaultNegativeAndRequiredParamShortInts(-1)", TNumber(-124)), // default: -123
                     // ("test.GetDefaultNegativeShortInt(-123)", TNumber(-123)),
-                    ("test.GetDefaultNegativeShortInt()", TNumber(-32768)), // default: -32768
+                    ("test.GetDefaultNegativeShortInt()", TNumber(-123)), // default: -123
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\")", TString("a; -1; False")),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23)", TString("a; 23; False")),
                     ("test.GetDefaultAndRequiredParamMixedTypes(\"a\", 23, true)", TString("a; 23; True"))

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -2000,7 +2000,8 @@ namespace DebuggerTests
             public long SumDefaultNegativeAndRequiredParamLongInts(long requiredParam, long optionalParam = -123) => requiredParam + optionalParam;
             public float SumDefaultNegativeAndRequiredParamFloats(float requiredParam, float optionalParam = -3.3f) => requiredParam + optionalParam;
             public double SumDefaultNegativeAndRequiredParamDoubles(double requiredParam, double optionalParam = -3.2) => requiredParam + optionalParam;
-            public double SumDefaultNegativeAndRequiredParamShortInts(short requiredParam, short optionalParam = -32768) => requiredParam + optionalParam;
+            public short SumDefaultNegativeAndRequiredParamShortInt(short requiredParam, short optionalParam = -32768) => (short)(requiredParam + optionalParam);
+            public short GetDefaultNegativeShortInt(short optionalParam = -32768) => optionalParam;
             public string GetDefaultAndRequiredParamMixedTypes(string requiredParam, int optionalParamFirst = -1, bool optionalParamSecond = false) => $"{requiredParam}; {optionalParamFirst}; {optionalParamSecond}";
         }
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -2000,8 +2000,8 @@ namespace DebuggerTests
             public long SumDefaultNegativeAndRequiredParamLongInts(long requiredParam, long optionalParam = -123) => requiredParam + optionalParam;
             public float SumDefaultNegativeAndRequiredParamFloats(float requiredParam, float optionalParam = -3.3f) => requiredParam + optionalParam;
             public double SumDefaultNegativeAndRequiredParamDoubles(double requiredParam, double optionalParam = -3.2) => requiredParam + optionalParam;
-            public short SumDefaultNegativeAndRequiredParamShortInts(short requiredParam, short optionalParam = -32768) => (short)(requiredParam + optionalParam);
-            public short GetDefaultNegativeShortInt(short optionalParam = -32768) => optionalParam;
+            public short SumDefaultNegativeAndRequiredParamShortInts(short requiredParam, short optionalParam = -123) => (short)(requiredParam + optionalParam);
+            public short GetDefaultNegativeShortInt(short optionalParam = -123) => optionalParam;
             public string GetDefaultAndRequiredParamMixedTypes(string requiredParam, int optionalParamFirst = -1, bool optionalParamSecond = false) => $"{requiredParam}; {optionalParamFirst}; {optionalParamSecond}";
         }
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -1995,9 +1995,12 @@ namespace DebuggerTests
 #nullable disable
 
             public bool GetNull(object param = null) => param == null ? true : false;
-            public int GetDefaultAndRequiredParam(int requiredParam, int optionalParam = 3) => requiredParam + optionalParam;
-            public float GetDefaultAndRequiredParam(long requiredParam, float optionalParam = 3.3f) => requiredParam + optionalParam;
-            public double GetDefaultAndRequiredParam(double requiredParam, short optionalParam = -32768) => requiredParam + optionalParam;
+            public int SumDefaultAndRequiredParam(int requiredParam, int optionalParam = 3) => requiredParam + optionalParam;
+            public int SumDefaultNegativeAndRequiredParamInts(int requiredParam, int optionalParam = -3) => requiredParam + optionalParam;
+            public long SumDefaultNegativeAndRequiredParamLongInts(long requiredParam, long optionalParam = -123) => requiredParam + optionalParam;
+            public float SumDefaultNegativeAndRequiredParamFloats(float requiredParam, float optionalParam = -3.3f) => requiredParam + optionalParam;
+            public double SumDefaultNegativeAndRequiredParamDoubles(double requiredParam, double optionalParam = -3.2) => requiredParam + optionalParam;
+            public double SumDefaultNegativeAndRequiredParamShortInts(short requiredParam, short optionalParam = -32768) => requiredParam + optionalParam;
             public string GetDefaultAndRequiredParamMixedTypes(string requiredParam, int optionalParamFirst = -1, bool optionalParamSecond = false) => $"{requiredParam}; {optionalParamFirst}; {optionalParamSecond}";
         }
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -2000,7 +2000,7 @@ namespace DebuggerTests
             public long SumDefaultNegativeAndRequiredParamLongInts(long requiredParam, long optionalParam = -123) => requiredParam + optionalParam;
             public float SumDefaultNegativeAndRequiredParamFloats(float requiredParam, float optionalParam = -3.3f) => requiredParam + optionalParam;
             public double SumDefaultNegativeAndRequiredParamDoubles(double requiredParam, double optionalParam = -3.2) => requiredParam + optionalParam;
-            public short SumDefaultNegativeAndRequiredParamShortInt(short requiredParam, short optionalParam = -32768) => (short)(requiredParam + optionalParam);
+            public short SumDefaultNegativeAndRequiredParamShortInts(short requiredParam, short optionalParam = -32768) => (short)(requiredParam + optionalParam);
             public short GetDefaultNegativeShortInt(short optionalParam = -32768) => optionalParam;
             public string GetDefaultAndRequiredParamMixedTypes(string requiredParam, int optionalParamFirst = -1, bool optionalParamSecond = false) => $"{requiredParam}; {optionalParamFirst}; {optionalParamSecond}";
         }


### PR DESCRIPTION
Follow up for https://github.com/dotnet/runtime/pull/92754. Added tests for negative literals that are passes as default and required parameters. Short int is a special case that cannot be tested the same way as other types. Details in the issue: https://github.com/dotnet/runtime/issues/93057.