### PR TITLE
Fix potential 'Floating Point Exception' with speculative execution

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3416,9 +3416,9 @@ gc_heap::dt_high_frag_p (gc_tuning_point tp,
                     fragmentation_burden = (gen_size ? ((float)fr / (float)gen_size) : 0.0f);
                     ret = (fragmentation_burden > dd_v_fragmentation_burden_limit (dd));
                 }
-                dprintf (GTC_LOG, ("h%d: gen%d, frag is %zd, alloc effi: %d%%, unusable frag is %zd, ratio is %d",
+                dprintf (GTC_LOG, ("h%d: gen%d, frag is %zd, alloc effi: %zu%%, unusable frag is %zd, ratio is %d",
                     heap_number, gen_number, dd_fragmentation (dd),
-                    (int)(generation_allocator_efficiency_percent (generation_of (gen_number))),
+                    generation_allocator_efficiency_percent (generation_of (gen_number)),
                     fr, (int)(fragmentation_burden*100)));
             }
             break;
@@ -33143,9 +33143,9 @@ void gc_heap::plan_phase (int condemned_gen_number)
         if ((free_list_allocated + rejected_free_space) != 0)
             free_list_efficiency = (int)(((float) (free_list_allocated) / (float)(free_list_allocated + rejected_free_space)) * (float)100);
 
-        int running_free_list_efficiency = (int)(generation_allocator_efficiency_percent(older_gen));
+        size_t running_free_list_efficiency = generation_allocator_efficiency_percent(older_gen);
 
-        dprintf (1, ("gen%d free list alloc effi: %d%%, current effi: %d%%",
+        dprintf (1, ("gen%d free list alloc effi: %d%%, current effi: %zu%%",
                     older_gen->gen_num,
                     free_list_efficiency, running_free_list_efficiency));
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3418,7 +3418,7 @@ gc_heap::dt_high_frag_p (gc_tuning_point tp,
                 }
                 dprintf (GTC_LOG, ("h%d: gen%d, frag is %zd, alloc effi: %d%%, unusable frag is %zd, ratio is %d",
                     heap_number, gen_number, dd_fragmentation (dd),
-                    (int)(100*generation_allocator_efficiency (generation_of (gen_number))),
+                    (int)(generation_allocator_efficiency_percent (generation_of (gen_number))),
                     fr, (int)(fragmentation_burden*100)));
             }
             break;
@@ -22420,7 +22420,7 @@ void gc_heap::gc1()
             }
         }
 
-        get_gc_data_per_heap()->maxgen_size_info.running_free_list_efficiency = (uint32_t)(generation_allocator_efficiency (generation_of (max_generation)) * 100);
+        get_gc_data_per_heap()->maxgen_size_info.running_free_list_efficiency = (uint32_t)(generation_allocator_efficiency_percent (generation_of (max_generation)));
 
         free_list_info (max_generation, "after computing new dynamic data");
     }
@@ -33143,7 +33143,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
         if ((free_list_allocated + rejected_free_space) != 0)
             free_list_efficiency = (int)(((float) (free_list_allocated) / (float)(free_list_allocated + rejected_free_space)) * (float)100);
 
-        int running_free_list_efficiency = (int)(generation_allocator_efficiency(older_gen)*100);
+        int running_free_list_efficiency = (int)(generation_allocator_efficiency_percent(older_gen));
 
         dprintf (1, ("gen%d free list alloc effi: %d%%, current effi: %d%%",
                     older_gen->gen_num,

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -5104,25 +5104,30 @@ size_t& generation_allocated_since_last_pin (generation* inst)
 }
 #endif //FREE_USAGE_STATS
 
+// Return the percentage of efficiency (between 0 and 100) of the allocator.
 inline
-uint64_t generation_allocator_efficiency_percent (generation* inst)
+size_t generation_allocator_efficiency_percent (generation* inst)
 {
+    // Use integer division to prevent potential floating point exception.
+    // FPE may occur if we use floating point division because of speculative execution.
     uint64_t free_obj_space = generation_free_obj_space (inst);
     uint64_t free_list_allocated = generation_free_list_allocated (inst);
-    if (free_list_allocated==0)
+    if (free_list_allocated == 0)
       return 0;
-    return (100 * free_list_allocated) / (free_list_allocated + free_obj_space);
+    return (size_t)((100 * free_list_allocated) / (free_list_allocated + free_obj_space));
 }
 
 inline
-uint64_t generation_unusable_fragmentation (generation* inst)
+size_t generation_unusable_fragmentation (generation* inst)
 {
+    // Use integer division to prevent potential floating point exception.
+    // FPE may occur if we use floating point division because of speculative execution.
     uint64_t free_obj_space = generation_free_obj_space (inst);
     uint64_t free_list_allocated = generation_free_list_allocated (inst);
     uint64_t free_list_space = generation_free_list_space (inst);
-    if (free_obj_space==0)
+    if (free_obj_space == 0)
       return 0;
-    return (free_obj_space + (free_obj_space * free_list_space) / (free_list_allocated + free_obj_space));
+    return (size_t)(free_obj_space + (free_obj_space * free_list_space) / (free_list_allocated + free_obj_space));
 }
 
 #define plug_skew           sizeof(ObjHeader)

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -5105,21 +5105,21 @@ size_t& generation_allocated_since_last_pin (generation* inst)
 #endif //FREE_USAGE_STATS
 
 inline
-size_t generation_allocator_efficiency_percent (generation* inst)
+uint64_t generation_allocator_efficiency_percent (generation* inst)
 {
-    size_t free_obj_space = generation_free_obj_space (inst);
-    size_t free_list_allocated = generation_free_list_allocated (inst);
+    uint64_t free_obj_space = generation_free_obj_space (inst);
+    uint64_t free_list_allocated = generation_free_list_allocated (inst);
     if (free_list_allocated==0)
       return 0;
     return (100 * free_list_allocated) / (free_list_allocated + free_obj_space);
 }
 
 inline
-size_t generation_unusable_fragmentation (generation* inst)
+uint64_t generation_unusable_fragmentation (generation* inst)
 {
-    size_t free_obj_space = generation_free_obj_space (inst);
-    size_t free_list_allocated = generation_free_list_allocated (inst);
-    size_t free_list_space = generation_free_list_space (inst);
+    uint64_t free_obj_space = generation_free_obj_space (inst);
+    uint64_t free_list_allocated = generation_free_list_allocated (inst);
+    uint64_t free_list_space = generation_free_list_space (inst);
     if (free_obj_space==0)
       return 0;
     return (free_obj_space + (free_obj_space * free_list_space) / (free_list_allocated + free_obj_space));

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -5112,7 +5112,7 @@ size_t generation_allocator_efficiency_percent (generation* inst)
     // FPE may occur if we use floating point division because of speculative execution.
     uint64_t free_obj_space = generation_free_obj_space (inst);
     uint64_t free_list_allocated = generation_free_list_allocated (inst);
-    if (free_list_allocated == 0)
+    if ((free_list_allocated + free_obj_space) == 0)
       return 0;
     return (size_t)((100 * free_list_allocated) / (free_list_allocated + free_obj_space));
 }
@@ -5125,7 +5125,7 @@ size_t generation_unusable_fragmentation (generation* inst)
     uint64_t free_obj_space = generation_free_obj_space (inst);
     uint64_t free_list_allocated = generation_free_list_allocated (inst);
     uint64_t free_list_space = generation_free_list_space (inst);
-    if (free_obj_space == 0)
+    if ((free_list_allocated + free_obj_space) == 0)
       return 0;
     return (size_t)(free_obj_space + (free_obj_space * free_list_space) / (free_list_allocated + free_obj_space));
 }

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -5107,12 +5107,15 @@ size_t& generation_allocated_since_last_pin (generation* inst)
 inline
 float generation_allocator_efficiency (generation* inst)
 {
-    if ((generation_free_list_allocated (inst) + generation_free_obj_space (inst)) != 0)
-    {
-        return ((float) (generation_free_list_allocated (inst)) / (float)(generation_free_list_allocated (inst) + generation_free_obj_space (inst)));
-    }
-    else
-        return 0;
+    // Because of speculative execution, it is not always safe to do the following code if sum is equal to zero
+    // if (sum!=0.0f)
+    //   return ... / sum;
+    // To prevent this, add a small value to the divider.
+    // It will not change the result if sum is not zero because in this
+    // case sum>1.0 and precision of float is limited to 7 digits
+
+    float sum = (float)(generation_free_list_allocated (inst) + generation_free_obj_space (inst));
+    return ((float) (generation_free_list_allocated (inst))) / (sum + 1.0e-10f);
 }
 inline
 size_t generation_unusable_fragmentation (generation* inst)


### PR DESCRIPTION
With the current version of runtime and version `8.0-rc2`, there is a 'Floating Point Exception' (signal `SIGFPE`) when floating point exception are enabled (via `feenableexcept()`).

It seems to be due to speculative execution of the division in the check.

This patch remove the check and make sure we do not divide by zero.

Alternatively, because the result of this function is only to check if the fragmentation is high enough, we can rewrite the part of the code to remove all divide operation. 