### PR TITLE
Update test build group boundaries to today test distribution

### DIFF
--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -65,11 +65,11 @@
         <GroupNumber>1</GroupNumber>
       </_GroupStartsWith> -->
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\Methodical\Boxing\callconv\_relinstance_il.ilproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_General_r.csproj">
         <GroupNumber>2</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b35351\b35351.ilproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_X86_Avx_r.csproj">
         <GroupNumber>3</GroupNumber>
       </_GroupStartsWith>
     </ItemGroup>
@@ -80,39 +80,39 @@
         <GroupNumber>1</GroupNumber>
       </_GroupStartsWith> -->
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\CodeGenBringUpTests\DblNeg_ro.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_Arm_r.csproj">
         <GroupNumber>2</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\Directed\shift\uint32_d.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_General_r.csproj">
         <GroupNumber>3</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\Methodical\AsgOp\r8\r8flat_cs_r.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_General_ro.csproj">
         <GroupNumber>4</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit4_ro.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_X86_Avx512_r.csproj">
         <GroupNumber>5</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25701\b25701.ilproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_X86_Avx_r.csproj">
         <GroupNumber>6</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\Regression\JitBlue\GitHub_19171\GitHub_19171.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\jit64\jit64_1.csproj">
         <GroupNumber>7</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value030.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\opt\JIT.opt.csproj">
         <GroupNumber>8</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest225\Generated225.ilproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\SIMD\AbsGeneric_r.csproj">
         <GroupNumber>9</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)Loader\classloader\generics\VSD\Class2_ImplicitOverrideVirtualNewslot.csproj">
+      <_GroupStartsWith Include="$(TestRoot)Loader\classloader\Casting\Functionpointer.csproj">
         <GroupNumber>10</GroupNumber>
       </_GroupStartsWith>
     </ItemGroup>

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -65,11 +65,11 @@
         <GroupNumber>1</GroupNumber>
       </_GroupStartsWith> -->
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics">
+      <_GroupStartsWith Include="$(TestRoot)JIT\Methodical">
         <GroupNumber>2</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\Methodical">
+      <_GroupStartsWith Include="$(TestRoot)JIT\Regression">
         <GroupNumber>3</GroupNumber>
       </_GroupStartsWith>
     </ItemGroup>
@@ -80,31 +80,31 @@
         <GroupNumber>1</GroupNumber>
       </_GroupStartsWith> -->
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_Arm_r.csproj">
+      <_GroupStartsWith Include="$(TestRoot)Interop">
         <GroupNumber>2</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_General_r.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\Directed">
         <GroupNumber>3</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_General_ro.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\IL_Conformance">
         <GroupNumber>4</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_X86_Avx512_r.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\Methodical">
         <GroupNumber>5</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_X86_Avx_r.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\Methodical\flowgraph">
         <GroupNumber>6</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\jit64">
+      <_GroupStartsWith Include="$(TestRoot)JIT\opt">
         <GroupNumber>7</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\opt">
+      <_GroupStartsWith Include="$(TestRoot)JIT\Regression\CLR-x86-JIT\V1-M11-Beta2">
         <GroupNumber>8</GroupNumber>
       </_GroupStartsWith>
 
@@ -112,7 +112,7 @@
         <GroupNumber>9</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)Loader\classloader\Casting">
+      <_GroupStartsWith Include="$(TestRoot)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest200">
         <GroupNumber>10</GroupNumber>
       </_GroupStartsWith>
     </ItemGroup>
@@ -128,11 +128,11 @@
         <InGroup>True</InGroup>
       </AllProjects>
 
-      <AllProjects Condition=" '$(_GroupStartsWith)' != '' And $([System.StringComparer]::Ordinal.Compare($(_GroupStartsWith), %(Identity))) &gt; 0 ">
+      <AllProjects Condition=" '$(_GroupStartsWith)' != '' And $([System.StringComparer]::OrdinalIgnoreCase.Compare($(_GroupStartsWith), %(Identity))) &gt; 0 ">
         <InGroup>False</InGroup>
       </AllProjects>
 
-      <AllProjects Condition=" '$(_GroupEndsWithExcl)' != '' And $([System.StringComparer]::Ordinal.Compare(%(Identity), $(_GroupEndsWithExcl))) &gt;= 0 ">
+      <AllProjects Condition=" '$(_GroupEndsWithExcl)' != '' And $([System.StringComparer]::OrdinalIgnoreCase.Compare(%(Identity), $(_GroupEndsWithExcl))) &gt;= 0 ">
         <InGroup>False</InGroup>
       </AllProjects>
     </ItemGroup>
@@ -142,6 +142,9 @@
         <AdditionalProperties>TargetOS=$(TargetOS)</AdditionalProperties>
       </Project>
     </ItemGroup>
+
+    <Message Importance="High" Text="Number of test projects total: @(Project->Count())" Condition="'$(__TestGroupToBuild)' == ''" />
+    <Message Importance="High" Text="Number of test projects in group $(__TestGroupToBuild): @(Project->Count())" Condition="'$(__TestGroupToBuild)' != ''" />
 
   </Target>
 

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -65,11 +65,11 @@
         <GroupNumber>1</GroupNumber>
       </_GroupStartsWith> -->
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_General_r.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics">
         <GroupNumber>2</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\HardwareIntrinsics\HardwareIntrinsics_X86_Avx_r.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\Methodical">
         <GroupNumber>3</GroupNumber>
       </_GroupStartsWith>
     </ItemGroup>
@@ -100,19 +100,19 @@
         <GroupNumber>6</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\jit64\jit64_1.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\jit64">
         <GroupNumber>7</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\opt\JIT.opt.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\opt">
         <GroupNumber>8</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)JIT\SIMD\AbsGeneric_r.csproj">
+      <_GroupStartsWith Include="$(TestRoot)JIT\SIMD">
         <GroupNumber>9</GroupNumber>
       </_GroupStartsWith>
 
-      <_GroupStartsWith Include="$(TestRoot)Loader\classloader\Casting\Functionpointer.csproj">
+      <_GroupStartsWith Include="$(TestRoot)Loader\classloader\Casting">
         <GroupNumber>10</GroupNumber>
       </_GroupStartsWith>
     </ItemGroup>


### PR DESCRIPTION
Test build group boundaries are several years old; since then, the JIT/HardwareIntrinsics tests have arrived and substantially changed the test distribution. Moreover, as by now the vast majority (over 95%) of tests use the new-style merged wrappers, it makes no sense to establish build group boundaries in the middle of merged wrappers because that only means that some test projects need to be traversed twice, once in the group they belong to according to the partitioning and one more time as a dependency of their merged test wrapper.

Thanks

Tomas