### PR TITLE
[release/7.0][mono] Backport offsets-tool fixes for Xcode 15 compatibility

### DIFF
--- a/src/mono/mono/tools/offsets-tool/clang/cindex.py
+++ b/src/mono/mono/tools/offsets-tool/clang/cindex.py
@@ -646,6 +646,11 @@ class BaseEnumeration(object):
 
     @classmethod
     def from_id(cls, id):
+        if cls == CursorKind and id == 300:
+            # --- DOTNET change ---
+            # The id of CursorKind.TRANSLATION_UNIT changed in https://github.com/llvm/llvm-project/commit/bb83f8e70bd1d56152f02307adacd718cd67e312,
+            # add mapping from the old to the new value so using the binding with an older clang still works.
+            return cls._kinds[350]
         if id >= len(cls._kinds) or cls._kinds[id] is None:
             raise ValueError('Unknown template argument kind %d' % id)
         return cls._kinds[id]
@@ -1312,7 +1317,7 @@ CursorKind.OMP_TEAMS_DISTRIBUTE_DIRECTIVE = CursorKind(271)
 #
 # The translation unit cursor exists primarily to act as the root cursor for
 # traversing the contents of a translation unit.
-CursorKind.TRANSLATION_UNIT = CursorKind(300)
+CursorKind.TRANSLATION_UNIT = CursorKind(350)
 
 ###
 # Attributes
@@ -1342,6 +1347,8 @@ CursorKind.VISIBILITY_ATTR = CursorKind(417)
 
 CursorKind.DLLEXPORT_ATTR = CursorKind(418)
 CursorKind.DLLIMPORT_ATTR = CursorKind(419)
+# Temporary fake value to work around xcode 15 beta / clang 15
+CursorKind.XCODEBETA_ATTR = CursorKind(437)
 CursorKind.CONVERGENT_ATTR = CursorKind(438)
 CursorKind.WARN_UNUSED_ATTR = CursorKind(439)
 CursorKind.WARN_UNUSED_RESULT_ATTR = CursorKind(440)
@@ -2059,6 +2066,7 @@ TypeKind.OBJCCLASS = TypeKind(28)
 TypeKind.OBJCSEL = TypeKind(29)
 TypeKind.FLOAT128 = TypeKind(30)
 TypeKind.HALF = TypeKind(31)
+TypeKind.IBM128 = TypeKind(40)
 TypeKind.COMPLEX = TypeKind(100)
 TypeKind.POINTER = TypeKind(101)
 TypeKind.BLOCKPOINTER = TypeKind(102)
@@ -2122,6 +2130,7 @@ TypeKind.OCLQUEUE = TypeKind(159)
 TypeKind.OCLRESERVEID = TypeKind(160)
 
 TypeKind.EXTVECTOR = TypeKind(176)
+TypeKind.ATOMIC = TypeKind(177)
 
 class RefQualifierKind(BaseEnumeration):
     """Describes a specific ref-qualifier of a type."""

--- a/src/mono/mono/tools/offsets-tool/offsets-tool.py
+++ b/src/mono/mono/tools/offsets-tool/offsets-tool.py
@@ -365,8 +365,11 @@ class OffsetsTool:
 			if type.size == -1:
 				continue
 			f.write ("DECL_SIZE2(%s,%s)\n" % (type.name, type.size))
+			done_fields = {}
 			for field in type.fields:
-				f.write ("DECL_OFFSET2(%s,%s,%s)\n" % (type.name, field.name, field.offset))
+				if field.name not in done_fields:
+					f.write ("DECL_OFFSET2(%s,%s,%s)\n" % (type.name, field.name, field.offset))
+					done_fields [field.name] = field.name
 		f.write ("#endif //disable metadata check\n")
 
 		f.write ("#ifndef DISABLE_JIT_OFFSETS\n")
@@ -376,8 +379,11 @@ class OffsetsTool:
 			if type.size == -1:
 				continue
 			f.write ("DECL_SIZE2(%s,%s)\n" % (type.name, type.size))
+			done_fields = {}
 			for field in type.fields:
-				f.write ("DECL_OFFSET2(%s,%s,%s)\n" % (type.name, field.name, field.offset))
+				if field.name not in done_fields:
+					f.write ("DECL_OFFSET2(%s,%s,%s)\n" % (type.name, field.name, field.offset))
+					done_fields [field.name] = field.name
 		f.write ("#endif //disable jit check\n")
 
 		f.write ("#endif //cross compiler checks\n")


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/93009
Backports relevant parts of https://github.com/dotnet/runtime/pull/88261, https://github.com/dotnet/runtime/pull/86256 and https://github.com/dotnet/runtime/pull/87190

## Customer Impact
Our official macOS builds in release/7.0 use an older Xcode for creating .NET 7 packages, but if we bump to a macOS build image which has Xcode 15 the mono build would fail because Xcode 15 contains some breaking changes.

This PR fixes these issues and allows us to build with latest Xcode. We're already using these changes in main and 8.0.

## Testing
Manually validated building with Xcode 15.0 works.

## Risk
Low, this is a build only change and makes sure we can build with newer Xcode versions.