### PR TITLE
[release/6.0-staging] Workaround for C++ compiler bug on Arm64

### DIFF
--- a/src/coreclr/inc/safemath.h
+++ b/src/coreclr/inc/safemath.h
@@ -481,6 +481,9 @@ public:
     Which ought to inline nicely
 */
     // Returns true if safe, false for overflow.
+#if defined(_MSC_VER) && defined(HOST_ARM64) // Workaround for https://github.com/dotnet/runtime/issues/93442
+#pragma optimize("", off)
+#endif
     static bool multiply(T lhs, T rhs, T &result)
     {
         if(Is64Bit())
@@ -675,6 +678,9 @@ public:
             }
         }
     }
+#if defined(_MSC_VER) && defined(HOST_ARM64) // Workaround for https://github.com/dotnet/runtime/issues/93442
+#pragma optimize("", on)
+#endif
 
     // Returns true if safe, false on overflow
     static inline bool addition(T lhs, T rhs, T &result)


### PR DESCRIPTION
Backport of #93523 to release/6.0

MSVC rolled out to the build machines a few days ago has a codegen bug that affects the JIT on Arm64. We are applying a temporary workaround to disable optimizations around the affected methods.

## Customer Impact

Multiplication of two constants produces bad result in some cases.

## Testing

The affected JIT tests are passing.

## Risk

Low