### PR TITLE
[wasm] Fix blazor startup measurements

### DIFF
--- a/src/mono/sample/wasm/blazor-frame/wwwroot/index.html
+++ b/src/mono/sample/wasm/blazor-frame/wwwroot/index.html
@@ -26,7 +26,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-    <script type="module" src="./_framework/blazor.webassembly.js"></script>
+    <script src="./_framework/blazor.webassembly.js"></script>
     <script type="module" src="./frame.js"></script>
 </body>
 

--- a/src/mono/sample/wasm/blazor-frame/wwwroot/start.html
+++ b/src/mono/sample/wasm/blazor-frame/wwwroot/start.html
@@ -26,7 +26,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-    <script type="module" src="./_framework/blazor.webassembly.js" autostart="false"></script>
+    <script src="./_framework/blazor.webassembly.js" autostart="false"></script>
     <script type="module" src="./start.js"></script>
 </body>
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/93548 introduced a typo, which caused the blazor startup measurements to not load the page completely.

The snapshot version is still not loading right, that's probably because we don't use https yet.