### PR TITLE
[release/6.0] Fix a memory leak in runtime interop stubs when using an array of structs of types that use old-style managed marshalers

### DIFF
--- a/src/coreclr/vm/ilmarshalers.h
+++ b/src/coreclr/vm/ilmarshalers.h
@@ -3134,39 +3134,33 @@ protected:
     void EmitClearNative(ILCodeStream* pslILEmit) override
     {
         WRAPPER_NO_CONTRACT;
-        ILCodeLabel* pNoManagedValueLabel = nullptr;
         if (IsFieldMarshal(m_dwMarshalFlags))
         {
-            pNoManagedValueLabel = pslILEmit->NewCodeLabel();
+            ILCodeLabel* pHasManagedValueLabel = pslILEmit->NewCodeLabel();
             pslILEmit->EmitLDARG(StructMarshalStubs::MANAGED_STRUCT_ARGIDX);
-            pslILEmit->EmitBRFALSE(pNoManagedValueLabel);
+            pslILEmit->EmitBRTRUE(pHasManagedValueLabel);
+            pslILEmit->EmitLDARG(StructMarshalStubs::MANAGED_STRUCT_ARGIDX);
+            EmitStoreManagedHomeAddr(pslILEmit);
+            pslILEmit->EmitLabel(pHasManagedValueLabel);
         }
 
         EmitCallMngdMarshalerMethod(pslILEmit, GetClearNativeMethod());
-
-        if (IsFieldMarshal(m_dwMarshalFlags))
-        {
-            pslILEmit->EmitLabel(pNoManagedValueLabel);
-        }
     }
 
     void EmitClearNativeContents(ILCodeStream* pslILEmit) override
     {
         WRAPPER_NO_CONTRACT;
-        ILCodeLabel* pNoManagedValueLabel = nullptr;
         if (IsFieldMarshal(m_dwMarshalFlags))
         {
-            pNoManagedValueLabel = pslILEmit->NewCodeLabel();
+            ILCodeLabel* pHasManagedValueLabel = pslILEmit->NewCodeLabel();
             pslILEmit->EmitLDARG(StructMarshalStubs::MANAGED_STRUCT_ARGIDX);
-            pslILEmit->EmitBRFALSE(pNoManagedValueLabel);
+            pslILEmit->EmitBRTRUE(pHasManagedValueLabel);
+            pslILEmit->EmitLDARG(StructMarshalStubs::MANAGED_STRUCT_ARGIDX);
+            EmitStoreManagedHomeAddr(pslILEmit);
+            pslILEmit->EmitLabel(pHasManagedValueLabel);
         }
 
         EmitCallMngdMarshalerMethod(pslILEmit, GetClearNativeContentsMethod());
-
-        if (IsFieldMarshal(m_dwMarshalFlags))
-        {
-            pslILEmit->EmitLabel(pNoManagedValueLabel);
-        }
     }
 
     bool NeedsClearCLR() override

--- a/src/coreclr/vm/ilmarshalers.h
+++ b/src/coreclr/vm/ilmarshalers.h
@@ -3134,32 +3134,12 @@ protected:
     void EmitClearNative(ILCodeStream* pslILEmit) override
     {
         WRAPPER_NO_CONTRACT;
-        if (IsFieldMarshal(m_dwMarshalFlags))
-        {
-            ILCodeLabel* pHasManagedValueLabel = pslILEmit->NewCodeLabel();
-            pslILEmit->EmitLDARG(StructMarshalStubs::MANAGED_STRUCT_ARGIDX);
-            pslILEmit->EmitBRTRUE(pHasManagedValueLabel);
-            pslILEmit->EmitLDARG(StructMarshalStubs::MANAGED_STRUCT_ARGIDX);
-            EmitStoreManagedHomeAddr(pslILEmit);
-            pslILEmit->EmitLabel(pHasManagedValueLabel);
-        }
-
         EmitCallMngdMarshalerMethod(pslILEmit, GetClearNativeMethod());
     }
 
     void EmitClearNativeContents(ILCodeStream* pslILEmit) override
     {
         WRAPPER_NO_CONTRACT;
-        if (IsFieldMarshal(m_dwMarshalFlags))
-        {
-            ILCodeLabel* pHasManagedValueLabel = pslILEmit->NewCodeLabel();
-            pslILEmit->EmitLDARG(StructMarshalStubs::MANAGED_STRUCT_ARGIDX);
-            pslILEmit->EmitBRTRUE(pHasManagedValueLabel);
-            pslILEmit->EmitLDARG(StructMarshalStubs::MANAGED_STRUCT_ARGIDX);
-            EmitStoreManagedHomeAddr(pslILEmit);
-            pslILEmit->EmitLabel(pHasManagedValueLabel);
-        }
-
         EmitCallMngdMarshalerMethod(pslILEmit, GetClearNativeContentsMethod());
     }
 


### PR DESCRIPTION
Fixes Issue (Issue was reported by a 1st party over email)

main PR #93089

# Description

When passing an array of structs that contains an array field marshalled as a SAFEARRAY or "ByValArray" field to a P/Invoke or a COM interop call, the native array and its contents are not released. This PR changes the marshalling logic such that the native array and contents will be released when they should be.

# Customer Impact

Customers without this fix that have interop code with this shape will have unmanaged memory leaks.

# Regression

This is a regression that was introduced in .NET 5.

# Testing

This fix has been manually validated in main and a unit test has been added to the PR in main. This fix has also manually been validated in this branch with the customer and it fixes their scenario.

# Risk

The risk for this PR is low. The logic here will only be hit in these two scenarios, and the expected and documented behavior is that we do not leak this memory. It is very unlikely that customers have taken a dependency on this memory being leaked.