### PR TITLE
[Arm64/Unix] Use native memcpy/memmove for ARM64 as glibc 2.36 added optimizations

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.Unix.cs
@@ -5,12 +5,10 @@ namespace System
 {
     public static partial class Buffer
     {
-#if TARGET_ARM64 || TARGET_LOONGARCH64
+#if TARGET_LOONGARCH64
         // Managed code is currently faster than glibc unoptimized memmove
-        // TODO-ARM64-UNIX-OPT revisit when glibc optimized memmove is in Linux distros
-        // https://github.com/dotnet/runtime/issues/8897
         private static nuint MemmoveNativeThreshold => nuint.MaxValue;
-#elif TARGET_ARM
+#elif TARGET_ARM || TARGET_ARM64
         private const nuint MemmoveNativeThreshold = 512;
 #else
         private const nuint MemmoveNativeThreshold = 2048;


### PR DESCRIPTION
This commit: https://github.com/bminor/glibc/commit/9f298bfe1f183804bb54b54ff9071afc0494906c added an optimized memcpy implementation for ARM64 which uses the SVE extensions to glibc 2.36 and newer.

It is now used in some Linux Distributions like Debian 12 (bookworm), Ubuntu 23.04 or the upcoming Ubuntu 24.04  LTS in April 2024.

see https://github.com/dotnet/runtime/issues/8897