### PR TITLE
Optimize JsonContent fast path

### DIFF
--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.cs
@@ -141,17 +141,21 @@ namespace System.Net.Http.Json
             }
         }
 
-        internal static async ValueTask<Stream> GetContentStreamAsync(HttpContent content, CancellationToken cancellationToken)
+        internal static ValueTask<Stream> GetContentStreamAsync(HttpContent content, CancellationToken cancellationToken)
         {
-            Stream contentStream = await ReadHttpContentStreamAsync(content, cancellationToken).ConfigureAwait(false);
+            Task<Stream> task = ReadHttpContentStreamAsync(content, cancellationToken);
+
+            return JsonHelpers.GetEncoding(content) is Encoding sourceEncoding && sourceEncoding != Encoding.UTF8
+                ? GetTranscodingStreamAsync(task, sourceEncoding)
+                : new(task);
+        }
+
+        private static async ValueTask<Stream> GetTranscodingStreamAsync(Task<Stream> task, Encoding sourceEncoding)
+        {
+            Stream contentStream = await task.ConfigureAwait(false);
 
             // Wrap content stream into a transcoding stream that buffers the data transcoded from the sourceEncoding to utf-8.
-            if (JsonHelpers.GetEncoding(content) is Encoding sourceEncoding && sourceEncoding != Encoding.UTF8)
-            {
-                contentStream = GetTranscodingStream(contentStream, sourceEncoding);
-            }
-
-            return contentStream;
+            return GetTranscodingStream(contentStream, sourceEncoding);
         }
     }
 }

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
@@ -94,7 +94,7 @@ namespace System.Net.Http.Json
         }
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
-            => SerializeToStreamAsyncCore(stream, async: true, CancellationToken.None);
+            => SerializeToStreamAsyncCore(stream, CancellationToken.None);
 
         protected override bool TryComputeLength(out long length)
         {
@@ -102,67 +102,40 @@ namespace System.Net.Http.Json
             return false;
         }
 
-        private async Task SerializeToStreamAsyncCore(Stream targetStream, bool async, CancellationToken cancellationToken)
+        private Task SerializeToStreamAsyncCore(Stream targetStream, CancellationToken cancellationToken)
         {
             Encoding? targetEncoding = JsonHelpers.GetEncoding(this);
 
-            // Wrap provided stream into a transcoding stream that buffers the data transcoded from utf-8 to the targetEncoding.
-            if (targetEncoding != null && targetEncoding != Encoding.UTF8)
-            {
-#if NETCOREAPP
-                Stream transcodingStream = Encoding.CreateTranscodingStream(targetStream, targetEncoding, Encoding.UTF8, leaveOpen: true);
-                try
-                {
-                    if (async)
-                    {
-                        await JsonSerializer.SerializeAsync(transcodingStream, Value, _typeInfo, cancellationToken).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        JsonSerializer.Serialize(transcodingStream, Value, _typeInfo);
-                    }
-                }
-                finally
-                {
-                    // Dispose/DisposeAsync will flush any partial write buffers. In practice our partial write
-                    // buffers should be empty as we expect JsonSerializer to emit only well-formed UTF-8 data.
-                    if (async)
-                    {
-                        await transcodingStream.DisposeAsync().ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        transcodingStream.Dispose();
-                    }
-                }
-#else
-                Debug.Assert(async, "HttpContent synchronous serialization is only supported since .NET 5.0");
+            return targetEncoding != null && targetEncoding != Encoding.UTF8
+                ? SerializeToStreamAsyncTranscoding(targetStream, targetEncoding, cancellationToken)
+                : JsonSerializer.SerializeAsync(targetStream, Value, _typeInfo, cancellationToken);
+        }
 
-                using (TranscodingWriteStream transcodingStream = new TranscodingWriteStream(targetStream, targetEncoding))
-                {
-                    await JsonSerializer.SerializeAsync(transcodingStream, Value, _typeInfo, cancellationToken).ConfigureAwait(false);
-                    // The transcoding streams use Encoders and Decoders that have internal buffers. We need to flush these
-                    // when there is no more data to be written. Stream.FlushAsync isn't suitable since it's
-                    // acceptable to Flush a Stream (multiple times) prior to completion.
-                    await transcodingStream.FinalWriteAsync(cancellationToken).ConfigureAwait(false);
-                }
-#endif
-            }
-            else
-            {
-                if (async)
-                {
-                    await JsonSerializer.SerializeAsync(targetStream, Value, _typeInfo, cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
+        private async Task SerializeToStreamAsyncTranscoding(Stream targetStream, Encoding targetEncoding, CancellationToken cancellationToken)
+        {
+            // Wrap provided stream into a transcoding stream that buffers the data transcoded from utf-8 to the targetEncoding.
 #if NETCOREAPP
-                    JsonSerializer.Serialize(targetStream, Value, _typeInfo);
-#else
-                    Debug.Fail("HttpContent synchronous serialization is only supported since .NET 5.0");
-#endif
-                }
+            Stream transcodingStream = Encoding.CreateTranscodingStream(targetStream, targetEncoding, Encoding.UTF8, leaveOpen: true);
+            try
+            {
+                await JsonSerializer.SerializeAsync(transcodingStream, Value, _typeInfo, cancellationToken).ConfigureAwait(false);
             }
+            finally
+            {
+                // DisposeAsync will flush any partial write buffers. In practice our partial write
+                // buffers should be empty as we expect JsonSerializer to emit only well-formed UTF-8 data.
+                await transcodingStream.DisposeAsync().ConfigureAwait(false);
+            }
+#else
+            using (TranscodingWriteStream transcodingStream = new TranscodingWriteStream(targetStream, targetEncoding))
+            {
+                await JsonSerializer.SerializeAsync(transcodingStream, Value, _typeInfo, cancellationToken).ConfigureAwait(false);
+                // The transcoding streams use Encoders and Decoders that have internal buffers. We need to flush these
+                // when there is no more data to be written. Stream.FlushAsync isn't suitable since it's
+                // acceptable to Flush a Stream (multiple times) prior to completion.
+                await transcodingStream.FinalWriteAsync(cancellationToken).ConfigureAwait(false);
+            }
+#endif
         }
 
         private static void EnsureTypeCompatibility(object? inputValue, Type inputType)

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.netcoreapp.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.netcoreapp.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,9 +12,23 @@ namespace System.Net.Http.Json
     public sealed partial class JsonContent
     {
         protected override void SerializeToStream(Stream stream, TransportContext? context, CancellationToken cancellationToken)
-            => SerializeToStreamAsyncCore(stream, async: false, cancellationToken).GetAwaiter().GetResult();
+        {
+            Encoding? targetEncoding = JsonHelpers.GetEncoding(this);
+            if (targetEncoding != null && targetEncoding != Encoding.UTF8)
+            {
+                // Wrap provided stream into a transcoding stream that buffers the data transcoded from utf-8 to the targetEncoding.
+                using Stream transcodingStream = Encoding.CreateTranscodingStream(stream, targetEncoding, Encoding.UTF8, leaveOpen: true);
+                JsonSerializer.Serialize(transcodingStream, Value, _typeInfo);
+                // Dispose will flush any partial write buffers. In practice our partial write
+                // buffers should be empty as we expect JsonSerializer to emit only well-formed UTF-8 data.
+            }
+            else
+            {
+                JsonSerializer.Serialize(stream, Value, _typeInfo);
+            }
+        }
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
-            => SerializeToStreamAsyncCore(stream, async: true, cancellationToken);
+            => SerializeToStreamAsyncCore(stream, cancellationToken);
     }
 }


### PR DESCRIPTION
Remove a few `async` methods from the common fast path.