### PR TITLE
Convert AllConfigurations and NETFX jobs to use the global build templates

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
@@ -90,6 +90,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NET48_$(_BuildConfig)
+            extraHelixArguments: /p:BuildTargetFramework=net48
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
@@ -75,15 +75,21 @@ jobs:
 # Run net48 tests on win-x64
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
-    jobTemplate: /eng/pipelines/libraries/build-job.yml
+    jobTemplate: /eng/pipelines/common/global-build-job.yml
     buildConfig: Release
     platforms:
     - windows_x64
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
       framework: net48
-      runTests: true
-      testScope: innerloop
+      buildArgs: -s tools+libs+libs.tests -framework net48 -c $(_BuildConfig) -testscope innerloop /p:ArchiveTests=true
+      nameSuffix: Libraries_NET48
+      timeoutInMinutes: 150
+      postBuildSteps:
+        - template: /eng/pipelines/libraries/helix.yml
+          parameters:
+            creator: dotnet-bot
+            testRunNamePrefixSuffix: NET48_$(_BuildConfig)
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -172,8 +172,6 @@ extends:
           - SourceBuild_linux_x64
           jobParameters:
             nameSuffix: PortableSourceBuild
-            extraStepsParameters:
-              name: SourceBuildPackages
             timeoutInMinutes: 95
             condition:
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true)

--- a/eng/pipelines/installer/jobs/build-job.yml
+++ b/eng/pipelines/installer/jobs/build-job.yml
@@ -11,7 +11,6 @@ parameters:
   container: ''
   buildSteps: []
   dependsOn: []
-  dependsOnGlobalBuild: false
   dependOnEvaluatePaths: false
   globalBuildSuffix: ''
   variables: []

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -5,7 +5,6 @@ parameters:
   osSubgroup: ''
   crossBuild: false
   framework: 'net9.0'
-  isOfficialAllConfigurations: false
   isSourceBuild: false
   liveRuntimeBuildConfig: ''
   runtimeFlavor: 'coreclr'
@@ -28,10 +27,10 @@ parameters:
 jobs:
   - template: /eng/common/templates/job/job.yml
     parameters:
-      ${{ if notIn(parameters.framework, 'allConfigurations', 'net48') }}:
+      ${{ if notIn(parameters.framework, 'net48') }}:
         displayName: ${{ format('Libraries {0} {1}{2} {3} {4}', parameters.displayName, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
         name: ${{ format('libraries_{0}_{1}{2}_{3}_{4}', parameters.name, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-      ${{ if in(parameters.framework, 'allConfigurations', 'net48') }}:
+      ${{ if in(parameters.framework, 'net48') }}:
         displayName: ${{ format('Libraries {0} {1} {2} {3} {4}', parameters.displayName, parameters.osGroup, parameters.framework, parameters.archType, parameters.buildConfig) }}
         name: ${{ format('libraries_{0}_{1}_{2}{3}_{4}_{5}', parameters.name, parameters.framework, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
 
@@ -78,13 +77,6 @@ jobs:
         - ${{ if ne(parameters.framework, '') }}:
           - _finalFrameworkArg: -framework ${{ parameters.framework }}
           - _extraHelixArguments: /p:BuildTargetFramework=${{ parameters.framework }}
-
-        - ${{ if eq(parameters.framework, 'allConfigurations') }}:
-          - _finalFrameworkArg: -allConfigurations
-          - _testModeArg: /p:TestAssemblies=false /p:TestPackages=true
-
-        - ${{ if eq(parameters.isOfficialAllConfigurations, true) }}:
-          - librariesBuildArtifactName: 'libraries_bin_official_allconfigurations'
 
         - ${{ if eq(parameters.isOfficialBuild, true) }}:
           - _msbuildCommonParameters: /p:OfficialBuildId=$(Build.BuildNumber)

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -27,12 +27,8 @@ parameters:
 jobs:
   - template: /eng/common/templates/job/job.yml
     parameters:
-      ${{ if notIn(parameters.framework, 'net48') }}:
-        displayName: ${{ format('Libraries {0} {1}{2} {3} {4}', parameters.displayName, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        name: ${{ format('libraries_{0}_{1}{2}_{3}_{4}', parameters.name, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-      ${{ if in(parameters.framework, 'net48') }}:
-        displayName: ${{ format('Libraries {0} {1} {2} {3} {4}', parameters.displayName, parameters.osGroup, parameters.framework, parameters.archType, parameters.buildConfig) }}
-        name: ${{ format('libraries_{0}_{1}_{2}{3}_{4}_{5}', parameters.name, parameters.framework, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+      displayName: ${{ format('Libraries {0} {1}{2} {3} {4}', parameters.displayName, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+      name: ${{ format('libraries_{0}_{1}{2}_{3}_{4}', parameters.name, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
 
       enableTelemetry: ${{ parameters.isOfficialBuild }} # TODO: figure out if it's needed
       container: ${{ parameters.container }}

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -29,8 +29,6 @@ parameters:
   pool: ''
   # Run tests as part of the build job (instead of running them in a separate job)
   runTests: false
-  # Package up the test builds so they can be sent to Helix
-  useHelix: true
   testScope: ''
 
 jobs:
@@ -66,18 +64,12 @@ jobs:
       variables:
         - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
         - _subset: tools+libs+libs.tests
-        - ${{ if and(eq(parameters.runTests, false), eq(parameters.useHelix, false)) }}:
+        - ${{ if eq(parameters.runTests, false) }}:
           - _subset: tools+libs
         - _buildAction: ''
-        - _additionalBuildArguments: ''
+        - _additionalBuildArguments: '/p:ArchiveTests=true'
         - ${{ parameters.variables }}
 
-        # Tests only run for 'net48' build-jobs
-        # Only pass -test for when we aren't running tests using Helix.
-        - ${{ if and(eq(parameters.runTests, true), eq(parameters.useHelix, false)) }}:
-          - _buildAction: -restore -build -test
-        - ${{ if eq(parameters.useHelix, true) }}:
-          - _additionalBuildArguments: /p:ArchiveTests=true
 
         - ${{ parameters.variables }}
 
@@ -123,7 +115,7 @@ jobs:
               displayName: Build Assets
 
           # Upload test assets if we are sending tests to Helix and not running them directly in this job.
-          - ${{ if and(eq(parameters.runTests, false), eq(parameters.useHelix, true)) }}:
+          - ${{ if and(eq(parameters.runTests, false)) }}:
             - template: /eng/pipelines/common/upload-artifact-step.yml
               parameters:
                 rootFolder: $(Build.SourcesDirectory)/artifacts/helix
@@ -134,7 +126,7 @@ jobs:
                 artifactName: $(librariesTestsArtifactName)
                 displayName: Test Assets
 
-        - ${{ if and(eq(parameters.runTests, true), eq(parameters.useHelix, true)) }}:
+        - ${{ if and(eq(parameters.runTests, true)) }}:
           - template: /eng/pipelines/libraries/helix.yml
             parameters:
               osGroup: ${{ parameters.osGroup }}

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -7,7 +7,6 @@ parameters:
   crossBuild: false
   framework: 'net9.0'
   isOfficialBuild: false
-  isOfficialAllConfigurations: false
   runtimeVariant: ''
   platform: ''
 
@@ -44,7 +43,6 @@ jobs:
       crossBuild: ${{ parameters.crossBuild }}
       framework:  ${{ parameters.framework }}
       isOfficialBuild: ${{ parameters.isOfficialBuild }}
-      isOfficialAllConfigurations: ${{ parameters.isOfficialAllConfigurations }}
       liveRuntimeBuildConfig: ${{ parameters.liveRuntimeBuildConfig }}
       runtimeFlavor: ${{ parameters.runtimeFlavor }}
       runTests: ${{ parameters.runTests }}
@@ -74,7 +72,7 @@ jobs:
         - _additionalBuildArguments: ''
         - ${{ parameters.variables }}
 
-        # Tests only run for 'allConfiguration' and 'net48' build-jobs
+        # Tests only run for 'net48' build-jobs
         # Only pass -test for when we aren't running tests using Helix.
         - ${{ if and(eq(parameters.runTests, true), eq(parameters.useHelix, false)) }}:
           - _buildAction: -restore -build -test
@@ -135,19 +133,6 @@ jobs:
                 tarCompression: $(tarCompression)
                 artifactName: $(librariesTestsArtifactName)
                 displayName: Test Assets
-
-          # Save AllConfigurations artifacts using the prepare-signed-artifacts format. The
-          # platform-specific jobs' nupkgs automatically flow through the matching platform-specific
-          # Installer build, but AllConfigurations should only be uploaded once, here.
-          - ${{ if eq(parameters.isOfficialAllConfigurations, true) }}:
-            - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-              parameters:
-                name: Libraries_AllConfigurations
-                publishPackagesCondition: >-
-                  or(
-                     eq(variables['_librariesBuildProducedPackages'], true),
-                     eq(variables['Build.SourceBranchName'], 'main'),
-                     eq(variables['System.PullRequest.TargetBranch'], 'main'))
 
         - ${{ if and(eq(parameters.runTests, true), eq(parameters.useHelix, true)) }}:
           - template: /eng/pipelines/libraries/helix.yml

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -9,17 +9,9 @@ parameters:
   isOfficialBuild: false
   runtimeVariant: ''
   platform: ''
-
-  # When set to a non-empty value (Debug / Release), it determines the runtime's
-  # build configuration to use for building libraries and tests. Setting this
-  # property implies a dependency of this job on the appropriate runtime build
-  # and is used to construct the name of the Azure artifact representing
-  # runtime build to use for building the libraries and library tests.
-  liveRuntimeBuildConfig: ''
-  runtimeFlavor: 'coreclr'
+  testScope: ''
 
   timeoutInMinutes: 150
-  preBuildSteps: []
   container: ''
   condition: true
   dependOnEvaluatePaths: false
@@ -27,9 +19,6 @@ parameters:
   shouldContinueOnError: false
   variables: {}
   pool: ''
-  # Run tests as part of the build job (instead of running them in a separate job)
-  runTests: false
-  testScope: ''
 
 jobs:
   - template: /eng/pipelines/libraries/base-job.yml
@@ -41,11 +30,9 @@ jobs:
       crossBuild: ${{ parameters.crossBuild }}
       framework:  ${{ parameters.framework }}
       isOfficialBuild: ${{ parameters.isOfficialBuild }}
-      liveRuntimeBuildConfig: ${{ parameters.liveRuntimeBuildConfig }}
       runtimeFlavor: ${{ parameters.runtimeFlavor }}
-      runTests: ${{ parameters.runTests }}
+      runTests: false
       timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
-      preBuildSteps: ${{ parameters.preBuildSteps }}
       container: ${{ parameters.container }}
       condition: ${{ parameters.condition }}
       dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
@@ -56,27 +43,14 @@ jobs:
       name: build
       displayName: 'Build'
 
-      ${{ if and(ne(parameters.liveRuntimeBuildConfig, ''), eq(parameters.runTests, true)) }}:
-        dependsOn:
-        # Use full product dependency for test runs
-        - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}', parameters.runtimeFlavor, parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveRuntimeBuildConfig) }}
-
       variables:
         - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
         - _subset: tools+libs+libs.tests
-        - ${{ if eq(parameters.runTests, false) }}:
-          - _subset: tools+libs
         - _buildAction: ''
         - _additionalBuildArguments: '/p:ArchiveTests=true'
         - ${{ parameters.variables }}
 
-
-        - ${{ parameters.variables }}
-
       steps:
-        - ${{ if eq(parameters.isOfficialBuild, true) }}:
-          - template: /eng/pipelines/common/restore-internal-tools.yml
-
         - ${{ if in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator') }}:
           - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }}
             displayName: Install Build Dependencies
@@ -99,43 +73,26 @@ jobs:
               df -h
             displayName: Disk Usage after Build
 
-        - ${{ if eq(parameters.runTests, false) }}:
-          - template: /eng/pipelines/libraries/prepare-for-bin-publish.yml
-            parameters:
-              isOfficialBuild: ${{ parameters.isOfficialBuild }}
+        - template: /eng/pipelines/libraries/prepare-for-bin-publish.yml
 
-          - template: /eng/pipelines/common/upload-artifact-step.yml
-            parameters:
-              rootFolder: $(Build.ArtifactStagingDirectory)/artifacts
-              includeRootFolder: false
-              archiveType: $(archiveType)
-              archiveExtension: $(archiveExtension)
-              tarCompression: $(tarCompression)
-              artifactName: $(librariesBuildArtifactName)
-              displayName: Build Assets
+        - template: /eng/pipelines/common/upload-artifact-step.yml
+          parameters:
+            rootFolder: $(Build.ArtifactStagingDirectory)/artifacts
+            includeRootFolder: false
+            archiveType: $(archiveType)
+            archiveExtension: $(archiveExtension)
+            tarCompression: $(tarCompression)
+            artifactName: $(librariesBuildArtifactName)
+            displayName: Build Assets
 
-          # Upload test assets if we are sending tests to Helix and not running them directly in this job.
-          - ${{ if and(eq(parameters.runTests, false)) }}:
-            - template: /eng/pipelines/common/upload-artifact-step.yml
-              parameters:
-                rootFolder: $(Build.SourcesDirectory)/artifacts/helix
-                includeRootFolder: true
-                archiveType: $(archiveType)
-                archiveExtension: $(archiveExtension)
-                tarCompression: $(tarCompression)
-                artifactName: $(librariesTestsArtifactName)
-                displayName: Test Assets
-
-        - ${{ if and(eq(parameters.runTests, true)) }}:
-          - template: /eng/pipelines/libraries/helix.yml
-            parameters:
-              osGroup: ${{ parameters.osGroup }}
-              targetRid: ${{ parameters.targetRid }}
-              archType: ${{ parameters.archType }}
-              buildConfig: ${{ parameters.buildConfig }}
-              helixQueues: ${{ parameters.helixQueues }}
-              testScope: ${{ parameters.testScope }}
-              shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-              creator: dotnet-bot
-              testRunNamePrefixSuffix: $(_testRunNamePrefixSuffix)
-              extraHelixArguments: $(_extraHelixArguments)
+        # Upload test assets
+        # We'll pull them down in another job to send to Helix
+        - template: /eng/pipelines/common/upload-artifact-step.yml
+          parameters:
+            rootFolder: $(Build.SourcesDirectory)/artifacts/helix
+            includeRootFolder: true
+            archiveType: $(archiveType)
+            archiveExtension: $(archiveExtension)
+            tarCompression: $(tarCompression)
+            artifactName: $(librariesTestsArtifactName)
+            displayName: Test Assets

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -68,6 +68,7 @@ jobs:
       - ${{ if ne(parameters.dependsOn[0], '') }}:
         - ${{ parameters.dependsOn }}
       - ${{ if eq(parameters.dependsOn[0], '') }}:
+        - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
         - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
           - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}', parameters.runtimeFlavor, parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveRuntimeBuildConfig) }}
       # SuperPMI collection needs to run mcs.exe on the AzDO machine. Assume that's an x64 machine, and download an x64 product build if needed.

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -68,8 +68,6 @@ jobs:
       - ${{ if ne(parameters.dependsOn[0], '') }}:
         - ${{ parameters.dependsOn }}
       - ${{ if eq(parameters.dependsOn[0], '') }}:
-        - ${{ if notIn(parameters.framework, 'net48') }}:
-          - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
         - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
           - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}', parameters.runtimeFlavor, parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveRuntimeBuildConfig) }}
       # SuperPMI collection needs to run mcs.exe on the AzDO machine. Assume that's an x64 machine, and download an x64 product build if needed.

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -68,7 +68,7 @@ jobs:
       - ${{ if ne(parameters.dependsOn[0], '') }}:
         - ${{ parameters.dependsOn }}
       - ${{ if eq(parameters.dependsOn[0], '') }}:
-        - ${{ if notIn(parameters.framework, 'allConfigurations', 'net48') }}:
+        - ${{ if notIn(parameters.framework, 'net48') }}:
           - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
         - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
           - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}', parameters.runtimeFlavor, parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveRuntimeBuildConfig) }}

--- a/eng/pipelines/runtime-android-grpc-client-tests.yml
+++ b/eng/pipelines/runtime-android-grpc-client-tests.yml
@@ -43,7 +43,7 @@ extends:
             buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunGrpcTestsOnly=true /p:BuildGrpcServerDockerImage=true
             timeoutInMinutes: 180
             # extra steps, run tests
-            extraStepsTemplats:
+            postBuildSteps:
               - template: /eng/pipelines/libraries/helix.yml
                 parameters:
                   creator: dotnet-bot

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -108,7 +108,7 @@ extends:
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
             buildArgs: -s clr+libs+tools.illink -c $(_BuildConfig)
-            extraStepsTemplats:
+            postBuildSteps:
               - template: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
 
       #

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1128,6 +1128,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   testRunNamePrefixSuffix: NET48_$(_BuildConfig)
+                  extraHelixArguments: /p:BuildTargetFramework=net48
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -658,15 +658,16 @@ extends:
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
             # extra steps, run tests
-            extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-              testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-              condition: >-
-                or(
-                eq(variables['librariesContainsChange'], true),
-                eq(variables['monoContainsChange'], true),
-                eq(variables['isRollingBuild'], true))
+            postBuildSteps:
+              - template: /eng/pipelines/libraries/helix.yml
+                parameters:
+                  creator: dotnet-bot
+                  testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                  condition: >-
+                    or(
+                    eq(variables['librariesContainsChange'], true),
+                    eq(variables['monoContainsChange'], true),
+                    eq(variables['isRollingBuild'], true))
 
       #
       # iOS/tvOS devices - Full AOT + AggressiveTrimming to reduce size
@@ -1614,8 +1615,6 @@ extends:
           - SourceBuild_centos8_x64
           jobParameters:
             nameSuffix: centos8SourceBuild
-            extraStepsParameters:
-              name: SourceBuildPackages
             timeoutInMinutes: 95
             condition: eq(variables['isRollingBuild'], true)
 
@@ -1628,7 +1627,5 @@ extends:
           - SourceBuild_banana24_x64
           jobParameters:
             nameSuffix: banana24SourceBuild
-            extraStepsParameters:
-              name: SourceBuildPackages
             timeoutInMinutes: 95
             condition: eq(variables['isRollingBuild'], true)

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1123,16 +1123,19 @@ extends:
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
+      #
+      # Build and test libraries AllConfigurations
+      #
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
-          jobTemplate: /eng/pipelines/libraries/build-job.yml
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
           platforms:
           - windows_x64
           jobParameters:
-            framework: allConfigurations
-            runTests: true
-            useHelix: false
+            buildArgs: -restore -build -test -s tools+libs+libs.tests -allConfigurations -c $(_BuildConfig) /p:TestAssemblies=false /p:TestPackages=true
+            nameSuffix: Libraries_AllConfigurations
+            timeoutInMinutes: 150
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1144,7 +1144,7 @@ extends:
           platforms:
           - windows_x64
           jobParameters:
-            buildArgs: -restore -build -test -s tools+libs+libs.tests -allConfigurations -c $(_BuildConfig) /p:TestAssemblies=false /p:TestPackages=true
+            buildArgs: -test -s tools+libs+libs.tests -allConfigurations -c $(_BuildConfig) /p:TestAssemblies=false /p:TestPackages=true
             nameSuffix: Libraries_AllConfigurations
             timeoutInMinutes: 150
             condition: >-

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1107,17 +1107,26 @@ extends:
               condition: >-
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true)
 
+      #
+      # Build and test libraries for .NET Framework
+      #
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
-          jobTemplate: /eng/pipelines/libraries/build-job.yml
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: Release
           platforms:
           - windows_x86
           helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
           jobParameters:
             framework: net48
-            runTests: true
-            testScope: innerloop
+            buildArgs: -s tools+libs+libs.tests -framework net48 -c $(_BuildConfig) -testscope innerloop /p:ArchiveTests=true
+            nameSuffix: Libraries_NET48
+            timeoutInMinutes: 150
+            postBuildSteps:
+              - template: /eng/pipelines/libraries/helix.yml
+                parameters:
+                  creator: dotnet-bot
+                  testRunNamePrefixSuffix: NET48_$(_BuildConfig)
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),


### PR DESCRIPTION
Moving these two jobs that have minor customizations to use the global build template + post build steps to reduce complexity in the libraries build and test jobs. Also clean up some places that were still on extraStepsTemplate or were attempting to be (but had typos).