### PR TITLE
[browser][HybridGlobalization] Fix incorrect value in `FirstDayOfWeek` test

### DIFF
--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoFirstDayOfWeek.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoFirstDayOfWeek.cs
@@ -12,9 +12,7 @@ namespace System.Globalization.Tests
         {
             yield return new object[] { DateTimeFormatInfo.InvariantInfo, DayOfWeek.Sunday, "invariant" };
             yield return new object[] { new CultureInfo("en-US", false).DateTimeFormat, DayOfWeek.Sunday, "en-US" };
-            // ActiveIssue: https://github.com/dotnet/runtime/issues/93354
-            if (!PlatformDetection.IsHybridGlobalizationOnBrowser)
-                yield return new object[] { new CultureInfo("fr-FR", false).DateTimeFormat, DayOfWeek.Monday, "fr-FR" };
+            yield return new object[] { new CultureInfo("fr-FR", false).DateTimeFormat, DayOfWeek.Monday, "fr-FR" };
         }
 
         public static IEnumerable<object[]> FirstDayOfWeek_Get_TestData_HybridGlobalization()

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
@@ -35,9 +35,7 @@ namespace System.Globalization
             int result = Interop.JsGlobalization.GetFirstDayOfWeek(localeName, out int exception, out object ex_result);
             if (exception != 0)
             {
-                // Failed, just use 0
                 Debug.Fail($"[CultureData.GetFirstDayOfWeek()] failed with {ex_result}");
-                return 0;
             }
             return result;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
@@ -45,9 +45,7 @@ namespace System.Globalization
             int result = Interop.JsGlobalization.GetFirstWeekOfYear(localeName, out int exception, out object ex_result);
             if (exception != 0)
             {
-                // Failed, just use 0
                 Debug.Fail($"[CultureData.GetFirstWeekOfYear()] failed with {ex_result}");
-                return 0;
             }
             return result;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
@@ -35,7 +35,9 @@ namespace System.Globalization
             int result = Interop.JsGlobalization.GetFirstDayOfWeek(localeName, out int exception, out object ex_result);
             if (exception != 0)
             {
+                // Failed, just use 0
                 Debug.Fail($"[CultureData.GetFirstDayOfWeek()] failed with {ex_result}");
+                return 0;
             }
             return result;
         }
@@ -45,7 +47,9 @@ namespace System.Globalization
             int result = Interop.JsGlobalization.GetFirstWeekOfYear(localeName, out int exception, out object ex_result);
             if (exception != 0)
             {
-                Debug.Fail($"[CultureData.GetFirstWeekOfYear()] failed with {ex_result}");
+                // Failed, just use 0
+                Debug.Fail($"[CultureData.GetFirstDayOfWeek()] failed with {ex_result}");
+                return 0;
             }
             return result;
         }

--- a/src/mono/wasm/runtime/hybrid-globalization/change-case.ts
+++ b/src/mono/wasm/runtime/hybrid-globalization/change-case.ts
@@ -75,6 +75,7 @@ export function mono_wasm_change_case_invariant(src: number, srcLength: number, 
                 }
             }
         }
+        wrap_no_error_root(is_exception, exceptionRoot);
     }
     catch (ex: any) {
         wrap_error_root(is_exception, ex, exceptionRoot);

--- a/src/mono/wasm/runtime/hybrid-globalization/locales.ts
+++ b/src/mono/wasm/runtime/hybrid-globalization/locales.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { wrap_error_root } from "../invoke-js";
+import { wrap_error_root, wrap_no_error_root } from "../invoke-js";
 import { mono_wasm_new_external_root } from "../roots";
 import { monoStringToString } from "../strings";
 import { Int32Ptr } from "../types/emscripten";
@@ -15,6 +15,7 @@ export function mono_wasm_get_first_day_of_week(culture: MonoStringRef, isExcept
     try {
         const cultureName = monoStringToString(cultureRoot);
         const canonicalLocale = normalizeLocale(cultureName);
+        wrap_no_error_root(isException, exceptionRoot);
         return getFirstDayOfWeek(canonicalLocale);
     }
     catch (ex: any) {
@@ -34,6 +35,7 @@ export function mono_wasm_get_first_week_of_year(culture: MonoStringRef, isExcep
     try {
         const cultureName = monoStringToString(cultureRoot);
         const canonicalLocale = normalizeLocale(cultureName);
+        wrap_no_error_root(isException, exceptionRoot);
         return getFirstWeekOfYear(canonicalLocale);
     }
     catch (ex: any) {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/93354.
0 decodes Sunday, 1 decodes Monday. We did not have exception wrapping when returning the value from JS function, so it was pointing to a random value in memory. If we were unlucky that this value was equal `0` then we were assuming the JS code returned exception and returning the default value for `DayOfWeek` which is `Sunday`.
