### PR TITLE
Add SuppressSingleFileAnalysisWarnings option to ILC and use it in runtime tests

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -51,6 +51,10 @@ The .NET Foundation licenses this file to you under the MIT license.
   <PropertyGroup Condition="'$(SuppressAotAnalysisWarnings)' == 'true'">
     <EnableAotAnalyzer Condition="'$(EnableAotAnalyzer)' == ''">false</EnableAotAnalyzer>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(SuppressSingleFileAnalysisWarnings)' == 'true'">
+    <EnableSingleFileAnalyzer Condition="'$(EnableSingleFileAnalyzer)' == ''">false</EnableSingleFileAnalyzer>
+  </PropertyGroup>
 
   <PropertyGroup>
     <NativeObjectExt Condition="'$(_targetOS)' == 'win'">.obj</NativeObjectExt>
@@ -267,6 +271,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(TrimmerSingleWarn) == 'true'" Include="--singlewarn" />
       <IlcArg Condition="$(SuppressTrimAnalysisWarnings) == 'true'" Include="--notrimwarn" />
       <IlcArg Condition="$(SuppressAotAnalysisWarnings) == 'true'" Include="--noaotwarn" />
+      <IlcArg Condition="$(SuppressSingleFileAnalysisWarnings) == 'true'" Include="--nosinglefilewarn" />
       <IlcArg Condition="$(IlcVerboseLogging) == 'true'" Include="--verbose" />
       <IlcArg Condition="$(IlcTrimMetadata) == 'false'" Include="--reflectiondata:all" />
       <IlcArg Condition="'$(ControlFlowGuard)' == 'Guard' and '$(_targetOS)' == 'win'" Include="--guard:cf" />

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -121,6 +121,8 @@ namespace ILCompiler
             new("--notrimwarn") { Description = "Disable warnings related to trimming" };
         public CliOption<bool> NoAotWarn { get; } =
             new("--noaotwarn") { Description = "Disable warnings related to AOT" };
+        public CliOption<bool> NoSingleFileWarn { get; } =
+            new("--nosinglefilewarn") { Description = "Disable warnings related to single file" };
         public CliOption<string[]> SingleWarnEnabledAssemblies { get; } =
             new("--singlewarnassembly") { DefaultValueFactory = _ => Array.Empty<string>(), Description = "Generate single AOT/trimming warning for given assembly" };
         public CliOption<string[]> SingleWarnDisabledAssemblies { get; } =
@@ -217,6 +219,7 @@ namespace ILCompiler
             Options.Add(SingleWarn);
             Options.Add(NoTrimWarn);
             Options.Add(NoAotWarn);
+            Options.Add(NoSingleFileWarn);
             Options.Add(SingleWarnEnabledAssemblies);
             Options.Add(SingleWarnDisabledAssemblies);
             Options.Add(DirectPInvokes);

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -72,6 +72,8 @@ namespace ILCompiler
                 suppressedWarningCategories.Add(MessageSubCategory.TrimAnalysis);
             if (Get(_command.NoAotWarn))
                 suppressedWarningCategories.Add(MessageSubCategory.AotAnalysis);
+            if (Get(_command.NoSingleFileWarn))
+                suppressedWarningCategories.Add(MessageSubCategory.SingleFileAnalysis);
 
             ILProvider ilProvider = new NativeAotILProvider();
 

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -128,6 +128,10 @@
     <RunAnalyzers>false</RunAnalyzers>
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>false</EnableSingleFileAnalyzer>
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+    <SuppressAotAnalysisWarnings>true</SuppressAotAnalysisWarnings>
+    <SuppressSingleFileAnalysisWarnings>true</SuppressSingleFileAnalysisWarnings>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SkipSigning Condition="'$(CrossGen)' == 'true'">true</SkipSigning>
     <AssemblyKey>Test</AssemblyKey>

--- a/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
@@ -223,6 +223,7 @@ namespace ILLink.Shared
 				2106 => MessageSubCategory.TrimAnalysis,
 				2107 => MessageSubCategory.TrimAnalysis,
 				>= 2109 and <= 2121 => MessageSubCategory.TrimAnalysis,
+				>= 3000 and <= 3049 => MessageSubCategory.SingleFileAnalysis,
 				>= 3050 and <= 3052 => MessageSubCategory.AotAnalysis,
 				>= 3054 and <= 3055 => MessageSubCategory.AotAnalysis,
 				_ => MessageSubCategory.None,

--- a/src/tools/illink/src/ILLink.Shared/MessageSubCategory.cs
+++ b/src/tools/illink/src/ILLink.Shared/MessageSubCategory.cs
@@ -12,5 +12,6 @@ namespace ILLink.Shared
 		public const string TrimAnalysis = "Trim analysis";
 		public const string UnresolvedAssembly = "Unresolved assembly";
 		public const string AotAnalysis = "AOT analysis";
+		public const string SingleFileAnalysis = "Single file analysis";
 	}
 }


### PR DESCRIPTION
ILC emitted warnings about single file analysis issues without a way to suppress them like we have for trimming/aot analysis.

Added that option and suppress these warnings in the runtime tests (we already disable the roslyn analyzers).