### PR TITLE
Optimize Ordinal.EqualsIgnoreCase_Vector with AVX2 and AVX512

### DIFF
--- a/src/libraries/Common/src/System/HexConverter.cs
+++ b/src/libraries/Common/src/System/HexConverter.cs
@@ -281,7 +281,7 @@ namespace System
                 // or some byte greater than 0x0f.
                 Vector128<byte> nibbles = Vector128.Min(t2 - Vector128.Create((byte)0xF0), t4);
                 // Any high bit is a sign that input is not a valid hex data
-                if (!Utf16Utility.AllCharsInVector128AreAscii(vec1 | vec2) ||
+                if (!Utf16Utility.AllCharsInVectorAreAscii(vec1 | vec2) ||
                     Vector128.AddSaturate(nibbles, Vector128.Create((byte)(127 - 15))).ExtractMostSignificantBits() != 0)
                 {
                     // Input is either non-ASCII or invalid hex data

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -82,7 +82,6 @@ namespace System.Globalization
             where TVector : struct, ISimdVector<TVector, ushort>
         {
             Debug.Assert(length >= TVector.Count);
-            Debug.Assert(TVector.IsHardwareAccelerated);
 
             nuint lengthU = (nuint)length;
             nuint lengthToExamine = lengthU - (nuint)TVector.Count;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.cs
@@ -278,41 +278,41 @@ namespace System.Text.Unicode
         }
 
         /// <summary>
-        /// Returns true iff the Vector128 represents 8 ASCII UTF-16 characters in machine endianness.
+        /// Returns true iff the TVector represents N ASCII UTF-16 characters in machine endianness.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool AllCharsInVector128AreAscii(Vector128<ushort> vec)
+        internal static bool AllCharsInVectorAreAscii<TVector>(TVector vec)
+            where TVector : struct, ISimdVector<TVector, ushort>
         {
-            return (vec & Vector128.Create(unchecked((ushort)~0x007F))) == Vector128<ushort>.Zero;
+            return (vec & TVector.Create(unchecked((ushort)~0x007F))) == TVector.Zero;
         }
 
         /// <summary>
-        /// Given two Vector128 that represent 8 ASCII UTF-16 characters each, returns true iff
+        /// Given two TVector that represent N ASCII UTF-16 characters each, returns true iff
         /// the two inputs are equal using an ordinal case-insensitive comparison.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool Vector128OrdinalIgnoreCaseAscii(Vector128<ushort> vec1, Vector128<ushort> vec2)
+        internal static bool VectorOrdinalIgnoreCaseAscii<TVector>(TVector vec1, TVector vec2)
+            where TVector : struct, ISimdVector<TVector, ushort>
         {
             // ASSUMPTION: Caller has validated that input values are ASCII.
 
             // the 0x80 bit of each word of 'lowerIndicator' will be set iff the word has value >= 'A'
-            Vector128<sbyte> lowIndicator1 = Vector128.Create((sbyte)(0x80 - 'A')) + vec1.AsSByte();
-            Vector128<sbyte> lowIndicator2 = Vector128.Create((sbyte)(0x80 - 'A')) + vec2.AsSByte();
+            TVector lowIndicator1 = TVector.Create(0x80 - 'A') + vec1;
+            TVector lowIndicator2 = TVector.Create(0x80 - 'A') + vec2;
 
             // the 0x80 bit of each word of 'combinedIndicator' will be set iff the word has value >= 'A' and <= 'Z'
-            Vector128<sbyte> combIndicator1 =
-                Vector128.LessThan(Vector128.Create(unchecked((sbyte)(('Z' - 'A') - 0x80))), lowIndicator1);
-            Vector128<sbyte> combIndicator2 =
-                Vector128.LessThan(Vector128.Create(unchecked((sbyte)(('Z' - 'A') - 0x80))), lowIndicator2);
+            TVector combIndicator1 =
+                TVector.LessThan(TVector.Create(unchecked((ushort)(('Z' - 'A') - 0x80))), lowIndicator1);
+            TVector combIndicator2 =
+                TVector.LessThan(TVector.Create(unchecked((ushort)(('Z' - 'A') - 0x80))), lowIndicator2);
 
             // Convert both vectors to lower case by adding 0x20 bit for all [A-Z][a-z] characters
-            Vector128<sbyte> lcVec1 =
-                Vector128.AndNot(Vector128.Create((sbyte)0x20), combIndicator1) + vec1.AsSByte();
-            Vector128<sbyte> lcVec2 =
-                Vector128.AndNot(Vector128.Create((sbyte)0x20), combIndicator2) + vec2.AsSByte();
+            TVector lcVec1 = TVector.AndNot(TVector.Create(0x20), combIndicator1) + vec1;
+            TVector lcVec2 = TVector.AndNot(TVector.Create(0x20), combIndicator2) + vec2;
 
             // Compare two lowercased vectors
-            return (lcVec1 ^ lcVec2) == Vector128<sbyte>.Zero;
+            return lcVec1 == lcVec2;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.cs
@@ -278,41 +278,13 @@ namespace System.Text.Unicode
         }
 
         /// <summary>
-        /// Returns true iff the TVector represents N ASCII UTF-16 characters in machine endianness.
+        /// Returns true iff the TVector represents ASCII UTF-16 characters in machine endianness.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool AllCharsInVectorAreAscii<TVector>(TVector vec)
             where TVector : struct, ISimdVector<TVector, ushort>
         {
             return (vec & TVector.Create(unchecked((ushort)~0x007F))) == TVector.Zero;
-        }
-
-        /// <summary>
-        /// Given two TVector that represent N ASCII UTF-16 characters each, returns true iff
-        /// the two inputs are equal using an ordinal case-insensitive comparison.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool VectorOrdinalIgnoreCaseAscii<TVector>(TVector vec1, TVector vec2)
-            where TVector : struct, ISimdVector<TVector, ushort>
-        {
-            // ASSUMPTION: Caller has validated that input values are ASCII.
-
-            // the 0x80 bit of each word of 'lowerIndicator' will be set iff the word has value >= 'A'
-            TVector lowIndicator1 = TVector.Create(0x80 - 'A') + vec1;
-            TVector lowIndicator2 = TVector.Create(0x80 - 'A') + vec2;
-
-            // the 0x80 bit of each word of 'combinedIndicator' will be set iff the word has value >= 'A' and <= 'Z'
-            TVector combIndicator1 =
-                TVector.LessThan(TVector.Create(unchecked((byte)(('Z' - 'A') - 0x80))), lowIndicator1);
-            TVector combIndicator2 =
-                TVector.LessThan(TVector.Create(unchecked((byte)(('Z' - 'A') - 0x80))), lowIndicator2);
-
-            // Convert both vectors to lower case by adding 0x20 bit for all [A-Z][a-z] characters
-            TVector lcVec1 = TVector.AndNot(TVector.Create(0x20), combIndicator1) + vec1;
-            TVector lcVec2 = TVector.AndNot(TVector.Create(0x20), combIndicator2) + vec2;
-
-            // Compare two lowercased vectors
-            return lcVec1 == lcVec2;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.cs
@@ -284,7 +284,7 @@ namespace System.Text.Unicode
         internal static bool AllCharsInVectorAreAscii<TVector>(TVector vec)
             where TVector : struct, ISimdVector<TVector, ushort>
         {
-            return (vec & TVector.Create(unchecked((ushort)~0x007F))) == TVector.Zero;
+            return (vec & TVector.Create(unchecked((ushort)~0x007F))).Equals(TVector.Zero);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.cs
@@ -303,9 +303,9 @@ namespace System.Text.Unicode
 
             // the 0x80 bit of each word of 'combinedIndicator' will be set iff the word has value >= 'A' and <= 'Z'
             TVector combIndicator1 =
-                TVector.LessThan(TVector.Create(unchecked((ushort)(('Z' - 'A') - 0x80))), lowIndicator1);
+                TVector.LessThan(TVector.Create(unchecked((byte)(('Z' - 'A') - 0x80))), lowIndicator1);
             TVector combIndicator2 =
-                TVector.LessThan(TVector.Create(unchecked((ushort)(('Z' - 'A') - 0x80))), lowIndicator2);
+                TVector.LessThan(TVector.Create(unchecked((byte)(('Z' - 'A') - 0x80))), lowIndicator2);
 
             // Convert both vectors to lower case by adding 0x20 bit for all [A-Z][a-z] characters
             TVector lcVec1 = TVector.AndNot(TVector.Create(0x20), combIndicator1) + vec1;


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/92497

Currently, `str1.Equals(str2, StringComparison.OrdinalIgnoreCase)` is only accelerated with `Vector128`, this PR adds `Vector256` and `Vector512` via `ISimdVector` abstraction - the best part that there is no code duplication.


```cs
public class Benchmarks
{
    static readonly string s1 = @"C:\prj\runtime\src\coreclr\System.Private.CoreLib\System.Private.CoreLib.csproj";
    static readonly string s2 = @"C:\prj\runtime\src\coreclr\System.Private.CoreLib\system.Private.CoreLib.csproj";

    [Benchmark]
    public bool EqualsIgnoreCase()
    {
        return s1.Equals(s2, StringComparison.OrdinalIgnoreCase);
    }
}
```

| Method           | Toolchain             | Mean      | Error    | StdDev    | Ratio |
|----------------- |---------------------- |----------:|---------:|----------:|------:|
| EqualsIgnoreCase | Core_Root\corerun.exe | 10.610 ns | 0.1701 ns | 0.1591 ns |  1.00 |
| EqualsIgnoreCase | Core_Root_PR\corerun.exe |  **5.878 ns** | 0.0354 ns | 0.0313 ns |  0.55 |
