### PR TITLE
Switch StandaloneAppActivation to using pre-built test assets

### DIFF
--- a/src/installer/tests/Assets/Projects/Directory.Build.targets
+++ b/src/installer/tests/Assets/Projects/Directory.Build.targets
@@ -2,4 +2,15 @@
   <Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" />
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
+
+  <!-- Override target from targetingpacks.targets. Use Version instead of ProductVersion (written into runtimeconfig.json).
+       Host tests are run against the built shared framework that has the normal version (with suffixes)  -->
+  <Target Name="UpdateRuntimeFrameworkVersion"
+          Condition="'$(UseLocalTargetingRuntimePack)' == 'true'"
+          AfterTargets="ResolveTargetingPackAssets">
+    <ItemGroup>
+      <RuntimeFramework Version="$(Version)"
+                        Condition="'%(RuntimeFramework.FrameworkName)' == '$(LocalFrameworkOverrideName)'" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/installer/tests/Assets/Projects/HelloWorld/HelloWorld.csproj
+++ b/src/installer/tests/Assets/Projects/HelloWorld/HelloWorld.csproj
@@ -5,4 +5,11 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
+  <!-- FileVersion always gets set for projects in this repo by _InitializeAssemblyVersion. Update the file version afterwards. -->
+  <Target Name="SetFileVersion" AfterTargets="_InitializeAssemblyVersion">
+    <PropertyGroup>
+      <FileVersion>$(ProductVersion)</FileVersion>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/src/installer/tests/HostActivation.Tests/InvalidHost.cs
+++ b/src/installer/tests/HostActivation.Tests/InvalidHost.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.DotNet.CoreSetup.Test;
+using Microsoft.NET.HostModel.AppHost;
+using Xunit;
+
+namespace HostActivation.Tests
+{
+    public class InvalidHost : IClassFixture<InvalidHost.SharedTestState>
+    {
+        private SharedTestState sharedTestState;
+
+        public InvalidHost(SharedTestState fixture)
+        {
+            sharedTestState = fixture;
+        }
+
+        [Fact]
+        public void AppHost_NotBound()
+        {
+            CommandResult result = Command.Create(sharedTestState.UnboundAppHost)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute(expectedToFail: true);
+
+            result.Should().Fail()
+                .And.HaveStdErrContaining("This executable is not bound to a managed DLL to execute.");
+
+            int exitCode = result.ExitCode;
+            const int AppHostExeNotBoundFailure = unchecked((int)0x80008095);
+            if (OperatingSystem.IsWindows())
+            {
+                exitCode.Should().Be(AppHostExeNotBoundFailure);
+            }
+            else
+            {
+                // Some Unix flavors filter exit code to ubyte.
+                (exitCode & 0xFF).Should().Be(AppHostExeNotBoundFailure & 0xFF);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // GUI app host is only supported on Windows.
+        public void AppHost_NotBound_GUI()
+        {
+            Command.Create(sharedTestState.UnboundAppHostGUI)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should().Fail()
+                .And.HaveStdErrContaining("This executable is not bound to a managed DLL to execute.");
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // GUI app host is only supported on Windows.
+        public void AppHost_NotBound_GUI_TraceFile()
+        {
+            string traceFilePath;
+            Command.Create(sharedTestState.UnboundAppHostGUI)
+                .EnableHostTracingToFile(out traceFilePath)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should().Fail()
+                .And.FileExists(traceFilePath)
+                .And.FileContains(traceFilePath, "This executable is not bound to a managed DLL to execute.")
+                .And.HaveStdErrContaining("This executable is not bound to a managed DLL to execute.");
+
+            FileUtils.DeleteFileIfPossible(traceFilePath);
+        }
+
+        [Fact]
+        public void DotNet_Renamed()
+        {
+            CommandResult result = Command.Create(sharedTestState.RenamedDotNet)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute(expectedToFail: true);
+
+            result.Should().Fail()
+                .And.HaveStdErrContaining($"Error: cannot execute dotnet when renamed to {Path.GetFileNameWithoutExtension(sharedTestState.RenamedDotNet)}");
+
+            int exitCode = result.ExitCode;
+            const int EntryPointFailure = unchecked((int)0x80008084);
+            if (OperatingSystem.IsWindows())
+            {
+                exitCode.Should().Be(EntryPointFailure);
+            }
+            else
+            {
+                // Some Unix flavors filter exit code to ubyte.
+                (exitCode & 0xFF).Should().Be(EntryPointFailure & 0xFF);
+            }
+        }
+
+        public class SharedTestState : IDisposable
+        {
+            public TestArtifact BaseDirectory { get; }
+
+            public string RenamedDotNet { get;  }
+            public string UnboundAppHost { get; }
+            public string UnboundAppHostGUI { get;  }
+
+            public SharedTestState()
+            {
+                BaseDirectory = new TestArtifact(SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, nameof(InvalidHost))));
+                Directory.CreateDirectory(BaseDirectory.Location);
+
+                RenamedDotNet = Path.Combine(BaseDirectory.Location, Binaries.GetExeFileNameForCurrentPlatform("renamed"));
+                File.Copy(Binaries.DotNet.FilePath, RenamedDotNet);
+
+                UnboundAppHost = Path.Combine(BaseDirectory.Location, Binaries.GetExeFileNameForCurrentPlatform("unbound"));
+                File.Copy(Binaries.AppHost.FilePath, UnboundAppHost);
+
+                if (OperatingSystem.IsWindows())
+                {
+                    // Mark the apphost as GUI, but don't bind it to anything - this will cause it to fail
+                    UnboundAppHostGUI = Path.Combine(BaseDirectory.Location, Binaries.GetExeFileNameForCurrentPlatform("unboundgui"));
+                    File.Copy(Binaries.AppHost.FilePath, UnboundAppHostGUI);
+                    PEUtils.SetWindowsGraphicalUserInterfaceBit(UnboundAppHostGUI);
+                }
+            }
+
+            public void Dispose()
+            {
+                BaseDirectory.Dispose();
+            }
+        }
+    }
+}
+

--- a/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Text;
 
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Build.Framework;
@@ -23,131 +22,62 @@ namespace HostActivation.Tests
         }
 
         [Fact]
-        public void Running_Build_Output_Standalone_EXE_with_DepsJson_and_RuntimeConfig_Local_Succeeds()
+        public void Default()
         {
-            var fixture = sharedTestState.StandaloneAppFixture_Built
-                .Copy();
-
-            var appExe = fixture.TestProject.AppExe;
-
+            string appExe = sharedTestState.App.AppExe;
             Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion);
+
+            if (OperatingSystem.IsWindows())
+            {
+                // App sets FileVersion to NETCoreApp version. On Windows, this should be copied to app resources.
+                string expectedVersion = RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion.Contains('-')
+                    ? RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion[..RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion.IndexOf('-')]
+                    : RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion;
+                Assert.Equal(expectedVersion, System.Diagnostics.FileVersionInfo.GetVersionInfo(appExe).FileVersion);
+            }
         }
 
         [Fact]
-        public void Running_Publish_Output_Standalone_EXE_with_DepsJson_and_RuntimeConfig_Local_Succeeds()
+        public void NoDepsJson_NoRuntimeConfig()
         {
-            var fixture = sharedTestState.StandaloneAppFixture_Published
-                .Copy();
+            var app = sharedTestState.App.Copy();
 
-            var appExe = fixture.TestProject.AppExe;
-
-            Command.Create(appExe)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute()
-                .Should().Pass()
-                .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
-        }
-
-        [Fact]
-        public void Running_Publish_Output_Standalone_EXE_with_no_DepsJson_and_no_RuntimeConfig_Local_Succeeds()
-        {
-            var fixture = sharedTestState.StandaloneAppFixture_Published
-                .Copy();
-
-            var appExe = fixture.TestProject.AppExe;
-            File.Delete(fixture.TestProject.RuntimeConfigJson);
-            File.Delete(fixture.TestProject.DepsJson);
+            File.Delete(app.RuntimeConfigJson);
+            File.Delete(app.DepsJson);
 
             // Make sure normal run succeeds and doesn't print any errors
-            Command.Create(appExe)
+            Command.Create(app.AppExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute()
                 .Should().Pass()
                 // Note that this is an exact match - we don't expect any output from the host itself
-                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
+                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
                 .And.NotHaveStdErr();
 
             // Make sure tracing indicates there is no runtime config and no deps json
-            Command.Create(appExe)
+            Command.Create(app.AppExe)
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
-                .And.HaveStdErrContaining($"Runtime config does not exist at [{fixture.TestProject.RuntimeConfigJson}]")
-                .And.HaveStdErrContaining($"Dependencies manifest does not exist at [{fixture.TestProject.DepsJson}]");
+                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
+                .And.HaveStdErrContaining($"Runtime config does not exist at [{app.RuntimeConfigJson}]")
+                .And.HaveStdErrContaining($"Dependencies manifest does not exist at [{app.DepsJson}]");
         }
 
         [Fact]
-        public void Running_Publish_Output_Standalone_EXE_with_Unbound_AppHost_Fails()
+        public void RenameApphost()
         {
-            var fixture = sharedTestState.StandaloneAppFixture_Published
-                .Copy();
+            var app = sharedTestState.App.Copy();
 
-            var appExe = fixture.TestProject.AppExe;
-            UseBuiltAppHost(appExe);
-
-            int exitCode = Command.Create(appExe)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute(expectedToFail: true)
-                .ExitCode;
-
-            if (OperatingSystem.IsWindows())
-            {
-                exitCode.Should().Be(-2147450731);
-            }
-            else
-            {
-                // Some Unix flavors filter exit code to ubyte.
-                (exitCode & 0xFF).Should().Be(0x95);
-            }
-        }
-
-        [Fact]
-        public void Running_Publish_Output_Standalone_EXE_By_Renaming_dotnet_exe_Fails()
-        {
-            var fixture = sharedTestState.StandaloneAppFixture_Published
-                .Copy();
-
-            var appExe = fixture.TestProject.AppExe;
-            File.Copy(Binaries.DotNet.FilePath, appExe, true);
-
-            int exitCode = Command.Create(appExe)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute(expectedToFail: true)
-                .ExitCode;
-
-            if (OperatingSystem.IsWindows())
-            {
-                exitCode.Should().Be(-2147450748);
-            }
-            else
-            {
-                // Some Unix flavors filter exit code to ubyte.
-                (exitCode & 0xFF).Should().Be(0x84);
-            }
-        }
-
-        [Fact]
-        public void Running_Publish_Output_Standalone_EXE_By_Renaming_apphost_exe_Succeeds()
-        {
-            var fixture = sharedTestState.StandaloneAppFixture_Published
-                .Copy();
-
-            var appExe = fixture.TestProject.AppExe;
-            var renamedAppExe = fixture.TestProject.AppExe + Binaries.GetExeFileNameForCurrentPlatform("renamed");
-
-            File.Copy(appExe, renamedAppExe, true);
+            var renamedAppExe = app.AppExe + Binaries.GetExeFileNameForCurrentPlatform("renamed");
+            File.Move(app.AppExe, renamedAppExe, true);
 
             Command.Create(renamedAppExe)
                 .CaptureStdErr()
@@ -155,35 +85,25 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
-        public void Running_Publish_Output_Standalone_EXE_With_Relative_Embedded_Path_Succeeds()
+        public void RelativeEmbeddedPath()
         {
-            var fixture = sharedTestState.StandaloneAppFixture_Published
-                .Copy();
+            var app = sharedTestState.App.Copy();
 
-            var appExe = fixture.TestProject.AppExe;
+            // Delete the apphost
+            File.Delete(app.AppExe);
 
-            // Move whole directory to a subdirectory
-            string currentOutDir = fixture.TestProject.OutputDirectory;
-            string relativeNewPath = "..";
-            relativeNewPath = Path.Combine(relativeNewPath, "newDir");
-            string newOutDir = Path.Combine(currentOutDir, relativeNewPath);
-            Directory.Move(currentOutDir, newOutDir);
-
-            // Move the apphost exe back to original location
-            string appExeName = Path.GetFileName(appExe);
-            string sourceAppExePath = Path.Combine(newOutDir, appExeName);
-            Directory.CreateDirectory(Path.GetDirectoryName(appExe));
-            File.Move(sourceAppExePath, appExe);
-
-            // Modify the apphost to include relative path
-            string appDll = fixture.TestProject.AppDll;
-            string appDllName = Path.GetFileName(appDll);
-            string relativeDllPath = Path.Combine(relativeNewPath, appDllName);
-            BinaryUtils.SearchAndReplace(appExe, Encoding.UTF8.GetBytes(appDllName), Encoding.UTF8.GetBytes(relativeDllPath));
+            // Create an apphost in a subdirectory pointing at the app using relative path
+            string subDir = Path.Combine(app.Location, "sub");
+            Directory.CreateDirectory(subDir);
+            string appExe = Path.Combine(subDir, Path.GetFileName(app.AppExe));
+            HostWriter.CreateAppHost(
+                Binaries.AppHost.FilePath,
+                appExe,
+                Path.GetRelativePath(subDir, app.AppDll));
 
             Command.Create(appExe)
                 .CaptureStdErr()
@@ -191,178 +111,46 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
-        public void Running_Publish_Output_Standalone_EXE_With_DOTNET_ROOT_Fails()
+        public void DotNetRoot_IncorrectLayout_Fails()
         {
-            var fixture = sharedTestState.StandaloneAppFixture_Published
-                .Copy();
+            var app = sharedTestState.App.Copy();
 
-            var appExe = fixture.TestProject.AppExe;
-            var appDll = fixture.TestProject.AppDll;
-
-            // Move whole directory to a subdirectory
-            string currentOutDir = fixture.TestProject.OutputDirectory;
-            string relativeNewPath = "..";
-            relativeNewPath = Path.Combine(relativeNewPath, "newDir2");
-            string newOutDir = Path.Combine(currentOutDir, relativeNewPath);
-            Directory.Move(currentOutDir, newOutDir);
-
-            // Move the apphost exe and app dll back to original location
-            string appExeName = Path.GetFileName(appExe);
-            string sourceAppExePath = Path.Combine(newOutDir, appExeName);
-            Directory.CreateDirectory(Path.GetDirectoryName(appExe));
-            File.Move(sourceAppExePath, appExe);
-
-            string appDllName = Path.GetFileName(appDll);
-            string sourceAppDllPath = Path.Combine(newOutDir, appDllName);
-            File.Move(sourceAppDllPath, appDll);
+            // Move the apphost exe and app dll to a subdirectory
+            string subDir = Path.Combine(app.Location, "sub");
+            Directory.CreateDirectory(subDir);
+            string appExe = Path.Combine(subDir, Path.GetFileName(app.AppExe));
+            File.Move(app.AppExe, appExe);
+            File.Move(app.AppDll, Path.Combine(subDir, Path.GetFileName(app.AppDll)));
 
             // This verifies a self-contained apphost cannot use DOTNET_ROOT to reference a flat
             // self-contained layout since a flat layout of the shared framework is not supported.
             Command.Create(appExe)
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(newOutDir)
+                .DotNetRoot(app.Location)
                 .Execute(expectedToFail: true)
                 .Should().Fail()
-                .And.HaveUsedDotNetRootInstallLocation(Path.GetFullPath(newOutDir), fixture.CurrentRid)
+                .And.HaveUsedDotNetRootInstallLocation(Path.GetFullPath(app.Location), RepoDirectoriesProvider.Default.TargetRID)
                 .And.HaveStdErrContaining($"The required library {Binaries.HostFxr.FileName} could not be found.");
-        }
-
-        [Fact]
-        public void Running_Publish_Output_Standalone_EXE_with_Bound_AppHost_Succeeds()
-        {
-            var fixture = sharedTestState.StandaloneAppFixture_Published
-                .Copy();
-
-            string appExe = fixture.TestProject.AppExe;
-            fixture.TestProject.BuiltApp.CreateAppHost();
-
-            Command.Create(appExe)
-                .EnableTracingAndCaptureOutputs()
-                .Execute()
-                .Should().Pass()
-                .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
-
-            if (OperatingSystem.IsWindows())
-            {
-                // StandaloneApp sets FileVersion to NETCoreApp version. On Windows, this should be copied to apphost resources.
-                Assert.Equal(System.Diagnostics.FileVersionInfo.GetVersionInfo(appExe).FileVersion, sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
-            }
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // GUI app host is only supported on Windows.
-        public void Running_AppHost_with_GUI_No_Console()
-        {
-            var fixture = sharedTestState.StandaloneAppFixture_Published
-                .Copy();
-
-            string appExe = fixture.TestProject.AppExe;
-
-            // Mark the apphost as GUI, but don't bind it to anything - this will cause it to fail
-            UseBuiltAppHost(appExe);
-            PEUtils.SetWindowsGraphicalUserInterfaceBit(appExe);
-
-            Command.Create(appExe)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute()
-                .Should().Fail()
-                .And.HaveStdErrContaining("This executable is not bound to a managed DLL to execute.");
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // GUI app host is only supported on Windows.
-        public void Running_AppHost_with_GUI_Traces()
-        {
-            var fixture = sharedTestState.StandaloneAppFixture_Published
-                .Copy();
-
-            string appExe = fixture.TestProject.AppExe;
-
-            // Mark the apphost as GUI, but don't bind it to anything - this will cause it to fail
-            UseBuiltAppHost(appExe);
-            PEUtils.SetWindowsGraphicalUserInterfaceBit(appExe);
-
-            string traceFilePath;
-            Command.Create(appExe)
-                .EnableHostTracingToFile(out traceFilePath)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute()
-                .Should().Fail()
-                .And.FileExists(traceFilePath)
-                .And.FileContains(traceFilePath, "This executable is not bound to a managed DLL to execute.")
-                .And.HaveStdErrContaining("This executable is not bound to a managed DLL to execute.");
-
-            FileUtils.DeleteFileIfPossible(traceFilePath);
-        }
-
-        private void UseBuiltAppHost(string appExe)
-        {
-            File.Copy(Binaries.AppHost.FilePath, appExe, true);
         }
 
         public class SharedTestState : IDisposable
         {
-            public TestProjectFixture StandaloneAppFixture_Built { get; }
-            public TestProjectFixture StandaloneAppFixture_Published { get; }
-            public RepoDirectoriesProvider RepoDirectories { get; }
+            public TestApp App { get; }
 
             public SharedTestState()
             {
-                RepoDirectories = new RepoDirectoriesProvider();
-
-                var buildFixture = new TestProjectFixture("StandaloneApp", RepoDirectories);
-                buildFixture
-                    .EnsureRestoredForRid(buildFixture.CurrentRid)
-                    .BuildProject(runtime: buildFixture.CurrentRid);
-
-                var publishFixture = new TestProjectFixture("StandaloneApp", RepoDirectories);
-                publishFixture
-                    .EnsureRestoredForRid(publishFixture.CurrentRid)
-                    .PublishProject(runtime: publishFixture.CurrentRid, selfContained: true);
-
-                ReplaceTestProjectOutputHostInTestProjectFixture(buildFixture);
-
-                StandaloneAppFixture_Built = buildFixture;
-                StandaloneAppFixture_Published = publishFixture;
+                App = TestApp.CreateFromBuiltAssets("HelloWorld");
+                App.PopulateSelfContained(TestApp.MockedComponent.None);
+                App.CreateAppHost();
             }
 
             public void Dispose()
             {
-                StandaloneAppFixture_Built.Dispose();
-                StandaloneAppFixture_Published.Dispose();
-            }
-
-            /*
-             * This method is needed to workaround dotnet build not placing the host from the package
-             * graph in the build output.
-             * https://github.com/dotnet/cli/issues/2343
-             */
-            private static void ReplaceTestProjectOutputHostInTestProjectFixture(TestProjectFixture testProjectFixture)
-            {
-                var dotnet = testProjectFixture.BuiltDotnet;
-
-                var testProjectHostPolicy = testProjectFixture.TestProject.HostPolicyDll;
-                var testProjectHostFxr = testProjectFixture.TestProject.HostFxrDll;
-
-                if (!File.Exists(testProjectHostPolicy))
-                {
-                    throw new Exception("host or hostpolicy does not exist in test project output. Is this a standalone app?");
-                }
-
-                var dotnetHostPolicy = Path.Combine(dotnet.GreatestVersionSharedFxPath, Binaries.HostPolicy.FileName);
-                File.Copy(dotnetHostPolicy, testProjectHostPolicy, true);
-
-                if (File.Exists(testProjectHostFxr))
-                {
-                    File.Copy(dotnet.GreatestVersionHostFxrFilePath, testProjectHostFxr, true);
-                }
+                App.Dispose();
             }
         }
     }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/AppLaunch.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/AppLaunch.cs
@@ -10,13 +10,13 @@ using BundleTests.Helpers;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace Microsoft.NET.HostModel.Tests
+namespace AppHost.Bundle.Tests
 {
-    public class BundleAndRun : IClassFixture<BundleAndRun.SharedTestState>
+    public class AppLaunch : IClassFixture<AppLaunch.SharedTestState>
     {
         private SharedTestState sharedTestState;
 
-        public BundleAndRun(BundleAndRun.SharedTestState fixture)
+        public AppLaunch(AppLaunch.SharedTestState fixture)
         {
             sharedTestState = fixture;
         }
@@ -69,6 +69,15 @@ namespace Microsoft.NET.HostModel.Tests
 
                 // Run the fat app
                 RunTheApp(fatApp, selfContained);
+            }
+
+            if (OperatingSystem.IsWindows())
+            {
+                // StandaloneApp sets FileVersion to NETCoreApp version. On Windows, this should be copied to singlefilehost resources.
+                string expectedVersion = RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion.Contains('-')
+                    ? RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion[..RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion.IndexOf('-')]
+                    : RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion;
+                Assert.Equal(expectedVersion, System.Diagnostics.FileVersionInfo.GetVersionInfo(singleFile).FileVersion);
             }
         }
 

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/StaticHost.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/StaticHost.cs
@@ -8,67 +8,22 @@ using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    public class StaticHost : BundleTestBase, IClassFixture<StaticHost.SharedTestState>
+    public class StaticHost
     {
-        private SharedTestState sharedTestState;
-
-        public StaticHost(SharedTestState fixture)
-        {
-            sharedTestState = fixture;
-        }
-
         [Fact]
-        private void Can_Run_App_With_StaticHost()
+        private void NotMarkedAsBundle_RunSelfContainedApp()
         {
-            var fixture = sharedTestState.TestFixture.Copy();
-
-            var appExe = UseSingleFileSelfContainedHost(fixture);
-
-            Command.Create(appExe)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("Hello World");
-        }
-
-        [Fact]
-        private void Can_Run_SingleFile_App_With_StaticHost()
-        {
-            var fixture = sharedTestState.TestFixture.Copy();
-
-            string singleFile = BundleSelfContainedApp(fixture);
-
-            Command.Create(singleFile)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute()
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("Hello World");
-
-            if (OperatingSystem.IsWindows())
+            using (TestApp app = TestApp.CreateFromBuiltAssets("HelloWorld"))
             {
-                // StandaloneApp sets FileVersion to NETCoreApp version. On Windows, this should be copied to singlefilehost resources.
-                Assert.Equal(System.Diagnostics.FileVersionInfo.GetVersionInfo(singleFile).FileVersion, sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
-            }
-        }
+                app.PopulateSelfContained(TestApp.MockedComponent.None);
+                app.CreateSingleFileHost();
 
-        public class SharedTestState : SharedTestStateBase, IDisposable
-        {
-            public TestProjectFixture TestFixture { get; set; }
-
-            public SharedTestState()
-            {
-                TestFixture = PreparePublishedSelfContainedTestProject("StandaloneApp");
-            }
-
-            public void Dispose()
-            {
-                TestFixture.Dispose();
+                Command.Create(app.AppExe)
+                    .CaptureStdErr()
+                    .CaptureStdOut()
+                    .Execute()
+                    .Should().Pass()
+                    .And.HaveStdOutContaining("Hello World");
             }
         }
     }

--- a/src/installer/tests/TestUtils/NetCoreAppBuilder.cs
+++ b/src/installer/tests/TestUtils/NetCoreAppBuilder.cs
@@ -49,7 +49,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
                     FileUtils.EnsureFileDirectoryExists(absolutePath);
                     File.Copy(SourcePath, absolutePath);
                 }
-                else if (FileOnDiskPath == null || FileOnDiskPath.Length > 0)
+                else if ((FileOnDiskPath == null || FileOnDiskPath.Length > 0)
+                    && !File.Exists(absolutePath))
                 {
                     FileUtils.CreateEmptyFile(absolutePath);
                 }

--- a/src/installer/tests/TestUtils/TestApp.cs
+++ b/src/installer/tests/TestUtils/TestApp.cs
@@ -103,9 +103,10 @@ namespace Microsoft.DotNet.CoreSetup.Test
         {
             var builder = NetCoreAppBuilder.ForNETCoreApp(Name, RepoDirectoriesProvider.Default.TargetRID);
 
-            // Update the .runtimeconfig.json
+            // Update the .runtimeconfig.json - add included framework and remove any existing NETCoreApp framework
             builder.WithRuntimeConfig(c =>
-                c.WithIncludedFramework(Constants.MicrosoftNETCoreApp, RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion));
+                c.WithIncludedFramework(Constants.MicrosoftNETCoreApp, RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion)
+                    .RemoveFramework(Constants.MicrosoftNETCoreApp));
 
             // Add main project assembly
             builder.WithProject(p => p.WithAssemblyGroup(null, g => g.WithMainAssembly()));


### PR DESCRIPTION

- Make `StandaloneAppActivation` use pre-built HelloWorld test app and construct a self-contained app from it instead of using the SDK to build/publish
- Update test app to set file version and use Version instead of ProductVersion for the framework version
- Put tests for invalid host scenarios that don't need an actual app to a separate `InvalidHost` class
  - `Running_Publish_Output_Standalone_EXE_with_Unbound_AppHost_Fails` -> `InvalidHost.AppHost_NotBound`
  - `Running_Publish_Output_Standalone_EXE_By_Renaming_dotnet_exe_Fails` -> `InvalidHost.DotNet_Renamed`
  - `Running_AppHost_with_GUI_No_Console` -> `InvalidHost.AppHost_NotBound_GUI`
  - `Running_AppHost_with_GUI_Traces` -> `InvalidHost.AppHost_NotBound_GUI_TraceFile`
- Move/rename `BundleAndRun` in `Microsoft.NET.HostModel.Bundle.Tests` to `AppLaunch` in `AppHost.Bundle.Tests`
  - `StaticHost.Can_Run_App_With_StaticHost` is covered by `AppLaunch.RunApp`