### PR TITLE
Mark TensorPrimitives as unsafe

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
@@ -11,7 +11,7 @@ using System.Security.Cryptography;
 
 namespace System.Numerics.Tensors
 {
-    public static partial class TensorPrimitives
+    public static unsafe partial class TensorPrimitives
     {
         private const nuint NonTemporalByteThreshold = 256 * 1024;
 


### PR DESCRIPTION
This was accidentally introduced due to two PRs going in which didn't conflict.