### PR TITLE
[PERF] Update hybridglobalization case conversion to be POSIX Standard

### DIFF
--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -371,7 +371,7 @@ if [[ "$physicalpromotion" == "true" ]]; then
     configurations="$configurations PhysicalPromotionType=physicalpromotion"
 fi
 
-if [[ "${hybridglobalization,,}" == "true" ]]; then # convert to lowercase to test
+if [[ "$(echo "$hybridglobalization" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then # convert to lowercase to test
     configurations="$configurations HybridGlobalization=True" # Force True for consistency
 fi
 


### PR DESCRIPTION
Update hybridglobalization case conversion to be POSIX Standard for maximum portability. This was missed because the image that the blazor_scenario run uses, supports the ,, for lowercase.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2287868&view=results