### PR TITLE
Fix NativeAOT test runs

### DIFF
--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -15,6 +15,7 @@
       <DisabledProjects Include="$(TestRoot)Performance\Scenario\JitBench\unofficial_dotnet\JitBench.csproj" /> <!-- no official build support for SDK-style netcoreapp2.0 projects -->
       <DisabledProjects Include="$(TestRoot)TestWrappers*\**\*.csproj" />
       <DisabledProjects Include="$(TestRoot)nativeaot\**\*.csproj" Condition="'$(TestBuildMode)' != 'nativeaot'" />
+      <DisabledProjects Include="$(TestRoot)readytorun\**\*.csproj" Condition="'$(TestBuildMode)' == 'nativeaot'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/tests/readytorun/Directory.Build.props
+++ b/src/tests/readytorun/Directory.Build.props
@@ -4,8 +4,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
-    <NativeAotIncompatible>true</NativeAotIncompatible>
-
     <RunAnalyzers>true</RunAnalyzers>
     <NoWarn>$(NoWarn);xUnit1013</NoWarn>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>


### PR DESCRIPTION
These got broken when readytorun tests got merged. We still execute this target:

https://github.com/dotnet/runtime/blob/2d47f845f895a361d3a56ee442345ddd8fa297e8/src/tests/readytorun/tests/mainv1.csproj#L159-L168

even though the test doesn't actually build. The copy task obviously fails. Not sure if there's a better way than what I'm proposing here.

Cc @dotnet/ilc-contrib 