### PR TITLE
[mono] Reenable Sse2.X64/StoreNonTemporal tests

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/X86/Sse2.X64/StoreNonTemporal.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Sse2.X64/StoreNonTemporal.cs
@@ -16,7 +16,6 @@ namespace IntelHardwareIntrinsicTest.SSE2.X64
         const int Pass = 100;
         const int Fail = 0;
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54176", TestRuntimes.Mono)]
         [Fact]
         public static unsafe void StoreNonTemporal()
         {

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1204,12 +1204,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Int128/Int128TestFieldLayout/*">
             <Issue>https://github.com/dotnet/runtime/issues/74223</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/HardwareIntrinsics/X86/Sse2.X64/StoreNonTemporal_r/**">
-            <Issue>https://github.com/dotnet/runtime/issues/54176</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/HardwareIntrinsics/X86/Sse2.X64/StoreNonTemporal_ro/**">
-            <Issue>https://github.com/dotnet/runtime/issues/54176</Issue>
-        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/HardwareIntrinsics/X86/Sse42.X64/Crc32_*/**">
             <Issue>https://github.com/dotnet/runtime/issues/54185</Issue>
         </ExcludeList>


### PR DESCRIPTION
Reenabling the tests, since all the intrinsic handling seems to be present. Addresses https://github.com/dotnet/runtime/issues/93202