### PR TITLE
[mono] Optimizing arm64 trampolines

### DIFF
--- a/src/mono/mono/arch/arm64/arm64-codegen.h
+++ b/src/mono/mono/arch/arm64/arm64-codegen.h
@@ -480,18 +480,19 @@ arm_encode_imm7 (int imm, int size)
 #define arm_neon_ldrq_lit(p, rd, target) arm_emit ((p), 0b00011100000000000000000000000000 | (0b10 << 30) | (arm_get_disp19 ((p), (target)) << 5) | (rd))
 #define arm_neon_ldrq_lit_fixup(p, target) *((guint32*)p) = (*((guint32*)p) & 0xff00001f) | (arm_get_disp19 ((p), (target)) << 5)
 
+#define ARM_MAX_ARITH_IMM (0xfff)
+
 /* Arithmetic (immediate) */
 static G_GNUC_UNUSED inline guint32
 arm_encode_arith_imm (int imm, guint32 *shift)
 {
 	// FIXME:
-	g_assert ((imm >= 0) && (imm < 0xfff));
+	g_assert ((imm >= 0) && (imm < ARM_MAX_ARITH_IMM));
 	*shift = 0;
 	return (guint32)imm;
 }
-
 // FIXME:
-#define arm_is_arith_imm(imm)  (((imm) >= 0) && ((imm) < 0xfff))
+#define arm_is_arith_imm(imm)  (((imm) >= 0) && ((imm) < ARM_MAX_ARITH_IMM))
 
 #define arm_format_alu_imm(p, sf, op, S, rd, rn, imm) do { \
 	guint32 _imm12, _shift; \
@@ -1048,7 +1049,12 @@ arm_encode_arith_imm (int imm, guint32 *shift)
 #define TYPE_F32 0
 #define TYPE_F64 1
 
-/* NEON :: move SIMD register*/
+/* NEON :: paired loads/stores */
+#define arm_neon_ldp_stp(p, opc, l, rt1, rt2, rn, imm7) arm_emit ((p), 0b00101101000000000000000000000000 | (opc) << 30 | (l) << 22 | (imm7) << 15 | (rt2) << 10 | (rn) << 5 | (rt1))
+#define arm_neon_stp_16b(p, rt1, rt2, rn, imm) arm_neon_ldp_stp ((p), 0b10, 0b0, (rt1), (rt2), (rn), arm_encode_imm7 (imm, 16))
+#define arm_neon_ltp_16b(p, rt1, rt2, rn, imm) arm_neon_ldp_stp ((p), 0b10, 0b1, (rt1), (rt2), (rn), arm_encode_imm7 (imm, 16))
+
+/* NEON :: move SIMD register */
 #define arm_neon_mov(p, rd, rn) arm_neon_orr ((p), VREG_FULL, (rd), (rn), (rn))
 #define arm_neon_mov_8b(p, rd, rn) arm_neon_orr ((p), VREG_LOW, (rd), (rn), (rn))
 

--- a/src/mono/mono/arch/arm64/arm64-codegen.h
+++ b/src/mono/mono/arch/arm64/arm64-codegen.h
@@ -1052,7 +1052,7 @@ arm_encode_arith_imm (int imm, guint32 *shift)
 /* NEON :: paired loads/stores */
 #define arm_neon_ldp_stp(p, opc, l, rt1, rt2, rn, imm7) arm_emit ((p), 0b00101101000000000000000000000000 | (opc) << 30 | (l) << 22 | (imm7) << 15 | (rt2) << 10 | (rn) << 5 | (rt1))
 #define arm_neon_stp_16b(p, rt1, rt2, rn, imm) arm_neon_ldp_stp ((p), 0b10, 0b0, (rt1), (rt2), (rn), arm_encode_imm7 (imm, 16))
-#define arm_neon_ltp_16b(p, rt1, rt2, rn, imm) arm_neon_ldp_stp ((p), 0b10, 0b1, (rt1), (rt2), (rn), arm_encode_imm7 (imm, 16))
+#define arm_neon_ldp_16b(p, rt1, rt2, rn, imm) arm_neon_ldp_stp ((p), 0b10, 0b1, (rt1), (rt2), (rn), arm_encode_imm7 (imm, 16))
 
 /* NEON :: move SIMD register */
 #define arm_neon_mov(p, rd, rn) arm_neon_orr ((p), VREG_FULL, (rd), (rn), (rn))


### PR DESCRIPTION
Two occurrences are addressed here:

(1) Sequential SIMD loads/stores try to use paired opcodes, e.g. in `generic_trampoline_jit`
```asm
A0 47 80 3D        str    q0, [x29, #0x110]  ;
A1 4B 80 3D        str    q1, [x29, #0x120]  ; Merge with above into one stp
A2 4F 80 3D        str    q2, [x29, #0x130]
A3 53 80 3D        str    q3, [x29, #0x140]
A4 57 80 3D        str    q4, [x29, #0x150]
A5 5B 80 3D        str    q5, [x29, #0x160]
A6 5F 80 3D        str    q6, [x29, #0x170]
A7 63 80 3D        str    q7, [x29, #0x180]
```

(2) Arithmetics with large immediate values takes advantage of the full immediate range (but not shifted imm), e.g. in `generic_trampoline_jit`:
```asm
31 02 04 91        add    x17, x17, #0x100
31 02 04 91        add    x17, x17, #0x100
31 82 00 91        add    x17, x17, #0x20   ; These three should fuse into add x17,x17,#0x220 
```
According to https://developer.arm.com/documentation/dui0801/c/A64-General-Instructions/ADD--immediate-?lang=en the immediate range is 0..4095