### PR TITLE
Replaced CMake's Repeated CONFIG Expressions With Their Condensed Counterparts

### DIFF
--- a/src/coreclr/dlls/mscordac/CMakeLists.txt
+++ b/src/coreclr/dlls/mscordac/CMakeLists.txt
@@ -144,7 +144,7 @@ if(CLR_CMAKE_HOST_WIN32)
     add_custom_command(
         DEPENDS mscordaccore_def "${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordac.def" mscordacobj daccess
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mscordaccore.exp
-        COMMAND lib.exe /NOLOGO /OUT:"${CMAKE_CURRENT_BINARY_DIR}/mscordaccore.lib" /DEF:"${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordac.def" "$<TARGET_FILE:daccess>" $<$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>:/LTCG> ${STATIC_LIBRARY_FLAGS} $<TARGET_OBJECTS:mscordacobj>
+        COMMAND lib.exe /NOLOGO /OUT:"${CMAKE_CURRENT_BINARY_DIR}/mscordaccore.lib" /DEF:"${CURRENT_BINARY_DIR_FOR_CONFIG}/mscordac.def" "$<TARGET_FILE:daccess>" $<$<CONFIG:Release,Relwithdebifo>:/LTCG> ${STATIC_LIBRARY_FLAGS} $<TARGET_OBJECTS:mscordacobj>
         COMMENT "Generating mscordaccore.exp export file"
     )
 

--- a/src/coreclr/nativeaot/Runtime/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/CMakeLists.txt
@@ -236,7 +236,7 @@ add_definitions(-DFEATURE_MANUALLY_MANAGED_CARD_BUNDLES)
 
 add_definitions(-DFEATURE_CUSTOM_IMPORTS)
 add_definitions(-DFEATURE_DYNAMIC_CODE)
-add_compile_definitions($<$<OR:$<CONFIG:Debug>,$<CONFIG:Checked>>:FEATURE_GC_STRESS>)
+add_compile_definitions($<$<CONFIG:Debug,Checked>:FEATURE_GC_STRESS>)
 add_definitions(-DFEATURE_NATIVEAOT)
 add_definitions(-DVERIFY_HEAP)
 add_definitions(-DNATIVEAOT)


### PR DESCRIPTION
Since 3.19, CMake now supports specifying multiple configurations with just one call to `$<CONFIG>`. Now, it supports multiple in one call using the following form:

Before 3.19:

`$<$<OR:$<CONFIG:X>,$<CONFIG:Y>>:-flag>`

From 3.19 and onwards:

`$<$<CONFIG:X,Y>:-flag>`

We now have a minimum required CMake version of 3.20, so this PR simplifies some code to use these new condensed generator expressions.