### PR TITLE
Adjust the DNS lookup duration metric

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -577,7 +577,7 @@ namespace System.Net
         }
 
         private static Task<T>? GetAddrInfoWithTelemetryAsync<T>(string hostName, bool justAddresses, AddressFamily addressFamily, CancellationToken cancellationToken)
-     where T : class
+            where T : class
         {
             long startingTimestamp = Stopwatch.GetTimestamp();
             Task? task = NameResolutionPal.GetAddrInfoAsync(hostName, justAddresses, addressFamily, cancellationToken);

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -23,13 +23,13 @@ namespace System.Net
             {
                 name = NameResolutionPal.GetHostName();
             }
-            catch when (LogFailure(string.Empty, startingTimestamp))
+            catch (Exception ex) when (LogFailure(string.Empty, startingTimestamp, ex))
             {
                 Debug.Fail("LogFailure should return false");
                 throw;
             }
 
-            NameResolutionTelemetry.Log.AfterResolution(string.Empty, startingTimestamp, successful: true);
+            NameResolutionTelemetry.Log.AfterResolution(string.Empty, startingTimestamp, errorType: null);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, name);
             return name;
@@ -394,13 +394,13 @@ namespace System.Net
                         Aliases = aliases
                     };
             }
-            catch when (LogFailure(hostName, startingTimestamp))
+            catch (Exception ex) when (LogFailure(hostName, startingTimestamp, ex))
             {
                 Debug.Fail("LogFailure should return false");
                 throw;
             }
 
-            NameResolutionTelemetry.Log.AfterResolution(hostName, startingTimestamp, successful: true);
+            NameResolutionTelemetry.Log.AfterResolution(hostName, startingTimestamp, errorType: null);
 
             return result;
         }
@@ -434,13 +434,13 @@ namespace System.Net
                 }
                 Debug.Assert(name != null);
             }
-            catch when (LogFailure(address, startingTimestamp))
+            catch (Exception ex) when (LogFailure(address, startingTimestamp, ex))
             {
                 Debug.Fail("LogFailure should return false");
                 throw;
             }
 
-            NameResolutionTelemetry.Log.AfterResolution(address, startingTimestamp, successful: true);
+            NameResolutionTelemetry.Log.AfterResolution(address, startingTimestamp, errorType: null);
 
             // Do the forward lookup to get the IPs for that host name
             startingTimestamp = NameResolutionTelemetry.Log.BeforeResolution(name);
@@ -464,13 +464,13 @@ namespace System.Net
                         AddressList = addresses
                     };
             }
-            catch when (LogFailure(name, startingTimestamp))
+            catch (Exception ex) when (LogFailure(name, startingTimestamp, ex))
             {
                 Debug.Fail("LogFailure should return false");
                 throw;
             }
 
-            NameResolutionTelemetry.Log.AfterResolution(name, startingTimestamp, successful: true);
+            NameResolutionTelemetry.Log.AfterResolution(name, startingTimestamp, errorType: null);
 
             // One of three things happened:
             // 1. Success.
@@ -577,7 +577,7 @@ namespace System.Net
         }
 
         private static Task<T>? GetAddrInfoWithTelemetryAsync<T>(string hostName, bool justAddresses, AddressFamily addressFamily, CancellationToken cancellationToken)
-             where T : class
+     where T : class
         {
             long startingTimestamp = Stopwatch.GetTimestamp();
             Task? task = NameResolutionPal.GetAddrInfoAsync(hostName, justAddresses, addressFamily, cancellationToken);
@@ -594,18 +594,32 @@ namespace System.Net
             static async Task<T> CompleteAsync(Task task, string hostName, long startingTimestamp)
             {
                 _ = NameResolutionTelemetry.Log.BeforeResolution(hostName);
-                T? result = null;
+                string? errorType = null;
                 try
                 {
-                    result = await ((Task<T>)task).ConfigureAwait(false);
-                    return result;
+                    return await ((Task<T>)task).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    errorType = GetErrorType(ex);
+                    throw;
                 }
                 finally
                 {
-                    NameResolutionTelemetry.Log.AfterResolution(hostName, startingTimestamp, successful: result is not null);
+                    NameResolutionTelemetry.Log.AfterResolution(hostName, startingTimestamp, errorType);
                 }
             }
         }
+
+        private static string GetErrorType(Exception exception) => (exception as SocketException)?.SocketErrorCode switch
+        {
+            SocketError.HostNotFound => "host_not_found",
+            SocketError.TryAgain => "try_again",
+            SocketError.AddressFamilyNotSupported => "address_family_not_supported",
+            SocketError.NoRecovery => "no_recovery",
+
+            _ => exception.GetType().Name
+        };
 
         private static IPHostEntry CreateHostEntryForAddress(IPAddress address) =>
             new IPHostEntry
@@ -627,9 +641,10 @@ namespace System.Net
             }
         }
 
-        private static bool LogFailure(object hostNameOrAddress, long? startingTimestamp)
+        private static bool LogFailure(object hostNameOrAddress, long? startingTimestamp, Exception exception)
         {
-            NameResolutionTelemetry.Log.AfterResolution(hostNameOrAddress, startingTimestamp, successful: false);
+            string errorType = GetErrorType(exception);
+            NameResolutionTelemetry.Log.AfterResolution(hostNameOrAddress, startingTimestamp, errorType);
             return false;
         }
 

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
@@ -41,7 +41,7 @@ namespace System.Net
             SocketError.AddressFamilyNotSupported => "address_family_not_supported",
             SocketError.NoRecovery => "no_recovery",
 
-            _ => exception.GetType().Name
+            _ => exception.GetType().FullName!
         };
     }
 }

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
@@ -19,9 +19,19 @@ namespace System.Net
 
         public static bool IsEnabled() => s_lookupDuration.Enabled;
 
-        public static void AfterResolution(TimeSpan duration, string hostName)
+        public static void AfterResolution(TimeSpan duration, string hostName, string? errorType)
         {
-            s_lookupDuration.Record(duration.TotalSeconds, KeyValuePair.Create("dns.question.name", (object?)hostName));
+            var hostNameTag = KeyValuePair.Create("dns.question.name", (object?)hostName);
+
+            if (errorType is null)
+            {
+                s_lookupDuration.Record(duration.TotalSeconds, hostNameTag);
+            }
+            else
+            {
+                var errorTypeTag = KeyValuePair.Create("error.type", (object?)errorType);
+                s_lookupDuration.Record(duration.TotalSeconds, hostNameTag, errorTypeTag);
+            }
         }
     }
 }

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
@@ -13,7 +13,7 @@ namespace System.Net
         private static readonly Meter s_meter = new("System.Net.NameResolution");
 
         private static readonly Histogram<double> s_lookupDuration = s_meter.CreateHistogram<double>(
-            name: "dns.lookups.duration",
+            name: "dns.lookup.duration",
             unit: "s",
             description: "Measures the time taken to perform a DNS lookup.");
 

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
@@ -81,7 +81,7 @@ namespace System.Net
         }
 
         [NonEvent]
-        public void AfterResolution(object hostNameOrAddress, long? startingTimestamp, bool successful)
+        public void AfterResolution(object hostNameOrAddress, long? startingTimestamp, string? errorType)
         {
             Debug.Assert(startingTimestamp.HasValue);
             if (startingTimestamp == 0)
@@ -99,7 +99,7 @@ namespace System.Net
 
                 if (IsEnabled(EventLevel.Informational, EventKeywords.None))
                 {
-                    if (!successful)
+                    if (errorType is not null)
                     {
                         ResolutionFailed();
                     }
@@ -110,7 +110,7 @@ namespace System.Net
 
             if (NameResolutionMetrics.IsEnabled())
             {
-                NameResolutionMetrics.AfterResolution(duration, GetHostnameFromStateObject(hostNameOrAddress));
+                NameResolutionMetrics.AfterResolution(duration, GetHostnameFromStateObject(hostNameOrAddress), errorType);
             }
         }
 

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
@@ -81,7 +81,7 @@ namespace System.Net
         }
 
         [NonEvent]
-        public void AfterResolution(object hostNameOrAddress, long? startingTimestamp, string? errorType)
+        public void AfterResolution(object hostNameOrAddress, long? startingTimestamp, Exception? exception = null)
         {
             Debug.Assert(startingTimestamp.HasValue);
             if (startingTimestamp == 0)
@@ -99,7 +99,7 @@ namespace System.Net
 
                 if (IsEnabled(EventLevel.Informational, EventKeywords.None))
                 {
-                    if (errorType is not null)
+                    if (exception is not null)
                     {
                         ResolutionFailed();
                     }
@@ -110,7 +110,7 @@ namespace System.Net
 
             if (NameResolutionMetrics.IsEnabled())
             {
-                NameResolutionMetrics.AfterResolution(duration, GetHostnameFromStateObject(hostNameOrAddress), errorType);
+                NameResolutionMetrics.AfterResolution(duration, GetHostnameFromStateObject(hostNameOrAddress), exception);
             }
         }
 

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/MetricsTest.cs
@@ -57,17 +57,26 @@ namespace System.Net.NameResolution.Tests
             Assert.ThrowsAny<SocketException>(() => Dns.EndGetHostEntry(Dns.BeginGetHostEntry(InvalidHostName, null, null)));
             Assert.ThrowsAny<SocketException>(() => Dns.EndGetHostAddresses(Dns.BeginGetHostAddresses(InvalidHostName, null, null)));
 
-            double[] measurements = GetMeasurementsForHostname(recorder, InvalidHostName);
+            double[] measurements = GetMeasurementsForHostname(recorder, InvalidHostName, "host_not_found");
 
             Assert.Equal(6, measurements.Length);
             Assert.All(measurements, m => Assert.True(m > double.Epsilon));
         }
 
-        private static double[] GetMeasurementsForHostname(InstrumentRecorder<double> recorder, string hostname)
+        private static double[] GetMeasurementsForHostname(InstrumentRecorder<double> recorder, string hostname, string? expectedErrorType = null)
         {
             return recorder
                 .GetMeasurements()
-                .Where(m => m.Tags.ToArray().Any(t => t.Key == "dns.question.name" && t.Value is string hostnameTag && hostnameTag == hostname))
+                .Where(m =>
+                {
+                    KeyValuePair<string, object?>[] tags = m.Tags.ToArray();
+                    if (!tags.Any(t => t.Key == "dns.question.name" && t.Value is string hostnameTag && hostnameTag == hostname))
+                    {
+                        return false;
+                    }
+                    string? actualErrorType = tags.FirstOrDefault(t => t.Key == "error.type").Value as string;
+                    return expectedErrorType == actualErrorType;
+                })
                 .Select(m => m.Value)
                 .ToArray();
         }

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/MetricsTest.cs
@@ -14,7 +14,7 @@ namespace System.Net.NameResolution.Tests
 {
     public class MetricsTest
     {
-        private const string DnsLookupDuration = "dns.lookups.duration";
+        private const string DnsLookupDuration = "dns.lookup.duration";
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public static void ResolveValidHostName_MetricsRecorded()


### PR DESCRIPTION
- #92917
- #92837

This is a necessary change  to ensure the metric is in sync with the spec and the OTel recommendations. An 8.0 backport is planned to avoid future breaking changes.