### PR TITLE
Add new nativeaot files to the platform manifest

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -141,6 +141,8 @@
     <PlatformManifestFileEntry Include="libeventpipe-enabled.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libRuntime.ServerGC.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libRuntime.WorkstationGC.a" IsNative="true" />
+    <PlatformManifestFileEntry Include="libstandalonegc-disabled.a " IsNative="true" />
+    <PlatformManifestFileEntry Include="libstandalonegc-enabled.a " IsNative="true" />
     <PlatformManifestFileEntry Include="libstdc++compat.a" IsNative="true" />
     <PlatformManifestFileEntry Include="System.Private.DisabledReflection.dll" />
     <PlatformManifestFileEntry Include="System.Private.Reflection.Execution.dll" />


### PR DESCRIPTION
#91038 caused the official build to fail https://dev.azure.com/dnceng/internal/_build/results?buildId=2285567&view=logs&j=1c10cb4a-4b1f-5dd9-3ecf-f4bf860ca96c&t=fce58ae7-1d52-5960-3c80-bf99aa5956a2&l=2360 this is just based off reading the error message

```
##[error].packages/microsoft.dotnet.sharedframework.sdk/8.0.0-beta.23463.1/targets/sharedfx.targets(294,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) The following files are missing entries in the templated manifest:
libstandalonegc-disabled.a
libstandalonegc-enabled.a. Add these file names with extensions to the 'PlatformManifestFileEntry' item group for the runtime pack and corresponding ref pack to include them in the platform manifest.
```