### PR TITLE
[RISC-V] Disable FastTailCall in case of split arg

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10341,7 +10341,7 @@ public:
 
     unsigned compArgSize; // total size of arguments in bytes (including register args (lvIsRegArg))
 
-#ifdef TARGET_ARM
+#if defined(TARGET_ARM) || defined(TARGET_RISCV64)
     bool compHasSplitParam;
 #endif
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -259,9 +259,9 @@ void Compiler::lvaInitTypeRef()
     LclVarDsc*              varDsc    = varDscInfo.varDsc;
     CORINFO_ARG_LIST_HANDLE localsSig = info.compMethodInfo->locals.args;
 
-#ifdef TARGET_ARM
+#if defined(TARGET_ARM) || defined(TARGET_RISCV64)
     compHasSplitParam = varDscInfo.hasSplitParam;
-#endif
+#endif // TARGET_ARM || TARGET_RISCV64
 
     for (unsigned i = 0; i < info.compMethodInfo->locals.numArgs;
          i++, varNum++, varDsc++, localsSig = info.compCompHnd->getArgNext(localsSig))
@@ -1043,6 +1043,9 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
                         varDscInfo->setAllRegArgUsed(argRegTypeInStruct1);
 #if FEATURE_FASTTAILCALL
                         varDscInfo->stackArgSize += TARGET_POINTER_SIZE;
+#endif
+#ifdef TARGET_RISCV64
+                        varDscInfo->hasSplitParam = true;
 #endif
                     }
                 }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5495,24 +5495,27 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
     {
         calleeArgStackSize = roundUp(calleeArgStackSize, arg.AbiInfo.ByteAlignment);
         calleeArgStackSize += arg.AbiInfo.GetStackByteSize();
-#ifdef TARGET_ARM
+
+#if defined(TARGET_ARM) || defined(TARGET_RISCV64)
         if (arg.AbiInfo.IsSplit())
         {
-            reportFastTailCallDecision("Argument splitting in callee is not supported on ARM32");
+            reportFastTailCallDecision("Argument splitting in callee is not supported on " TARGET_READABLE_NAME);
             return false;
         }
-#endif // TARGET_ARM
+#endif // TARGET_ARM || TARGET_RISCV64
     }
 
     calleeArgStackSize = GetOutgoingArgByteSize(calleeArgStackSize);
 
-#ifdef TARGET_ARM
+#if defined(TARGET_ARM) || defined(TARGET_RISCV64)
     if (compHasSplitParam)
     {
-        reportFastTailCallDecision("Argument splitting in caller is not supported on ARM32");
+        reportFastTailCallDecision("Argument splitting in caller is not supported on " TARGET_READABLE_NAME);
         return false;
     }
+#endif // TARGET_ARM || TARGET_RISCV64
 
+#ifdef TARGET_ARM
     if (compIsProfilerHookNeeded())
     {
         reportFastTailCallDecision("Profiler is not supported on ARM32");

--- a/src/coreclr/jit/registerargconvention.h
+++ b/src/coreclr/jit/registerargconvention.h
@@ -23,8 +23,11 @@ struct InitVarDscInfo
     // handles arguments.
     regMaskTP fltArgSkippedRegMask;
     bool      anyFloatStackArgs;
-    bool      hasSplitParam;
 #endif // TARGET_ARM
+
+#if defined(TARGET_ARM) || defined(TARGET_RISCV64)
+    bool hasSplitParam;
+#endif // TARGET_ARM || TARGET_RISCV64
 
 #if FEATURE_FASTTAILCALL
     // It is used to calculate argument stack size information in byte
@@ -46,8 +49,11 @@ public:
 #ifdef TARGET_ARM
         fltArgSkippedRegMask = RBM_NONE;
         anyFloatStackArgs    = false;
-        hasSplitParam        = false;
 #endif // TARGET_ARM
+
+#if defined(TARGET_ARM) || defined(TARGET_RISCV64)
+        hasSplitParam = false;
+#endif // TARGET_ARM || TARGET_RISCV64
 
 #if FEATURE_FASTTAILCALL
         stackArgSize = 0;


### PR DESCRIPTION
Disable TCO in case if *callee* split arg fixes System.Security.Cryptography.Tests SIGSEGV/Release and assert/Checked.
Also disable TCO in case if *caller* split arg as for ARM32: #66282.

Part of #84834
cc @clamp03 @gbalykov @tomeksowi @Sirntar @viewizard @ashaurtaev.