### PR TITLE
[release/8.0][wasm] Update workload description to include target framework

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
@@ -15,7 +15,7 @@
       "platforms": [ "win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64"]
     },
     "wasm-experimental": {
-      "description": ".NET WebAssembly experimental tooling",
+      "description": ".NET WebAssembly experimental tooling for net8.0",
       "packs": [
         "Microsoft.NET.Runtime.WebAssembly.Templates",
         "Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm",
@@ -24,7 +24,7 @@
       "platforms": [ "win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64" ]
     },
     "wasi-experimental": {
-      "description": ".NET WASI experimental",
+      "description": ".NET WASI experimental for net8.0",
       "packs": [
         "Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk",
         "Microsoft.NETCore.App.Runtime.Mono.wasi-wasm",

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
@@ -5,7 +5,7 @@
   },
   "workloads": {
     "wasm-tools": {
-      "description": ".NET WebAssembly build tools",
+      "description": ".NET WebAssembly build tools for net8.0",
       "packs": [
         "Microsoft.NET.Runtime.WebAssembly.Sdk",
         "Microsoft.NETCore.App.Runtime.Mono.browser-wasm",


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/93314

## Customer Impact

Disambiguates the workload description for the 8.0 workload, so instead of `.NET WebAssembly build tools` the user will see `.NET WebAssembly build tools for net8.0`. And that's the same for 6.0, and 7.0 wasm workloads.

## Testing

Manual.

## Risk

None. Just a change in description.