### PR TITLE
Obsolete `AuthenticationManager` of `System.Net.Requests`

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -63,7 +63,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0006`__ | Thread.Abort is not supported and throws PlatformNotSupportedException. |
 |  __`SYSLIB0007`__ | The default implementation of this cryptography algorithm is not supported. |
 |  __`SYSLIB0008`__ | The CreatePdbGenerator API is not supported and throws PlatformNotSupportedException. |
-|  __`SYSLIB0009`__ | The AuthenticationManager Authenticate and PreAuthenticate methods are not supported and throw PlatformNotSupportedException. |
+|  __`SYSLIB0009`__ | AuthenticationManager is not supported. Methods will no-op or throw PlatformNotSupportedException. |
 |  __`SYSLIB0010`__ | This Remoting API is not supported and throws PlatformNotSupportedException. |
 |  __`SYSLIB0011`__ | `BinaryFormatter` serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for recommended alternatives. |
 |  __`SYSLIB0012`__ | Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location instead. |

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -37,7 +37,7 @@ namespace System
         internal const string CreatePdbGeneratorMessage = "The CreatePdbGenerator API is not supported and throws PlatformNotSupportedException.";
         internal const string CreatePdbGeneratorDiagId = "SYSLIB0008";
 
-        internal const string AuthenticationManagerMessage = "The AuthenticationManager Authenticate and PreAuthenticate methods are not supported and throw PlatformNotSupportedException.";
+        internal const string AuthenticationManagerMessage = "AuthenticationManager is not supported. Methods will no-op or throw PlatformNotSupportedException.";
         internal const string AuthenticationManagerDiagId = "SYSLIB0009";
 
         internal const string RemotingApisMessage = "This Remoting API is not supported and throws PlatformNotSupportedException.";

--- a/src/libraries/System.Net.Requests/ref/System.Net.Requests.cs
+++ b/src/libraries/System.Net.Requests/ref/System.Net.Requests.cs
@@ -6,6 +6,7 @@
 
 namespace System.Net
 {
+    [System.ObsoleteAttribute("AuthenticationManager is not supported. Methods will no-op or throw PlatformNotSupportedException.", DiagnosticId="SYSLIB0009", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
     public partial class AuthenticationManager
     {
         internal AuthenticationManager() { }

--- a/src/libraries/System.Net.Requests/ref/System.Net.Requests.cs
+++ b/src/libraries/System.Net.Requests/ref/System.Net.Requests.cs
@@ -13,9 +13,7 @@ namespace System.Net
         public static System.Net.ICredentialPolicy? CredentialPolicy { get { throw null; } set { } }
         public static System.Collections.Specialized.StringDictionary CustomTargetNameDictionary { get { throw null; } }
         public static System.Collections.IEnumerator RegisteredModules { get { throw null; } }
-        [System.ObsoleteAttribute("The AuthenticationManager Authenticate and PreAuthenticate methods are not supported and throw PlatformNotSupportedException.", DiagnosticId = "SYSLIB0009", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.Authorization? Authenticate(string challenge, System.Net.WebRequest request, System.Net.ICredentials credentials) { throw null; }
-        [System.ObsoleteAttribute("The AuthenticationManager Authenticate and PreAuthenticate methods are not supported and throw PlatformNotSupportedException.", DiagnosticId = "SYSLIB0009", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.Authorization? PreAuthenticate(System.Net.WebRequest request, System.Net.ICredentials credentials) { throw null; }
         public static void Register(System.Net.IAuthenticationModule authenticationModule) { }
         public static void Unregister(System.Net.IAuthenticationModule authenticationModule) { }

--- a/src/libraries/System.Net.Requests/src/System/Net/AuthenticationManager.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/AuthenticationManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 
 namespace System.Net
 {
+    [Obsolete(Obsoletions.AuthenticationManagerMessage, DiagnosticId = Obsoletions.AuthenticationManagerDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
     public class AuthenticationManager
     {
         private AuthenticationManager() { }

--- a/src/libraries/System.Net.Requests/src/System/Net/AuthenticationManager.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/AuthenticationManager.cs
@@ -15,11 +15,9 @@ namespace System.Net
 
         public static StringDictionary CustomTargetNameDictionary { get; } = new StringDictionary();
 
-        [Obsolete(Obsoletions.AuthenticationManagerMessage, DiagnosticId = Obsoletions.AuthenticationManagerDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static Authorization? Authenticate(string challenge, WebRequest request, ICredentials credentials) =>
             throw new PlatformNotSupportedException();
 
-        [Obsolete(Obsoletions.AuthenticationManagerMessage, DiagnosticId = Obsoletions.AuthenticationManagerDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static Authorization? PreAuthenticate(WebRequest request, ICredentials credentials) =>
             throw new PlatformNotSupportedException();
 

--- a/src/libraries/System.Net.Requests/tests/AuthenticationManagerTest.cs
+++ b/src/libraries/System.Net.Requests/tests/AuthenticationManagerTest.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 #pragma warning disable CS0618 // obsolete warnings
+#pragma warning disable SYSLIB0009 // The class is obsolete
 
 namespace System.Net.Tests
 {
@@ -14,10 +15,8 @@ namespace System.Net.Tests
         [Fact]
         public void Authenticate_NotSupported()
         {
-#pragma warning disable SYSLIB0009 // The methods are obsolete
             Assert.Throws<PlatformNotSupportedException>(() => AuthenticationManager.Authenticate(null, null, null));
             Assert.Throws<PlatformNotSupportedException>(() => AuthenticationManager.PreAuthenticate(null, null));
-#pragma warning restore SYSLIB0009
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #77459. This PR obsoletes the class `AuthenticationManager`.

### Changed API Scheme
```diff
namespace System.Net;

+ [System.ObsoleteAttribute(
+   "AuthenticationManager is not supported. Methods will no-op or throw PlatformNotSupportedException.",
+    DiagnosticId = "SYSLIB0009",
+    UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
public partial class AuthenticationManager
{
    // ...
}
```

### Changes made

* Change message of existing diagnostic `SYSLIB0009`
* Apply `SYSLIB0009` obsoletion at class-level (`AuthenticationManager`)
* Disable diagnostic in AuthenticationManager tests
* Update runtime docs

/cc @MihaZupan 