### PR TITLE
[mono] Enable branch optimizations when using LLVM.

### DIFF
--- a/src/mono/mono/mini/branch-opts.c
+++ b/src/mono/mono/mini/branch-opts.c
@@ -1311,7 +1311,7 @@ mono_optimize_branches (MonoCompile *cfg)
 					/* the block are in sequence anyway ... */
 
 					/* branches to the following block can be removed */
-					if (bb->last_ins && bb->last_ins->opcode == OP_BR && !bbn->out_of_line) {
+					if (!COMPILE_LLVM (cfg) && bb->last_ins && bb->last_ins->opcode == OP_BR && !bbn->out_of_line) {
 						NULLIFY_INS (bb->last_ins);
 						changed = TRUE;
 						if (cfg->verbose_level > 2)

--- a/src/mono/mono/mini/mini-codegen.c
+++ b/src/mono/mono/mini/mini-codegen.c
@@ -2165,8 +2165,9 @@ mono_local_regalloc (MonoCompile *cfg, MonoBasicBlock *bb)
 
 MONO_RESTORE_WARNING
 
+/* Returns -1 if opcode is not a conditional */
 CompRelation
-mono_opcode_to_cond (int opcode)
+mono_opcode_to_cond_unchecked (int opcode)
 {
 	switch (opcode) {
 	case OP_CEQ:
@@ -2286,10 +2287,21 @@ mono_opcode_to_cond (int opcode)
 	case OP_CMOV_LGT_UN:
 		return CMP_GT_UN;
 	default:
+		return (CompRelation)-1;
+	}
+}
+
+CompRelation
+mono_opcode_to_cond (int opcode)
+{
+	CompRelation rel = mono_opcode_to_cond_unchecked (opcode);
+
+	if (rel == (CompRelation)-1) {
 		printf ("%s\n", mono_inst_name (opcode));
 		g_assert_not_reached ();
 		return (CompRelation)0;
 	}
+	return rel;
 }
 
 CompRelation

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -6145,7 +6145,10 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 				/* The comparison result is not needed */
 				continue;
 
-			rel = mono_opcode_to_cond (ins->next->opcode);
+			rel = mono_opcode_to_cond_unchecked (ins->next->opcode);
+			if (rel == (CompRelation)-1)
+				/* The following branch etc. was optimized away */
+				continue;
 
 			if (ins->opcode == OP_ICOMPARE_IMM) {
 				lhs = convert (ctx, lhs, LLVMInt32Type ());
@@ -12138,7 +12141,7 @@ MONO_RESTORE_WARNING
 	if (!ctx_ok (ctx))
 		return;
 
-	if (!has_terminator && bb->next_bb && (bb == cfg->bb_entry || bb->in_count > 0)) {
+	if (!has_terminator && bb->next_bb && bb != cfg->bb_exit && (bb == cfg->bb_entry || bb->in_count > 0)) {
 		LLVMBuildBr (builder, get_bb (ctx, bb->next_bb));
 	}
 
@@ -12961,8 +12964,13 @@ emit_method_inner (EmitContext *ctx)
 		bb = (MonoBasicBlock*)g_ptr_array_index (bblock_list, bb_index);
 
 		// Prune unreachable mono BBs.
-		if (!(bb == cfg->bb_entry || bb->in_count > 0))
+		if (!(bb == cfg->bb_entry || bb->in_count > 0)) {
+			LLVMBasicBlockRef target_bb = ctx->bblocks [bb->block_num].call_handler_target_bb;
+			if (target_bb)
+				/* Unused */
+				LLVMDeleteBasicBlock (target_bb);
 			continue;
+		}
 
 		process_bb (ctx, bb);
 		if (!ctx_ok (ctx))

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3550,9 +3550,6 @@ mini_method_compile (MonoMethod *method, guint32 opts, JitFlags flags, int parts
 		}
 
 		cfg->opt &= ~MONO_OPT_LINEARS;
-
-		/* FIXME: */
-		cfg->opt &= ~MONO_OPT_BRANCH;
 	}
 
 	cfg->after_method_to_ir = TRUE;

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2356,6 +2356,7 @@ MonoMethod*       mini_get_memset_method (void);
 int               mini_class_check_context_used (MonoCompile *cfg, MonoClass *klass);
 MonoRgctxAccess   mini_get_rgctx_access_for_method (MonoMethod *method);
 
+CompRelation      mono_opcode_to_cond_unchecked (int opcode);
 CompRelation      mono_opcode_to_cond (int opcode);
 CompType          mono_opcode_to_type (int opcode, int cmp_opcode);
 CompRelation      mono_negate_cond (CompRelation cond);


### PR DESCRIPTION
Doing these optimizations early enables the removal of some dead code which decreases the amount of generic instances the aot compiler generates since the aot compiler will no longer encounter the methods called in the dead code.