### PR TITLE
[docs][wasm] Merge duplicated wasm build instructions.

### DIFF
--- a/docs/workflow/building/libraries/webassembly-instructions.md
+++ b/docs/workflow/building/libraries/webassembly-instructions.md
@@ -1,39 +1,22 @@
-# Build for WebAssembly
+# Build libraries for WebAssembly
 
 ## Prerequisites
 
 If you haven't already done so, please read [this document](../../README.md#Build_Requirements) to understand the build requirements for your operating system.
 
-The **correct version** of Emscripten SDK (emsdk) needs to be installed.
-* Run `make -C src/mono/wasm provision-wasm` to install emsdk into `src/mono/wasm/emsdk`.
-* Alternatively follow the [installation guide](https://emscripten.org/docs/getting_started/downloads.html#sdk-download-and-install).
-Do not install `latest` but rather specific version e.g. `./emsdk install 2.0.23`. See [emscripten-version.txt](../../../../src/mono/wasm/emscripten-version.txt)
+The **correct version** of Emscripten SDK (emsdk) needs to be installed. To read how to install it, see [Installing emsdk](../../../../src/mono/wasm/README.md#installing-emsdk).
 
-Once installed the `EMSDK_PATH` environment variable needs to be set:
+## Building
 
-On Linux and macOS:
-
-```bash
-export EMSDK_PATH=<FULL_PATH_TO_SDK_INSTALL>/emsdk
-```
-
-## Building everything
-
-At this time no other build dependencies are necessary to start building for WebAssembly.
+At this time no other build dependencies are necessary to start building for WebAssembly. To read how to build on specific platforms, see [Building](../../../../src/mono/wasm/README.md#building).
 
 This document explains how to work on the runtime or libraries. If you haven't already done so, please read [this document](../../README.md#Configurations) to understand configurations.
 
-For Linux and macOS:
-
-```bash
-./build.sh -os browser -configuration Release
-```
-
-Artifacts will be placed in `artifacts/bin/microsoft.netcore.app.runtime.browser-wasm/Release/`. When rebuilding with `build.sh` after a code change, you need to ensure that the `mono.wasmruntime` and `libs.pretest` subsets are included even for a Mono-only change or this directory will not be updated (details below).
+When rebuilding with `build.sh` after a code change, you need to ensure that the `mono.wasmruntime` and `libs.pretest` subsets are included even for a Mono-only change or this directory will not be updated (details below).
 
 ### Note: do not mix runtime and library configurations
 
-At this time, it is not possible to specify different configurations for the runtime and libraries.  That is mixing a Release `-runtimeConfiguration` with a Debug `-libraryConfiguration` (or `-configuration`), or vice versa will not work.
+At this time, it is not possible to specify different configurations for the runtime and libraries. That is mixing a Release `-runtimeConfiguration` with a Debug `-libraryConfiguration` (or `-configuration`), or vice versa will not work.
 
 Please only use the `-configuration` option with `Debug` or `Release`, and do not specify a `-runtimeConfiguration` and `-libraryConfiguration`.
 
@@ -68,7 +51,7 @@ Building both Mono/System.Private.CoreLib and the managed libraries:
 
 ## Building the WebAssembly runtime files
 
-The WebAssembly implementation files are built after the libraries source build and made available in the artifacts folder.  If you are working on the code base and need to compile just these modules then building the `Mono.WasmRuntime` subset will allow one to do that:
+The WebAssembly implementation files are built after the libraries source build and made available in the artifacts folder. If you are working on the code base and need to compile just these modules then building the `Mono.WasmRuntime` subset will allow one to do that:
 
 ```bash
 ./build.sh mono.wasmruntime -os browser -c Debug|Release
@@ -174,3 +157,7 @@ container:
 ```
 
 Open a PR request with the new image.
+
+# Test libraries
+
+You can read about running library tests in [Libraries tests](../../../../src/mono/wasm/README.md#libraries-tests).

--- a/docs/workflow/building/libraries/webassembly-instructions.md
+++ b/docs/workflow/building/libraries/webassembly-instructions.md
@@ -4,11 +4,9 @@
 
 If you haven't already done so, please read [this document](../../README.md#Build_Requirements) to understand the build requirements for your operating system.
 
-The **correct version** of Emscripten SDK (emsdk) needs to be installed. To read how to install it, see [Installing emsdk](../../../../src/mono/wasm/README.md#installing-emsdk).
-
 ## Building
 
-At this time no other build dependencies are necessary to start building for WebAssembly. To read how to build on specific platforms, see [Building](../../../../src/mono/wasm/README.md#building).
+At this time no other build dependencies are necessary to start building for WebAssembly. Emscripten will be downloaded and installed automatically in the build process. To read how to build on specific platforms, see [Building](../../../../src/mono/wasm/README.md#building).
 
 This document explains how to work on the runtime or libraries. If you haven't already done so, please read [this document](../../README.md#Configurations) to understand configurations.
 

--- a/docs/workflow/building/libraries/webassembly-instructions.md
+++ b/docs/workflow/building/libraries/webassembly-instructions.md
@@ -16,7 +16,7 @@ When rebuilding with `build.sh` after a code change, you need to ensure that the
 
 ### Note: do not mix runtime and library configurations
 
-At this time, it is not possible to specify different configurations for the runtime and libraries. That is mixing a Release `-runtimeConfiguration` with a Debug `-libraryConfiguration` (or `-configuration`), or vice versa will not work.
+At this time, it is not possible to specify different configurations for the runtime and libraries. That is mixing a Release `-runtimeConfiguration` with a Debug `-libraryConfiguration` (or `-configuration`), or vice versa will not work. The same applies to single and multithreaded configurations.
 
 Please only use the `-configuration` option with `Debug` or `Release`, and do not specify a `-runtimeConfiguration` and `-libraryConfiguration`.
 

--- a/docs/workflow/building/mono/README.md
+++ b/docs/workflow/building/mono/README.md
@@ -72,7 +72,7 @@ The build has a number of options that you can learn about using build -?.
 
 ### WebAssembly
 
-See the instructions for [Building WebAssembly](../../building/libraries/webassembly-instructions.md).
+See the instructions for [Building WebAssembly](../../../../src/mono/wasm/README.md).
 
 ### Android
 

--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -1,32 +1,10 @@
 # Build WebAssembly
 
-If you haven't already done so, please read [this document](../../../docs/workflow/README.md#Build_Requirements) to understand the build requirements for your operating system. If you are specifically interested in building libraries for WebAssembly, read [Libraries WebAssembly](../../../docs/workflow/building/libraries/webassembly-instructions.md).
-
-## Installing emsdk
-
-The **correct version** of Emscripten SDK (emsdk) needs to be installed. Version number is saved in [emscripten-version.txt](./emscripten-version.txt).
-
-### macOS/Linux
-
-* You can run `make provision-wasm`, which will install it to `$reporoot/src/mono/wasm/emsdk` .
-Note: Irrespective of `$(EMSDK_PATH)`'s value, `provision-wasm` will always install into `$reporoot/src/mono/wasm/emsdk`.
-
-Note: `EMSDK_PATH` is set by default in `src/mono/wasm/Makefile`, so building targets from that will have it set. But you might need to set it manually if you are directly using the `dotnet build`, or `build.sh` by `source ./emsdk_env.sh`.
-
-* Alternatively you can install **correct version** yourself from the [Emscripten SDK guide](https://emscripten.org/docs/getting_started/downloads.html).
-Do not install `latest` but rather specific version e.g. `./emsdk install 2.0.23`. See [emscripten-version.txt](./emscripten-version.txt)
-
-Make sure to set `EMSDK_PATH` variable, whenever building, or running tests for wasm.
-
-```bash
-export EMSDK_PATH=<FULL_PATH_TO_SDK_INSTALL>/emsdk
-```
+If you haven't already done so, please read [this document](../../../docs/workflow/README.md#Build_Requirements) to understand the build requirements for your operating system. If you are specifically interested in building libraries for WebAssembly, read [Libraries WebAssembly](../../../docs/workflow/building/libraries/webassembly-instructions.md). Emscripten that is needed to build the project will be provisioned automatically, unless `EMSDK_PATH` variable is set or emscripten is already present in `src\mono\wasm\emsdk` directory.
 
 ### Windows
 
 Windows build [requirements](../../../docs/workflow/requirements/windows-requirements.md)
-
-If `EMSDK_PATH` is not set, the `emsdk` should be provisioned automatically during the build.
 
 **Note:** The EMSDK has an implicit dependency on Python for it to be initialized. A consequence of this is that if the system doesn't have Python installed prior to attempting a build, the automatic provisioning will fail and be in an invalid state. Therefore, if Python needs to be installed after a build attempt the `$reporoot/src/mono/wasm/emsdk` directory should be manually deleted and then a rebuild attempted.
 

--- a/src/mono/wasm/README.md
+++ b/src/mono/wasm/README.md
@@ -1,25 +1,42 @@
-# Building
+# Build WebAssembly
 
-This depends on `emsdk` to be installed.
+If you haven't already done so, please read [this document](../../../docs/workflow/README.md#Build_Requirements) to understand the build requirements for your operating system. If you are specifically interested in building libraries for WebAssembly, read [Libraries WebAssembly](../../../docs/workflow/building/libraries/webassembly-instructions.md).
 
-## emsdk on macOS
+## Installing emsdk
+
+The **correct version** of Emscripten SDK (emsdk) needs to be installed. Version number is saved in [emscripten-version.txt](./emscripten-version.txt).
+
+### macOS/Linux
 
 * You can run `make provision-wasm`, which will install it to `$reporoot/src/mono/wasm/emsdk` .
 Note: Irrespective of `$(EMSDK_PATH)`'s value, `provision-wasm` will always install into `$reporoot/src/mono/wasm/emsdk`.
 
-`EMSDK_PATH` is set to `$reporoot/src/mono/wasm/emsdk` by default, by the Makefile.
-
-Note: `EMSDK_PATH` is set by default in `src/mono/wasm/Makefile`, so building targets from that will have it set. But you might need to set it manually if
-you are directly using the `dotnet build`, or `build.sh`.
+Note: `EMSDK_PATH` is set by default in `src/mono/wasm/Makefile`, so building targets from that will have it set. But you might need to set it manually if you are directly using the `dotnet build`, or `build.sh` by `source ./emsdk_env.sh`.
 
 * Alternatively you can install **correct version** yourself from the [Emscripten SDK guide](https://emscripten.org/docs/getting_started/downloads.html).
 Do not install `latest` but rather specific version e.g. `./emsdk install 2.0.23`. See [emscripten-version.txt](./emscripten-version.txt)
 
 Make sure to set `EMSDK_PATH` variable, whenever building, or running tests for wasm.
 
-## Building on macOS
+```bash
+export EMSDK_PATH=<FULL_PATH_TO_SDK_INSTALL>/emsdk
+```
 
-* To build the whole thing, with libraries:
+### Windows
+
+Windows build [requirements](../../../docs/workflow/requirements/windows-requirements.md)
+
+If `EMSDK_PATH` is not set, the `emsdk` should be provisioned automatically during the build.
+
+**Note:** The EMSDK has an implicit dependency on Python for it to be initialized. A consequence of this is that if the system doesn't have Python installed prior to attempting a build, the automatic provisioning will fail and be in an invalid state. Therefore, if Python needs to be installed after a build attempt the `$reporoot/src/mono/wasm/emsdk` directory should be manually deleted and then a rebuild attempted.
+
+## Building
+
+At this time no other build dependencies are necessary to start building for WebAssembly. If you haven't already done so, please read [this document](../../../docs/workflow/README.md#Configurations) to understand configurations. Artifacts will be placed in `artifacts/bin/microsoft.netcore.app.runtime.browser-wasm/Release/`.
+
+## macOS
+
+* To build the whole repository, including libraries:
 
 `make build-all`
 
@@ -29,19 +46,16 @@ Make sure to set `EMSDK_PATH` variable, whenever building, or running tests for 
 
 **Note:** Additional msbuild arguments can be passed with: `make build-all MSBUILD_ARGS="/p:a=b"`
 
-## emsdk on Windows
-
-Windows build [requirements](https://github.com/dotnet/runtime/blob/main/docs/workflow/requirements/windows-requirements.md)
-
-If `EMSDK_PATH` is not set, the `emsdk` should be provisioned automatically during the build.
-
-**Note:** The EMSDK has an implicit dependency on Python for it to be initialized. A consequence of this is that if the system doesn't have Python installed prior to attempting a build, the automatic provisioning will fail and be in an invalid state. Therefore, if Python needs to be installed after a build attempt the `$reporoot/src/mono/wasm/emsdk` directory should be manually deleted and then a rebuild attempted.
-
-## Building on Windows
-
-* To build everything
+## Windows
 
 `build.cmd -os browser -subset mono+libs` in the repo top level directory.
+
+## Linux
+
+* To build the whole repository, including libraries:
+
+`build.sh -os browser -subset mono+libs` in the repo top level directory.
+
 
 # Running tests
 
@@ -96,7 +110,7 @@ For example, for `System.Collections.Concurrent`: `make run-tests-v8-System.Coll
 
 ### Windows
 
-Library tests on windows can be run as described in [testing-libraries](https://github.com/dotnet/runtime/blob/main/docs/workflow/testing/libraries/testing.md#testing-libraries) documentation. Without setting additional properties, it will run tests for all libraries on `v8` engine:
+Library tests on windows can be run as described in [testing-libraries](../../../docs/workflow/testing/libraries/testing.md#testing-libraries) documentation. Without setting additional properties, it will run tests for all libraries on `v8` engine:
 
 `.\build.cmd libs.tests -test -os browser`
 


### PR DESCRIPTION
When evaluating docs with @matouskozak we found out there are two files with build instructions and emsdk setup and they do not contain the same information. I moved all the wasm building steps to be in `src/mono/wasm/README.md` and libraries doc only references them and adds library-specific information.