### PR TITLE
Add `repeatCount` in superpmi.exe to repeat the compilation of 1 or more methods

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontextreader.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontextreader.h
@@ -68,6 +68,8 @@ private:
     const int* Indexes;
     int        IndexCount;
     int        curIndexPos;
+    int        RepeatCount;
+    int        curRepeatIter;
 
     // Method hash to process
     // If you have an index file, these things get processed
@@ -124,12 +126,14 @@ private:
 
 public:
     MethodContextReader(const char* inputFileName,
-                        const int*  indexes    = nullptr,
-                        int         indexCount = -1,
-                        char*       hash       = nullptr,
-                        int         offset     = -1,
-                        int         increment  = -1);
+                        const int*  indexes     = nullptr,
+                        int         indexCount  = -1,
+                        int         repeatCount = -1,
+                        char*       hash        = nullptr,
+                        int         offset      = -1,
+                        int         increment   = -1);
     ~MethodContextReader();
+    void Reset();
 
     // Read a method context buffer from the ContextCollection
     // (either a hive [single] or an index)

--- a/src/coreclr/tools/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.cpp
@@ -117,6 +117,9 @@ void CommandLine::DumpHelp(const char* program)
     printf(" -skipCleanup\n");
     printf("     Skip deletion of temporary files created by child SuperPMI processes with -parallel.\n");
     printf("\n");
+    printf(" -repeatCount <repetition>\n");
+    printf("     Number of times the compilation should repeat for given method contexts. Usually used when trying to measure JIT TP for specific set of methods. Default= 1.\n");
+    printf("\n");
     printf(" -target <target>\n");
     printf("     Used by the assembly differences calculator. This specifies the target\n");
     printf("     architecture for cross-compilation. Currently allowed <target> values: x64, x86, arm, arm64\n");
@@ -525,6 +528,38 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
             else if ((_stricmp(&argv[i][1], "skipCleanup") == 0))
             {
                 o->skipCleanup = true;
+            }
+            else if ((_stricmp(&argv[i][1], "repeatCount") == 0))
+            {
+                if (++i < argc)
+                {
+                    bool isValidCompileCount = true;
+                    size_t nextlen       = strlen(argv[i]);
+                    for (size_t j = 0; j < nextlen; j++)
+                    {
+                        if (!isdigit(argv[i][j]))
+                        {
+                            isValidCompileCount = false;
+                            break;
+                        }
+                    }
+                    if (isValidCompileCount)
+                    {
+                        o->repeatCount = atoi(argv[i]);
+
+                        if (o->repeatCount < 1)
+                        {
+                            LogError("Invalid repeat count specified, workers count must be between 1 and INT_MAX.");
+                            DumpHelp(argv[0]);
+                            return false;
+                        }
+                    }
+                }
+                else
+                {
+                    DumpHelp(argv[0]);
+                    return false;
+                }
             }
             else if ((_strnicmp(&argv[i][1], "stride", argLen) == 0))
             {

--- a/src/coreclr/tools/superpmi/superpmi/commandline.h
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.h
@@ -34,6 +34,7 @@ public:
         int   workerCount = -1; // Number of workers to use for /parallel mode. -1 (or 1) means don't use parallel mode.
         int   indexCount = -1;  // If indexCount is -1 and hash points to nullptr it means compile all.
         int   failureLimit = -1; // Number of failures after which bail out the replay/asmdiffs.
+        int   repeatCount  = 1;   // Number of times given methods should be compiled.
         int*  indexes = nullptr;
         char* hash = nullptr;
         char* methodStatsTypes = nullptr;

--- a/src/coreclr/tools/superpmi/superpmi/parallelsuperpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/parallelsuperpmi.cpp
@@ -592,6 +592,11 @@ int doParallelSuperPMI(CommandLine::Options& o)
 
         bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -v ewmin %s", spmiArgs);
 
+        if (o.repeatCount > 1)
+        {
+            bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -repeatCount %d", o.repeatCount);
+        }
+
         SECURITY_ATTRIBUTES sa;
         sa.nLength              = sizeof(sa);
         sa.lpSecurityDescriptor = NULL;

--- a/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
@@ -288,7 +288,7 @@ int __cdecl main(int argc, char* argv[])
     // The method context reader handles skipping any unrequested method contexts
     // Used in conjunction with an MCI file, it does a lot less work...
     MethodContextReader* reader =
-        new MethodContextReader(o.nameOfInputMethodContextFile, o.indexes, o.indexCount, o.hash, o.offset, o.increment);
+        new MethodContextReader(o.nameOfInputMethodContextFile, o.indexes, o.indexCount, o.repeatCount, o.hash, o.offset, o.increment);
     if (!reader->isValid())
     {
         return (int)SpmiResult::GeneralFailure;
@@ -327,6 +327,8 @@ int __cdecl main(int argc, char* argv[])
         }
     }
 
+    for (int iter = 0; iter < o.repeatCount; iter++)
+    {
     while (true)
     {
         MethodContextBuffer mcb = reader->GetNextMethodContext();
@@ -709,6 +711,8 @@ int __cdecl main(int argc, char* argv[])
 
         delete crl;
         delete mc;
+    }
+        reader->Reset();
     }
     delete reader;
 


### PR DESCRIPTION
I wanted to investigate the TP of 1 particular method and why it takes longer to JIT. Using superpmi if I can compile it multiple times I can see the area that is slow. One option would be to specify the method context id in `mcl` file repeatedly, but we have a check that they should be incremental. So I added a `-repeatCount` flag that will compile a single context id or entire `mch` file specified number of times, which will help in gathering accurate profile information.

Edit: For now, I did not propagated to `superpmi.py` and can be done if people find this option useful.