### PR TITLE
Emit/Call member references in new ILGenerator

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeILGenerator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeILGenerator.cs
@@ -128,7 +128,7 @@ namespace System.Reflection.Emit
                 m_ILStream[m_length++] = (byte)opcodeValue;
             }
 
-            UpdateStackSize(opcode, opcode.StackChange());
+            UpdateStackSize(opcode, opcode.StackDifference());
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/Opcode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/Opcode.cs
@@ -45,7 +45,7 @@ namespace System.Reflection.Emit
         internal bool EndsUncondJmpBlk() =>
             (m_flags & EndsUncondJmpBlkFlag) != 0;
 
-        internal int StackChange() =>
+        public int StackDifference() =>
             m_flags >> StackChangeShift;
 
         public OperandType OperandType => (OperandType)(m_flags & OperandTypeMask);

--- a/src/libraries/System.Reflection.Emit/src/Resources/Strings.resx
+++ b/src/libraries/System.Reflection.Emit/src/Resources/Strings.resx
@@ -186,4 +186,7 @@
   <data name="InvalidOperation_ShouldNotHaveMethodBody" xml:space="preserve">
     <value>Method body should not exist.</value>
   </data>
+  <data name="Argument_NotMethodCallOpcode" xml:space="preserve">
+    <value>The specified opcode cannot be passed to EmitCall.</value>
+  </data>
 </root>

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/FieldBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/FieldBuilderImpl.cs
@@ -7,8 +7,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
 
 namespace System.Reflection.Emit
 {
@@ -23,6 +21,7 @@ namespace System.Reflection.Emit
         internal int _offset;
         internal List<CustomAttributeWrapper>? _customAttributes;
         internal object? _defaultValue = DBNull.Value;
+        internal FieldDefinitionHandle _handle;
 
         internal FieldBuilderImpl(TypeBuilderImpl typeBuilder, string fieldName, Type type, FieldAttributes attributes)
         {
@@ -107,7 +106,7 @@ namespace System.Reflection.Emit
                     return;
                 case "System.Runtime.InteropServices.MarshalAsAttribute":
                     _attributes |= FieldAttributes.HasFieldMarshal;
-                    _marshallingData = MarshallingData.CreateMarshallingData(con, binaryAttribute, isField : true);
+                    _marshallingData = MarshallingData.CreateMarshallingData(con, binaryAttribute, isField: true);
                     return;
             }
 
@@ -124,7 +123,7 @@ namespace System.Reflection.Emit
 
         #region MemberInfo Overrides
 
-        public override int MetadataToken => throw new NotImplementedException();
+        public override int MetadataToken => _handle == default ? 0 : MetadataTokens.GetToken(_handle);
 
         public override Module Module => _typeBuilder.Module;
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
@@ -46,10 +46,12 @@ namespace System.Reflection.Emit
             {
                 StackBehaviour.Pop0
                 or StackBehaviour.Push0 => 0,
+                
                 StackBehaviour.Pop1
                 or StackBehaviour.Popi
                 or StackBehaviour.Popref
                 or StackBehaviour.Varpop => -1,
+                
                 StackBehaviour.Pop1_pop1
                 or StackBehaviour.Popi_pop1
                 or StackBehaviour.Popi_popi
@@ -58,6 +60,7 @@ namespace System.Reflection.Emit
                 or StackBehaviour.Popi_popr8
                 or StackBehaviour.Popref_pop1
                 or StackBehaviour.Popref_popi => -2,
+                
                 StackBehaviour.Popi_popi_popi
                 or StackBehaviour.Popref_popi_pop1
                 or StackBehaviour.Popref_popi_popi
@@ -65,6 +68,7 @@ namespace System.Reflection.Emit
                 or StackBehaviour.Popref_popi_popr4
                 or StackBehaviour.Popref_popi_popr8
                 or StackBehaviour.Popref_popi_popref => -3,
+                
                 StackBehaviour.Push1
                 or StackBehaviour.Pushi
                 or StackBehaviour.Pushi8
@@ -72,7 +76,9 @@ namespace System.Reflection.Emit
                 or StackBehaviour.Pushr8
                 or StackBehaviour.Pushref
                 or StackBehaviour.Varpush => 1,
+                
                 StackBehaviour.Push1_push1 => 2,
+                
                 _ => throw new InvalidOperationException()
             };
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
@@ -46,10 +46,10 @@ namespace System.Reflection.Emit
             {
                 StackBehaviour.Pop0 or
                 StackBehaviour.Push0 => 0,
-                StackBehaviour.Pop1 or
-                StackBehaviour.Popi or
-                StackBehaviour.Popref or
-                StackBehaviour.Varpop => -1,
+                StackBehaviour.Pop1
+                or StackBehaviour.Popi
+                or StackBehaviour.Popref
+                or StackBehaviour.Varpop => -1,
                 StackBehaviour.Pop1_pop1 or
                 StackBehaviour.Popi_pop1 or
                 StackBehaviour.Popi_popi or
@@ -80,10 +80,7 @@ namespace System.Reflection.Emit
         {
             _currentStack += GetStackChangeFor(opCode.StackBehaviourPush) + GetStackChangeFor(opCode.StackBehaviourPop);
 
-            if (_currentStack > _maxStackSize)
-            {
-                _maxStackSize = _currentStack;
-            }
+            _maxStackSize = Math.Max(_maxStackSize, _currentStack);
         }
 
         public void EmitOpcode(OpCode opcode)
@@ -97,10 +94,7 @@ namespace System.Reflection.Emit
             UpdateStackSize(opcode);
         }
 
-        public override void Emit(OpCode opcode)
-        {
-            EmitOpcode(opcode);
-        }
+        public override void Emit(OpCode opcode) => EmitOpcode(opcode);
 
         public override void Emit(OpCode opcode, byte arg)
         {

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
@@ -44,34 +44,34 @@ namespace System.Reflection.Emit
         private static int GetStackChangeFor(StackBehaviour stackBehaviour) =>
             stackBehaviour switch
             {
-                StackBehaviour.Pop0 or
-                StackBehaviour.Push0 => 0,
+                StackBehaviour.Pop0
+                or StackBehaviour.Push0 => 0,
                 StackBehaviour.Pop1
                 or StackBehaviour.Popi
                 or StackBehaviour.Popref
                 or StackBehaviour.Varpop => -1,
-                StackBehaviour.Pop1_pop1 or
-                StackBehaviour.Popi_pop1 or
-                StackBehaviour.Popi_popi or
-                StackBehaviour.Popi_popi8 or
-                StackBehaviour.Popi_popr4 or
-                StackBehaviour.Popi_popr8 or
-                StackBehaviour.Popref_pop1 or
-                StackBehaviour.Popref_popi => -2,
-                StackBehaviour.Popi_popi_popi or
-                StackBehaviour.Popref_popi_pop1 or
-                StackBehaviour.Popref_popi_popi or
-                StackBehaviour.Popref_popi_popi8 or
-                StackBehaviour.Popref_popi_popr4 or
-                StackBehaviour.Popref_popi_popr8 or
-                StackBehaviour.Popref_popi_popref => -3,
-                StackBehaviour.Push1 or
-                StackBehaviour.Pushi or
-                StackBehaviour.Pushi8 or
-                StackBehaviour.Pushr4 or
-                StackBehaviour.Pushr8 or
-                StackBehaviour.Pushref or
-                StackBehaviour.Varpush => 1,
+                StackBehaviour.Pop1_pop1
+                or StackBehaviour.Popi_pop1
+                or StackBehaviour.Popi_popi
+                or StackBehaviour.Popi_popi8
+                or StackBehaviour.Popi_popr4
+                or StackBehaviour.Popi_popr8
+                or StackBehaviour.Popref_pop1
+                or StackBehaviour.Popref_popi => -2,
+                StackBehaviour.Popi_popi_popi
+                or StackBehaviour.Popref_popi_pop1
+                or StackBehaviour.Popref_popi_popi
+                or StackBehaviour.Popref_popi_popi8
+                or StackBehaviour.Popref_popi_popr4
+                or StackBehaviour.Popref_popi_popr8
+                or StackBehaviour.Popref_popi_popref => -3,
+                StackBehaviour.Push1
+                or StackBehaviour.Pushi
+                or StackBehaviour.Pushi8
+                or StackBehaviour.Pushr4
+                or StackBehaviour.Pushr8
+                or StackBehaviour.Pushref
+                or StackBehaviour.Varpush => 1,
                 StackBehaviour.Push1_push1 => 2,
                 _ => throw new InvalidOperationException()
             };

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
@@ -46,12 +46,12 @@ namespace System.Reflection.Emit
             {
                 StackBehaviour.Pop0
                 or StackBehaviour.Push0 => 0,
-                
+
                 StackBehaviour.Pop1
                 or StackBehaviour.Popi
                 or StackBehaviour.Popref
                 or StackBehaviour.Varpop => -1,
-                
+
                 StackBehaviour.Pop1_pop1
                 or StackBehaviour.Popi_pop1
                 or StackBehaviour.Popi_popi
@@ -60,7 +60,7 @@ namespace System.Reflection.Emit
                 or StackBehaviour.Popi_popr8
                 or StackBehaviour.Popref_pop1
                 or StackBehaviour.Popref_popi => -2,
-                
+
                 StackBehaviour.Popi_popi_popi
                 or StackBehaviour.Popref_popi_pop1
                 or StackBehaviour.Popref_popi_popi
@@ -68,7 +68,7 @@ namespace System.Reflection.Emit
                 or StackBehaviour.Popref_popi_popr4
                 or StackBehaviour.Popref_popi_popr8
                 or StackBehaviour.Popref_popi_popref => -3,
-                
+
                 StackBehaviour.Push1
                 or StackBehaviour.Pushi
                 or StackBehaviour.Pushi8
@@ -76,9 +76,9 @@ namespace System.Reflection.Emit
                 or StackBehaviour.Pushr8
                 or StackBehaviour.Pushref
                 or StackBehaviour.Varpush => 1,
-                
+
                 StackBehaviour.Push1_push1 => 2,
-                
+
                 _ => throw new InvalidOperationException()
             };
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers.Binary;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace System.Reflection.Emit
@@ -17,6 +15,7 @@ namespace System.Reflection.Emit
         private readonly InstructionEncoder _il;
         private bool _hasDynamicStackAllocation;
         private int _maxStackSize;
+        private int _currentStack;
 
         internal ILGeneratorImpl(MethodBuilder methodBuilder, int size)
         {
@@ -42,40 +41,88 @@ namespace System.Reflection.Emit
         public override LocalBuilder DeclareLocal(Type localType, bool pinned) => throw new NotImplementedException();
         public override Label DefineLabel() => throw new NotImplementedException();
 
-        public override void Emit(OpCode opcode)
+        private static int GetStackChangeFor(StackBehaviour stackBehaviour) =>
+            stackBehaviour switch
+            {
+                StackBehaviour.Pop0 or
+                StackBehaviour.Push0 => 0,
+                StackBehaviour.Pop1 or
+                StackBehaviour.Popi or
+                StackBehaviour.Popref or
+                StackBehaviour.Varpop => -1,
+                StackBehaviour.Pop1_pop1 or
+                StackBehaviour.Popi_pop1 or
+                StackBehaviour.Popi_popi or
+                StackBehaviour.Popi_popi8 or
+                StackBehaviour.Popi_popr4 or
+                StackBehaviour.Popi_popr8 or
+                StackBehaviour.Popref_pop1 or
+                StackBehaviour.Popref_popi => -2,
+                StackBehaviour.Popi_popi_popi or
+                StackBehaviour.Popref_popi_pop1 or
+                StackBehaviour.Popref_popi_popi or
+                StackBehaviour.Popref_popi_popi8 or
+                StackBehaviour.Popref_popi_popr4 or
+                StackBehaviour.Popref_popi_popr8 or
+                StackBehaviour.Popref_popi_popref => -3,
+                StackBehaviour.Push1 or
+                StackBehaviour.Pushi or
+                StackBehaviour.Pushi8 or
+                StackBehaviour.Pushr4 or
+                StackBehaviour.Pushr8 or
+                StackBehaviour.Pushref or
+                StackBehaviour.Varpush => 1,
+                StackBehaviour.Push1_push1 => 2,
+                _ => throw new InvalidOperationException()
+            };
+
+        private void UpdateStackSize(OpCode opCode)
+        {
+            _currentStack += GetStackChangeFor(opCode.StackBehaviourPush) + GetStackChangeFor(opCode.StackBehaviourPop);
+
+            if (_currentStack > _maxStackSize)
+            {
+                _maxStackSize = _currentStack;
+            }
+        }
+
+        public void EmitOpcode(OpCode opcode)
         {
             if (opcode == OpCodes.Localloc)
             {
                 _hasDynamicStackAllocation = true;
             }
-            _il.OpCode((ILOpCode)opcode.Value);
 
-            // TODO: for now only count the Opcodes emitted, in order to calculate it correctly we might need to make internal Opcode APIs public
-            // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/Opcode.cs#L48
-            _maxStackSize++;
+            _il.OpCode((ILOpCode)opcode.Value);
+            UpdateStackSize(opcode);
+        }
+
+        public override void Emit(OpCode opcode)
+        {
+            EmitOpcode(opcode);
         }
 
         public override void Emit(OpCode opcode, byte arg)
         {
-            _il.OpCode((ILOpCode)opcode.Value);
+            EmitOpcode(opcode);
             _builder.WriteByte(arg);
         }
 
         public override void Emit(OpCode opcode, double arg)
         {
-            _il.OpCode((ILOpCode)opcode.Value);
+            EmitOpcode(opcode);
             _builder.WriteDouble(arg);
         }
 
         public override void Emit(OpCode opcode, float arg)
         {
-            _il.OpCode((ILOpCode)opcode.Value);
+            EmitOpcode(opcode);
             _builder.WriteSingle(arg);
         }
 
         public override void Emit(OpCode opcode, short arg)
         {
-            _il.OpCode((ILOpCode)opcode.Value);
+            EmitOpcode(opcode);
             _builder.WriteInt16(arg);
         }
 
@@ -86,26 +133,25 @@ namespace System.Reflection.Emit
             {
                 if (arg >= -1 && arg <= 8)
                 {
-                    _il.OpCode(arg switch
+                    EmitOpcode(arg switch
                     {
-                        -1 => ILOpCode.Ldc_i4_m1,
-                        0 => ILOpCode.Ldc_i4_0,
-                        1 => ILOpCode.Ldc_i4_1,
-                        2 => ILOpCode.Ldc_i4_2,
-                        3 => ILOpCode.Ldc_i4_3,
-                        4 => ILOpCode.Ldc_i4_4,
-                        5 => ILOpCode.Ldc_i4_5,
-                        6 => ILOpCode.Ldc_i4_6,
-                        7 => ILOpCode.Ldc_i4_7,
-                        _ => ILOpCode.Ldc_i4_8,
+                        -1 => OpCodes.Ldc_I4_M1,
+                        0 => OpCodes.Ldc_I4_0,
+                        1 => OpCodes.Ldc_I4_1,
+                        2 => OpCodes.Ldc_I4_2,
+                        3 => OpCodes.Ldc_I4_3,
+                        4 => OpCodes.Ldc_I4_4,
+                        5 => OpCodes.Ldc_I4_5,
+                        6 => OpCodes.Ldc_I4_6,
+                        7 => OpCodes.Ldc_I4_7,
+                        _ => OpCodes.Ldc_I4_8
                     });
                     return;
                 }
 
                 if (arg >= -128 && arg <= 127)
                 {
-                    _il.OpCode(ILOpCode.Ldc_i4_s);
-                    _builder.WriteSByte((sbyte)arg) ;
+                    Emit(OpCodes.Ldc_I4_S, (sbyte)arg);
                     return;
                 }
             }
@@ -113,27 +159,25 @@ namespace System.Reflection.Emit
             {
                 if ((uint)arg <= 3)
                 {
-                    _il.OpCode(arg switch
+                    EmitOpcode(arg switch
                     {
-                        0 => ILOpCode.Ldarg_0,
-                        1 => ILOpCode.Ldarg_1,
-                        2 => ILOpCode.Ldarg_2,
-                        _ => ILOpCode.Ldarg_3,
+                        0 => OpCodes.Ldarg_0,
+                        1 => OpCodes.Ldarg_1,
+                        2 => OpCodes.Ldarg_2,
+                        _ => OpCodes.Ldarg_3,
                     });
                     return;
                 }
 
                 if ((uint)arg <= byte.MaxValue)
                 {
-                    _il.OpCode(ILOpCode.Ldarg_s);
-                    _builder.WriteByte((byte)arg);
+                    Emit(OpCodes.Ldarg_S, (byte)arg);
                     return;
                 }
 
                 if ((uint)arg <= ushort.MaxValue) // this will be true except on misuse of the opcode
                 {
-                    _il.OpCode(ILOpCode.Ldarg);
-                    _builder.WriteInt16((short)arg);
+                    Emit(OpCodes.Ldarg, (short)arg);
                     return;
                 }
             }
@@ -141,15 +185,13 @@ namespace System.Reflection.Emit
             {
                 if ((uint)arg <= byte.MaxValue)
                 {
-                    _il.OpCode(ILOpCode.Ldarga_s);
-                    _builder.WriteByte((byte)arg);
+                    Emit(OpCodes.Ldarga_S, (byte)arg);
                     return;
                 }
 
                 if ((uint)arg <= ushort.MaxValue) // this will be true except on misuse of the opcode
                 {
-                    _il.OpCode(ILOpCode.Ldarga);
-                    _builder.WriteInt16((short)arg);
+                    Emit(OpCodes.Ldarga, (short)arg);
                     return;
                 }
             }
@@ -157,27 +199,25 @@ namespace System.Reflection.Emit
             {
                 if ((uint)arg <= byte.MaxValue)
                 {
-                    _il.OpCode(ILOpCode.Starg_s);
-                    _builder.WriteByte((byte)arg);
+                    Emit(OpCodes.Starg_S, (byte)arg);
                     return;
                 }
 
                 if ((uint)arg <= ushort.MaxValue) // this will be true except on misuse of the opcode
                 {
-                    _il.OpCode(ILOpCode.Starg);
-                    _builder.WriteInt16((short)arg);
+                    Emit(OpCodes.Starg, (short)arg);
                     return;
                 }
             }
 
             // For everything else, put the opcode followed by the arg onto the stream of instructions.
-            _il.OpCode((ILOpCode)opcode.Value);
+            EmitOpcode(opcode);
             _builder.WriteInt32(arg);
         }
 
         public override void Emit(OpCode opcode, long arg)
         {
-            _il.OpCode((ILOpCode)opcode.Value);
+            EmitOpcode(opcode);
             _il.CodeBuilder.WriteInt64(arg);
         }
 
@@ -187,7 +227,7 @@ namespace System.Reflection.Emit
             // represented by str.
             ModuleBuilder modBuilder = (ModuleBuilder)_methodBuilder.Module;
             int tempVal = modBuilder.GetStringMetadataToken(str);
-            _il.OpCode((ILOpCode)opcode.Value);
+            EmitOpcode(opcode);
             _il.Token(tempVal);
         }
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ILGeneratorImpl.cs
@@ -41,51 +41,9 @@ namespace System.Reflection.Emit
         public override LocalBuilder DeclareLocal(Type localType, bool pinned) => throw new NotImplementedException();
         public override Label DefineLabel() => throw new NotImplementedException();
 
-        private static int GetStackChangeFor(StackBehaviour stackBehaviour) =>
-            stackBehaviour switch
-            {
-                StackBehaviour.Pop0
-                or StackBehaviour.Push0 => 0,
-
-                StackBehaviour.Pop1
-                or StackBehaviour.Popi
-                or StackBehaviour.Popref
-                or StackBehaviour.Varpop => -1,
-
-                StackBehaviour.Pop1_pop1
-                or StackBehaviour.Popi_pop1
-                or StackBehaviour.Popi_popi
-                or StackBehaviour.Popi_popi8
-                or StackBehaviour.Popi_popr4
-                or StackBehaviour.Popi_popr8
-                or StackBehaviour.Popref_pop1
-                or StackBehaviour.Popref_popi => -2,
-
-                StackBehaviour.Popi_popi_popi
-                or StackBehaviour.Popref_popi_pop1
-                or StackBehaviour.Popref_popi_popi
-                or StackBehaviour.Popref_popi_popi8
-                or StackBehaviour.Popref_popi_popr4
-                or StackBehaviour.Popref_popi_popr8
-                or StackBehaviour.Popref_popi_popref => -3,
-
-                StackBehaviour.Push1
-                or StackBehaviour.Pushi
-                or StackBehaviour.Pushi8
-                or StackBehaviour.Pushr4
-                or StackBehaviour.Pushr8
-                or StackBehaviour.Pushref
-                or StackBehaviour.Varpush => 1,
-
-                StackBehaviour.Push1_push1 => 2,
-
-                _ => throw new InvalidOperationException()
-            };
-
         private void UpdateStackSize(OpCode opCode)
         {
-            _currentStack += GetStackChangeFor(opCode.StackBehaviourPush) + GetStackChangeFor(opCode.StackBehaviourPop);
-
+            _currentStack += opCode.StackDifference();
             _maxStackSize = Math.Max(_maxStackSize, _currentStack);
         }
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
@@ -27,6 +27,7 @@ namespace System.Reflection.Emit
         internal DllImportData? _dllImportData;
         internal List<CustomAttributeWrapper>? _customAttributes;
         internal ParameterBuilderImpl[]? _parameters;
+        internal MethodDefinitionHandle _handle;
 
         internal MethodBuilderImpl(string name, MethodAttributes attributes, CallingConventions callingConventions, Type? returnType,
             Type[]? parameterTypes, ModuleBuilderImpl module, TypeBuilderImpl declaringType)
@@ -51,6 +52,8 @@ namespace System.Reflection.Emit
             _methodImplFlags = MethodImplAttributes.IL;
             _initLocals = true;
         }
+
+        internal int ParameterCount => _parameterTypes == null? 0 : _parameterTypes.Length;
 
         internal ILGeneratorImpl? ILGeneratorImpl => _ilGenerator;
 
@@ -201,7 +204,7 @@ namespace System.Reflection.Emit
         public override bool IsSecurityCritical => true;
         public override bool IsSecuritySafeCritical => false;
         public override bool IsSecurityTransparent => false;
-        public override int MetadataToken { get => throw new NotImplementedException(); }
+        public override int MetadataToken => _handle == default ? 0 : MetadataTokens.GetToken(_handle);
         public override RuntimeMethodHandle MethodHandle => throw new NotSupportedException(SR.NotSupported_DynamicModule);
         public override Type? ReflectedType { get => throw new NotImplementedException(); }
         public override ParameterInfo ReturnParameter { get => throw new NotImplementedException(); }
@@ -224,8 +227,7 @@ namespace System.Reflection.Emit
         public override MethodImplAttributes GetMethodImplementationFlags()
             => _methodImplFlags;
 
-        public override ParameterInfo[] GetParameters()
-            => throw new NotImplementedException();
+        public override ParameterInfo[] GetParameters() => throw new NotImplementedException();
 
         public override object Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
              => throw new NotSupportedException(SR.NotSupported_DynamicModule);

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -245,4 +245,4 @@ namespace System.Reflection.Emit.Tests
             return ilgType.GetMethod("GetMaxStackSize", BindingFlags.NonPublic | BindingFlags.Instance, Type.EmptyTypes);
         }
     }
-}  
+}

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -168,5 +168,81 @@ namespace System.Reflection.Emit.Tests
                 Assert.Equal(OpCodes.Ldc_I8.Value, longBody[0]);
             }
         }
+
+        [Fact]
+        public void ILOffset_Test()
+        {
+            AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderTypeBuilderAndSaveMethod(out TypeBuilder type, out MethodInfo saveMethod);
+            MethodBuilder method = type.DefineMethod("Method1", MethodAttributes.Public | MethodAttributes.Static, typeof(Type), new Type[0]);
+            ILGenerator ilGenerator = method.GetILGenerator();
+
+            Assert.Equal(0, ilGenerator.ILOffset);
+            ilGenerator.Emit(OpCodes.Ret);
+            Assert.Equal(1, ilGenerator.ILOffset);
+        }
+
+        [Fact]
+        public void ILMaxStack_Test()
+        {
+            using (TempFile file = TempFile.Create())
+            {
+                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderTypeBuilderAndSaveMethod(out TypeBuilder type, out MethodInfo saveMethod);
+                MethodBuilder method1 = type.DefineMethod("Method1", MethodAttributes.Public, typeof(long), new Type[] { typeof(int), typeof(long), typeof(short), typeof(byte) });
+                ILGenerator il1 = method1.GetILGenerator();
+
+                // public int Method1(int x, int y, short z, byte r) =>
+                //  x + (z + 2 * (r + (8 * y + 3 * (y - (5 + x))))
+                il1.Emit(OpCodes.Ldarg_1);     // push 1 MaxStack 1
+                il1.Emit(OpCodes.Ldarg_3);     // push 1 MaxStack 2
+                il1.Emit(OpCodes.Ldc_I4_2);    // push 1 MaxStack 3
+                il1.Emit(OpCodes.Ldarg_S, 4);  // push 1 MaxStack 4
+                il1.Emit(OpCodes.Ldc_I4_8);    // push 1 MaxStack 5
+                il1.Emit(OpCodes.Ldarg_2);     // push 1 MaxStack 6
+                il1.Emit(OpCodes.Mul);         // pop 2 push 1 MaxStack 5
+                il1.Emit(OpCodes.Ldc_I4_3);    // push 1 MaxStack 6
+                il1.Emit(OpCodes.Ldarg_2);     // push 1 MaxStack 7
+                il1.Emit(OpCodes.Ldc_I4_5);    // push 1 MaxStack 8
+                il1.Emit(OpCodes.Ldarg_1);     // push 1 MaxStack 9
+                il1.Emit(OpCodes.Add);         // pop 2 push 1 stack size 8 
+                il1.Emit(OpCodes.Sub);         // pop 2 push 1 stack size 7
+                il1.Emit(OpCodes.Mul);         // pop 2 push 1 stack size 6
+                il1.Emit(OpCodes.Add);         // pop 2 push 1 stack size 5
+                il1.Emit(OpCodes.Add);         // pop 2 push 1 stack size 4
+                il1.Emit(OpCodes.Mul);         // pop 2 push 1 stack size 3
+                il1.Emit(OpCodes.Add);         // pop 2 push 1 stack size 2
+                il1.Emit(OpCodes.Add);         // pop 2 push 1 stack size 1
+                il1.Emit(OpCodes.Ret);         // pop 1 stack size 0
+
+                MethodBuilder method2 = type.DefineMethod("Method2", MethodAttributes.Public, typeof(int), new Type[] { typeof(int), typeof(byte) });
+                ILGenerator il2 = method2.GetILGenerator();
+
+                // int Method2(int x, int y) =>  x + (y + 18);
+                il2.Emit(OpCodes.Ldarg_1);     // push 1 MaxStack 1
+                il2.Emit(OpCodes.Ldarg_2);     // push 1 MaxStack 2
+                il2.Emit(OpCodes.Ldc_I4_S, 8); // push 1 MaxStack 3
+                il2.Emit(OpCodes.Add);         // pop 2 push 1 stack size 2
+                il2.Emit(OpCodes.Add);         // pop 2 push 1 stack size 1
+                il2.Emit(OpCodes.Ret);         // pop 1 stack size 0
+
+                saveMethod.Invoke(ab, new object[] { file.Path });
+
+                MethodInfo getMaxStackSizeMethod = LoadILGenerator_GetMaxStackSizeMethod();
+                Assert.Equal(9, getMaxStackSizeMethod.Invoke(il1, new object[0]));
+                Assert.Equal(3, getMaxStackSizeMethod.Invoke(il2, new object[0]));
+
+                Assembly assemblyFromDisk = AssemblySaveTools.LoadAssemblyFromPath(file.Path);
+                Type typeFromDisk = assemblyFromDisk.Modules.First().GetType("MyType");
+                MethodBody body1 = typeFromDisk.GetMethod("Method1").GetMethodBody();
+                MethodBody body2 = typeFromDisk.GetMethod("Method2").GetMethodBody();
+                Assert.Equal(9, body1.MaxStackSize);
+                Assert.Equal(8, body2.MaxStackSize); // apparently doesn't write lower than 8 
+            }
+        }
+
+        private MethodInfo LoadILGenerator_GetMaxStackSizeMethod()
+        {
+            Type ilgType = Type.GetType("System.Reflection.Emit.ILGeneratorImpl, System.Reflection.Emit", throwOnError: true)!;
+            return ilgType.GetMethod("GetMaxStackSize", BindingFlags.NonPublic | BindingFlags.Instance, Type.EmptyTypes);
+        }
     }
-}
+}  

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTools.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTools.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Reflection.Emit.Tests

--- a/src/libraries/System.Reflection.Primitives/ref/System.Reflection.Primitives.cs
+++ b/src/libraries/System.Reflection.Primitives/ref/System.Reflection.Primitives.cs
@@ -33,6 +33,7 @@ namespace System.Reflection.Emit
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public bool Equals(System.Reflection.Emit.OpCode obj) { throw null; }
         public override int GetHashCode() { throw null; }
+        public int StackDifference() { throw null; }
         public static bool operator ==(System.Reflection.Emit.OpCode a, System.Reflection.Emit.OpCode b) { throw null; }
         public static bool operator !=(System.Reflection.Emit.OpCode a, System.Reflection.Emit.OpCode b) { throw null; }
         public override string? ToString() { throw null; }


### PR DESCRIPTION
Add implementation for `Emit(OpCode opcode, FieldInfo field)`, `Emit(OpCode opcode, MethodInfo meth)`, `Emit(OpCode opcode, Type cls)` and `EmitCall(OpCode opcode, MethodInfo methodInfo, Type[]? optionalParameterTypes)`

The PR depend on https://github.com/dotnet/runtime/pull/93244 which is blocked by https://github.com/dotnet/runtime/issues/93419, will be cleaned up after #93244 merged.
Contributes to https://github.com/dotnet/runtime/issues/92975