### PR TITLE
Use live reference pack for IntrinsicsInSystemPrivatecorelibAnalyzer.Tests

### DIFF
--- a/src/libraries/System.Private.CoreLib/tests/IntrinsicsInSystemPrivatecoreLibAnalyzer.Tests/CSharpAnalyzerVerifier`1+Test.cs
+++ b/src/libraries/System.Private.CoreLib/tests/IntrinsicsInSystemPrivatecoreLibAnalyzer.Tests/CSharpAnalyzerVerifier`1+Test.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace IntrinsicsInSystemPrivateCoreLib.Test
@@ -11,6 +12,11 @@ namespace IntrinsicsInSystemPrivateCoreLib.Test
         {
             public Test()
             {
+                // Clear out the default reference assemblies. We explicitly add references from the live ref pack,
+                // so we don't want the Roslyn test infrastructure to resolve/add any default reference assemblies
+                ReferenceAssemblies = new ReferenceAssemblies(string.Empty);
+                TestState.AdditionalReferences.AddRange(SourceGenerators.Tests.LiveReferencePack.GetMetadataReferences());
+
                 SolutionTransforms.Add((solution, projectId) =>
                 {
                     var compilationOptions = solution.GetProject(projectId).CompilationOptions;

--- a/src/libraries/System.Private.CoreLib/tests/IntrinsicsInSystemPrivatecoreLibAnalyzer.Tests/IntrinsicsInSystemPrivateCoreLib.Tests.csproj
+++ b/src/libraries/System.Private.CoreLib/tests/IntrinsicsInSystemPrivatecoreLibAnalyzer.Tests/IntrinsicsInSystemPrivateCoreLib.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TestRunRequiresLiveRefPack>true</TestRunRequiresLiveRefPack>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\gen\System.Private.CoreLib.Generators.csproj" />
+    <Compile Include="$(CommonTestPath)SourceGenerators\LiveReferencePack.cs" Link="Common\SourceGenerators\LiveReferencePack.cs" />
     <Compile Include="IntrinsicsInSystemPrivateCoreLibUnitTests.cs" />
     <Compile Include="CSharpAnalyzerVerifier`1.cs" />
     <Compile Include="CSharpAnalyzerVerifier`1+Test.cs" />

--- a/src/libraries/System.Private.CoreLib/tests/IntrinsicsInSystemPrivatecoreLibAnalyzer.Tests/IntrinsicsInSystemPrivateCoreLibUnitTests.cs
+++ b/src/libraries/System.Private.CoreLib/tests/IntrinsicsInSystemPrivatecoreLibAnalyzer.Tests/IntrinsicsInSystemPrivateCoreLibUnitTests.cs
@@ -5,7 +5,6 @@ using VerifyCS = IntrinsicsInSystemPrivateCoreLib.Test.CSharpAnalyzerVerifier<
 
 namespace IntrinsicsInSystemPrivateCoreLib.Test
 {
-    [SkipOnPlatform(TestPlatforms.Browser, "Do not try to run analyzer tests in the browser")]
     public class IntrinsicsInSystemPrivateCoreLibUnitTest
     {
         string BoilerPlate = @"

--- a/src/libraries/System.Private.CoreLib/tests/IntrinsicsInSystemPrivatecoreLibAnalyzer.Tests/IntrinsicsInSystemPrivateCoreLibUnitTests.cs
+++ b/src/libraries/System.Private.CoreLib/tests/IntrinsicsInSystemPrivatecoreLibAnalyzer.Tests/IntrinsicsInSystemPrivateCoreLibUnitTests.cs
@@ -90,7 +90,6 @@ namespace System.Runtime.Intrinsics.Wasm
 
 ";
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodUnprotectedUse()
         {
             var test = BoilerPlate + @"
@@ -110,7 +109,6 @@ namespace System.Runtime.Intrinsics.Wasm
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodUnprotectedUseWithIntrinsicsHelperAttribute()
         {
             var test = BoilerPlate + @"
@@ -131,7 +129,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodUnprotectedUseWithIntrinsicsHelperAttributeComplex()
         {
             var test = BoilerPlate + @"
@@ -157,7 +154,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodUnprotectedUseInLocalFunctionWithIntrinsicsHelperAttributeNotOnLocalFunction()
         {
             var test = BoilerPlate + @"
@@ -183,7 +179,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodUnprotectedUseInLambdaWithIntrinsicsHelperAttributeOnOuterFunction()
         {
             var test = BoilerPlate + @"
@@ -209,7 +204,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodUnprotectedUseInLocalFunctionWithIntrinsicsHelperAttributeOnLocalFunction()
         {
             var test = BoilerPlate + @"
@@ -235,7 +229,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodUnprotectedNestedTypeUse()
         {
             var test = BoilerPlate + @"
@@ -275,7 +268,6 @@ namespace ConsoleApplication1
 
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodWithIfStatementButWithInadequateHelperMethodAttribute()
         {
             var test = BoilerPlate + @"
@@ -317,7 +309,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodWithIfStatementWithNestedAndBaseTypeLookupRequired()
         {
             var test = BoilerPlate + @"
@@ -337,7 +328,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodWithTernaryOperator()
         {
             var test = BoilerPlate + @"
@@ -356,7 +346,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodWithIfStatementWithOrOperationCase()
         {
             var test = BoilerPlate + @"
@@ -386,7 +375,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodWithIfStatementWithOrOperationCaseWithImplicationProcessingRequired()
         {
             var test = BoilerPlate + @"
@@ -416,7 +404,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodWithIfStatementAroundLocalFunctionDefinition()
         {
             var test = BoilerPlate + @"
@@ -446,7 +433,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodWithIfStatementAroundLambdaFunctionDefinition()
         {
             var test = BoilerPlate + @"
@@ -473,7 +459,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestHelperMethodsCanOnlyBeCalledWithAppropriateIsSupportedChecksError()
         {
             var test = BoilerPlate + @"
@@ -524,7 +509,6 @@ namespace ConsoleApplication1
             await VerifyCS.VerifyAnalyzerAsync(test, expected, expected2, expected3, expected4, expected5);
         }
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestHelperMethodsCanOnlyBeCalledWithAppropriateIsSupportedChecksSuccess()
         {
             var test = BoilerPlate + @"
@@ -565,7 +549,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestHelperMethodsUnrelatedPropertyDoesntHelp()
         {
             var test = BoilerPlate + @"
@@ -596,7 +579,6 @@ namespace ConsoleApplication1
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestHelperMethodsWithHelperProperty()
         {
             var test = BoilerPlate + @"
@@ -627,7 +609,6 @@ namespace ConsoleApplication1
 
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "https://github.com/dotnet/runtime/issues/93103")]
         public async Task TestMethodUseOfIntrinsicsFromWithinOtherMethodOnIntrinsicType()
         {
             var test = @"

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -89,10 +89,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetsMobile)' == 'true' or '$(TargetsLinuxBionic)' == 'true' or '$(TargetArchitecture)' == 'ARMv6'">
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\LibraryImportGenerator.Tests\LibraryImportGenerator.Tests.csproj" />
+    <!-- don't run source generator or roslyn analyzer tests on mobile -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\ComInterfaceGenerator.Tests\ComInterfaceGenerator.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\LibraryImportGenerator.UnitTests\LibraryImportGenerator.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\ComInterfaceGenerator.Unit.Tests\ComInterfaceGenerator.Unit.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\LibraryImportGenerator.Tests\LibraryImportGenerator.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\LibraryImportGenerator.UnitTests\LibraryImportGenerator.Unit.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.JavaScript\tests\JSImportGenerator.UnitTest\JSImportGenerator.Unit.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.CoreLib\tests\IntrinsicsInSystemPrivatecoreLibAnalyzer.Tests\IntrinsicsInSystemPrivateCoreLib.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'windows' and '$(TargetArchitecture)' == 'arm'">
@@ -330,19 +333,16 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Unit.Tests\System.Text.Json.SourceGeneration.Roslyn3.11.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Unit.Tests\System.Text.Json.SourceGeneration.Roslyn4.4.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\FunctionalTests\System.Text.RegularExpressions.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.JavaScript\tests\JSImportGenerator.UnitTest\JSImportGenerator.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Binder\tests\SourceGenerationTests\Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Options.ConfigurationExtensions\tests\SourceGenerationTests\Microsoft.Extensions.Options.ConfigurationExtensions.SourceGeneration.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Options/tests/SourceGenerationTests/Microsoft.Extensions.Options.SourceGeneration.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Microsoft.Extensions.Options.SourceGeneration.Unit.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.CoreLib/tests/IntrinsicsInSystemPrivatecoreLibAnalyzer.Tests/IntrinsicsInSystemPrivateCoreLib.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(RunDisabledWasmTests)' != 'true' and '$(RunAOTCompilation)' != 'true'">
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(RunDisabledWasmTests)' != 'true'">
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.JavaScript\tests\JSImportGenerator.UnitTest\JSImportGenerator.Unit.Tests.csproj" />
 
     <!-- This test is disabled via an assembly-level attribute in source. We exclude it here to avoid queuing/running a work item entirely.
          https://github.com/dotnet/runtime/issues/35970 -->


### PR DESCRIPTION
This avoids an issue where the analyzer test tries to restore reference assemblies from nuget.org during the test. We already have helpers in place to use the live reference pack instead.

Fixes https://github.com/dotnet/runtime/issues/90951
Fixes https://github.com/dotnet/runtime/issues/93103