### PR TITLE
Only write cmake_cmd_line.txt cache file if cmake succeeded

### DIFF
--- a/eng/native/gen-buildsys.cmd
+++ b/eng/native/gen-buildsys.cmd
@@ -101,10 +101,7 @@ if not "%__ConfigureOnly%" == "1" (
                 exit /B 0
             ) else (
                 echo The CMake command line differs from the last run. Running CMake again.
-                echo %__ExtraCmakeParams% > %__CmdLineOptionsUpToDateFile%
             )
-        ) else (
-            echo %__ExtraCmakeParams% > %__CmdLineOptionsUpToDateFile%
         )
     )
 )
@@ -114,6 +111,11 @@ if /i "%__UseEmcmake%" == "1" (
 ) else (
     "%CMakePath%" %__ExtraCmakeParams% --no-warn-unused-cli -G "%__CmakeGenerator%" -B %__IntermediatesDir% -S %__SourceDir%
 )
+
+if "%errorlevel%" == "0" (
+    echo %__ExtraCmakeParams% > %__CmdLineOptionsUpToDateFile%
+)
+
 endlocal
 exit /B %errorlevel%
 


### PR DESCRIPTION
I noticed that we wrote the cache file before invoking cmake, this meant that if the cmake configure step failed (e.g. because of an invalid command like in #93670) then running the build again would skip cmake configure, resulting in a broken build setup.

This only applies to non-VS generators like ninja.