### PR TITLE
[QUIC] Stream remove the asserts

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -713,9 +713,6 @@ public sealed partial class QuicStream
             await valueTask.ConfigureAwait(false);
         }
         Debug.Assert(_startedTcs.IsCompleted);
-        // TODO: If there was and ongoing read/write when dispose was called, MsQuic events might be processed, but the continuations may not thus the state can still be in Ready.
-        //Debug.Assert(_receiveTcs.IsCompleted);
-        //Debug.Assert(_sendTcs.IsCompleted);
         _handle.Dispose();
 
         // TODO: memory leak if not disposed


### PR DESCRIPTION
They get hit in H/3 stress when the H3 stream is canceled, disposing itself in the process while still having writing side task active. For more details see https://github.com/dotnet/runtime/issues/93713

I decided to just remove them as theirs added value is questionable. We can revisit with the above mentioned issues.