### PR TITLE
Align data in Buffer.Memmove for arm64

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
@@ -248,7 +248,7 @@ namespace System
             }
 
 #if HAS_CUSTOM_BLOCKS
-            if (len > 128)
+            if (len >= 256)
             {
                 // Try to opportunistically align the destination below. The input isn't pinned, so the GC
                 // is free to move the references. We're therefore assuming that reads may still be unaligned.
@@ -261,6 +261,7 @@ namespace System
                 dest = ref Unsafe.Add(ref dest, misalignedElements);
                 len -= misalignedElements;
             }
+#endif
 
             // Copy 64-bytes at a time until the remainder is less than 64.
             // If remainder is greater than 16 bytes, then jump to MCPY00. Otherwise, unconditionally copy the last 16 bytes and return.

--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
@@ -246,25 +246,23 @@ namespace System
             //
             // TODO: Consider doing the same on x86/AMD64 for V256 and V512
 #if HAS_CUSTOM_BLOCKS && TARGET_ARM64
-            if (len >= 512 && Vector128.IsHardwareAccelerated)
+            if (Vector128.IsHardwareAccelerated && len >= 512)
             {
-                const nuint alignment = 16;
-
                 // Try to opportunistically align the destination below. The input isn't pinned, so the GC
                 // is free to move the references. We're therefore assuming that reads may still be unaligned.
                 //
                 // dest is more important to align than src because an unaligned store is more expensive
                 // than an unaligned load.
-                nuint misalignedElements = (nuint)Unsafe.AsPointer(ref dest) & (alignment - 1);
+                nuint misalignedElements = (nuint)Unsafe.AsPointer(ref dest) & (Vector128.Size - 1);
                 if (misalignedElements != 0)
                 {
                     // E.g. if misalignedElements is 4, it means we need to use a scalar loop
                     // for 16 - 4 = 12 elements till we're aligned to 16b boundary.
-                    misalignedElements = alignment - misalignedElements;
+                    misalignedElements = Vector128.Size - misalignedElements;
                     nuint offset = 0;
                     do
                     {
-                        // For large misalignments on x64 we might want to use smaller SIMD here.
+                        // For large misalignment on x64 we might want to use smaller SIMD here.
                         Unsafe.Add(ref dest, offset) = Unsafe.Add(ref src, offset);
                         offset++;
                     }


### PR DESCRIPTION
Currently, we [never switch](https://github.com/dotnet/runtime/blob/9f4884c1aa724e96f665c04d3b4be96125213ffc/src/libraries/System.Private.CoreLib/src/System/Buffer.Unix.cs#L8-L13) to the native `memmove` on ARM64 for Mac/Linux. Instead of enabling it back, I tested manual alignment for `dest` and for most cases saw small wins or the same performance as the native `memmove` on Apple M2 (macOS) and Ampere (Linux).

What's more important, it shows nice wins compared to the current impl when data is not 16 bytes aligned (even just 8-byte alignment is expensive) which is quite a common case since GC only offers 8-byte alignment and e.g. String's data is always 4-byte aligned, etc. A benchmark on Apple M2:

```cs
static byte[] _src = new byte[10000];
static byte[] _dst = new byte[10000];

[Benchmark]
public void CopyTo_align4() => _src.AsSpan(4).CopyTo(_dst.AsSpan(4));
```
Presumably, it should also help with the noise in microbenchmarks since GC gives us 8-byte alignment which can be sometimes naturally aligned to 16 bytes or may be not, depends on the Moon's phase.

| Method        | Toolchain               | Mean     | Error   | StdDev  | Ratio |
|-------------- |------------------------ |---------:|--------:|--------:|------:|
| CopyTo_align4 | /Core_Root_base/corerun | 195.1 ns | 0.75 ns | 0.70 ns |  1.68 |
| CopyTo_align4 | /Core_Root_pr/corerun   | **116.2 ns** | 0.54 ns | 0.50 ns |  1.00 |

I was using the following benchmark to get exact alignment in my tests:
```cs
static Benchmarks()
{
    byte* align64_src = (byte*)NativeMemory.AlignedAlloc(1_000_000, 64);
    byte* align64_dst = (byte*)NativeMemory.AlignedAlloc(1_000_000, 64);
    _align4_src = align64_src + 4;
    _align4_dst = align64_dst + 4;
}

[Benchmark]
[Arguments(...)]
public void CopyTo_align4(int len) =>
    new Span<byte>(_align4_src, len).CopyTo(new Span<byte>(_align4_dst, len));
```