### PR TITLE
Add missing readonly modifiers to GCHandle and DependentHandle

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/DependentHandle.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/DependentHandle.cs
@@ -81,9 +81,9 @@ namespace System.Runtime
         /// <exception cref="InvalidOperationException">
         /// Thrown if <see cref="IsAllocated"/> is <see langword="false"/> or if the input value is not <see langword="null"/>.</exception>
         /// <remarks>This property is thread-safe.</remarks>
-        public readonly object? Target
+        public object? Target
         {
-            get
+            readonly get
             {
                 IntPtr handle = _handle;
 
@@ -118,9 +118,9 @@ namespace System.Runtime
         /// </remarks>
         /// <exception cref="InvalidOperationException">Thrown if <see cref="IsAllocated"/> is <see langword="false"/>.</exception>
         /// <remarks>This property is thread-safe.</remarks>
-        public readonly object? Dependent
+        public object? Dependent
         {
-            get
+            readonly get
             {
                 IntPtr handle = _handle;
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/DependentHandle.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/DependentHandle.cs
@@ -71,7 +71,7 @@ namespace System.Runtime
         /// <see cref="DependentHandle(object?, object?)"/> and has not yet been disposed.
         /// </summary>
         /// <remarks>This property is thread-safe.</remarks>
-        public bool IsAllocated => (nint)_handle != 0;
+        public readonly bool IsAllocated => (nint)_handle != 0;
 
         /// <summary>
         /// Gets or sets the target object instance for the current handle. The target can only be set to a <see langword="null"/> value
@@ -81,7 +81,7 @@ namespace System.Runtime
         /// <exception cref="InvalidOperationException">
         /// Thrown if <see cref="IsAllocated"/> is <see langword="false"/> or if the input value is not <see langword="null"/>.</exception>
         /// <remarks>This property is thread-safe.</remarks>
-        public object? Target
+        public readonly object? Target
         {
             get
             {
@@ -118,7 +118,7 @@ namespace System.Runtime
         /// </remarks>
         /// <exception cref="InvalidOperationException">Thrown if <see cref="IsAllocated"/> is <see langword="false"/>.</exception>
         /// <remarks>This property is thread-safe.</remarks>
-        public object? Dependent
+        public readonly object? Dependent
         {
             get
             {
@@ -154,7 +154,7 @@ namespace System.Runtime
         /// <returns>The values of <see cref="Target"/> and <see cref="Dependent"/>.</returns>
         /// <exception cref="InvalidOperationException">Thrown if <see cref="IsAllocated"/> is <see langword="false"/>.</exception>
         /// <remarks>This property is thread-safe.</remarks>
-        public (object? Target, object? Dependent) TargetAndDependent
+        public readonly (object? Target, object? Dependent) TargetAndDependent
         {
             get
             {
@@ -176,7 +176,7 @@ namespace System.Runtime
         /// </summary>
         /// <returns>The target object instance, if present.</returns>
         /// <remarks>This method mirrors <see cref="Target"/>, but without the allocation check.</remarks>
-        internal object? UnsafeGetTarget()
+        internal readonly object? UnsafeGetTarget()
         {
             return InternalGetTarget(_handle);
         }
@@ -191,7 +191,7 @@ namespace System.Runtime
         /// The signature is also kept the same as the one for the internal call, to improve the codegen.
         /// Note that <paramref name="dependent"/> is required to be on the stack (or it might not be tracked).
         /// </remarks>
-        internal object? UnsafeGetTargetAndDependent(out object? dependent)
+        internal readonly object? UnsafeGetTargetAndDependent(out object? dependent)
         {
             return InternalGetTargetAndDependent(_handle, out dependent);
         }
@@ -200,7 +200,7 @@ namespace System.Runtime
         /// Sets the dependent object instance for the current handle to <see langword="null"/>.
         /// </summary>
         /// <remarks>This method mirrors the <see cref="Target"/> setter, but without allocation and input checks.</remarks>
-        internal void UnsafeSetTargetToNull()
+        internal readonly void UnsafeSetTargetToNull()
         {
             InternalSetTargetToNull(_handle);
         }
@@ -209,7 +209,7 @@ namespace System.Runtime
         /// Sets the dependent object instance for the current handle.
         /// </summary>
         /// <remarks>This method mirrors <see cref="Dependent"/>, but without the allocation check.</remarks>
-        internal void UnsafeSetDependent(object? dependent)
+        internal readonly void UnsafeSetDependent(object? dependent)
         {
             InternalSetDependent(_handle, dependent);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
@@ -76,7 +76,7 @@ namespace System.Runtime.InteropServices
         }
 
         // Target property - allows getting / updating of the handle's referent.
-        public object? Target
+        public readonly object? Target
         {
             get
             {
@@ -103,7 +103,7 @@ namespace System.Runtime.InteropServices
         /// Retrieve the address of an object in a Pinned handle.  This throws
         /// an exception if the handle is any type other than Pinned.
         /// </summary>
-        public IntPtr AddrOfPinnedObject()
+        public readonly IntPtr AddrOfPinnedObject()
         {
             // Check if the handle was not a pinned handle.
             // You can only get the address of pinned handles.
@@ -141,7 +141,7 @@ namespace System.Runtime.InteropServices
         }
 
         /// <summary>Determine whether this handle has been allocated or not.</summary>
-        public bool IsAllocated => (nint)_handle != 0;
+        public readonly bool IsAllocated => (nint)_handle != 0;
 
         /// <summary>
         /// Used to create a GCHandle from an int.  This is intended to
@@ -160,14 +160,14 @@ namespace System.Runtime.InteropServices
 
         public static IntPtr ToIntPtr(GCHandle value) => value._handle;
 
-        public override int GetHashCode() => _handle.GetHashCode();
+        public override readonly int GetHashCode() => _handle.GetHashCode();
 
-        public override bool Equals([NotNullWhen(true)] object? o) => o is GCHandle other && Equals(other);
+        public override readonly bool Equals([NotNullWhen(true)] object? o) => o is GCHandle other && Equals(other);
 
         /// <summary>Indicates whether the current instance is equal to another instance of the same type.</summary>
         /// <param name="other">An instance to compare with this instance.</param>
         /// <returns>true if the current instance is equal to the other instance; otherwise, false.</returns>
-        public bool Equals(GCHandle other) => _handle == other._handle;
+        public readonly bool Equals(GCHandle other) => _handle == other._handle;
 
         public static bool operator ==(GCHandle a, GCHandle b) => (nint)a._handle == (nint)b._handle;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
@@ -76,9 +76,9 @@ namespace System.Runtime.InteropServices
         }
 
         // Target property - allows getting / updating of the handle's referent.
-        public readonly object? Target
+        public object? Target
         {
-            get
+            readonly get
             {
                 IntPtr handle = _handle;
                 ThrowIfInvalid(handle);

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -12428,9 +12428,9 @@ namespace System.Runtime
         private object _dummy;
         private int _dummyPrimitive;
         public DependentHandle(object? target, object? dependent) { throw null; }
-        public readonly object? Dependent { get { throw null; } set { } }
+        public object? Dependent { readonly get { throw null; } set { } }
         public readonly bool IsAllocated { get { throw null; } }
-        public readonly object? Target { get { throw null; } set { } }
+        public object? Target { readonly get { throw null; } set { } }
         public readonly (object? Target, object? Dependent) TargetAndDependent { get { throw null; } }
         public void Dispose() { }
     }
@@ -13456,7 +13456,7 @@ namespace System.Runtime.InteropServices
     {
         private int _dummyPrimitive;
         public readonly bool IsAllocated { get { throw null; } }
-        public readonly object? Target { get { throw null; } set { } }
+        public object? Target { readonly get { throw null; } set { } }
         public readonly System.IntPtr AddrOfPinnedObject() { throw null; }
         public static System.Runtime.InteropServices.GCHandle Alloc(object? value) { throw null; }
         public static System.Runtime.InteropServices.GCHandle Alloc(object? value, System.Runtime.InteropServices.GCHandleType type) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -12428,10 +12428,10 @@ namespace System.Runtime
         private object _dummy;
         private int _dummyPrimitive;
         public DependentHandle(object? target, object? dependent) { throw null; }
-        public object? Dependent { get { throw null; } set { } }
-        public bool IsAllocated { get { throw null; } }
-        public object? Target { get { throw null; } set { } }
-        public (object? Target, object? Dependent) TargetAndDependent { get { throw null; } }
+        public readonly object? Dependent { get { throw null; } set { } }
+        public readonly bool IsAllocated { get { throw null; } }
+        public readonly object? Target { get { throw null; } set { } }
+        public readonly (object? Target, object? Dependent) TargetAndDependent { get { throw null; } }
         public void Dispose() { }
     }
     public enum GCLargeObjectHeapCompactionMode
@@ -13455,16 +13455,16 @@ namespace System.Runtime.InteropServices
     public partial struct GCHandle : System.IEquatable<System.Runtime.InteropServices.GCHandle>
     {
         private int _dummyPrimitive;
-        public bool IsAllocated { get { throw null; } }
-        public object? Target { get { throw null; } set { } }
-        public System.IntPtr AddrOfPinnedObject() { throw null; }
+        public readonly bool IsAllocated { get { throw null; } }
+        public readonly object? Target { get { throw null; } set { } }
+        public readonly System.IntPtr AddrOfPinnedObject() { throw null; }
         public static System.Runtime.InteropServices.GCHandle Alloc(object? value) { throw null; }
         public static System.Runtime.InteropServices.GCHandle Alloc(object? value, System.Runtime.InteropServices.GCHandleType type) { throw null; }
-        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? o) { throw null; }
-        public bool Equals(System.Runtime.InteropServices.GCHandle other) { throw null; }
+        public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? o) { throw null; }
+        public readonly bool Equals(System.Runtime.InteropServices.GCHandle other) { throw null; }
         public void Free() { }
         public static System.Runtime.InteropServices.GCHandle FromIntPtr(System.IntPtr value) { throw null; }
-        public override int GetHashCode() { throw null; }
+        public override readonly int GetHashCode() { throw null; }
         public static bool operator ==(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { throw null; }
         public static explicit operator System.Runtime.InteropServices.GCHandle (System.IntPtr value) { throw null; }
         public static explicit operator System.IntPtr (System.Runtime.InteropServices.GCHandle value) { throw null; }


### PR DESCRIPTION
This PR sprinkles a bunch of missing `readonly` modifiers to APIs of `GCHandle` and `DependentHandle` that are not actually modifying instance state. This allows Roslyn to skip some unnecessary defensive copies when invoking any of these APIs over values stored in either readonly fields, or from members marked as readonly (from mutable struct types).