### PR TITLE
Fix the test template for LoadVectorx* 

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/LoadVectorx2Test.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/LoadVectorx2Test.template
@@ -78,7 +78,7 @@ namespace JIT.HardwareIntrinsics.Arm
                     throw new ArgumentException("Invalid value of alignment");
                 }
 
-                this.inArray = new byte[alignment * 2];
+                this.inArray = new byte[alignment * 2 * 2];
                 this.outArray1 = new byte[alignment * 2];
                 this.outArray2 = new byte[alignment * 2];
 
@@ -142,7 +142,7 @@ namespace JIT.HardwareIntrinsics.Arm
         public {TestName}Test()
         {
             Succeeded = true;
-            for (var i = 0; i < OpElementCount; i++) { _data[i] = {NextValueOp2}; }
+            for (var i = 0; i < DestElementCount; i++) { _data[i] = {NextValueOp2}; }
             _dataTable = new DataTable(new {Op1BaseType}[OpElementCount], new {Op1BaseType}[OpElementCount], _data, LargestVectorSize);
         }
 

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/LoadVectorx3Test.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/LoadVectorx3Test.template
@@ -81,7 +81,7 @@ namespace JIT.HardwareIntrinsics.Arm
                     throw new ArgumentException("Invalid value of alignment");
                 }
 
-                this.inArray = new byte[alignment * 3];
+                this.inArray = new byte[alignment * 2 * 3];
                 this.outArray1 = new byte[alignment * 2];
                 this.outArray2 = new byte[alignment * 2];
                 this.outArray3 = new byte[alignment * 2];
@@ -151,7 +151,7 @@ namespace JIT.HardwareIntrinsics.Arm
         public {TestName}Test()
         {
             Succeeded = true;
-            for (var i = 0; i < OpElementCount; i++) { _data[i] = {NextValueOp2}; }
+            for (var i = 0; i < DestElementCount; i++) { _data[i] = {NextValueOp2}; }
             _dataTable = new DataTable(new {Op1BaseType}[OpElementCount], new {Op1BaseType}[OpElementCount], new {Op1BaseType}[OpElementCount], _data, LargestVectorSize);
         }
 

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/LoadVectorx4Test.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/LoadVectorx4Test.template
@@ -84,7 +84,7 @@ namespace JIT.HardwareIntrinsics.Arm
                     throw new ArgumentException("Invalid value of alignment");
                 }
 
-                this.inArray = new byte[alignment * 4];
+                this.inArray = new byte[alignment * 2 * 4];
                 this.outArray1 = new byte[alignment * 2];
                 this.outArray2 = new byte[alignment * 2];
                 this.outArray3 = new byte[alignment * 2];
@@ -160,7 +160,7 @@ namespace JIT.HardwareIntrinsics.Arm
         public {TestName}Test()
         {
             Succeeded = true;
-            for (var i = 0; i < OpElementCount; i++) { _data[i] = {NextValueOp2}; }
+            for (var i = 0; i < DestElementCount; i++) { _data[i] = {NextValueOp2}; }
             _dataTable = new DataTable(new {Op1BaseType}[OpElementCount], new {Op1BaseType}[OpElementCount], new {Op1BaseType}[OpElementCount], new {Op1BaseType}[OpElementCount], _data, LargestVectorSize);
         }
 


### PR DESCRIPTION
The input data is 2x, 3x or 4x the size of output, depending on the `LoadVectorx` API under test. Fix the initialization of them as  well as the allocation of input data array.

Fixes: https://github.com/dotnet/runtime/issues/93230