### PR TITLE
[mono][jit] Partially implemented logical immediates on arm64

### DIFF
--- a/src/mono/mono/arch/arm64/arm64-codegen.h
+++ b/src/mono/mono/arch/arm64/arm64-codegen.h
@@ -523,18 +523,19 @@ arm_encode_arith_imm (int imm, guint32 *shift)
 /* Logical (immediate) */
 
 // FIXME: imm
+
+#define arm_format_and(p, sf, opc, rd, rn, n, immr, imms) arm_emit ((p), 0b00010010000000000000000000000000 | ((sf) << 31) | ((opc) << 29) | ((n) << 22) | ((immr) << 16) | ((imms) << 10) | ((rn) << 5) | ((rd) << 0))
+
+#define arm_andw_imm(p, rd, rn, immr, imms) arm_format_and ((p), 0b0, 0b00, (rd), (rn), 0b0, (immr), (imms))
+#define arm_andx_imm(p, rd, rn, n, immr, imms) arm_format_and ((p), 0b1, 0b00, (rd), (rn), (n), (immr), (imms))
+#define arm_andsw_imm(p, rd, rn, immr, imms) arm_format_and ((p), 0b0, 0b11, (rd), (rn), 0b0, (immr), (imms))
+#define arm_andsx_imm(p, rd, rn, n, immr, imms) arm_format_and ((p), 0b1, 0b11, (rd), (rn), (n), (immr), (imms))
+#define arm_eorw_imm(p, rd, rn, immr, imms) arm_format_and ((p), 0b0, 0b10, (rd), (rn), 0b0, (immr), (imms))
+#define arm_eorx_imm(p, rd, rn, n, immr, imms) arm_format_and ((p), 0b1, 0b10, (rd), (rn), (n), (immr), (imms))
+#define arm_orrw_imm(p, rd, rn, immr, imms) arm_format_and ((p), 0b0, 0b01, (rd), (rn), 0b0, (immr), (imms))
+#define arm_orrx_imm(p, rd, rn, n, immr, imms) arm_format_and ((p), 0b1, 0b01, (rd), (rn), (n), (immr), (imms))
+
 #if 0
-#define arm_format_and(p, sf, opc, rd, rn, imm) arm_emit ((p), ((sf) << 31) | ((opc) << 29) | (0x24 << 23) | ((0) << 22) | ((imm) << 10) | ((rn) << 5) | ((rd) << 0))
-
-#define arm_andx_imm(p, rd, rn, imm) arm_format_and ((p), 0x1, 0x0, (rd), (rn), (imm))
-#define arm_andw_imm(p, rd, rn, imm) arm_format_and ((p), 0x0, 0x0, (rd), (rn), (imm))
-#define arm_andsx_imm(p, rd, rn, imm) arm_format_and ((p), 0x1, 0x3, (rd), (rn), (imm))
-#define arm_andsw_imm(p, rd, rn, imm) arm_format_and ((p), 0x0, 0x3, (rd), (rn), (imm))
-#define arm_eorx_imm(p, rd, rn, imm) arm_format_and ((p), 0x1, 0x2, (rd), (rn), (imm))
-#define arm_eorw_imm(p, rd, rn, imm) arm_format_and ((p), 0x0, 0x2, (rd), (rn), (imm))
-#define arm_orrx_imm(p, rd, rn, imm) arm_format_and ((p), 0x1, 0x1, (rd), (rn), (imm))
-#define arm_orrw_imm(p, rd, rn, imm) arm_format_and ((p), 0x0, 0x1, (rd), (rn), (imm))
-
 #define arm_tstx_imm(p, rn, imm) arm_andsx_imm ((p), ARMREG_RZR, (rn), (imm))
 #define arm_tstw_imm(p, rn, imm) arm_andsw_imm ((p), ARMREG_RZR, (rn), (imm))
 #endif

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -33,6 +33,11 @@
 
 #include "interp/interp.h"
 
+#ifdef _MSC_VER
+// for _BitScanFroward
+#include <intrin.h>
+#endif
+
 // The following defines are here to support the inclusion of simd-arm64.h
 #define EXPAND(x) x
 #define PARENTHESIZE(...) (__VA_ARGS__)
@@ -624,8 +629,15 @@ emit_subx_sp_imm (guint8 *code, int imm)
 static int 
 num_trailing_zeros (guint64 imm)
 {
-	// TODO: other platforms/compilers
+#ifdef _MSC_VER
+	long index = 0;
+	if ( _BitScanForward( &index, value ) )
+		return index;
+	else
+		return 32;
+#else
 	return __builtin_ctz(imm);
+#endif
 }
 
 static gboolean

--- a/src/mono/mono/utils/CMakeLists.txt
+++ b/src/mono/mono/utils/CMakeLists.txt
@@ -176,6 +176,8 @@ set(utils_common_sources
     ftnptr.h
     wasm-module-reader.h
     wasm-module-reader.c
+    mono-bitutils.h
+    mono-bitutils.c
   )
 
 if(MONO_CROSS_COMPILE)

--- a/src/mono/mono/utils/mono-bitutils.c
+++ b/src/mono/mono/utils/mono-bitutils.c
@@ -1,0 +1,61 @@
+/**
+ * \file
+ */
+
+#include "mono/utils/mono-bitutils.h"
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
+int mono_lzcnt32 (guint32 x)
+{
+#ifdef _MSC_VER
+	long index = 0;
+	if ( _BitScanReverse( &index, x ) )
+		return index;
+	else
+		return 32;
+#else
+	return __builtin_clz(x);
+#endif
+}
+
+int mono_lzcnt64 (guint64 x)
+{
+#ifdef _MSC_VER
+	long index = 0;
+	if ( _BitScanReverse64( &index, (__int64)x ) )
+		return index;
+	else
+		return 64;
+#else
+	return __builtin_clzll(x);
+#endif
+}
+
+int mono_tzcnt32 (guint32 x)
+{
+#ifdef _MSC_VER
+	long index = 0;
+	if ( _BitScanForward( &index, x ) )
+		return index;
+	else
+		return 32;
+#else
+	return __builtin_ctz(x);
+#endif
+}
+
+int mono_tzcnt64 (guint64 x)
+{
+#ifdef _MSC_VER
+	long index = 0;
+	if ( _BitScanForward64( &index, (__int64)x ) )
+		return index;
+	else
+		return 64;
+#else
+	return __builtin_ctzll(x);
+#endif
+}

--- a/src/mono/mono/utils/mono-bitutils.c
+++ b/src/mono/mono/utils/mono-bitutils.c
@@ -8,6 +8,9 @@
 #include <intrin.h>
 #endif
 
+#define LOW32(x) ((guint32)(x & 0xffffffff))
+#define HIGH32(x) ((guint32)((x >> 32) & 0xffffffff))
+
 int mono_lzcnt32 (guint32 x)
 {
 #ifdef _MSC_VER
@@ -23,12 +26,20 @@ int mono_lzcnt32 (guint32 x)
 
 int mono_lzcnt64 (guint64 x)
 {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC) || defined (_M_X64))
 	unsigned long index = 0;
 	if ( _BitScanReverse64( &index, x ) )
 		return (int)index;
 	else
 		return 64;
+#elif defined(_MSC_VER)
+  guint32 high = HIGH32 (x);
+  if (x == 0)
+    return 64;
+  else if (high == 0)
+    return mono_lzcnt32 (LOW32 (x)) + 32;
+  else
+    return mono_lzcnt32 (high);
 #else
 	return __builtin_clzll(x);
 #endif
@@ -49,12 +60,20 @@ int mono_tzcnt32 (guint32 x)
 
 int mono_tzcnt64 (guint64 x)
 {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC) || defined (_M_X64))
 	unsigned long index = 0;
 	if ( _BitScanForward64( &index, x ) )
 		return (int)index;
 	else
 		return 64;
+#elif defined(_MSC_VER)
+  guint32 low = LOW32 (x);
+  if (x == 0)
+    return 64;
+  else if (low == 0)
+    return mono_tzcnt32 (HIGH32 (x)) + 32;
+  else
+    return mono_tzcnt32 (low);
 #else
 	return __builtin_ctzll(x);
 #endif

--- a/src/mono/mono/utils/mono-bitutils.c
+++ b/src/mono/mono/utils/mono-bitutils.c
@@ -11,9 +11,9 @@
 int mono_lzcnt32 (guint32 x)
 {
 #ifdef _MSC_VER
-	long index = 0;
+	unsigned long index = 0;
 	if ( _BitScanReverse( &index, x ) )
-		return index;
+		return (int)index;
 	else
 		return 32;
 #else
@@ -24,9 +24,9 @@ int mono_lzcnt32 (guint32 x)
 int mono_lzcnt64 (guint64 x)
 {
 #ifdef _MSC_VER
-	long index = 0;
-	if ( _BitScanReverse64( &index, (__int64)x ) )
-		return index;
+	unsigned long index = 0;
+	if ( _BitScanReverse64( &index, x ) )
+		return (int)index;
 	else
 		return 64;
 #else
@@ -37,9 +37,9 @@ int mono_lzcnt64 (guint64 x)
 int mono_tzcnt32 (guint32 x)
 {
 #ifdef _MSC_VER
-	long index = 0;
+	unsigned long index = 0;
 	if ( _BitScanForward( &index, x ) )
-		return index;
+		return (int)index;
 	else
 		return 32;
 #else
@@ -50,9 +50,9 @@ int mono_tzcnt32 (guint32 x)
 int mono_tzcnt64 (guint64 x)
 {
 #ifdef _MSC_VER
-	long index = 0;
-	if ( _BitScanForward64( &index, (__int64)x ) )
-		return index;
+	unsigned long index = 0;
+	if ( _BitScanForward64( &index, x ) )
+		return (int)index;
 	else
 		return 64;
 #else

--- a/src/mono/mono/utils/mono-bitutils.h
+++ b/src/mono/mono/utils/mono-bitutils.h
@@ -1,0 +1,11 @@
+#ifndef __MONO_BITUTILS_H__
+#define __MONO_BITUTILS_H__
+
+#include <glib.h>
+
+int mono_lzcnt32 (guint32 x);
+int mono_lzcnt64 (guint64 x);
+int mono_tzcnt32 (guint32 x);
+int mono_tzcnt64 (guint64 x);
+
+#endif


### PR DESCRIPTION
This implements a subset of https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/AND--immediate---Bitwise-AND--immediate-- (incl. `ands`, `eor`, `orr`). If the immediate value can be expressed as `(1<<n) - 1`, the new codegen is used. Although this covers only a few of the cases supported by the instruction, the instances where we are trying to mask away some of the upper bits seem prevalent (in our codebase) and are handled here.

E.g. clamping the shift amount in long shifts:
```asm
0000000000000018        mov     x30, #0x3f
000000000000001c        and     w1, w0, w30
```

becomes
```asm
0000000000000018        and     w1, w0, #0x3f
```

EDIT: The recognized bit pattern is now expanded to `0*1+0*`. A plain-ish HelloWorld build revealed almost 400 instances of this pattern.
