### PR TITLE
[browser] Resolve asset URL only once

### DIFF
--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -182,11 +182,12 @@ type MonoConfig = {
         [name: string]: any;
     };
     /**
-     * This is current working directory for the runtime on the virtual file system. Default is "/".
+     * This is initial working directory for the runtime on the virtual file system. Default is "/".
      */
     virtualWorkingDirectory?: string;
     /**
-     * This is the arguments to the Main() method of the program. Default is [].
+     * This is the arguments to the Main() method of the program when called with dotnet.run() Default is [].
+     * Note: RuntimeAPI.runMain() and RuntimeAPI.runMainAndExit() will replace this value, if they provide it.
      */
     applicationArguments?: string[];
 };


### PR DESCRIPTION
- Resolve URL in `resolve_single_asset_path` only if `asset.resolvedUrl` is empty
- The same is used in `resolve_path` for resolving other asset urls
- For MT it means that `resolvedUrl` (resolved in main thread) is also used for web workers

Fixes https://github.com/dotnet/runtime/issues/93133