### PR TITLE
[LoongArch64] Fix some issues for CoreRoot test cases:

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5848,6 +5848,7 @@ void CodeGen::genFnProlog()
     const bool isOSRx64Root = false;
 #endif // TARGET_AMD64
 
+#ifndef TARGET_LOONGARCH64
     tempMask = initRegs & ~excludeMask & ~regSet.rsMaskResvd;
 
     if (tempMask != RBM_NONE)
@@ -5869,6 +5870,7 @@ void CodeGen::genFnProlog()
             initReg  = genRegNumFromMask(tempMask);
         }
     }
+#endif
 
 #if defined(TARGET_AMD64)
     // For x64 OSR root frames, we can't use any as of yet unsaved

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5848,7 +5848,6 @@ void CodeGen::genFnProlog()
     const bool isOSRx64Root = false;
 #endif // TARGET_AMD64
 
-#ifndef TARGET_LOONGARCH64
     tempMask = initRegs & ~excludeMask & ~regSet.rsMaskResvd;
 
     if (tempMask != RBM_NONE)
@@ -5870,7 +5869,6 @@ void CodeGen::genFnProlog()
             initReg  = genRegNumFromMask(tempMask);
         }
     }
-#endif
 
 #if defined(TARGET_AMD64)
     // For x64 OSR root frames, we can't use any as of yet unsaved
@@ -5887,6 +5885,13 @@ void CodeGen::genFnProlog()
     if (isRoot && compiler->opts.IsOSR())
     {
         initReg = REG_IP1;
+    }
+#elif defined(TARGET_LOONGARCH64)
+    // For LoongArch64 OSR root frames, we may need a scratch register for large
+    // offset addresses. Use a register that won't be allocated.
+    if (isRoot && compiler->opts.IsOSR())
+    {
+        initReg = REG_SCRATCH;
     }
 #endif
 

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -3754,6 +3754,13 @@ void CodeGen::genFloatToIntCast(GenTree* treeNode)
         GetEmitter()->emitIns_R_R(ins1, dstSize, tmpReg, tmpReg);
         GetEmitter()->emitIns_R_R(ins2, dstSize, treeNode->GetRegNum(), tmpReg);
 
+        if (dstType == TYP_UINT)
+        {
+            GetEmitter()->emitIns_R_R_I(INS_addu16i_d, EA_PTRSIZE, REG_RA, REG_R0, -32768);
+            GetEmitter()->emitIns_R_R_I(INS_bne, EA_PTRSIZE, treeNode->GetRegNum(), REG_RA, (2 << 2));
+            GetEmitter()->emitIns_R_R_I(INS_ori, dstSize, treeNode->GetRegNum(), REG_R0, 0);
+        }
+
         GetEmitter()->emitIns_I_I(INS_bcnez, EA_PTRSIZE, 3, 2 << 2); // cc=3
         GetEmitter()->emitIns_R_I(INS_beqz, EA_PTRSIZE, treeNode->GetRegNum(), 2 << 2);
 


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

Fix some issues for CoreRoot test cases:
* fix the cast of floating-point types to uint32 in volatileLocal1.dll.
* fix the register conflict for large offset addresses of OSR root frames when `DOTNET_JitStressRegs=2` in more_tailcalls.sh.