### PR TITLE
[release/8.0] [android][ios] Fix dispose problem with NativeHttpHandlers (#93262)

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
@@ -51,10 +51,7 @@ namespace System.Net.Http
                         MetricsHandler metricsHandler = new MetricsHandler(handler, _nativeMeterFactory, out _);
 
                         // Ensure a single handler is used for all requests.
-                        if (Interlocked.CompareExchange(ref _nativeMetricsHandler, metricsHandler, null) != null)
-                        {
-                            handler.Dispose();
-                        }
+                        Interlocked.CompareExchange(ref _nativeMetricsHandler, metricsHandler, null);
                     }
 
                     return _nativeMetricsHandler;
@@ -87,7 +84,7 @@ namespace System.Net.Http
 
                 if (IsNativeHandlerEnabled)
                 {
-                    _nativeHandler!.Dispose();
+                    Handler.Dispose();
                 }
                 else
                 {


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/93262 to release/8.0

/cc @steveisok

Fixes #93252

## Customer Impact
https://github.com/dotnet/runtime/issues/93252 identified a regression in `HttpClientHandler` on mobile where repeat requests would prematurely dispose the underlying native http handler. This leads to calling `Dispose` more than once and the runtime will throw `Cannot access a disposed object` and terminate the requests.

The fix was to avoid disposing of the underlying native handler prematurely. 

## Testing
Tested a patched SDK locally against a MAUI app that made multiple requests.

## Risk
Low
