### PR TITLE
Mention Frozen.* types in PACKAGE.md for System.Collections.Immutable

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/PACKAGE.md
+++ b/src/libraries/System.Collections.Immutable/src/PACKAGE.md
@@ -53,6 +53,10 @@ The main types provided by this library are:
 * `System.Collections.Immutable.ImmutableSortedSet<T>`
 * `System.Collections.Immutable.ImmutableStack`
 * `System.Collections.Immutable.ImmutableStack<T>`
+* `System.Collections.Frozen.FrozenDictionary`
+* `System.Collections.Frozen.FrozenDictionary<TKey, TValue>`
+* `System.Collections.Frozen.FrozenSet`
+* `System.Collections.Frozen.FrozenSet<T>`
 
 ## Additional Documentation
 


### PR DESCRIPTION
This PR mentions `Frozen` collections in `System.Collections.Immutable` package's README.
Right now these types are missing in https://www.nuget.org/packages/System.Collections.Immutable/8.0.0-rc.2.23479.6#readme-body-tab