### PR TITLE
Add a couple feature switches to the repro project

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
@@ -39,6 +39,8 @@
       <ReproResponseLines Include="--feature:System.Resources.ResourceManager.AllowCustomResourceTypes=false" />
       <ReproResponseLines Include="--feature:System.Linq.Expressions.CanEmitObjectArrayDelegate=false" />
       <ReproResponseLines Include="--feature:System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported=false" />
+      <ReproResponseLines Include="--feature:System.Globalization.Invariant=true" />
+      <ReproResponseLines Include="--feature:System.Diagnostics.Debugger.IsSupported=false" />
     </ItemGroup>
 
     <WriteLinesToFile File="$(OutputPath)\compile-with-$(LibrariesConfiguration)-libs.rsp"


### PR DESCRIPTION
These are defaults for console apps. Shaves off a second from debug run of the compiler (10%).

cc @dotnet/ilc-contrib 