### PR TITLE
[QUIC] Fix test for debug/release version of a library

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -103,6 +103,9 @@ namespace System
         public static bool IsReleaseRuntime => s_isReleaseRuntime.Value;
         public static bool IsDebugRuntime => s_isDebugRuntime.Value;
 
+        public static bool IsReleaseLibrary(Assembly assembly) => !IsDebuggable(assembly);
+        public static bool IsDebugLibrary(Assembly assembly) => IsDebuggable(assembly);
+
         // For use as needed on tests that time out when run on a Debug runtime.
         // Not relevant for timeouts on external activities, such as network timeouts.
         public static int SlowRuntimeTimeoutModifier = (PlatformDetection.IsDebugRuntime ? 5 : 1);
@@ -659,6 +662,13 @@ namespace System
 
             return assemblyConfigurationAttribute != null &&
                 string.Equals(assemblyConfigurationAttribute.Configuration, configuration, StringComparison.InvariantCulture);
+        }
+
+        private static bool IsDebuggable(Assembly assembly)
+        {
+            DebuggableAttribute debuggableAttribute = assembly.GetCustomAttribute<DebuggableAttribute>();
+
+            return debuggableAttribute != null && debuggableAttribute.IsJITTrackingEnabled;
         }
 
         private static bool GetSupportsSha3()

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicRemoteExecutorTests.cs
@@ -22,7 +22,7 @@ namespace System.Net.Quic.Tests
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void SslKeyLogFile_IsCreatedAndFilled()
         {
-            if (PlatformDetection.IsReleaseRuntime)
+            if (PlatformDetection.IsReleaseLibrary(typeof(QuicConnection).Assembly))
             {
                 throw new SkipTestException("Retrieving SSL secrets is not supported in Release mode.");
             }


### PR DESCRIPTION
The originally used preexisting platform detection is for runtime not libraries.

Fixes #93404