### PR TITLE
[release/6.0-staging] Re-add emsdk key to NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,6 +9,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-emsdk -->
+    <add key="darc-pub-dotnet-emsdk-f472bde" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-f472bde6/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-wcf -->
     <!--  End: Package sources from dotnet-wcf -->


### PR DESCRIPTION
The key was removed by the bot in this PR https://github.com/dotnet/runtime/pull/92884 