### PR TITLE
Fix analysis of interface methods on generic types

### DIFF
--- a/src/tests/Loader/classloader/StaticVirtualMethods/NegativeTestCases/MethodBodyOnUnrelatedType.ilproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/NegativeTestCases/MethodBodyOnUnrelatedType.ilproj
@@ -5,6 +5,9 @@
 
     <!-- Crossgen2 currently doesn't support this negative check - that should be fine as runtime behavior is undefined in the presence of invalid IL. -->
     <CrossGenTest>false</CrossGenTest>
+
+    <!-- Testing TypeLoad/MissingMethod exceptions in situations that are expensive to detect -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -40,6 +40,7 @@ public class Interfaces
         TestDefaultInterfaceVariance.Run();
         TestVariantInterfaceOptimizations.Run();
         TestSharedInterfaceMethods.Run();
+        TestGenericAnalysis.Run();
         TestCovariantReturns.Run();
         TestDynamicInterfaceCastable.Run();
         TestStaticInterfaceMethodsAnalysis.Run();
@@ -649,6 +650,54 @@ public class Interfaces
             IFace<object> o = new Yadda() { InnerValue = "SomeString" };
             string r3 = o.GrabValue("Hello there");
             if (r3 != "'SomeString' over 'System.Object' with 'Hello there'")
+                throw new Exception();
+        }
+    }
+
+    class TestGenericAnalysis
+    {
+        interface IInterface
+        {
+            string Method(object p);
+        }
+
+        interface IInterface<T>
+        {
+            string Method(T p);
+        }
+
+        class C1<T> : IInterface, IInterface<T>
+        {
+            public string Method(object p) => "Method(object)";
+            public string Method(T p) => "Method(T)";
+        }
+
+        class C2<T> : IInterface, IInterface<T>
+        {
+            public string Method(object p) => "Method(object)";
+            public string Method(T p) => "Method(T)";
+        }
+
+        class C3<T> : IInterface, IInterface<T>
+        {
+            public string Method(object p) => "Method(object)";
+            public string Method(T p) => "Method(T)";
+        }
+
+        static IInterface s_c1 = new C1<object>();
+        static IInterface<object> s_c2 = new C2<object>();
+        static IInterface<object> s_c3a = new C3<object>();
+        static IInterface s_c3b = new C3<object>();
+
+        public static void Run()
+        {
+            if (s_c1.Method(null) != "Method(object)")
+                throw new Exception();
+            if (s_c2.Method(null) != "Method(T)")
+                throw new Exception();
+            if (s_c3a.Method(null) != "Method(T)")
+                throw new Exception();
+            if (s_c3b.Method(null) != "Method(object)")
                 throw new Exception();
         }
     }


### PR DESCRIPTION
Fixes an issue observed in #92881. The dependency analysis within the compiler was incorrectly considering `Equals(object x, object y)` to be the implementation of `IEqualityComparer<T>.Equals(T, T)`. When we generate the interface dispatch table, we'd use the correct algorithm (that looks at uninstantiated types) and fail the compilation. The fix is to use the same algorithm during dependency analysis.

Looks like this has been broken ever since interface support was added to CoreRT in 2016 and the bug survived additions of default and static interface methods: https://github.com/dotnet/corert/pull/626.

Cc @dotnet/ilc-contrib 