### PR TITLE
Add GT_ARR_LEN to optNonNullAssertionProp_Ind

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4454,14 +4454,14 @@ GenTree* Compiler::optNonNullAssertionProp_Call(ASSERT_VALARG_TP assertions, Gen
 //
 bool Compiler::optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir)
 {
-    assert(indir->OperIsIndir() || indir->OperIs(GT_ARR_LENGTH));
+    assert(indir->OperIsIndir() || indir->OperIsArrLength());
 
     if (!(indir->gtFlags & GTF_EXCEPT))
     {
         return false;
     }
 
-    GenTree* addr = indir->OperIs(GT_ARR_LENGTH) ? indir->AsArrLen()->ArrRef() : indir->AsIndir()->Addr();
+    GenTree* addr = indir->OperIsArrLength() ? indir->AsArrCommon()->ArrRef() : indir->AsIndir()->Addr();
 #ifdef DEBUG
     bool           vnBased = false;
     AssertionIndex index   = NO_ASSERTION_INDEX;
@@ -4478,7 +4478,7 @@ bool Compiler::optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree*
 #endif
         indir->gtFlags &= ~GTF_EXCEPT;
         indir->gtFlags |= GTF_IND_NONFAULTING;
-        if (!indir->OperIs(GT_ARR_LENGTH))
+        if (!indir->OperIsArrLength())
         {
             // Set this flag to prevent reordering
             indir->SetHasOrderingSideEffect();
@@ -4793,7 +4793,6 @@ GenTree* Compiler::optAssertionProp(ASSERT_VALARG_TP assertions, GenTree* tree, 
         case GT_STOREIND:
         case GT_NULLCHECK:
         case GT_STORE_DYN_BLK:
-        case GT_ARR_LENGTH:
             return optAssertionProp_Ind(assertions, tree, stmt);
 
         case GT_BOUNDS_CHECK:
@@ -5860,7 +5859,7 @@ void Compiler::optVnNonNullPropCurStmt(BasicBlock* block, Statement* stmt, GenTr
     {
         newTree = optNonNullAssertionProp_Call(empty, tree->AsCall());
     }
-    else if (tree->OperIsIndir())
+    else if (tree->OperIsIndir() || tree->OperIsArrLength())
     {
         newTree = optAssertionProp_Ind(empty, tree, stmt);
     }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4793,6 +4793,8 @@ GenTree* Compiler::optAssertionProp(ASSERT_VALARG_TP assertions, GenTree* tree, 
         case GT_STOREIND:
         case GT_NULLCHECK:
         case GT_STORE_DYN_BLK:
+        case GT_ARR_LENGTH:
+        case GT_MDARR_LENGTH:
             return optAssertionProp_Ind(assertions, tree, stmt);
 
         case GT_BOUNDS_CHECK:

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4477,10 +4477,13 @@ bool Compiler::optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree*
 #endif
         indir->gtFlags &= ~GTF_EXCEPT;
         indir->gtFlags |= GTF_IND_NONFAULTING;
+
         // Set this flag to prevent reordering
         indir->SetHasOrderingSideEffect();
+
         return true;
     }
+
     return false;
 }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7148,6 +7148,9 @@ bool GenTree::OperSupportsOrderingSideEffect() const
         case GT_CMPXCHG:
         case GT_MEMORYBARRIER:
         case GT_CATCH_ARG:
+        case GT_ARR_LENGTH:
+        case GT_MDARR_LENGTH:
+        case GT_MDARR_LOWER_BOUND:
             return true;
         default:
             return false;

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -834,6 +834,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
         m_comp->gtSetStmtInfo(m_testInfo1.testStmt);
         m_comp->fgSetStmtSeq(m_testInfo1.testStmt);
     }
+    m_comp->gtUpdateStmtSideEffects(m_testInfo1.testStmt);
 
     if (!optReturnBlock)
     {


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/84248
We were not taking advantage of assert propagation for GT_ARR_LENGTH (and MD_LENGHT).

```cs
void Test(int[]? arr)
{
    if (arr != null)
    {
        var _ = arr.Length;
    }
}
```
```diff
; Assembly listing for method Prog:Test(int[]):this (FullOpts)
-      test     rdx, rdx
-      je       SHORT G_M2580_IG04
-      mov      eax, dword ptr [rdx+0x08]
-G_M2580_IG04:
       ret      
-; Total bytes of code 9
+; Total bytes of code 1
```