### PR TITLE
[RISC-V] NaN-box float arguments

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -7773,8 +7773,8 @@ void CodeGen::genFnPrologCalleeRegArgs()
                     assert(genIsValidFloatReg(varDsc->GetArgInitReg()));
                     if (genIsValidIntReg(varDsc->GetArgReg()))
                     {
-                        GetEmitter()->emitIns_Mov(INS_fmv_d_x, EA_PTRSIZE, varDsc->GetArgInitReg(), varDsc->GetArgReg(),
-                                                  false);
+                        emitAttr size = (varDsc->TypeGet() == TYP_FLOAT) ? EA_4BYTE : EA_PTRSIZE;
+                        GetEmitter()->emitIns_Mov(size, varDsc->GetArgInitReg(), varDsc->GetArgReg(), false);
                         regArgMaskLive &= ~genRegMask(varDsc->GetArgReg());
                     }
                     else if (varDsc->GetArgInitReg() > REG_ARG_FP_LAST)

--- a/src/coreclr/vm/argdestination.h
+++ b/src/coreclr/vm/argdestination.h
@@ -98,6 +98,13 @@ public:
     //               of the T value inside of the Nullable<T>
     void CopyStructToRegisters(void *src, int fieldBytes, int destOffset)
     {
+        static const INT64 NanBox =
+        #ifdef TARGET_RISCV64
+            0xffffffff00000000L;
+        #else
+            0L;
+        #endif // TARGET_RISCV64
+
         _ASSERTE(IsStructPassedInRegs());
         _ASSERTE(fieldBytes <= 16);
 
@@ -107,8 +114,8 @@ public:
         { // struct with two floats.
             _ASSERTE(m_argLocDescForStructInRegs->m_cFloatReg == 2);
             _ASSERTE(m_argLocDescForStructInRegs->m_cGenReg == 0);
-            *(INT64*)((char*)m_base + argOfs) = *(INT32*)src;
-            *(INT64*)((char*)m_base + argOfs + 8) = *((INT32*)src + 1);
+            *(INT64*)((char*)m_base + argOfs) = NanBox | *(INT32*)src;
+            *(INT64*)((char*)m_base + argOfs + 8) = NanBox | *((INT32*)src + 1);
         }
         else if ((m_argLocDescForStructInRegs->m_structFields & STRUCT_FLOAT_FIELD_FIRST) != 0)
         { // the first field is float or double.
@@ -118,7 +125,7 @@ public:
 
             if ((m_argLocDescForStructInRegs->m_structFields & STRUCT_FIRST_FIELD_SIZE_IS8) == 0)
             {
-                *(INT64*)((char*)m_base + argOfs) = *(INT32*)src; // the first field is float
+                *(INT64*)((char*)m_base + argOfs) = NanBox | *(INT32*)src; // the first field is float
             }
             else
             {
@@ -146,7 +153,7 @@ public:
             if ((m_argLocDescForStructInRegs->m_structFields & STRUCT_HAS_8BYTES_FIELDS_MASK) == 0)
             {
                 // the second field is float.
-                *(INT64*)((char*)m_base + argOfs) = destOffset == 0 ? *((INT32*)src + 1) : *(INT32*)src;
+                *(INT64*)((char*)m_base + argOfs) = NanBox | (destOffset == 0 ? *((INT32*)src + 1) : *(INT32*)src);
             }
             else
             {
@@ -163,7 +170,7 @@ public:
         }
         else
         {
-            _ASSERTE(!"---------UNReachable-------LoongArch64!!!");
+            _ASSERTE(!"---------UNReachable-------LoongArch64/RISC-V64!!!");
         }
     }
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/vm/invokeutil.cpp
+++ b/src/coreclr/vm/invokeutil.cpp
@@ -138,6 +138,47 @@ void InvokeUtil::CopyArg(TypeHandle th, PVOID argRef, ArgDestination *argDest) {
     CorElementType type = th.GetVerifierCorElementType();
 
     switch (type) {
+#ifdef TARGET_RISCV64
+    // RISC-V call convention requires signed ints sign-extended (unsigned -- zero-extended) to register width
+    case ELEMENT_TYPE_BOOLEAN:
+    case ELEMENT_TYPE_U1:
+        _ASSERTE(argRef != NULL);
+        *(UINT64 *)pArgDst = *(UINT8 *)argRef;
+        break;
+
+    case ELEMENT_TYPE_I1:
+        _ASSERTE(argRef != NULL);
+        *(INT64 *)pArgDst = *(INT8 *)argRef;
+        break;
+
+    case ELEMENT_TYPE_U2:
+    case ELEMENT_TYPE_CHAR:
+        _ASSERTE(argRef != NULL);
+        *(UINT64 *)pArgDst = *(UINT16 *)argRef;
+        break;
+
+    case ELEMENT_TYPE_I2:
+        _ASSERTE(argRef != NULL);
+        *(INT64 *)pArgDst = *(INT16 *)argRef;
+        break;
+
+    case ELEMENT_TYPE_R4:
+        _ASSERTE(argRef != NULL);
+        // NaN-box the register value or single-float instructions will treat it as NaN
+        *(UINT64 *)pArgDst = 0xffffffff00000000L | *(UINT32 *)argRef;
+        break;
+
+    case ELEMENT_TYPE_I4:
+        _ASSERTE(argRef != NULL);
+        *(INT64 *)pArgDst = *(INT32 *)argRef;
+        break;
+
+    case ELEMENT_TYPE_U4:
+        _ASSERTE(argRef != NULL);
+        *(UINT64 *)pArgDst = *(UINT32 *)argRef;
+        break;
+
+#else // !TARGET_RISCV64
     case ELEMENT_TYPE_BOOLEAN:
     case ELEMENT_TYPE_U1:
     case ELEMENT_TYPE_I1:
@@ -156,15 +197,9 @@ void InvokeUtil::CopyArg(TypeHandle th, PVOID argRef, ArgDestination *argDest) {
         break;
     }
 
-    case ELEMENT_TYPE_R4:
-#ifdef TARGET_RISCV64
-        _ASSERTE(argRef != NULL);
-        // NaN-box the register value or single-float instructions will treat it as NaN
-        *(INT64 *)pArgDst = 0xffffffff00000000L | *(INT32 *)argRef;
-        break;
-#endif // TARGET_RISCV64
     case ELEMENT_TYPE_I4:
     case ELEMENT_TYPE_U4:
+    case ELEMENT_TYPE_R4:
     IN_TARGET_32BIT(case ELEMENT_TYPE_U:)
     IN_TARGET_32BIT(case ELEMENT_TYPE_I:)
     {
@@ -172,6 +207,7 @@ void InvokeUtil::CopyArg(TypeHandle th, PVOID argRef, ArgDestination *argDest) {
         *(INT32 *)pArgDst = *(INT32 *)argRef;
         break;
     }
+#endif // TARGET_RISCV64
 
     case ELEMENT_TYPE_I8:
     case ELEMENT_TYPE_U8:

--- a/src/coreclr/vm/invokeutil.cpp
+++ b/src/coreclr/vm/invokeutil.cpp
@@ -156,9 +156,15 @@ void InvokeUtil::CopyArg(TypeHandle th, PVOID argRef, ArgDestination *argDest) {
         break;
     }
 
+    case ELEMENT_TYPE_R4:
+#ifdef TARGET_RISCV64
+        _ASSERTE(argRef != NULL);
+        // NaN-box the register value or single-float instructions will treat it as NaN
+        *(INT64 *)pArgDst = 0xffffffff00000000L | *(INT32 *)argRef;
+        break;
+#endif // TARGET_RISCV64
     case ELEMENT_TYPE_I4:
     case ELEMENT_TYPE_U4:
-    case ELEMENT_TYPE_R4:
     IN_TARGET_32BIT(case ELEMENT_TYPE_U:)
     IN_TARGET_32BIT(case ELEMENT_TYPE_I:)
     {


### PR DESCRIPTION
* NaN-box the arguments passed to CallDescrWorkerInternal because that stub is unaware of floating-point argument sizes
* NaN-box floats in CopyStructToRegisters
* Use variant of fmv.?.x appropriate for the size of the floating-point argument in function prolog

    Floats passed in integer registers need to be NaN-boxed.

This fixes System.Text.Json.Tests.Utf8JsonWriterTests.(WriteNumberValueSingle|WriteFloatValue)

Part of #84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @gbalykov @clamp03 @sirntar @yurai007
cc @shushanhf for changes in CopyStructToRegisters