### PR TITLE
Use our now-split MarshalAs parsing to simplify our "forwarder with marshalling attributes" logic

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Interop.Analyzers
             AttributeData dllImportAttribute = method.GetAttributes().First(attr => attr.AttributeClass.ToDisplayString() == TypeNames.DllImportAttribute);
             SignatureContext targetSignatureContext = SignatureContext.Create(
                 method,
-                DefaultMarshallingInfoParser.Create(env, diagnostics, method, CreateInteropAttributeDataFromDllImport(dllImportData), dllImportAttribute),
+                LibraryImportGeneratorHelpers.CreateMarshallingInfoParser(env, diagnostics, method, CreateInteropAttributeDataFromDllImport(dllImportData), dllImportAttribute),
                 env,
                 new CodeEmitOptions(SkipInit: tf.TargetFramework == TargetFramework.Net),
                 typeof(ConvertToLibraryImportAnalyzer).Assembly);

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Interop.Analyzers
             AttributeData dllImportAttribute = method.GetAttributes().First(attr => attr.AttributeClass.ToDisplayString() == TypeNames.DllImportAttribute);
             SignatureContext targetSignatureContext = SignatureContext.Create(
                 method,
-                LibraryImportGeneratorHelpers.CreateMarshallingInfoParser(env, diagnostics, method, CreateInteropAttributeDataFromDllImport(dllImportData), dllImportAttribute),
+                LibraryImportGeneratorHelpers.CreateMarshallingInfoParser(env, tf, diagnostics, method, CreateInteropAttributeDataFromDllImport(dllImportData), dllImportAttribute),
                 env,
                 new CodeEmitOptions(SkipInit: tf.TargetFramework == TargetFramework.Net),
                 typeof(ConvertToLibraryImportAnalyzer).Assembly);

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Interop
             // Create the stub.
             var signatureContext = SignatureContext.Create(
                 symbol,
-                DefaultMarshallingInfoParser.Create(environment, generatorDiagnostics, symbol, libraryImportData, generatedDllImportAttr),
+                LibraryImportGeneratorHelpers.CreateMarshallingInfoParser(environment, generatorDiagnostics, symbol, libraryImportData, generatedDllImportAttr),
                 environment,
                 new CodeEmitOptions(SkipInit: targetFramework.TargetFramework == TargetFramework.Net),
                 typeof(LibraryImportGenerator).Assembly);

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Interop
             // Create the stub.
             var signatureContext = SignatureContext.Create(
                 symbol,
-                LibraryImportGeneratorHelpers.CreateMarshallingInfoParser(environment, generatorDiagnostics, symbol, libraryImportData, generatedDllImportAttr),
+                LibraryImportGeneratorHelpers.CreateMarshallingInfoParser(environment, targetFramework, generatorDiagnostics, symbol, libraryImportData, generatedDllImportAttr),
                 environment,
                 new CodeEmitOptions(SkipInit: targetFramework.TargetFramework == TargetFramework.Net),
                 typeof(LibraryImportGenerator).Assembly);

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGeneratorHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGeneratorHelpers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -11,6 +12,58 @@ namespace Microsoft.Interop
 {
     internal static class LibraryImportGeneratorHelpers
     {
+        public static MarshallingInfoParser CreateMarshallingInfoParser(StubEnvironment env, TargetFrameworkSettings tf, GeneratorDiagnosticsBag diagnostics, IMethodSymbol method, InteropAttributeCompilationData interopAttributeData, AttributeData unparsedAttributeData)
+        {
+            // Compute the current default string encoding value.
+            CharEncoding defaultEncoding = CharEncoding.Undefined;
+            if (interopAttributeData.IsUserDefined.HasFlag(InteropAttributeMember.StringMarshalling))
+            {
+                defaultEncoding = interopAttributeData.StringMarshalling switch
+                {
+                    StringMarshalling.Utf16 => CharEncoding.Utf16,
+                    StringMarshalling.Utf8 => CharEncoding.Utf8,
+                    StringMarshalling.Custom => CharEncoding.Custom,
+                    _ => CharEncoding.Undefined, // [Compat] Do not assume a specific value
+                };
+            }
+            else if (interopAttributeData.IsUserDefined.HasFlag(InteropAttributeMember.StringMarshallingCustomType))
+            {
+                defaultEncoding = CharEncoding.Custom;
+            }
+
+            var defaultInfo = new DefaultMarshallingInfo(defaultEncoding, interopAttributeData.StringMarshallingCustomType);
+
+            var useSiteAttributeParsers = ImmutableArray.Create<IUseSiteAttributeParser>(
+                    new MarshalAsAttributeParser(diagnostics, defaultInfo),
+                    new MarshalUsingAttributeParser(env.Compilation, diagnostics));
+
+            IMarshallingInfoAttributeParser marshalAsAttributeParser = new MarshalAsAttributeParser(diagnostics, defaultInfo);
+
+            if (tf.TargetFramework == TargetFramework.Net && tf.Version.Major >= 7)
+            {
+                // If we have support for the attributed marshalling model, then we want to use that to provide the marshalling logic
+                // when possible. On other target frameworks, we'll fall back to using the Forwarder logic and re-emitting the MarshalAs attribute.
+                marshalAsAttributeParser = new MarshalAsWithCustomMarshallersParser(env.Compilation, diagnostics, marshalAsAttributeParser);
+            }
+
+            return new MarshallingInfoParser(
+                diagnostics,
+                new MethodSignatureElementInfoProvider(env.Compilation, diagnostics, method, useSiteAttributeParsers),
+                useSiteAttributeParsers,
+                ImmutableArray.Create(
+                    marshalAsAttributeParser,
+                    new MarshalUsingAttributeParser(env.Compilation, diagnostics),
+                    new NativeMarshallingAttributeParser(env.Compilation, diagnostics),
+                    new ComInterfaceMarshallingInfoProvider(env.Compilation)),
+                ImmutableArray.Create<ITypeBasedMarshallingInfoProvider>(
+                    new SafeHandleMarshallingInfoProvider(env.Compilation, method.ContainingType),
+                    new ArrayMarshallingInfoProvider(env.Compilation),
+                    new CharMarshallingInfoProvider(defaultInfo),
+                    new StringMarshallingInfoProvider(env.Compilation, diagnostics, unparsedAttributeData, defaultInfo),
+                    new BooleanMarshallingInfoProvider(),
+                    new BlittableTypeMarshallingInfoProvider(env.Compilation)));
+        }
+
         public static IMarshallingGeneratorFactory CreateGeneratorFactory(TargetFrameworkSettings tf, LibraryImportGeneratorOptions options, EnvironmentFlags env)
         {
             IMarshallingGeneratorFactory generatorFactory;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshalAsWithCustomMarshallersParser.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshalAsWithCustomMarshallersParser.cs
@@ -77,14 +77,7 @@ namespace Microsoft.Interop
                     elementMarshallingInfo = marshallingInfoCallback(elementType, useSiteAttributes, indirectionDepth + 1);
                 }
 
-                CountInfo countInfo = NoCountInfo.Instance;
-
-                if (useSiteAttributes.TryGetUseSiteAttributeInfo(indirectionDepth, out UseSiteAttributeData useSiteAttributeData))
-                {
-                    countInfo = useSiteAttributeData.CountInfo;
-                }
-
-                return ArrayMarshallingInfoProvider.CreateArrayMarshallingInfo(_compilation, type, elementType, countInfo, elementMarshallingInfo);
+                return ArrayMarshallingInfoProvider.CreateArrayMarshallingInfo(_compilation, type, elementType, arrayInfo.CountInfo, elementMarshallingInfo);
             }
 
             if (type.SpecialType == SpecialType.System_String)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/IForwardedMarshallingInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/IForwardedMarshallingInfo.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.Interop
+{
+    internal interface IForwardedMarshallingInfo
+    {
+        bool TryCreateAttributeSyntax([NotNullWhen(true)] out AttributeSyntax? attribute);
+    }
+}


### PR DESCRIPTION
Use our now-split MarshalAs parsing to simplify our "forwarder with marshalling attributes" logic and avoid "hydrating" a MarshalAs attribute from a parsed "use ArrayMarshaller<T>" attribute info.

> [!NOTE]
> This is not a breaking change as we would only end up in this scenario in a downlevel platform where `ArrayMarshaller<T>` is unavailable anyway.