### PR TITLE
Improve performance of re-used symmetric one shots

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
@@ -573,7 +573,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
         [InlineData(CipherMode.ECB)]
         [InlineData(CipherMode.CBC)]
         [InlineData(CipherMode.CFB)]
@@ -620,7 +620,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
         [InlineData(CipherMode.ECB)]
         [InlineData(CipherMode.CBC)]
         [InlineData(CipherMode.CFB)]
@@ -667,7 +667,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
         [InlineData(CipherMode.ECB)]
         [InlineData(CipherMode.CBC)]
         [InlineData(CipherMode.CFB)]
@@ -730,7 +730,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
         [InlineData(CipherMode.ECB)]
         [InlineData(CipherMode.CBC)]
         [InlineData(CipherMode.CFB)]

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.cs
@@ -9,7 +9,12 @@ namespace System.Security.Cryptography
 {
     internal sealed partial class AesImplementation : Aes
     {
-        private ILiteSymmetricCipher? _encryptCbcLiteHash, _decryptCbcLiteHash, _encryptEcbLiteHash, _decryptEcbLiteHash;
+        private const int BitsPerByte = 8;
+
+        private ILiteSymmetricCipher? _encryptCbcLiteHash;
+        private ILiteSymmetricCipher? _decryptCbcLiteHash;
+        private ILiteSymmetricCipher? _encryptEcbLiteHash;
+        private ILiteSymmetricCipher? _decryptEcbLiteHash;
 
         public sealed override ICryptoTransform CreateDecryptor()
         {
@@ -274,7 +279,5 @@ namespace System.Security.Cryptography
             Interlocked.Exchange(ref _encryptEcbLiteHash, null)?.Dispose();
             Interlocked.Exchange(ref _decryptEcbLiteHash, null)?.Dispose();
         }
-
-        private const int BitsPerByte = 8;
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesImplementation.cs
@@ -43,7 +43,7 @@ namespace System.Security.Cryptography
 
         protected sealed override void Dispose(bool disposing)
         {
-            InvalidOneShotAlgorithms();
+            InvalidateOneShotAlgorithms();
             base.Dispose(disposing);
         }
 
@@ -52,7 +52,7 @@ namespace System.Security.Cryptography
             set
             {
                 base.Key = value;
-                InvalidOneShotAlgorithms();
+                InvalidateOneShotAlgorithms();
             }
         }
 
@@ -267,7 +267,7 @@ namespace System.Security.Cryptography
             return result;
         }
 
-        private void InvalidOneShotAlgorithms()
+        private void InvalidateOneShotAlgorithms()
         {
             Interlocked.Exchange(ref _encryptCbcLiteHash, null)?.Dispose();
             Interlocked.Exchange(ref _decryptCbcLiteHash, null)?.Dispose();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DesImplementation.cs
@@ -11,7 +11,11 @@ namespace System.Security.Cryptography
     internal sealed partial class DesImplementation : DES
     {
         private const int BitsPerByte = 8;
-        private ILiteSymmetricCipher? _encryptCbcLiteHash, _decryptCbcLiteHash, _encryptEcbLiteHash, _decryptEcbLiteHash;
+
+        private ILiteSymmetricCipher? _encryptCbcLiteHash;
+        private ILiteSymmetricCipher? _decryptCbcLiteHash;
+        private ILiteSymmetricCipher? _encryptEcbLiteHash;
+        private ILiteSymmetricCipher? _decryptEcbLiteHash;
 
         public DesImplementation()
         {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DesImplementation.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Threading;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -9,6 +11,7 @@ namespace System.Security.Cryptography
     internal sealed partial class DesImplementation : DES
     {
         private const int BitsPerByte = 8;
+        private ILiteSymmetricCipher? _encryptCbcLiteHash, _decryptCbcLiteHash, _encryptEcbLiteHash, _decryptEcbLiteHash;
 
         public DesImplementation()
         {
@@ -52,7 +55,23 @@ namespace System.Security.Cryptography
             {
                 RandomNumberGenerator.Fill(key);
             }
-            KeyValue = key;
+
+            Key = key;
+        }
+
+        protected sealed override void Dispose(bool disposing)
+        {
+            InvalidateOneShotAlgorithms();
+            base.Dispose(disposing);
+        }
+
+        public override byte[] Key
+        {
+            set
+            {
+                base.Key = value;
+                InvalidateOneShotAlgorithms();
+            }
         }
 
         private UniversalCryptoTransform CreateTransform(byte[] rgbKey, byte[]? rgbIV, bool encrypting)
@@ -99,19 +118,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = CreateLiteCipher(
+            return OneShotTransformation(
+                ref _decryptEcbLiteHash,
                 CipherMode.ECB,
-                Key,
-                iv: null,
-                blockSize: BlockSize / BitsPerByte,
-                0, /*feedback size */
-                paddingSize: BlockSize / BitsPerByte,
-                encrypting: false);
-
-            using (cipher)
-            {
-                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
-            }
+                iv: default,
+                encrypting: false,
+                paddingMode,
+                ciphertext,
+                destination,
+                UniversalCryptoOneShot.OneShotDecrypt,
+                out bytesWritten);
         }
 
         protected override bool TryEncryptEcbCore(
@@ -120,19 +136,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = CreateLiteCipher(
+            return OneShotTransformation(
+                ref _encryptEcbLiteHash,
                 CipherMode.ECB,
-                Key,
-                iv: null,
-                blockSize: BlockSize / BitsPerByte,
-                0, /*feedback size */
-                paddingSize: BlockSize / BitsPerByte,
-                encrypting: true);
-
-            using (cipher)
-            {
-                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
-            }
+                iv: default,
+                encrypting: true,
+                paddingMode,
+                plaintext,
+                destination,
+                UniversalCryptoOneShot.OneShotEncrypt,
+                out bytesWritten);
         }
 
         protected override bool TryEncryptCbcCore(
@@ -142,19 +155,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = CreateLiteCipher(
+            return OneShotTransformation(
+                ref _encryptCbcLiteHash,
                 CipherMode.CBC,
-                Key,
                 iv,
-                blockSize: BlockSize / BitsPerByte,
-                0, /*feedback size */
-                paddingSize: BlockSize / BitsPerByte,
-                encrypting: true);
-
-            using (cipher)
-            {
-                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
-            }
+                encrypting: true,
+                paddingMode,
+                plaintext,
+                destination,
+                UniversalCryptoOneShot.OneShotEncrypt,
+                out bytesWritten);
         }
 
         protected override bool TryDecryptCbcCore(
@@ -164,19 +174,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = CreateLiteCipher(
+            return OneShotTransformation(
+                ref _decryptCbcLiteHash,
                 CipherMode.CBC,
-                Key,
                 iv,
-                blockSize: BlockSize / BitsPerByte,
-                0, /*feedback size */
-                paddingSize: BlockSize / BitsPerByte,
-                encrypting: false);
-
-            using (cipher)
-            {
-                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
-            }
+                encrypting: false,
+                paddingMode,
+                ciphertext,
+                destination,
+                UniversalCryptoOneShot.OneShotDecrypt,
+                out bytesWritten);
         }
 
         protected override bool TryDecryptCfbCore(
@@ -236,6 +243,59 @@ namespace System.Security.Cryptography
             {
                 throw new CryptographicException(SR.Format(SR.Cryptography_CipherModeFeedbackNotSupported, feedback, CipherMode.CFB));
             }
+        }
+
+        private bool OneShotTransformation(
+            ref ILiteSymmetricCipher? cipherCache,
+            CipherMode cipherMode,
+            ReadOnlySpan<byte> iv,
+            bool encrypting,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            UniversalCryptoOneShot.UniversalOneShotCallback callback,
+            out int bytesWritten)
+        {
+            // Ensures we have a zero feedback size.
+            Debug.Assert(cipherMode is CipherMode.CBC or CipherMode.ECB);
+
+            // Try grabbing a cached instance.
+            ILiteSymmetricCipher? cipher = Interlocked.Exchange(ref cipherCache, null);
+
+            if (cipher is null)
+            {
+                // If there is no cached instance available, create one. This also sets the initialization vector during creation.
+                cipher = CreateLiteCipher(
+                    cipherMode,
+                    Key,
+                    iv,
+                    blockSize: BlockSize / BitsPerByte,
+                    0, /*feedback size */
+                    paddingSize: BlockSize / BitsPerByte,
+                    encrypting);
+            }
+            else
+            {
+                // If we did grab a cached instance, put it back in to a working state. This needs to happen even for ECB
+                // since lite ciphers do not reset after the final transformation automatically.
+                cipher.Reset(iv);
+            }
+
+            bool result = callback(cipher, paddingMode, source, destination, out bytesWritten);
+
+            // Try making this instance available to use again later. If another thread put one there, dispose of it.
+            cipher = Interlocked.Exchange(ref cipherCache, cipher);
+            cipher?.Dispose();
+
+            return result;
+        }
+
+        private void InvalidateOneShotAlgorithms()
+        {
+            Interlocked.Exchange(ref _encryptCbcLiteHash, null)?.Dispose();
+            Interlocked.Exchange(ref _decryptCbcLiteHash, null)?.Dispose();
+            Interlocked.Exchange(ref _encryptEcbLiteHash, null)?.Dispose();
+            Interlocked.Exchange(ref _decryptEcbLiteHash, null)?.Dispose();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RC2Implementation.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RC2Implementation.cs
@@ -11,7 +11,11 @@ namespace System.Security.Cryptography
     internal sealed partial class RC2Implementation : RC2
     {
         private const int BitsPerByte = 8;
-        private ILiteSymmetricCipher? _encryptCbcLiteHash, _decryptCbcLiteHash, _encryptEcbLiteHash, _decryptEcbLiteHash;
+
+        private ILiteSymmetricCipher? _encryptCbcLiteHash;
+        private ILiteSymmetricCipher? _decryptCbcLiteHash;
+        private ILiteSymmetricCipher? _encryptEcbLiteHash;
+        private ILiteSymmetricCipher? _decryptEcbLiteHash;
 
         public override int EffectiveKeySize
         {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RC2Implementation.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RC2Implementation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Threading;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -10,6 +11,7 @@ namespace System.Security.Cryptography
     internal sealed partial class RC2Implementation : RC2
     {
         private const int BitsPerByte = 8;
+        private ILiteSymmetricCipher? _encryptCbcLiteHash, _decryptCbcLiteHash, _encryptEcbLiteHash, _decryptEcbLiteHash;
 
         public override int EffectiveKeySize
         {
@@ -54,6 +56,21 @@ namespace System.Security.Cryptography
             Key = RandomNumberGenerator.GetBytes(KeySize / BitsPerByte);
         }
 
+        protected sealed override void Dispose(bool disposing)
+        {
+            InvalidateOneShotAlgorithms();
+            base.Dispose(disposing);
+        }
+
+        public override byte[] Key
+        {
+            set
+            {
+                base.Key = value;
+                InvalidateOneShotAlgorithms();
+            }
+        }
+
         private UniversalCryptoTransform CreateTransform(byte[] rgbKey, byte[]? rgbIV, bool encrypting)
         {
             ArgumentNullException.ThrowIfNull(rgbKey);
@@ -85,22 +102,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            if (!ValidKeySize(Key.Length))
-                throw new InvalidOperationException(SR.Cryptography_InvalidKeySize);
-
-            Debug.Assert(EffectiveKeySize == KeySize);
-            ILiteSymmetricCipher cipher = CreateLiteCipher(
+            return OneShotTransformation(
+                ref _decryptEcbLiteHash,
                 CipherMode.ECB,
-                Key,
-                iv: null,
-                blockSize: BlockSize / BitsPerByte,
-                paddingSize: BlockSize / BitsPerByte,
-                encrypting: false);
-
-            using (cipher)
-            {
-                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
-            }
+                iv: default,
+                encrypting: false,
+                paddingMode,
+                ciphertext,
+                destination,
+                UniversalCryptoOneShot.OneShotDecrypt,
+                out bytesWritten);
         }
 
         protected override bool TryEncryptEcbCore(
@@ -109,22 +120,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            if (!ValidKeySize(Key.Length))
-                throw new InvalidOperationException(SR.Cryptography_InvalidKeySize);
-
-            Debug.Assert(EffectiveKeySize == KeySize);
-            ILiteSymmetricCipher cipher = CreateLiteCipher(
+            return OneShotTransformation(
+                ref _encryptEcbLiteHash,
                 CipherMode.ECB,
-                Key,
                 iv: default,
-                blockSize: BlockSize / BitsPerByte,
-                paddingSize: BlockSize / BitsPerByte,
-                encrypting: true);
-
-            using (cipher)
-            {
-                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
-            }
+                encrypting: true,
+                paddingMode,
+                plaintext,
+                destination,
+                UniversalCryptoOneShot.OneShotEncrypt,
+                out bytesWritten);
         }
 
         protected override bool TryEncryptCbcCore(
@@ -134,22 +139,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            if (!ValidKeySize(Key.Length))
-                throw new InvalidOperationException(SR.Cryptography_InvalidKeySize);
-
-            Debug.Assert(EffectiveKeySize == KeySize);
-            ILiteSymmetricCipher cipher = CreateLiteCipher(
+            return OneShotTransformation(
+                ref _encryptCbcLiteHash,
                 CipherMode.CBC,
-                Key,
                 iv,
-                blockSize: BlockSize / BitsPerByte,
-                paddingSize: BlockSize / BitsPerByte,
-                encrypting: true);
-
-            using (cipher)
-            {
-                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
-            }
+                encrypting: true,
+                paddingMode,
+                plaintext,
+                destination,
+                UniversalCryptoOneShot.OneShotEncrypt,
+                out bytesWritten);
         }
 
         protected override bool TryDecryptCbcCore(
@@ -159,22 +158,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            if (!ValidKeySize(Key.Length))
-                throw new InvalidOperationException(SR.Cryptography_InvalidKeySize);
-
-            Debug.Assert(EffectiveKeySize == KeySize);
-            ILiteSymmetricCipher cipher = CreateLiteCipher(
+            return OneShotTransformation(
+                ref _decryptCbcLiteHash,
                 CipherMode.CBC,
-                Key,
                 iv,
-                blockSize: BlockSize / BitsPerByte,
-                paddingSize: BlockSize / BitsPerByte,
-                encrypting: false);
-
-            using (cipher)
-            {
-                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
-            }
+                encrypting: false,
+                paddingMode,
+                ciphertext,
+                destination,
+                UniversalCryptoOneShot.OneShotDecrypt,
+                out bytesWritten);
         }
 
         protected override bool TryDecryptCfbCore(
@@ -219,6 +212,61 @@ namespace System.Security.Cryptography
 
             int keySizeBits = keySizeBytes << 3;
             return keySizeBits.IsLegalSize(LegalKeySizes);
+        }
+
+        private bool OneShotTransformation(
+            ref ILiteSymmetricCipher? cipherCache,
+            CipherMode cipherMode,
+            ReadOnlySpan<byte> iv,
+            bool encrypting,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            UniversalCryptoOneShot.UniversalOneShotCallback callback,
+            out int bytesWritten)
+        {
+            // Ensures we have a zero feedback size.
+            Debug.Assert(cipherMode is CipherMode.CBC or CipherMode.ECB);
+
+            if (!ValidKeySize(Key.Length))
+                throw new InvalidOperationException(SR.Cryptography_InvalidKeySize);
+
+            // Try grabbing a cached instance.
+            ILiteSymmetricCipher? cipher = Interlocked.Exchange(ref cipherCache, null);
+
+            if (cipher is null)
+            {
+                // If there is no cached instance available, create one. This also sets the initialization vector during creation.
+                cipher = CreateLiteCipher(
+                    cipherMode,
+                    Key,
+                    iv,
+                    blockSize: BlockSize / BitsPerByte,
+                    paddingSize: BlockSize / BitsPerByte,
+                    encrypting);
+            }
+            else
+            {
+                // If we did grab a cached instance, put it back in to a working state. This needs to happen even for ECB
+                // since lite ciphers do not reset after the final transformation automatically.
+                cipher.Reset(iv);
+            }
+
+            bool result = callback(cipher, paddingMode, source, destination, out bytesWritten);
+
+            // Try making this instance available to use again later. If another thread put one there, dispose of it.
+            cipher = Interlocked.Exchange(ref cipherCache, cipher);
+            cipher?.Dispose();
+
+            return result;
+        }
+
+        private void InvalidateOneShotAlgorithms()
+        {
+            Interlocked.Exchange(ref _encryptCbcLiteHash, null)?.Dispose();
+            Interlocked.Exchange(ref _decryptCbcLiteHash, null)?.Dispose();
+            Interlocked.Exchange(ref _encryptEcbLiteHash, null)?.Dispose();
+            Interlocked.Exchange(ref _decryptEcbLiteHash, null)?.Dispose();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/TripleDesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/TripleDesImplementation.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Threading;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -9,6 +11,7 @@ namespace System.Security.Cryptography
     internal sealed partial class TripleDesImplementation : TripleDES
     {
         private const int BitsPerByte = 8;
+        private ILiteSymmetricCipher? _encryptCbcLiteHash, _decryptCbcLiteHash, _encryptEcbLiteHash, _decryptEcbLiteHash;
 
         public TripleDesImplementation()
         {
@@ -45,6 +48,21 @@ namespace System.Security.Cryptography
         public sealed override void GenerateKey()
         {
             Key = RandomNumberGenerator.GetBytes(KeySize / BitsPerByte);
+        }
+
+        protected sealed override void Dispose(bool disposing)
+        {
+            InvalidateOneShotAlgorithms();
+            base.Dispose(disposing);
+        }
+
+        public override byte[] Key
+        {
+            set
+            {
+                base.Key = value;
+                InvalidateOneShotAlgorithms();
+            }
         }
 
         private UniversalCryptoTransform CreateTransform(byte[] rgbKey, byte[]? rgbIV, bool encrypting)
@@ -96,19 +114,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = CreateLiteCipher(
+            return OneShotTransformation(
+                ref _decryptEcbLiteHash,
                 CipherMode.ECB,
-                Key,
                 iv: default,
-                blockSize: BlockSize / BitsPerByte,
-                paddingSize: BlockSize / BitsPerByte,
-                0, /*feedback size */
-                encrypting: false);
-
-            using (cipher)
-            {
-                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
-            }
+                encrypting: false,
+                paddingMode,
+                ciphertext,
+                destination,
+                UniversalCryptoOneShot.OneShotDecrypt,
+                out bytesWritten);
         }
 
         protected override bool TryEncryptEcbCore(
@@ -117,19 +132,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = CreateLiteCipher(
+            return OneShotTransformation(
+                ref _encryptEcbLiteHash,
                 CipherMode.ECB,
-                Key,
                 iv: default,
-                blockSize: BlockSize / BitsPerByte,
-                paddingSize: BlockSize / BitsPerByte,
-                0, /*feedback size */
-                encrypting: true);
-
-            using (cipher)
-            {
-                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
-            }
+                encrypting: true,
+                paddingMode,
+                plaintext,
+                destination,
+                UniversalCryptoOneShot.OneShotEncrypt,
+                out bytesWritten);
         }
 
         protected override bool TryEncryptCbcCore(
@@ -139,19 +151,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = CreateLiteCipher(
+            return OneShotTransformation(
+                ref _encryptCbcLiteHash,
                 CipherMode.CBC,
-                Key,
                 iv,
-                blockSize: BlockSize / BitsPerByte,
-                paddingSize: BlockSize / BitsPerByte,
-                0, /*feedback size */
-                encrypting: true);
-
-            using (cipher)
-            {
-                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
-            }
+                encrypting: true,
+                paddingMode,
+                plaintext,
+                destination,
+                UniversalCryptoOneShot.OneShotEncrypt,
+                out bytesWritten);
         }
 
         protected override bool TryDecryptCbcCore(
@@ -161,19 +170,16 @@ namespace System.Security.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            ILiteSymmetricCipher cipher = CreateLiteCipher(
+            return OneShotTransformation(
+                ref _decryptCbcLiteHash,
                 CipherMode.CBC,
-                Key,
                 iv,
-                blockSize: BlockSize / BitsPerByte,
-                paddingSize: BlockSize / BitsPerByte,
-                0, /*feedback size */
-                encrypting: false);
-
-            using (cipher)
-            {
-                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
-            }
+                encrypting: false,
+                paddingMode,
+                ciphertext,
+                destination,
+                UniversalCryptoOneShot.OneShotDecrypt,
+                out bytesWritten);
         }
 
         protected override bool TryDecryptCfbCore(
@@ -233,6 +239,59 @@ namespace System.Security.Cryptography
             {
                 throw new CryptographicException(SR.Format(SR.Cryptography_CipherModeFeedbackNotSupported, feedback, CipherMode.CFB));
             }
+        }
+
+        private bool OneShotTransformation(
+            ref ILiteSymmetricCipher? cipherCache,
+            CipherMode cipherMode,
+            ReadOnlySpan<byte> iv,
+            bool encrypting,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            UniversalCryptoOneShot.UniversalOneShotCallback callback,
+            out int bytesWritten)
+        {
+            // Ensures we have a zero feedback size.
+            Debug.Assert(cipherMode is CipherMode.CBC or CipherMode.ECB);
+
+            // Try grabbing a cached instance.
+            ILiteSymmetricCipher? cipher = Interlocked.Exchange(ref cipherCache, null);
+
+            if (cipher is null)
+            {
+                // If there is no cached instance available, create one. This also sets the initialization vector during creation.
+                cipher = CreateLiteCipher(
+                    cipherMode,
+                    Key,
+                    iv,
+                    blockSize: BlockSize / BitsPerByte,
+                    paddingSize: BlockSize / BitsPerByte,
+                    0, /*feedback size */
+                    encrypting);
+            }
+            else
+            {
+                // If we did grab a cached instance, put it back in to a working state. This needs to happen even for ECB
+                // since lite ciphers do not reset after the final transformation automatically.
+                cipher.Reset(iv);
+            }
+
+            bool result = callback(cipher, paddingMode, source, destination, out bytesWritten);
+
+            // Try making this instance available to use again later. If another thread put one there, dispose of it.
+            cipher = Interlocked.Exchange(ref cipherCache, cipher);
+            cipher?.Dispose();
+
+            return result;
+        }
+
+        private void InvalidateOneShotAlgorithms()
+        {
+            Interlocked.Exchange(ref _encryptCbcLiteHash, null)?.Dispose();
+            Interlocked.Exchange(ref _decryptCbcLiteHash, null)?.Dispose();
+            Interlocked.Exchange(ref _encryptEcbLiteHash, null)?.Dispose();
+            Interlocked.Exchange(ref _decryptEcbLiteHash, null)?.Dispose();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/TripleDesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/TripleDesImplementation.cs
@@ -11,7 +11,11 @@ namespace System.Security.Cryptography
     internal sealed partial class TripleDesImplementation : TripleDES
     {
         private const int BitsPerByte = 8;
-        private ILiteSymmetricCipher? _encryptCbcLiteHash, _decryptCbcLiteHash, _encryptEcbLiteHash, _decryptEcbLiteHash;
+
+        private ILiteSymmetricCipher? _encryptCbcLiteHash;
+        private ILiteSymmetricCipher? _decryptCbcLiteHash;
+        private ILiteSymmetricCipher? _encryptEcbLiteHash;
+        private ILiteSymmetricCipher? _decryptEcbLiteHash;
 
         public TripleDesImplementation()
         {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/UniversalCryptoOneShot.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/UniversalCryptoOneShot.cs
@@ -223,5 +223,12 @@ namespace System.Security.Cryptography
             Debug.Assert(padWritten == bytesWritten);
             return true;
         }
+
+        internal delegate bool UniversalOneShotCallback(
+            ILiteSymmetricCipher cipher,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            out int bytesWritten);
     }
 }


### PR DESCRIPTION
Today, when you use the symmetric one-shots to decrypt or decrypt, it creates a new lite cipher, uses it, then clean it up every time.

(Context: "lite cipher" is the internal facade over the platform's native encryption components)

Creating a lite cipher is expensive from various things like creating handles, validating keys and inputs, and simply the natural of the algorithm itself from activities like key expansion.

This change allows caching the lite cipher for the duration of the key, so long as the key doesn't change. If the key changes, then the lite cipher is invalidated.

The scenario this improves is this:

```C#
using Aes aes = aes.Create();
aes.Key = GetTheKey();
byte[] iv1 = RandomNumberGenerator.GetBytes(16);
byte[] iv2 = RandomNumberGenerator.GetBytes(16);
byte[] ciphertext1 = aes.EncryptCbc(plaintext1, iv1);
byte[] ciphertext2 = aes.EncryptCbc(plaintext2, iv2);
// N or more calls to EncryptCbc / DecryptCbc, etc.
```

Because the one-shots were previously more-or-less fully contained, they were thread safe - such that calling the one shots from a single instance of SymmetricAlgorithm would work and produce correct results. This is trait I would like to keep and I am not comfortable breaking. Because of this then, the caching uses interlocked exchanges of handles. Since we are only caching one instance at a given time, using an instance from multiple threads may not benefit from the cache. I think this is reasonable to keep the caching mechanism simple, and there is an easy developer workaround: pool an instance of the SymmetricAlgorithm.

This does mean though that there is a performance penalty, albeit a small one, for when the one-shot is used exactly once. The extra bookkeeping for the caching is wasted. However, it is far outweighed if you use it more than once.

Full data is below, but some examples:

Aes.EncryptCbc with a single call when from 579.0ns to 606.2ns.
Aes.EncryptCbc with three calls when from 1,395.5ns to 757.2ns.

TripleDES.EncryptCbc with a single call when from 11,311.6ns to 11,294.2ns (this "improvement" is within error)
TripleDES.EncryptCbc with three calls when from 33,826.3ns to 13,004.6ns.

The performance improvements can be substantial when it's used multiple times. For single uses, the performance loss is two `Interlocked.Exchange` calls.

This pull request addresses ECB and CBC only. Absent is CFB. CFB, because of feedback size, could be addressed differently, which is why I am leaving it out of this pull request. ECB and CBC are the far more common modes as well.

Benchmarks are in this Gist so they don't wrap funny in this comment. https://gist.github.com/vcsjones/b79889c4c6196bec50d783ff6e9aba0d

[CBC benchmark source](https://github.com/vcsjones/DotNetCryptoBenches/blob/main/src/CbcOneShot.cs)
[ECB benchmark source](https://github.com/vcsjones/DotNetCryptoBenches/blob/main/src/EcbOneShot.cs)