### PR TITLE
Fix "warning : Reference to undeclared extern assembly 'mscorlib'" in tst.il

### DIFF
--- a/src/tests/Regressions/coreclr/44465/tst.il
+++ b/src/tests/Regressions/coreclr/44465/tst.il
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 .assembly tst { }
+.assembly extern mscorlib { }
 .assembly extern xunit.core {}
  
 .method static void* GetValue()


### PR DESCRIPTION
The test was missing the reference.