### PR TITLE
[mono] Revert part of 93092 since it causes a regression when aot-ing corlib.

### DIFF
--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3550,6 +3550,8 @@ mini_method_compile (MonoMethod *method, guint32 opts, JitFlags flags, int parts
 		}
 
 		cfg->opt &= ~MONO_OPT_LINEARS;
+
+		cfg->opt &= ~MONO_OPT_BRANCH;
 	}
 
 	cfg->after_method_to_ir = TRUE;


### PR DESCRIPTION
It causes a regression: https://github.com/dotnet/runtime/issues/93188.