### PR TITLE
Fix analyzer treatment of flow captures of arrays

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LValueFlowCaptureProvider.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LValueFlowCaptureProvider.cs
@@ -44,12 +44,6 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			if (assignment?.Target == flowCaptureReference)
 				return true;
 
-			if (flowCaptureReference.Parent is IArrayElementReferenceOperation arrayAlementRef) {
-				assignment = arrayAlementRef.Parent as IAssignmentOperation;
-				if (assignment?.Target == arrayAlementRef)
-					return true;
-			}
-
 			assignment = null;
 			return flowCaptureReference.IsInLeftOfDeconstructionAssignment (out _);
 		}

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -362,6 +362,9 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 				if (operation.Value is IFlowCaptureReferenceOperation)
 					return TopValue;
 
+				// Note: technically we should save some information about the value for LValue flow captures
+				// (for example, the object instance of a property reference) and avoid re-computing it when
+				// assigning to the FlowCaptureReference.
 				var capturedRef = new CapturedReferenceValue (operation.Value);
 				var currentState = state.Current;
 				currentState.CapturedReferences.Set (operation.Id, capturedRef);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -235,45 +235,11 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 					if (arrayElementRef.Indices.Length != 1)
 						break;
 
-					// Similarly to VisitSimpleAssignment, this needs to handle cases where the array reference
-					// is a captured variable, even if the target of the assignment (the array element reference) is not.
 
-					TValue arrayRef;
-					TValue index;
-					TValue value;
-					if (arrayElementRef.ArrayReference is not IFlowCaptureReferenceOperation captureReference) {
-						arrayRef = Visit (arrayElementRef.ArrayReference, state);
-						index = Visit (arrayElementRef.Indices[0], state);
-						value = Visit (operation.Value, state);
-						HandleArrayElementWrite (arrayRef, index, value, operation, merge: merge);
-						return value;
-					}
-
-					index = Visit (arrayElementRef.Indices[0], state);
-					value = Visit (operation.Value, state);
-
-					var capturedReferences = state.Current.CapturedReferences.Get (captureReference.Id);
-					if (!capturedReferences.HasMultipleValues) {
-						// Single captured reference. Treat this as an overwriting assignment,
-						// unless the caller already told us to merge values because this is an
-						// assignment to one of multiple captured array element references.
-						var enumerator = capturedReferences.GetEnumerator ();
-						enumerator.MoveNext ();
-						var capture = enumerator.Current;
-						arrayRef = Visit (capture.Reference, state);
-						HandleArrayElementWrite (arrayRef, index, value, operation, merge: merge);
-						return value;
-					}
-
-					// The capture id may have captured multiple references, as in:
-					// (b ? arr1 : arr2)[0] = value;
-					// We treat this as possible write to each of the captured references,
-					// which requires merging with the previous values of each.
-
-					foreach (var capture in state.Current.CapturedReferences.Get (captureReference.Id)) {
-						arrayRef = Visit (capture.Reference, state);
-						HandleArrayElementWrite (arrayRef, index, value, operation, merge: true);
-					}
+					TValue arrayRef = Visit (arrayElementRef.ArrayReference, state);
+					TValue index = Visit (arrayElementRef.Indices[0], state);
+					TValue value = Visit (operation.Value, state);
+					HandleArrayElementWrite (arrayRef, index, value, operation, merge: merge);
 					return value;
 				}
 			case IInlineArrayAccessOperation inlineArrayAccess: {
@@ -371,19 +337,10 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		TValue GetFlowCaptureValue (IFlowCaptureReferenceOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
 		{
-			if (!operation.GetValueUsageInfo (OwningSymbol).HasFlag (ValueUsageInfo.Read)) {
-				// There are known cases where this assert doesn't hold, because LValueFlowCaptureProvider
-				// produces the wrong result in some cases for flow captures with IsInitialization = true.
-				// https://github.com/dotnet/linker/issues/2749
-				// Debug.Assert (IsLValueFlowCapture (operation.Id));
+			Debug.Assert (!IsLValueFlowCapture (operation.Id));
+			Debug.Assert (operation.GetValueUsageInfo (OwningSymbol).HasFlag (ValueUsageInfo.Read));
+			if (!operation.GetValueUsageInfo (OwningSymbol).HasFlag (ValueUsageInfo.Read))
 				return TopValue;
-			}
-
-			// This assert is incorrect for cases like (b ? arr1 : arr2)[0] = v;
-			// Here the ValueUsageInfo shows that the value usage is for reading (this is probably wrong!)
-			// but the value is actually an LValueFlowCapture.
-			// Let's just disable the assert for now.
-			// Debug.Assert (IsRValueFlowCapture (operation.Id));
 
 			return state.Get (new LocalKey (operation.Id));
 		}
@@ -399,26 +356,38 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		// is like a local reference.
 		public override TValue VisitFlowCapture (IFlowCaptureOperation operation, LocalDataFlowState<TValue, TValueLattice> state)
 		{
-			// If the captured value is a property reference, we can't easily tell inside of
-			// VisitPropertyReference whether it is accessed for reads or writes.
-			// https://github.com/dotnet/roslyn/issues/25057
-			// Avoid visiting the captured value unless it is an RValue.
 			if (IsLValueFlowCapture (operation.Id)) {
-				// Note: technically we should save some information about the value for LValue flow captures
-				// (for example, the object instance of a property reference) and avoid re-computing it when
-				// assigning to the FlowCaptureReference.
+				// Should never see an l-value flow capture of another flow capture.
+				Debug.Assert (operation.Value is not IFlowCaptureReferenceOperation);
+				if (operation.Value is IFlowCaptureReferenceOperation)
+					return TopValue;
+
+				var capturedRef = new CapturedReferenceValue (operation.Value);
 				var currentState = state.Current;
-				currentState.CapturedReferences.Set (operation.Id, new CapturedReferenceValue (operation.Value));
+				currentState.CapturedReferences.Set (operation.Id, capturedRef);
 				state.Current = currentState;
-			}
+				return TopValue;
+			} else {
+				TValue capturedValue;
+				if (operation.Value is IFlowCaptureReferenceOperation captureRef) {
+					if (IsLValueFlowCapture (captureRef.Id)) {
+						// If an r-value captures an l-value, we must dereference the l-value
+						// and copy out the value to capture.
+						capturedValue = TopValue;
+						foreach (var capturedReference in state.Current.CapturedReferences.Get (captureRef.Id)) {
+							var value = Visit (capturedReference.Reference, state);
+							capturedValue = LocalStateLattice.Lattice.ValueLattice.Meet (capturedValue, value);
+						}
+					} else {
+						capturedValue = state.Get (new LocalKey (captureRef.Id));
+					}
+				} else {
+					capturedValue = Visit (operation.Value, state);
+				}
 
-			if (IsRValueFlowCapture (operation.Id)) {
-				TValue value = Visit (operation.Value, state);
-				state.Set (new LocalKey (operation.Id), value);
-				return value;
+				state.Set (new LocalKey (operation.Id), capturedValue);
+				return capturedValue;
 			}
-
-			return TopValue;
 		}
 
 		public override TValue VisitExpressionStatement (IExpressionStatementOperation operation, LocalDataFlowState<TValue, TValueLattice> state)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -357,7 +357,9 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 				// LValueFlowCaptureProvider doesn't take into account IsInitialization = true,
 				// so it doesn't properly detect this as an l-value capture.
 				// Context: https://github.com/dotnet/roslyn/issues/60757
-				Debug.Assert (operation.GetValueUsageInfo (OwningSymbol).HasFlag (ValueUsageInfo.Write));
+				// Debug.Assert (IsLValueFlowCapture (operation.Id));
+				Debug.Assert (operation.GetValueUsageInfo (OwningSymbol).HasFlag (ValueUsageInfo.Write),
+					$"{operation.Syntax.GetLocation ().GetLineSpan ()}");
 				return TopValue;
 			}
 			return GetFlowCaptureValue (operation, state);

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -162,6 +162,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task InterpolatedStringHandlerDataFlow ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task MakeGenericDataFlow ()
 		{
 			return RunTest ();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
 
@@ -30,6 +32,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestArraySetElementAndInitializerMultipleElementsMix<TestType> (typeof (TestType));
 
 			TestGetElementAtUnknownIndex ();
+			TestGetMergedArrayElement ();
 			TestMergedArrayElementWithUnknownIndex (0);
 
 			// Array reset - certain operations on array are not tracked fully (or impossible due to unknown inputs)
@@ -46,6 +49,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestMultiDimensionalArray.Test ();
 
 			WriteCapturedArrayElement.Test ();
+
+			WriteElementOfCapturedArray.Test ();
 
 			ConstantFieldValuesAsIndex.Test ();
 
@@ -203,6 +208,23 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		{
 			Type[] arr = new Type[] { typeof (TestType) };
 			arr[i].RequiresPublicFields ();
+		}
+
+		// https://github.com/dotnet/runtime/issues/93416 tracks the discrepancy between
+		// the analyzer and ILLink/ILCompiler.
+		[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll),
+			ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+		[ExpectedWarning ("IL2087", nameof (GetMethods), nameof (DataFlowTypeExtensions.RequiresAll),
+			ProducedBy = Tool.Analyzer)]
+		[ExpectedWarning ("IL2087", nameof (GetFields), nameof (DataFlowTypeExtensions.RequiresAll),
+			ProducedBy = Tool.Analyzer)]
+		static void TestGetMergedArrayElement (bool b = true)
+		{
+			Type[] arr = new Type[] { GetMethods () };
+			Type[] arr2 = new Type[] { GetFields () };
+			if (b)
+				arr = arr2;
+			arr[0].RequiresAll ();
 		}
 
 		// Trimmer code doesnt handle locals from different branches separetely, therefore merges incorrectly GetMethods with Unknown producing both warnings
@@ -611,6 +633,102 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestNullCoalescingAssignmentToEmpty ();
 				TestNullCoalescingAssignmentComplex ();
 				TestNullCoalescingAssignmentToEmptyComplex ();
+			}
+		}
+
+		class WriteElementOfCapturedArray
+		{
+			[Kept]
+			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicConstructors), nameof (DataFlowTypeExtensions.RequiresAll))]
+			// Analysis hole: https://github.com/dotnet/runtime/issues/90335
+			// The array element assignment assigns to a temp array created as a copy of
+			// arr1 or arr2, and writes to it aren't reflected back in arr1/arr2.
+			static void TestArrayElementAssignment (bool b = true)
+			{
+				var arr1 = new Type[] { GetUnknownType () };
+				var arr2 = new Type[] { GetTypeWithPublicConstructors () };
+				(b ? arr1 : arr2)[0] = GetWithPublicMethods ();
+				arr1[0].RequiresAll ();
+				arr2[0].RequiresAll ();
+			}
+
+			[Kept]
+			[KeptAttributeAttribute (typeof (InlineArrayAttribute))]
+			[InlineArray (8)]
+			public struct InlineTypeArray
+			{
+				[Kept]
+				public Type t;
+			}
+
+			[Kept]
+			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll))]
+			static void TestInlineArrayElementReferenceAssignment (bool b = true)
+			{
+				var arr1 = new InlineTypeArray ();
+				arr1[0] = GetUnknownType ();
+				var arr2 = new InlineTypeArray ();
+				arr2[0] = GetTypeWithPublicConstructors ();
+				(b ? ref arr1[0] : ref arr2[0]) = GetTypeWithPublicConstructors ();
+				arr1[0].RequiresAll ();
+				arr2[0].RequiresAll ();
+			}
+
+			// Inline array references are not allowed in conditionals, unlike array references.
+			// static void TestInlineArrayElementAssignment (bool b = true)
+			// {
+			// 	var arr1 = new InlineTypeArray ();
+			// 	arr1[0] = GetUnknownType ();
+			// 	var arr2 = new InlineTypeArray ();
+			// 	arr2[0] = GetTypeWithPublicConstructors ();
+			// 	(b ? arr1 : arr2)[0] = GetWithPublicMethods ();
+			// 	arr1[0].RequiresAll ();
+			// 	arr2[0].RequiresAll ();
+			// }
+
+			[ExpectedWarning ("IL2087", nameof (T), nameof (DataFlowTypeExtensions.RequiresAll))]
+			[ExpectedWarning ("IL2087", nameof (U), nameof (DataFlowTypeExtensions.RequiresPublicFields))]
+			// Missing warnings for 'V' possibly assigned to arr or arr2 because write to temp
+			// array isn't reflected back in the local variables. https://github.com/dotnet/linker/issues/2158
+			static void TestNullCoalesce<T, U, V> (bool b = false)
+			{
+				Type[]? arr = new Type[1] { typeof (T) };
+				Type[] arr2 = new Type[1] { typeof (U) };
+
+				(arr ?? arr2)[0] = typeof (V);
+				arr[0].RequiresAll ();
+				arr2[0].RequiresPublicFields ();
+			}
+
+			[ExpectedWarning ("IL2087", nameof (T), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL2087", nameof (U), nameof (DataFlowTypeExtensions.RequiresPublicFields))]
+			// Missing warnings for 'V' possibly assigned to arr or arr2 because write to temp
+			// array isn't reflected back in the local variables. https://github.com/dotnet/linker/issues/2158
+			// This also causes an extra analyzer warning for 'U' in 'arr', because the analyzer models the
+			// possible assignment of arr2 to arr, without overwriting index '0'. And it produces a warning
+			// for each possible value, unlike ILLink/ILCompiler, which produce an unknown value for a merged
+			// array value: https://github.com/dotnet/runtime/issues/93416
+			[ExpectedWarning ("IL2087", nameof (U), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
+			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			static void TestNullCoalescingAssignment<T, U, V> (bool b = true)
+			{
+				Type[]? arr = new Type[1] { typeof (T) };
+				Type[] arr2 = new Type[1] { typeof (U) };
+
+				(arr ??= arr2)[0] = typeof (V);
+				arr[0].RequiresAll ();
+				arr2[0].RequiresPublicFields ();
+			}
+
+			public static void Test ()
+			{
+				TestArrayElementAssignment ();
+				TestInlineArrayElementReferenceAssignment ();
+				// TestInlineArrayElementAssignment ();
+				TestNullCoalesce<int, int, int> ();
+				TestNullCoalescingAssignment<int, int, int> ();
 			}
 		}
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ArrayDataFlow.cs
@@ -214,9 +214,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		// the analyzer and ILLink/ILCompiler.
 		[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll),
 			ProducedBy = Tool.Trimmer | Tool.NativeAot)]
-		[ExpectedWarning ("IL2087", nameof (GetMethods), nameof (DataFlowTypeExtensions.RequiresAll),
+		[ExpectedWarning ("IL2072", nameof (GetMethods), nameof (DataFlowTypeExtensions.RequiresAll),
 			ProducedBy = Tool.Analyzer)]
-		[ExpectedWarning ("IL2087", nameof (GetFields), nameof (DataFlowTypeExtensions.RequiresAll),
+		[ExpectedWarning ("IL2072", nameof (GetFields), nameof (DataFlowTypeExtensions.RequiresAll),
 			ProducedBy = Tool.Analyzer)]
 		static void TestGetMergedArrayElement (bool b = true)
 		{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ByRefDataflow.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 using Mono.Linker.Tests.Cases.Expectations.Helpers;
@@ -262,56 +260,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			[Kept]
-			[ExpectedWarning ("IL2072", nameof (GetUnknownType), nameof (DataFlowTypeExtensions.RequiresAll))]
-			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicConstructors), nameof (DataFlowTypeExtensions.RequiresAll))]
-			// ILLink/ILCompiler analysis hole: https://github.com/dotnet/runtime/issues/90335
-			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
-			[ExpectedWarning ("IL2072", nameof (GetTypeWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), ProducedBy = Tool.Analyzer)]
-			static void TestArrayElementAssignment (bool b = true)
-			{
-				var arr1 = new Type[] { GetUnknownType () };
-				var arr2 = new Type[] { GetTypeWithPublicConstructors () };
-				(b ? arr1 : arr2)[0] = GetTypeWithPublicFields ();
-				arr1[0].RequiresAll ();
-				arr2[0].RequiresAll ();
-			}
-
-			[Kept]
-			[KeptAttributeAttribute (typeof (InlineArrayAttribute))]
-			[InlineArray (8)]
-			public struct InlineTypeArray
-			{
-				[Kept]
-				public Type t;
-			}
-
-			[Kept]
-			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll))]
-			[ExpectedWarning ("IL2062", nameof (DataFlowTypeExtensions.RequiresAll))]
-			static void TestInlineArrayElementReferenceAssignment (bool b = true)
-			{
-				var arr1 = new InlineTypeArray ();
-				arr1[0] = GetUnknownType ();
-				var arr2 = new InlineTypeArray ();
-				arr2[0] = GetTypeWithPublicConstructors ();
-				(b ? ref arr1[0] : ref arr2[0]) = GetTypeWithPublicFields ();
-				arr1[0].RequiresAll ();
-				arr2[0].RequiresAll ();
-			}
-
-			// Inline array references are not allowed in conditionals, unlike array references.
-			// static void TestInlineArrayElementAssignment (bool b = true)
-			// {
-			// 	var arr1 = new InlineTypeArray ();
-			// 	arr1[0] = GetUnknownType ();
-			// 	var arr2 = new InlineTypeArray ();
-			// 	arr2[0] = GetTypeWithPublicConstructors ();
-			// 	(b ? arr1 : arr2)[0] = GetTypeWithPublicFields ();
-			// 	arr1[0].RequiresAll ();
-			// 	arr2[0].RequiresAll ();
-			// }
-
-			[Kept]
 			[ExpectedWarning ("IL2074", nameof (_publicMethodsField), nameof (GetUnknownType))]
 			[ExpectedWarning ("IL2074", nameof (_publicPropertiesField), nameof (GetUnknownType))]
 			static void TestNullCoalescingAssignment (bool b = true)
@@ -358,9 +306,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestParameterAssignment ();
 				TestLocalAssignment ();
 				TestArrayElementReferenceAssignment ();
-				TestArrayElementAssignment ();
-				TestInlineArrayElementReferenceAssignment ();
-				// TestInlineArrayElementAssignment ();
 				TestNullCoalescingAssignment ();
 				TestNullCoalescingAssignmentComplex ();
 				TestDataFlowOnRightHandOfAssignment ();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
@@ -33,6 +33,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.WriteUnknownValue ();
 
 			WriteCapturedField.Test ();
+			WriteFieldOfCapturedInstance.Test ();
 
 			_ = _annotationOnWrongType;
 
@@ -189,6 +190,35 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				TestNullCoalesce ();
 				TestNullCoalescingAssignment ();
 				TestNullCoalescingAssignmentComplex ();
+			}
+		}
+
+		class WriteFieldOfCapturedInstance
+		{
+			class ClassWithAnnotatedField
+			{
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+				public Type field;
+			}
+
+			[ExpectedWarning ("IL2074", nameof (GetUnknownType), nameof (ClassWithAnnotatedField.field))]
+			static void TestNullCoalesce ()
+			{
+				ClassWithAnnotatedField? instance = null;
+				(instance ?? new ClassWithAnnotatedField ()).field = GetUnknownType ();
+			}
+
+			[ExpectedWarning ("IL2074", nameof (GetUnknownType), nameof (ClassWithAnnotatedField.field))]
+			static void TestNullCoalescingAssignment ()
+			{
+				ClassWithAnnotatedField? instance = null;
+				(instance ??= new ClassWithAnnotatedField ()).field = GetUnknownType ();
+			}
+
+			public static void Test ()
+			{
+				TestNullCoalesce ();
+				TestNullCoalescingAssignment ();
 			}
 		}
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/InterpolatedStringHandlerDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/InterpolatedStringHandlerDataFlow.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Helpers;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[ExpectedNoWarnings]
+	[SkipKeptItemsValidation]
+	[Define ("DEBUG")]
+	public class InterpolatedStringHandlerDataFlow
+	{
+		public static void Main ()
+		{
+			Test ();
+		}
+
+		static void Test(bool b = true) {
+			// Creates a control-flow graph for the analyzer that has an
+			// IFlowCaptureReferenceOperation that represents a capture
+			// because it is used as an out param (so has IsInitialization = true).
+			// See https://github.com/dotnet/roslyn/issues/57484 for context.
+			// This test ensures the analyzer has coverage for cases
+			// where IsInitialization = true.
+			Debug.Assert (b, $"Debug interpolated string handler {b}");
+		}
+	}
+}


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/93259 uncovered an issue around how the analyzer tracks arrays. It hit an analyzer assert while trying to create an l-value flow capture of another flow capture reference, which should never happen as far as I understand. The assert was firing for https://github.com/dotnet/runtime/blob/946c5245aea149d9ece53fd0debc18328c29083b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs#L511
Now tested in TestNullCoalescingAssignment:
```csharp
(arr ??= arr2)[0] = typeof (V);
```
The CFG had three flow captures:
- capture 0: an l-value flow capture of `arr`. Used later in the branch that assigns `arr2` to `arr`.
- capture 1: an r-value flow capture of capture 0. This was checked for null.
- capture 2: an l-value flow capture representing `arr ??= arr2`, used to write index 0 of the array.
  - In the == null branch, this captured the result of an assignment (capture 0 = `arr2`)
  - In the other branch, it captured "capture 1". This is where the assert was hit.

```mermaid
flowchart TD
style 0 text-align: left;
0("<code></code>")
style 1 text-align: left;
1("<code>&nbsp;&nbsp;LocalReferenceOperation: arr = new Type[1] { typeof (T) }
&nbsp;&nbsp;&nbsp;&nbsp;LiteralOperation: 1
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;TypeOfOperation: typeof (T)
&nbsp;&nbsp;&nbsp;&nbsp;ArrayInitializerOperation: { typeof (T) }
&nbsp;&nbsp;ArrayCreationOperation: new Type[1] { typeof (T) }
SimpleAssignmentOperation: arr = new Type[1] { typeof (T) }
&nbsp;&nbsp;LocalReferenceOperation: arr2 = new Type[1] { typeof (U) }
&nbsp;&nbsp;&nbsp;&nbsp;LiteralOperation: 1
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;TypeOfOperation: typeof (U)
&nbsp;&nbsp;&nbsp;&nbsp;ArrayInitializerOperation: { typeof (U) }
&nbsp;&nbsp;ArrayCreationOperation: new Type[1] { typeof (U) }
SimpleAssignmentOperation: arr2 = new Type[1] { typeof (U) }
</code>")
0 --> 1
style 2 text-align: left;
2("<code>&nbsp;&nbsp;LocalReferenceOperation: arr
FlowCaptureOperation: arr (0)
</code>")
1 --> 2
style 3 text-align: left;
3("<code>&nbsp;&nbsp;FlowCaptureReferenceOperation: arr (0)
FlowCaptureOperation: arr (1)
&nbsp;&nbsp;FlowCaptureReferenceOperation: arr (1)
IsNullOperation: arr
</code>")
2 --> 3
style 4 text-align: left;
4("<code>&nbsp;&nbsp;FlowCaptureReferenceOperation: arr (1)
FlowCaptureOperation: arr ??= arr2 (2)
</code>")
3 --> 4
style 5 text-align: left;
5("<code>&nbsp;&nbsp;&nbsp;&nbsp;FlowCaptureReferenceOperation: arr (0)
&nbsp;&nbsp;&nbsp;&nbsp;LocalReferenceOperation: arr2
&nbsp;&nbsp;SimpleAssignmentOperation: arr ??= arr2
FlowCaptureOperation: arr ??= arr2 (2)
</code>")
3 --> 5
style 6 text-align: left;
6("<code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;FlowCaptureReferenceOperation: arr ??= arr2 (2)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LiteralOperation: 0
&nbsp;&nbsp;&nbsp;&nbsp;ArrayElementReferenceOperation: (arr ??= arr2)[0]
&nbsp;&nbsp;&nbsp;&nbsp;TypeOfOperation: typeof (V)
&nbsp;&nbsp;SimpleAssignmentOperation: (arr ??= arr2)[0] = typeof (V)
ExpressionStatementOperation: (arr ??= arr2)[0] = typeof (V);
</code>")
4 --> 6
5 --> 6
style 7 text-align: left;
7("<code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LocalReferenceOperation: arr
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LiteralOperation: 0
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ArrayElementReferenceOperation: arr[0]
&nbsp;&nbsp;&nbsp;&nbsp;ArgumentOperation: arr[0]
&nbsp;&nbsp;InvocationOperation: arr[0].RequiresAll ()
ExpressionStatementOperation: arr[0].RequiresAll ();
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LocalReferenceOperation: arr2
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;LiteralOperation: 0
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ArrayElementReferenceOperation: arr2[0]
&nbsp;&nbsp;&nbsp;&nbsp;ArgumentOperation: arr2[0]
&nbsp;&nbsp;InvocationOperation: arr2[0].RequiresPublicFields ()
ExpressionStatementOperation: arr2[0].RequiresPublicFields ();
</code>")
6 --> 7
style 8 text-align: left;
8("<code></code>")
7 --> 8
```

The bug, I believe, is that capture 2 should have been an r-value flow capture instead. Even though it's used for writing to the array, the assignment doesn't modify the array pointer represented by this capture - it dereferences this pointer and modifies the array. This was introduced by my modifications to the l-value detection logic in https://github.com/dotnet/runtime/pull/90287.

This undoes that portion of the change so that capture 2 is now treated as an r-value capture. This simplifies the array element assignment logic so that it no longer can see an assignment where the array is an l-value.

Fixes https://github.com/dotnet/runtime/pull/93420 by adding an explicit check for `IsInitialization` so that we don't hit the related asserts for string interpolation handlers.