### PR TITLE
[mono][jit] Improved imm64 for negative numbers

### DIFF
--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -509,22 +509,39 @@ emit_imm64 (guint8 *code, int dreg, guint64 imm)
 {
 	if (imm == 0) {
 		arm_movzx (code, dreg, 0, 0);
-	} else {
-		gboolean is_inited = FALSE;
 
-		for (int idx = 0; idx < 64; idx += 16) {
-			int w = (imm >> idx) & 0xffff;
+	int num0 = 0, num1 = 0;
+	for (int idx = 0; idx < 64; idx++) {
+		int w = (imm >> idx) & 0xffff;
+		if (w == 0)
+			num0++;
+		else if (w == 0xffff)
+			num1++;
+	}
 
-			if (w) {
-				if (is_inited) {
-					arm_movkx (code, dreg, w, idx);
-				} else {
-					arm_movzx (code, dreg, w, idx);
-					is_inited = TRUE;
-				}
-			}
+	gboolean is_negated = num1 > num0;
+	gboolean is_inited = FALSE;
+	
+	for (int idx = 0; idx < 64; idx++) {
+		int w = (imm >> idx) & 0xffff;
+		if (!is_inited && is_negated && w != 0xffff) {
+			arm_movnx (code, dreg, (~w) & 0xffff, idx);
+			is_inited = TRUE;
+		} else if (!is_inited && !is_negated && w != 0x0) {
+			arm_movzx (code, dreg, w, idx);
+			is_inited = TRUE;
+		} else if (is_inited && ((is_negated && w != 0xffff) || (!is_negated && w != 0x0))) {
+			arm_movkx (code, dreg, w, idx);
 		}
 	}
+
+	if (!is_inited) {
+		if (is_negated)
+			arm_movnx (code, dreg, 0, 0);
+		else
+			arm_movzx (code, dreg, 0, 0);
+	}
+
 	return code;
 }
 


### PR DESCRIPTION
Codegen is improved for emitting 64-bit negative integer constants on arm64. LLVM codegen is not affected.

Example from a check in `long` division:

```asm
...
0000000000000020        mov     x30, #0xffff
0000000000000024        movk    x30, #0xffff, lsl #16
0000000000000028        movk    x30, #0xffff, lsl #32
000000000000002c        movk    x30, #0xffff, lsl #48
0000000000000030        cmp     x26, x30
...
```

becomes


```asm
0000000000000020        mov     x30, #-0x1
0000000000000024        cmp     x26, x30
```
