### PR TITLE
[RISC-V] Test NFloat.IsNegative against its native type equivalent

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.cs
@@ -793,7 +793,14 @@ namespace System.Runtime.InteropServices.Tests
         public void IsNegative(float value)
         {
             bool result = NFloat.IsNegative(value);
-            Assert.Equal(float.IsNegative(value), result);
+            if (Environment.Is64BitProcess)
+            {
+                Assert.Equal(double.IsNegative(value), result);
+            }
+            else
+            {
+                Assert.Equal(float.IsNegative(value), result);
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Comparing it with the result of float.IsNegative failed for RISC-V64 because NFloat.IsNegative implicitly converts to NFloat, which upcasts to NativeType (double), which canonicalizes the NaN value (drops the sign and payload) on RISC-V. Comparing it to double.IsNegative ensures a similar platform-specific upcast is on the expected side.

I saw some other tests feature a similar condition.

This fixes System.Runtime.InteropServices.Tests.NFloatTests.IsNegative

Part of #84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @gbalykov @clamp03 @Sirntar @yurai007