### PR TITLE
Report Exception.FullName for `http.client.request.duration/error.type`

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
@@ -169,7 +169,7 @@ namespace System.Net.Http.Metrics
                 HttpRequestError.ConfigurationLimitExceeded => "configuration_limit_exceeded",
 
                 // Fall back to the exception type name in case of HttpRequestError.Unknown or when exception is not an HttpRequestException.
-                _ => exception.GetType().Name
+                _ => exception.GetType().FullName!
             };
             return true;
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -655,8 +655,8 @@ namespace System.Net.Http.Functional.Tests
                 _output.WriteLine($"Client exception: {clientException}");
 
                 string[] expectedExceptionTypes = TestAsync
-                    ? [nameof(TaskCanceledException)]
-                    : [nameof(TaskCanceledException), nameof(OperationCanceledException)];
+                    ? [typeof(TaskCanceledException).FullName]
+                    : [typeof(TaskCanceledException).FullName, typeof(OperationCanceledException).FullName];
 
                 Measurement<double> m = Assert.Single(recorder.GetMeasurements());
                 VerifyRequestDuration(m, uri, acceptedErrorTypes: expectedExceptionTypes);
@@ -837,7 +837,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.True(ex is HttpRequestException or TaskCanceledException);
 
                 Measurement<double> m = Assert.Single(recorder.GetMeasurements());
-                VerifyRequestDuration(m, uri, acceptedErrorTypes: [nameof(TaskCanceledException), "response_ended"]);
+                VerifyRequestDuration(m, uri, acceptedErrorTypes: [typeof(TaskCanceledException).FullName, "response_ended"]);
             }, async server =>
             {
                 try


### PR DESCRIPTION
Address #93302 as agreed. This should be backported to 8.0.