### PR TITLE
Vector512 Support for Enumerable<int>.Min/Max

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Max.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Max.cs
@@ -18,9 +18,7 @@ namespace System.Linq
             public static bool Compare(T left, T right) => left > right;
             public static Vector128<T> Compare(Vector128<T> left, Vector128<T> right) => Vector128.Max(left, right);
             public static Vector256<T> Compare(Vector256<T> left, Vector256<T> right) => Vector256.Max(left, right);
-#if NET8_0_OR_GREATER
             public static Vector512<T> Compare(Vector512<T> left, Vector512<T> right) => Vector512.Max(left, right);
-#endif
         }
 
         public static int? Max(this IEnumerable<int?> source) => MaxInteger(source);

--- a/src/libraries/System.Linq/src/System/Linq/Max.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Max.cs
@@ -18,6 +18,9 @@ namespace System.Linq
             public static bool Compare(T left, T right) => left > right;
             public static Vector128<T> Compare(Vector128<T> left, Vector128<T> right) => Vector128.Max(left, right);
             public static Vector256<T> Compare(Vector256<T> left, Vector256<T> right) => Vector256.Max(left, right);
+#if NET8_0_OR_GREATER
+            public static Vector512<T> Compare(Vector512<T> left, Vector512<T> right) => Vector512.Max(left, right);
+#endif
         }
 
         public static int? Max(this IEnumerable<int?> source) => MaxInteger(source);

--- a/src/libraries/System.Linq/src/System/Linq/MaxMin.cs
+++ b/src/libraries/System.Linq/src/System/Linq/MaxMin.cs
@@ -122,7 +122,7 @@ namespace System.Linq
                         }
                     }
                 }
-#endif                
+#endif
             }
             else
             {

--- a/src/libraries/System.Linq/src/System/Linq/MaxMin.cs
+++ b/src/libraries/System.Linq/src/System/Linq/MaxMin.cs
@@ -16,9 +16,7 @@ namespace System.Linq
             public static abstract bool Compare(T left, T right);
             public static abstract Vector128<T> Compare(Vector128<T> left, Vector128<T> right);
             public static abstract Vector256<T> Compare(Vector256<T> left, Vector256<T> right);
-#if NET8_0_OR_GREATER
             public static abstract Vector512<T> Compare(Vector512<T> left, Vector512<T> right);
-#endif
         }
 
         private static T MinMaxInteger<T, TMinMax>(this IEnumerable<T> source)
@@ -69,11 +67,7 @@ namespace System.Linq
                         }
                     }
                 }
-#if NET8_0_OR_GREATER
                 else if(!Vector512.IsHardwareAccelerated || span.Length < Vector512<T>.Count)
-#else
-                else
-#endif
                 {
                     ref T current = ref MemoryMarshal.GetReference(span);
                     ref T lastVectorStart = ref Unsafe.Add(ref current, span.Length - Vector256<T>.Count);
@@ -97,7 +91,6 @@ namespace System.Linq
                         }
                     }
                 }
-#if NET8_0_OR_GREATER
                 else
                 {
                     ref T current = ref MemoryMarshal.GetReference(span);
@@ -122,7 +115,6 @@ namespace System.Linq
                         }
                     }
                 }
-#endif
             }
             else
             {

--- a/src/libraries/System.Linq/src/System/Linq/MaxMin.cs
+++ b/src/libraries/System.Linq/src/System/Linq/MaxMin.cs
@@ -16,6 +16,9 @@ namespace System.Linq
             public static abstract bool Compare(T left, T right);
             public static abstract Vector128<T> Compare(Vector128<T> left, Vector128<T> right);
             public static abstract Vector256<T> Compare(Vector256<T> left, Vector256<T> right);
+#if NET8_0_OR_GREATER
+            public static abstract Vector512<T> Compare(Vector512<T> left, Vector512<T> right);
+#endif
         }
 
         private static T MinMaxInteger<T, TMinMax>(this IEnumerable<T> source)
@@ -66,7 +69,11 @@ namespace System.Linq
                         }
                     }
                 }
+#if NET8_0_OR_GREATER
+                else if(!Vector512.IsHardwareAccelerated || span.Length < Vector512<T>.Count)
+#else
                 else
+#endif
                 {
                     ref T current = ref MemoryMarshal.GetReference(span);
                     ref T lastVectorStart = ref Unsafe.Add(ref current, span.Length - Vector256<T>.Count);
@@ -90,6 +97,32 @@ namespace System.Linq
                         }
                     }
                 }
+#if NET8_0_OR_GREATER
+                else
+                {
+                    ref T current = ref MemoryMarshal.GetReference(span);
+                    ref T lastVectorStart = ref Unsafe.Add(ref current, span.Length - Vector512<T>.Count);
+
+                    Vector512<T> best = Vector512.LoadUnsafe(ref current);
+                    current = ref Unsafe.Add(ref current, Vector512<T>.Count);
+
+                    while (Unsafe.IsAddressLessThan(ref current, ref lastVectorStart))
+                    {
+                        best = TMinMax.Compare(best, Vector512.LoadUnsafe(ref current));
+                        current = ref Unsafe.Add(ref current, Vector512<T>.Count);
+                    }
+                    best = TMinMax.Compare(best, Vector512.LoadUnsafe(ref lastVectorStart));
+
+                    value = best[0];
+                    for (int i = 1; i < Vector512<T>.Count; i++)
+                    {
+                        if (TMinMax.Compare(best[i], value))
+                        {
+                            value = best[i];
+                        }
+                    }
+                }
+#endif                
             }
             else
             {

--- a/src/libraries/System.Linq/src/System/Linq/MaxMin.cs
+++ b/src/libraries/System.Linq/src/System/Linq/MaxMin.cs
@@ -67,7 +67,7 @@ namespace System.Linq
                         }
                     }
                 }
-                else if(!Vector512.IsHardwareAccelerated || span.Length < Vector512<T>.Count)
+                else if (!Vector512.IsHardwareAccelerated || span.Length < Vector512<T>.Count)
                 {
                     ref T current = ref MemoryMarshal.GetReference(span);
                     ref T lastVectorStart = ref Unsafe.Add(ref current, span.Length - Vector256<T>.Count);

--- a/src/libraries/System.Linq/src/System/Linq/Min.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Min.cs
@@ -18,9 +18,7 @@ namespace System.Linq
             public static bool Compare(T left, T right) => left < right;
             public static Vector128<T> Compare(Vector128<T> left, Vector128<T> right) => Vector128.Min(left, right);
             public static Vector256<T> Compare(Vector256<T> left, Vector256<T> right) => Vector256.Min(left, right);
-#if NET8_0_OR_GREATER
             public static Vector512<T> Compare(Vector512<T> left, Vector512<T> right) => Vector512.Min(left, right);
-#endif
         }
 
         public static int? Min(this IEnumerable<int?> source) => MinInteger(source);

--- a/src/libraries/System.Linq/src/System/Linq/Min.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Min.cs
@@ -18,6 +18,9 @@ namespace System.Linq
             public static bool Compare(T left, T right) => left < right;
             public static Vector128<T> Compare(Vector128<T> left, Vector128<T> right) => Vector128.Min(left, right);
             public static Vector256<T> Compare(Vector256<T> left, Vector256<T> right) => Vector256.Min(left, right);
+#if NET8_0_OR_GREATER
+            public static Vector512<T> Compare(Vector512<T> left, Vector512<T> right) => Vector512.Min(left, right);
+#endif
         }
 
         public static int? Min(this IEnumerable<int?> source) => MinInteger(source);

--- a/src/libraries/System.Linq/tests/MaxTests.cs
+++ b/src/libraries/System.Linq/tests/MaxTests.cs
@@ -67,7 +67,8 @@ namespace System.Linq.Tests
             T first = source.First();
             Assert.Equal(first, source.Max(Comparer<T>.Create((x, y) => x == first ? 1 : -1)));
 
-            Assert.Equal(expected + T.One, source.Max(x => x + T.One));
+            if(expected != T.MaxValue)
+                Assert.Equal(expected + T.One, source.Max(x => x + T.One));
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/MaxTests.cs
+++ b/src/libraries/System.Linq/tests/MaxTests.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Tests
     {
         public static IEnumerable<object[]> Max_AllTypes_TestData()
         {
-            for (int length = 2; length < 33; length++)
+            for (int length = 2; length < 65; length++)
             {
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i)), (byte)(length + length - 1) };
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i).ToArray()), (byte)(length + length - 1) };

--- a/src/libraries/System.Linq/tests/MaxTests.cs
+++ b/src/libraries/System.Linq/tests/MaxTests.cs
@@ -16,8 +16,11 @@ namespace System.Linq.Tests
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i)), (byte)(length + length - 1) };
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i).ToArray()), (byte)(length + length - 1) };
 
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (sbyte)i)), (sbyte)(length + length - 1) };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (sbyte)i).ToArray()), (sbyte)(length + length - 1) };
+                // Unit Tests does +T.One so we should generate data up to one value below sbyte.MaxValue
+                if ((length + length) < sbyte.MaxValue) {
+                    yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (sbyte)i)), (sbyte)(length + length - 1) };
+                    yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (sbyte)i).ToArray()), (sbyte)(length + length - 1) };
+                }
 
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ushort)i)), (ushort)(length + length - 1) };
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ushort)i).ToArray()), (ushort)(length + length - 1) };
@@ -67,8 +70,7 @@ namespace System.Linq.Tests
             T first = source.First();
             Assert.Equal(first, source.Max(Comparer<T>.Create((x, y) => x == first ? 1 : -1)));
 
-            if(expected != T.MaxValue)
-                Assert.Equal(expected + T.One, source.Max(x => x + T.One));
+            Assert.Equal(expected + T.One, source.Max(x => x + T.One));
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/MinTests.cs
+++ b/src/libraries/System.Linq/tests/MinTests.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Tests
     {
         public static IEnumerable<object[]> Min_AllTypes_TestData()
         {
-            for (int length = 2; length < 33; length++)
+            for (int length = 2; length < 65; length++)
             {
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i)), (byte)length };
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i).ToArray()), (byte)length };

--- a/src/libraries/System.Linq/tests/MinTests.cs
+++ b/src/libraries/System.Linq/tests/MinTests.cs
@@ -16,9 +16,11 @@ namespace System.Linq.Tests
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i)), (byte)length };
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i).ToArray()), (byte)length };
 
-                // dont generate testdata outside of the datatype bounds
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Where(i => i <= sbyte.MaxValue).Select(i => (sbyte)i)), (sbyte)length };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Where(i => i <= sbyte.MaxValue).Select(i => (sbyte)i).ToArray()), (sbyte)length };
+                // Unit Tests does +T.One so we should generate data up to one value below sbyte.MaxValue, otherwise the type overflows
+                if ((length + length) < sbyte.MaxValue) {
+                    yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (sbyte)i)), (sbyte)length };
+                    yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (sbyte)i).ToArray()), (sbyte)length };
+                }
 
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ushort)i)), (ushort)length };
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ushort)i).ToArray()), (ushort)length };
@@ -68,8 +70,7 @@ namespace System.Linq.Tests
             T first = source.First();
             Assert.Equal(first, source.Min(Comparer<T>.Create((x, y) => x == first ? -1 : 1)));
 
-            if(expected != T.MaxValue)
-                Assert.Equal(expected + T.One, source.Min(x => x + T.One));
+            Assert.Equal(expected + T.One, source.Min(x => x + T.One));
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/MinTests.cs
+++ b/src/libraries/System.Linq/tests/MinTests.cs
@@ -16,8 +16,9 @@ namespace System.Linq.Tests
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i)), (byte)length };
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i).ToArray()), (byte)length };
 
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (sbyte)i)), (sbyte)length };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (sbyte)i).ToArray()), (sbyte)length };
+                // dont generate testdata outside of the datatype bounds
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Where(i => i <= sbyte.MaxValue).Select(i => (sbyte)i)), (sbyte)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Where(i => i <= sbyte.MaxValue).Select(i => (sbyte)i).ToArray()), (sbyte)length };
 
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ushort)i)), (ushort)length };
                 yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ushort)i).ToArray()), (ushort)length };

--- a/src/libraries/System.Linq/tests/MinTests.cs
+++ b/src/libraries/System.Linq/tests/MinTests.cs
@@ -68,7 +68,8 @@ namespace System.Linq.Tests
             T first = source.First();
             Assert.Equal(first, source.Min(Comparer<T>.Create((x, y) => x == first ? -1 : 1)));
 
-            Assert.Equal(expected + T.One, source.Min(x => x + T.One));
+            if(expected != T.MaxValue)
+                Assert.Equal(expected + T.One, source.Min(x => x + T.One));
         }
 
         [Fact]


### PR DESCRIPTION
Use the new Vector512 type introduced in NET 8, when
- enough elements
- hardware support is present

to calculate Enumerable<int>.Min() and Enumerable<int>.Max()