### PR TITLE
Revert "Adjust the DNS lookup duration metric (#93254)"

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionMetrics.cs
@@ -13,35 +13,15 @@ namespace System.Net
         private static readonly Meter s_meter = new("System.Net.NameResolution");
 
         private static readonly Histogram<double> s_lookupDuration = s_meter.CreateHistogram<double>(
-            name: "dns.lookup.duration",
+            name: "dns.lookups.duration",
             unit: "s",
             description: "Measures the time taken to perform a DNS lookup.");
 
         public static bool IsEnabled() => s_lookupDuration.Enabled;
 
-        public static void AfterResolution(TimeSpan duration, string hostName, Exception? exception)
+        public static void AfterResolution(TimeSpan duration, string hostName)
         {
-            var hostNameTag = KeyValuePair.Create("dns.question.name", (object?)hostName);
-
-            if (exception is null)
-            {
-                s_lookupDuration.Record(duration.TotalSeconds, hostNameTag);
-            }
-            else
-            {
-                var errorTypeTag = KeyValuePair.Create("error.type", (object?)GetErrorType(exception));
-                s_lookupDuration.Record(duration.TotalSeconds, hostNameTag, errorTypeTag);
-            }
+            s_lookupDuration.Record(duration.TotalSeconds, KeyValuePair.Create("dns.question.name", (object?)hostName));
         }
-
-        private static string GetErrorType(Exception exception) => (exception as SocketException)?.SocketErrorCode switch
-        {
-            SocketError.HostNotFound => "host_not_found",
-            SocketError.TryAgain => "try_again",
-            SocketError.AddressFamilyNotSupported => "address_family_not_supported",
-            SocketError.NoRecovery => "no_recovery",
-
-            _ => exception.GetType().FullName!
-        };
     }
 }

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionTelemetry.cs
@@ -81,7 +81,7 @@ namespace System.Net
         }
 
         [NonEvent]
-        public void AfterResolution(object hostNameOrAddress, long? startingTimestamp, Exception? exception = null)
+        public void AfterResolution(object hostNameOrAddress, long? startingTimestamp, bool successful)
         {
             Debug.Assert(startingTimestamp.HasValue);
             if (startingTimestamp == 0)
@@ -99,7 +99,7 @@ namespace System.Net
 
                 if (IsEnabled(EventLevel.Informational, EventKeywords.None))
                 {
-                    if (exception is not null)
+                    if (!successful)
                     {
                         ResolutionFailed();
                     }
@@ -110,7 +110,7 @@ namespace System.Net
 
             if (NameResolutionMetrics.IsEnabled())
             {
-                NameResolutionMetrics.AfterResolution(duration, GetHostnameFromStateObject(hostNameOrAddress), exception);
+                NameResolutionMetrics.AfterResolution(duration, GetHostnameFromStateObject(hostNameOrAddress));
             }
         }
 


### PR DESCRIPTION
This reverts commit 946c5245aea149d9ece53fd0debc18328c29083b.

@antonfirsov looks like the build started failing after #93254 there were known failures but the build analysis was red with several new failures.  Reverting until this is fixed