### PR TITLE
[MT][browser] Disable new CI failures on library MT tests

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -117,6 +117,9 @@ jobs:
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       # Always run for runtime-wasm because tests are not run in runtime
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+
+       # NOTE - Since threading is experimental, we don't want to block mainline work
+      shouldContinueOnError: true
       scenarios:
         - WasmTestOnBrowser
         #- WasmTestOnNodeJS - this is not supported yet, https://github.com/dotnet/runtime/issues/85592

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -117,9 +117,6 @@ jobs:
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       # Always run for runtime-wasm because tests are not run in runtime
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
-
-       # NOTE - Since threading is experimental, we don't want to block mainline work
-      shouldContinueOnError: true
       scenarios:
         - WasmTestOnBrowser
         #- WasmTestOnNodeJS - this is not supported yet, https://github.com/dotnet/runtime/issues/85592

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -387,8 +387,6 @@
     <!-- https://github.com/dotnet/runtime/issues/91593 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Dataflow\tests\System.Threading.Tasks.Dataflow.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Channels\tests\System.Threading.Channels.Tests.csproj" />
-
-
   </ItemGroup>
 
   <!-- Aggressive Trimming related failures -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -57,6 +57,7 @@
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'" >
     <!-- https://github.com/dotnet/runtime/issues/91676 -->
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-eventpipe\Wasm.Browser.EventPipe.Sample.csproj" />
+    <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-threads-minimal\Wasm.Browser.Threads.Minimal.Sample.csproj" />
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\browser-minimal-config\Wasm.Browser.Config.Sample.csproj" />
   </ItemGroup>
 
@@ -370,12 +371,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Xml\tests\System.Security.Cryptography.Xml.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.X509Certificates\tests\System.Security.Cryptography.X509Certificates.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Cose\tests\System.Security.Cryptography.Cose.Tests.csproj" />
-    <!-- https://github.com/dotnet/runtime/issues/91538 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks\tests\System.Threading.Tasks.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections.Concurrent\tests\System.Collections.Concurrent.Tests.csproj" />
-    <!-- https://github.com/dotnet/runtime/issues/91593 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Dataflow\tests\System.Threading.Tasks.Dataflow.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Channels\tests\System.Threading.Channels.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread' and '$(RunDisabledWasmTests)' != 'true'">
@@ -385,6 +380,15 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
     <!-- Issue: https://github.com/dotnet/runtime/issues/74413 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\System.Net.WebSockets.Client.Tests.csproj" />
+    <!-- https://github.com/dotnet/runtime/issues/91538 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks\tests\System.Threading.Tasks.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections.Concurrent\tests\System.Collections.Concurrent.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyInjection\tests\DI.Tests\Microsoft.Extensions.DependencyInjection.Tests.csproj" />
+    <!-- https://github.com/dotnet/runtime/issues/91593 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Dataflow\tests\System.Threading.Tasks.Dataflow.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Channels\tests\System.Threading.Channels.Tests.csproj" />
+
+
   </ItemGroup>
 
   <!-- Aggressive Trimming related failures -->

--- a/src/mono/wasm/runtime/loader/worker.ts
+++ b/src/mono/wasm/runtime/loader/worker.ts
@@ -39,7 +39,7 @@ function onMonoConfigReceived(config: MonoConfigInternal): void {
     loaderHelpers.afterConfigLoaded.promise_control.resolve(loaderHelpers.config);
 
     if (ENVIRONMENT_IS_WEB && config.forwardConsoleLogsToWS && typeof globalThis.WebSocket != "undefined") {
-        loaderHelpers.setup_proxy_console("pthread-worker", console, self.location.href);
+        loaderHelpers.setup_proxy_console("pthread-worker", console, globalThis.location.origin);
     }
 }
 


### PR DESCRIPTION
- Block `Wasm.Browser.Threads.Minimal.Sample.csproj` for MT
- Move issues connected with MT exclusions to be blocked only in MT mode.
- Add project exclusion for Microsoft.Extensions.DependencyInjection.Tests

- Fixing ```fail: [out of order message from the browser]: http://127.0.0.1:33323/_framework/dotnet.js 2 WebSocket connection to 'ws://127.0.0.1:33323/_framework/dotnet.native.worker.js/console' failed: Error during WebSocket handshake: Unexpected response code: 404```