### PR TITLE
[mono][tests] Make sure to log the exit code for library mode tests

### DIFF
--- a/src/tasks/AppleAppBuilder/Templates/runtime-librarymode.m
+++ b/src/tasks/AppleAppBuilder/Templates/runtime-librarymode.m
@@ -76,6 +76,8 @@ mono_ios_runtime_init (void)
     chdir (bundle);
 
     int res = invoke_netlibrary_entrypoints ();
+    // Print the return code so XHarness can detect it in the logs
+    os_log_info (OS_LOG_DEFAULT, EXIT_CODE_TAG ": %d", res);
 
     exit (res);
 }


### PR DESCRIPTION
In order for XHarness to properly detect the exit code on iOS 15+ versions of the OS, we need to provide the exit code in the logs marked with `DOTNET.APP_EXIT_CODE` (ref: https://github.com/dotnet/xharness/pull/847) 

---
Fixes https://github.com/dotnet/dnceng/issues/639