### PR TITLE
Disable negative interop tests on GCStress.

### DIFF
--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionNegativeTest.csproj
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionNegativeTest.csproj
@@ -8,6 +8,7 @@
     <CLRTestExitCode>134</CLRTestExitCode>
     <CLRTestExitCode Condition="'$(TestWrapperTargetsWindows)' == 'true'">-2146233082</CLRTestExitCode>
     <CLRTestPriority>1</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(InteropCommonDir)CheckGCMode.cs" />

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyNegativeTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyNegativeTest.csproj
@@ -9,6 +9,7 @@
     <CLRTestExitCode Condition="'$(TestWrapperTargetsWindows)' == 'true'">-2146233082</CLRTestExitCode>
     <CLRTestPriority>1</CLRTestPriority>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="UnmanagedCallersOnlyNegativeTest.cs" />


### PR DESCRIPTION
Fixes #93533. Fixes #93534

These tests both do bad things with GC modes and intentionally crash the process. Disable these tests on GCStress runs as these tests are expected to violate runtime invariants.