### PR TITLE
JIT: make bbID available in release, use it for pred list ordering

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -220,27 +220,27 @@ bool BasicBlock::IsFirstColdBlock(Compiler* compiler) const
 // checkPredListOrder: see if pred list is properly ordered
 //
 // Returns:
-//    false if pred list is not in increasing bbNum order.
+//    false if pred list is not in increasing bbID order.
 //
 bool BasicBlock::checkPredListOrder()
 {
-    unsigned lastBBNum = 0;
+    unsigned lastBBID = 0;
     for (BasicBlock* const predBlock : PredBlocks())
     {
-        const unsigned bbNum = predBlock->bbNum;
-        if (bbNum <= lastBBNum)
+        const unsigned bbID = predBlock->bbID;
+        if (bbID <= lastBBID)
         {
-            assert(bbNum != lastBBNum);
+            assert(bbID != lastBBID);
             return false;
         }
-        lastBBNum = bbNum;
+        lastBBID = bbID;
     }
     return true;
 }
 
 //------------------------------------------------------------------------
 // ensurePredListOrder: ensure all pred list entries appear in increasing
-//    bbNum order.
+//    bbID order.
 //
 // Arguments:
 //    compiler - current compiler instance
@@ -305,7 +305,7 @@ void BasicBlock::reorderPredList(Compiler* compiler)
     {
         bool operator()(const FlowEdge* f1, const FlowEdge* f2)
         {
-            return f1->getSourceBlock()->bbNum < f2->getSourceBlock()->bbNum;
+            return f1->getSourceBlock()->bbID < f2->getSourceBlock()->bbID;
         }
     };
 
@@ -1469,10 +1469,7 @@ BasicBlock* Compiler::bbNewBasicBlock(BBjumpKinds jumpKind)
     // boundaries), or have been inserted by the JIT
     block->bbCodeOffs    = BAD_IL_OFFSET;
     block->bbCodeOffsEnd = BAD_IL_OFFSET;
-
-#ifdef DEBUG
-    block->bbID = compBasicBlockID++;
-#endif
+    block->bbID          = ++compBasicBlockID;
 
     /* Give the block a number, set the ancestor count and weight */
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1259,9 +1259,10 @@ public:
     // still in the BB list by whether they have the same stamp (with high probability).
     unsigned bbTraversalStamp;
 
+#endif // DEBUG
+
     // bbID is a unique block identifier number that does not change: it does not get renumbered, like bbNum.
     unsigned bbID;
-#endif // DEBUG
 
     unsigned bbStackDepthOnEntry() const;
     void bbSetStack(StackEntry* stack);

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -6795,10 +6795,11 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE classPtr,
     lvaTable  = nullptr;
 
     // Reset node and block ID counter
-    compGenTreeID    = 0;
-    compStatementID  = 0;
-    compBasicBlockID = 0;
+    compGenTreeID   = 0;
+    compStatementID = 0;
 #endif
+
+    compBasicBlockID = 0;
 
 #ifdef TARGET_ARM64
     info.compNeedsConsecutiveRegisters = false;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10283,9 +10283,9 @@ public:
 #ifdef DEBUG
     unsigned compGenTreeID;
     unsigned compStatementID;
-    unsigned compBasicBlockID;
 #endif
-    LONG compMethodID;
+    unsigned compBasicBlockID;
+    LONG     compMethodID;
 
     BasicBlock* compCurBB;   // the current basic block in process
     Statement*  compCurStmt; // the current statement in process

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -5718,10 +5718,6 @@ bool Compiler::fgRenumberBlocks()
     //
     if (renumbered)
     {
-        for (BasicBlock* const block : Blocks())
-        {
-            block->ensurePredListOrder(this);
-        }
         JITDUMP("\n*************** After renumbering the basic blocks\n");
         JITDUMPEXEC(fgDispBasicBlocks());
         JITDUMPEXEC(fgDispHandlerTab());

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -104,11 +104,11 @@ FlowEdge* Compiler::fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowE
 
     block->bbRefs++;
 
-    // Keep the predecessor list in lowest to highest bbNum order. This allows us to discover the loops in
+    // Keep the predecessor list in lowest to highest bbID order. This allows us to discover the loops in
     // optFindNaturalLoops from innermost to outermost.
     //
     // If we are initializing preds, we rely on the fact that we are adding references in increasing
-    // order of blockPred->bbNum to avoid searching the list.
+    // order of blockPred->bbID to avoid searching the list.
     //
     // TODO-Throughput: Inserting an edge for a block in sorted order requires searching every existing edge.
     // Thus, inserting all the edges for a block is quadratic in the number of edges. We need to either
@@ -123,7 +123,7 @@ FlowEdge* Compiler::fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowE
     if (initializingPreds)
     {
         // List is sorted order and we're adding references in
-        // increasing blockPred->bbNum order. The only possible
+        // increasing blockPred->bbID order. The only possible
         // dup list entry is the last one.
         //
         FlowEdge* flowLast = block->bbLastPred;
@@ -131,7 +131,7 @@ FlowEdge* Compiler::fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowE
         {
             listp = flowLast->getNextPredEdgeRef();
 
-            assert(flowLast->getSourceBlock()->bbNum <= blockPred->bbNum);
+            assert(flowLast->getSourceBlock()->bbID <= blockPred->bbID);
 
             if (flowLast->getSourceBlock() == blockPred)
             {
@@ -143,7 +143,7 @@ FlowEdge* Compiler::fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowE
     {
         // References are added randomly, so we have to search.
         //
-        while ((*listp != nullptr) && ((*listp)->getSourceBlock()->bbNum < blockPred->bbNum))
+        while ((*listp != nullptr) && ((*listp)->getSourceBlock()->bbID < blockPred->bbID))
         {
             listp = (*listp)->getNextPredEdgeRef();
         }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2451,20 +2451,6 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
                 bNext->bbNum);
 
         block->bbNum = bNext->bbNum;
-
-        // Because we may have reordered pred lists when we swapped in
-        // block for bNext above, we now need to re-reorder pred lists
-        // to reflect the bbNum update.
-        //
-        // This process of reordering and re-reordering could likely be avoided
-        // via a different update strategy. But because it's probably rare,
-        // and we avoid most of the work if pred lists are already in order,
-        // we'll just ensure everything is properly ordered.
-        //
-        for (BasicBlock* const checkBlock : Blocks())
-        {
-            checkBlock->ensurePredListOrder(this);
-        }
     }
 
     fgUpdateLoopsAfterCompacting(block, bNext);


### PR DESCRIPTION
Avoid needing to reorder pred lists (in most cases) by relying on `bbID` for a persistent stable ordering.