### PR TITLE
[LoongArch64] Fix the `System.NullReferenceException: Object reference not set to an instance of an object.` in Methodical_r2.sh-deep_array_nz_r.dll when DOTNET_GCStress=4.

### DIFF
--- a/src/coreclr/vm/gccover.cpp
+++ b/src/coreclr/vm/gccover.cpp
@@ -774,8 +774,8 @@ void replaceSafePointInstructionWithGcStressInstr(UINT32 safePointOffset, LPVOID
     {
         instructionIsACallThroughImmediate = TRUE;
     }
-    // jirl
-    else if (((instr >> 26) & 0x3F) == 0x13)
+    // jirl ra, target, offs
+    else if ((((instr >> 26) & 0x3F) == 0x13) && ((instr & 0x1F) == 1))
     {
         instructionIsACallThroughRegister = TRUE;
     }
@@ -1014,7 +1014,7 @@ static PBYTE getTargetOfCall(PBYTE instrPtr, PCONTEXT regs, PBYTE* nextInstr) {
         *nextInstr = instrPtr + 4;
         return PC + imm26;
     }
-    else if ((((*reinterpret_cast<DWORD*>(instrPtr)) >> 26) & 0x3F) == 0x13)
+    else if (((((*reinterpret_cast<DWORD*>(instrPtr)) >> 26) & 0x3F) == 0x13) && (((*reinterpret_cast<DWORD*>(instrPtr)) & 0x1F) == 1))
     {
         // call through register
         *nextInstr = instrPtr + 4;


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

Fix the `System.NullReferenceException: Object reference not set to an instance of an object.` in Methodical_r2.sh-deep_array_nz_r.dll when DOTNET_GCStress=4. 