### PR TITLE
Add UZP1

### DIFF
--- a/src/coreclr/jit/emitfmtsarm64.h
+++ b/src/coreclr/jit/emitfmtsarm64.h
@@ -220,6 +220,8 @@ IF_DEF(DV_3E,  IS_NONE, NONE) // DV_3E  ........XX.mmmmm ......nnnnnddddd      V
 IF_DEF(DV_3EI, IS_NONE, NONE) // DV_3EI ........XXLMmmmm ....H.nnnnnddddd      Vd Vn Vm[] (scalar by element)
 IF_DEF(DV_3F,  IS_NONE, NONE) // DV_3F  ...........mmmmm ......nnnnnddddd      Qd Sn Vm   (Qd used as both source and destination)
 IF_DEF(DV_3G,  IS_NONE, NONE) // DV_3G   .Q.........mmmmm .iiii.nnnnnddddd     Vd Vn Vm imm (vector)
+IF_DEF(DV_3H,  IS_NONE, NONE) // DV_3H  ........XX.mmmmm ......nnnnnddddd      Vd Vn Vm   (SVE vector)
+IF_DEF(DV_3I,  IS_NONE, NONE) // DV_3I  ........XX..mmmm .......nnnn.dddd      Pd Pn Pm   (SVE predicate)
 
 IF_DEF(DV_4A,  IS_NONE, NONE) // DV_4A  .........X.mmmmm .aaaaannnnnddddd      Vd Vn Vm Va (scalar)
 

--- a/src/coreclr/jit/hwintrinsiclistarm64.h
+++ b/src/coreclr/jit/hwintrinsiclistarm64.h
@@ -764,6 +764,15 @@ HARDWARE_INTRINSIC(Sha256,        HashUpdate2,                                  
 HARDWARE_INTRINSIC(Sha256,        ScheduleUpdate0,                                                  16,      2,     false,  {INS_invalid,        INS_invalid,        INS_invalid,        INS_invalid,        INS_invalid,        INS_sha256su0,      INS_invalid,        INS_invalid,        INS_invalid,        INS_invalid},     HW_Category_SIMD,                  HW_Flag_HasRMWSemantics)
 HARDWARE_INTRINSIC(Sha256,        ScheduleUpdate1,                                                  16,      3,     false,  {INS_invalid,        INS_invalid,        INS_invalid,        INS_invalid,        INS_invalid,        INS_sha256su1,      INS_invalid,        INS_invalid,        INS_invalid,        INS_invalid},     HW_Category_SIMD,                  HW_Flag_HasRMWSemantics)
 
+
+// ***************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
+//                 ISA            Function name                                              SIMD size  NumArg  EncodesExtraTypeArg                                                                                            Instructions                                                                                        Category                           Flags
+//                                                                                                                          {TYP_BYTE,           TYP_UBYTE,          TYP_SHORT,          TYP_USHORT,         TYP_INT,            TYP_UINT,           TYP_LONG,           TYP_ULONG,          TYP_FLOAT,          TYP_DOUBLE}
+// ***************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
+//  SVE Intrinsics
+HARDWARE_INTRINSIC(SVE_Arm64,     UnzipEven,                                                        -1,      2,      true,  {INS_uzp1,           INS_uzp1,           INS_uzp1,           INS_uzp1,           INS_uzp1,           INS_uzp1,           INS_uzp1,           INS_uzp1,           INS_uzp1,           INS_uzp1},        HW_Category_SVE,                  HW_Flag_NoFlag)
+
+
 #endif // FEATURE_HW_INTRINSIC
 
 #undef HARDWARE_INTRINSIC

--- a/src/coreclr/jit/instrsarm64.h
+++ b/src/coreclr/jit/instrsarm64.h
@@ -1680,8 +1680,10 @@ INST1(fminnmv,     "fminnmv",      0,      IF_DV_2R,  0x2EB0C800)
 INST1(fminv,       "fminv",        0,      IF_DV_2R,  0x2EB0F800)
                                    //  fminv   Vd,Vn                DV_2R  0Q1011101X110000 111110nnnnnddddd   2EB0 F800   Vd,Vn      (vector)
 
-INST1(uzp1,        "uzp1",         0,      IF_DV_3A,  0x0E001800)
+INST3(uzp1,        "uzp1",         0,      IF_EN3n,   0x0E001800,  0x05206800, 0x05204800)
                                    //  uzp1    Vd,Vn,Vm             DV_3A  0Q001110XX0mmmmm 000110nnnnnddddd   0E00 1800   Vd,Vn,Vm  (vector)
+                                   //  uzp1    Zd,Zn,Zm             DV_3H  00000101XX1mmmmm 011010nnnnnddddd   0520 6800   Zd,Zn,Zm  (SVE vector)
+                                   //  uzp1    Pd,Pn,Pm             DV_3I  00000101XX10mmmm 0100100nnnn0dddd   0520 4800   Pd,Pn,Pm  (SVE predicate)
 
 INST1(uzp2,        "uzp2",         0,      IF_DV_3A,  0x0E005800)
                                    //  upz2    Vd,Vn,Vm             DV_3A  0Q001110XX0mmmmm 010110nnnnnddddd   0E00 5800   Vd,Vn,Vm  (vector)


### PR DESCRIPTION
Add SVE variants of the UZP1 instruction.

This will not build as the corresponding SVE functions do not exist.