### PR TITLE
Keep using RO metadata after creating IMetaDataImporter for PDB reading

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -2102,7 +2102,7 @@ BOOL Module::IsInSameVersionBubble(Module *target)
 
 //---------------------------------------------------------------------------------------
 //
-// Wrapper for Module::GetRWImporter + QI when writing is not needed.
+// Wrapper for Module::GetImporter + QI when writing is not needed.
 //
 // Arguments:
 //      * dwOpenFlags - Combo from CorOpenFlags. Better not contain ofWrite!
@@ -2113,7 +2113,7 @@ BOOL Module::IsInSameVersionBubble(Module *target)
 // Return Value:
 //      HRESULT indicating success or failure.
 //
-HRESULT Module::GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, LPVOID * ppvInterface)
+HRESULT Module::GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, bool swapForRWMDImport, LPVOID * ppvInterface)
 {
     CONTRACTL
     {
@@ -2137,7 +2137,7 @@ HRESULT Module::GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID rii
     // Normally, we just get an RWImporter to do the QI on, and we're on our way.
     EX_TRY
     {
-        pIUnk = GetRWImporter();
+        pIUnk = GetRWImporter(swapForRWMDImport);
     }
     EX_CATCH_HRESULT_NO_ERRORINFO(hr);
 
@@ -2306,7 +2306,7 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
             }
             if (SUCCEEDED(hr))
             {
-                hr = pBinder->GetReaderFromStream(GetRWImporter(), pIStream, &pReader);
+                hr = pBinder->GetReaderFromStream(GetRWImporter(/* swapForRWMDImport */ false), pIStream, &pReader);
             }
         }
         else
@@ -2318,7 +2318,7 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
             // trying to get a symbol reader. This has to be done once per
             // Assembly.
             ReleaseHolder<IUnknown> pUnk = NULL;
-            hr = GetReadablePublicMetaDataInterface(ofReadOnly, IID_IMetaDataImport, &pUnk);
+            hr = GetReadablePublicMetaDataInterface(ofReadOnly, IID_IMetaDataImport, /* swapForRWMDImport */ false, &pUnk);
             if (SUCCEEDED(hr))
                 hr = pBinder->GetReaderForFile(pUnk, path, NULL, &pReader);
         }

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1042,14 +1042,14 @@ public:
         return m_pPEAssembly->GetEmitter();
     }
 
-    IMetaDataImport2 *GetRWImporter()
+    IMetaDataImport2 *GetRWImporter(bool swapForRWMDImport = true)
     {
         WRAPPER_NO_CONTRACT;
 
-        return m_pPEAssembly->GetRWImporter();
+        return m_pPEAssembly->GetRWImporter(swapForRWMDImport);
     }
 
-    HRESULT GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, LPVOID * ppvInterface);
+    HRESULT GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, bool swapForRWMDImport, LPVOID * ppvInterface);
 #endif // !DACCESS_COMPILE
 
 #if defined(FEATURE_READYTORUN)

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -836,14 +836,6 @@ public:
         PREFIX_ASSUME(pModule != NULL);
         return pModule->GetEmitter();
     }
-
-    IMetaDataImport* GetRWImporter()
-    {
-        WRAPPER_NO_CONTRACT;
-        Module *pModule = GetModule();
-        PREFIX_ASSUME(pModule != NULL);
-        return pModule->GetRWImporter();
-    }
 #endif // !DACCESS_COMPILE
 
 #ifdef FEATURE_COMINTEROP

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -161,12 +161,12 @@ public:
 
 #ifndef DACCESS_COMPILE
     IMetaDataEmit *GetEmitter();
-    IMetaDataImport2 *GetRWImporter();
+    IMetaDataImport2 *GetRWImporter(bool swapForRWMDImport = true);
 #else
     TADDR GetMDInternalRWAddress();
 #endif // DACCESS_COMPILE
 
-    void ConvertMDInternalToReadWrite();
+    void ConvertMDInternalToReadWrite(bool swapForRWMDImport = true);
 
     void GetMVID(GUID* pMvid);
     ULONG GetHashAlgId();
@@ -382,7 +382,7 @@ private:
 #endif
 
     void OpenMDImport();
-    void OpenImporter();
+    void OpenImporter(bool swapForRWMDImport = true);
     void OpenEmitter();
 
 private:
@@ -419,6 +419,8 @@ private:
         IMDInternalImport* m_pMDImport_UseAccessor;
 #endif
     };
+
+    IMDInternalImport* m_pConvertedMDImport;
 
     IMetaDataImport2* m_pImporter;
     IMetaDataEmit* m_pEmitter;

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -275,7 +275,7 @@ inline IMDInternalImport* PEAssembly::GetMDImport()
 
 #ifndef DACCESS_COMPILE
 
-inline IMetaDataImport2 *PEAssembly::GetRWImporter()
+inline IMetaDataImport2 *PEAssembly::GetRWImporter(bool swapForRWMDImport)
 {
     CONTRACT(IMetaDataImport2 *)
     {
@@ -288,7 +288,7 @@ inline IMetaDataImport2 *PEAssembly::GetRWImporter()
     CONTRACT_END;
 
     if (m_pImporter == NULL)
-        OpenImporter();
+        OpenImporter(swapForRWMDImport);
 
     RETURN m_pImporter;
 }

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -2172,7 +2172,7 @@ HRESULT ProfToEEInterfaceImpl::GetTokenAndMetaDataFromFunction(
     if (ppOut)
     {
         Module * pMod = pMD->GetModule();
-        hr = pMod->GetReadablePublicMetaDataInterface(ofRead, riid, (LPVOID *) ppOut);
+        hr = pMod->GetReadablePublicMetaDataInterface(ofRead, riid, /* swapForRWMDImport */ true, (LPVOID *) ppOut);
     }
 
     return hr;
@@ -4254,7 +4254,7 @@ HRESULT ProfToEEInterfaceImpl::GetModuleMetaData(ModuleID    moduleId,
     if ((dwOpenFlags & ofWrite) == 0)
     {
         // Readable interface
-        return pModule->GetReadablePublicMetaDataInterface(dwOpenFlags, riid, (LPVOID *) ppOut);
+        return pModule->GetReadablePublicMetaDataInterface(dwOpenFlags, riid, /* swapForRWMDImport */ true, (LPVOID *) ppOut);
     }
 
     // Writeable interface


### PR DESCRIPTION
This change allows the runtime to keep using the read-only view of the metadata interfaces
after the conversion of it has been requested to back calls into the classic PDB parser.
Swapping of the cached RW converted view it will be deferred until some other path (e.g.
profiler, MD emit) requests a RW view of it.

Fixes #90563