### PR TITLE
Rename `server.socket.address` to `network.peer.address`

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetrics.cs
@@ -14,10 +14,10 @@ namespace System.Net.Http.Metrics
         private readonly object _schemeTag;
         private readonly object _hostTag;
         private readonly object? _portTag;
-        private readonly object? _socketAddressTag;
+        private readonly object? _peerAddressTag;
         private bool _currentlyIdle;
 
-        public ConnectionMetrics(SocketsHttpHandlerMetrics metrics, string protocolVersion, string scheme, string host, int? port, string? socketAddress)
+        public ConnectionMetrics(SocketsHttpHandlerMetrics metrics, string protocolVersion, string scheme, string host, int? port, string? peerAddress)
         {
             _metrics = metrics;
             _openConnectionsEnabled = _metrics.OpenConnections.Enabled;
@@ -25,7 +25,7 @@ namespace System.Net.Http.Metrics
             _schemeTag = scheme;
             _hostTag = host;
             _portTag = port;
-            _socketAddressTag = socketAddress;
+            _peerAddressTag = peerAddress;
         }
 
         // TagList is a huge struct, so we avoid storing it in a field to reduce the amount we allocate on the heap.
@@ -42,9 +42,9 @@ namespace System.Net.Http.Metrics
                 tags.Add("server.port", _portTag);
             }
 
-            if (_socketAddressTag is not null)
+            if (_peerAddressTag is not null)
             {
-                tags.Add("server.socket.address", _socketAddressTag);
+                tags.Add("network.peer.address", _peerAddressTag);
             }
 
             return tags;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -47,7 +47,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        private static void VerifyPeerAddress(KeyValuePair<string, object?>[] tags, Uri uri)
+        private static void VerifyPeerAddress(KeyValuePair<string, object?>[] tags)
         {
             string ipString = (string)tags.Single(t => t.Key == "network.peer.address").Value;
             IPAddress ip = IPAddress.Parse(ipString);
@@ -122,7 +122,7 @@ namespace System.Net.Http.Functional.Tests
             VerifySchemeHostPortTags(tags, uri);
             VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
             VerifyTag(tags, "http.connection.state", state);
-            VerifyPeerAddress(tags, uri);
+            VerifyPeerAddress(tags);
         }
 
         protected static void VerifyConnectionDuration(string instrumentName, object measurement, KeyValuePair<string, object?>[] tags, Uri uri, Version? protocolVersion)
@@ -132,7 +132,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.InRange(value, double.Epsilon, 60);
             VerifySchemeHostPortTags(tags, uri);
             VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
-            VerifyPeerAddress(tags, uri);
+            VerifyPeerAddress(tags);
         }
 
         protected static void VerifyTimeInQueue(string instrumentName, object measurement, KeyValuePair<string, object?>[] tags, Uri uri, Version? protocolVersion, string method = "GET")

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -47,9 +47,9 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        private static void VerifySocketAddress(KeyValuePair<string, object?>[] tags)
+        private static void VerifyPeerAddress(KeyValuePair<string, object?>[] tags, Uri uri)
         {
-            string ipString = (string)tags.Single(t => t.Key == "server.socket.address").Value;
+            string ipString = (string)tags.Single(t => t.Key == "network.peer.address").Value;
             IPAddress ip = IPAddress.Parse(ipString);
             Assert.True(ip.Equals(IPAddress.Loopback.MapToIPv6()) ||
                     ip.Equals(IPAddress.Loopback) ||
@@ -122,7 +122,7 @@ namespace System.Net.Http.Functional.Tests
             VerifySchemeHostPortTags(tags, uri);
             VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
             VerifyTag(tags, "http.connection.state", state);
-            VerifySocketAddress(tags);
+            VerifyPeerAddress(tags, uri);
         }
 
         protected static void VerifyConnectionDuration(string instrumentName, object measurement, KeyValuePair<string, object?>[] tags, Uri uri, Version? protocolVersion)
@@ -132,7 +132,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.InRange(value, double.Epsilon, 60);
             VerifySchemeHostPortTags(tags, uri);
             VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
-            VerifySocketAddress(tags);
+            VerifyPeerAddress(tags, uri);
         }
 
         protected static void VerifyTimeInQueue(string instrumentName, object measurement, KeyValuePair<string, object?>[] tags, Uri uri, Version? protocolVersion, string method = "GET")


### PR DESCRIPTION
Address #92956:

Keep .NET metrics in sync with OTel by implementing a naming change from https://github.com/open-telemetry/semantic-conventions/pull/342.  An 8.0 backport is planned to avoid future breaking changes.