### PR TITLE
Attribute HttpListenerRequest.UserAgent as nullable

### DIFF
--- a/src/libraries/System.Net.HttpListener/ref/System.Net.HttpListener.cs
+++ b/src/libraries/System.Net.HttpListener/ref/System.Net.HttpListener.cs
@@ -103,7 +103,7 @@ namespace System.Net
         public System.Net.TransportContext TransportContext { get { throw null; } }
         public System.Uri? Url { get { throw null; } }
         public System.Uri? UrlReferrer { get { throw null; } }
-        public string UserAgent { get { throw null; } }
+        public string? UserAgent { get { throw null; } }
         public string UserHostAddress { get { throw null; } }
         public string UserHostName { get { throw null; } }
         public string[]? UserLanguages { get { throw null; } }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
@@ -202,7 +202,7 @@ namespace System.Net
 
         private string RequestScheme => IsSecureConnection ? UriScheme.Https : UriScheme.Http;
 
-        public string UserAgent => Headers[HttpKnownHeaderNames.UserAgent]!;
+        public string? UserAgent => Headers[HttpKnownHeaderNames.UserAgent];
 
         public string UserHostAddress => LocalEndPoint!.ToString();
 


### PR DESCRIPTION
Changed the datatype for HttpListenerRequest.UserAgent to be a nullable string to match internally and externally expected behaviour.

Fix #93033