### PR TITLE
Skip non virtual generic methods in build_imt_slots

### DIFF
--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -1549,8 +1549,10 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, gpointer* imt, GSList *extra_
 			}
 			method = mono_class_get_method_by_index (iface, method_slot_in_interface);
 			if (method->is_generic) {
-				has_generic_virtual = TRUE;
-				vt_slot ++;
+				if (m_method_is_virtual (method)) {
+					has_generic_virtual = TRUE;
+					vt_slot ++;
+				}
 				continue;
 			}
 
@@ -1560,7 +1562,7 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, gpointer* imt, GSList *extra_
 				continue;
 			}
 
-			if (method->flags & METHOD_ATTRIBUTE_VIRTUAL) {
+			if (m_method_is_virtual (method)) {
 				add_imt_builder_entry (imt_builder, method, &imt_collisions_bitmap, vt_slot, slot_num);
 				vt_slot ++;
 			}
@@ -1576,7 +1578,7 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, gpointer* imt, GSList *extra_
 			for (method_slot_in_interface = 0; method_slot_in_interface < mcount; method_slot_in_interface++) {
 				MonoMethod *method = mono_class_get_method_by_index (iface, method_slot_in_interface);
 
-				if (method->is_generic)
+				if (method->is_generic && m_method_is_virtual(method))
 					has_generic_virtual = TRUE;
 				add_imt_builder_entry (imt_builder, method, &imt_collisions_bitmap, interface_offset + method_slot_in_interface, slot_num);
 			}

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github93349.cs
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github93349.cs
@@ -1,0 +1,56 @@
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+public class Program
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        int ret;
+        ITestInterface itf = new TestClass();
+
+        // The calls need to made twice as the first time is the trampoline
+        // the section is post build_imt_slots
+
+        ret = itf.TestMethod1(10);
+        if (ret != 100) return ret;
+
+        ret = itf.TestMethod1(10);
+        if (ret != 100) return ret;
+
+        ret = itf.TestMethod2(20);
+        if (ret != 100) return ret;
+
+        ret = itf.TestMethod2(20);
+        if (ret != 100) return ret;
+
+        ret = itf.TestMethod3(30);
+        if (ret != 100) return ret;
+
+        ret = itf.TestMethod3(30);
+        if (ret != 100) return ret;
+
+        return ret;
+    }
+}
+
+public interface ITestInterface
+{
+    int TestMethod1(int arg) => arg + 90;
+
+    // This static generic non virtual method was causing a mis-calculation of the vtable slot
+    // in mono build_imt_slots
+    static int StaticGenericMethod<T>()
+    {
+        return 1;
+    }
+    int TestMethod2(int arg) => arg + 80;
+    int TestMethod3(int arg) => arg + 70;
+}
+
+public class TestClass : ITestInterface
+{
+
+}

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github93349.cs
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github93349.cs
@@ -12,7 +12,7 @@ public class Program
         ITestInterface itf = new TestClass();
 
         // The calls need to made twice as the first time is the trampoline
-        // the section is post build_imt_slots
+        // the second call is post build_imt_slots which is the point of the test
 
         ret = itf.TestMethod1(10);
         if (ret != 100) return ret;

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github93349.csproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github93349.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When processing the methods of an interface, check that a generic method has the virtual flag to avoid corrupting the vtable.