### PR TITLE
Don't use File.OpenWrite when trying to overwrite a file

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILAssemblyGeneratingMethodDebugInfoProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILAssemblyGeneratingMethodDebugInfoProvider.cs
@@ -28,7 +28,7 @@ namespace ILCompiler
         {
             _wrappedProvider = wrappedProvider;
             _fileName = fileName;
-            _tw = new StreamWriter(File.OpenWrite(fileName));
+            _tw = new StreamWriter(new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None));
         }
 
         public override MethodDebugInformation GetDebugInfo(MethodIL methodIL)

--- a/src/tasks/MonoTargetsTasks/RuntimeConfigParser/RuntimeConfigParser.cs
+++ b/src/tasks/MonoTargetsTasks/RuntimeConfigParser/RuntimeConfigParser.cs
@@ -71,7 +71,7 @@ public class RuntimeConfigParserTask : Task
         ConvertDictionaryToBlob(configProperties, blobBuilder);
 
         Directory.CreateDirectory(Path.GetDirectoryName(OutputFile!)!);
-        using var stream = File.OpenWrite(OutputFile);
+        using var stream = new FileStream(OutputFile, FileMode.Create, FileAccess.Write, FileShare.None);
         blobBuilder.WriteContentTo(stream);
 
         return !Log.HasLoggedErrors;

--- a/src/tasks/WasmAppBuilder/WasmAppBuilderBaseTask.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilderBaseTask.cs
@@ -152,7 +152,7 @@ public abstract class WasmAppBuilderBaseTask : Task
         AddToRuntimeConfig(wasmHostProperties: wasmHostProperties, runtimeArgsArray: runtimeArgsArray, perHostConfigs: perHostConfigs);
 
         string dstPath = Path.Combine(AppDir!, Path.GetFileName(runtimeConfigPath));
-        using FileStream? fs = File.OpenWrite(dstPath);
+        using FileStream? fs = new FileStream(dstPath, FileMode.Create, FileAccess.Write, FileShare.None);
         using var writer = new Utf8JsonWriter(fs, new JsonWriterOptions { Indented = true });
         rootObject.WriteTo(writer);
         _fileWrites.Add(dstPath);

--- a/src/tasks/WasmBuildTasks/GetChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/GetChromeVersions.cs
@@ -292,7 +292,7 @@ public partial class GetChromeVersions : MBU.Task
             {
                 Log.LogMessage(MessageImportance.Low, $"Downloading {url} ...");
                 using Stream stream = await s_httpClient.GetStreamAsync(url).ConfigureAwait(false);
-                using FileStream fs = File.OpenWrite(filePath);
+                using FileStream fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
                 await stream.CopyToAsync(fs).ConfigureAwait(false);
             }
             catch (HttpRequestException hre)

--- a/src/tools/illink/src/linker/Linker/DgmlDependencyRecorder.cs
+++ b/src/tools/illink/src/linker/Linker/DgmlDependencyRecorder.cs
@@ -38,7 +38,7 @@ namespace Mono.Linker
 				Directory.CreateDirectory (context.OutputDirectory);
 			}
 
-			var depsFile = File.OpenWrite (fileName);
+			var depsFile = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None);
 			stream = depsFile;
 
 			writer = XmlWriter.Create (stream, settings);

--- a/src/tools/illink/src/linker/Linker/XmlDependencyRecorder.cs
+++ b/src/tools/illink/src/linker/Linker/XmlDependencyRecorder.cs
@@ -61,7 +61,7 @@ namespace Mono.Linker
 				Directory.CreateDirectory (context.OutputDirectory);
 			}
 
-			var depsFile = File.OpenWrite (fileName);
+			var depsFile = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None);
 			stream = depsFile;
 
 			writer = XmlWriter.Create (stream, settings);


### PR DESCRIPTION
File.OpenWrite will open an existing file which means if you write data that is shorter than the existing data the file will be corrupt. This is documented on https://learn.microsoft.com/en-us/dotnet/api/system.io.file.openwrite

> The OpenWrite method opens a file if one already exists for the file path, or creates a new file if one does not exist. For an existing file, it does not append the new text to the existing text. Instead, it overwrites the existing characters with the new characters. If you overwrite a longer string (such as "This is a test of the OpenWrite method") with a shorter string (such as "Second run"), the file will contain a mix of the strings ("Second runtest of the OpenWrite method").

The fix is to use the `FileMode.Create` option in cases where the intention is to create a new file or overwrite an existing one.

I noticed this recently when using the illink feature to dump a dependency analysis xml, the next time I ran the build after making a change that'd reduce dependencies the xml would get corrupted since it wrote less data than the existing file had.

There were a couple instances across the codebase, this fixes them.