### PR TITLE
JIT: Optimize constant range tests

### DIFF
--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -405,8 +405,25 @@ bool OptBoolsDsc::FindCompareChain(GenTree* condition, bool* isTestCondition)
     return false;
 }
 
-// Given two ranges, return true if they intersect and form a closed range.
-// Returns its bounds in pRangeStart and pRangeEnd (both are inclusive).
+//------------------------------------------------------------------------------
+// GetIntersection: Given two ranges, return true if they intersect and form a closed range.
+//    Examples:
+//      >10 and <=20 -> [11,20]
+//      >10 and >100 -> false
+//      <10 and >10  -> false
+//
+// Arguments:
+//    type        - The type of the compare nodes.
+//    cmp1        - The first compare node.
+//    cmp2        - The second compare node.
+//    cns1        - The constant value of the first compare node (always RHS).
+//    cns2        - The constant value of the second compare node (always RHS).
+//    pRangeStart - [OUT] The start of the intersection range (inclusive).
+//    pRangeEnd   - [OUT] The end of the intersection range (inclusive).
+//
+// Returns:
+//    true if the ranges intersect and form a closed range.
+//
 static bool GetIntersection(var_types  type,
                             genTreeOps cmp1,
                             genTreeOps cmp2,
@@ -469,6 +486,7 @@ static bool GetIntersection(var_types  type,
 
     return true;
 }
+
 //------------------------------------------------------------------------------
 // IsConstantRangeTest: Does the given compare node represent a constant range test? E.g.
 //    "X relop CNS" or "CNS relop X" where relop is [<, <=, >, >=]

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -497,7 +497,7 @@ bool OptBoolsDsc::optOptimizeRangeTests()
         return false;
     }
 
-    if (!BasicBlock::sameEHRegion(m_b1, m_b2))
+    if (!BasicBlock::sameEHRegion(m_b1, m_b2) || ((m_b2->bbFlags & BBF_DONT_REMOVE) != 0))
     {
         // Conditions aren't in the same EH region
         return false;


### PR DESCRIPTION
```cs
void Test(char c)
{
    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'))
        Console.WriteLine("a-zA-Z");

// also: "X < CNS1 || X > CNS2", etc
}
```
Current codegen:
```asm
; Assembly listing for method Prog:Test(ushort):this (FullOpts)
       movzx    rcx, dx
       cmp      ecx, 97
       jl       SHORT G_M56518_IG04
       cmp      ecx, 122
       jle      SHORT G_M56518_IG05
G_M56518_IG04:
       cmp      ecx, 65
       jl       SHORT G_M56518_IG07
       cmp      ecx, 90
       jg       SHORT G_M56518_IG07
G_M56518_IG05:
       mov      rcx, 0x13A00208D40      ; 'a-zA-Z'
       tail.jmp [System.Console:WriteLine(System.String)]
G_M56518_IG07:
       ret      
; Total bytes of code 40
```
New codegen:
```asm
; Assembly listing for method Prog:Test(ushort):this (FullOpts)
       movzx    rcx, dx
       mov      eax, ecx
       sub      eax, 97
       cmp      eax, 25
       jbe      SHORT G_M56518_IG04
       sub      ecx, 65
       cmp      ecx, 25
       ja       SHORT G_M56518_IG06
G_M56518_IG04:
       mov      rcx, 0x1E200008D40      ; 'a-zA-Z'
G_M56518_IG05:
       tail.jmp [System.Console:WriteLine(System.String)]
G_M56518_IG06:
       ret      
; Total bytes of code 38
```

Not a big size win (sometimes even a size regression actually), but less branches (takes PGO into account).

Alternative patterns:

- `c < 'a' || c > 'z'`
- `c is >= 'a' and <= 'z' or >= 'A' and <= 'Z'`
