### PR TITLE
Handle binding to initialized abstract members

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
@@ -1047,15 +1047,13 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     else
                     {
                         Debug.Assert(!type.IsValueType);
-
+                        EmitStartBlock($"if ({instanceToBindExpr} is not null)");
+                        EmitBindCoreCall();
+                        EmitEndBlock();
                         if (type is ObjectSpec { InitExceptionMessage: string exMsg })
                         {
+                            EmitStartBlock("else");
                             _writer.WriteLine($@"throw new {Identifier.InvalidOperationException}(""{exMsg}"");");
-                        }
-                        else
-                        {
-                            EmitStartBlock($"if ({instanceToBindExpr} is not null)");
-                            EmitBindCoreCall();
                             EmitEndBlock();
                         }
                     }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -842,6 +842,11 @@ namespace Microsoft.Extensions
         {
             public int Value2 { get; set; }
         }
+        
+        internal class ClassWithAbstractProp
+        {
+            public AbstractBase AbstractProp { get; set; }
+        }
 
         internal class ClassWithAbstractCtorParam
         {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -2325,6 +2325,25 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         }
 
         [Fact]
+        public static void TestBindingInitializedAbstractMember()
+        {
+            IConfiguration configuration = TestHelpers.GetConfigurationFromJsonString(@"{ ""AbstractProp"": {""Value"":1} }");
+            ClassWithAbstractProp c = new();
+            c.AbstractProp = new Derived();
+            configuration.Bind(c);
+            Assert.Equal(1, c.AbstractProp.Value);            
+        }
+
+        [Fact]
+        public static void TestBindingUninitializedAbstractMember()
+        {
+            IConfiguration configuration = TestHelpers.GetConfigurationFromJsonString(@"{ ""AbstractProp"": {""Value"":1} }");
+            ClassWithAbstractProp c = new();
+            c.AbstractProp = null;
+            Assert.Throws<InvalidOperationException>(() => configuration.Bind(c));        
+        }
+        
+        [Fact]
         public void GetIConfigurationSection()
         {
             var configuration = TestHelpers.GetConfigurationFromJsonString("""


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/92137

If an abstract member is encountered in an object graph we should only throw if it's not already initialized.