### PR TITLE
Fix test build error when BuildAsStandalone is true

### DIFF
--- a/src/tests/Regressions/coreclr/22021/provider.ilproj
+++ b/src/tests/Regressions/coreclr/22021/provider.ilproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="provider.il" />
   </ItemGroup>


### PR DESCRIPTION
Build error of provider.ilproj test when BuildAsStandalone is true
`EXEC : error : No entry point declared for executable`

This is due to https://github.com/dotnet/runtime/pull/92029
Restore OutputType to Library.