### PR TITLE
Reduce differences between successor iterators

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -887,15 +887,7 @@ public:
     // GetSucc() without a Compiler*.
     //
     // The behavior of NumSucc()/GetSucc() is different when passed a Compiler* for blocks that end in:
-    // (1) BBJ_EHFINALLYRET (a return from a finally block)
-    // (2) BBJ_EHFILTERRET (a return from EH filter block)
-    // (3) BBJ_SWITCH
-    //
-    // For BBJ_EHFINALLYRET, if no Compiler* is passed, then the block is considered to have no
-    // successor. If Compiler* is passed, we use the actual successors.
-    //
-    // Similarly, BBJ_EHFILTERRET blocks are assumed to have no successors if Compiler* is not passed; if
-    // Compiler* is passed, NumSucc/GetSucc yields the first block of the try block's handler.
+    // (1) BBJ_SWITCH
     //
     // For BBJ_SWITCH, if Compiler* is not passed, then all switch successors are returned. If Compiler*
     // is passed, then only unique switch successors are returned; the duplicate successors are omitted.
@@ -1751,9 +1743,7 @@ inline BasicBlock::BBSuccList::BBSuccList(const BasicBlock* block)
     {
         case BBJ_THROW:
         case BBJ_RETURN:
-        case BBJ_EHFINALLYRET:
         case BBJ_EHFAULTRET:
-        case BBJ_EHFILTERRET:
             // We don't need m_succs.
             m_begin = nullptr;
             m_end   = nullptr;
@@ -1762,6 +1752,7 @@ inline BasicBlock::BBSuccList::BBSuccList(const BasicBlock* block)
         case BBJ_CALLFINALLY:
         case BBJ_ALWAYS:
         case BBJ_EHCATCHRET:
+        case BBJ_EHFILTERRET:
         case BBJ_LEAVE:
             m_succs[0] = block->GetJumpDest();
             m_begin    = &m_succs[0];
@@ -1788,6 +1779,22 @@ inline BasicBlock::BBSuccList::BBSuccList(const BasicBlock* block)
             {
                 m_succs[1] = block->GetJumpDest();
                 m_end      = &m_succs[2];
+            }
+            break;
+
+        case BBJ_EHFINALLYRET:
+            // We don't use the m_succs in-line data; use the existing successor table in the block.
+            // We must tolerate iterating successors early in the system, before EH_FINALLYRET successors have
+            // been computed.
+            if (block->GetJumpEhf() == nullptr)
+            {
+                m_begin = nullptr;
+                m_end   = nullptr;
+            }
+            else
+            {
+                m_begin = block->GetJumpEhf()->bbeSuccs;
+                m_end   = block->GetJumpEhf()->bbeSuccs + block->GetJumpEhf()->bbeCount;
             }
             break;
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -616,12 +616,6 @@ BasicBlockVisit BasicBlock::VisitAllSuccs(Compiler* comp, TFunc func)
 {
     switch (bbJumpKind)
     {
-        case BBJ_EHFILTERRET:
-            RETURN_ON_ABORT(func(bbJumpDest));
-            RETURN_ON_ABORT(VisitEHSuccessors(comp, this, func));
-            RETURN_ON_ABORT(VisitSuccessorEHSuccessors(comp, this, bbJumpDest, func));
-            break;
-
         case BBJ_EHFINALLYRET:
             for (unsigned i = 0; i < bbJumpEhf->bbeCount; i++)
             {
@@ -639,6 +633,7 @@ BasicBlockVisit BasicBlock::VisitAllSuccs(Compiler* comp, TFunc func)
 
         case BBJ_CALLFINALLY:
         case BBJ_EHCATCHRET:
+        case BBJ_EHFILTERRET:
         case BBJ_LEAVE:
             RETURN_ON_ABORT(func(bbJumpDest));
             RETURN_ON_ABORT(VisitEHSuccessors(comp, this, func));
@@ -728,10 +723,6 @@ BasicBlockVisit BasicBlock::VisitRegularSuccs(Compiler* comp, TFunc func)
 {
     switch (bbJumpKind)
     {
-        case BBJ_EHFILTERRET:
-            RETURN_ON_ABORT(func(bbJumpDest));
-            break;
-
         case BBJ_EHFINALLYRET:
             for (unsigned i = 0; i < bbJumpEhf->bbeCount; i++)
             {
@@ -741,6 +732,7 @@ BasicBlockVisit BasicBlock::VisitRegularSuccs(Compiler* comp, TFunc func)
 
         case BBJ_CALLFINALLY:
         case BBJ_EHCATCHRET:
+        case BBJ_EHFILTERRET:
         case BBJ_LEAVE:
         case BBJ_ALWAYS:
             RETURN_ON_ABORT(func(bbJumpDest));

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11471,16 +11471,14 @@ SPILLSTACK:
         // This will re-import all the successors of block (as well as each of their predecessors)
         impReimportSpillClique(block);
 
-        // For blocks that haven't been imported yet, we still need to mark them as pending import.
-        // Filter successor from BBJ_EHFILTERRET have already been handled, above.
-        if (!block->KindIs(BBJ_EHFILTERRET))
+        // We don't expect to see BBJ_EHFILTERRET here.
+        assert(!block->KindIs(BBJ_EHFILTERRET));
+
+        for (BasicBlock* const succ : block->Succs())
         {
-            for (BasicBlock* const succ : block->Succs())
+            if ((succ->bbFlags & BBF_IMPORTED) == 0)
             {
-                if ((succ->bbFlags & BBF_IMPORTED) == 0)
-                {
-                    impImportBlockPending(succ);
-                }
+                impImportBlockPending(succ);
             }
         }
     }
@@ -11489,7 +11487,8 @@ SPILLSTACK:
         // otherwise just import the successors of block
 
         // Does this block jump to any other blocks?
-        // Filter successor from BBJ_EHFILTERRET have already been handled, above.
+        // Filter successor from BBJ_EHFILTERRET have already been handled above in the call
+        // to impVerifyEHBlock().
         if (!block->KindIs(BBJ_EHFILTERRET))
         {
             for (BasicBlock* const succ : block->Succs())

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11472,11 +11472,15 @@ SPILLSTACK:
         impReimportSpillClique(block);
 
         // For blocks that haven't been imported yet, we still need to mark them as pending import.
-        for (BasicBlock* const succ : block->Succs())
+        // Filter successor from BBJ_EHFILTERRET have already been handled, above.
+        if (!block->KindIs(BBJ_EHFILTERRET))
         {
-            if ((succ->bbFlags & BBF_IMPORTED) == 0)
+            for (BasicBlock* const succ : block->Succs())
             {
-                impImportBlockPending(succ);
+                if ((succ->bbFlags & BBF_IMPORTED) == 0)
+                {
+                    impImportBlockPending(succ);
+                }
             }
         }
     }
@@ -11484,10 +11488,14 @@ SPILLSTACK:
     {
         // otherwise just import the successors of block
 
-        /* Does this block jump to any other blocks? */
-        for (BasicBlock* const succ : block->Succs())
+        // Does this block jump to any other blocks?
+        // Filter successor from BBJ_EHFILTERRET have already been handled, above.
+        if (!block->KindIs(BBJ_EHFILTERRET))
         {
-            impImportBlockPending(succ);
+            for (BasicBlock* const succ : block->Succs())
+            {
+                impImportBlockPending(succ);
+            }
         }
     }
 }


### PR DESCRIPTION
The NumSucc/GetSucc/Succs iterators have two variants. It is hard to understand the distinction. The goal of this change is to reduce the differences, so the only difference is the SWITCH case (iterating either all successors or only unique successors).

So:
1. BBJ_EHFILTERRET: always return the single successor, which is the first block of the filter handler.
2. BBJ_EHFINALLYRET: Move to standard successor iterator