### PR TITLE
Use Sync Send methods in Sync HttpClient tests

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/DribbleStream.cs
+++ b/src/libraries/Common/tests/System/Net/Http/DribbleStream.cs
@@ -20,8 +20,8 @@ namespace System.Net.Http.Functional.Tests
         {
             for (int i = 0; i < count; i++)
             {
-                await _wrapped.WriteAsync(buffer, offset + i, 1);
-                await _wrapped.FlushAsync();
+                await _wrapped.WriteAsync(buffer, offset + i, 1, cancellationToken);
+                await _wrapped.FlushAsync(cancellationToken);
                 await Task.Yield(); // introduce short delays, enough to send packets individually but not so long as to extend test duration significantly
             }
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AutoRedirect.cs
@@ -184,7 +184,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await LoopbackServer.CreateServerAsync(async (redirectServer, redirectUrl) =>
                     {
-                        Task<HttpResponseMessage> getResponseTask = client.GetAsync(origUrl);
+                        Task<HttpResponseMessage> getResponseTask = client.GetAsync(TestAsync, origUrl);
 
                         Task redirectTask = redirectServer.AcceptConnectionSendResponseAndCloseAsync();
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
@@ -238,5 +238,10 @@ namespace System.Net.Http.Functional.Tests
             return client.GetByteArrayAsync(uri);
 #endif
         }
+
+        public static Task<HttpResponseMessage> GetAsync(this HttpClient client, bool async, Uri uri, HttpCompletionOption completionOption = default, CancellationToken cancellationToken = default)
+        {
+            return SendAsync(client, async, new HttpRequestMessage(HttpMethod.Get, uri), completionOption, cancellationToken);
+        }
     }
 }

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -368,7 +368,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task GetAsync_ResponseHasNormalLineEndings_Success(string lineEnding)
         {
             // Using an unusually high timeout as this test can take a longer time to execute on busy CI machines.
-            TimeSpan timeout = TestHelper.PassingTestTimeout * 5;
+            TimeSpan timeout = TimeSpan.FromMilliseconds(TestHelper.PassingTestTimeoutMilliseconds * 5);
 
             await LoopbackServer.CreateClientAndServerAsync(async url =>
             {

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -384,7 +384,7 @@ namespace System.Net.Http.Functional.Tests
             async server =>
             {
                 await server.AcceptConnectionSendCustomResponseAndCloseAsync(
-                    "HTTP/1.1 200 OK\nConnection: close\nDate: {DateTimeOffset.UtcNow:R}\nServer: TestServer\nContent-Length: 0\n\n".ReplaceLineEndings(lineEnding))
+                    "HTTP/1.1 200 OK\nConnection: close\nDate: {DateTimeOffset.UtcNow:R}\nServer: TestServer\nContent-Length: 0\n\n".Replace("\n", lineEnding))
                     .WaitAsync(timeout);
             }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -373,8 +373,9 @@ namespace System.Net.Http.Functional.Tests
             await LoopbackServer.CreateClientAndServerAsync(async url =>
             {
                 using HttpClient client = CreateHttpClient();
+                client.Timeout = timeout;
 
-                using HttpResponseMessage response = await client.GetAsync(TestAsync, url).WaitAsync(timeout);
+                using HttpResponseMessage response = await client.GetAsync(TestAsync, url);
 
                 Assert.Equal(200, (int)response.StatusCode);
                 Assert.Equal("OK", response.ReasonPhrase);

--- a/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpProtocolTests.cs
@@ -266,7 +266,8 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (HttpClient client = CreateHttpClient())
                 {
-                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(TestAsync, url);
+
                     await TestHelper.WhenAllCompletedOrAnyFailed(
                         getResponseTask,
                         server.AcceptConnectionSendCustomResponseAndCloseAsync(
@@ -356,7 +357,7 @@ namespace System.Net.Http.Functional.Tests
                     Task ignoredServerTask = server.AcceptConnectionSendCustomResponseAndCloseAsync(
                         responseString + "\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
 
-                    await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
+                    await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(TestAsync, url));
                 }
             }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
@@ -366,23 +367,24 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("\n")]
         public async Task GetAsync_ResponseHasNormalLineEndings_Success(string lineEnding)
         {
-            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            // Using an unusually high timeout as this test can take a longer time to execute on busy CI machines.
+            TimeSpan timeout = TestHelper.PassingTestTimeout * 5;
+
+            await LoopbackServer.CreateClientAndServerAsync(async url =>
             {
-                using (HttpClient client = CreateHttpClient())
-                {
-                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendCustomResponseAndCloseAsync(
-                        $"HTTP/1.1 200 OK{lineEnding}Connection: close\r\nDate: {DateTimeOffset.UtcNow:R}{lineEnding}Server: TestServer{lineEnding}Content-Length: 0{lineEnding}{lineEnding}");
+                using HttpClient client = CreateHttpClient();
 
-                    await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
+                using HttpResponseMessage response = await client.GetAsync(TestAsync, url).WaitAsync(timeout);
 
-                    using (HttpResponseMessage response = await getResponseTask)
-                    {
-                        Assert.Equal(200, (int)response.StatusCode);
-                        Assert.Equal("OK", response.ReasonPhrase);
-                        Assert.Equal("TestServer", response.Headers.Server.ToString());
-                    }
-                }
+                Assert.Equal(200, (int)response.StatusCode);
+                Assert.Equal("OK", response.ReasonPhrase);
+                Assert.Equal("TestServer", response.Headers.Server.ToString());
+            },
+            async server =>
+            {
+                await server.AcceptConnectionSendCustomResponseAndCloseAsync(
+                    "HTTP/1.1 200 OK\nConnection: close\nDate: {DateTimeOffset.UtcNow:R}\nServer: TestServer\nContent-Length: 0\n\n".ReplaceLineEndings(lineEnding))
+                    .WaitAsync(timeout);
             }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/IdnaProtocolTests.cs
+++ b/src/libraries/Common/tests/System/Net/Http/IdnaProtocolTests.cs
@@ -40,7 +40,7 @@ namespace System.Net.Http.Functional.Tests
 
                 using (HttpClient client = CreateHttpClient(handler))
                 {
-                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(uri);
+                    Task<HttpResponseMessage> getResponseTask = client.GetAsync(TestAsync, uri);
                     Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync();
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -717,10 +717,17 @@ namespace System.Net.Http.Functional.Tests
             base.Dispose(disposing);
         }
 
-        protected Task<HttpResponseMessage> SendAsync(HttpMessageInvoker invoker, HttpRequestMessage request, CancellationToken cancellationToken = default) =>
-            TestHttpMessageInvoker ?
-            invoker.SendAsync(request, cancellationToken) :
-            ((HttpClient)invoker).SendAsync(TestAsync, request, cancellationToken);
+        protected Task<HttpResponseMessage> SendAsync(HttpMessageInvoker invoker, HttpRequestMessage request, CancellationToken cancellationToken = default)
+        {
+            if (TestHttpMessageInvoker)
+            {
+                return TestAsync
+                    ? invoker.SendAsync(request, cancellationToken)
+                    : Task.Run(() => invoker.Send(request, cancellationToken));
+            }
+
+            return ((HttpClient)invoker).SendAsync(TestAsync, request, cancellationToken);
+        }
 
         protected HttpMessageInvoker CreateHttpMessageInvoker(HttpMessageHandler? handler = null) =>
             TestHttpMessageInvoker ?


### PR DESCRIPTION
Updated a few existing tests that weren't propagating the `TestAsync` flag through and would always test the async paths.

Also increased the timeout on `GetAsync_ResponseHasNormalLineEndings_Success` because AFAICT, the test isn't actually getting stuck, but can just take a long time to execute on busy machines.
In [these logs](https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-92354-merge-70a82f736021417bab/System.Net.Http.Functional.Tests/1/console.e7806bbb.log?helixlogtype=result), you can see how bytes were slowly being sent through, but sometimes with ~20-second delays (the test is sending the response one byte at a time).
Contributes to #76678 (I'll keep an eye on CI to see if this decreases the number of times we're retrying this test).
```
[19.0790] [Http/HandlerMessage] poolId: 30383028, workerId: 32561634, requestId: 50430218, memberName: FillAsync, message: Received 1 bytes.
[19.0960] [Sockets/DumpBuffer] thisOrContextObject: AwaitableSocketAsyncEventArgs#44062838, memberName: LogBuffer, buffer: 47
[19.0964] [Http/HandlerMessage] poolId: 30383028, workerId: 32561634, requestId: 50430218, memberName: FillAsync, message: Received 1 bytes.
[20.0123] [Sockets/DumpBuffer] thisOrContextObject: AwaitableSocketAsyncEventArgs#44062838, memberName: LogBuffer, buffer: 4D
[20.0128] [Http/HandlerMessage] poolId: 30383028, workerId: 32561634, requestId: 50430218, memberName: FillAsync, message: Received 1 bytes.
[24.0540] [Http/HandlerMessage] poolId: 30383028, workerId: 32561634, requestId: 50430218, memberName: FillAsync, message: Received 1 bytes.
[24.0541] [Sockets/DumpBuffer] thisOrContextObject: AwaitableSocketAsyncEventArgs#44062838, memberName: LogBuffer, buffer: 54
[24.0638] [Http/HandlerMessage] poolId: 30383028, workerId: 32561634, requestId: 50430218, memberName: FillAsync, message: Received 1 bytes.
[24.0639] [Sockets/DumpBuffer] thisOrContextObject: AwaitableSocketAsyncEventArgs#44062838, memberName: LogBuffer, buffer: 0D
[24.0671] [Sockets/DumpBuffer] thisOrContextObject: AwaitableSocketAsyncEventArgs#44062838, memberName: LogBuffer, buffer: 0A
[24.0671] [Http/HandlerMessage] poolId: 30383028, workerId: 32561634, requestId: 50430218, memberName: FillAsync, message: Received 1 bytes.
[47.0215] [Sockets/DumpBuffer] thisOrContextObject: AwaitableSocketAsyncEventArgs#44062838, memberName: LogBuffer, buffer: 53
[47.0216] [Http/HandlerMessage] poolId: 30383028, workerId: 32561634, requestId: 50430218, memberName: FillAsync, message: Received 1 bytes.
[47.0320] [Http/HandlerMessage] poolId: 30383028, workerId: 32561634, requestId: 50430218, memberName: FillAsync, message: Received 1 bytes.
```