### PR TITLE
[release/8.0] Adjust System.Net metrics for OTel conformance and consistency

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs
@@ -169,7 +169,7 @@ namespace System.Net.Http.Metrics
                 HttpRequestError.ConfigurationLimitExceeded => "configuration_limit_exceeded",
 
                 // Fall back to the exception type name in case of HttpRequestError.Unknown or when exception is not an HttpRequestException.
-                _ => exception.GetType().Name
+                _ => exception.GetType().FullName!
             };
             return true;
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetrics.cs
@@ -14,10 +14,10 @@ namespace System.Net.Http.Metrics
         private readonly object _schemeTag;
         private readonly object _hostTag;
         private readonly object? _portTag;
-        private readonly object? _socketAddressTag;
+        private readonly object? _peerAddressTag;
         private bool _currentlyIdle;
 
-        public ConnectionMetrics(SocketsHttpHandlerMetrics metrics, string protocolVersion, string scheme, string host, int? port, string? socketAddress)
+        public ConnectionMetrics(SocketsHttpHandlerMetrics metrics, string protocolVersion, string scheme, string host, int? port, string? peerAddress)
         {
             _metrics = metrics;
             _openConnectionsEnabled = _metrics.OpenConnections.Enabled;
@@ -25,7 +25,7 @@ namespace System.Net.Http.Metrics
             _schemeTag = scheme;
             _hostTag = host;
             _portTag = port;
-            _socketAddressTag = socketAddress;
+            _peerAddressTag = peerAddress;
         }
 
         // TagList is a huge struct, so we avoid storing it in a field to reduce the amount we allocate on the heap.
@@ -42,9 +42,9 @@ namespace System.Net.Http.Metrics
                 tags.Add("server.port", _portTag);
             }
 
-            if (_socketAddressTag is not null)
+            if (_peerAddressTag is not null)
             {
-                tags.Add("server.socket.address", _socketAddressTag);
+                tags.Add("network.peer.address", _peerAddressTag);
             }
 
             return tags;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -655,8 +655,8 @@ namespace System.Net.Http.Functional.Tests
                 _output.WriteLine($"Client exception: {clientException}");
 
                 string[] expectedExceptionTypes = TestAsync
-                    ? [nameof(TaskCanceledException)]
-                    : [nameof(TaskCanceledException), nameof(OperationCanceledException)];
+                    ? [typeof(TaskCanceledException).FullName]
+                    : [typeof(TaskCanceledException).FullName, typeof(OperationCanceledException).FullName];
 
                 Measurement<double> m = Assert.Single(recorder.GetMeasurements());
                 VerifyRequestDuration(m, uri, acceptedErrorTypes: expectedExceptionTypes);
@@ -837,7 +837,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.True(ex is HttpRequestException or TaskCanceledException);
 
                 Measurement<double> m = Assert.Single(recorder.GetMeasurements());
-                VerifyRequestDuration(m, uri, acceptedErrorTypes: [nameof(TaskCanceledException), "response_ended"]);
+                VerifyRequestDuration(m, uri, acceptedErrorTypes: [typeof(TaskCanceledException).FullName, "response_ended"]);
             }, async server =>
             {
                 try

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -47,9 +47,9 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        private static void VerifySocketAddress(KeyValuePair<string, object?>[] tags)
+        private static void VerifyPeerAddress(KeyValuePair<string, object?>[] tags)
         {
-            string ipString = (string)tags.Single(t => t.Key == "server.socket.address").Value;
+            string ipString = (string)tags.Single(t => t.Key == "network.peer.address").Value;
             IPAddress ip = IPAddress.Parse(ipString);
             Assert.True(ip.Equals(IPAddress.Loopback.MapToIPv6()) ||
                     ip.Equals(IPAddress.Loopback) ||
@@ -122,7 +122,7 @@ namespace System.Net.Http.Functional.Tests
             VerifySchemeHostPortTags(tags, uri);
             VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
             VerifyTag(tags, "http.connection.state", state);
-            VerifySocketAddress(tags);
+            VerifyPeerAddress(tags);
         }
 
         protected static void VerifyConnectionDuration(string instrumentName, object measurement, KeyValuePair<string, object?>[] tags, Uri uri, Version? protocolVersion)
@@ -132,7 +132,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.InRange(value, double.Epsilon, 60);
             VerifySchemeHostPortTags(tags, uri);
             VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
-            VerifySocketAddress(tags);
+            VerifyPeerAddress(tags);
         }
 
         protected static void VerifyTimeInQueue(string instrumentName, object measurement, KeyValuePair<string, object?>[] tags, Uri uri, Version? protocolVersion, string method = "GET")

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -23,13 +23,13 @@ namespace System.Net
             {
                 name = NameResolutionPal.GetHostName();
             }
-            catch when (LogFailure(string.Empty, startingTimestamp))
+            catch (Exception ex) when (LogFailure(string.Empty, startingTimestamp, ex))
             {
                 Debug.Fail("LogFailure should return false");
                 throw;
             }
 
-            NameResolutionTelemetry.Log.AfterResolution(string.Empty, startingTimestamp, successful: true);
+            NameResolutionTelemetry.Log.AfterResolution(string.Empty, startingTimestamp);
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, name);
             return name;
@@ -394,13 +394,13 @@ namespace System.Net
                         Aliases = aliases
                     };
             }
-            catch when (LogFailure(hostName, startingTimestamp))
+            catch (Exception ex) when (LogFailure(hostName, startingTimestamp, ex))
             {
                 Debug.Fail("LogFailure should return false");
                 throw;
             }
 
-            NameResolutionTelemetry.Log.AfterResolution(hostName, startingTimestamp, successful: true);
+            NameResolutionTelemetry.Log.AfterResolution(hostName, startingTimestamp);
 
             return result;
         }
@@ -434,13 +434,13 @@ namespace System.Net
                 }
                 Debug.Assert(name != null);
             }
-            catch when (LogFailure(address, startingTimestamp))
+            catch (Exception ex) when (LogFailure(address, startingTimestamp, ex))
             {
                 Debug.Fail("LogFailure should return false");
                 throw;
             }
 
-            NameResolutionTelemetry.Log.AfterResolution(address, startingTimestamp, successful: true);
+            NameResolutionTelemetry.Log.AfterResolution(address, startingTimestamp);
 
             // Do the forward lookup to get the IPs for that host name
             startingTimestamp = NameResolutionTelemetry.Log.BeforeResolution(name);
@@ -464,13 +464,13 @@ namespace System.Net
                         AddressList = addresses
                     };
             }
-            catch when (LogFailure(name, startingTimestamp))
+            catch (Exception ex) when (LogFailure(name, startingTimestamp, ex))
             {
                 Debug.Fail("LogFailure should return false");
                 throw;
             }
 
-            NameResolutionTelemetry.Log.AfterResolution(name, startingTimestamp, successful: true);
+            NameResolutionTelemetry.Log.AfterResolution(name, startingTimestamp);
 
             // One of three things happened:
             // 1. Success.
@@ -577,7 +577,7 @@ namespace System.Net
         }
 
         private static Task<T>? GetAddrInfoWithTelemetryAsync<T>(string hostName, bool justAddresses, AddressFamily addressFamily, CancellationToken cancellationToken)
-             where T : class
+            where T : class
         {
             long startingTimestamp = Stopwatch.GetTimestamp();
             Task? task = NameResolutionPal.GetAddrInfoAsync(hostName, justAddresses, addressFamily, cancellationToken);
@@ -594,15 +594,19 @@ namespace System.Net
             static async Task<T> CompleteAsync(Task task, string hostName, long startingTimestamp)
             {
                 _ = NameResolutionTelemetry.Log.BeforeResolution(hostName);
-                T? result = null;
+                Exception? exception = null;
                 try
                 {
-                    result = await ((Task<T>)task).ConfigureAwait(false);
-                    return result;
+                    return await ((Task<T>)task).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    throw;
                 }
                 finally
                 {
-                    NameResolutionTelemetry.Log.AfterResolution(hostName, startingTimestamp, successful: result is not null);
+                    NameResolutionTelemetry.Log.AfterResolution(hostName, startingTimestamp, exception);
                 }
             }
         }
@@ -627,9 +631,9 @@ namespace System.Net
             }
         }
 
-        private static bool LogFailure(object hostNameOrAddress, long? startingTimestamp)
+        private static bool LogFailure(object hostNameOrAddress, long? startingTimestamp, Exception exception)
         {
-            NameResolutionTelemetry.Log.AfterResolution(hostNameOrAddress, startingTimestamp, successful: false);
+            NameResolutionTelemetry.Log.AfterResolution(hostNameOrAddress, startingTimestamp, exception);
             return false;
         }
 

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
@@ -81,7 +81,7 @@ namespace System.Net
         }
 
         [NonEvent]
-        public void AfterResolution(object hostNameOrAddress, long? startingTimestamp, bool successful)
+        public void AfterResolution(object hostNameOrAddress, long? startingTimestamp, Exception? exception = null)
         {
             Debug.Assert(startingTimestamp.HasValue);
             if (startingTimestamp == 0)
@@ -99,7 +99,7 @@ namespace System.Net
 
                 if (IsEnabled(EventLevel.Informational, EventKeywords.None))
                 {
-                    if (!successful)
+                    if (exception is not null)
                     {
                         ResolutionFailed();
                     }
@@ -110,7 +110,7 @@ namespace System.Net
 
             if (NameResolutionMetrics.IsEnabled())
             {
-                NameResolutionMetrics.AfterResolution(duration, GetHostnameFromStateObject(hostNameOrAddress));
+                NameResolutionMetrics.AfterResolution(duration, GetHostnameFromStateObject(hostNameOrAddress), exception);
             }
         }
 


### PR DESCRIPTION
Fixes #92956, fixes #92917, fixes #92837, fixes #93302

Backport of PRs #93255, #93254, #93322

## Customer Impact

OpenTelemetry metrics is a new feature in .NET 8.0.
There are minor semantic aspects which are either not conforming to the OpenTelemetry standard (#92956, #92917), inconsistent with ASP.NET (#93302) or highly undesirable (#92837). Fixing these problems in .NET 9.0 would be a breaking change against 8.0, while implementing them in 8.0 GA has a much lower negative impact on customers.

## Testing

Target test cases were added.

## Risk

Low. It is new feature in 8.0, therefore only early adopters of the new feature may be broken - we expect they will prefer conformance to standard.