### PR TITLE
Remove RequiresProcessIsolation from some loader tests

### DIFF
--- a/src/tests/Loader/classloader/Casting/Functionpointer.csproj
+++ b/src/tests/Loader/classloader/Casting/Functionpointer.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/Casting/castclasspointer.ilproj
+++ b/src/tests/Loader/classloader/Casting/castclasspointer.ilproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="castclasspointer.il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/Casting/punning.csproj
+++ b/src/tests/Loader/classloader/Casting/punning.csproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="punning.cs" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2.ilproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="constrained2.il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2_gm.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2_gm.ilproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="constrained2_gm.il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained3.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained3.ilproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="constrained3.il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained3_gm.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained3_gm.ilproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="constrained3_gm.il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrainedcall.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrainedcall.ilproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/genericmethods/genericmethods.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/genericmethods/genericmethods.ilproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/methodimpl/methodimpl.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/methodimpl/methodimpl.ilproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/reabstraction/reabstraction.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/reabstraction/reabstraction.ilproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github58394.csproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github58394.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github61244.csproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github61244.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github81882.csproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github81882.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github82577.csproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github82577.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/non_virtual_calls_to_instance_methods.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/non_virtual_calls_to_instance_methods.ilproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="non_virtual_calls_to_instance_methods.il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/simple/simple.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/simple/simple.ilproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/valuetypes/valuetypes.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/valuetypes/valuetypes.ilproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/InterfaceVariance/ComplexHierarchyPositive.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/InterfaceVariance/ComplexHierarchyPositive.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GetInterfaceMapWithStaticVirtualsAndConstraints.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GetInterfaceMapWithStaticVirtualsAndConstraints.csproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_59432.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_59432.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_70385.ilproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_70385.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_71319.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_71319.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_74792.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_74792.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_76673.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_76673.csproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_78866.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_78866.csproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_80350.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_80350.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_86993.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_86993.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/RecursiveConstraintOnDIOfStaticAbstractMember.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/RecursiveConstraintOnDIOfStaticAbstractMember.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/StaticVirtualsAndMethodConstraintsAndDI.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/StaticVirtualsAndMethodConstraintsAndDI.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Works around https://github.com/dotnet/runtime/issues/80602 -->
-    <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
 
-    <!-- Needed for NativeAotIncompatible -->
+    <!-- Both needed to work around https://github.com/dotnet/runtime/issues/80602 -->
+    <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <NativeAotIncompatible>true</NativeAotIncompatible> <!-- https://github.com/dotnet/runtime/issues/89101 -->
+
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
I had a look at these tests and none of them do weird stuff.

I can continue chipping off these in the Loader area if it's helpful.

One question I have:

I tried to remove this on:

```
src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextTest/GenericContextTest.ilproj
```

And this failed to build with:

```
C:\git\runtime\src\tests\Loader\XUnitWrapperGenerator\XUnitWrapperGenerator.XUnitWrapperGenerator\FullRunner.g.cs(439,7
3): error CS0012: The type 'Object' is defined in an assembly that is not referenced. You must add a reference to assem
bly 'System.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. [C:\git\runtime\src\tests\Loader\Loader.cs
proj] [C:\git\runtime\src\tests\build.proj]
```

Is there something special for tests that have a ProjectReference (I can't think of anything else that would be special here).