### PR TITLE
[browser] start MonoVM during DLL download

### DIFF
--- a/src/mono/mono/metadata/bundled-resources.c
+++ b/src/mono/mono/metadata/bundled-resources.c
@@ -126,8 +126,9 @@ bundled_resources_resource_id_hash (const char *id)
 void
 mono_bundled_resources_add (MonoBundledResource **resources_to_bundle, uint32_t len)
 {
-	MonoDomain *domain = mono_get_root_domain ();
-	g_assert (!domain);
+	// TODO FIXME, why this was necessary ?
+	// MonoDomain *domain = mono_get_root_domain ();
+	// g_assert (!domain);
 
 	if (!bundled_resources)
 		bundled_resources = g_hash_table_new_full ((GHashFunc)bundled_resources_resource_id_hash, (GEqualFunc)bundled_resources_resource_id_equal, NULL, bundled_resources_value_destroy_func);

--- a/src/mono/wasm/runtime/assets.ts
+++ b/src/mono/wasm/runtime/assets.ts
@@ -106,7 +106,7 @@ export async function instantiate_symbols_asset(pendingAsset: AssetEntryInternal
 
 export async function wait_for_all_assets() {
     // wait for all assets in memory
-    await runtimeHelpers.allAssetsInMemory.promise;
+    await runtimeHelpers.remainingAssetsInMemory.promise;
     if (runtimeHelpers.config.assets) {
         mono_assert(loaderHelpers.actual_downloaded_assets_count == loaderHelpers.expected_downloaded_assets_count, () => `Expected ${loaderHelpers.expected_downloaded_assets_count} assets to be downloaded, but only finished ${loaderHelpers.actual_downloaded_assets_count}`);
         mono_assert(loaderHelpers.actual_instantiated_assets_count == loaderHelpers.expected_instantiated_assets_count, () => `Expected ${loaderHelpers.expected_instantiated_assets_count} assets to be in memory, but only instantiated ${loaderHelpers.actual_instantiated_assets_count}`);

--- a/src/mono/wasm/runtime/globals.ts
+++ b/src/mono/wasm/runtime/globals.ts
@@ -64,7 +64,9 @@ export function setRuntimeGlobals(globalObjects: GlobalObjects) {
 
     Object.assign(runtimeHelpers, {
         gitHash,
-        allAssetsInMemory: createPromiseController<void>(),
+        coreAssetsInMemory: createPromiseController<void>(),
+        remainingAssetsInMemory: createPromiseController<void>(),
+        AssetsInMemory: createPromiseController<void>(),
         dotnetReady: createPromiseController<any>(),
         afterInstantiateWasm: createPromiseController<void>(),
         beforePreInit: createPromiseController<void>(),

--- a/src/mono/wasm/runtime/types/internal.ts
+++ b/src/mono/wasm/runtime/types/internal.ts
@@ -97,6 +97,7 @@ export interface AssetEntryInternal extends AssetEntry {
     pendingDownloadInternal?: LoadingResource
     noCache?: boolean
     useCredentials?: boolean
+    isCoreAssembly?: boolean
 }
 
 export type LoaderHelpers = {
@@ -189,11 +190,13 @@ export type RuntimeHelpers = {
     memorySnapshotCacheKey: string,
     subtle: SubtleCrypto | null,
     updateMemoryViews: () => void
+    monoReady: boolean,
     runtimeReady: boolean,
     jsSynchronizationContextInstalled: boolean,
     cspPolicy: boolean,
 
-    allAssetsInMemory: PromiseAndController<void>,
+    coreAssetsInMemory: PromiseAndController<void>,
+    remainingAssetsInMemory: PromiseAndController<void>,
     dotnetReady: PromiseAndController<any>,
     afterInstantiateWasm: PromiseAndController<void>,
     beforePreInit: PromiseAndController<void>,


### PR DESCRIPTION
start MonoVM when essential DLLs are downloaded and continue downloading the rest of the assets

- `System.Private.CoreLib`
- `System.Collections`
- `System.Runtime.InteropServices.JavaScript`

I estimate that this could shave 50ms from cold start