### PR TITLE
[wasm] Disable failing runtime tests

### DIFF
--- a/src/tests/Interop/PInvoke/Vector2_3_4/Vector2_3_4.cs
+++ b/src/tests/Interop/PInvoke/Vector2_3_4/Vector2_3_4.cs
@@ -12,6 +12,7 @@ public class Vector2_3_4Test
     private const int NewIntValue = 18;
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/93669", TestPlatforms.Browser)]
     public static void RunVector2Tests()
     {
         Console.WriteLine($"Running {nameof(RunVector2Tests)}... ");
@@ -55,6 +56,7 @@ public class Vector2_3_4Test
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/93669", TestPlatforms.Browser)]
     public static void RunVector3Tests()
     {
         Console.WriteLine($"Running {nameof(RunVector3Tests)}... ");
@@ -98,6 +100,7 @@ public class Vector2_3_4Test
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/93669", TestPlatforms.Browser)]
     public static void RunVector4Tests()
     {
         Console.WriteLine($"Running {nameof(RunVector4Tests)}... ");


### PR DESCRIPTION
`Interop/PInvoke/Vector2_3_4/` tests are failing as they depend on native test libraries. But
wasm build for runtime tests does not support that yet.

Issue: https://github.com/dotnet/runtime/issues/93669