### PR TITLE
[wasm] Make it easy to run blazor startup measurements

### DIFF
--- a/src/mono/sample/wasm/browser-bench/README.md
+++ b/src/mono/sample/wasm/browser-bench/README.md
@@ -28,7 +28,7 @@ To run the benchmark with blazor startup measurements, set `BlazorStartup` prope
 
 ### Additional build arguments
 
-The benchark project is built in a separate process, so to pass additional msbuild arguments, use `BuildAdditionalArgs` property, like:
+The benchmark project is built in a separate process, so to pass additional msbuild arguments, use `BuildAdditionalArgs` property, like:
 
     > dotnet build /t:RunSample  /p:BuildAdditionalArgs="/p:WasmEnableSIMD=false"
 

--- a/src/mono/sample/wasm/browser-bench/README.md
+++ b/src/mono/sample/wasm/browser-bench/README.md
@@ -20,6 +20,18 @@ To run the benchmark on windows:
 
     > dotnet build /t:RunSample
 
+### Blazor startup measurements
+
+To run the benchmark with blazor startup measurements, set `BlazorStartup` property to `true`, like:
+
+    > dotnet build /t:RunSample /p:BlazorStartup=true
+
+### Additional build arguments
+
+The benchark project is built in a separate process, so to pass additional msbuild arguments, use `BuildAdditionalArgs` property, like:
+
+    > dotnet build /t:RunSample  /p:BuildAdditionalArgs="/p:WasmEnableSIMD=false"
+
 Example console output:
 
     > make run

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -8,6 +8,8 @@
     <EnableAggressiveTrimming Condition="'$(EnableAOTAndTrimming)' != ''">$(EnableAOTAndTrimming)</EnableAggressiveTrimming>
     <PublishTrimmed Condition="'$(EnableAOTAndTrimming)' != ''">$(EnableAOTAndTrimming)</PublishTrimmed>
     <RunAOTCompilation Condition="'$(EnableAOTAndTrimming)' != ''">$(EnableAOTAndTrimming)</RunAOTCompilation>
+    <RunSampleDependencies>RunSampleWithBrowserAndSimpleServer</RunSampleDependencies>
+    <RunSampleDependencies Condition="'$(BlazorStartup)' == 'true'">BuildBlazorFrame;$(RunSampleDependencies)</RunSampleDependencies>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,5 +21,61 @@
     <Compile Remove="Console/Console.cs" />
   </ItemGroup>
 
-  <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowserAndSimpleServer" />
+  <Target Name="RunSample" DependsOnTargets="$(RunSampleDependencies)" />
+
+  <Target Name="BuildWBT">
+    <PropertyGroup>
+      <_ScriptExt Condition="'$(OS)' == 'Windows_NT'">.cmd</_ScriptExt>
+      <_ScriptExt Condition="'$(OS)' != 'Windows_NT'">.sh</_ScriptExt>
+      <_Dotnet>$(RepoRoot)dotnet$(_ScriptExt)</_Dotnet>
+    </PropertyGroup>
+
+    <Exec IgnoreExitCode="true" Command="$(_Dotnet) build $(MSBuildThisFileDirectory)../../../wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj -c $(Configuration) -t:Test -p:TargetOS=browser -p:TargetArchitecture=wasm -p:XUnitClassName=none $(BuildAdditionalArgs)" />
+  </Target>
+
+  <Target Name="BuildBlazorFrame" DependsOnTargets="BuildSampleInTree;BuildWBT">
+    <ItemGroup>
+        <OverrideFiles Include="$(MSBuildThisFileDirectory)../../../../../src/mono/wasm/Wasm.Build.Tests/data/WasmOverridePacks.targets" />
+        <OverrideFiles Include="$(MSBuildThisFileDirectory)../../../../../src/mono/wasm/Wasm.Build.Tests/data/Blazor.Directory.Build.targets" />
+        <OverrideDestFiles Include="$(MSBuildThisFileDirectory)../blazor-frame/WasmOverridePacks.targets" />
+        <OverrideDestFiles Include="$(MSBuildThisFileDirectory)../blazor-frame/Directory.Build.targets" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(OverrideFiles)" DestinationFiles="@(OverrideDestFiles)" UseSymbolicLinksIfPossible="true" OverwriteReadOnlyFiles="true" />
+
+    <PropertyGroup>
+      <NugetConfigContent>&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
+&lt;configuration&gt;
+  &lt;!-- Don't use any higher level config files. --&gt;
+  &lt;fallbackPackageFolders&gt;
+    &lt;clear /&gt;
+  &lt;/fallbackPackageFolders&gt;
+  &lt;packageSources&gt;
+    &lt;clear /&gt;
+    &lt;add key=&quot;nuget-local&quot; value=&quot;$(ArtifactsDir)packages/Release/Shipping/&quot; /&gt;
+    &lt;add key=&quot;dotnet8&quot; value=&quot;https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json&quot; /&gt;
+    &lt;add key=&quot;nuget.org&quot;  value=&quot;https://api.nuget.org/v3/index.json&quot; protocolVersion=&quot;3&quot; /&gt;
+  &lt;/packageSources&gt;
+    &lt;disabledPackageSources&gt;
+    &lt;clear /&gt;
+  &lt;/disabledPackageSources&gt;
+&lt;/configuration&gt;
+      </NugetConfigContent>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+        File="$(MSBuildThisFileDirectory)../blazor-frame/nuget.config"
+        Overwrite="true"
+        Lines="$(NugetConfigContent)" />
+
+    <Exec EnvironmentVariables="MSBuildSDKsPath=;DOTNET_ROOT=$(ArtifactsDir)bin/dotnet-latest;PATH=$(ArtifactsDir)bin/dotnet-latest:$(PATH)" WorkingDirectory="$(MSBuildThisFileDirectory)../blazor-frame" Command="dotnet publish blazor.csproj -c $(Configuration) -p:WBTOverrideRuntimePack=true -p:TargetOS=browser -p:TargetArchitecture=wasm $(BuildAdditionalArgs)" />
+
+    <ItemGroup>
+        <BlazorSourceFiles Include="$(MSBuildThisFileDirectory)../blazor-frame/bin/Release/net8.0/publish/wwwroot/blazor-template/**/*.*"/>
+    </ItemGroup>
+
+    <Copy
+        SourceFiles="@(BlazorSourceFiles)"
+        DestinationFolder="$(MSBuildThisFileDirectory)/bin/$(Configuration)/AppBundle/blazor-template/%(RecursiveDir)" />
+  </Target>
 </Project>

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -30,15 +30,15 @@
       <_Dotnet>$(RepoRoot)dotnet$(_ScriptExt)</_Dotnet>
     </PropertyGroup>
 
-    <Exec IgnoreExitCode="true" Command="$(_Dotnet) build $(MSBuildThisFileDirectory)../../../wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj -c $(Configuration) -t:Test -p:TargetOS=browser -p:TargetArchitecture=wasm -p:XUnitClassName=none $(BuildAdditionalArgs)" />
+    <Exec IgnoreExitCode="true" Command="$(_Dotnet) build $(MonoProjectRoot)wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj -c $(Configuration) -t:InstallWorkloadUsingArtifacts -p:TargetOS=browser -p:TargetArchitecture=wasm $(BuildAdditionalArgs)" />
   </Target>
 
   <Target Name="BuildBlazorFrame" DependsOnTargets="BuildSampleInTree;BuildWBT">
     <ItemGroup>
-        <OverrideFiles Include="$(MSBuildThisFileDirectory)../../../../../src/mono/wasm/Wasm.Build.Tests/data/WasmOverridePacks.targets" />
-        <OverrideFiles Include="$(MSBuildThisFileDirectory)../../../../../src/mono/wasm/Wasm.Build.Tests/data/Blazor.Directory.Build.targets" />
-        <OverrideDestFiles Include="$(MSBuildThisFileDirectory)../blazor-frame/WasmOverridePacks.targets" />
-        <OverrideDestFiles Include="$(MSBuildThisFileDirectory)../blazor-frame/Directory.Build.targets" />
+        <OverrideFiles Include="$(MonoProjectRoot)wasm/Wasm.Build.Tests/data/WasmOverridePacks.targets" />
+        <OverrideFiles Include="$(MonoProjectRoot)wasm/Wasm.Build.Tests/data/Blazor.Directory.Build.targets" />
+        <OverrideDestFiles Include="$(MonoProjectRoot)sample/wasm/blazor-frame/WasmOverridePacks.targets" />
+        <OverrideDestFiles Include="$(MonoProjectRoot)sample/wasm/blazor-frame/Directory.Build.targets" />
     </ItemGroup>
 
     <Copy SourceFiles="@(OverrideFiles)" DestinationFiles="@(OverrideDestFiles)" UseSymbolicLinksIfPossible="true" OverwriteReadOnlyFiles="true" />
@@ -52,7 +52,7 @@
   &lt;/fallbackPackageFolders&gt;
   &lt;packageSources&gt;
     &lt;clear /&gt;
-    &lt;add key=&quot;nuget-local&quot; value=&quot;$(ArtifactsDir)packages/Release/Shipping/&quot; /&gt;
+    &lt;add key=&quot;nuget-local&quot; value=&quot;$(ArtifactsDir)packages/$(Configuration)/Shipping/&quot; /&gt;
     &lt;add key=&quot;dotnet8&quot; value=&quot;https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json&quot; /&gt;
     &lt;add key=&quot;nuget.org&quot;  value=&quot;https://api.nuget.org/v3/index.json&quot; protocolVersion=&quot;3&quot; /&gt;
   &lt;/packageSources&gt;
@@ -71,7 +71,7 @@
     <Exec EnvironmentVariables="MSBuildSDKsPath=;DOTNET_ROOT=$(ArtifactsDir)bin/dotnet-latest;PATH=$(ArtifactsDir)bin/dotnet-latest:$(PATH)" WorkingDirectory="$(MSBuildThisFileDirectory)../blazor-frame" Command="dotnet publish blazor.csproj -c $(Configuration) -p:WBTOverrideRuntimePack=true -p:TargetOS=browser -p:TargetArchitecture=wasm $(BuildAdditionalArgs)" />
 
     <ItemGroup>
-        <BlazorSourceFiles Include="$(MSBuildThisFileDirectory)../blazor-frame/bin/Release/net8.0/publish/wwwroot/blazor-template/**/*.*"/>
+        <BlazorSourceFiles Include="$(MSBuildThisFileDirectory)../blazor-frame/bin/$(Configuration)/net8.0/publish/wwwroot/blazor-template/**/*.*"/>
     </ItemGroup>
 
     <Copy


### PR DESCRIPTION
Add `BlazorStartup` property, which can be used to enable blazor startup measurements