### PR TITLE
Remove duplicate semicolon in CSharpSyntaxUtilities.cs

### DIFF
--- a/src/libraries/Common/src/SourceGenerators/CSharpSyntaxUtilities.cs
+++ b/src/libraries/Common/src/SourceGenerators/CSharpSyntaxUtilities.cs
@@ -25,7 +25,7 @@ internal static class CSharpSyntaxUtilities
         switch (value)
         {
             case string @string:
-                return SymbolDisplay.FormatLiteral(@string, quote: true); ;
+                return SymbolDisplay.FormatLiteral(@string, quote: true);
             case char @char:
                 return SymbolDisplay.FormatLiteral(@char, quote: true);
             case double.NegativeInfinity:


### PR DESCRIPTION
Saw it in https://github.com/dotnet/runtime/pull/93160 but it was too late.