### PR TITLE
Skip Jitted Methods Counting Test when DOTNET_EnableHWIntrinsic=0

### DIFF
--- a/src/tests/readytorun/JittedMethodsCountingTest/JittedMethodsCountingTest.cs
+++ b/src/tests/readytorun/JittedMethodsCountingTest/JittedMethodsCountingTest.cs
@@ -23,18 +23,8 @@ public class JittedMethodsCountingTest
             return 100;
         }
 
-        // This test is currently not compatible with the R2R-CG2 pipelines on Arm64.
-        // if (IsRunCrossgen2Set() && IsRunningOnARM64())
-        // {
-        //     Console.WriteLine("\nThis test is currently unsupported on ARM64 when"
-        //                       + " RunCrossGen2 is enabled. Skipping...\n");
-        //     return 100;
-        // }
-
         Console.WriteLine("\nHello World from Jitted Methods Counting Test!");
-
-        // Get the total amount of Jitted Methods.
-        long jits = JitInfo.GetCompiledMethodCount(false);
+        long jits = JitInfo.GetCompiledMethodCount(currentThread: false);
 
         Console.WriteLine("Number of Jitted Methods in App: {0} - Max Threshold: {1}\n",
                           jits,

--- a/src/tests/readytorun/JittedMethodsCountingTest/JittedMethodsCountingTest.cs
+++ b/src/tests/readytorun/JittedMethodsCountingTest/JittedMethodsCountingTest.cs
@@ -24,6 +24,7 @@ public class JittedMethodsCountingTest
         }
 
         Console.WriteLine("\nHello World from Jitted Methods Counting Test!");
+
         long jits = JitInfo.GetCompiledMethodCount(currentThread: false);
 
         Console.WriteLine("Number of Jitted Methods in App: {0} - Max Threshold: {1}\n",
@@ -37,21 +38,6 @@ public class JittedMethodsCountingTest
     {
         string? dotnetR2R = Environment.GetEnvironmentVariable("DOTNET_ReadyToRun");
         return (string.IsNullOrEmpty(dotnetR2R) || dotnetR2R == "1");
-    }
-
-    private static bool IsRunCrossgen2Set()
-    {
-        string? runCrossgen2 = Environment.GetEnvironmentVariable("RunCrossGen2");
-        return (!string.IsNullOrEmpty(runCrossgen2) && runCrossgen2 == "1");
-    }
-
-    private static bool IsRunningOnARM64()
-    {
-        InteropServices.Architecture thisMachineArch = InteropServices
-                                                      .RuntimeInformation
-                                                      .OSArchitecture;
-
-        return (thisMachineArch == InteropServices.Architecture.Arm64);
     }
 
     private static bool IsHardwareIntrinsicsEnabled()

--- a/src/tests/readytorun/JittedMethodsCountingTest/JittedMethodsCountingTest.cs
+++ b/src/tests/readytorun/JittedMethodsCountingTest/JittedMethodsCountingTest.cs
@@ -24,12 +24,12 @@ public class JittedMethodsCountingTest
         }
 
         // This test is currently not compatible with the R2R-CG2 pipelines on Arm64.
-        if (IsRunCrossgen2Set() && IsRunningOnARM64())
-        {
-            Console.WriteLine("\nThis test is currently unsupported on ARM64 when"
-                              + " RunCrossGen2 is enabled. Skipping...\n");
-            return 100;
-        }
+        // if (IsRunCrossgen2Set() && IsRunningOnARM64())
+        // {
+        //     Console.WriteLine("\nThis test is currently unsupported on ARM64 when"
+        //                       + " RunCrossGen2 is enabled. Skipping...\n");
+        //     return 100;
+        // }
 
         Console.WriteLine("\nHello World from Jitted Methods Counting Test!");
 


### PR DESCRIPTION
Resolves Issue #93261.

Recently, a new regression uncovered an untreated case in the Jitted Methods Counting Test. Due to its purpose and how it works, this test is incompatible when Hardware Intrinsics are disabled (i.e., `DOTNET_EnableHWIntrinsic=0`). This PR tells it to skip when such environment is detected.