### PR TITLE
[browser] Trim globalization code

### DIFF
--- a/eng/testing/tests.browser.targets
+++ b/eng/testing/tests.browser.targets
@@ -38,6 +38,7 @@
     <WasmEnableLegacyJsInterop Condition="'$(WasmEnableLegacyJsInterop)' == ''">true</WasmEnableLegacyJsInterop>
     <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">false</UseSystemResourceKeys>
     <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">true</EventSourceSupport>
+    <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">true</NullabilityInfoContextSupport>
   </PropertyGroup>
 
   <!-- We expect WASM users to indicate they would like to have bigger download size by adding WasmIncludeFullIcuData, -->

--- a/eng/testing/tests.browser.targets
+++ b/eng/testing/tests.browser.targets
@@ -37,6 +37,7 @@
     <_BundleAOTTestWasmAppForHelixDependsOn>$(_BundleAOTTestWasmAppForHelixDependsOn);PrepareForWasmBuildApp;_PrepareForAOTOnHelix</_BundleAOTTestWasmAppForHelixDependsOn>
     <WasmEnableLegacyJsInterop Condition="'$(WasmEnableLegacyJsInterop)' == ''">true</WasmEnableLegacyJsInterop>
     <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">false</UseSystemResourceKeys>
+    <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">true</EventSourceSupport>
   </PropertyGroup>
 
   <!-- We expect WASM users to indicate they would like to have bigger download size by adding WasmIncludeFullIcuData, -->

--- a/eng/testing/tests.browser.targets
+++ b/eng/testing/tests.browser.targets
@@ -36,6 +36,7 @@
     <GetNuGetsToBuildForWorkloadTestingDependsOn>_GetRuntimePackNuGetsToBuild;_GetNugetsForAOT;$(GetNuGetsToBuildForWorkloadTestingDependsOn)</GetNuGetsToBuildForWorkloadTestingDependsOn>
     <_BundleAOTTestWasmAppForHelixDependsOn>$(_BundleAOTTestWasmAppForHelixDependsOn);PrepareForWasmBuildApp;_PrepareForAOTOnHelix</_BundleAOTTestWasmAppForHelixDependsOn>
     <WasmEnableLegacyJsInterop Condition="'$(WasmEnableLegacyJsInterop)' == ''">true</WasmEnableLegacyJsInterop>
+    <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">false</UseSystemResourceKeys>
   </PropertyGroup>
 
   <!-- We expect WASM users to indicate they would like to have bigger download size by adding WasmIncludeFullIcuData, -->

--- a/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/System.Diagnostics.Tracing.TrimmingTests.proj
+++ b/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/System.Diagnostics.Tracing.TrimmingTests.proj
@@ -2,12 +2,8 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
   <ItemGroup>
-    <TestConsoleAppSourceFiles Include="EventSourcePropertyValueTest.cs" >
-      <EnabledProperties>EventSourceSupport</EnabledProperties>
-    </TestConsoleAppSourceFiles>
-    <TestConsoleAppSourceFiles Include="EventSourceManifestTest.cs" >
-      <EnabledProperties>EventSourceSupport</EnabledProperties>
-    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="EventSourcePropertyValueTest.cs" EnabledProperties="EventSourceSupport" />
+    <TestConsoleAppSourceFiles Include="EventSourceManifestTest.cs" EnabledProperties="EventSourceSupport" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/System.Diagnostics.Tracing.TrimmingTests.proj
+++ b/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/System.Diagnostics.Tracing.TrimmingTests.proj
@@ -2,8 +2,12 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
   <ItemGroup>
-    <TestConsoleAppSourceFiles Include="EventSourcePropertyValueTest.cs" />
-    <TestConsoleAppSourceFiles Include="EventSourceManifestTest.cs" />
+    <TestConsoleAppSourceFiles Include="EventSourcePropertyValueTest.cs" >
+      <EnabledProperties>EventSourceSupport</EnabledProperties>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="EventSourceManifestTest.cs" >
+      <EnabledProperties>EventSourceSupport</EnabledProperties>
+    </TestConsoleAppSourceFiles>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Browser.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Browser.xml
@@ -1,9 +1,9 @@
 <linker>
   <assembly fullname="System.Private.CoreLib">
-    <type fullname="System.Globalization.GlobalizationMode/Settings">
+    <type fullname="System.Globalization.GlobalizationMode">
       <method signature="System.Boolean get_Hybrid()" body="stub" value="false" feature="System.Globalization.Hybrid" featurevalue="false" />
     </type>
-    <type fullname="System.Globalization.GlobalizationMode/Settings">
+    <type fullname="System.Globalization.GlobalizationMode">
       <method signature="System.Boolean get_Hybrid()" body="stub" value="true" feature="System.Globalization.Hybrid" featurevalue="true" />
     </type>
   </assembly>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Browser.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Browser.xml
@@ -1,10 +1,10 @@
 <linker>
   <assembly fullname="System.Private.CoreLib">
-      <type fullname="System.Globalization.GlobalizationMode">
-      <method signature="System.Boolean get_Hybrid()" body="stub" value="true" feature="System.Globalization.Hybrid" featurevalue="true" />
-    </type>
     <type fullname="System.Globalization.GlobalizationMode/Settings">
       <method signature="System.Boolean get_Hybrid()" body="stub" value="false" feature="System.Globalization.Hybrid" featurevalue="false" />
+    </type>
+    <type fullname="System.Globalization.GlobalizationMode/Settings">
+      <method signature="System.Boolean get_Hybrid()" body="stub" value="true" feature="System.Globalization.Hybrid" featurevalue="true" />
     </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Browser.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Browser.xml
@@ -1,7 +1,10 @@
 <linker>
   <assembly fullname="System.Private.CoreLib">
-    <type fullname="System.Globalization.GlobalizationMode">
-      <method signature="System.Boolean get_Hybrid()" body="stub" value="true" feature="System.Globalization.Hybrid" featurevalue="false" />
+      <type fullname="System.Globalization.GlobalizationMode">
+      <method signature="System.Boolean get_Hybrid()" body="stub" value="true" feature="System.Globalization.Hybrid" featurevalue="true" />
+    </type>
+    <type fullname="System.Globalization.GlobalizationMode/Settings">
+      <method signature="System.Boolean get_Hybrid()" body="stub" value="false" feature="System.Globalization.Hybrid" featurevalue="false" />
     </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
@@ -13,15 +13,15 @@
     <TestConsoleAppSourceFiles Include="InheritedAttributeTests.cs" />
     <TestConsoleAppSourceFiles Include="InterfacesOnArrays.cs" />
     <TestConsoleAppSourceFiles Include="InvariantGlobalizationFalse.cs">
-      <DisabledFeatureSwitches>System.Globalization.Invariant</DisabledFeatureSwitches>
-      <EnabledFeatureSwitches>System.Globalization.Hybrid</EnabledFeatureSwitches>
+      <DisabledProperties>InvariantGlobalization</DisabledProperties>
+      <EnabledProperties>HybridGlobalization</EnabledProperties>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="InvariantGlobalizationFalse.cs">
-      <DisabledFeatureSwitches>System.Globalization.Invariant</DisabledFeatureSwitches>
+      <DisabledProperties>InvariantGlobalization</DisabledProperties>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="InvariantGlobalizationTrue.cs">
-      <DisabledFeatureSwitches>System.Globalization.Hybrid</DisabledFeatureSwitches>
-      <EnabledFeatureSwitches>System.Globalization.Invariant;System.Globalization.PredefinedCulturesOnly</EnabledFeatureSwitches>
+      <DisabledProperties>HybridGlobalization</DisabledProperties>
+      <EnabledProperties>InvariantGlobalization;PredefinedCulturesOnly</EnabledProperties>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="StackFrameHelperTest.cs">
       <!-- There is a bug with the linker where it is corrupting the pdbs while trimming
@@ -39,16 +39,16 @@
     <TestConsoleAppSourceFiles Include="VerifyResourcesGetTrimmedTest.cs">
       <!-- Setting the Trimming feature switch to make sure that the Resources get trimmed by the trimmer
       as this test will ensure exceptions are using Resource keys -->
-      <EnabledFeatureSwitches>System.Resources.UseSystemResourceKeys</EnabledFeatureSwitches>
+      <EnabledProperties>UseSystemResourceKeys</EnabledProperties>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="TypeBuilderComDisabled.cs">
-      <DisabledFeatureSwitches>System.Runtime.InteropServices.BuiltInComInterop.IsSupported</DisabledFeatureSwitches>
+      <DisabledProperties>BuiltInComInteropSupport</DisabledProperties>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="NullabilityInfoContextSupportFalse.cs">
-      <DisabledFeatureSwitches>System.Reflection.NullabilityInfoContext.IsSupported</DisabledFeatureSwitches>
+      <DisabledProperties>NullabilityInfoContextSupport</DisabledProperties>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="NullabilityInfoContextSupportTrue.cs">
-      <EnabledFeatureSwitches>System.Reflection.NullabilityInfoContext.IsSupported</EnabledFeatureSwitches>
+      <EnabledProperties>NullabilityInfoContextSupport</EnabledProperties>
     </TestConsoleAppSourceFiles>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">

--- a/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
@@ -6,8 +6,12 @@
     <TestConsoleAppSourceFiles Include="AppDomainGetThreadWindowsPrincipalTest.cs">
       <SkipOnTestRuntimes>osx-x64;linux-x64;browser-wasm</SkipOnTestRuntimes>
     </TestConsoleAppSourceFiles>
-    <TestConsoleAppSourceFiles Include="DebuggerTypeProxyAttributeTests.cs" />
-    <TestConsoleAppSourceFiles Include="DebuggerVisualizerAttributeTests.cs" />
+    <TestConsoleAppSourceFiles Include="DebuggerTypeProxyAttributeTests.cs" >
+      <EnabledProperties>DebuggerSupport</EnabledProperties>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="DebuggerVisualizerAttributeTests.cs" >
+      <EnabledProperties>DebuggerSupport</EnabledProperties>
+    </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="DefaultValueAttributeCtorTest.cs" />
     <TestConsoleAppSourceFiles Include="GenericArraySortHelperTest.cs" />
     <TestConsoleAppSourceFiles Include="InheritedAttributeTests.cs" />

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -63,16 +63,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
     <!-- Runtime feature defaults to trim unnecessary code -->
-    <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
     <InvariantTimezone Condition="'$(BlazorEnableTimeZoneSupport)' == 'false'">true</InvariantTimezone>
-    <InvariantTimezone Condition="'$(InvariantTimezone)' == ''">false</InvariantTimezone>
-    <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
-    <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
-    <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
-    <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
-    <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
-    <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
-    <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(Configuration)' != 'Debug'">false</DebuggerSupport>
     <BlazorCacheBootResources Condition="'$(BlazorCacheBootResources)' == ''">true</BlazorCacheBootResources>
     <WasmFingerprintDotnetJs Condition="'$(WasmFingerprintDotnetJs)' == ''">false</WasmFingerprintDotnetJs>
 

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
@@ -37,6 +37,18 @@
     <WasmNativeWorkloadAvailable Condition="'$(TargetsNet6)' == 'true'">$(WasmNativeWorkload)</WasmNativeWorkloadAvailable>
     <WasmNativeWorkloadAvailable Condition="'$(WasmNativeWorkloadAvailable)' == '' or '$(WasmNativeWorkload)' == 'false'">false</WasmNativeWorkloadAvailable>
     <WasmNativeWorkload>$(WasmNativeWorkloadAvailable)</WasmNativeWorkload>
+
+    <!-- Runtime feature defaults to trim unnecessary code -->
+    <InvariantTimezone Condition="'$(InvariantTimezone)' == ''">false</InvariantTimezone>
+    <HybridGlobalization Condition="'$(HybridGlobalization)' == ''">false</HybridGlobalization>
+    <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
+    <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
+    <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
+    <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
+    <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
+    <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
+    <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
+    <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(Configuration)' != 'Debug'">false</DebuggerSupport>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">

--- a/src/mono/wasm/Wasm.Build.Tests/IcuTestsBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/IcuTestsBase.cs
@@ -108,9 +108,9 @@ public abstract class IcuTestsBase : TestMainJsTestBase
         bool dotnetWasmFromRuntimePack = !(buildArgs.AOT || buildArgs.Config == "Release");
 
         buildArgs = buildArgs with { ProjectName = projectName };
-        string extraProperties = onlyPredefinedCultures ?
-            $"<WasmIcuDataFileName>{shardName}</WasmIcuDataFileName><PredefinedCulturesOnly>true</PredefinedCulturesOnly>" :
-            $"<WasmIcuDataFileName>{shardName}</WasmIcuDataFileName>";
+        string extraProperties = $"<WasmIcuDataFileName>{shardName}</WasmIcuDataFileName><UseSystemResourceKeys>false</UseSystemResourceKeys>";
+        if (onlyPredefinedCultures)
+            extraProperties = $"{extraProperties}<PredefinedCulturesOnly>true</PredefinedCulturesOnly>";
         buildArgs = ExpandBuildArgs(buildArgs, extraProperties: extraProperties);
 
         string programText = GetProgramText(testedLocales, onlyPredefinedCultures);

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -166,7 +166,6 @@
     <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
     <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(Configuration)' != 'Debug'">false</DebuggerSupport>
-    <WasmFingerprintDotnetJs Condition="'$(WasmFingerprintDotnetJs)' == ''">false</WasmFingerprintDotnetJs>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -155,22 +155,21 @@
 
     <WasmRuntimeAssetsLocation Condition="'$(WasmRuntimeAssetsLocation)' == ''">_framework</WasmRuntimeAssetsLocation>
 
-    <!-- Default values for build properties -->
+    <!-- Runtime feature defaults to trim unnecessary code -->
     <InvariantTimezone Condition="'$(InvariantTimezone)' == ''">false</InvariantTimezone>
+    <HybridGlobalization Condition="'$(HybridGlobalization)' == ''">false</HybridGlobalization>
+    <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
+    <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
+    <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
+    <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
+    <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
+    <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
+    <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
+    <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(Configuration)' != 'Debug'">false</DebuggerSupport>
+    <WasmFingerprintDotnetJs Condition="'$(WasmFingerprintDotnetJs)' == ''">false</WasmFingerprintDotnetJs>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Runtime feature defaults to trim unnecessary code -->
-    <RuntimeHostConfigurationOption Condition="'$(HybridGlobalization)' == ''" Include="System.Globalization.Hybrid" Value="false"/>
-    <RuntimeHostConfigurationOption Condition="'$(InvariantGlobalization)' == ''" Include="System.Globalization.Invariant" Value="false" />
-    <RuntimeHostConfigurationOption Condition="'$(EventSourceSupport)' == ''" Include="System.Diagnostics.Tracing.EventSource.IsSupported" Value="false" />
-    <RuntimeHostConfigurationOption Condition="'$(UseSystemResourceKeys)' == ''" Include="System.Resources.UseSystemResourceKeys" Value="true" />
-    <RuntimeHostConfigurationOption Condition="'$(EnableUnsafeUTF7Encoding)' == ''" Include="System.Text.Encoding.EnableUnsafeUTF7Encoding" Value="false" />
-    <RuntimeHostConfigurationOption Condition="'$(HttpActivityPropagationSupport)' == ''" Include="System.Net.Http.EnableActivityPropagation" Value="false" />
-    <RuntimeHostConfigurationOption Condition="'$(NullabilityInfoContextSupport)' == ''" Include="System.Reflection.NullabilityInfoContext.IsSupported" Value="false" />
-    <RuntimeHostConfigurationOption Condition="'$(_AggressiveAttributeTrimming)' == ''" Include="System.AggressiveAttributeTrimming" Value="true" />
-    <RuntimeHostConfigurationOption Condition="'$(DebuggerSupport)' == ''and '$(Configuration)' != 'Debug'" Include="System.Diagnostics.Debugger.IsSupported" Value="false" />
-
     <!-- Allow running/debugging from VS -->
     <ProjectCapability Include="DotNetCoreWeb"/>
 

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -154,12 +154,10 @@
     <WasmStripILAfterAOT Condition="'$(WasmStripILAfterAOT)' == ''">false</WasmStripILAfterAOT>
 
     <WasmRuntimeAssetsLocation Condition="'$(WasmRuntimeAssetsLocation)' == ''">_framework</WasmRuntimeAssetsLocation>
-    <BlazorCacheBootResources Condition="'$(BlazorCacheBootResources)' == ''">true</BlazorCacheBootResources>
 
     <!-- Runtime feature defaults to trim unnecessary code -->
     <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
     <HybridGlobalization Condition="'$(HybridGlobalization)' == ''">false</HybridGlobalization>
-    <InvariantTimezone Condition="'$(BlazorEnableTimeZoneSupport)' == 'false'">true</InvariantTimezone>
     <InvariantTimezone Condition="'$(InvariantTimezone)' == ''">false</InvariantTimezone>
     <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
     <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
@@ -168,7 +166,6 @@
     <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
     <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(Configuration)' != 'Debug'">false</DebuggerSupport>
-    <BlazorCacheBootResources Condition="'$(BlazorCacheBootResources)' == ''">true</BlazorCacheBootResources>
     <WasmFingerprintDotnetJs Condition="'$(WasmFingerprintDotnetJs)' == ''">false</WasmFingerprintDotnetJs>
   </PropertyGroup>
 

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -155,20 +155,22 @@
 
     <WasmRuntimeAssetsLocation Condition="'$(WasmRuntimeAssetsLocation)' == ''">_framework</WasmRuntimeAssetsLocation>
 
-    <!-- Runtime feature defaults to trim unnecessary code -->
-    <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
-    <HybridGlobalization Condition="'$(HybridGlobalization)' == ''">false</HybridGlobalization>
+    <!-- Default values for build properties -->
     <InvariantTimezone Condition="'$(InvariantTimezone)' == ''">false</InvariantTimezone>
-    <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
-    <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
-    <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
-    <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
-    <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
-    <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(Configuration)' != 'Debug'">false</DebuggerSupport>
-    <WasmFingerprintDotnetJs Condition="'$(WasmFingerprintDotnetJs)' == ''">false</WasmFingerprintDotnetJs>
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Runtime feature defaults to trim unnecessary code -->
+    <RuntimeHostConfigurationOption Condition="'$(HybridGlobalization)' == ''" Include="System.Globalization.Hybrid" Value="false"/>
+    <RuntimeHostConfigurationOption Condition="'$(InvariantGlobalization)' == ''" Include="System.Globalization.Invariant" Value="false" />
+    <RuntimeHostConfigurationOption Condition="'$(EventSourceSupport)' == ''" Include="System.Diagnostics.Tracing.EventSource.IsSupported" Value="false" />
+    <RuntimeHostConfigurationOption Condition="'$(UseSystemResourceKeys)' == ''" Include="System.Resources.UseSystemResourceKeys" Value="true" />
+    <RuntimeHostConfigurationOption Condition="'$(EnableUnsafeUTF7Encoding)' == ''" Include="System.Text.Encoding.EnableUnsafeUTF7Encoding" Value="false" />
+    <RuntimeHostConfigurationOption Condition="'$(HttpActivityPropagationSupport)' == ''" Include="System.Net.Http.EnableActivityPropagation" Value="false" />
+    <RuntimeHostConfigurationOption Condition="'$(NullabilityInfoContextSupport)' == ''" Include="System.Reflection.NullabilityInfoContext.IsSupported" Value="false" />
+    <RuntimeHostConfigurationOption Condition="'$(_AggressiveAttributeTrimming)' == ''" Include="System.AggressiveAttributeTrimming" Value="true" />
+    <RuntimeHostConfigurationOption Condition="'$(DebuggerSupport)' == ''and '$(Configuration)' != 'Debug'" Include="System.Diagnostics.Debugger.IsSupported" Value="false" />
+
     <!-- Allow running/debugging from VS -->
     <ProjectCapability Include="DotNetCoreWeb"/>
 

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -155,6 +155,21 @@
 
     <WasmRuntimeAssetsLocation Condition="'$(WasmRuntimeAssetsLocation)' == ''">_framework</WasmRuntimeAssetsLocation>
     <BlazorCacheBootResources Condition="'$(BlazorCacheBootResources)' == ''">true</BlazorCacheBootResources>
+
+    <!-- Runtime feature defaults to trim unnecessary code -->
+    <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
+    <HybridGlobalization Condition="'$(HybridGlobalization)' == ''">false</HybridGlobalization>
+    <InvariantTimezone Condition="'$(BlazorEnableTimeZoneSupport)' == 'false'">true</InvariantTimezone>
+    <InvariantTimezone Condition="'$(InvariantTimezone)' == ''">false</InvariantTimezone>
+    <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
+    <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
+    <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
+    <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
+    <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
+    <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
+    <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(Configuration)' != 'Debug'">false</DebuggerSupport>
+    <BlazorCacheBootResources Condition="'$(BlazorCacheBootResources)' == ''">true</BlazorCacheBootResources>
+    <WasmFingerprintDotnetJs Condition="'$(WasmFingerprintDotnetJs)' == ''">false</WasmFingerprintDotnetJs>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -154,18 +154,6 @@
     <WasmStripILAfterAOT Condition="'$(WasmStripILAfterAOT)' == ''">false</WasmStripILAfterAOT>
 
     <WasmRuntimeAssetsLocation Condition="'$(WasmRuntimeAssetsLocation)' == ''">_framework</WasmRuntimeAssetsLocation>
-
-    <!-- Runtime feature defaults to trim unnecessary code -->
-    <InvariantTimezone Condition="'$(InvariantTimezone)' == ''">false</InvariantTimezone>
-    <HybridGlobalization Condition="'$(HybridGlobalization)' == ''">false</HybridGlobalization>
-    <InvariantGlobalization Condition="'$(InvariantGlobalization)' == ''">false</InvariantGlobalization>
-    <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
-    <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
-    <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
-    <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
-    <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>
-    <_AggressiveAttributeTrimming Condition="'$(_AggressiveAttributeTrimming)' == ''">true</_AggressiveAttributeTrimming>
-    <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(Configuration)' != 'Debug'">false</DebuggerSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -160,7 +160,6 @@
     <HybridGlobalization Condition="'$(HybridGlobalization)' == ''">false</HybridGlobalization>
     <InvariantTimezone Condition="'$(InvariantTimezone)' == ''">false</InvariantTimezone>
     <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">false</EventSourceSupport>
-    <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">true</UseSystemResourceKeys>
     <EnableUnsafeUTF7Encoding Condition="'$(EnableUnsafeUTF7Encoding)' == ''">false</EnableUnsafeUTF7Encoding>
     <HttpActivityPropagationSupport Condition="'$(HttpActivityPropagationSupport)' == ''">false</HttpActivityPropagationSupport>
     <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">false</NullabilityInfoContextSupport>


### PR DESCRIPTION
In the measurements a [sample WASM](https://github.com/dotnet/runtime/tree/e8b8a77b0c1364e90263bc565d0c0a5552f53dba/src/mono/sample/wasm/browser) app is used with added a few Globalization method calls.

Goal: 
- reduce size of Hybrid Globalization application (sample app: 6 408 kB)
- reduce size of non-Hybrid Globalization application (sample app: 8 428 kB)

Changes:
- correct a bug in `System.Globalization.Hybrid` feature switch substitution,
- globalization-connected task `_GetWasmGenerateAppBundleDependencies` that was setting MsBuild properties for feature switches used to be run **after** `IILink` task. From this reason, all unset MsBuild properties that were planned to be substituted when they are "false" were ignored. Initial feature switches setup was copied from https://github.com/dotnet/runtime/blob/e8b8a77b0c1364e90263bc565d0c0a5552f53dba/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets#L65
- Blazor trims localizable resources by default, so wasm app should do the same. Because we expect certain exception message in IcuSharding WBT, build setting for that test was changed.
- Trimming tests used to set feature switches that do not have any effect on trimming when we add default values definitions in `WasmApp.targets`. They were changed to property switches.
- Trimming tests `DebuggerTypeProxyAttributeTests` and `DebuggerVisualizerAttributeTests` need to set `DebuggerSupport=true` in order not to have the debugger code trimmed:
https://github.com/dotnet/runtime/blob/04ede0dadfbf2f1082d3bd218cea6fe46bbbed4a/docs/workflow/trimming/feature-switches.md?plain=1#L11
The test used to expect the debugger code to be preserved even though it did not set the property to `true`.
Same thing for `EventSourcePropertyValueTest`, `EventSourceManifestTest`.

Results:
- HG: 6 408 kB -> 6 096 kB (-312 kB)
- non HG: 8 428 kB -> 8 360 kB (-68 kB)

Quoted sizes of `AppBundles` are not brotlied.