### PR TITLE
[Android][build] Fix android package name containing `-`

### DIFF
--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -393,6 +393,9 @@ public partial class ApkBuilder
         if (!string.IsNullOrEmpty(ProjectName) && checkNumerics.IsMatch(ProjectName))
             ProjectName = checkNumerics.Replace(ProjectName, @"_$1");
 
+        if (!string.IsNullOrEmpty(ProjectName) && ProjectName.Contains('-'))
+            ProjectName = ProjectName.Replace("-", "_");
+
         string packageId = $"net.dot.{ProjectName}";
 
         File.WriteAllText(javaActivityPath,

--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -338,7 +338,6 @@ public partial class ApkBuilder
         string monodroidSource = (IsLibraryMode) ? "monodroid-librarymode.c" : "monodroid.c";
 
         string cmakeLists = Utils.GetEmbeddedResource("CMakeLists-android.txt")
-            .Replace("%ProjectName%", ProjectName)
             .Replace("%MonoInclude%", monoRuntimeHeaders)
             .Replace("%NativeLibrariesToLink%", nativeLibraries)
             .Replace("%MONODROID_SOURCE%", monodroidSource)


### PR DESCRIPTION
The android app builder formats the final package name based on the ProjectName. Some projects contain hyphens `-`, which is not allowed in the android package name.

This PR looks to substitute underscores in place of hyphens in the produced android package name.