### PR TITLE
Fix crossgen2 invocation error under sourcebuild

### DIFF
--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -120,9 +120,10 @@
       Text="Generating native image of System.Private.CoreLib for $(OSPlatformConfig). Logging to $(CrossGenCoreLibLog)" />
 
     <PropertyGroup>
-      <CrossGenDllCmd>$(DotNetCli) @(Crossgen2)</CrossGenDllCmd>
+      <CrossGenDllCmd>$(DotNetCli)</CrossGenDllCmd>
       <!-- When running under source build, the SDK might already target the next major version. -->
       <CrossGenDllCmd Condition="'$(DotNetBuildFromSource)' == 'true'">$(CrossGenDllCmd) --roll-forward Major</CrossGenDllCmd>
+      <CrossGenDllCmd>$(CrossGenDllCmd) @(Crossgen2)</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -o:$(CoreLibOutputPath)</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -r:$([MSBuild]::NormalizePath('$(BinDir)', 'IL', '*.dll'))</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) --targetarch:$(TargetArchitecture)</CrossGenDllCmd>

--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -121,6 +121,8 @@
 
     <PropertyGroup>
       <CrossGenDllCmd>$(DotNetCli) @(Crossgen2)</CrossGenDllCmd>
+      <!-- When running under source build, the SDK might alrady target the next major version. -->
+      <CrossGenDllCmd Condition="'$(DotNetBuildFromSource)' == 'true'">$(CrossGenDllCmd) --roll-forward Major</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -o:$(CoreLibOutputPath)</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -r:$([MSBuild]::NormalizePath('$(BinDir)', 'IL', '*.dll'))</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) --targetarch:$(TargetArchitecture)</CrossGenDllCmd>

--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -121,7 +121,7 @@
 
     <PropertyGroup>
       <CrossGenDllCmd>$(DotNetCli) @(Crossgen2)</CrossGenDllCmd>
-      <!-- When running under source build, the SDK might alrady target the next major version. -->
+      <!-- When running under source build, the SDK might already target the next major version. -->
       <CrossGenDllCmd Condition="'$(DotNetBuildFromSource)' == 'true'">$(CrossGenDllCmd) --roll-forward Major</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -o:$(CoreLibOutputPath)</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -r:$([MSBuild]::NormalizePath('$(BinDir)', 'IL', '*.dll'))</CrossGenDllCmd>


### PR DESCRIPTION
Unsure if this is the right direction but wanted to open the PR to make some progress on unblocking the installer PR.

See failure in https://github.com/dotnet/installer/pull/17524

> /vmr/src/runtime/artifacts/source-build/self/src/dotnet.sh /vmr/src/runtime/artifacts/source-build/self/src/artifacts/bin/coreclr/linux.x64.Release/x64/crossgen2/tools/crossgen2.dll -o:/vmr/src/runtime/artifacts/source-build/self/src/artifacts/bin/coreclr/linux.x64.Release/System.Private.CoreLib.dll -r:/vmr/src/runtime/artifacts/source-build/self/src/artifacts/bin/coreclr/linux.x64.Release/IL/*.dll --targetarch:x64 --targetos:linux -O /vmr/src/runtime/artifacts/source-build/self/src/artifacts/bin/coreclr/linux.x64.Release/IL/System.Private.CoreLib.dll --perfmap-format-version:1 --perfmap --perfmap-path:/vmr/src/runtime/artifacts/source-build/self/src/artifacts/bin/coreclr/linux.x64.Release/
      You must install or update .NET to run this application.
      App: /vmr/src/runtime/artifacts/source-build/self/src/artifacts/bin/coreclr/linux.x64.Release/x64/crossgen2/tools/crossgen2.dll
      Architecture: x64
      Framework: 'Microsoft.NETCore.App', version '8.0.0-preview.7.23375.6' (x64)
      .NET location: /vmr/.dotnet/ 
      The following frameworks were found:
        9.0.0-alpha.1.23470.17 at [/vmr/.dotnet/shared/Microsoft.NETCore.App]

@jkoritzinsky why do we invoke crossgen2.dll manually here instead of going through the SDK integration?

One more question, why does runtimeconfig.json list `8.0.0-preview.7.23375.6`? Shouldn't we require `9.0.0-alpha.1.23470.17` during source build?