### PR TITLE
WIP: experimental LoadLibrary monitoring in CoreCLR native runtime

### DIFF
--- a/src/coreclr/pal/src/CMakeLists.txt
+++ b/src/coreclr/pal/src/CMakeLists.txt
@@ -342,3 +342,6 @@ endif(FEATURE_EVENT_TRACE)
 
 # Install the static PAL library for VS
 install_clr (TARGETS coreclrpal DESTINATIONS lib)
+
+# .NET 9 experiment - enable PAL_PERF
+add_definitions(-DPAL_PERF)

--- a/src/coreclr/pal/src/CMakeLists.txt
+++ b/src/coreclr/pal/src/CMakeLists.txt
@@ -342,6 +342,3 @@ endif(FEATURE_EVENT_TRACE)
 
 # Install the static PAL library for VS
 install_clr (TARGETS coreclrpal DESTINATIONS lib)
-
-# .NET 9 experiment - enable PAL_PERF
-add_definitions(-DPAL_PERF)

--- a/src/coreclr/utilcode/longfilepathwrappers.cpp
+++ b/src/coreclr/utilcode/longfilepathwrappers.cpp
@@ -286,6 +286,10 @@ DWORD WINAPI GetEnvironmentVariableWrapper(
 
 #ifdef HOST_WINDOWS
 
+volatile static int64_t s_loadLibraryFrequency = 0;
+volatile static int64_t s_loadLibraryTicks = 0;
+volatile static int32_t s_loadLibraryCount = 0;
+
 HMODULE
 LoadLibraryExWrapper(
         LPCWSTR lpLibFileName,
@@ -311,7 +315,24 @@ LoadLibraryExWrapper(
         {
             LongFile::NormalizeDirectorySeparators(path);
 
+            int64_t frequency = s_loadLibraryFrequency;
+            if (frequency == 0)
+            {
+                QueryPerformanceFrequency((LARGE_INTEGER *)&frequency);
+                s_loadLibraryFrequency = frequency;
+            }
+
+            int64_t before;
+            QueryPerformanceCounter((LARGE_INTEGER *)&before);
             ret = LoadLibraryExW(path.GetUnicode(), hFile, dwFlags);
+            int64_t after;
+            QueryPerformanceCounter((LARGE_INTEGER *)&after);
+            int64_t loadTime = after - before;
+            int64_t totalTime = ::InterlockedAdd64(&s_loadLibraryTicks, loadTime);
+            printf("\nLoadLibrary(%S): %.6f seconds, %.6f total\n",
+                lpLibFileName,
+                loadTime / (double)s_loadLibraryFrequency, 
+                totalTime / (double)s_loadLibraryFrequency);
         }
 
         lastError = GetLastError();

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -522,6 +522,8 @@ LoadedImageLayout::LoadedImageLayout(PEImage* pOwner, HRESULT* loadFailure)
     m_pOwner = pOwner;
     _ASSERTE(pOwner->GetUncompressedSize() == 0);
 
+    int64_t before = GetPreciseTickCount();
+
 #ifndef TARGET_UNIX
     _ASSERTE(!pOwner->IsInBundle());
     m_Module = CLRLoadLibraryEx(pOwner->GetPath(), NULL, GetLoadWithAlteredSearchPathFlag());
@@ -581,6 +583,7 @@ LoadedImageLayout::LoadedImageLayout(PEImage* pOwner, HRESULT* loadFailure)
         SetRelocated();
     }
 #endif
+    ReportLoadLibraryTime(pOwner->GetPath(), GetPreciseTickCount() - before);
 }
 
 #if !defined(TARGET_UNIX)
@@ -1197,6 +1200,9 @@ UNSUPPORTED:
 NativeImageLayout::NativeImageLayout(LPCWSTR fullPath)
 {
     PVOID loadedImage;
+    
+    int64_t before = GetPreciseTickCount();
+
 #if TARGET_UNIX
     {
         HANDLE fileHandle = WszCreateFile(
@@ -1218,6 +1224,8 @@ NativeImageLayout::NativeImageLayout(LPCWSTR fullPath)
 #else
     loadedImage = CLRLoadLibraryEx(fullPath, NULL, GetLoadWithAlteredSearchPathFlag());
 #endif
+
+    ReportLoadLibraryTime(fullPath, GetPreciseTickCount() - before);
 
     if (loadedImage == NULL)
     {

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -540,6 +540,8 @@ LoadedImageLayout::LoadedImageLayout(PEImage* pOwner, HRESULT* loadFailure)
 #endif // LOGGING
 
 #else
+    ReportPreloadTime(pOwner->GetPath());
+
     int64_t before = GetPreciseTickCount();
 
     HANDLE hFile = pOwner->GetFileHandle();
@@ -582,7 +584,7 @@ LoadedImageLayout::LoadedImageLayout(PEImage* pOwner, HRESULT* loadFailure)
         ApplyBaseRelocations(/* relocationMustWriteCopy*/ false);
         SetRelocated();
     }
-    ReportTime("LOAD_LIBRARY", pOwner->GetPath(), before);
+    ReportActionTime("LOAD_LIBRARY", pOwner->GetPath(), before);
 #endif
 }
 
@@ -1202,6 +1204,8 @@ NativeImageLayout::NativeImageLayout(LPCWSTR fullPath)
     PVOID loadedImage;
     
 #if TARGET_UNIX
+    ReportPreloadTime(fullPath);
+
     int64_t before = GetPreciseTickCount();
 
     {
@@ -1221,7 +1225,7 @@ NativeImageLayout::NativeImageLayout(LPCWSTR fullPath)
 
         loadedImage = PAL_LOADLoadPEFile(fileHandle, 0);
     }
-    ReportTime("LOAD_LIBRARY", fullPath, before);
+    ReportActionTime("LOAD_LIBRARY", fullPath, before);
 
 #else
     loadedImage = CLRLoadLibraryEx(fullPath, NULL, GetLoadWithAlteredSearchPathFlag());

--- a/src/coreclr/vm/util.cpp
+++ b/src/coreclr/vm/util.cpp
@@ -930,7 +930,7 @@ static int64_t GetPreciseTickCount()
     return result;
 #else
     struct timespec ts;
-    timespec_get(&ts, TIME_UTC);
+    clock_gettime(CLOCK_MONOTONIC, &ts);
     return ts.tv_sec * (1000 * 1000 * 1000) + ts.tv_nsec;
 #endif
 }

--- a/src/coreclr/vm/util.cpp
+++ b/src/coreclr/vm/util.cpp
@@ -937,7 +937,7 @@ static int64_t GetPreciseTickCount()
 
 static void ReportLoadLibraryTime(LPCWSTR lpFileName, int64_t loadTime)
 {
-    int32_t loadLibraryCount = ::InterlockedAdd((long *)&s_loadLibraryCount, 1);
+    int32_t loadLibraryCount = ::InterlockedAdd((volatile int *)&s_loadLibraryCount, 1);
     int64_t totalTime = ::InterlockedAdd64(&s_loadLibraryTicks, loadTime);
     double frequency = (double)GetTimerFrequency();
     printf("\nLoadLibrary(%d: %S): %.6f seconds, %.6f total\n",

--- a/src/coreclr/vm/util.cpp
+++ b/src/coreclr/vm/util.cpp
@@ -904,7 +904,7 @@ CLRUnmapViewOfFile(
 
 volatile static int64_t s_timerFrequency = 0;
 volatile static int64_t s_loadLibraryTicks = 0;
-volatile static uint32_t s_loadLibraryCount = 0;
+volatile static int32_t s_loadLibraryCount = 0;
 
 static int64_t GetTimerFrequency()
 {
@@ -937,7 +937,7 @@ static int64_t GetPreciseTickCount()
 
 static void ReportLoadLibraryTime(LPCWSTR lpFileName, int64_t loadTime)
 {
-    int32_t loadLibraryCount = ::InterlockedIncrement(&s_loadLibraryCount);
+    int32_t loadLibraryCount = ::InterlockedAdd((long *)&s_loadLibraryCount, 1);
     int64_t totalTime = ::InterlockedAdd64(&s_loadLibraryTicks, loadTime);
     double frequency = (double)GetTimerFrequency();
     printf("\nLoadLibrary(%d: %S): %.6f seconds, %.6f total\n",

--- a/src/coreclr/vm/util.cpp
+++ b/src/coreclr/vm/util.cpp
@@ -905,20 +905,21 @@ CLRUnmapViewOfFile(
 volatile static int64_t s_loadLibraryTicks = 0;
 volatile static LONG s_loadLibraryCount = 0;
 
-static int64_t GetPreciseTickCount()
+int64_t GetPreciseTickCount()
 {
     int64_t result;
     QueryPerformanceCounter((LARGE_INTEGER *)&result);
     return result;
 }
 
-static void ReportLoadLibraryTime(LPCWSTR lpFileName, int64_t loadTime)
+void ReportLoadLibraryTime(LPCWSTR lpFileName, int64_t loadTime)
 {
     long loadLibraryCount = ::InterlockedAdd(&s_loadLibraryCount, 1);
     int64_t totalTime = ::InterlockedAdd64(&s_loadLibraryTicks, loadTime);
-    printf("\nLoadLibrary(%ld: %S): %.6f seconds, %.6f total\n",
+    MAKE_UTF8PTR_FROMWIDE_NOTHROW(fileNameUtf8, lpFileName);
+    printf("\nLoadLibrary [%ld]: '%s' - %.6f seconds, %.6f total\n",
         loadLibraryCount,
-        (wchar_t *)lpFileName,
+        fileNameUtf8,
         loadTime * 1e-9,
         totalTime * 1e-9);
 }

--- a/src/coreclr/vm/util.cpp
+++ b/src/coreclr/vm/util.cpp
@@ -916,9 +916,9 @@ static void ReportLoadLibraryTime(LPCWSTR lpFileName, int64_t loadTime)
 {
     long loadLibraryCount = ::InterlockedAdd(&s_loadLibraryCount, 1);
     int64_t totalTime = ::InterlockedAdd64(&s_loadLibraryTicks, loadTime);
-    printf("\nLoadLibrary(%d: %S): %.6f seconds, %.6f total\n",
+    printf("\nLoadLibrary(%ld: %S): %.6f seconds, %.6f total\n",
         loadLibraryCount,
-        lpFileName,
+        (wchar_t *)lpFileName,
         loadTime * 1e-9,
         totalTime * 1e-9);
 }

--- a/src/coreclr/vm/util.cpp
+++ b/src/coreclr/vm/util.cpp
@@ -916,12 +916,14 @@ void ReportLoadLibraryTime(LPCWSTR lpFileName, int64_t loadTime)
 {
     long loadLibraryCount = ::InterlockedAdd(&s_loadLibraryCount, 1);
     int64_t totalTime = ::InterlockedAdd64(&s_loadLibraryTicks, loadTime);
+    int64_t frequency;
+    QueryPerformanceFrequency((LARGE_INTEGER *)&frequency);
     MAKE_UTF8PTR_FROMWIDE_NOTHROW(fileNameUtf8, lpFileName);
     printf("\nLoadLibrary [%ld]: '%s' - %.6f seconds, %.6f total\n",
         loadLibraryCount,
         fileNameUtf8,
-        loadTime * 1e-9,
-        totalTime * 1e-9);
+        loadTime / (double)frequency,
+        totalTime / (double)frequency);
 }
 
 static HMODULE CLRLoadLibraryWorker(LPCWSTR lpLibFileName, DWORD *pLastError)

--- a/src/coreclr/vm/util.cpp
+++ b/src/coreclr/vm/util.cpp
@@ -903,7 +903,7 @@ CLRUnmapViewOfFile(
 }
 
 volatile static int64_t s_loadLibraryTicks = 0;
-volatile static long s_loadLibraryCount = 0;
+volatile static LONG s_loadLibraryCount = 0;
 
 static int64_t GetPreciseTickCount()
 {

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -501,6 +501,7 @@ CLRUnmapViewOfFile(
 
 int64_t GetPreciseTickCount();
 void ReportActionTime(const char *actionName, LPCWSTR lpFileName, int64_t beforeTicks);
+void ReportPreloadTime(LPCWSTR lpFileName);
 
 #ifndef DACCESS_COMPILE
 FORCEINLINE void VoidCLRUnmapViewOfFile(void *ptr) { CLRUnmapViewOfFile(ptr); }

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -499,6 +499,9 @@ CLRUnmapViewOfFile(
     IN LPVOID lpBaseAddress
     );
 
+int64_t GetPreciseTickCount();
+void ReportLoadLibraryTime(LPCWSTR lpFileName, int64_t loadTime);
+
 #ifndef DACCESS_COMPILE
 FORCEINLINE void VoidCLRUnmapViewOfFile(void *ptr) { CLRUnmapViewOfFile(ptr); }
 typedef Wrapper<void *, DoNothing, VoidCLRUnmapViewOfFile> CLRMapViewHolder;

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -500,7 +500,7 @@ CLRUnmapViewOfFile(
     );
 
 int64_t GetPreciseTickCount();
-void ReportLoadLibraryTime(LPCWSTR lpFileName, int64_t loadTime);
+void ReportActionTime(const char *actionName, LPCWSTR lpFileName, int64_t beforeTicks);
 
 #ifndef DACCESS_COMPILE
 FORCEINLINE void VoidCLRUnmapViewOfFile(void *ptr) { CLRUnmapViewOfFile(ptr); }


### PR DESCRIPTION
As an initial step towards analyzing ASP.NET startup perf I have added bits of instrumentation to the native CoreCLR runtime to measure LoadLibrary performance. According to my initial measurements there is a vast difference between Windows and Linux w.r.t. LoadLibrary perf; as a first step I would be grateful if you could double-check my implementation for obvious flaws or overlookings, after that we can drill into more detail regarding the actual numbers. I also think it might be useful to figure out how to merge this in somehow to make such measurements repeatable, I'm looking forward to any feedback you might have.

Thanks

Tomas