### PR TITLE
Do not clone empty arrays in CloneByteArray

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Helpers.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Helpers.cs
@@ -48,7 +48,7 @@ namespace Internal.Cryptography
             return src switch
             {
                 null => null,
-                [] => src,
+                { Length: 0 } => src,
                 _ => (byte[])src.Clone(),
             };
         }

--- a/src/libraries/Common/src/System/Security/Cryptography/Helpers.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Helpers.cs
@@ -45,12 +45,12 @@ namespace Internal.Cryptography
         [return: NotNullIfNotNull(nameof(src))]
         public static byte[]? CloneByteArray(this byte[]? src)
         {
-            if (src == null)
+            return src switch
             {
-                return null;
-            }
-
-            return (byte[])(src.Clone());
+                null => null,
+                [] => src,
+                _ => (byte[])src.Clone(),
+            };
         }
 
         internal static bool TryCopyToDestination(this ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)


### PR DESCRIPTION
`CloneByteArray` is used heavily in S.S.Cryptography to create defensive copies of byte arrays. This is to avoid exposing any kind of mutability to callers.

`Clone` however appears to [create a new `byte[]`][lab] for empty byte arrays every time. Empty arrays are not uncommon. It could be for a CNG property, it could be for key parameters, or other `AsnEncodedData`.

If its empty, just return the identity to save the allocation.

[lab]: https://sharplab.io/#v2:C4LgTgrgdgPgAgJgIwFgBQ6BGBPYBTAbQF0ACMEgXhKjwHcSd8CAGIgbi10NIGNKSAFI24BKMADoAwgBsA9jQEiOaYcRI8E/IV2JipchUvTo4SAJwCASngBmeMHig88AUQCOEAIbSAzgLAANOoiRmimFtZ2Dk6uHt5+AIJgYJ7Y4i4AtgAOwNgAPMIAfIpBPCHK4Va29o7O7l6+AjylCOVAA