### PR TITLE
JIT: Fix `TryLowerNegToMulLongOp` transformation with HW intrinsics disabled

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2887,6 +2887,9 @@ GenTree* Lowering::TryLowerNegToMulLongOp(GenTreeOp* op)
     if (!comp->opts.OptimizationEnabled())
         return nullptr;
 
+    if (!JitConfig.EnableHWIntrinsic())
+        return nullptr;
+
     if (op->isContained())
         return nullptr;
 


### PR DESCRIPTION
The transform creates a HW intrinsic node, so needs a defensive check here. The other transform of the same kind, `TryLowerAddSubToMulLongOp`, already has the check.

Fix #93299