### PR TITLE
Optimize Options Source Gen when no need to run

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/gen/Generator.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Generator.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Extensions.Options.Generators
 
         private static void HandleAnnotatedTypes(Compilation compilation, ImmutableArray<(TypeDeclarationSyntax? TypeSyntax, SemanticModel SemanticModel)> types, SourceProductionContext context)
         {
+            if (types.Length == 0)
+            {
+                return;
+            }
+
             if (!SymbolLoader.TryLoad(compilation, out var symbolHolder))
             {
                 // Not eligible compilation


### PR DESCRIPTION
This should contribute to improvements in the results of speedometer and Visual Studio (VS) tests, which have exhibited regressions. This contribute a little to https://github.com/dotnet/runtime/issues/93313 too.