### PR TITLE
[android][ios] Fix dispose problem with NativeHttpHandlers

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
@@ -51,10 +51,7 @@ namespace System.Net.Http
                         MetricsHandler metricsHandler = new MetricsHandler(handler, _nativeMeterFactory, out _);
 
                         // Ensure a single handler is used for all requests.
-                        if (Interlocked.CompareExchange(ref _nativeMetricsHandler, metricsHandler, null) != null)
-                        {
-                            handler.Dispose();
-                        }
+                        Interlocked.CompareExchange(ref _nativeMetricsHandler, metricsHandler, null);
                     }
 
                     return _nativeMetricsHandler;
@@ -87,7 +84,7 @@ namespace System.Net.Http
 
                 if (IsNativeHandlerEnabled)
                 {
-                    _nativeHandler!.Dispose();
+                    Handler.Dispose();
                 }
                 else
                 {


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/90298 made sure the MetricsHandler was the top level handler for all NativeHttpHandler requests similar to what is done with SocketsHttpHandler. After creating the MetricsHandler, the code mistakenly disposed of `_nativeHandler`, which resulted in `Dispose` being called multiple times and eventually throwing a `Cannot access a disposed object` exception.

Fixes https://github.com/dotnet/runtime/issues/93252