### PR TITLE
[release/8.0][wasm] Fix Vector128 SIMD fmin and fmax

### DIFF
--- a/src/mono/mono/mini/llvm-intrinsics.h
+++ b/src/mono/mono/mini/llvm-intrinsics.h
@@ -291,6 +291,8 @@ INTRINS_OVR_2_ARG(WASM_NARROW_UNSIGNED_V16, wasm_narrow_unsigned, Wasm, sse_i1_t
 INTRINS_OVR_2_ARG(WASM_NARROW_UNSIGNED_V8, wasm_narrow_unsigned, Wasm, sse_i2_t, sse_i4_t)
 INTRINS_OVR_2_ARG(WASM_CONV_R8_TO_I4, fptosi_sat, Generic, v64_i4_t, v128_r8_t)
 INTRINS_OVR_2_ARG(WASM_CONV_R8_TO_U4, fptoui_sat, Generic, v64_i4_t, v128_r8_t)
+INTRINS_OVR_TAG(WASM_FMAX, maximum, Generic, V128 | R4 | R8)
+INTRINS_OVR_TAG(WASM_FMIN, minimum, Generic, V128 | R4 | R8)
 INTRINS_OVR_TAG(WASM_PMAX, wasm_pmax, Wasm, V128 | R4 | R8)
 INTRINS_OVR_TAG(WASM_PMIN, wasm_pmin, Wasm, V128 | R4 | R8)
 INTRINS_OVR(WASM_PMAX_V4, fabs, Generic, sse_r4_t)

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -8183,9 +8183,13 @@ MONO_RESTORE_WARNING
 					result = fcmp_and_select (builder, ins, l, r);
 				}
 
-#elif defined(TARGET_ARM64)
+#elif defined(TARGET_ARM64) || defined(TARGET_WASM)
 				LLVMValueRef min_max_args [] = { l, r };
+#ifdef TARGET_WASM
+				IntrinsicId iid = ins->inst_c0 == OP_FMAX ? INTRINS_WASM_FMAX : INTRINS_WASM_FMIN;
+#else
 				IntrinsicId iid = ins->inst_c0 == OP_FMAX ? INTRINS_AARCH64_ADV_SIMD_FMAX : INTRINS_AARCH64_ADV_SIMD_FMIN;
+#endif
 				llvm_ovr_tag_t ovr_tag = ovr_tag_from_mono_vector_class (ins->klass);
 				result = call_overloaded_intrins (ctx, iid, ovr_tag, min_max_args, "");
 #else


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/93556

## Customer Impact

Customers on WebAssembly platforms using Vector128 min and max methods may see wrong results as the NaN values are not propagated.

## Risk

Low

## Change description

Fix https://github.com/dotnet/runtime/issues/92885

Min and max now use NaN propagating SIMD instructions, `f32x4.min`, `f64x2.min`, `f32x4.max` and `f64x2.max`.

Example emitted code:

    ...
    f32x4.min    [SIMD]
    v128.store    [SIMD]

for

    return Vector128.Min(/* Vector128<float> */ v1, v2);
