### PR TITLE
JIT: remove incorrect type deduction for an Unsafe.As case

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18752,10 +18752,12 @@ CORINFO_CLASS_HANDLE Compiler::gtGetFieldClassHandle(CORINFO_FIELD_HANDLE fieldH
             {
                 JITDUMP("Field's current class not available\n");
             }
+
+            return fieldClass;
         }
     }
 
-    return fieldClass;
+    return NO_CLASS_HANDLE;
 }
 
 //------------------------------------------------------------------------

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93650/Runtime_93650.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93650/Runtime_93650.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Xunit;
+
+public struct Holder
+{
+    internal StringBuilder.AppendInterpolatedStringHandler _h;
+    public Holder() => _h = new(0, 0, new());
+
+    internal StringBuilder GetBuilder() => Unsafe.As<StringBuilder.AppendInterpolatedStringHandler, StringBuilder>(ref _h);
+}
+
+public static class Runtime_93650
+{
+    static int N = 1;
+
+    [Fact]
+    public static int Problem()
+    {
+        var sb = new Holder();
+        for (int i = 0; i < N; i++)
+        {
+            var s = Bind(ref sb);
+            if (s.Length != 0)
+            {
+                Console.WriteLine("FAILED: StringBuilder.ToString() returned: " + s);
+                return -1;
+            }
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static string Bind(ref Holder parameters) => GetString(parameters.GetBuilder());
+
+    public static string GetString(StringBuilder sb) => sb.ToString();
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93650/Runtime_93650.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93650/Runtime_93650.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Thanks to @SingleAccretion for the fix.

The JIT was assuming that an indirectly accessed value type field had the type of the field, but that might not be the case if the field was accessed via `Unsafe.As`.

Fix this by limiting type deduction from these indirectly accessed fields to only ref type fields.

Closes #93650.