### PR TITLE
[NativeAOT] Support library mode with NativeAOT on iOS-like platforms

### DIFF
--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -10,13 +10,14 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BuildTestsOnHelix)' == 'true'">
-    <_AOTBuildCommand>export PATH=$HELIX_CORRELATION_PAYLOAD/build/cmake/cmake-3.16.4-Darwin-x86_64/CMake.app/Contents/bin:$PATH &amp;&amp; </_AOTBuildCommand>
+    <_AOTBuildCommand>export PATH=$HELIX_CORRELATION_PAYLOAD/build/cmake/cmake-3.28.0-macos-universal/CMake.app/Contents/bin:$PATH &amp;&amp; </_AOTBuildCommand>
     <_AOTBuildCommand>$(_AOTBuildCommand) dotnet msbuild publish/ProxyProjectForAOTOnHelix.proj /bl:$XHARNESS_OUT/AOTBuild.binlog</_AOTBuildCommand>
 
     <!-- running aot-helix tests locally, so we can test with the same project file as CI -->
     <_AOTBuildCommand Condition="'$(ContinuousIntegrationBuild)' != 'true'">$(_AOTBuildCommand) /p:RuntimeSrcDir=$(RepoRoot) /p:RuntimeConfig=$(Configuration)</_AOTBuildCommand>
     <!-- The command below sets default properties for runtime and library tests -->
     <_AOTBuildCommand>$(_AOTBuildCommand) /p:XHARNESS_EXECUTION_DIR=&quot;$XHARNESS_EXECUTION_DIR&quot; /p:RunAOTCompilation=$(RunAOTCompilation) /p:UseNativeAOTRuntime=$(UseNativeAOTRuntime) /p:TargetOS=$(TargetOS) /p:TargetArchitecture=$(TargetArchitecture) /p:MonoForceInterpreter=$(MonoForceInterpreter) /p:MonoEnableLLVM=true /p:DevTeamProvisioning=$(DevTeamProvisioning) /p:UsePortableRuntimePack=true /p:Configuration=$(Configuration)</_AOTBuildCommand>
+    <_AOTBuildCommand Condition="'$(NativeLib)' != ''">$(_AOTBuildCommand) /p:NativeLib=$(NativeLib) /p:BundlesResources=$(BundlesResources) /p:ForceLibraryModeGenerateAppBundle=$(ForceLibraryModeGenerateAppBundle)</_AOTBuildCommand>
     <_AOTBuildCommand>$(_AOTBuildCommand) </_AOTBuildCommand>
 
     <_ResetSimulatorSwitch Condition="('$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'tvossimulator') and '$(IncludesTestRunner)' == 'true'">--reset-simulator</_ResetSimulatorSwitch>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -105,8 +105,8 @@
       <_symbolExt Condition="'$(OS)' != 'Windows_NT'">$(NativeBinaryExt)$(NativeSymbolExt)</_symbolExt>
       <_symbolSourcePath>$(NativeOutputPath)$(TargetName)$(_symbolExt)</_symbolSourcePath>
       <_symbolTargetPath>$(PublishDir)\$(TargetName)$(_symbolExt)</_symbolTargetPath>
-      <!-- If the symbol is a dsym bundle, it's a folder not a file. -->
-      <_symbolIsFile Condition="'$(NativeSymbolExt)' == '.dsym'">false</_symbolIsFile>
+      <!-- If the symbol is a dSYM bundle, it's a folder not a file. -->
+      <_symbolIsFile Condition="'$(NativeSymbolExt)' == '.dSYM'">false</_symbolIsFile>
       <_symbolIsFile Condition="'$(_symbolIsFile)' == ''">true</_symbolIsFile>
     </PropertyGroup>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -58,17 +58,6 @@ The .NET Foundation licenses this file to you under the MIT license.
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(_IsiOSLikePlatform)' == 'true'">
-      <Xcrun Condition="'$(Xcrun)' == ''">xcrun</Xcrun>
-      <_WhereXcrun>0</_WhereXcrun>
-    </PropertyGroup>
-
-    <Exec Command="command -v &quot;$(Xcrun)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_IsiOSLikePlatform)' == 'true'">
-      <Output TaskParameter="ExitCode" PropertyName="_WhereXcrun" />
-    </Exec>
-    <Error Condition="'$(_WhereXcrun)' != '0' and '$(_IsiOSLikePlatform)' == 'true'"
-      Text="'$(Xcrun)' not found in PATH. Make sure '$(Xcrun)' is available in PATH." />
-
-    <PropertyGroup Condition="'$(_IsiOSLikePlatform)' == 'true'">
       <AppleMinOSVersion Condition="'$(AppleMinOSVersion)' == '' and '$(_targetOS)' == 'maccatalyst' and '$(_targetArchitecture)' == 'x64'">13.5</AppleMinOSVersion>
       <AppleMinOSVersion Condition="'$(AppleMinOSVersion)' == '' and '$(_targetOS)' == 'maccatalyst'">14.2</AppleMinOSVersion>
       <AppleMinOSVersion Condition="'$(AppleMinOSVersion)' == '' and ($(_targetOS.StartsWith('ios')) or $(_targetOS.StartsWith('tvos')))">11.0</AppleMinOSVersion>
@@ -92,6 +81,17 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <Error Condition="'$(_IsiOSLikePlatform)' == 'true' and ('$(_AppleSdkName)' == '' or '$(CrossCompileArch)' == '' or '$(_AppleTripleOS)' == ''  or '$(AppleMinOSVersion)' == '' or '$(_AppleTripleAbi)' == '')"
       Text="One of the required Apple SDK properties is empty and was not properly resolved: _AppleSdkName = '$(_AppleSdkName)' CrossCompileArch = '$(CrossCompileArch)' _AppleTripleOS = '$(_AppleTripleOS)' AppleMinOSVersion = '$(AppleMinOSVersion)' _AppleTripleAbi = '$(_AppleTripleAbi)'" />
+
+    <PropertyGroup Condition="'$(_IsiOSLikePlatform)' == 'true'">
+      <Xcrun Condition="'$(Xcrun)' == ''">xcrun</Xcrun>
+      <_WhereXcrun>0</_WhereXcrun>
+    </PropertyGroup>
+
+    <Exec Command="command -v &quot;$(Xcrun)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_IsiOSLikePlatform)' == 'true'">
+      <Output TaskParameter="ExitCode" PropertyName="_WhereXcrun" />
+    </Exec>
+    <Error Condition="'$(_WhereXcrun)' != '0' and '$(_IsiOSLikePlatform)' == 'true'"
+      Text="'$(Xcrun)' not found in PATH. Make sure '$(Xcrun)' is available in PATH." />
 
     <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(SysRoot)' == '' and '$(_IsiOSLikePlatform)' == 'true'" ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="SysRoot" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -96,7 +96,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <Error Condition="'$(_iOSLibraryMode)' == 'true' and ('$(_AppleSdkName)' == '' or '$(_AppleTripleArch)' == '' or '$(_AppleTripleOS)' == ''  or '$(AppleMinOSVersion)' == '' or '$(_AppleTripleAbi)' == '')"
       Text="One of the required Apple SDK properties is empty and was not properly resolved: _AppleSdkName = '$(_AppleSdkName)' _AppleTripleArch = '$(_AppleTripleArch)' _AppleTripleOS = '$(_AppleTripleOS)' AppleMinOSVersion = '$(AppleMinOSVersion)' _AppleTripleAbi = '$(_AppleTripleAbi)'" />
 
-    <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_iOSLibraryMode)' == 'true'" ConsoleToMsBuild="true">
+    <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(SysRoot)' == '' and '$(_iOSLibraryMode)' == 'true'" ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="SysRoot" />
     </Exec>
     <Error Condition="!Exists('$(SysRoot)') and '$(_iOSLibraryMode)' == 'true'"
@@ -175,8 +175,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-gz=zlib" Condition="'$(CompressSymbols)' != 'false'" />
       <LinkerArg Include="-fuse-ld=$(LinkerFlavor)" Condition="'$(LinkerFlavor)' != ''" />
       <LinkerArg Include="@(NativeLibrary)" />
-      <LinkerArg Include="--sysroot=$(SysRoot)" Condition="'$(SysRoot)' != '' and '$(_iOSLibraryMode)' != 'true'" />
-      <LinkerArg Include="-isysroot $(SysRoot)" Condition="'$(SysRoot)' != '' and '$(_iOSLibraryMode)' == 'true'" />
+      <LinkerArg Include="--sysroot=&quot;$(SysRoot)&quot;" Condition="'$(SysRoot)' != '' and '$(_IsApplePlatform)' != 'true'" />
+      <LinkerArg Include="-isysroot &quot;$(SysRoot)&quot;" Condition="'$(SysRoot)' != '' and '$(_IsApplePlatform)' == 'true'" />
       <LinkerArg Include="--target=$(TargetTriple)" Condition="('$(_IsApplePlatform)' != 'true' or '$(_iOSLibraryMode)' == 'true') and '$(TargetTriple)' != ''" />
       <LinkerArg Include="-arch $(CrossCompileArch)" Condition="'$(_IsApplePlatform)' == 'true' and '$(CrossCompileArch)' != ''" />
       <LinkerArg Include="-g" Condition="$(NativeDebugSymbols) == 'true'" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -33,7 +33,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <FullRuntimeName Condition="'$(ServerGarbageCollection)' == 'true'">libRuntime.ServerGC</FullRuntimeName>
 
       <CrossCompileRid />
-      <CrossCompileRid Condition="$(_hostOS) != $(_originalTargetOS) or !$(RuntimeIdentifier.EndsWith('-$(_hostArchitecture)'))">$(RuntimeIdentifier)</CrossCompileRid>
+      <CrossCompileRid Condition="'$(_hostOS)' != '$(_originalTargetOS)' or '$(_hostArchitecture)' != '$(_targetArchitecture)'">$(RuntimeIdentifier)</CrossCompileRid>
 
       <CrossCompileArch />
       <CrossCompileArch Condition="$(CrossCompileRid.EndsWith('-x64'))">x86_64</CrossCompileArch>
@@ -79,9 +79,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_AppleSdkName Condition="'$(_targetOS)' == 'tvossimulator'">appletvsimulator</_AppleSdkName>
       <_AppleSdkName Condition="'$(_targetOS)' == 'maccatalyst'">macosx</_AppleSdkName>
 
-      <_AppleTripleArch Condition="'$(_targetArchitecture)' == 'x64'">x86_64</_AppleTripleArch>
-      <_AppleTripleArch Condition="'$(_targetArchitecture)' == 'arm64'">arm64</_AppleTripleArch>
-
       <_AppleTripleOS Condition="'$(_targetOS)' == 'maccatalyst' or $(_targetOS.StartsWith('ios'))">ios</_AppleTripleOS>
       <_AppleTripleOS Condition="$(_targetOS.StartsWith('tvos'))">tvos</_AppleTripleOS>
 
@@ -89,12 +86,12 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_AppleTripleAbi Condition="'$(_targetOS)' == 'maccatalyst'">macabi</_AppleTripleAbi>
       <_AppleTripleAbi Condition="$(_targetOS.EndsWith('simulator'))">simulator</_AppleTripleAbi>
 
-      <TargetTriple>$(_AppleTripleArch)-apple-$(_AppleTripleOS)$(AppleMinOSVersion)-$(_AppleTripleAbi)</TargetTriple>
+      <TargetTriple>$(CrossCompileArch)-apple-$(_AppleTripleOS)$(AppleMinOSVersion)-$(_AppleTripleAbi)</TargetTriple>
       <SharedLibraryInstallName Condition="'$(SharedLibraryInstallName)' == '' and '$(NativeLib)' == 'Shared'">@rpath/$(TargetName)$(NativeBinaryExt)</SharedLibraryInstallName>
     </PropertyGroup>
 
-    <Error Condition="'$(_IsiOSLikePlatform)' == 'true' and ('$(_AppleSdkName)' == '' or '$(_AppleTripleArch)' == '' or '$(_AppleTripleOS)' == ''  or '$(AppleMinOSVersion)' == '' or '$(_AppleTripleAbi)' == '')"
-      Text="One of the required Apple SDK properties is empty and was not properly resolved: _AppleSdkName = '$(_AppleSdkName)' _AppleTripleArch = '$(_AppleTripleArch)' _AppleTripleOS = '$(_AppleTripleOS)' AppleMinOSVersion = '$(AppleMinOSVersion)' _AppleTripleAbi = '$(_AppleTripleAbi)'" />
+    <Error Condition="'$(_IsiOSLikePlatform)' == 'true' and ('$(_AppleSdkName)' == '' or '$(CrossCompileArch)' == '' or '$(_AppleTripleOS)' == ''  or '$(AppleMinOSVersion)' == '' or '$(_AppleTripleAbi)' == '')"
+      Text="One of the required Apple SDK properties is empty and was not properly resolved: _AppleSdkName = '$(_AppleSdkName)' CrossCompileArch = '$(CrossCompileArch)' _AppleTripleOS = '$(_AppleTripleOS)' AppleMinOSVersion = '$(AppleMinOSVersion)' _AppleTripleAbi = '$(_AppleTripleAbi)'" />
 
     <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(SysRoot)' == '' and '$(_IsiOSLikePlatform)' == 'true'" ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="SysRoot" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -57,6 +57,51 @@ The .NET Foundation licenses this file to you under the MIT license.
       <StandaloneGCSupportName Condition="'$(IlcStandaloneGCSupport)' == 'true'">libstandalonegc-enabled</StandaloneGCSupportName>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(_iOSLibraryMode)' == 'true'">
+      <Xcrun Condition="'$(Xcrun)' == ''">xcrun</Xcrun>
+      <_WhereXcrun>0</_WhereXcrun>
+    </PropertyGroup>
+
+    <Exec Command="command -v &quot;$(Xcrun)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_iOSLibraryMode)' == 'true'">
+      <Output TaskParameter="ExitCode" PropertyName="_WhereXcrun" />
+    </Exec>
+    <Error Condition="'$(_WhereXcrun)' != '0' and '$(_iOSLibraryMode)' == 'true'"
+      Text="'$(Xcrun)' not found in PATH. Make sure '$(Xcrun)' is available in PATH." />
+
+    <PropertyGroup Condition="'$(_iOSLibraryMode)' == 'true'">
+      <AppleMinOSVersion Condition="'$(AppleMinOSVersion)' == '' and '$(_targetOS)' == 'maccatalyst' and '$(TargetArchitecture)' == 'x64'">13.5</AppleMinOSVersion>
+      <AppleMinOSVersion Condition="'$(AppleMinOSVersion)' == '' and '$(_targetOS)' == 'maccatalyst'">14.2</AppleMinOSVersion>
+      <AppleMinOSVersion Condition="'$(AppleMinOSVersion)' == '' and '$(_targetOS)' != 'maccatalyst'">11.0</AppleMinOSVersion>
+
+      <_AppleSdkName Condition="'$(_targetOS)' == 'ios'">iphoneos</_AppleSdkName>
+      <_AppleSdkName Condition="'$(_targetOS)' == 'iossimulator'">iphonesimulator</_AppleSdkName>
+      <_AppleSdkName Condition="'$(_targetOS)' == 'tvos'">appletvos</_AppleSdkName>
+      <_AppleSdkName Condition="'$(_targetOS)' == 'tvossimulator'">appletvsimulator</_AppleSdkName>
+      <_AppleSdkName Condition="'$(_targetOS)' == 'maccatalyst'">macosx</_AppleSdkName>
+
+      <_AppleTripleArch Condition="'$(TargetArchitecture)' == 'x64'">x86_64</_AppleTripleArch>
+      <_AppleTripleArch Condition="'$(TargetArchitecture)' == 'arm64'">arm64</_AppleTripleArch>
+
+      <_AppleTripleOS Condition="'$(_targetOS)' == 'maccatalyst' or $(_targetOS.StartsWith('ios'))">ios</_AppleTripleOS>
+      <_AppleTripleOS Condition="$(_targetOS.StartsWith('tvos'))">tvos</_AppleTripleOS>
+
+      <_AppleTripleAbi Condition="'$(_targetOS)' == 'ios' or '$(_targetOS)' == 'tvos'">macho</_AppleTripleAbi>
+      <_AppleTripleAbi Condition="'$(_targetOS)' == 'maccatalyst'">macabi</_AppleTripleAbi>
+      <_AppleTripleAbi Condition="$(_targetOS.EndsWith('simulator'))">simulator</_AppleTripleAbi>
+
+      <TargetTriple>$(_AppleTripleArch)-apple-$(_AppleTripleOS)$(AppleMinOSVersion)-$(_AppleTripleAbi)</TargetTriple>
+      <SharedLibraryInstallName Condition="'$(SharedLibraryInstallName)' == ''">@rpath/$(TargetName)$(NativeBinaryExt)</SharedLibraryInstallName>
+    </PropertyGroup>
+
+    <Error Condition="'$(_iOSLibraryMode)' == 'true' and ('$(_AppleSdkName)' == '' or '$(_AppleTripleArch)' == '' or '$(_AppleTripleOS)' == ''  or '$(AppleMinOSVersion)' == '' or '$(_AppleTripleAbi)' == '')"
+      Text="One of the required Apple SDK properties is empty and was not properly resolved: _AppleSdkName = '$(_AppleSdkName)' _AppleTripleArch = '$(_AppleTripleArch)' _AppleTripleOS = '$(_AppleTripleOS)' AppleMinOSVersion = '$(AppleMinOSVersion)' _AppleTripleAbi = '$(_AppleTripleAbi)'" />
+
+    <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_iOSLibraryMode)' == 'true'" ConsoleToMsBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="SysRoot" />
+    </Exec>
+    <Error Condition="!Exists('$(SysRoot)') and '$(_iOSLibraryMode)' == 'true'"
+      Text="Apple SDK was not found in: '$(SysRoot)'" />
+
     <ItemGroup>
       <NativeLibrary Condition="'$(IlcMultiModule)' == 'true'" Include="$(SharedLibrary)" />
       <NativeLibrary Condition="'$(NativeLib)' == '' and '$(CustomNativeMain)' != 'true'" Include="$(IlcSdkPath)libbootstrapper.o" />
@@ -130,13 +175,15 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-gz=zlib" Condition="'$(CompressSymbols)' != 'false'" />
       <LinkerArg Include="-fuse-ld=$(LinkerFlavor)" Condition="'$(LinkerFlavor)' != ''" />
       <LinkerArg Include="@(NativeLibrary)" />
-      <LinkerArg Include="--sysroot=$(SysRoot)" Condition="'$(SysRoot)' != ''" />
-      <LinkerArg Include="--target=$(TargetTriple)" Condition="'$(_IsApplePlatform)' != 'true' and '$(TargetTriple)' != ''" />
+      <LinkerArg Include="--sysroot=$(SysRoot)" Condition="'$(SysRoot)' != '' and '$(_iOSLibraryMode)' != 'true'" />
+      <LinkerArg Include="-isysroot $(SysRoot)" Condition="'$(SysRoot)' != '' and '$(_iOSLibraryMode)' == 'true'" />
+      <LinkerArg Include="--target=$(TargetTriple)" Condition="('$(_IsApplePlatform)' != 'true' or '$(_iOSLibraryMode)' == 'true') and '$(TargetTriple)' != ''" />
       <LinkerArg Include="-arch $(CrossCompileArch)" Condition="'$(_IsApplePlatform)' == 'true' and '$(CrossCompileArch)' != ''" />
       <LinkerArg Include="-g" Condition="$(NativeDebugSymbols) == 'true'" />
       <LinkerArg Include="-Wl,--strip-debug" Condition="$(NativeDebugSymbols) != 'true' and '$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-Wl,-rpath,'$(IlcRPath)'" Condition="'$(StaticExecutable)' != 'true' and !$([MSBuild]::IsOSPlatform('Windows'))" />
       <LinkerArg Include="-Wl,-rpath,&quot;$(IlcRPath)&quot;" Condition="'$(StaticExecutable)' != 'true' and $([MSBuild]::IsOSPlatform('Windows'))" />
+      <LinkerArg Include="-Wl,-install_name,&quot;$(SharedLibraryInstallName)&quot;" Condition="'$(_iOSLibraryMode)' == 'true'" />
       <LinkerArg Include="-Wl,--build-id=sha1" Condition="'$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-Wl,--as-needed" Condition="'$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-Wl,-e0x0" Condition="'$(NativeLib)' == 'Shared' and '$(_IsApplePlatform)' != 'true'" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -57,21 +57,21 @@ The .NET Foundation licenses this file to you under the MIT license.
       <StandaloneGCSupportName Condition="'$(IlcStandaloneGCSupport)' == 'true'">libstandalonegc-enabled</StandaloneGCSupportName>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(_iOSLibraryMode)' == 'true'">
+    <PropertyGroup Condition="'$(_IsiOSLikePlatform)' == 'true'">
       <Xcrun Condition="'$(Xcrun)' == ''">xcrun</Xcrun>
       <_WhereXcrun>0</_WhereXcrun>
     </PropertyGroup>
 
-    <Exec Command="command -v &quot;$(Xcrun)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_iOSLibraryMode)' == 'true'">
+    <Exec Command="command -v &quot;$(Xcrun)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_IsiOSLikePlatform)' == 'true'">
       <Output TaskParameter="ExitCode" PropertyName="_WhereXcrun" />
     </Exec>
-    <Error Condition="'$(_WhereXcrun)' != '0' and '$(_iOSLibraryMode)' == 'true'"
+    <Error Condition="'$(_WhereXcrun)' != '0' and '$(_IsiOSLikePlatform)' == 'true'"
       Text="'$(Xcrun)' not found in PATH. Make sure '$(Xcrun)' is available in PATH." />
 
-    <PropertyGroup Condition="'$(_iOSLibraryMode)' == 'true'">
-      <AppleMinOSVersion Condition="'$(AppleMinOSVersion)' == '' and '$(_targetOS)' == 'maccatalyst' and '$(TargetArchitecture)' == 'x64'">13.5</AppleMinOSVersion>
+    <PropertyGroup Condition="'$(_IsiOSLikePlatform)' == 'true'">
+      <AppleMinOSVersion Condition="'$(AppleMinOSVersion)' == '' and '$(_targetOS)' == 'maccatalyst' and '$(_targetArchitecture)' == 'x64'">13.5</AppleMinOSVersion>
       <AppleMinOSVersion Condition="'$(AppleMinOSVersion)' == '' and '$(_targetOS)' == 'maccatalyst'">14.2</AppleMinOSVersion>
-      <AppleMinOSVersion Condition="'$(AppleMinOSVersion)' == '' and '$(_targetOS)' != 'maccatalyst'">11.0</AppleMinOSVersion>
+      <AppleMinOSVersion Condition="'$(AppleMinOSVersion)' == '' and ($(_targetOS.StartsWith('ios')) or $(_targetOS.StartsWith('tvos')))">11.0</AppleMinOSVersion>
 
       <_AppleSdkName Condition="'$(_targetOS)' == 'ios'">iphoneos</_AppleSdkName>
       <_AppleSdkName Condition="'$(_targetOS)' == 'iossimulator'">iphonesimulator</_AppleSdkName>
@@ -79,8 +79,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_AppleSdkName Condition="'$(_targetOS)' == 'tvossimulator'">appletvsimulator</_AppleSdkName>
       <_AppleSdkName Condition="'$(_targetOS)' == 'maccatalyst'">macosx</_AppleSdkName>
 
-      <_AppleTripleArch Condition="'$(TargetArchitecture)' == 'x64'">x86_64</_AppleTripleArch>
-      <_AppleTripleArch Condition="'$(TargetArchitecture)' == 'arm64'">arm64</_AppleTripleArch>
+      <_AppleTripleArch Condition="'$(_targetArchitecture)' == 'x64'">x86_64</_AppleTripleArch>
+      <_AppleTripleArch Condition="'$(_targetArchitecture)' == 'arm64'">arm64</_AppleTripleArch>
 
       <_AppleTripleOS Condition="'$(_targetOS)' == 'maccatalyst' or $(_targetOS.StartsWith('ios'))">ios</_AppleTripleOS>
       <_AppleTripleOS Condition="$(_targetOS.StartsWith('tvos'))">tvos</_AppleTripleOS>
@@ -90,16 +90,16 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_AppleTripleAbi Condition="$(_targetOS.EndsWith('simulator'))">simulator</_AppleTripleAbi>
 
       <TargetTriple>$(_AppleTripleArch)-apple-$(_AppleTripleOS)$(AppleMinOSVersion)-$(_AppleTripleAbi)</TargetTriple>
-      <SharedLibraryInstallName Condition="'$(SharedLibraryInstallName)' == ''">@rpath/$(TargetName)$(NativeBinaryExt)</SharedLibraryInstallName>
+      <SharedLibraryInstallName Condition="'$(SharedLibraryInstallName)' == '' and '$(NativeLib)' == 'Shared'">@rpath/$(TargetName)$(NativeBinaryExt)</SharedLibraryInstallName>
     </PropertyGroup>
 
-    <Error Condition="'$(_iOSLibraryMode)' == 'true' and ('$(_AppleSdkName)' == '' or '$(_AppleTripleArch)' == '' or '$(_AppleTripleOS)' == ''  or '$(AppleMinOSVersion)' == '' or '$(_AppleTripleAbi)' == '')"
+    <Error Condition="'$(_IsiOSLikePlatform)' == 'true' and ('$(_AppleSdkName)' == '' or '$(_AppleTripleArch)' == '' or '$(_AppleTripleOS)' == ''  or '$(AppleMinOSVersion)' == '' or '$(_AppleTripleAbi)' == '')"
       Text="One of the required Apple SDK properties is empty and was not properly resolved: _AppleSdkName = '$(_AppleSdkName)' _AppleTripleArch = '$(_AppleTripleArch)' _AppleTripleOS = '$(_AppleTripleOS)' AppleMinOSVersion = '$(AppleMinOSVersion)' _AppleTripleAbi = '$(_AppleTripleAbi)'" />
 
-    <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(SysRoot)' == '' and '$(_iOSLibraryMode)' == 'true'" ConsoleToMsBuild="true">
+    <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(SysRoot)' == '' and '$(_IsiOSLikePlatform)' == 'true'" ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="SysRoot" />
     </Exec>
-    <Error Condition="!Exists('$(SysRoot)') and '$(_iOSLibraryMode)' == 'true'"
+    <Error Condition="!Exists('$(SysRoot)') and '$(_IsiOSLikePlatform)' == 'true'"
       Text="Apple SDK was not found in: '$(SysRoot)'" />
 
     <ItemGroup>
@@ -177,13 +177,13 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="@(NativeLibrary)" />
       <LinkerArg Include="--sysroot=&quot;$(SysRoot)&quot;" Condition="'$(SysRoot)' != '' and '$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-isysroot &quot;$(SysRoot)&quot;" Condition="'$(SysRoot)' != '' and '$(_IsApplePlatform)' == 'true'" />
-      <LinkerArg Include="--target=$(TargetTriple)" Condition="('$(_IsApplePlatform)' != 'true' or '$(_iOSLibraryMode)' == 'true') and '$(TargetTriple)' != ''" />
+      <LinkerArg Include="--target=$(TargetTriple)" Condition="'$(_targetOS)' != 'osx' and '$(TargetTriple)' != ''" />
       <LinkerArg Include="-arch $(CrossCompileArch)" Condition="'$(_IsApplePlatform)' == 'true' and '$(CrossCompileArch)' != ''" />
       <LinkerArg Include="-g" Condition="$(NativeDebugSymbols) == 'true'" />
       <LinkerArg Include="-Wl,--strip-debug" Condition="$(NativeDebugSymbols) != 'true' and '$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-Wl,-rpath,'$(IlcRPath)'" Condition="'$(StaticExecutable)' != 'true' and !$([MSBuild]::IsOSPlatform('Windows'))" />
       <LinkerArg Include="-Wl,-rpath,&quot;$(IlcRPath)&quot;" Condition="'$(StaticExecutable)' != 'true' and $([MSBuild]::IsOSPlatform('Windows'))" />
-      <LinkerArg Include="-Wl,-install_name,&quot;$(SharedLibraryInstallName)&quot;" Condition="'$(_iOSLibraryMode)' == 'true'" />
+      <LinkerArg Include="-Wl,-install_name,&quot;$(SharedLibraryInstallName)&quot;" Condition="'$(_IsiOSLikePlatform)' == 'true' and '$(NativeLib)' == 'Shared'" />
       <LinkerArg Include="-Wl,--build-id=sha1" Condition="'$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-Wl,--as-needed" Condition="'$(_IsApplePlatform)' != 'true'" />
       <LinkerArg Include="-Wl,-e0x0" Condition="'$(NativeLib)' == 'Shared' and '$(_IsApplePlatform)' != 'true'" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -30,6 +30,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <RunILLink>false</RunILLink>
     <_IsiOSLikePlatform Condition="'$(_targetOS)' == 'maccatalyst' or $(_targetOS.StartsWith('ios')) or $(_targetOS.StartsWith('tvos'))">true</_IsiOSLikePlatform>
     <_IsApplePlatform Condition="'$(_targetOS)' == 'osx' or '$(_IsiOSLikePlatform)' == 'true'">true</_IsApplePlatform>
+    <_iOSLibraryMode Condition="'$(_IsiOSLikePlatform)' == 'true' and !$(TargetFramework.Contains('$(_targetOS)')) and '$(NativeLib)' != '' and '$(CustomNativeMain)' != 'true'">true</_iOSLibraryMode>
   </PropertyGroup>
 
   <!-- Set up default feature switches -->
@@ -71,7 +72,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <NativeBinaryExt Condition="'$(IsNativeExecutable)' != 'true' and '$(_targetOS)' == 'win' and '$(NativeLib)' == 'Static'">.lib</NativeBinaryExt>
     <NativeBinaryExt Condition="'$(IsNativeExecutable)' != 'true' and '$(_targetOS)' != 'win' and '$(NativeLib)' == 'Static'">.a</NativeBinaryExt>
 
-    <NativeSymbolExt Condition="'$(NativeSymbolExt)' == '' and '$(_IsApplePlatform)' == 'true'">.dsym</NativeSymbolExt>
+    <NativeSymbolExt Condition="'$(NativeSymbolExt)' == '' and '$(_IsApplePlatform)' == 'true'">.dSYM</NativeSymbolExt>
     <NativeSymbolExt Condition="'$(NativeSymbolExt)' == '' and '$(_targetOS)' == 'win'">.pdb</NativeSymbolExt>
     <NativeSymbolExt Condition="'$(NativeSymbolExt)' == ''">.dbg</NativeSymbolExt>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -30,7 +30,6 @@ The .NET Foundation licenses this file to you under the MIT license.
     <RunILLink>false</RunILLink>
     <_IsiOSLikePlatform Condition="'$(_targetOS)' == 'maccatalyst' or $(_targetOS.StartsWith('ios')) or $(_targetOS.StartsWith('tvos'))">true</_IsiOSLikePlatform>
     <_IsApplePlatform Condition="'$(_targetOS)' == 'osx' or '$(_IsiOSLikePlatform)' == 'true'">true</_IsApplePlatform>
-    <_iOSLibraryMode Condition="'$(_IsiOSLikePlatform)' == 'true' and !$(TargetFramework.Contains('$(_targetOS)')) and '$(NativeLib)' != '' and '$(CustomNativeMain)' != 'true'">true</_iOSLibraryMode>
   </PropertyGroup>
 
   <!-- Set up default feature switches -->

--- a/src/libraries/sendtohelix-mobile.targets
+++ b/src/libraries/sendtohelix-mobile.targets
@@ -53,7 +53,7 @@
       <iOSLikeLibraryBuilderTargetsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'mono', 'msbuild', 'common'))</iOSLikeLibraryBuilderTargetsDir>
       <WorkItemPrefix Condition="'$(Scenario)' == 'BuildiOSApps' and '$(TestUsingWorkloads)' != 'true'">$(TargetOS)-</WorkItemPrefix>
 
-      <CMakeUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/macos/cmake/cmake-3.16.4-Darwin-x86_64.tar.gz</CMakeUrl>
+      <CMakeUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/macos/cmake/cmake-3.28.0-macos-universal.tar.gz</CMakeUrl>
 
       <_XHarnessAppleCustomCommand Condition="'$(NeedsiOSSDK)' == 'true'">
         source build-apple-app.sh
@@ -64,6 +64,7 @@
     <ItemGroup Condition="'$(NeedsiOSSDK)' == 'true'">
       <HelixCorrelationPayload Include="cmake" Uri="$(CMakeUrl)"                 Destination="build/cmake" />
       <HelixCorrelationPayload Include="$(AppleAppBuilderDir)"                   Destination="build/AppleAppBuilder" />
+      <HelixCorrelationPayload Include="$(LibraryBuilderDir)"                    Destination="build/LibraryBuilder" />
       <HelixCorrelationPayload Include="$(MonoAOTCompilerDir)"                   Condition="'$(RuntimeFlavor)' == 'mono'"
                                                                                  Destination="build/MonoAOTCompiler" />
       <HelixCorrelationPayload Include="$(MicrosoftNetCoreAppRuntimePackDir)"    Destination="build/microsoft.netcore.app.runtime.$(TargetOS)-$(TargetArchitecture.ToLower())" />

--- a/src/mono/msbuild/apple/build/AppleBuild.props
+++ b/src/mono/msbuild/apple/build/AppleBuild.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <!-- iOS/tvOS arm64 simulators do not support JIT, so force interpreter fallback, devices should FullAOT -->
-  <PropertyGroup Condition="('$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'tvossimulator') And '$(TargetArchitecture)' == 'arm64'">
+  <PropertyGroup Condition="('$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'tvossimulator') And '$(TargetArchitecture)' == 'arm64' and '$(UseNativeAOTRuntime)' != 'true'">
     <MonoForceInterpreter Condition="'$(MonoForceInterpreter)' == ''">true</MonoForceInterpreter>
   </PropertyGroup>
 
@@ -19,7 +19,8 @@
     <!-- Tracking issue: https://github.com/dotnet/runtime/issues/87740 -->
     <!-- <ShouldILStrip Condition="'$(RunAOTCompilation)' == 'true' and '$(MonoForceInterpreter)' != 'true'">true</ShouldILStrip> -->
 
-    <_IsLibraryMode Condition="'$(UseNativeAOTRuntime)' != 'true' and '$(NativeLib)' != ''">true</_IsLibraryMode>
+    <!-- TODO: We currently do not support bundling a static iOS-library with NativeAOT -->
+    <_IsLibraryMode Condition="('$(UseNativeAOTRuntime)' != 'true' and '$(NativeLib)' != '') or ('$(UseNativeAOTRuntime)' == 'true' and '$(NativeLib)' == 'Shared')">true</_IsLibraryMode>
 
     <_AotCompileTargetName Condition="'$(UseNativeAOTRuntime)' == 'true'">_AppleNativeAotCompile</_AotCompileTargetName>
     <_AotCompileTargetName Condition="'$(UseNativeAOTRuntime)' != 'true'">_AppleAotCompile</_AotCompileTargetName>

--- a/src/mono/msbuild/apple/build/AppleBuild.targets
+++ b/src/mono/msbuild/apple/build/AppleBuild.targets
@@ -4,7 +4,7 @@
     <AppleGenerateAppBundle Condition="'$(AppleGenerateAppBundle)' == ''">true</AppleGenerateAppBundle>
     <!-- Unable to properly integrate nativelib into app build, so not supported for now. -->
     <AppleGenerateAppBundle Condition="'$(_IsLibraryMode)' == 'true' and '$(ForceLibraryModeGenerateAppBundle)' != 'true' and '$(UseNativeAOTRuntime)' != 'true'">false</AppleGenerateAppBundle>
-    <_ProcessRuntimeComponentsForLibraryMode Condition="'$(_IsLibraryMode)' == 'true'">_ProcessRuntimeComponentsForLibraryMode</_ProcessRuntimeComponentsForLibraryMode>
+    <_ProcessRuntimeComponentsForLibraryMode Condition="'$(_IsLibraryMode)' == 'true' and '$(UseNativeAOTRuntime)' != 'true'">_ProcessRuntimeComponentsForLibraryMode</_ProcessRuntimeComponentsForLibraryMode>
     <EnableDefaultAssembliesToBundle Condition="'$(EnableDefaultAssembliesToBundle)' == ''">false</EnableDefaultAssembliesToBundle>
   </PropertyGroup>
 
@@ -267,7 +267,7 @@
   </Target>
 
   <Target Name="_AppleNativeAotCompile"
-          DependsOnTargets="SetupProperties;ComputeIlcCompileInputs;IlcCompile" />
+          DependsOnTargets="SetupProperties;ComputeIlcCompileInputs;IlcCompile;$(_IlcLibraryBuildDependsOn)" />
 
   <Target Name="_AppleGenerateAppBundle" 
           Condition="'$(AppleGenerateAppBundle)' == 'true'"
@@ -275,17 +275,18 @@
     <!-- Run App bundler, it uses AOT libs (if needed), link all native bits, compile simple UI (written in ObjC)
          and produce an app bundle (with xcode project) -->
 
+    <Error Condition="'$(NativeMainSource)' != '' and !Exists('$(NativeMainSource)')" Text="Project property NativeMainSource is defined, but the specified file: '$(NativeMainSource)' does not exist." />
+
     <ItemGroup>
       <ExtraAppLinkerArgs Include="@(_CommonLinkerArgs)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(_IsLibraryMode)' == 'true'">
+    <ItemGroup Condition="'$(_IsLibraryMode)' == 'true' and '$(UseNativeAOTRuntime)' != 'true'">
       <NativeDependencies Include="$(LibraryOutputPath)" />
     </ItemGroup>
 
-    <Error Condition="'$(NativeMainSource)' != '' and !Exists('$(NativeMainSource)')" Text="Project property NativeMainSource is defined, but the specified file: '$(NativeMainSource)' does not exist." />
-
-    <ItemGroup Condition="'$(UseNativeAOTRuntime)' == 'true'">
+    <!-- Only pass additional linker flags with NativeAOT when we are not in the library mode -->
+    <ItemGroup Condition="'$(_IsLibraryMode)' != 'true' and '$(UseNativeAOTRuntime)' == 'true'">
       <NativeDependencies Condition="$(NativeDependencies) == ''" Include="%(ManagedBinary.IlcOutputFile)" />
       <_LinkerFlagsToDrop Include="@(NativeFramework->'-framework %(Identity)')" />
       <LinkerArg Remove="@(_LinkerFlagsToDrop)" />

--- a/src/mono/msbuild/apple/data/ProxyProjectForAOTOnHelix.proj
+++ b/src/mono/msbuild/apple/data/ProxyProjectForAOTOnHelix.proj
@@ -11,18 +11,34 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseNativeAOTRuntime)' == 'true'">
-    <IntermediateOutputPath>$(OriginalPublishDir)</IntermediateOutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <UseArtifactsIntermediateOutput>true</UseArtifactsIntermediateOutput>
-    <NativeLib>static</NativeLib>
-    <CustomNativeMain>true</CustomNativeMain>
-    <NativeCompilationDuringPublish>false</NativeCompilationDuringPublish>
+    <_UseLibraryModeBundling Condition="'$(NativeLib)' != ''">true</_UseLibraryModeBundling>
+
     <_IsApplePlatform>true</_IsApplePlatform>
     <TargetsAppleMobile>true</TargetsAppleMobile>
     <_targetOS>$(TargetOS)</_targetOS>
-
+  
     <!-- Forced by ILLink targets -->
     <SelfContained>true</SelfContained>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UseNativeAOTRuntime)' == 'true' and '$(_UseLibraryModeBundling)' != 'true'">
+    <!-- TODO: we probably want to recreate everything in the intermediate directory instead (see library mode bellow) -->
+    <IntermediateOutputPath>$(OriginalPublishDir)</IntermediateOutputPath>
+    <NativeLib>static</NativeLib>
+    <CustomNativeMain>true</CustomNativeMain>
+    <NativeCompilationDuringPublish>false</NativeCompilationDuringPublish>
+  </PropertyGroup>
+  <!-- In library mode we depend on NativeAOT publish integration targets -->
+  <PropertyGroup Condition="'$(UseNativeAOTRuntime)' == 'true' and '$(_UseLibraryModeBundling)' == 'true'">
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
+    <OutputPath>$([MSBuild]::NormalizeDirectory($(TestRootDir), '..', 'bin'))</OutputPath>
+    <PublishDir>$(OriginalPublishDir)</PublishDir>
+    <_IlcLibraryBuildDependsOn>LinkNative;CopyNativeBinary</_IlcLibraryBuildDependsOn>
+    <!-- we should not strip symbols from the generated library as xcode build will attempt to strip already stripped symbols -->
+    <StripSymbols>false</StripSymbols>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UseNativeAOTRuntime)' == 'true'">
@@ -56,6 +72,13 @@
       <AppleNativeFilesToBundle Include="@(_ExtraFiles)" Exclude="$(OriginalPublishDir)\*.dll" />
       <AppleNativeFilesToBundle Include="$(OriginalPublishDir)\**\*.*" Exclude="$(OriginalPublishDir)\*.dll" />
     </ItemGroup>
+
+    <!-- For NativeAOT library mode we need to manually create the 'obj' dir and copy all assemblies in there to properly build the library -->
+    <MakeDir Condition="'$(UseNativeAOTRuntime)' == 'true' and '$(_UseLibraryModeBundling)' == 'true'"
+      Directories="$(IntermediateOutputPath)" />
+    <Copy Condition="'$(UseNativeAOTRuntime)' == 'true' and '$(_UseLibraryModeBundling)' == 'true'"
+      SourceFiles="@(AppleAssembliesToBundle)"
+      DestinationFolder="$(IntermediateOutputPath)" />
 
     <PropertyGroup Condition="'$(UseRuntimeComponents)' == 'true'">
       <DiagnosticPorts>127.0.0.1:9000,nosuspend,listen</DiagnosticPorts>

--- a/src/mono/msbuild/apple/data/ProxyProjectForAOTOnHelix.proj
+++ b/src/mono/msbuild/apple/data/ProxyProjectForAOTOnHelix.proj
@@ -13,7 +13,7 @@
   <PropertyGroup Condition="'$(UseNativeAOTRuntime)' == 'true'">
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <UseArtifactsIntermediateOutput>true</UseArtifactsIntermediateOutput>
-    <_UseLibraryModeBundling Condition="'$(NativeLib)' != ''">true</_UseLibraryModeBundling>
+    <_UseNativeAOTLibraryModeBundling Condition="'$(NativeLib)' == 'Shared'">true</_UseNativeAOTLibraryModeBundling>
 
     <_IsApplePlatform>true</_IsApplePlatform>
     <TargetsAppleMobile>true</TargetsAppleMobile>
@@ -23,7 +23,7 @@
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(UseNativeAOTRuntime)' == 'true' and '$(_UseLibraryModeBundling)' != 'true'">
+  <PropertyGroup Condition="'$(_UseNativeAOTLibraryModeBundling)' != 'true'">
     <!-- TODO: we probably want to recreate everything in the intermediate directory instead (see library mode bellow) -->
     <IntermediateOutputPath>$(OriginalPublishDir)</IntermediateOutputPath>
     <NativeLib>static</NativeLib>
@@ -31,7 +31,7 @@
     <NativeCompilationDuringPublish>false</NativeCompilationDuringPublish>
   </PropertyGroup>
   <!-- In library mode we depend on NativeAOT publish integration targets -->
-  <PropertyGroup Condition="'$(UseNativeAOTRuntime)' == 'true' and '$(_UseLibraryModeBundling)' == 'true'">
+  <PropertyGroup Condition="'$(_UseNativeAOTLibraryModeBundling)' == 'true'">
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
     <OutputPath>$([MSBuild]::NormalizeDirectory($(TestRootDir), '..', 'bin'))</OutputPath>
@@ -74,9 +74,9 @@
     </ItemGroup>
 
     <!-- For NativeAOT library mode we need to manually create the 'obj' dir and copy all assemblies in there to properly build the library -->
-    <MakeDir Condition="'$(UseNativeAOTRuntime)' == 'true' and '$(_UseLibraryModeBundling)' == 'true'"
+    <MakeDir Condition="'$(_UseNativeAOTLibraryModeBundling)' == 'true'"
       Directories="$(IntermediateOutputPath)" />
-    <Copy Condition="'$(UseNativeAOTRuntime)' == 'true' and '$(_UseLibraryModeBundling)' == 'true'"
+    <Copy Condition="'$(_UseNativeAOTLibraryModeBundling)' == 'true'"
       SourceFiles="@(AppleAssembliesToBundle)"
       DestinationFolder="$(IntermediateOutputPath)" />
 

--- a/src/tasks/AppleAppBuilder/Templates/CMakeLists-librarymode.txt.template
+++ b/src/tasks/AppleAppBuilder/Templates/CMakeLists-librarymode.txt.template
@@ -5,21 +5,17 @@ enable_language(OBJC ASM)
 
 set(APP_RESOURCES
 %AppResources%
-lib%ProjectName%.dylib
 )
 
 add_executable(
     %ProjectName%
     %MainSource%
     ${APP_RESOURCES}
+    util.h
+    util.m
+    runtime-librarymode.h
+    runtime-librarymode.m
 )
-
-if(NOT %UseNativeAOTRuntime%)
-    target_sources(
-        %ProjectName%
-        PRIVATE
-        runtime.m)
-endif()
 
 %Defines%
 
@@ -36,6 +32,7 @@ set_target_properties(%ProjectName% PROPERTIES
     XCODE_EMBED_FRAMEWORKS "%DYLIB_PATH%"
     XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/Frameworks"
     XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST "YES"
+    XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY "YES"
     RESOURCE "${APP_RESOURCES}"
 )
 

--- a/src/tasks/AppleAppBuilder/Templates/main-console.m
+++ b/src/tasks/AppleAppBuilder/Templates/main-console.m
@@ -2,13 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #import <UIKit/UIKit.h>
+
+#if !USE_LIBRARY_MODE
 #if !USE_NATIVE_AOT
 #import "runtime.h"
 #else
 #import <os/log.h>
 #import "util.h"
 extern int __managed__Main(int argc, char* argv[]);
-#endif
+#endif // !USE_NATIVE_AOT
+#else
+#import "runtime-librarymode.h"
+#endif // !USE_LIBRARY_MODE
 
 @interface ViewController : UIViewController
 @end
@@ -69,19 +74,23 @@ UITextView* logLabel;
     [self.view addSubview:summaryLabel];
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+#if !USE_LIBRARY_MODE
 #if !USE_NATIVE_AOT
         mono_ios_runtime_init ();
 #else
 #if INVARIANT_GLOBALIZATION
         setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1", TRUE);
-#endif
+#endif // INVARIANT_GLOBALIZATION
         char **managed_argv;
         int managed_argc = get_managed_args (&managed_argv);
         int ret_val = __managed__Main (managed_argc, managed_argv);
         free_managed_args (&managed_argv, managed_argc);
         os_log_info (OS_LOG_DEFAULT, EXIT_CODE_TAG ": %d", ret_val);
         exit (ret_val);
-#endif
+#endif // !USE_NATIVE_AOT
+#else
+        library_mode_init();
+#endif //!USE_LIBRARY_MODE
     });
 }
 

--- a/src/tasks/AppleAppBuilder/Templates/runtime-librarymode.h
+++ b/src/tasks/AppleAppBuilder/Templates/runtime-librarymode.h
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef runtime_librarymode_h
+#define runtime_librarymode_h
+
+void library_mode_init (void);
+
+#endif /* runtime_librarymode_h */

--- a/src/tasks/AppleAppBuilder/Templates/runtime-librarymode.m
+++ b/src/tasks/AppleAppBuilder/Templates/runtime-librarymode.m
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #import <Foundation/Foundation.h>
+#if !USE_NATIVE_AOT
 #include <mono/utils/mono-publib.h>
 #include <mono/utils/mono-logger.h>
 #include <mono/metadata/assembly.h>
@@ -13,6 +14,7 @@
 #include <mono/metadata/object.h>
 #include <mono/jit/jit.h>
 #include <mono/jit/mono-private-unstable.h>
+#endif
 #include <TargetConditionals.h>
 #import <os/log.h>
 #include <sys/stat.h>
@@ -49,7 +51,7 @@ get_bundle_path (void)
 }
 
 void
-mono_ios_runtime_init (void)
+library_mode_init (void)
 {
 #if INVARIANT_GLOBALIZATION
     setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1", TRUE);
@@ -59,17 +61,19 @@ mono_ios_runtime_init (void)
     setenv ("DOTNET_SYSTEM_GLOBALIZATION_HYBRID", "1", TRUE);
 #endif
 
-#if ENABLE_RUNTIME_LOGGING
+#if ENABLE_RUNTIME_LOGGING && !USE_NATIVE_AOT
     setenv ("MONO_LOG_LEVEL", "debug", TRUE);
     setenv ("MONO_LOG_MASK", "all", TRUE);
 #endif
 
+#if !USE_NATIVE_AOT
     // build using DiagnosticPorts property in AppleAppBuilder
     // or set DOTNET_DiagnosticPorts env via mlaunch, xharness when undefined.
     // NOTE, using DOTNET_DiagnosticPorts requires app build using AppleAppBuilder and RuntimeComponents to include 'diagnostics_tracing' component
 #ifdef DIAGNOSTIC_PORTS
     setenv ("DOTNET_DiagnosticPorts", DIAGNOSTIC_PORTS, true);
 #endif
+#endif // !USE_NATIVE_AOT
 
     // When not bundling, this will make sure the runtime can access all the assemblies
     const char* bundle = get_bundle_path ();

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -259,6 +259,18 @@ internal sealed class Xcode
     {
         // bundle everything as resources excluding native files
         var predefinedExcludes = new List<string> { ".dll.o", ".dll.s", ".dwarf", ".m", ".h", ".a", ".bc", "libmonosgen-2.0.dylib", "libcoreclr.dylib", "icudt*" };
+
+        // TODO: All of these exclusions shouldn't be needed once we carefully construct the publish folder on Helix
+        if (useNativeAOTRuntime)
+        {
+            predefinedExcludes.Add(".dll");
+            predefinedExcludes.Add(".pdb");
+            predefinedExcludes.Add(".json");
+            predefinedExcludes.Add(".txt");
+            predefinedExcludes.Add(".bin");
+            predefinedExcludes.Add(".dSYM");
+        }
+
         predefinedExcludes = predefinedExcludes.Concat(excludes).ToList();
         if (!preferDylibs)
         {
@@ -278,7 +290,7 @@ internal sealed class Xcode
         {
             // use built-in main.m (with default UI) if it's not set
             nativeMainSource = Path.Combine(binDir, "main.m");
-            File.WriteAllText(nativeMainSource, Utils.GetEmbeddedResource(useConsoleUiTemplate ? "main-console.m" : "main-simple.m"));
+            File.WriteAllText(nativeMainSource, Utils.GetEmbeddedResource((useConsoleUiTemplate || isLibraryMode) ? "main-console.m" : "main-simple.m"));
         }
         else
         {
@@ -330,8 +342,30 @@ internal sealed class Xcode
 
         if (isLibraryMode)
         {
-            string dylibName = $"lib{projectName}.dylib";
-            cmakeLists = cmakeLists.Replace("%DYLIB_PATH%", $"{Path.Combine(binDir, dylibName)}");
+            string libraryPath;
+            // TODO: unify MonoAOT and NativeAOT library paths
+            // Current differences:
+            // - NativeAOT produces {ProjectName}.dylib, while MonoAOT produces lib{ProjectName}.dylib
+            // - NativeAOT places the library in the 'workspace' location ie 'publish' folder, while MonoAOT places it in 'binDir' ie 'AppBundle'
+            if (useNativeAOTRuntime)
+            {
+                libraryPath = Path.Combine(workspace, $"{projectName}.dylib");
+            }
+            else
+            {
+                libraryPath = Path.Combine(binDir, $"lib{projectName}.dylib");
+            }
+
+            if (!File.Exists(libraryPath))
+            {
+                throw new Exception($"Library not found at: {libraryPath} when building in the library mode.");
+            }
+
+            cmakeLists = cmakeLists.Replace("%DYLIB_PATH%", libraryPath);
+
+            // pass the shared library to the linker for dynamic linking
+            if (useNativeAOTRuntime)
+                toLink += $"    {libraryPath}{Environment.NewLine}";
         }
         else
         {
@@ -454,6 +488,11 @@ internal sealed class Xcode
             defines.AppendLine("add_definitions(-DUSE_NATIVE_AOT=1)");
         }
 
+        if (isLibraryMode)
+        {
+            defines.AppendLine("add_definitions(-DUSE_LIBRARY_MODE=1)");
+        }
+
         cmakeLists = cmakeLists.Replace("%Defines%", defines.ToString());
 
         string plist = Utils.GetEmbeddedResource("Info.plist.template")
@@ -477,7 +516,12 @@ internal sealed class Xcode
             File.WriteAllText(Path.Combine(binDir, "app.entitlements"), entitlementsTemplate.Replace("%Entitlements%", ent.ToString()));
         }
 
-        if (!useNativeAOTRuntime)
+        if (isLibraryMode)
+        {
+            File.WriteAllText(Path.Combine(binDir, "runtime-librarymode.h"), Utils.GetEmbeddedResource("runtime-librarymode.h"));
+            File.WriteAllText(Path.Combine(binDir, "runtime-librarymode.m"), Utils.GetEmbeddedResource("runtime-librarymode.m"));
+        }
+        else if (!useNativeAOTRuntime)
         {
             File.WriteAllText(Path.Combine(binDir, "runtime.h"),
                 Utils.GetEmbeddedResource("runtime.h"));
@@ -496,9 +540,8 @@ internal sealed class Xcode
 
             pinvokeOverrides.AppendLine($"        \"System.Globalization.Native\",");
 
-            string runtimeTemplateName = (isLibraryMode) ? "runtime-librarymode.m" : "runtime.m";
             File.WriteAllText(Path.Combine(binDir, "runtime.m"),
-                Utils.GetEmbeddedResource(runtimeTemplateName)
+                Utils.GetEmbeddedResource("runtime.m")
                     .Replace("//%PInvokeOverrideLibraries%", pinvokeOverrides.ToString())
                     .Replace("//%APPLE_RUNTIME_IDENTIFIER%", RuntimeIdentifier)
                     .Replace("%EntryPointLibName%", Path.GetFileName(entryPointLib)));

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -443,7 +443,8 @@ internal sealed class Xcode
         }
 
         string appLinkLibraries = $"    {frameworks}{Environment.NewLine}";
-        string extraLinkerArgsConcat = $"\"{string.Join('\n', extraLinkerArgs)}\"";
+        string extraLinkerArgsConcatEscapeQuotes = string.Join('\n', extraLinkerArgs).Replace("\"", "\\\"");
+        string extraLinkerArgsConcat = $"\"{extraLinkerArgsConcatEscapeQuotes}\"";
 
         cmakeLists = cmakeLists.Replace("%NativeLibrariesToLink%", toLink);
         cmakeLists = cmakeLists.Replace("%APP_LINK_LIBRARIES%", appLinkLibraries);

--- a/src/tests/FunctionalTests/iOS/Device/LibraryMode/ClassLibrary.cs
+++ b/src/tests/FunctionalTests/iOS/Device/LibraryMode/ClassLibrary.cs
@@ -6,24 +6,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 
-public static class Program
+public static class ClassLibrary
 {
-    [DllImport("__Internal")]
-    public static extern void mono_ios_set_summary (string value);
-
     [UnmanagedCallersOnly(EntryPoint = nameof(SayHello))]
     public static int SayHello()
     {
         Console.WriteLine("Called from native!  Hello!");
-        return 42;
-    }
-
-    public static async Task<int> Main(string[] args)
-    {
-        mono_ios_set_summary($"Starting functional test");
-        Console.WriteLine("Done!");
-        await Task.Delay(5000);
-
         return 42;
     }
 }

--- a/src/tests/FunctionalTests/iOS/Device/LibraryMode/ILLink.Descriptors.xml
+++ b/src/tests/FunctionalTests/iOS/Device/LibraryMode/ILLink.Descriptors.xml
@@ -1,5 +1,5 @@
 <linker>
-  <assembly fullname="iOS.Simulator.LibraryMode.Test">
+  <assembly fullname="iOS.Device.LibraryMode.Test">
     <type fullname="ClassLibrary">
       <method name="SayHello" />
     </type>

--- a/src/tests/FunctionalTests/iOS/Device/LibraryMode/iOS.Device.LibraryMode.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Device/LibraryMode/iOS.Device.LibraryMode.Test.csproj
@@ -5,22 +5,22 @@
     <TestRuntime>true</TestRuntime>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <RuntimeIdentifier>$(TargetOS)-$(TargetArchitecture)</RuntimeIdentifier>
-    <TargetOS Condition="'$(TargetOS)' == ''">iossimulator</TargetOS>
+    <TargetOS Condition="'$(TargetOS)' == ''">ios</TargetOS>
     <IncludesTestRunner>false</IncludesTestRunner>
     <ExpectedExitCode>42</ExpectedExitCode>
+    <SelfContained>true</SelfContained>
+    <UseConsoleUITemplate>true</UseConsoleUITemplate>
     <ForceLibraryModeGenerateAppBundle>true</ForceLibraryModeGenerateAppBundle>
     <NativeLib Condition="'$(NativeLib)' == ''">shared</NativeLib>
     <BundlesResources Condition="'$(BundlesResources)' == ''">false</BundlesResources>
-    <UseConsoleUITemplate>true</UseConsoleUITemplate>
+    <Optimized Condition="'$(Configuration)' == 'Release'">true</Optimized>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RuntimeFlavor)' == 'Mono'">
     <RunAOTCompilation>true</RunAOTCompilation>
     <MonoEnableLLVM>true</MonoEnableLLVM>
-    <MainLibraryFileName>iOS.Simulator.LibraryMode.Test.dll</MainLibraryFileName>
+    <MainLibraryFileName>iOS.Device.LibraryMode.Test.dll</MainLibraryFileName>
     <MonoForceInterpreter>false</MonoForceInterpreter>
-    <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
-    <iOSLikeDedup Condition="'$(iOSLikeDedup)' == ''">false</iOSLikeDedup>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/FunctionalTests/iOS/Device/LibraryMode/iOS.Device.LibraryMode.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Device/LibraryMode/iOS.Device.LibraryMode.Test.csproj
@@ -47,9 +47,6 @@
       <IlcFrameworkPath>$(LibrariesAllBinArtifactsPath)</IlcFrameworkPath>
       <IlcFrameworkNativePath>$(LibrariesAllBinArtifactsPath)</IlcFrameworkNativePath>
     </PropertyGroup>
-    <ItemGroup>
-      <DirectPInvoke Include="__Internal" KeepDuplicates="false" />
-    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/tests/FunctionalTests/iOS/Simulator/LibraryMode/ClassLibrary.cs
+++ b/src/tests/FunctionalTests/iOS/Simulator/LibraryMode/ClassLibrary.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+public static class ClassLibrary
+{
+    [UnmanagedCallersOnly(EntryPoint = nameof(SayHello))]
+    public static int SayHello()
+    {
+        Console.WriteLine("Called from native!  Hello!");
+        return 42;
+    }
+}

--- a/src/tests/FunctionalTests/iOS/Simulator/LibraryMode/iOS.Simulator.LibraryMode.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Simulator/LibraryMode/iOS.Simulator.LibraryMode.Test.csproj
@@ -47,9 +47,6 @@
       <IlcFrameworkPath>$(LibrariesAllBinArtifactsPath)</IlcFrameworkPath>
       <IlcFrameworkNativePath>$(LibrariesAllBinArtifactsPath)</IlcFrameworkNativePath>
     </PropertyGroup>
-    <ItemGroup>
-      <DirectPInvoke Include="__Internal" KeepDuplicates="false" />
-    </ItemGroup>
   </Target>
 
 </Project>


### PR DESCRIPTION
This PR enables support for building libraries for iOS-like platforms with NativeAOT.

## Changes

- Extended NativeAOT build integration targets to support building libraries for iOS-like platforms
- Adapted `AppleAppBuilder` to support bundling in library mode for both MonoAOT and NativeAOT
- Adapted `AppleAppBuilder` to support bundling in library mode when targeting iOS-like devices
- Adapted `src/tests/FunctionalTests/iOS/Simulator/LibraryMode` for testing the library mode on `iossimulators-arm64/x64` with NativeAOT - currently this only works **locally** please see comments in the project file for more info
    - https://github.com/dotnet/runtime/issues/93447)
- Added `src/tests/FunctionalTests/iOS/Device/LibraryMode` for testing the library mode on `ios-arm64` for both MonoAOT and NativeAOT

## Additional notes

To test **locally** one can execute the following from the repo root directory:
- Test `MonoAOT` library mode on `ios-arm64`:
    ```
    ./dotnet.sh build /t:Test -c Debug /p:TargetOS=ios /p:TargetArchitecture=arm64 src/tests/FunctionalTests/iOS/Device/LibraryMode/iOS.Device.LibraryMode.Test.csproj /p:RuntimeFlavor=Mono
    ```
    
- Test `NativeAOT` library mode on `ios-arm64`:
    ```
    ./dotnet.sh build /t:Test -c Debug /p:TargetOS=ios /p:TargetArchitecture=arm64 src/tests/FunctionalTests/iOS/Device/LibraryMode/iOS.Device.LibraryMode.Test.csproj /p:UseNativeAOTRuntime=true /p:RunAOTCompilation=false /p:RuntimeFlavor=CoreCLR
    ```
    
## Documentation

- [x] https://github.com/dotnet/runtime/issues/96742

--- 
Fixes https://github.com/dotnet/runtime/issues/88737