### PR TITLE
Enable Adding Disabled Tests Skip Reason to their XML Results Log From issues.targets

### DIFF
--- a/src/tests/Common/XHarnessRunnerLibrary/GeneratedTestRunner.cs
+++ b/src/tests/Common/XHarnessRunnerLibrary/GeneratedTestRunner.cs
@@ -12,24 +12,26 @@ namespace XHarnessRunnerLibrary;
 
 public sealed class GeneratedTestRunner : TestRunner
 {
-    string _assemblyName;
-    TestFilter.ISearchClause? _filter;
-    Func<TestFilter?, TestSummary> _runTestsCallback;
-    HashSet<string> _testExclusionList;
+    private string _assemblyName;
+    private TestFilter.ISearchClause? _filter;
+    private Func<TestFilter?, TestSummary> _runTestsCallback;
+    private Dictionary<string, string> _testExclusionTable;
+
     private readonly Boolean _writeBase64TestResults;
 
     public GeneratedTestRunner(
         LogWriter logger, 
         Func<TestFilter?, TestSummary> runTestsCallback, 
         string assemblyName,
-        HashSet<string> testExclusionList,
+        Dictionary<string, string> testExclusionTable,
         bool writeBase64TestResults)
-        :base(logger)
+        : base(logger)
     {
         _assemblyName = assemblyName;
         _runTestsCallback = runTestsCallback;
-        _testExclusionList = testExclusionList;
+        _testExclusionTable = testExclusionTable;
         _writeBase64TestResults = writeBase64TestResults;
+
         ResultsFileName = $"{_assemblyName}.testResults.xml";
     }
 
@@ -39,7 +41,7 @@ public sealed class GeneratedTestRunner : TestRunner
 
     public override Task Run(IEnumerable<TestAssemblyInfo> testAssemblies)
     {
-        LastTestRun = _runTestsCallback(new TestFilter(_filter, _testExclusionList));
+        LastTestRun = _runTestsCallback(new TestFilter(_filter, _testExclusionTable));
         PassedTests = LastTestRun.PassedTests;
         FailedTests = LastTestRun.FailedTests;
         SkippedTests = LastTestRun.SkippedTests;

--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -169,6 +169,7 @@ public sealed class ConditionalTest : ITestInfo
 
         using (builder.NewBracesScope())
         {
+            builder.AppendLine("string reason = string.Empty;");
             builder.AppendLine(testReporterWrapper.GenerateSkippedTestReporting(_innerTest));
         }
         return builder;
@@ -448,13 +449,15 @@ public sealed class WrapperLibraryTestSummaryReporting : ITestReporterWrapper
 
             using (builder.NewBracesScope())
             {
-                builder.AppendLine($"{_summaryLocalIdentifier}.ReportStartingTest({test.TestNameExpression},"
+                builder.AppendLine($"{_summaryLocalIdentifier}.ReportStartingTest("
+                                 + $"{test.TestNameExpression},"
                                  + $" System.Console.Out);");
 
                 builder.AppendLine($"{_outputRecorderIdentifier}.ResetTestOutput();");
                 builder.Append(testExecutionExpression);
 
-                builder.AppendLine($"{_summaryLocalIdentifier}.ReportPassedTest({test.TestNameExpression},"
+                builder.AppendLine($"{_summaryLocalIdentifier}.ReportPassedTest("
+                                 + $"{test.TestNameExpression},"
                                  + $" \"{test.ContainingType}\","
                                  + $" @\"{test.Method}\","
                                  + $" stopwatch.Elapsed - testStart,"
@@ -468,7 +471,8 @@ public sealed class WrapperLibraryTestSummaryReporting : ITestReporterWrapper
 
             using (builder.NewBracesScope())
             {
-                builder.AppendLine($"{_summaryLocalIdentifier}.ReportFailedTest({test.TestNameExpression},"
+                builder.AppendLine($"{_summaryLocalIdentifier}.ReportFailedTest("
+                                 + $"{test.TestNameExpression},"
                                  + $" \"{test.ContainingType}\","
                                  + $" @\"{test.Method}\","
                                  + $" stopwatch.Elapsed - testStart,"
@@ -484,6 +488,8 @@ public sealed class WrapperLibraryTestSummaryReporting : ITestReporterWrapper
 
         using (builder.NewBracesScope())
         {
+            builder.AppendLine($"string reason = {_filterLocalIdentifier}"
+                             + $".GetTestExclusionReason({test.TestNameExpression});");
             builder.AppendLine(GenerateSkippedTestReporting(test));
         }
         return builder;
@@ -491,11 +497,12 @@ public sealed class WrapperLibraryTestSummaryReporting : ITestReporterWrapper
 
     public string GenerateSkippedTestReporting(ITestInfo skippedTest)
     {
-        return $"{_summaryLocalIdentifier}.ReportSkippedTest({skippedTest.TestNameExpression},"
+        return $"{_summaryLocalIdentifier}.ReportSkippedTest("
+             + $"{skippedTest.TestNameExpression},"
              + $" \"{skippedTest.ContainingType}\","
              + $" @\"{skippedTest.Method}\","
              + $" System.TimeSpan.Zero,"
-             + $" string.Empty,"
+             + $" reason,"
              + $" tempLogSw,"
              + $" statsCsvSw);";
     }

--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -29,20 +29,26 @@ public interface ITestReporterWrapper
 
 public sealed class BasicTestMethod : ITestInfo
 {
-    public BasicTestMethod(IMethodSymbol method, string externAlias, ImmutableArray<string> arguments = default, string? displayNameExpression = null)
+    public BasicTestMethod(IMethodSymbol method,
+                           string externAlias,
+                           ImmutableArray<string> arguments = default,
+                           string? displayNameExpression = null)
     {
         var args = arguments.IsDefaultOrEmpty ? "" : string.Join(", ", arguments);
-        ContainingType = method.ContainingType.ToDisplayString(XUnitWrapperGenerator.FullyQualifiedWithoutGlobalNamespace);
+
+        ContainingType = method.ContainingType.ToDisplayString(XUnitWrapperGenerator
+                                                               .FullyQualifiedWithoutGlobalNamespace);
         Method = method.Name;
         DisplayNameForFiltering = $"{ContainingType}.{Method}({args})";
         TestNameExpression = displayNameExpression ?? $"\"{externAlias}::{ContainingType}.{Method}({args})\"";
+
         if (method.IsStatic)
         {
-            ExecutionStatement = $"{externAlias}::{ContainingType}.{Method}({args});";
+            _executionStatement = $"{externAlias}::{ContainingType}.{Method}({args});";
         }
         else
         {
-            ExecutionStatement = $"using ({externAlias}::{ContainingType} obj = new()) obj.{Method}({args});";
+            _executionStatement = $"using ({externAlias}::{ContainingType} obj = new()) obj.{Method}({args});";
         }
     }
 
@@ -50,11 +56,13 @@ public sealed class BasicTestMethod : ITestInfo
     public string DisplayNameForFiltering { get; }
     public string Method { get; }
     public string ContainingType { get; }
-    private string ExecutionStatement { get; }
+
+    private string _executionStatement { get; }
 
     public CodeBuilder GenerateTestExecution(ITestReporterWrapper testReporterWrapper)
     {
-        return testReporterWrapper.WrapTestExecutionWithReporting(CodeBuilder.CreateNewLine(ExecutionStatement), this);
+        return testReporterWrapper.WrapTestExecutionWithReporting(CodeBuilder.CreateNewLine(_executionStatement),
+                                                                  this);
     }
 
     public override bool Equals(object obj)
@@ -63,7 +71,7 @@ public sealed class BasicTestMethod : ITestInfo
             && TestNameExpression == other.TestNameExpression
             && Method == other.Method
             && ContainingType == other.ContainingType
-            && ExecutionStatement == other.ExecutionStatement;
+            && _executionStatement == other._executionStatement;
     }
 
     public override int GetHashCode()
@@ -72,7 +80,7 @@ public sealed class BasicTestMethod : ITestInfo
         hash = hash * 23 + (TestNameExpression?.GetHashCode() ?? 0);
         hash = hash * 23 + (Method?.GetHashCode() ?? 0);
         hash = hash * 23 + (ContainingType?.GetHashCode() ?? 0);
-        hash = hash * 23 + (ExecutionStatement?.GetHashCode() ?? 0);
+        hash = hash * 23 + (_executionStatement?.GetHashCode() ?? 0);
         return hash;
     }
 }
@@ -81,23 +89,26 @@ public sealed class LegacyStandaloneEntryPointTestMethod : ITestInfo
 {
     public LegacyStandaloneEntryPointTestMethod(IMethodSymbol method, string externAlias)
     {
-        ContainingType = method.ContainingType.ToDisplayString(XUnitWrapperGenerator.FullyQualifiedWithoutGlobalNamespace);
+        ContainingType = method.ContainingType.ToDisplayString(XUnitWrapperGenerator
+                                                               .FullyQualifiedWithoutGlobalNamespace);
         Method = method.Name;
         TestNameExpression = $"\"{externAlias}::{ContainingType}.{Method}()\"";
         DisplayNameForFiltering = $"{ContainingType}.{Method}()";
-        ExecutionStatement = $"Xunit.Assert.Equal(100, {externAlias}::{ContainingType}.{Method}());";
+
+        _executionStatement = $"Xunit.Assert.Equal(100, {externAlias}::{ContainingType}.{Method}());";
     }
 
     public string TestNameExpression { get; }
     public string DisplayNameForFiltering { get; }
-
     public string Method { get; }
     public string ContainingType { get; }
-    private string ExecutionStatement { get; }
+
+    private string _executionStatement { get; }
 
     public CodeBuilder GenerateTestExecution(ITestReporterWrapper testReporterWrapper)
     {
-        return testReporterWrapper.WrapTestExecutionWithReporting(CodeBuilder.CreateNewLine(ExecutionStatement), this);
+        return testReporterWrapper.WrapTestExecutionWithReporting(CodeBuilder.CreateNewLine(_executionStatement),
+                                                                  this);
     }
 
     public override bool Equals(object obj)
@@ -120,17 +131,16 @@ public sealed class LegacyStandaloneEntryPointTestMethod : ITestInfo
 
 public sealed class ConditionalTest : ITestInfo
 {
-    private ITestInfo _innerTest;
-    private string _condition;
     public ConditionalTest(ITestInfo innerTest, string condition)
     {
-        _innerTest = innerTest;
-        _condition = condition;
         TestNameExpression = innerTest.TestNameExpression;
         DisplayNameForFiltering = innerTest.DisplayNameForFiltering;
         Method = innerTest.Method;
         ContainingType = innerTest.ContainingType;
-    }
+
+        _innerTest = innerTest;
+        _condition = condition;
+   }
 
     public ConditionalTest(ITestInfo innerTest, Xunit.TestPlatforms platform)
         : this(innerTest, GetPlatformConditionFromTestPlatform(platform))
@@ -138,21 +148,25 @@ public sealed class ConditionalTest : ITestInfo
     }
 
     public string TestNameExpression { get; }
-
     public string DisplayNameForFiltering { get; }
-
     public string Method { get; }
     public string ContainingType { get; }
+
+    private ITestInfo _innerTest;
+    private string _condition;
 
     public CodeBuilder GenerateTestExecution(ITestReporterWrapper testReporterWrapper)
     {
         CodeBuilder builder = new();
         builder.AppendLine($"if ({_condition})");
+
         using (builder.NewBracesScope())
         {
             builder.Append(_innerTest.GenerateTestExecution(testReporterWrapper));
         }
+
         builder.AppendLine($"else");
+
         using (builder.NewBracesScope())
         {
             builder.AppendLine(testReporterWrapper.GenerateSkippedTestReporting(_innerTest));
@@ -184,6 +198,7 @@ public sealed class ConditionalTest : ITestInfo
     private static string GetPlatformConditionFromTestPlatform(Xunit.TestPlatforms platform)
     {
         List<string> platformCheckConditions = new();
+
         if (platform.HasFlag(Xunit.TestPlatforms.Windows))
         {
             platformCheckConditions.Add("global::System.OperatingSystem.IsWindows()");
@@ -210,7 +225,8 @@ public sealed class ConditionalTest : ITestInfo
         }
         if (platform.HasFlag(Xunit.TestPlatforms.iOS))
         {
-            platformCheckConditions.Add("(global::System.OperatingSystem.IsIOS() && !global::System.OperatingSystem.IsMacCatalyst())");
+            platformCheckConditions.Add("(global::System.OperatingSystem.IsIOS()"
+                                      + " && !global::System.OperatingSystem.IsMacCatalyst())");
         }
         if (platform.HasFlag(Xunit.TestPlatforms.tvOS))
         {
@@ -232,43 +248,56 @@ public sealed class ConditionalTest : ITestInfo
         {
             platformCheckConditions.Add(@"global::System.OperatingSystem.IsOSPlatform(""NetBSD"")");
         }
+
         return string.Join(" || ", platformCheckConditions);
     }
 }
 
 public sealed class MemberDataTest : ITestInfo
 {
-    private ITestInfo _innerTest;
-    private string _memberInvocation;
-    private string _loopVarIdentifier;
-    public MemberDataTest(ISymbol referencedMember, ITestInfo innerTest, string externAlias, string argumentLoopVarIdentifier)
-    {
-        TestNameExpression = innerTest.TestNameExpression;
-        Method = innerTest.Method;
-        ContainingType = innerTest.ContainingType;
-        DisplayNameForFiltering = $"{ContainingType}.{Method}(...)";
-        _innerTest = innerTest;
-        _loopVarIdentifier = argumentLoopVarIdentifier;
-
-        string containingType = referencedMember.ContainingType.ToDisplayString(XUnitWrapperGenerator.FullyQualifiedWithoutGlobalNamespace);
-        _memberInvocation = referencedMember switch
-        {
-            IPropertySymbol { IsStatic: true } => $"{externAlias}::{containingType}.{referencedMember.Name}",
-            IMethodSymbol { IsStatic: true, Parameters.Length: 0 } => $"{externAlias}::{containingType}.{referencedMember.Name}()",
-            _ => throw new ArgumentException("MemberDataTest only supports properties and parameterless methods", nameof(referencedMember))
-        };
-    }
-
     public string TestNameExpression { get; }
     public string DisplayNameForFiltering { get; }
     public string Method { get; }
     public string ContainingType { get; }
 
+    private ITestInfo _innerTest;
+    private string _memberInvocation;
+    private string _loopVarIdentifier;
+
+    public MemberDataTest(ISymbol referencedMember,
+                          ITestInfo innerTest,
+                          string externAlias,
+                          string argumentLoopVarIdentifier)
+    {
+        TestNameExpression = innerTest.TestNameExpression;
+        Method = innerTest.Method;
+        ContainingType = innerTest.ContainingType;
+        DisplayNameForFiltering = $"{ContainingType}.{Method}(...)";
+
+        _innerTest = innerTest;
+        _loopVarIdentifier = argumentLoopVarIdentifier;
+
+        string containingType = referencedMember.ContainingType.ToDisplayString(XUnitWrapperGenerator
+                                                                                .FullyQualifiedWithoutGlobalNamespace);
+        _memberInvocation = referencedMember switch
+        {
+            IPropertySymbol { IsStatic: true } => $"{externAlias}::{containingType}.{referencedMember.Name}",
+
+            IMethodSymbol { IsStatic: true, Parameters.Length: 0 } =>
+                $"{externAlias}::{containingType}.{referencedMember.Name}()",
+
+            _ => throw new ArgumentException("MemberDataTest only supports properties and parameterless methods",
+                                             nameof(referencedMember))
+        };
+    }
+
     public CodeBuilder GenerateTestExecution(ITestReporterWrapper testReporterWrapper)
     {
         CodeBuilder builder = new();
+
         builder.AppendLine();
         builder.AppendLine($@"foreach (object[] {_loopVarIdentifier} in {_memberInvocation})");
+
         using (builder.NewBracesScope())
         {
             builder.Append(_innerTest.GenerateTestExecution(testReporterWrapper));
@@ -298,34 +327,34 @@ public sealed class MemberDataTest : ITestInfo
 
 public sealed class OutOfProcessTest : ITestInfo
 {
+    public string TestNameExpression { get; }
+    public string DisplayNameForFiltering { get; }
+    public string Method { get; }
+    public string ContainingType => "OutOfProcessTest";
+
+    private CodeBuilder _executionStatement { get; }
+    private string RelativeAssemblyPath { get; }
+
     public OutOfProcessTest(string displayName, string relativeAssemblyPath)
     {
         Method = displayName;
         DisplayNameForFiltering = displayName;
         TestNameExpression = $"@\"{displayName}\"";
         RelativeAssemblyPath = relativeAssemblyPath;
-        ExecutionStatement = new CodeBuilder();
-        ExecutionStatement.AppendLine();
-        ExecutionStatement.AppendLine("if (TestLibrary.OutOfProcessTest.OutOfProcessTestsSupported)");
-        using (ExecutionStatement.NewBracesScope())
+
+        _executionStatement = new CodeBuilder();
+        _executionStatement.AppendLine();
+        _executionStatement.AppendLine("if (TestLibrary.OutOfProcessTest.OutOfProcessTestsSupported)");
+
+        using (_executionStatement.NewBracesScope())
         {
-            ExecutionStatement.AppendLine($@"TestLibrary.OutOfProcessTest.RunOutOfProcessTest(@""{relativeAssemblyPath}"");");
+            _executionStatement.AppendLine($@"TestLibrary.OutOfProcessTest"
+                                        + $@".RunOutOfProcessTest(@""{relativeAssemblyPath}"");");
         }
     }
 
-    public string TestNameExpression { get; }
-
-    public string DisplayNameForFiltering { get; }
-
-    private string RelativeAssemblyPath { get; }
-
-    public string Method { get; }
-
-    public string ContainingType => "OutOfProcessTest";
-
-    private CodeBuilder ExecutionStatement { get; }
-
-    public CodeBuilder GenerateTestExecution(ITestReporterWrapper testReporterWrapper) => testReporterWrapper.WrapTestExecutionWithReporting(ExecutionStatement, this);
+    public CodeBuilder GenerateTestExecution(ITestReporterWrapper testReporterWrapper) =>
+        testReporterWrapper.WrapTestExecutionWithReporting(_executionStatement, this);
 
     public override bool Equals(object obj)
     {
@@ -345,6 +374,11 @@ public sealed class OutOfProcessTest : ITestInfo
 
 public sealed class TestWithCustomDisplayName : ITestInfo
 {
+    public string DisplayNameForFiltering { get; }
+    public string TestNameExpression => $@"""{DisplayNameForFiltering.Replace(@"\", @"\\")}""";
+    public string Method => _inner.Method;
+    public string ContainingType => _inner.ContainingType;
+
     private ITestInfo _inner;
 
     public TestWithCustomDisplayName(ITestInfo inner, string displayName)
@@ -352,14 +386,6 @@ public sealed class TestWithCustomDisplayName : ITestInfo
         _inner = inner;
         DisplayNameForFiltering = displayName;
     }
-
-    public string TestNameExpression => $@"""{DisplayNameForFiltering.Replace(@"\", @"\\")}""";
-
-    public string DisplayNameForFiltering { get; }
-
-    public string Method => _inner.Method;
-
-    public string ContainingType => _inner.ContainingType;
 
     public CodeBuilder GenerateTestExecution(ITestReporterWrapper testReporterWrapper)
     {
@@ -397,39 +423,65 @@ public sealed class WrapperLibraryTestSummaryReporting : ITestReporterWrapper
     private readonly string _filterLocalIdentifier;
     private readonly string _outputRecorderIdentifier;
 
-    public WrapperLibraryTestSummaryReporting(string summaryLocalIdentifier, string filterLocalIdentifier, string outputRecorderIdentifier)
+    public WrapperLibraryTestSummaryReporting(string summaryLocalIdentifier,
+                                              string filterLocalIdentifier,
+                                              string outputRecorderIdentifier)
     {
         _summaryLocalIdentifier = summaryLocalIdentifier;
         _filterLocalIdentifier = filterLocalIdentifier;
         _outputRecorderIdentifier = outputRecorderIdentifier;
     }
 
-    public CodeBuilder WrapTestExecutionWithReporting(CodeBuilder testExecutionExpression, ITestInfo test)
+    public CodeBuilder WrapTestExecutionWithReporting(CodeBuilder testExecutionExpression,
+                                                      ITestInfo test)
     {
         CodeBuilder builder = new();
-        builder.AppendLine($"if ({_filterLocalIdentifier} is null || {_filterLocalIdentifier}.ShouldRunTest(@\"{test.ContainingType}.{test.Method}\","
+
+        builder.AppendLine($"if ({_filterLocalIdentifier} is null"
+                         + $" || {_filterLocalIdentifier}.ShouldRunTest(@\"{test.ContainingType}.{test.Method}\","
                          + $" {test.TestNameExpression}))");
+
         using (builder.NewBracesScope())
         {
             builder.AppendLine($"System.TimeSpan testStart = stopwatch.Elapsed;");
             builder.AppendLine("try");
+
             using (builder.NewBracesScope())
             {
-                builder.AppendLine($"{_summaryLocalIdentifier}.ReportStartingTest({test.TestNameExpression}, System.Console.Out);");
+                builder.AppendLine($"{_summaryLocalIdentifier}.ReportStartingTest({test.TestNameExpression},"
+                                 + $" System.Console.Out);");
+
                 builder.AppendLine($"{_outputRecorderIdentifier}.ResetTestOutput();");
                 builder.Append(testExecutionExpression);
 
-                builder.AppendLine($"{_summaryLocalIdentifier}.ReportPassedTest({test.TestNameExpression}, \"{test.ContainingType}\", @\"{test.Method}\","
-                                 + $" stopwatch.Elapsed - testStart, {_outputRecorderIdentifier}.GetTestOutput(), System.Console.Out, tempLogSw, statsCsvSw);");
+                builder.AppendLine($"{_summaryLocalIdentifier}.ReportPassedTest({test.TestNameExpression},"
+                                 + $" \"{test.ContainingType}\","
+                                 + $" @\"{test.Method}\","
+                                 + $" stopwatch.Elapsed - testStart,"
+                                 + $" {_outputRecorderIdentifier}.GetTestOutput(),"
+                                 + $" System.Console.Out,"
+                                 + $" tempLogSw,"
+                                 + $" statsCsvSw);");
             }
+
             builder.AppendLine("catch (System.Exception ex)");
+
             using (builder.NewBracesScope())
             {
-                builder.AppendLine($"{_summaryLocalIdentifier}.ReportFailedTest({test.TestNameExpression}, \"{test.ContainingType}\", @\"{test.Method}\","
-                                 + $" stopwatch.Elapsed - testStart, ex, {_outputRecorderIdentifier}.GetTestOutput(), System.Console.Out, tempLogSw, statsCsvSw);");
+                builder.AppendLine($"{_summaryLocalIdentifier}.ReportFailedTest({test.TestNameExpression},"
+                                 + $" \"{test.ContainingType}\","
+                                 + $" @\"{test.Method}\","
+                                 + $" stopwatch.Elapsed - testStart,"
+                                 + $" ex,"
+                                 + $" {_outputRecorderIdentifier}.GetTestOutput(),"
+                                 + $" System.Console.Out,"
+                                 + $" tempLogSw,"
+                                 + $" statsCsvSw);");
             }
         }
+
         builder.AppendLine("else");
+
         using (builder.NewBracesScope())
         {
             builder.AppendLine(GenerateSkippedTestReporting(test));
@@ -439,7 +491,12 @@ public sealed class WrapperLibraryTestSummaryReporting : ITestReporterWrapper
 
     public string GenerateSkippedTestReporting(ITestInfo skippedTest)
     {
-        return $"{_summaryLocalIdentifier}.ReportSkippedTest({skippedTest.TestNameExpression}, \"{skippedTest.ContainingType}\", @\"{skippedTest.Method}\","
-             + $" System.TimeSpan.Zero, string.Empty, tempLogSw, statsCsvSw);";
+        return $"{_summaryLocalIdentifier}.ReportSkippedTest({skippedTest.TestNameExpression},"
+             + $" \"{skippedTest.ContainingType}\","
+             + $" @\"{skippedTest.Method}\","
+             + $" System.TimeSpan.Zero,"
+             + $" string.Empty,"
+             + $" tempLogSw,"
+             + $" statsCsvSw);";
     }
 }

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -309,7 +309,8 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         builder.AppendLine("void Initialize()");
         using (builder.NewBracesScope())
         {
-            builder.AppendLine("System.Collections.Generic.HashSet<string> testExclusionList = XUnitWrapperLibrary.TestFilter.LoadTestExclusionList();");
+            builder.AppendLine("System.Collections.Generic.Dictionary<string, string> testExclusionTable ="
+                               + " XUnitWrapperLibrary.TestFilter.LoadTestExclusionTable();");
             builder.AppendLine();
 
             builder.AppendLine($@"if (System.IO.File.Exists(""{assemblyName}.tempLog.xml""))");
@@ -317,6 +318,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
             {
                 builder.AppendLine($@"System.IO.File.Delete(""{assemblyName}.tempLog.xml"");");
             }
+
             builder.AppendLine($@"if (System.IO.File.Exists(""{assemblyName}.testStats.csv""))");
             using (builder.NewBracesScope())
             {
@@ -324,7 +326,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
             }
             builder.AppendLine();
 
-            builder.AppendLine("filter = new (args, testExclusionList);");
+            builder.AppendLine("filter = new (args, testExclusionTable);");
             builder.AppendLine("summary = new();");
             builder.AppendLine("stopwatch = System.Diagnostics.Stopwatch.StartNew();");
             builder.AppendLine("outputRecorder = new(System.Console.Out);");
@@ -441,12 +443,20 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         builder.AppendLine();
 
         builder.AppendLine("try");
+
         using (builder.NewBracesScope())
         {
-            builder.AppendLine("System.Collections.Generic.HashSet<string> testExclusionList = XUnitWrapperLibrary.TestFilter.LoadTestExclusionList();");
-            builder.AppendLine($@"return await XHarnessRunnerLibrary.RunnerEntryPoint.RunTests(RunTests, ""{assemblyName}"", args.Length != 0 ? args[0] : null, testExclusionList);");
+            builder.AppendLine("System.Collections.Generic.Dictionary<string, string> testExclusionTable ="
+                               + " XUnitWrapperLibrary.TestFilter.LoadTestExclusionTable();");
+
+            builder.AppendLine($@"return await XHarnessRunnerLibrary.RunnerEntryPoint.RunTests(RunTests,"
+                               + $@" ""{assemblyName}"","
+                               + $@" args.Length != 0 ? args[0] : null,"
+                               + $@" testExclusionTable);");
         }
+
         builder.AppendLine("catch (System.Exception ex)");
+
         using (builder.NewBracesScope())
         {
             builder.AppendLine("System.Console.WriteLine(ex.ToString());");
@@ -455,6 +465,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         builder.AppendLine();
 
         builder.AppendLine("void Initialize()");
+
         using (builder.NewBracesScope())
         {
             builder.AppendLine($@"if (System.IO.File.Exists(""{assemblyName}.tempLog.xml""))");
@@ -462,6 +473,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
             {
                 builder.AppendLine($@"System.IO.File.Delete(""{assemblyName}.tempLog.xml"");");
             }
+
             builder.AppendLine($@"if (System.IO.File.Exists(""{assemblyName}.testStats.csv""))");
             using (builder.NewBracesScope())
             {
@@ -477,6 +489,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         builder.AppendLine();
 
         builder.AppendLine("XUnitWrapperLibrary.TestSummary RunTests(XUnitWrapperLibrary.TestFilter filter)");
+
         using (builder.NewBracesScope())
         {
             builder.AppendLine("Initialize();");

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -212,6 +212,18 @@ public class TestFilter
         return false;
     }
 
+    public string GetTestExclusionReason(string testDisplayName)
+    {
+        if (_testExclusionTable is null)
+            return string.Empty;
+
+        string trueDisplayName = testDisplayName.Replace("\\", "/");
+
+        return _testExclusionTable.ContainsKey(trueDisplayName)
+               ? _testExclusionTable[trueDisplayName]
+               : string.Empty;
+    }
+
     public static Dictionary<string, string> LoadTestExclusionTable()
     {
         Dictionary<string, string> output = new Dictionary<string, string>();

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -6,7 +6,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+
 namespace XUnitWrapperLibrary;
+
+using Interlocked = System.Threading.Interlocked;
 
 public class TestFilter
 {
@@ -28,6 +31,7 @@ public class TestFilter
             Filter = filter;
             Substring = substring;
         }
+
         public TermKind Kind { get; }
         public string Filter { get; }
         public bool Substring { get; }
@@ -65,7 +69,9 @@ public class TestFilter
             _right = right;
         }
 
-        public bool IsMatch(string fullyQualifiedName, string displayName, string[] traits) => _left.IsMatch(fullyQualifiedName, displayName, traits) && _right.IsMatch(fullyQualifiedName, displayName, traits);
+        public bool IsMatch(string fullyQualifiedName, string displayName, string[] traits) =>
+            _left.IsMatch(fullyQualifiedName, displayName, traits)
+            && _right.IsMatch(fullyQualifiedName, displayName, traits);
 
         public override string ToString()
         {
@@ -84,7 +90,9 @@ public class TestFilter
             _right = right;
         }
 
-        public bool IsMatch(string fullyQualifiedName, string displayName, string[] traits) => _left.IsMatch(fullyQualifiedName, displayName, traits) || _right.IsMatch(fullyQualifiedName, displayName, traits);
+        public bool IsMatch(string fullyQualifiedName, string displayName, string[] traits) =>
+            _left.IsMatch(fullyQualifiedName, displayName, traits)
+            || _right.IsMatch(fullyQualifiedName, displayName, traits);
 
         public override string ToString()
         {
@@ -101,7 +109,8 @@ public class TestFilter
             _inner = inner;
         }
 
-        public bool IsMatch(string fullyQualifiedName, string displayName, string[] traits) => !_inner.IsMatch(fullyQualifiedName, displayName, traits);
+        public bool IsMatch(string fullyQualifiedName, string displayName, string[] traits)
+            => !_inner.IsMatch(fullyQualifiedName, displayName, traits);
 
         public override string ToString()
         {
@@ -116,17 +125,18 @@ public class TestFilter
     // all tests to the new model, it's easier to keep bug exclusions in the existing
     // issues.targets file as a split model would be very confusing for developers
     // and test monitors.
-    private readonly HashSet<string>? _testExclusionList;
+
+    private readonly Dictionary<string, string>? _testExclusionTable;
     private readonly int _stripe;
     private readonly int _stripeCount = 1;
     private int _shouldRunQuery = -1;
 
-    public TestFilter(string? filterString, HashSet<string>? testExclusionList) :
-        this(filterString == null ? Array.Empty<string>() : new string[]{filterString}, testExclusionList)
+    public TestFilter(string? filterString, Dictionary<string, string>? testExclusionTable) :
+        this(filterString == null ? Array.Empty<string>() : new string[]{filterString}, testExclusionTable)
     {
     }
 
-    public TestFilter(string[] filterArgs, HashSet<string>? testExclusionList)
+    public TestFilter(string[] filterArgs, Dictionary<string, string>? testExclusionTable)
     {
         string? filterString = null;
 
@@ -149,7 +159,8 @@ public class TestFilter
             var stripes = stripeEnvironment.Split('.');
             if (stripes.Length == 3)
             {
-                Console.WriteLine($"Test striping enabled via TEST_HARNESS_STRIPE_TO_EXECUTE environment variable set to '{stripeEnvironment}'");
+                Console.WriteLine($"Test striping enabled via TEST_HARNESS_STRIPE_TO_EXECUTE environment"
+                                  + $" variable set to '{stripeEnvironment}'");
                 _stripe = int.Parse(stripes[1]);
                 _stripeCount = int.Parse(stripes[2]);
             }
@@ -159,23 +170,28 @@ public class TestFilter
         {
             if (filterString.IndexOfAny(new[] { '!', '(', ')', '~', '=' }) != -1)
             {
-                throw new ArgumentException("Complex test filter expressions are not supported today. The only filters supported today are the simple form supported in 'dotnet test --filter' (substrings of the test's fully qualified name). If further filtering options are desired, file an issue on dotnet/runtime for support.", nameof(filterArgs));
+                throw new ArgumentException("Complex test filter expressions are not supported today."
+                                          + " The only filters currently supported are the simple forms"
+                                          + " supported in 'dotnet test --filter' (substrings of the"
+                                          + " test's fully qualified name). If further filtering options"
+                                          + " are desired, file an issue on dotnet/runtime for support.",
+                                            nameof(filterArgs));
             }
             _filter = new NameClause(TermKind.FullyQualifiedName, filterString, substring: true);
         }
-        _testExclusionList = testExclusionList;
+        _testExclusionTable = testExclusionTable;
     }
 
-    public TestFilter(ISearchClause? filter, HashSet<string>? testExclusionList)
+    public TestFilter(ISearchClause? filter, Dictionary<string, string>? testExclusionTable)
     {
         _filter = filter;
-        _testExclusionList = testExclusionList;
+        _testExclusionTable = testExclusionTable;
     }
 
     public bool ShouldRunTest(string fullyQualifiedName, string displayName, string[]? traits = null)
     {
         bool shouldRun;
-        if (_testExclusionList is not null && _testExclusionList.Contains(displayName.Replace("\\", "/")))
+        if (_testExclusionTable is not null && _testExclusionTable.ContainsKey(displayName.Replace("\\", "/")))
         {
             shouldRun = false;
         }
@@ -191,30 +207,47 @@ public class TestFilter
         if (shouldRun)
         {
             // Test stripe, if true, then report success
-            return ((System.Threading.Interlocked.Increment(ref _shouldRunQuery)) % _stripeCount) == _stripe;
+            return ((Interlocked.Increment(ref _shouldRunQuery)) % _stripeCount) == _stripe;
         }
         return false;
     }
 
-    public static HashSet<string> LoadTestExclusionList()
+    public static Dictionary<string, string> LoadTestExclusionTable()
     {
-        HashSet<string> output = new ();
+        Dictionary<string, string> output = new Dictionary<string, string>();
 
         // Try reading the exclusion list as a base64-encoded semicolon-delimited string as a commmand-line arg.
         string[] arguments = Environment.GetCommandLineArgs();
         string? testExclusionListArg = arguments.FirstOrDefault(arg => arg.StartsWith("--exclusion-list="));
-        if (testExclusionListArg is not null)
+
+        if (!string.IsNullOrEmpty(testExclusionListArg))
         {
             string testExclusionListPathFromCommandLine = testExclusionListArg.Substring("--exclusion-list=".Length);
-            output.UnionWith(File.ReadAllLines(testExclusionListPathFromCommandLine));
+            ReadExclusionListToTable(testExclusionListPathFromCommandLine, output);
         }
 
         // Try reading the exclusion list as a line-delimited file.
         string? testExclusionListPath = Environment.GetEnvironmentVariable("TestExclusionListPath");
+
         if (!string.IsNullOrEmpty(testExclusionListPath))
         {
-            output.UnionWith(File.ReadAllLines(testExclusionListPath));
+            ReadExclusionListToTable(testExclusionListPath, output);
         }
         return output;
+    }
+
+    private static void ReadExclusionListToTable(string exclusionListPath,
+                                                 Dictionary<string, string> table)
+    {
+        IEnumerable<string[]> excludedTestsWithReasons = File.ReadAllLines(exclusionListPath)
+                                                             .Select(t => t.Split(','));
+
+        foreach (string[] testInfo in excludedTestsWithReasons)
+        {
+            if (!table.ContainsKey(testInfo[0]))
+            {
+                table.Add(testInfo[0], testInfo[1]);
+            }
+        }
     }
 }

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -227,9 +227,9 @@ public class TestFilter
                : string.Empty;
     }
 
-    // Some tests are purposefully not run for a number of reasons. They are specified
-    // in src/tests/issues.targets, along with a brief explanation on why they are
-    // skipped inside an '<Issue>' tag.
+    // GH dotnet/runtime issue #91562: Some tests are purposefully not run for a number
+    // of reasons. They are specified in src/tests/issues.targets, along with a brief
+    // explanation on why they are skipped inside an '<Issue>' tag.
     //
     // When building any test or test subtree, if any of the tests built matches an entry
     // in issues.targets, then the exclusions list file ($CORE_ROOT/TestExclusions.txt is

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -283,9 +283,12 @@ public class TestFilter
             // This translates to the two-element arrays we are adding to the test
             // exclusions table here.
 
-            if (!table.ContainsKey(testInfo[0]))
+            string testPath = testInfo[0];
+            string skipReason = testInfo.Length > 1 ? testInfo[1] : string.Empty;
+
+            if (!table.ContainsKey(testPath)
             {
-                table.Add(testInfo[0], testInfo[1]);
+                table.Add(testPath, skipReason);
             }
         }
     }

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -286,7 +286,7 @@ public class TestFilter
             string testPath = testInfo[0];
             string skipReason = testInfo.Length > 1 ? testInfo[1] : string.Empty;
 
-            if (!table.ContainsKey(testPath)
+            if (!table.ContainsKey(testPath))
             {
                 table.Add(testPath, skipReason);
             }

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -126,7 +126,10 @@ public class TestFilter
     // issues.targets file as a split model would be very confusing for developers
     // and test monitors.
 
+    // Explanation on the Test Exclusion Table is detailed in method LoadTestExclusionTable()
+    // later on in this file.
     private readonly Dictionary<string, string>? _testExclusionTable;
+
     private readonly int _stripe;
     private readonly int _stripeCount = 1;
     private int _shouldRunQuery = -1;
@@ -224,6 +227,23 @@ public class TestFilter
                : string.Empty;
     }
 
+    // Some tests are purposefully not run for a number of reasons. They are specified
+    // in src/tests/issues.targets, along with a brief explanation on why they are
+    // skipped inside an '<Issue>' tag.
+    //
+    // When building any test or test subtree, if any of the tests built matches an entry
+    // in issues.targets, then the exclusions list file ($CORE_ROOT/TestExclusions.txt is
+    // the default) is updated by adding a new a comma-separated entry:
+    //
+    // 1) Test's Path (What is added to <ExcludeList> in issues.targets)
+    // 2) Reason for Skipping (What is written in the <Issue> tag)
+    //
+    // When a test runner is executed (e.g. Methodical_d1.sh), it uses a compiler-generated
+    // source file to actually run the tests (e.g. FullRunner.g.cs - This is detailed in
+    // XUnitWrapperGenerator.cs). This generated source file is the one in charge of
+    // reading the test exclusions list file, and stores the comma-separated values into a
+    // table represented by the dictionary called _testExclusionTable in this file.
+
     public static Dictionary<string, string> LoadTestExclusionTable()
     {
         Dictionary<string, string> output = new Dictionary<string, string>();
@@ -256,6 +276,13 @@ public class TestFilter
 
         foreach (string[] testInfo in excludedTestsWithReasons)
         {
+            // Each line read from the exclusion list file follows the following format:
+            //
+            // Test Path, Reason For Skipping
+            //
+            // This translates to the two-element arrays we are adding to the test
+            // exclusions table here.
+
             if (!table.ContainsKey(testInfo[0]))
             {
                 table.Add(testInfo[0], testInfo[1]);

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -20,6 +20,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/opt/SSA/MemorySsa/**">
             <Issue>https://github.com/dotnet/runtime/issues/86112</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray2_cs_d/**">
+            <Issue>Learning and Testing to Include Reasons in Logs</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All OS/Arch CoreCLR excludes -->
@@ -3728,9 +3731,9 @@
     <Target Name="GetFilteredExcludeList" Returns="@(FilteredExcludeList)">
         <ItemGroup>
             <FilteredExcludeList
-                Include="$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.FullPath)').Replace('\', '/'))"
+                Include="$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.FullPath)').Replace('\', '/')), %(ExcludeList.Issue)"
                 Condition="'%(ExcludeList.Extension)' == '.dll'" />
-            <FilteredExcludeList Include="$([System.IO.Path]::ChangeExtension('$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.Identity)'))', '.cmd').Replace('\', '/'))"
+            <FilteredExcludeList Include="$([System.IO.Path]::ChangeExtension('$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.Identity)'))', '.cmd').Replace('\', '/')), %(ExcludeList.Issue)"
                 Condition="'%(ExcludeList.Extension)' == '.OutOfProcessTest'" />
       </ItemGroup>
     </Target>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3731,9 +3731,9 @@
     <Target Name="GetFilteredExcludeList" Returns="@(FilteredExcludeList)">
         <ItemGroup>
             <FilteredExcludeList
-                Include="$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.FullPath)').Replace('\', '/')), %(ExcludeList.Issue)"
+                Include="$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.FullPath)').Replace('\', '/')),%(ExcludeList.Issue)"
                 Condition="'%(ExcludeList.Extension)' == '.dll'" />
-            <FilteredExcludeList Include="$([System.IO.Path]::ChangeExtension('$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.Identity)'))', '.cmd').Replace('\', '/')), %(ExcludeList.Issue)"
+            <FilteredExcludeList Include="$([System.IO.Path]::ChangeExtension('$([System.IO.Path]::GetRelativePath('$(XunitTestBinBase)', '%(ExcludeList.Identity)'))', '.cmd').Replace('\', '/')),%(ExcludeList.Issue)"
                 Condition="'%(ExcludeList.Extension)' == '.OutOfProcessTest'" />
       </ItemGroup>
     </Target>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -20,9 +20,6 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/opt/SSA/MemorySsa/**">
             <Issue>https://github.com/dotnet/runtime/issues/86112</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray2_cs_d/**">
-            <Issue>Learning and Testing to Include Reasons in Logs</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- All OS/Arch CoreCLR excludes -->


### PR DESCRIPTION
Feature that fixes issue #91562. This PR adds the necessary functionality to write the reason any given test was skipped in their results _xml_ file.

Currently, it is hard-coded to the message _"No Known Skip Reason"_. With this PR, the reason will be taken from the test's disable explanation in `src/tests/issues.targets`, in their respective `<Issue>` tag. If there is no such message, then we will default to today's message of _"No Known Skip Reason"_.

A good amount of code cleanup was done as part of this PR as well. Due to how Github handles file differences and spacing, especially with long lines, I highly recommend using the *Unified* view instead of the *Split* one for reviewing this one PR.