### PR TITLE
Use isRollingBuild variable instead of removed isFullMatrix in pipelines

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -32,7 +32,6 @@ jobs:
 
     # Linux armv6
     - ${{ if eq(parameters.platform, 'linux_armv6') }}:
-#      - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
       - (Raspbian.10.Armv6.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:raspbian-10-helix-arm32v6
 
     # Linux arm64

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -271,7 +271,7 @@ extends:
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
+                eq(variables['isRollingBuild'], true))
 
       #
       # CoreCLR NativeAOT checked build and smoke tests
@@ -309,7 +309,7 @@ extends:
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
+                eq(variables['isRollingBuild'], true))
 
       #
       # CoreCLR NativeAOT release build and smoke tests
@@ -353,7 +353,7 @@ extends:
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
+                eq(variables['isRollingBuild'], true))
 
       #
       # CoreCLR NativeAOT release build and libraries tests
@@ -384,7 +384,7 @@ extends:
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
+                eq(variables['isRollingBuild'], true))
 
       # Build and test clr tools
       - template: /eng/pipelines/common/platform-matrix.yml


### PR DESCRIPTION
isFullMatrix was replaced by isRollingBuild in https://github.com/dotnet/runtime/pull/62564, but we missed a couple places.