### PR TITLE
Get rid of static constructor in Task<T>

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -1041,7 +1041,7 @@ namespace System.IO
                     Task.CompletedTask;
 
             public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>
-                TaskToAsyncResult.Begin(Task<int>.s_defaultResultTask, callback, state);
+                TaskToAsyncResult.Begin(TaskCache.CachedDefaultValueTask<int>.s_defaultResultTask, callback, state);
 
             public override int EndRead(IAsyncResult asyncResult) =>
                 TaskToAsyncResult.End<int>(asyncResult);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -1041,7 +1041,7 @@ namespace System.IO
                     Task.CompletedTask;
 
             public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>
-                TaskToAsyncResult.Begin(TaskCache.CachedDefaultValueTask<int>.s_defaultResultTask, callback, state);
+                TaskToAsyncResult.Begin(TaskCache.CachedDefaultTask<int>.s_defaultResultTask, callback, state);
 
             public override int EndRead(IAsyncResult asyncResult) =>
                 TaskToAsyncResult.End<int>(asyncResult);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
@@ -58,9 +58,6 @@ namespace System.Threading.Tasks
     [DebuggerDisplay("Id = {Id}, Status = {Status}, Method = {DebuggerDisplayMethodDescription}, Result = {DebuggerDisplayResultDescription}")]
     public class Task<TResult> : Task
     {
-        /// <summary>A cached task for default(TResult).</summary>
-        internal static readonly Task<TResult> s_defaultResultTask = TaskCache.CreateCacheableTask<TResult>(default);
-
         private static TaskFactory<TResult>? s_Factory;
 
         // The value itself, if set.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -5274,7 +5274,7 @@ namespace System.Threading.Tasks
             if (result is null)
             {
                 // null reference types and default(Nullable<T>)
-                return TaskCache.CachedDefaultValueTask<TResult>.s_defaultResultTask;
+                return TaskCache.CachedDefaultTask<TResult>.s_defaultResultTask;
             }
 
             // For Boolean, we cache all possible values.
@@ -5307,7 +5307,7 @@ namespace System.Threading.Tasks
                     (sizeof(TResult) == sizeof(ulong) && *(ulong*)&result == default) ||
                     (sizeof(TResult) == sizeof(UInt128) && *(UInt128*)&result == default))
                 {
-                    return TaskCache.CachedDefaultValueTask<TResult>.s_defaultResultTask;
+                    return TaskCache.CachedDefaultTask<TResult>.s_defaultResultTask;
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -5274,7 +5274,7 @@ namespace System.Threading.Tasks
             if (result is null)
             {
                 // null reference types and default(Nullable<T>)
-                return Task<TResult>.s_defaultResultTask;
+                return TaskCache.CachedDefaultValueTask<TResult>.s_defaultResultTask;
             }
 
             // For Boolean, we cache all possible values.
@@ -5307,7 +5307,7 @@ namespace System.Threading.Tasks
                     (sizeof(TResult) == sizeof(ulong) && *(ulong*)&result == default) ||
                     (sizeof(TResult) == sizeof(UInt128) && *(UInt128*)&result == default))
                 {
-                    return Task<TResult>.s_defaultResultTask;
+                    return TaskCache.CachedDefaultValueTask<TResult>.s_defaultResultTask;
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
@@ -40,5 +40,14 @@ namespace System.Threading.Tasks
 
             return tasks;
         }
+
+        /// <summary>
+        /// A cached task for default(TResult).
+        /// </summary>
+        internal static class CachedDefaultValueTask<TResult>
+        {
+            internal static Task<TResult> s_defaultResultTask = CreateCacheableTask<TResult>(default);
+        }
+
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
@@ -44,7 +44,7 @@ namespace System.Threading.Tasks
         /// <summary>
         /// A cached task for default(TResult).
         /// </summary>
-        internal static class CachedDefaultValueTask<TResult>
+        internal static class CachedDefaultTask<TResult>
         {
             internal static readonly Task<TResult> s_defaultResultTask = CreateCacheableTask<TResult>(default);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
@@ -46,7 +46,7 @@ namespace System.Threading.Tasks
         /// </summary>
         internal static class CachedDefaultValueTask<TResult>
         {
-            internal static Task<TResult> s_defaultResultTask = CreateCacheableTask<TResult>(default);
+            internal static readonly Task<TResult> s_defaultResultTask = CreateCacheableTask<TResult>(default);
         }
 
     }


### PR DESCRIPTION
Because the `default(TResult)` task was cached in in the `Task<TResult>` class, every instantiation would run the static constructor.

With this change, the cached value is stored in
`TaskCache.CachedDefaultTask<TResult>` instead, and `Task<TResult>` no longer needs to execute a static constructor.

This is expected to improve startup time for applications that do a lot of async work.  (But no measurements have been done).  Validated that ``Task`1::.cctor`` does not exist in the IL after this change
