### PR TITLE
[browser] Disable HybridGlobalization failure

### DIFF
--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoFirstDayOfWeek.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoFirstDayOfWeek.cs
@@ -12,7 +12,9 @@ namespace System.Globalization.Tests
         {
             yield return new object[] { DateTimeFormatInfo.InvariantInfo, DayOfWeek.Sunday, "invariant" };
             yield return new object[] { new CultureInfo("en-US", false).DateTimeFormat, DayOfWeek.Sunday, "en-US" };
-            yield return new object[] { new CultureInfo("fr-FR", false).DateTimeFormat, DayOfWeek.Monday, "fr-FR" };
+            // ActiveIssue: https://github.com/dotnet/runtime/issues/93354
+            if (!PlatformDetection.IsHybridGlobalizationOnBrowser)
+                yield return new object[] { new CultureInfo("fr-FR", false).DateTimeFormat, DayOfWeek.Monday, "fr-FR" };
         }
 
         public static IEnumerable<object[]> FirstDayOfWeek_Get_TestData_HybridGlobalization()


### PR DESCRIPTION
Scenarios: browser (ChromeDriver 118.0.5993.0) and normal (v8-11.8.172) fail on Linux and Windows (but Windows does not preserve logs from Helix). Failures is not deterministic even though theoretically we should get the same result each time. Disabling till I reproduce and investigate.