### PR TITLE
[release/8.0] Add package readmes (continued)

### DIFF
--- a/src/libraries/Microsoft.Bcl.Cryptography/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/PACKAGE.md
@@ -1,0 +1,44 @@
+## About
+
+<!-- A description of the package and where one can find more documentation -->
+
+
+
+## Key Features
+
+<!-- The key features of this package -->
+
+*
+*
+*
+
+## How to Use
+
+<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+## Main Types
+
+<!-- The main types provided in this library -->
+
+The main types provided by this library are:
+
+* ``
+* ``
+* ``
+
+## Additional Documentation
+
+<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
+
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+
+## Related Packages
+
+<!-- The related packages associated with this package -->
+
+## Feedback & Contributing
+
+<!-- How to provide feedback on this package and contribute to it -->
+
+Microsoft.Bcl.Cryptography is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/PACKAGE.md
@@ -32,7 +32,7 @@ The main types provided by this library are:
 
 ## Additional Documentation
 
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/System.Security.Cryptography)
+* [API documentation](https://learn.microsoft.com/dotnet/api/System.Security.Cryptography)
 
 ## Feedback & Contributing
 

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/PACKAGE.md
@@ -1,44 +1,39 @@
 ## About
 
-<!-- A description of the package and where one can find more documentation -->
-
-
+This library provides some cryptographic types and functionality for .NET Standard and .NET Framework. This library is not necessary nor recommended when targeting versions of .NET that include the relevant support.
 
 ## Key Features
 
-<!-- The key features of this package -->
-
-*
-*
-*
+* Enables the use of some cryptographic functionality on older .NET platforms.
 
 ## How to Use
 
-<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+This package should only be used by platforms where the desired functionality is not built-in.
+
+```C#
+using System.Security.Cryptography;
+
+internal static class Program
+{
+    private static void Main()
+    {
+        byte[] key = LoadKey();
+        SP800108HmacCounterKdf kbkdf = new(key, HashAlgorithmName.SHA256);
+        byte[] derivedKey = kbkdf.DeriveKey("label"u8, "context"u8, derivedKeyLengthInBytes: 32);
+    }
+}
+```
 
 ## Main Types
 
-<!-- The main types provided in this library -->
-
 The main types provided by this library are:
 
-* ``
-* ``
-* ``
+* `System.Security.Cryptography.SP800108HmacCounterKdf`
 
 ## Additional Documentation
 
-<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
-
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
-
-## Related Packages
-
-<!-- The related packages associated with this package -->
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/System.Security.Cryptography)
 
 ## Feedback & Contributing
-
-<!-- How to provide feedback on this package and contribute to it -->
 
 Microsoft.Bcl.Cryptography is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/PACKAGE.md
@@ -1,0 +1,44 @@
+## About
+
+<!-- A description of the package and where one can find more documentation -->
+
+
+
+## Key Features
+
+<!-- The key features of this package -->
+
+*
+*
+*
+
+## How to Use
+
+<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+## Main Types
+
+<!-- The main types provided in this library -->
+
+The main types provided by this library are:
+
+* ``
+* ``
+* ``
+
+## Additional Documentation
+
+<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
+
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+
+## Related Packages
+
+<!-- The related packages associated with this package -->
+
+## Feedback & Contributing
+
+<!-- How to provide feedback on this package and contribute to it -->
+
+Microsoft.Extensions.Caching.Abstractions is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/PACKAGE.md
@@ -2,19 +2,22 @@
 
 <!-- A description of the package and where one can find more documentation -->
 
+Provides the abstractions to create and use in-memory and distributed caching in your applications.
 
+This library defines how in-memory and distributed caches should be implemented; it doesn’t contain any cache implementation.
+With the abstractions provided in this library, various types of caches can be built and used interchangeably, whether the data is kept in memory, in files, or even across a network.
 
 ## Key Features
 
 <!-- The key features of this package -->
 
-*
-*
-*
+* Interfaces for building and using in-memory and distributed caches.
 
 ## How to Use
 
 <!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+This package is typically used with an implementation of the caching abstractions, such as `Microsoft.Extensions.Caching.Memory` or `Microsoft.Extensions.Caching.SqlServer`.
 
 ## Main Types
 
@@ -22,20 +25,26 @@
 
 The main types provided by this library are:
 
-* ``
-* ``
-* ``
+* `Microsoft.Extensions.Caching.Abstractions.ICacheEntry`
+* `Microsoft.Extensions.Caching.Abstractions.IMemoryCache`
+* `Microsoft.Extensions.Caching.Abstractions.IDistributedCache`
 
 ## Additional Documentation
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+* [Conceptual documentation](https://learn.microsoft.com/dotnet/core/extensions/caching)
+* API documentation
+  * [Microsoft.Extensions.Caching.Memory](https://learn.microsoft.com/dotnet/api/microsoft.extensions.caching.memory)
+  * [Microsoft.Extensions.Caching.Distributed](https://learn.microsoft.com/dotnet/api/microsoft.extensions.caching.distributed)
 
 ## Related Packages
 
 <!-- The related packages associated with this package -->
+
+* In-memory caching: [Microsoft.Extensions.Caching.Memory](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Memory/)
+* SQL Server caching: [Microsoft.Extensions.Caching.SqlServer](https://www.nuget.org/packages/Microsoft.Extensions.Caching.SqlServer/)
+* Redis caching: [Microsoft.Extensions.Caching.StackExchangeRedis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.StackExchangeRedis/)
 
 ## Feedback & Contributing
 

--- a/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/PACKAGE.md
@@ -1,0 +1,44 @@
+## About
+
+<!-- A description of the package and where one can find more documentation -->
+
+
+
+## Key Features
+
+<!-- The key features of this package -->
+
+*
+*
+*
+
+## How to Use
+
+<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+## Main Types
+
+<!-- The main types provided in this library -->
+
+The main types provided by this library are:
+
+* ``
+* ``
+* ``
+
+## Additional Documentation
+
+<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
+
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+
+## Related Packages
+
+<!-- The related packages associated with this package -->
+
+## Feedback & Contributing
+
+<!-- How to provide feedback on this package and contribute to it -->
+
+Microsoft.Extensions.FileProviders.Abstractions is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).

--- a/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/src/PACKAGE.md
@@ -2,19 +2,20 @@
 
 <!-- A description of the package and where one can find more documentation -->
 
-
+Serves as the foundation for creating file providers in .NET, offering core abstractions to develop custom file providers capable of fetching files from various sources.
 
 ## Key Features
 
 <!-- The key features of this package -->
 
-*
-*
-*
+* Core abstractions for creating and managing file providers.
+* Flexibility to develop custom file providers for fetching files from distinct sources.
 
 ## How to Use
 
 <!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+This package is typically used with an implementation of the file provider abstractions, such as `Microsoft.Extensions.FileProviders.Composite` or `Microsoft.Extensions.FileProviders.Physical`.
 
 ## Main Types
 
@@ -22,20 +23,26 @@
 
 The main types provided by this library are:
 
-* ``
-* ``
-* ``
+* `Microsoft.Extensions.FileProviders.IFileProvider`
+* `Microsoft.Extensions.FileProviders.IDirectoryContents`
+* `Microsoft.Extensions.FileProviders.IFileInfo`
+* `Microsoft.Extensions.FileProviders.NullFileProvider`
 
 ## Additional Documentation
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+* [Conceptual documentation](https://learn.microsoft.com/aspnet/core/fundamentals/file-providers)
+* [Detect changes with change tokens](https://learn.microsoft.com/aspnet/core/fundamentals/change-tokens)
+* [API documentation](https://learn.microsoft.com/dotnet/api/microsoft.extensions.fileproviders)
 
 ## Related Packages
 
 <!-- The related packages associated with this package -->
+
+* File provider for physical files: [Microsoft.Extensions.FileProviders.Physical](https://www.nuget.org/packages/Microsoft.Extensions.FileProviders.Physical/)
+* File provider for files in embedded resources: [Microsoft.Extensions.FileProviders.Embedded](https://www.nuget.org/packages/Microsoft.Extensions.FileProviders.Embedded/)
+* Composite file and directory providers: [Microsoft.Extensions.FileProviders.Composite](https://www.nuget.org/packages/Microsoft.Extensions.FileProviders.Composite/)
 
 ## Feedback & Contributing
 

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PACKAGE.md
@@ -1,0 +1,44 @@
+## About
+
+<!-- A description of the package and where one can find more documentation -->
+
+
+
+## Key Features
+
+<!-- The key features of this package -->
+
+*
+*
+*
+
+## How to Use
+
+<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+## Main Types
+
+<!-- The main types provided in this library -->
+
+The main types provided by this library are:
+
+* ``
+* ``
+* ``
+
+## Additional Documentation
+
+<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
+
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+
+## Related Packages
+
+<!-- The related packages associated with this package -->
+
+## Feedback & Contributing
+
+<!-- How to provide feedback on this package and contribute to it -->
+
+Microsoft.Extensions.FileProviders.Physical is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PACKAGE.md
@@ -2,19 +2,42 @@
 
 <!-- A description of the package and where one can find more documentation -->
 
+Provides an implementation of a physical file provider, facilitating file access and monitoring on the disk. The primary type, [`PhysicalFileProvider`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.fileproviders.physicalfileprovider), enables the lookup of files on disk and can watch for changes either via `FileSystemWatcher` or polling mechanisms.
 
 
 ## Key Features
 
 <!-- The key features of this package -->
 
-*
-*
-*
+* Easy access and monitoring of files on the disk.
+* Ability to watch for file changes either by using `FileSystemWatcher` or through polling.
 
 ## How to Use
 
 <!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+This library can be used to look up files on disk and monitor file changes effectively.
+Below is an example of how to use the `PhysicalFileProvider` to access files on disk and monitor changes:
+
+```c#
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
+
+using var provider = new PhysicalFileProvider(AppContext.BaseDirectory);
+
+Environment.SetEnvironmentVariable("DOTNET_USE_POLLING_FILE_WATCHER", "1");
+
+var contents = provider.GetDirectoryContents(string.Empty);
+foreach (PhysicalFileInfo fileInfo in contents)
+{
+    Console.WriteLine(fileInfo.PhysicalPath);
+}
+
+var changeToken = provider.Watch("*.txt");
+changeToken.RegisterChangeCallback(_ => Console.WriteLine("Text file changed"), null);
+
+Console.ReadLine();
+```
 
 ## Main Types
 
@@ -22,20 +45,23 @@
 
 The main types provided by this library are:
 
-* ``
-* ``
-* ``
+* `Microsoft.Extensions.FileProviders.PhysicalFileProvider`
+* `Microsoft.Extensions.FileProviders.PhysicalDirectoryInfo`
+* `Microsoft.Extensions.FileProviders.PhysicalFileInfo`
 
 ## Additional Documentation
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+* [Conceptual documentation](https://learn.microsoft.com/aspnet/core/fundamentals/file-providers#physical-file-provider)
+* [API documentation](https://learn.microsoft.com/dotnet/api/microsoft.extensions.fileproviders.physical)
 
 ## Related Packages
 
 <!-- The related packages associated with this package -->
+
+* Abstractions of files and directories: [Microsoft.Extensions.FileProviders.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.FileProviders.Abstractions/)
+* File system globbing to find files matching a specified pattern: [Microsoft.Extensions.FileSystemGlobbing](https://www.nuget.org/packages/Microsoft.Extensions.FileSystemGlobbing/)
 
 ## Feedback & Contributing
 

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/PACKAGE.md
@@ -2,19 +2,33 @@
 
 <!-- A description of the package and where one can find more documentation -->
 
-
+Provides support for matching file system names/paths using [glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)).
 
 ## Key Features
 
 <!-- The key features of this package -->
 
-*
-*
-*
+* Contains the `Matcher` type, which can be used to match files in the file system based on user-defined patterns.
 
 ## How to Use
 
 <!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+Get all matching files:
+
+```c#
+using Microsoft.Extensions.FileSystemGlobbing;
+
+Matcher matcher = new();
+matcher.AddIncludePatterns(new[] { "*.txt", "*.asciidoc", "*.md" });
+
+string searchDirectory = "../starting-folder/";
+
+IEnumerable<string> matchingFiles = matcher.GetResultsInFullPath(searchDirectory);
+
+// Use matchingFiles if there are any found.
+// The files in this collection are fully qualified file system paths.
+```
 
 ## Main Types
 
@@ -22,20 +36,14 @@
 
 The main types provided by this library are:
 
-* ``
-* ``
-* ``
+* `Microsoft.Extensions.FileSystemGlobbing.Matcher`
 
-## Addtional Documentation
+## Additional Documentation
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
-
-## Related Packages
-
-<!-- The related packages associated with this package -->
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/core/extensions/file-globbing)
+* [API documentation](https://learn.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing)
 
 ## Feedback & Contributing
 

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/PACKAGE.md
@@ -42,7 +42,7 @@ The main types provided by this library are:
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/core/extensions/file-globbing)
+* [Conceptual documentation](https://learn.microsoft.com/dotnet/core/extensions/file-globbing)
 * [API documentation](https://learn.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing)
 
 ## Feedback & Contributing

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/PACKAGE.md
@@ -1,0 +1,44 @@
+## About
+
+<!-- A description of the package and where one can find more documentation -->
+
+
+
+## Key Features
+
+<!-- The key features of this package -->
+
+*
+*
+*
+
+## How to Use
+
+<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+## Main Types
+
+<!-- The main types provided in this library -->
+
+The main types provided by this library are:
+
+* ``
+* ``
+* ``
+
+## Addtional Documentation
+
+<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
+
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+
+## Related Packages
+
+<!-- The related packages associated with this package -->
+
+## Feedback & Contributing
+
+<!-- How to provide feedback on this package and contribute to it -->
+
+Microsoft.Extensions.FileSystemGlobbing is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).

--- a/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/PACKAGE.md
@@ -1,0 +1,44 @@
+## About
+
+<!-- A description of the package and where one can find more documentation -->
+
+
+
+## Key Features
+
+<!-- The key features of this package -->
+
+*
+*
+*
+
+## How to Use
+
+<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+## Main Types
+
+<!-- The main types provided in this library -->
+
+The main types provided by this library are:
+
+* ``
+* ``
+* ``
+
+## Additional Documentation
+
+<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
+
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+
+## Related Packages
+
+<!-- The related packages associated with this package -->
+
+## Feedback & Contributing
+
+<!-- How to provide feedback on this package and contribute to it -->
+
+Microsoft.Extensions.Logging.TraceSource is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).

--- a/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/PACKAGE.md
@@ -65,7 +65,7 @@ The main types provided by this library are:
 <!-- The related packages associated with this package -->
 
 * Abstractions for dependency injection: [Microsoft.Extensions.DependencyInjection.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions/)
-* Defult implementation of logging infrastructure: [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging/)
+* Default implementation of logging infrastructure: [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging/)
 * Abstractions for logging: [Microsoft.Extensions.Logging.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/)
 
 ## Feedback & Contributing

--- a/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/PACKAGE.md
@@ -2,19 +2,49 @@
 
 <!-- A description of the package and where one can find more documentation -->
 
-
+Implements a trace logger provider for the .NET logging infrastructre facilitating enhanced logging capabilities and trace-level diagnostics in application by writing messages to a trace listener using System.Diagnostic.TraceSource.
 
 ## Key Features
 
 <!-- The key features of this package -->
 
-*
-*
-*
+* Seamless integration with .NET logging infrastructure.
+* Fine-grained control over trace messages using SourceSwitch.
+* A set of builder methods to configure logging infrastructure.
 
 ## How to Use
 
 <!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+The Microsoft.Extensions.Logging.TraceSource library provides extension methods to the logger factory and the logger builder to add a trace source with trace listeners.
+
+```csharp
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+using var consoleTraceListener = new ConsoleTraceListener();
+using var textWriterTraceListener = new TextWriterTraceListener("/traces.txt");
+using var loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder
+        .AddTraceSource(new SourceSwitch("Something") { Level = SourceLevels.All }, consoleTraceListener)
+        .AddTraceSource(new SourceSwitch("HouseKeeping") { Level = SourceLevels.All }, textWriterTraceListener);
+});
+
+var logger = loggerFactory.CreateLogger<Program>();
+
+logger.LogInformation("Information message.");
+// Program Information: 0 : Information message.
+logger.LogWarning("Warning message.");
+// Program Warning: 0 : Warning message.
+
+var traceSource = new TraceSource("HouseKeeping", SourceLevels.All);
+traceSource.Listeners.Add(consoleTraceListener);
+traceSource.Listeners.Add(textWriterTraceListener);
+
+traceSource.TraceEvent(TraceEventType.Error, 0, "Error message.");
+//HouseKeeping Error: 0 : Error message.
+```
 
 ## Main Types
 
@@ -22,20 +52,21 @@
 
 The main types provided by this library are:
 
-* ``
-* ``
-* ``
+* `Microsoft.Extensions.Logging.TraceSource.TraceSourceLoggerProvider`
 
 ## Additional Documentation
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.tracesource)
 
 ## Related Packages
 
 <!-- The related packages associated with this package -->
+
+* Abstractions for dependency injection: [Microsoft.Extensions.DependencyInjection.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions/)
+* Defult implementation of logging infrastructure: [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging/)
+* Abstractions for logging: [Microsoft.Extensions.Logging.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/)
 
 ## Feedback & Contributing
 

--- a/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.Logging.TraceSource/src/PACKAGE.md
@@ -58,7 +58,7 @@ The main types provided by this library are:
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.tracesource)
+* [API documentation](https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.tracesource)
 
 ## Related Packages
 

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/PACKAGE.md
@@ -1,0 +1,44 @@
+## About
+
+<!-- A description of the package and where one can find more documentation -->
+
+
+
+## Key Features
+
+<!-- The key features of this package -->
+
+*
+*
+*
+
+## How to Use
+
+<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+## Main Types
+
+<!-- The main types provided in this library -->
+
+The main types provided by this library are:
+
+* ``
+* ``
+* ``
+
+## Additional Documentation
+
+<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
+
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+
+## Related Packages
+
+<!-- The related packages associated with this package -->
+
+## Feedback & Contributing
+
+<!-- How to provide feedback on this package and contribute to it -->
+
+Microsoft.Extensions.Options.DataAnnotations is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/PACKAGE.md
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/PACKAGE.md
@@ -2,19 +2,49 @@
 
 <!-- A description of the package and where one can find more documentation -->
 
+Microsoft.Extensions.Options.DataAnnotations is a library that adds extra validation functionality to configuration options using data annotations.
 
+It allows to apply validation rules to configuration classes to ensure they are correctly configured before the application starts running.
+
+This way, misconfiguration issues are catched early during the application startup rather than facing them later in production.
 
 ## Key Features
 
 <!-- The key features of this package -->
 
-*
-*
-*
+* Enables validation of configuration options using data annotations.
+* Early detection of misconfiguration issues during application startup.
 
 ## How to Use
 
 <!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+While configuring services, chain the `ValidateDataAnnotations()` and `ValidateOnStart()` methods to the `AddOptions` method for your configuration class.
+
+Here is a simple example demonstrating how to validate options on application startup:
+
+```csharp
+services
+    .AddOptions<MyOptions>()
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+```
+
+In the configuration class, use data annotations to specify the validation rules.
+
+For instance, in the following `MyOptions` class, the  `Name` property is marked as required:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+public class MyOptions
+{
+    [Required(AllowEmptyStrings = false)]
+    public string Name { get; set; }
+}
+```
+
+With this setup, an error indicating that the `Name` field is required will be thrown upon startup if it hasn't been configured.
 
 ## Main Types
 
@@ -22,20 +52,21 @@
 
 The main types provided by this library are:
 
-* ``
-* ``
-* ``
+* `Microsoft.Extensions.Options.DataAnnotationsValidateOptions<TOptions>`
+* `Microsoft.Extensions.DependencyInjection.OptionsBuilderDataAnnotationsExtensions`
 
 ## Additional Documentation
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+* [Conceptual documentation](https://learn.microsoft.com/dotnet/core/extensions/options)
+* [API documentation](https://learn.microsoft.com/dotnet/api/microsoft.extensions.options.dataannotationvalidateoptions-1)
 
 ## Related Packages
 
 <!-- The related packages associated with this package -->
+
+Core options: [Microsoft.Extensions.Options](https://www.nuget.org/packages/Microsoft.Extensions.Options/)
 
 ## Feedback & Contributing
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/PACKAGE.md
+++ b/src/libraries/System.DirectoryServices.Protocols/src/PACKAGE.md
@@ -2,19 +2,40 @@
 
 <!-- A description of the package and where one can find more documentation -->
 
+System.DirectoryServices.Protocols provides a managed implementation of Lightweight Directory Access Protocol (LDAP) version 3 and Directory Services Markup Language (DSML) version 2.0 (V2) standards.
 
+It primarily uses the `LdapConnection` type for interacting with LDAP servers, using system native libraries to establish TCP/IP or UDP LDAP connections.
+Supports both Windows and Unix, but certain features, such as setting client or server certificate options, are not available on Unix.
 
 ## Key Features
 
 <!-- The key features of this package -->
 
-*
-*
-*
+* Managed implementation of LDAP v3 and DSML V2 standards.
 
 ## How to Use
 
 <!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+Using the `LdapConnection` type, you can establish connections to LDAP servers and issue requests.
+
+Here is a simple example:
+
+```csharp
+using System.DirectoryServices.Protocols;
+
+// Create a new LdapConnection instance using the server URL.
+using (LdapConnection connection = new LdapConnection("ldap.example.com")) {
+
+    // Some credentials
+    connection.Credential = new NetworkCredential(dn, password);
+
+    // Connect to the server
+    connection.Bind();
+
+    // Perform LDAP operations
+}
+```
 
 ## Main Types
 
@@ -22,20 +43,24 @@
 
 The main types provided by this library are:
 
-* ``
-* ``
-* ``
+* `System.DirectoryServices.Protocols.LdapConnection`
+* `System.DirectoryServices.Protocols.DirectoryAttribute`
+* `System.DirectoryServices.Protocols.DirectoryOperation`
+* `System.DirectoryServices.Protocols.DirectoryRequest`
+* `System.DirectoryServices.Protocols.DirectoryResponse`
 
 ## Additional Documentation
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+* [API documentation](https://learn.microsoft.com/dotnet/api/system.directoryservices.protocols)
+* [Active Directory Domain Services](https://learn.microsoft.com/windows/win32/ad/active-directory-domain-services)
 
 ## Related Packages
 
 <!-- The related packages associated with this package -->
+
+* [System.DirectoryServices](https://www.nuget.org/packages/System.DirectoryServices/)
 
 ## Feedback & Contributing
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/PACKAGE.md
+++ b/src/libraries/System.DirectoryServices.Protocols/src/PACKAGE.md
@@ -1,0 +1,44 @@
+## About
+
+<!-- A description of the package and where one can find more documentation -->
+
+
+
+## Key Features
+
+<!-- The key features of this package -->
+
+*
+*
+*
+
+## How to Use
+
+<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+## Main Types
+
+<!-- The main types provided in this library -->
+
+The main types provided by this library are:
+
+* ``
+* ``
+* ``
+
+## Additional Documentation
+
+<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
+
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+
+## Related Packages
+
+<!-- The related packages associated with this package -->
+
+## Feedback & Contributing
+
+<!-- How to provide feedback on this package and contribute to it -->
+
+System.DirectoryServices.Protocols is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).

--- a/src/libraries/System.Formats.Cbor/src/PACKAGE.md
+++ b/src/libraries/System.Formats.Cbor/src/PACKAGE.md
@@ -1,0 +1,44 @@
+## About
+
+<!-- A description of the package and where one can find more documentation -->
+
+
+
+## Key Features
+
+<!-- The key features of this package -->
+
+*
+*
+*
+
+## How to Use
+
+<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+## Main Types
+
+<!-- The main types provided in this library -->
+
+The main types provided by this library are:
+
+* ``
+* ``
+* ``
+
+## Addtional Documentation
+
+<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
+
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+
+## Related Packages
+
+<!-- The related packages associated with this package -->
+
+## Feedback & Contributing
+
+<!-- How to provide feedback on this package and contribute to it -->
+
+System.Formats.Cbor is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).

--- a/src/libraries/System.Formats.Cbor/src/PACKAGE.md
+++ b/src/libraries/System.Formats.Cbor/src/PACKAGE.md
@@ -86,7 +86,7 @@ The main types provided by this library are:
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/system.formats.cbor)
+* [API documentation](https://learn.microsoft.com/dotnet/api/system.formats.cbor)
 
 ## Feedback & Contributing
 

--- a/src/libraries/System.Formats.Cbor/src/PACKAGE.md
+++ b/src/libraries/System.Formats.Cbor/src/PACKAGE.md
@@ -2,19 +2,72 @@
 
 <!-- A description of the package and where one can find more documentation -->
 
+Provides support for reading and writing values in Concise Binary Object Representation (CBOR) format, as originally defined in [IETF RFC 7049](https://www.ietf.org/rfc/rfc7049.html).
 
 
 ## Key Features
 
 <!-- The key features of this package -->
 
-*
-*
-*
+* Reader and writer types for the CBOR format.
+* Built-in support for different CBOR conformance modes.
 
 ## How to Use
 
 <!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+Write and read primitives:
+
+```csharp
+using System.Formats.Cbor;
+
+var cborWriter = new CborWriter(CborConformanceMode.Lax);
+cborWriter.WriteTextString("Hello World");
+
+var cborReader = new CborReader(cborWriter.Encode(), CborConformanceMode.Lax);
+Console.WriteLine(cborReader.ReadTextString());
+// Hello World
+```
+
+Write and read an array:
+
+```csharp
+var cborWriter = new CborWriter(CborConformanceMode.Lax);
+cborWriter.WriteStartArray(5);
+for (var index = 0; index < 5; index++)
+{
+    cborWriter.WriteInt32(index);
+}
+cborWriter.WriteEndArray();
+
+var cborReader = new CborReader(cborWriter.Encode(), CborConformanceMode.Lax);
+var arrayLength = cborReader.ReadStartArray();
+for (var index = 0; index < arrayLength; index++)
+{
+    Console.Write(cborReader.ReadInt32());
+}
+// 01234
+cborReader.ReadEndArray();
+```
+
+Inspect writer and reader state:
+
+```csharp
+var cborWriter = new CborWriter(CborConformanceMode.Lax);
+cborWriter.WriteTextString("SomeArray");
+Console.WriteLine(cborWriter.BytesWritten);
+// 10
+Console.WriteLine(cborWriter.IsWriteCompleted);
+// True
+
+var cborReader = new CborReader(cborWriter.Encode(), CborConformanceMode.Lax);
+Console.WriteLine(cborReader.BytesRemaining);
+// 10
+Console.WriteLine(cborReader.ReadTextString());
+// SomeArray
+Console.WriteLine(cborReader.BytesRemaining);
+// 0
+```
 
 ## Main Types
 
@@ -22,20 +75,18 @@
 
 The main types provided by this library are:
 
-* ``
-* ``
-* ``
+* `System.Formats.Cbor.CborReader`
+* `System.Formats.Cbor.CborWriter`
+* `System.Formats.Cbor.CborReaderState`
+* `System.Formats.Cbor.CborConformanceMode`
+* `System.Formats.Cbor.CborContentException`
+* `System.Formats.Cbor.CborTag`
 
-## Addtional Documentation
+## Additional Documentation
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
-
-## Related Packages
-
-<!-- The related packages associated with this package -->
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/system.formats.cbor)
 
 ## Feedback & Contributing
 

--- a/src/libraries/System.IO.Hashing/src/PACKAGE.md
+++ b/src/libraries/System.IO.Hashing/src/PACKAGE.md
@@ -1,0 +1,44 @@
+## About
+
+<!-- A description of the package and where one can find more documentation -->
+
+
+
+## Key Features
+
+<!-- The key features of this package -->
+
+*
+*
+*
+
+## How to Use
+
+<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+## Main Types
+
+<!-- The main types provided in this library -->
+
+The main types provided by this library are:
+
+* ``
+* ``
+* ``
+
+## Additional Documentation
+
+<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
+
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+
+## Related Packages
+
+<!-- The related packages associated with this package -->
+
+## Feedback & Contributing
+
+<!-- How to provide feedback on this package and contribute to it -->
+
+System.IO.Hashing is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).

--- a/src/libraries/System.IO.Hashing/src/PACKAGE.md
+++ b/src/libraries/System.IO.Hashing/src/PACKAGE.md
@@ -8,7 +8,7 @@ Hash code algorithms are pivotal for generating unique values for objects based 
 The namespace encompasses algorithms like CRC-32, CRC-64, xxHash3, xxHash32, xxHash64, and xxHash128, all engineered for swift and efficient hash code generation, with xxHash being an "Extremely fast hash algorithm".
 
 **Warning**: The hash functions provided by System.IO.Hashing are not suitable for security purposes such as handling passwords or verifying untrusted content.
-For such security-critical applications, consider using cryptographic hash functions provided by the [System.Security.Cryptography](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography) namespace.
+For such security-critical applications, consider using cryptographic hash functions provided by the [System.Security.Cryptography](https://learn.microsoft.com/dotnet/api/system.security.cryptography) namespace.
 
 ## Key Features
 

--- a/src/libraries/System.IO.Hashing/src/PACKAGE.md
+++ b/src/libraries/System.IO.Hashing/src/PACKAGE.md
@@ -2,19 +2,61 @@
 
 <!-- A description of the package and where one can find more documentation -->
 
+System.IO.Hashing offers a variety of hash code algorithms.
 
+Hash code algorithms are pivotal for generating unique values for objects based on their content, facilitating object comparisons, and detecting content alterations.
+The namespace encompasses algorithms like CRC-32, CRC-64, xxHash3, xxHash32, xxHash64, and xxHash128, all engineered for swift and efficient hash code generation, with xxHash being an "Extremely fast hash algorithm".
+
+**Warning**: The hash functions provided by System.IO.Hashing are not suitable for security purposes such as handling passwords or verifying untrusted content.
+For such security-critical applications, consider using cryptographic hash functions provided by the [System.Security.Cryptography](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography) namespace.
 
 ## Key Features
 
 <!-- The key features of this package -->
 
-*
-*
-*
+* Variety of hash code algorithms including CRC-32, CRC-64, xxHash3, xxHash32, xxHash64, and xxHash128.
+* Implementations of CRC-32 and CRC-64 algorithms, as used in IEEE 802.3, and described in ECMA-182, Annex B respectively.
+* Implementations of XxHash32 for generating 32-bit hashes, XxHash3 and XxHash64 for generating 64-bit hashes, and xxHash128 for generating 128-bit hashes.
 
 ## How to Use
 
 <!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+Creating hash codes is straightforward.
+Call the `Hash` method with the content to be hashed.
+
+Here is a practical example:
+
+```csharp
+using System;
+using System.IO.Hashing;
+
+byte[] data = new byte[] { 1, 2, 3, 4 };
+
+byte[] crc32Value = Crc32.Hash(data);
+Console.WriteLine($"CRC-32 Hash: {BitConverter.ToString(crc32Value)}");
+// CRC-32 Hash: CD-FB-3C-B6
+
+byte[] crc64Value = Crc64.Hash(data);
+Console.WriteLine($"CRC-64 Hash: {BitConverter.ToString(crc64Value)}");
+// CRC-64 Hash: 58-8D-5A-D4-2A-70-1D-B2
+
+byte[] xxHash3Value = XxHash3.Hash(data);
+Console.WriteLine($"XxHash3 Hash: {BitConverter.ToString(xxHash3Value)}");
+// XxHash3 Hash: 98-8B-7B-90-33-AC-46-22
+
+byte[] xxHash32Value = XxHash32.Hash(data);
+Console.WriteLine($"XxHash32 Hash: {BitConverter.ToString(xxHash32Value)}");
+// XxHash32 Hash: FE-96-D1-9C
+
+byte[] xxHash64Value = XxHash64.Hash(data);
+Console.WriteLine($"XxHash64 Hash: {BitConverter.ToString(xxHash64Value)}");
+// XxHash64 Hash: 54-26-20-E3-A2-A9-2E-D1
+
+byte[] xxHash128Value = XxHash128.Hash(data);
+Console.WriteLine($"XxHash128 Hash: {BitConverter.ToString(xxHash128Value)}");
+// XxHash128 Hash: 49-A0-48-99-59-7A-35-67-53-76-53-A0-D9-95-5B-86
+```
 
 ## Main Types
 
@@ -22,20 +64,25 @@
 
 The main types provided by this library are:
 
-* ``
-* ``
-* ``
+* `System.IO.Hashing.Crc32`
+* `System.IO.Hashing.Crc64`
+* `System.IO.Hashing.XxHash3`
+* `System.IO.Hashing.XxHash32`
+* `System.IO.Hashing.XxHash64`
+* `System.IO.Hashing.XxHash128`
 
 ## Additional Documentation
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+* [API documentation](https://learn.microsoft.com/dotnet/api/system.io.hashing)
+* [xxHash - Extremely fast hash algorithm](https://github.com/Cyan4973/xxHash/blob/release/doc/xxhash_spec.md)
 
 ## Related Packages
 
 <!-- The related packages associated with this package -->
+
+Cryptographic services, including secure encryption and decryption of data: [System.Security.Cryptography](https://learn.microsoft.com/dotnet/api/system.security.cryptography)
 
 ## Feedback & Contributing
 

--- a/src/libraries/System.Memory.Data/src/PACKAGE.md
+++ b/src/libraries/System.Memory.Data/src/PACKAGE.md
@@ -1,0 +1,44 @@
+## About
+
+<!-- A description of the package and where one can find more documentation -->
+
+
+
+## Key Features
+
+<!-- The key features of this package -->
+
+*
+*
+*
+
+## How to Use
+
+<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+## Main Types
+
+<!-- The main types provided in this library -->
+
+The main types provided by this library are:
+
+* ``
+* ``
+* ``
+
+## Additional Documentation
+
+<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
+
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+
+## Related Packages
+
+<!-- The related packages associated with this package -->
+
+## Feedback & Contributing
+
+<!-- How to provide feedback on this package and contribute to it -->
+
+System.Memory.Data is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).

--- a/src/libraries/System.Memory.Data/src/PACKAGE.md
+++ b/src/libraries/System.Memory.Data/src/PACKAGE.md
@@ -2,19 +2,84 @@
 
 <!-- A description of the package and where one can find more documentation -->
 
+System.Memory.Data introduces the `BinaryData` type, a lightweight abstraction for a byte payload.
+It makes it easy to convert between string, bytes, and stream.
+
+This abstraction can simplify the API surface by exposing a single type instead of numerous overloads or properties.
+The `BinaryData` type handles data ownership efficiently, wrapping passed-in bytes when using `byte[]` or `ReadOnlyMemory<byte>` constructors or methods, and managing data as bytes when dealing with streams, strings, or rich model types serialized as JSON.
 
 
 ## Key Features
 
 <!-- The key features of this package -->
 
-*
-*
-*
+* Lightweight abstraction for byte payload via `BinaryData` type.
+* Convenient helper methods for common conversions among string, bytes, and stream.
+* Efficient data ownership handling.
 
 ## How to Use
 
 <!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+To/From String:
+
+```csharp
+var data = new BinaryData("some data");
+
+// ToString will decode the bytes using UTF-8
+Console.WriteLine(data.ToString()); // prints "some data"
+```
+
+To/From Bytes:
+
+```csharp
+byte[] bytes = Encoding.UTF8.GetBytes("some data");
+
+// Create BinaryData using a constructor ...
+BinaryData data = new BinaryData(bytes);
+
+// Or using a static factory method.
+data = BinaryData.FromBytes(bytes);
+
+// There is an implicit cast defined for ReadOnlyMemory<byte>
+ReadOnlyMemory<byte> rom = data;
+
+// There is also an implicit cast defined for ReadOnlySpan<byte>
+ReadOnlySpan<byte> ros = data;
+
+// there is also a ToMemory method that gives access to the ReadOnlyMemory.
+rom = data.ToMemory();
+
+// and a ToArray method that converts into a byte array.
+byte[] array = data.ToArray();
+```
+
+To/From stream:
+
+```csharp
+var bytes = Encoding.UTF8.GetBytes("some data");
+Stream stream = new MemoryStream(bytes);
+var data = BinaryData.FromStream(stream);
+
+// Calling ToStream will give back a stream that is backed by ReadOnlyMemory, so it is not writable.
+stream = data.ToStream();
+Console.WriteLine(stream.CanWrite); // prints false
+```
+
+`BinaryData` also can be used to integrate with `ObjectSerializer`.
+By default, the `JsonObjectSerializer` will be used, but any serializer deriving from `ObjectSerializer` can be used.
+
+```csharp
+var model = new CustomModel
+{
+    A = "some text",
+    B = 5,
+    C = true
+};
+
+var data = BinaryData.FromObjectAsJson(model);
+model = data.ToObjectFromJson<CustomModel>();
+```
 
 ## Main Types
 
@@ -22,20 +87,13 @@
 
 The main types provided by this library are:
 
-* ``
-* ``
-* ``
+* `System.BinaryData`
 
 ## Additional Documentation
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
-
-## Related Packages
-
-<!-- The related packages associated with this package -->
+* [API documentation](https://learn.microsoft.com/dotnet/api/system.binarydata)
 
 ## Feedback & Contributing
 

--- a/src/libraries/System.Security.Cryptography.ProtectedData/src/PACKAGE.md
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/src/PACKAGE.md
@@ -2,40 +2,68 @@
 
 <!-- A description of the package and where one can find more documentation -->
 
+System.Security.Cryptography.ProtectedData offers a simplified interface for utilizing Microsoft Windows DPAPI's [CryptProtectData](https://learn.microsoft.com/windows/win32/api/dpapi/nf-dpapi-cryptprotectdata) and [CryptUnprotectData](https://learn.microsoft.com/windows/win32/api/dpapi/nf-dpapi-cryptunprotectdata) functions.
 
+**Note**: Since it relies on Windows DPAPI, this package is only supported on Windows platforms.
+For more complex cryptographic operations or cross-platform support, consider the [System.Security.Cryptography](https://learn.microsoft.com/dotnet/api/system.security.cryptography) namespace.
 
 ## Key Features
 
 <!-- The key features of this package -->
 
-*
-*
-*
+* Built upon the robust and secure Windows Data Protection API (DPAPI).
+* Data can be protected either for current process or for any process on the machine.
+* Scope of protection can be defined either to the current user or the local machine.
 
 ## How to Use
 
 <!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
 
+Utilizing this package is quite simple, and it mainly revolves around two methods: `Protect` and `Unprotect`.
+
+Here, `originalData` is the data you want to protect, `optionalEntropy` is an additional byte array used to increase encryption complexity, and `DataProtectionScope` specifies whether the data protection should apply to the current user or the machine.
+
+```csharp
+using System.Security.Cryptography;
+using System.Text;
+
+byte[] originalData = Encoding.UTF8.GetBytes("This is a secret");
+byte[] optionalEntropy = new byte[64];
+Random.Shared.NextBytes(optionalEntropy);
+
+// To protect:
+byte[] encryptedData = ProtectedData.Protect(
+    originalData,
+    optionalEntropy,
+    DataProtectionScope.CurrentUser);
+
+// To unprotect:
+byte[] decryptedData = ProtectedData.Unprotect(
+    encryptedData,
+    optionalEntropy,
+    DataProtectionScope.CurrentUser);
+```
+
 ## Main Types
 
 <!-- The main types provided in this library -->
 
-The main types provided by this library are:
+The main type provided by this library is:
 
-* ``
-* ``
-* ``
+* `System.Security.Cryptography.ProtectedData`
 
 ## Additional Documentation
 
 <!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
 
-* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
-* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+* [Conceptual documentation](https://learn.microsoft.com/dotnet/standard/security/how-to-use-data-protection)
+* [API documentation](https://learn.microsoft.com/dotnet/api/system.security.cryptography.protecteddata)
 
 ## Related Packages
 
 <!-- The related packages associated with this package -->
+
+* PKCS and CMS algorithms: [System.Security.Cryptography.Pkcs](https://www.nuget.org/packages/System.Security.Cryptography.Pkcs/)
 
 ## Feedback & Contributing
 

--- a/src/libraries/System.Security.Cryptography.ProtectedData/src/PACKAGE.md
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/src/PACKAGE.md
@@ -1,0 +1,44 @@
+## About
+
+<!-- A description of the package and where one can find more documentation -->
+
+
+
+## Key Features
+
+<!-- The key features of this package -->
+
+*
+*
+*
+
+## How to Use
+
+<!-- A compelling example on how to use this package with code, as well as any specific guidelines for when to use the package -->
+
+## Main Types
+
+<!-- The main types provided in this library -->
+
+The main types provided by this library are:
+
+* ``
+* ``
+* ``
+
+## Additional Documentation
+
+<!-- Links to further documentation. Remove conceptual documentation if not available for the library. -->
+
+* [Conceptual documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/**LIBRARYNAME**/overview)
+* [API documentation](https://learn.microsoft.com/en-us/dotnet/api/**LIBRARYNAME**)
+
+## Related Packages
+
+<!-- The related packages associated with this package -->
+
+## Feedback & Contributing
+
+<!-- How to provide feedback on this package and contribute to it -->
+
+System.Security.Cryptography.ProtectedData is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/dotnet/runtime).


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/92228
Continuation of https://github.com/dotnet/runtime/pull/91210

One of the top customer problems that package consumers are facing is lack of documentation. As such, we are driving an effort to increase the adoption and quality of NuGet package READMEs.

---

This tell-mode change backports the 12 new package readmes into the release/8.0 branch.

🥳🥳🥳 Kudos to 🥳🥳🥳
- @eNeRGy164 (8 package readmes!)
- @illialarka
- @vcsjones
- @EnsignPayton

This wouldn't have been possible without your dedication.