### PR TITLE
[PERF] Remove --experimental-wasm-eh argument from used wasm_args

### DIFF
--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -421,7 +421,7 @@ if [[ -n "$wasm_bundle_directory" ]]; then
     using_wasm=true
     wasm_bundle_directory_path=$payload_directory
     mv $wasm_bundle_directory/* $wasm_bundle_directory_path
-    wasm_args="--experimental-wasm-eh --expose_wasm"
+    wasm_args="--expose_wasm"
     if [ "$javascript_engine" == "v8" ]; then
         # for es6 module support
         wasm_args="$wasm_args --module"


### PR DESCRIPTION
Remove --experimental-wasm-eh argument from the wasm_args used for wasm performance runs. The versions of v8 should now be in sync to latest so --experimental-wasm-eh is no longer needed.

Per: https://github.com/dotnet/performance/issues/3399