### PR TITLE
Disable failing win-arm64 JIT tests

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -332,6 +332,18 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_45929/test45929/*">
             <Issue>https://github.com/dotnet/runtime/issues/60152</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/IL_Conformance/Old/Conformance_Base/ldc_mul_ovf_i4/**">
+            <Issue>https://github.com/dotnet/runtime/issues/93441</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/rtchecks/overflow/overflow02_mul/**">
+            <Issue>https://github.com/dotnet/runtime/issues/93442</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b25815/**">
+            <Issue>https://github.com/dotnet/runtime/issues/93443</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b71869/**">
+            <Issue>https://github.com/dotnet/runtime/issues/93444</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are x64 Unix failures on CoreCLR. -->

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -344,6 +344,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b71869/**">
             <Issue>https://github.com/dotnet/runtime/issues/93444</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/AssertionPropagation/ArrBoundElim/**">
+            <Issue>https://github.com/dotnet/runtime/issues/93441</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are x64 Unix failures on CoreCLR. -->


### PR DESCRIPTION
Disable these while we investigate what happened.

Related: #93424, #93441, #93442, #93443, #93444