### PR TITLE
Clean up some ifdefs in EventSource

### DIFF
--- a/src/coreclr/clr.featuredefines.props
+++ b/src/coreclr/clr.featuredefines.props
@@ -4,8 +4,6 @@
         <FeatureCollectibleALC>true</FeatureCollectibleALC>
         <FeatureEventTrace>true</FeatureEventTrace>
         <FeatureICastable>true</FeatureICastable>
-        <FeatureManagedEtwChannels>true</FeatureManagedEtwChannels>
-        <FeatureManagedEtw>true</FeatureManagedEtw>
         <FeaturePerfTracing>true</FeaturePerfTracing>
         <FeatureTypeEquivalence>true</FeatureTypeEquivalence>
         <FeatureBasicFreeze>true</FeatureBasicFreeze>
@@ -54,8 +52,6 @@
         <DefineConstants Condition="'$(FeatureCominterop)' == 'true'">$(DefineConstants);FEATURE_COMINTEROP</DefineConstants>
         <DefineConstants Condition="'$(FeatureCominteropApartmentSupport)' == 'true'">$(DefineConstants);FEATURE_COMINTEROP_APARTMENT_SUPPORT</DefineConstants>
         <DefineConstants Condition="'$(FeatureObjCMarshal)' == 'true'">$(DefineConstants);FEATURE_OBJCMARSHAL</DefineConstants>
-        <DefineConstants Condition="'$(FeatureManagedEtw)' == 'true'">$(DefineConstants);FEATURE_MANAGED_ETW</DefineConstants>
-        <DefineConstants Condition="'$(FeatureManagedEtwChannels)' == 'true'">$(DefineConstants);FEATURE_MANAGED_ETW_CHANNELS</DefineConstants>
         <DefineConstants Condition="'$(FeaturePerfTracing)' == 'true'">$(DefineConstants);FEATURE_PERFTRACING</DefineConstants>
         <DefineConstants Condition="'$(FeatureXplatEventSource)' == 'true'">$(DefineConstants);FEATURE_EVENTSOURCE_XPLAT</DefineConstants>
         <DefineConstants Condition="'$(FeatureWin32Registry)' == 'true'">$(DefineConstants);FEATURE_WIN32_REGISTRY</DefineConstants>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DefineConstants>SYSTEM_PRIVATE_CORELIB;FEATURE_MANAGED_ETW_CHANNELS;FEATURE_MANAGED_ETW;$(DefineConstants)</DefineConstants>
+    <DefineConstants>SYSTEM_PRIVATE_CORELIB;$(DefineConstants)</DefineConstants>
     <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
     <FeatureNativeAot>true</FeatureNativeAot>
     <RuntimeBasePath>..\..\Runtime.Base\src\</RuntimeBasePath>

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestNegative.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestNegative.cs
@@ -94,11 +94,6 @@ namespace BasicEventSourceTests
                     GetResourceString("EventSource_KeywordCollision", "Session3", "Kwd1", "0x100000000000")),
                 e);
 
-#if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
-            e = AssertExtensions.Throws<ArgumentException>(GetResourceString("EventSource_MaxChannelExceeded"),
-                () => EventSource.GenerateManifest(typeof(Sdt.TooManyChannelsEventSource), string.Empty));
-#endif
-
             if (PlatformDetection.IsWindows)
             {
                 e = AssertExtensions.Throws<ArgumentException>(null, () => EventSource.GenerateManifest(typeof(Sdt.EventWithAdminChannelNoMessageEventSource), string.Empty, strictOptions));

--- a/src/libraries/System.Diagnostics.Tracing/tests/CustomEventSources/InvalidEventSources.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/CustomEventSources/InvalidEventSources.cs
@@ -168,51 +168,6 @@ namespace SdtEventSources
         public void WriteString(string msg)
         { WriteEvent(1, msg); }
     }
-#if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
-    public sealed class TooManyChannelsEventSource : EventSource
-    {
-        [Event(1, Channel = Channels.Analytic, Level = EventLevel.Informational)]
-        public void WriteInteger(int n)
-        {
-            WriteEvent(1, n);
-        }
-
-    #region Keywords / Tasks /Opcodes / Channels
-        /// <summary>
-        /// The Channels definition for the ETW manifest
-        /// </summary>
-        public static class Channels
-        {
-            [Channel(Enabled = true, ChannelType = ChannelType.Admin)]
-            public const EventChannel Admin = (EventChannel)16;
-
-            [Channel(Enabled = true, ChannelType = ChannelType.Operational)]
-            public const EventChannel Operational = (EventChannel)17;
-
-            [Channel(Enabled = false, ChannelType = ChannelType.Analytic)]
-            public const EventChannel Analytic = (EventChannel)18;
-
-            [Channel(Enabled = false, ChannelType = ChannelType.Debug)]
-            public const EventChannel Debug = (EventChannel)19;
-
-            [Channel(Enabled = true, ChannelType = ChannelType.Admin)]
-            public const EventChannel Admin2 = (EventChannel)20;
-
-            [Channel(Enabled = true, ChannelType = ChannelType.Operational)]
-            public const EventChannel Operational2 = (EventChannel)21;
-
-            [Channel(Enabled = false, ChannelType = ChannelType.Analytic)]
-            public const EventChannel Analytic2 = (EventChannel)22;
-
-            [Channel(Enabled = false, ChannelType = ChannelType.Debug)]
-            public const EventChannel Debug2 = (EventChannel)23;
-
-            [Channel(Enabled = false, ChannelType = ChannelType.Debug)]
-            public const EventChannel BrokeCamelsBack = (EventChannel)24;
-        }
-    #endregion
-    }
-#endif
 
     public sealed class EventWithAdminChannelNoMessageEventSource : EventSource
     {
@@ -221,19 +176,6 @@ namespace SdtEventSources
         {
             WriteEvent(1, n);
         }
-
-        #region Keywords / Tasks /Opcodes / Channels
-#if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
-        /// <summary>
-        /// The Channels definition for the ETW manifest
-        /// </summary>
-        public static class Channels
-        {
-            [Channel(Enabled = true, ChannelType = ChannelType.Admin)]
-            public const EventChannel Admin = (EventChannel)16;
-        }
-#endif
-        #endregion
     }
 
     public abstract class AbstractWithKwdTaskOpcodeEventSource : EventSource

--- a/src/libraries/System.Diagnostics.Tracing/tests/CustomEventSources/SimpleEventSource.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/CustomEventSources/SimpleEventSource.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// #define FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
-
 using System;
 #if USE_MDT_EVENTSOURCE
 using Microsoft.Diagnostics.Tracing;
@@ -85,26 +83,6 @@ namespace SdtEventSources
         {
             public const EventOpcode Delete = (EventOpcode)100;
         }
-
-#if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
-        /// <summary>
-        /// The Channels definition for the ETW manifest
-        /// </summary>
-        public static class Channels
-        {
-            [EventChannel(Enabled = true, EventChannelType = EventChannelType.Admin)]
-            public const EventChannel MyAdmin = (EventChannel)20;
-
-            // [EventChannel(Enabled = true, EventChannelType = EventChannelType.Operational)]
-            // public const EventChannel Operational = (EventChannel)17;
-
-            [EventChannel(Enabled = false, EventChannelType = EventChannelType.Analytic)]
-            public const EventChannel Analytic = (EventChannel)18;
-
-            [EventChannel(Enabled = false, EventChannelType = EventChannelType.Debug)]
-            public const EventChannel Debug = (EventChannel)19;
-        }
-#endif
         #endregion
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -545,7 +545,6 @@ namespace System.Diagnostics.Tracing
 
             // We ignore errors to keep with the convention that EventSources do not throw errors.
             // Note we can't access m_throwOnWrites because this is a static method.
-#if FEATURE_MANAGED_ETW
 #if FEATURE_PERFTRACING
             // Set the activity id via EventPipe.
             EventPipeEventProvider.EventActivityIdControl(
@@ -558,7 +557,6 @@ namespace System.Diagnostics.Tracing
                 Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_SET_ID,
                 ref activityId);
 #endif // TARGET_WINDOWS
-#endif // FEATURE_MANAGED_ETW
         }
 
         /// <summary>
@@ -576,7 +574,6 @@ namespace System.Diagnostics.Tracing
                 // We ignore errors to keep with the convention that EventSources do not throw
                 // errors. Note we can't access m_throwOnWrites because this is a static method.
                 Guid retVal = default;
-#if FEATURE_MANAGED_ETW
 #if TARGET_WINDOWS
                 Interop.Advapi32.EventActivityIdControl(
                     Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_GET_ID,
@@ -586,7 +583,6 @@ namespace System.Diagnostics.Tracing
                     Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_GET_ID,
                     ref retVal);
 #endif // TARGET_WINDOWS
-#endif // FEATURE_MANAGED_ETW
                 return retVal;
             }
         }
@@ -619,7 +615,6 @@ namespace System.Diagnostics.Tracing
             }
 
             oldActivityThatWillContinue = activityId;
-#if FEATURE_MANAGED_ETW
             // We ignore errors to keep with the convention that EventSources do not throw errors.
             // Note we can't access m_throwOnWrites because this is a static method.
 
@@ -638,7 +633,6 @@ namespace System.Diagnostics.Tracing
                 Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_GET_SET_ID,
                     ref oldActivityThatWillContinue);
 #endif // TARGET_WINDOWS
-#endif // FEATURE_MANAGED_ETW
 
             // We don't call the activityDying callback here because the caller has declared that
             // it is not dying.
@@ -1331,7 +1325,6 @@ namespace System.Diagnostics.Tracing
                             relatedActivityId = &relActivityId;
                     }
 
-#if FEATURE_MANAGED_ETW
                     if (!SelfDescribingEvents)
                     {
                         if (metadata.EnabledForETW && !m_etwProvider.WriteEvent(ref metadata.Descriptor, metadata.EventHandle, pActivityId, relatedActivityId, eventDataCount, (IntPtr)data))
@@ -1356,7 +1349,6 @@ namespace System.Diagnostics.Tracing
 
                         WriteMultiMerge(metadata.Name, ref opt, metadata.TraceLoggingEventTypes, pActivityId, relatedActivityId, data);
                     }
-#endif // FEATURE_MANAGED_ETW
 
                     if (m_Dispatchers != null && metadata.EnabledForAnyListener)
                     {
@@ -1472,7 +1464,6 @@ namespace System.Diagnostics.Tracing
 
             if (disposing)
             {
-#if FEATURE_MANAGED_ETW
                 // Send the manifest one more time to ensure circular buffers have a chance to get to this information
                 // even in scenarios with a high volume of ETW events.
                 if (m_eventSourceEnabled)
@@ -1489,7 +1480,6 @@ namespace System.Diagnostics.Tracing
                     m_etwProvider.Dispose();
                     m_etwProvider = null!;
                 }
-#endif
 #if FEATURE_PERFTRACING
                 if (m_eventPipeProvider != null)
                 {
@@ -1521,16 +1511,12 @@ namespace System.Diagnostics.Tracing
             int dataCount,
             IntPtr data)
         {
-#if FEATURE_MANAGED_ETW || FEATURE_PERFTRACING
-            bool allAreNull = true;
-#if FEATURE_MANAGED_ETW
-            allAreNull &= (m_etwProvider == null);
+            bool allAreNull = m_etwProvider == null;
             if (m_etwProvider != null
                 && !m_etwProvider.WriteEventRaw(ref eventDescriptor, eventHandle, activityID, relatedActivityID, dataCount, data))
             {
                 ThrowEventSourceException(eventName);
             }
-#endif // FEATURE_MANAGED_ETW
 #if FEATURE_PERFTRACING
             allAreNull &= (m_eventPipeProvider == null);
             if (m_eventPipeProvider != null
@@ -1543,7 +1529,6 @@ namespace System.Diagnostics.Tracing
             {
                 ThrowEventSourceException(eventName);
             }
-#endif // FEATURE_MANAGED_ETW || FEATURE_PERFTRACING
         }
 
         // FrameworkEventSource is on the startup path for the framework, so we have this internal overload that it can use
@@ -1598,7 +1583,6 @@ namespace System.Diagnostics.Tracing
                 // Enable Implicit Activity tracker
                 m_activityTracker = ActivityTracker.Instance;
 
-#if FEATURE_MANAGED_ETW || FEATURE_PERFTRACING
 #if !DEBUG
                 if (ProviderMetadata.Length == 0)
 #endif
@@ -1607,12 +1591,11 @@ namespace System.Diagnostics.Tracing
                     // In the self-describing event case.
                     InitializeProviderMetadata();
                 }
-#endif
-#if FEATURE_MANAGED_ETW
+
                 // Register the provider with ETW
                 var etwProvider = new OverrideEventProvider(this, EventProviderType.ETW);
                 etwProvider.Register(this);
-#endif
+
 #if FEATURE_PERFTRACING
                 // Register the provider with EventPipe
                 var eventPipeProvider = new OverrideEventProvider(this, EventProviderType.EventPipe);
@@ -1625,7 +1608,6 @@ namespace System.Diagnostics.Tracing
                 // This also sets m_id, which is the index in the list.
                 EventListener.AddEventSource(this);
 
-#if FEATURE_MANAGED_ETW
                 // OK if we get this far without an exception, then we can at least write out error messages.
                 // Set m_provider, which allows this.
                 m_etwProvider = etwProvider;
@@ -1645,7 +1627,6 @@ namespace System.Diagnostics.Tracing
                     }
                 }
 #endif // TARGET_WINDOWS
-#endif // FEATURE_MANAGED_ETW
 
 #if FEATURE_PERFTRACING
                 m_eventPipeProvider = eventPipeProvider;
@@ -1956,7 +1937,6 @@ namespace System.Diagnostics.Tracing
                             childActivityID = &relatedActivityId;
                     }
 
-#if FEATURE_MANAGED_ETW
                     if (metadata.EnabledForETW
 #if FEATURE_PERFTRACING
                             || metadata.EnabledForEventPipe
@@ -1985,7 +1965,7 @@ namespace System.Diagnostics.Tracing
                             WriteMultiMerge(metadata.Name, ref opt, metadata.TraceLoggingEventTypes, pActivityId, childActivityID, args);
                         }
                     }
-#endif // FEATURE_MANAGED_ETW
+
                     if (m_Dispatchers != null && metadata.EnabledForAnyListener)
                     {
                         // Maintain old behavior - object identity is preserved
@@ -2147,11 +2127,7 @@ namespace System.Diagnostics.Tracing
         // is listening gets the message.
         private unsafe void WriteEventString(string msgString)
         {
-#if FEATURE_MANAGED_ETW || FEATURE_PERFTRACING
-            bool allAreNull = true;
-#if FEATURE_MANAGED_ETW
-            allAreNull &= (m_etwProvider == null);
-#endif // FEATURE_MANAGED_ETW
+            bool allAreNull = m_etwProvider == null;
 #if FEATURE_PERFTRACING
             allAreNull &= (m_eventPipeProvider == null);
 #endif // FEATURE_PERFTRACING
@@ -2203,9 +2179,7 @@ namespace System.Diagnostics.Tracing
                     data.Ptr = (ulong)msgStringPtr;
                     data.Size = (uint)(2 * (msgString.Length + 1));
                     data.Reserved = 0;
-#if FEATURE_MANAGED_ETW
                     m_etwProvider?.WriteEvent(ref descr, IntPtr.Zero, null, null, 1, (IntPtr)((void*)&data));
-#endif // FEATURE_MANAGED_ETW
 #if FEATURE_PERFTRACING
                     if (m_eventPipeProvider != null)
                     {
@@ -2240,7 +2214,6 @@ namespace System.Diagnostics.Tracing
 #endif // FEATURE_PERFTRACING
                 }
             }
-#endif // FEATURE_MANAGED_ETW || FEATURE_PERFTRACING
         }
 
         private static ReadOnlyCollection<string>? s_errorPayloadNames;
@@ -2305,12 +2278,7 @@ namespace System.Diagnostics.Tracing
             Debug.Assert(m_eventData != null);
             EventLevel eventLevel = (EventLevel)m_eventData[eventNum].Descriptor.Level;
             EventKeywords eventKeywords = unchecked((EventKeywords)((ulong)m_eventData[eventNum].Descriptor.Keywords & (~(SessionMask.All.ToEventKeywords()))));
-
-#if FEATURE_MANAGED_ETW_CHANNELS
             EventChannel channel = unchecked((EventChannel)m_eventData[eventNum].Descriptor.Channel);
-#else
-            EventChannel channel = EventChannel.None;
-#endif
 
             return IsEnabledCommon(enable, currentLevel, currentMatchAnyKeyword, eventLevel, eventKeywords, channel);
         }
@@ -2328,7 +2296,6 @@ namespace System.Diagnostics.Tracing
             // if yes, does it pass the keywords test?
             if (currentMatchAnyKeyword != 0 && eventKeywords != 0)
             {
-#if FEATURE_MANAGED_ETW_CHANNELS
                 // is there a channel with keywords that match currentMatchAnyKeyword?
                 if (eventChannel != EventChannel.None && this.m_channelData != null && this.m_channelData.Length > (int)eventChannel)
                 {
@@ -2337,7 +2304,6 @@ namespace System.Diagnostics.Tracing
                         return false;
                 }
                 else
-#endif
                 {
                     if ((unchecked((ulong)eventKeywords & (ulong)currentMatchAnyKeyword)) == 0)
                         return false;
@@ -2418,7 +2384,6 @@ namespace System.Diagnostics.Tracing
             return opcode;
         }
 
-#if FEATURE_MANAGED_ETW
         /// <summary>
         /// This class lets us hook the 'OnEventCommand' from the eventSource.
         /// </summary>
@@ -2441,7 +2406,6 @@ namespace System.Diagnostics.Tracing
             private readonly EventSource m_eventSource;
             private readonly EventProviderType m_eventProviderType;
         }
-#endif
 
         /// <summary>
         /// Used to hold all the static information about an event.  This includes everything in the event
@@ -2609,10 +2573,9 @@ namespace System.Diagnostics.Tracing
             // We defer commands until we are completely inited.  This allows error messages to be sent.
             Debug.Assert(m_completelyInited);
 
-#if FEATURE_MANAGED_ETW
             if (m_etwProvider == null)     // If we failed to construct
                 return;
-#endif // FEATURE_MANAGED_ETW
+
 #if FEATURE_PERFTRACING
             if (m_eventPipeProvider == null)
                 return;
@@ -2780,10 +2743,10 @@ namespace System.Diagnostics.Tracing
             {
                 if (eventId >= m_eventData.Length)
                     return false;
-#if FEATURE_MANAGED_ETW
+
                 if (m_etwProvider != null && eventProviderType == EventProviderType.ETW)
                     m_eventData[eventId].EnabledForETW = value;
-#endif
+
 #if FEATURE_PERFTRACING
                 if (m_eventPipeProvider != null && eventProviderType == EventProviderType.EventPipe)
                     m_eventData[eventId].EnabledForEventPipe = value;
@@ -2871,7 +2834,6 @@ namespace System.Diagnostics.Tracing
 
             Debug.Assert(!SelfDescribingEvents);
 
-#if FEATURE_MANAGED_ETW
             fixed (byte* dataPtr = rawManifest)
             {
                 // we don't want the manifest to show up in the event log channels so we specify as keywords
@@ -2934,7 +2896,6 @@ namespace System.Diagnostics.Tracing
                     }
                 }
             }
-#endif // FEATURE_MANAGED_ETW
         }
 
         // Helper to deal with the fact that the type we are reflecting over might be loaded in the ReflectionOnly context.
@@ -3330,7 +3291,6 @@ namespace System.Diagnostics.Tracing
                             // Do checking for user errors (optional, but not a big deal so we do it).
                             DebugCheckEvent(ref eventsByName, eventData, method, eventAttribute, manifest, flags);
 
-#if FEATURE_MANAGED_ETW_CHANNELS
                             // add the channel keyword for Event Viewer channel based filters. This is added for creating the EventDescriptors only
                             // and is not required for the manifest
                             if (eventAttribute.Channel != EventChannel.None)
@@ -3340,7 +3300,7 @@ namespace System.Diagnostics.Tracing
                                     eventAttribute.Keywords |= (EventKeywords)manifest.GetChannelKeyword(eventAttribute.Channel, (ulong)eventAttribute.Keywords);
                                 }
                             }
-#endif
+
                             if (manifest.HasResources)
                             {
                                 string eventKey = "event_" + eventName;
@@ -3364,19 +3324,13 @@ namespace System.Diagnostics.Tracing
                     Debug.Assert(eventData != null);
                     TrimEventDescriptors(ref eventData);
                     source.m_eventData = eventData;     // officially initialize it. We do this at most once (it is racy otherwise).
-#if FEATURE_MANAGED_ETW_CHANNELS
                     source.m_channelData = manifest.GetChannelData();
-#endif
                 }
 
                 // if this is an abstract event source we've already performed all the validation we can
                 if (!eventSourceType.IsAbstract && (source == null || !source.SelfDescribingEvents))
                 {
-                    bNeedsManifest = (flags & EventManifestOptions.OnlyIfNeededForRegistration) == 0
-#if FEATURE_MANAGED_ETW_CHANNELS
-                                            || manifest.GetChannelData().Length > 0
-#endif
-;
+                    bNeedsManifest = (flags & EventManifestOptions.OnlyIfNeededForRegistration) == 0 || manifest.GetChannelData().Length > 0;
 
                     // if the manifest is not needed and we're not requested to validate the event source return early
                     if (!bNeedsManifest && (flags & EventManifestOptions.Strict) == 0)
@@ -3494,11 +3448,7 @@ namespace System.Diagnostics.Tracing
             metadata.Descriptor = new EventDescriptor(
                     eventAttribute.EventId,
                     eventAttribute.Version,
-#if FEATURE_MANAGED_ETW_CHANNELS
                     (byte)eventAttribute.Channel,
-#else
-                    (byte)0,
-#endif
                     (byte)eventAttribute.Level,
                     (byte)eventAttribute.Opcode,
                     (int)eventAttribute.Task,
@@ -3876,9 +3826,7 @@ namespace System.Diagnostics.Tracing
 
         // Dispatching state
         internal volatile EventDispatcher? m_Dispatchers;    // Linked list of code:EventDispatchers we write the data to (we also do ETW specially)
-#if FEATURE_MANAGED_ETW
         private volatile OverrideEventProvider m_etwProvider = null!;   // This hooks up ETW commands to our 'OnEventCommand' callback
-#endif
 #if FEATURE_PERFTRACING
         private object? m_createEventLock;
         private IntPtr m_writeEventStringEventHandle = IntPtr.Zero;
@@ -3894,9 +3842,8 @@ namespace System.Diagnostics.Tracing
         [ThreadStatic]
         private static byte m_EventSourceExceptionRecurenceCount; // current recursion count inside ThrowEventSourceException
 
-#if FEATURE_MANAGED_ETW_CHANNELS
         internal volatile ulong[]? m_channelData;
-#endif
+
         // We use a single instance of ActivityTracker for all EventSources instances to allow correlation between multiple event providers.
         // We have m_activityTracker field simply because instance field is more efficient than static field fetch.
         private ActivityTracker m_activityTracker = null!;
@@ -4777,12 +4724,10 @@ namespace System.Diagnostics.Tracing
             internal set => MoreInfo.Message = value;
         }
 
-#if FEATURE_MANAGED_ETW_CHANNELS
         /// <summary>
         /// Gets the channel for the event.
         /// </summary>
         public EventChannel Channel => EventId <= 0 ? EventChannel.None : (EventChannel)Metadata.Descriptor.Channel;
-#endif
 
         /// <summary>
         /// Gets the version of the event.
@@ -4939,10 +4884,10 @@ namespace System.Diagnostics.Tracing
 
         /// <summary>Event's task: allows logical grouping of events</summary>
         public EventTask Task { get; set; }
-#if FEATURE_MANAGED_ETW_CHANNELS
+
         /// <summary>Event's channel: defines an event log as an additional destination for the event</summary>
         public EventChannel Channel { get; set; }
-#endif
+
         /// <summary>Event's version</summary>
         public byte Version { get; set; }
 
@@ -4985,7 +4930,6 @@ namespace System.Diagnostics.Tracing
     }
 
     // FUTURE we may want to expose this at some point once we have a partner that can help us validate the design.
-#if FEATURE_MANAGED_ETW_CHANNELS
     /// <summary>
     /// EventChannelAttribute allows customizing channels supported by an EventSource. This attribute must be
     /// applied to an member of type EventChannel defined in a Channels class nested in the EventSource class:
@@ -5084,7 +5028,6 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         Custom,
     }
-#endif
 #endif
 
     /// <summary>
@@ -5263,9 +5206,7 @@ namespace System.Diagnostics.Tracing
         public ManifestBuilder(string providerName, Guid providerGuid, string? dllName, ResourceManager? resources,
                                EventManifestOptions flags) : this(resources, flags)
         {
-#if FEATURE_MANAGED_ETW_CHANNELS
             this.providerName = providerName;
-#endif
 
             sb = new StringBuilder();
             events = new StringBuilder();
@@ -5361,7 +5302,6 @@ namespace System.Diagnostics.Tracing
             keywordTab[value] = name;
         }
 
-#if FEATURE_MANAGED_ETW_CHANNELS
         /// <summary>
         /// Add a channel.  channelAttribute can be null
         /// </summary>
@@ -5429,7 +5369,6 @@ namespace System.Diagnostics.Tracing
             return channelMask;
         }
 
-#endif
         public void StartEvent(string eventName, EventAttribute eventAttribute)
         {
             Debug.Assert(numParams == 0);
@@ -5468,13 +5407,11 @@ namespace System.Diagnostics.Tracing
                 events?.Append(" task=\"").Append(str).Append('"');
             }
 
-#if FEATURE_MANAGED_ETW_CHANNELS
             if (eventAttribute.Channel != 0)
             {
                 string? str = GetChannelName(eventAttribute.Channel, eventName, eventAttribute.Message);
                 events?.Append(" channel=\"").Append(str).Append('"');
             }
-#endif
         }
 
         public void AddEventParameter(Type type, string name)
@@ -5539,7 +5476,6 @@ namespace System.Diagnostics.Tracing
             byteArrArgIndices = null;
         }
 
-#if FEATURE_MANAGED_ETW_CHANNELS
         // Channel keywords are generated one per channel to allow channel based filtering in event viewer. These keywords are autogenerated
         // by mc.exe for compiling a manifest and are based on the order of the channels (fields) in the Channels inner class (when advanced
         // channel support is enabled), or based on the order the predefined channels appear in the EventAttribute properties (for simple
@@ -5575,7 +5511,6 @@ namespace System.Diagnostics.Tracing
 
             return channelKeyword;
         }
-#endif
 
         public byte[] CreateManifest()
         {
@@ -5606,7 +5541,6 @@ namespace System.Diagnostics.Tracing
         {
             Span<char> ulongHexScratch = stackalloc char[16]; // long enough for ulong.MaxValue formatted as hex
 
-#if FEATURE_MANAGED_ETW_CHANNELS
             // Write out the channels
             if (channelTab != null)
             {
@@ -5664,7 +5598,6 @@ namespace System.Diagnostics.Tracing
                 }
                 sb?.AppendLine(" </channels>");
             }
-#endif
 
             // Write out the tasks
             if (taskTab != null)
@@ -5894,7 +5827,6 @@ namespace System.Diagnostics.Tracing
             });
         }
 
-#if FEATURE_MANAGED_ETW_CHANNELS
         private string? GetChannelName(EventChannel channel, string eventName, string? eventMessage)
         {
             if (channelTab == null || !channelTab.TryGetValue((int)channel, out ChannelInfo? info))
@@ -5923,7 +5855,6 @@ namespace System.Diagnostics.Tracing
                 ManifestError(SR.Format(SR.EventSource_EventWithAdminChannelMustHaveMessage, eventName, info.Name));
             return info.Name;
         }
-#endif
         private string GetTaskName(EventTask task, string eventName)
         {
             if (task == EventTask.None)
@@ -5974,11 +5905,9 @@ namespace System.Diagnostics.Tracing
 
         private void AppendKeywords(StringBuilder? sb, ulong keywords, string eventName)
         {
-#if FEATURE_MANAGED_ETW_CHANNELS
             // ignore keywords associate with channels
             // See ValidPredefinedChannelKeywords def for more.
             keywords &= ~ValidPredefinedChannelKeywords;
-#endif
 
             bool appended = false;
             for (ulong bit = 1; bit != 0; bit <<= 1)
@@ -6169,25 +6098,20 @@ namespace System.Diagnostics.Tracing
             return idx + 1;
         }
 
-#if FEATURE_MANAGED_ETW_CHANNELS
         private sealed class ChannelInfo
         {
             public string? Name;
             public ulong Keywords;
             public EventChannelAttribute? Attribs;
         }
-#endif
 
         private readonly Dictionary<int, string> opcodeTab;
         private Dictionary<int, string>? taskTab;
-#if FEATURE_MANAGED_ETW_CHANNELS
         private Dictionary<int, ChannelInfo>? channelTab;
-#endif
         private Dictionary<ulong, string>? keywordTab;
         private Dictionary<string, Type>? mapsTab;
         private readonly Dictionary<string, string> stringTab;       // Maps unlocalized strings to localized ones
 
-#if FEATURE_MANAGED_ETW_CHANNELS
         // WCF used EventSource to mimic a existing ETW manifest.   To support this
         // in just their case, we allowed them to specify the keywords associated
         // with their channels explicitly.   ValidPredefinedChannelKeywords is
@@ -6196,15 +6120,11 @@ namespace System.Diagnostics.Tracing
         internal const ulong ValidPredefinedChannelKeywords = 0xF000000000000000;
         private ulong nextChannelKeywordBit = 0x8000000000000000;   // available Keyword bit to be used for next channel definition, grows down
         private const int MaxCountChannels = 8; // a manifest can defined at most 8 ETW channels
-#endif
 
         private readonly StringBuilder? sb;               // Holds the provider information.
         private readonly StringBuilder? events;           // Holds the events.
         private readonly StringBuilder? templates;
-
-#if FEATURE_MANAGED_ETW_CHANNELS
         private readonly string providerName;
-#endif
         private readonly ResourceManager? resources;      // Look up localized strings here.
         private readonly EventManifestOptions flags;
         private readonly List<string> errors;           // list of currently encountered errors
@@ -6228,14 +6148,12 @@ namespace System.Diagnostics.Tracing
             SimpleXmlFormat = 1,          // simply dump the XML manifest as UTF8
         }
 
-#if FEATURE_MANAGED_ETW
         public ManifestFormats Format;
         public byte MajorVersion;
         public byte MinorVersion;
         public byte Magic;
         public ushort TotalChunks;
         public ushort ChunkNumber;
-#endif
     }
 
 #endregion

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3006,11 +3006,7 @@ namespace System.Diagnostics.Tracing
                     // either Microsoft.Diagnostics.Tracing or System.Diagnostics.Tracing)?
                     string.Equals(attributeType.Name, reflectedAttributeType.Name, StringComparison.Ordinal) &&
                     attributeType.Namespace!.EndsWith("Diagnostics.Tracing", StringComparison.Ordinal) &&
-                    (reflectedAttributeType.Namespace!.EndsWith("Diagnostics.Tracing", StringComparison.Ordinal)
-#if EVENT_SOURCE_LEGACY_NAMESPACE_SUPPORT
-                     || reflectedAttributeType.Namespace.EndsWith("Diagnostics.Eventing", StringComparison.Ordinal)
-#endif
-);
+                    reflectedAttributeType.Namespace!.EndsWith("Diagnostics.Tracing", StringComparison.Ordinal);
         }
 
         private static Type? GetEventSourceBaseType(Type eventSourceType, bool allowEventSourceOverride, bool reflectionOnly)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -4,29 +4,23 @@
 // This program uses code hyperlinks available as part of the HyperAddin Visual Studio plug-in.
 // It is available from http://www.codeplex.com/hyperAddin
 
-#if TARGET_WINDOWS
-#define FEATURE_MANAGED_ETW
-#endif // TARGET_WINDOWS
-
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
-using System.Runtime.CompilerServices;
 namespace System.Diagnostics.Tracing
 {
     public partial class EventSource
     {
-#if FEATURE_MANAGED_ETW
         private byte[]? m_providerMetadata;
         private protected virtual ReadOnlySpan<byte> ProviderMetadata => m_providerMetadata;
         private const string EventSourceRequiresUnreferenceMessage = "EventSource will serialize the whole object graph. Trimmer will not safely handle this case because properties may be trimmed.";
         private const string EventSourceSuppressMessage = "Parameters to this method are primitive and are trimmer safe";
-#endif
 
 #if FEATURE_PERFTRACING
         private readonly TraceLoggingEventHandleTable m_eventHandleTable = null!;
@@ -399,7 +393,6 @@ namespace System.Diagnostics.Tracing
             Guid* childActivityID,
             params object?[] values)
         {
-#if FEATURE_MANAGED_ETW
             int identity = 0;
             byte level = (options.valuesSet & EventSourceOptions.levelSet) != 0
                 ? options.level
@@ -479,7 +472,6 @@ namespace System.Diagnostics.Tracing
                     WriteCleanup(pins, pinCount);
                 }
             }
-#endif // FEATURE_MANAGED_ETW
         }
 
         /// <summary>
@@ -520,7 +512,6 @@ namespace System.Diagnostics.Tracing
             Guid* childActivityID,
             EventData* data)
         {
-#if FEATURE_MANAGED_ETW
             if (!this.IsEnabled())
             {
                 return;
@@ -581,7 +572,6 @@ namespace System.Diagnostics.Tracing
                         (IntPtr)descriptors);
                 }
             }
-#endif // FEATURE_MANAGED_ETW
         }
 
         private unsafe void WriteImpl(
@@ -610,7 +600,6 @@ namespace System.Diagnostics.Tracing
                     IntPtr eventHandle = IntPtr.Zero;
 #endif
 
-#if FEATURE_MANAGED_ETW
                     int pinCount = eventTypes.pinCount;
                     byte* scratch = stackalloc byte[eventTypes.scratchSize];
                     EventData* descriptors = stackalloc EventData[eventTypes.dataCount + 3];
@@ -630,7 +619,6 @@ namespace System.Diagnostics.Tracing
                         descriptors[0].SetMetadata(pMetadata0, providerMetadata.Length, 2);
                         descriptors[1].SetMetadata(pMetadata1, nameInfo.nameMetadata.Length, 1);
                         descriptors[2].SetMetadata(pMetadata2, eventTypes.typeMetadata.Length, 1);
-#endif // FEATURE_MANAGED_ETW
 
                         EventOpcode opcode = (EventOpcode)descriptor.Opcode;
 
@@ -657,7 +645,6 @@ namespace System.Diagnostics.Tracing
 
                         try
                         {
-#if FEATURE_MANAGED_ETW
                             DataCollector.ThreadInstance.Enable(
                                 scratch,
                                 eventTypes.scratchSize,
@@ -677,7 +664,6 @@ namespace System.Diagnostics.Tracing
                                 pRelatedActivityId,
                                 (int)(DataCollector.ThreadInstance.Finish() - descriptors),
                                 (IntPtr)descriptors);
-#endif // FEATURE_MANAGED_ETW
 
                             // TODO enable filtering for listeners.
                             if (m_Dispatchers != null)
@@ -693,13 +679,11 @@ namespace System.Diagnostics.Tracing
                             else
                                 ThrowEventSourceException(eventName, ex);
                         }
-#if FEATURE_MANAGED_ETW
                         finally
                         {
                             WriteCleanup(pins, pinCount);
                         }
                     }
-#endif // FEATURE_MANAGED_ETW
                 }
             }
             catch (Exception ex)
@@ -748,7 +732,6 @@ namespace System.Diagnostics.Tracing
 
         private void InitializeProviderMetadata()
         {
-#if FEATURE_MANAGED_ETW
             bool hasProviderMetadata = ProviderMetadata.Length > 0;
 #if !DEBUG
             if (hasProviderMetadata)
@@ -807,7 +790,6 @@ namespace System.Diagnostics.Tracing
                 Debug.Assert(ProviderMetadata.SequenceEqual(m_providerMetadata));
             }
 #endif
-#endif //FEATURE_MANAGED_ETW
         }
 
         private static int AddValueToMetaData(List<byte> metaData, string value)

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -123,8 +123,6 @@
     <FeatureMono>true</FeatureMono>
     <FeatureWasmThreads Condition="('$(TargetsBrowser)' == 'true' or '$(TargetsWasi)' == 'true') and '$(MonoWasmBuildVariant)' == 'multithread'">true</FeatureWasmThreads>
     <FeatureWasmPerfTracing Condition="('$(TargetsBrowser)' == 'true' or '$(TargetsWasi)' == 'true') and ('$(MonoWasmBuildVariant)' == 'multithread')">true</FeatureWasmPerfTracing>
-    <FeatureManagedEtwChannels>true</FeatureManagedEtwChannels>
-    <FeatureManagedEtw>true</FeatureManagedEtw>
     <FeaturePortableTimer Condition="'$(TargetsBrowser)' != 'true' and '$(TargetsWasi)' != 'true'">true</FeaturePortableTimer>
     <FeaturePortableThreadPool Condition="('$(TargetsBrowser)' != 'true' and '$(TargetsWasi)' != 'true') or '$(FeatureWasmThreads)' == 'true'">true</FeaturePortableThreadPool>
     <FeaturePerfTracing Condition="('$(TargetsBrowser)' != 'true' and '$(TargetsWasi)' != 'true') or '$(FeatureWasmPerftracing)' == 'true'">true</FeaturePerfTracing>
@@ -132,8 +130,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants Condition="'$(FeatureManagedEtw)' == 'true'">$(DefineConstants);FEATURE_MANAGED_ETW</DefineConstants>
-    <DefineConstants Condition="'$(FeatureManagedEtwChannels)' == 'true'">$(DefineConstants);FEATURE_MANAGED_ETW_CHANNELS</DefineConstants>
     <DefineConstants Condition="'$(FeaturePerfTracing)' == 'true'">$(DefineConstants);FEATURE_PERFTRACING</DefineConstants>
     <DefineConstants Condition="'$(FeatureObjCMarshal)' == 'true'">$(DefineConstants);FEATURE_OBJCMARSHAL</DefineConstants>
     <DefineConstants Condition="'$(FeatureWasmThreads)' == 'true'">$(DefineConstants);FEATURE_WASM_THREADS</DefineConstants>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/90433

FEATURE_MANAGED_ETW and FEATURE_MANAGED_ETW_CHANNELS are always defined.

FEATURE_ADVANCED_MANAGED_ETW_CHANNELS and EVENT_SOURCE_LEGACY_NAMESPACE_SUPPORT are never defined.