### PR TITLE
JIT: Add explicit block fallthrough successor

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5297,7 +5297,7 @@ public:
             {
                 // Scenario where next block and conditional block, both point to the same block.
                 // In such case, intersect the assertions present on both the out edges of predBlock.
-                assert(predBlock->NextIs(block));
+                assert(predBlock->FallsInto(block));
                 BitVecOps::IntersectionD(apTraits, pAssertionOut, predBlock->bbAssertionOut);
 
                 if (VerboseDataflow())

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1278,7 +1278,7 @@ BasicBlock* BasicBlock::GetSucc(unsigned i, Compiler* comp)
             return bbJumpDest;
 
         case BBJ_NONE:
-            return bbNext;
+            return GetFallThroughSucc();
 
         case BBJ_COND:
             if (i == 0)

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -681,9 +681,9 @@ public:
     {
         // TODO: Once we allow bbFallThroughSucc to diverge from bbNext, ensure we only set bbFallThroughSucc
         // to something other than bbNext when this block is a BBJ_COND.
-        // BBJ_CALLFINALLY can fall through too, but we don't allow its fallthrough successor to diverge from bbNext
-        // because we aren't interested in splitting up call-always pairs
-        assert(KindIs(BBJ_COND, BBJ_NONE));
+        // For BBJ_CALLFINALLY blocks part of call-always pairs, bbFallThroughSucc points to the BBJ_ALWAYS block.
+        // For now, call-always pairs are always contiguous, so bbFallThroughSucc cannot diverge from bbNext.
+        assert(KindIs(BBJ_COND));
         bbFallThroughSucc = fallThroughSucc;
         // For now, bbFallThroughSucc cannot diverge from bbNext
         assert(FallsIntoNext());

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2176,6 +2176,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     }
     else
     {
+        assert(block->isBBCallAlwaysPair());
+
         // Because of the way the flowgraph is connected, the liveness info for this one instruction
         // after the call is not (can not be) correct in cases where a variable has a last use in the
         // handler.  So turn off GC reporting for this single instruction.
@@ -2198,17 +2200,14 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         }
 
         GetEmitter()->emitEnableGC();
-    }
 
-    // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
-    // jump target using bbJumpDest - that is already used to point
-    // to the finally block. So just skip past the BBJ_ALWAYS unless the
-    // block is RETLESS.
-    if (!(block->bbFlags & BBF_RETLESS_CALL))
-    {
-        assert(block->isBBCallAlwaysPair());
+        // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
+        // jump target using bbJumpDest - that is already used to point
+        // to the finally block. So just skip past the BBJ_ALWAYS unless the
+        // block is RETLESS.
         block = nextBlock;
     }
+
     return block;
 }
 

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -1536,6 +1536,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     }
     else
     {
+        assert(block->isBBCallAlwaysPair());
+
         // Because of the way the flowgraph is connected, the liveness info for this one instruction
         // after the call is not (can not be) correct in cases where a variable has a last use in the
         // handler.  So turn off GC reporting for this single instruction.
@@ -1558,17 +1560,14 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         }
 
         GetEmitter()->emitEnableGC();
-    }
 
-    // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
-    // jump target using bbJumpDest - that is already used to point
-    // to the finally block. So just skip past the BBJ_ALWAYS unless the
-    // block is RETLESS.
-    if (!(block->bbFlags & BBF_RETLESS_CALL))
-    {
-        assert(block->isBBCallAlwaysPair());
+        // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
+        // jump target using bbJumpDest - that is already used to point
+        // to the finally block. So just skip past the BBJ_ALWAYS unless the
+        // block is RETLESS.
         block = nextBlock;
     }
+
     return block;
 }
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1174,6 +1174,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     }
     else
     {
+        assert(block->isBBCallAlwaysPair());
+
         // Because of the way the flowgraph is connected, the liveness info for this one instruction
         // after the call is not (can not be) correct in cases where a variable has a last use in the
         // handler.  So turn off GC reporting for this single instruction.
@@ -1196,17 +1198,14 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         }
 
         GetEmitter()->emitEnableGC();
-    }
 
-    // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
-    // jump target using bbJumpDest - that is already used to point
-    // to the finally block. So just skip past the BBJ_ALWAYS unless the
-    // block is RETLESS.
-    if (!(block->bbFlags & BBF_RETLESS_CALL))
-    {
-        assert(block->isBBCallAlwaysPair());
+        // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
+        // jump target using bbJumpDest - that is already used to point
+        // to the finally block. So just skip past the BBJ_ALWAYS unless the
+        // block is RETLESS.
         block = nextBlock;
     }
+
     return block;
 }
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -374,7 +374,7 @@ void Compiler::fgConvertBBToThrowBB(BasicBlock* block)
     // Must do this after we update bbJumpKind of block.
     if (isCallAlwaysPair)
     {
-        BasicBlock* leaveBlk = block->GetFallThroughSucc();
+        BasicBlock* leaveBlk = block->Next();
         noway_assert(leaveBlk->KindIs(BBJ_ALWAYS));
 
         leaveBlk->bbFlags &= ~BBF_DONT_REMOVE;

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2697,11 +2697,12 @@ bool BBPredsChecker::CheckJump(BasicBlock* blockPred, BasicBlock* block)
     switch (blockPred->GetJumpKind())
     {
         case BBJ_COND:
-            assert(blockPred->NextIs(block) || blockPred->HasJumpTo(block));
+            assert(blockPred->FallsInto(block) || blockPred->HasJumpTo(block));
             return true;
 
         case BBJ_NONE:
-            assert(blockPred->NextIs(block));
+            assert(blockPred->FallsInto(block));
+            assert(blockPred->FallsIntoNext());
             return true;
 
         case BBJ_CALLFINALLY:
@@ -4871,7 +4872,7 @@ void Compiler::fgDebugCheckLoopTable()
             else
             {
                 assert(h->KindIs(BBJ_NONE));
-                assert(h->NextIs(e));
+                assert(h->FallsInto(e));
                 assert(loop.lpTop == e);
                 assert(loop.lpIsTopEntry());
             }

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -807,7 +807,7 @@ PhaseStatus Compiler::fgCloneFinally()
 
             if (block->KindIs(BBJ_NONE) && (block == lastTryBlock))
             {
-                jumpDest = block->Next();
+                jumpDest = block->GetFallThroughSucc();
             }
             else if (block->KindIs(BBJ_ALWAYS))
             {
@@ -1032,7 +1032,7 @@ PhaseStatus Compiler::fgCloneFinally()
 
                 // If the clone ends up just after the finally, adjust
                 // the stopping point for finally traversal.
-                if (newBlock->NextIs(nextBlock))
+                if (newBlock->FallsInto(nextBlock))
                 {
                     assert(newBlock->PrevIs(lastBlock));
                     nextBlock = newBlock;
@@ -2178,7 +2178,7 @@ PhaseStatus Compiler::fgTailMergeThrows()
                 case BBJ_COND:
                 {
                     // Flow to non canonical block could be via fall through or jump or both.
-                    if (predBlock->NextIs(nonCanonicalBlock))
+                    if (predBlock->FallsInto(nonCanonicalBlock))
                     {
                         fgTailMergeThrowsFallThroughHelper(predBlock, nonCanonicalBlock, canonicalBlock, predEdge);
                     }
@@ -2254,7 +2254,8 @@ void Compiler::fgTailMergeThrowsFallThroughHelper(BasicBlock* predBlock,
                                                   BasicBlock* canonicalBlock,
                                                   FlowEdge*   predEdge)
 {
-    assert(predBlock->NextIs(nonCanonicalBlock));
+    assert(predBlock->bbFallsThrough());
+    assert(predBlock->FallsInto(nonCanonicalBlock));
 
     BasicBlock* const newBlock = fgNewBBafter(BBJ_ALWAYS, predBlock, true, canonicalBlock);
 

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -350,13 +350,13 @@ void Compiler::fgRemoveBlockAsPred(BasicBlock* block)
             fgRemoveRefPred(block->GetJumpDest(), block);
             break;
 
-        case BBJ_NONE:
-            fgRemoveRefPred(block->Next(), block);
-            break;
-
         case BBJ_COND:
             fgRemoveRefPred(block->GetJumpDest(), block);
-            fgRemoveRefPred(block->Next(), block);
+
+            FALLTHROUGH;
+
+        case BBJ_NONE:
+            fgRemoveRefPred(block->GetFallThroughSucc(), block);
             break;
 
         case BBJ_EHFINALLYRET:

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -529,7 +529,7 @@ void BlockCountInstrumentor::RelocateProbes()
 
                 // Handle case where we had a fall through critical edge
                 //
-                if (pred->NextIs(intermediary))
+                if (pred->FallsInto(intermediary))
                 {
                     m_comp->fgRemoveRefPred(pred, block);
                     m_comp->fgAddRefPred(intermediary, block);
@@ -984,7 +984,7 @@ void Compiler::WalkSpanningTree(SpanningTreeVisitor* visitor)
                     break;
                 }
 
-                __fallthrough;
+                FALLTHROUGH;
 
             case BBJ_RETURN:
             {
@@ -2688,7 +2688,7 @@ PhaseStatus Compiler::fgIncorporateProfileData()
                     }
                 }
 
-                __fallthrough;
+                FALLTHROUGH;
 
             default:
                 JITDUMP("Unknown PGO record type 0x%x in schema entry %u (offset 0x%x count 0x%x other 0x%x)\n",
@@ -4428,7 +4428,7 @@ bool Compiler::fgComputeMissingBlockWeights(weight_t* returnWeight)
                     // Does this block flow into only one other block
                     if (bSrc->KindIs(BBJ_NONE))
                     {
-                        bOnlyNext = bSrc->Next();
+                        bOnlyNext = bSrc->GetFallThroughSucc();
                     }
                     else if (bSrc->KindIs(BBJ_ALWAYS))
                     {
@@ -4449,7 +4449,7 @@ bool Compiler::fgComputeMissingBlockWeights(weight_t* returnWeight)
                 // Does this block flow into only one other block
                 if (bDst->KindIs(BBJ_NONE))
                 {
-                    bOnlyNext = bDst->Next();
+                    bOnlyNext = bDst->GetFallThroughSucc();
                 }
                 else if (bDst->KindIs(BBJ_ALWAYS))
                 {
@@ -4758,13 +4758,13 @@ PhaseStatus Compiler::fgComputeEdgeWeights()
                     weight_t    diff;
                     FlowEdge*   otherEdge;
                     BasicBlock* otherDst;
-                    if (bSrc->NextIs(bDst))
+                    if (bSrc->FallsInto(bDst))
                     {
                         otherDst = bSrc->GetJumpDest();
                     }
                     else
                     {
-                        otherDst = bSrc->Next();
+                        otherDst = bSrc->GetFallThroughSucc();
                     }
                     otherEdge = fgGetPredForBlock(otherDst, bSrc);
 

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -317,7 +317,7 @@ void ProfileSynthesis::AssignLikelihoodJump(BasicBlock* block)
 void ProfileSynthesis::AssignLikelihoodCond(BasicBlock* block)
 {
     BasicBlock* const jump = block->GetJumpDest();
-    BasicBlock* const next = block->Next();
+    BasicBlock* const next = block->GetFallThroughSucc();
 
     // Watch for degenerate case
     //
@@ -1221,7 +1221,7 @@ void ProfileSynthesis::ComputeCyclicProbabilities(SimpleLoop* loop)
                             exitBlock->bbNum, exitEdge->getLikelihood());
 
                     BasicBlock* const jump               = exitBlock->GetJumpDest();
-                    BasicBlock* const next               = exitBlock->Next();
+                    BasicBlock* const next               = exitBlock->GetFallThroughSucc();
                     FlowEdge* const   jumpEdge           = m_comp->fgGetPredForBlock(jump, exitBlock);
                     FlowEdge* const   nextEdge           = m_comp->fgGetPredForBlock(next, exitBlock);
                     weight_t const    exitLikelihood     = (missingExitWeight + currentExitWeight) / exitBlockWeight;

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -256,7 +256,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
 
         if (top->KindIs(BBJ_COND))
         {
-            topFallThrough     = top->Next();
+            topFallThrough     = top->GetFallThroughSucc();
             lpIndexFallThrough = topFallThrough->bbNatLoopNum;
         }
 
@@ -380,7 +380,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
         switch (oldJumpKind)
         {
             case BBJ_NONE:
-                fgReplacePred(bottom->Next(), top, bottom);
+                fgReplacePred(bottom->GetFallThroughSucc(), top, bottom);
                 break;
             case BBJ_RETURN:
             case BBJ_THROW:
@@ -389,7 +389,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
             case BBJ_COND:
                 // replace predecessor in the fall through block.
                 noway_assert(!bottom->IsLast());
-                fgReplacePred(bottom->Next(), top, bottom);
+                fgReplacePred(bottom->GetFallThroughSucc(), top, bottom);
 
                 // fall through for the jump target
                 FALLTHROUGH;

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -121,8 +121,9 @@ bool OptIfConversionDsc::IfConvertCheckInnerBlockFlow(BasicBlock* block)
 //
 bool OptIfConversionDsc::IfConvertCheckThenFlow()
 {
+    assert(m_startBlock->KindIs(BBJ_COND));
     m_flowFound           = false;
-    BasicBlock* thenBlock = m_startBlock->Next();
+    BasicBlock* thenBlock = m_startBlock->GetFallThroughSucc();
 
     for (int thenLimit = 0; thenLimit < m_checkLimit; thenLimit++)
     {
@@ -575,7 +576,7 @@ bool OptIfConversionDsc::optIfConvert()
     }
 
     // Check the Then and Else blocks have a single operation each.
-    if (!IfConvertCheckStmts(m_startBlock->Next(), &m_thenOperation))
+    if (!IfConvertCheckStmts(m_startBlock->GetFallThroughSucc(), &m_thenOperation))
     {
         return false;
     }
@@ -742,7 +743,7 @@ bool OptIfConversionDsc::optIfConvert()
     }
 
     // Update the flow from the original block.
-    m_comp->fgRemoveAllRefPreds(m_startBlock->Next(), m_startBlock);
+    m_comp->fgRemoveAllRefPreds(m_startBlock->GetFallThroughSucc(), m_startBlock);
     assert(m_startBlock->HasJump());
     m_startBlock->SetJumpKind(BBJ_ALWAYS);
 

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -2281,7 +2281,7 @@ bool Compiler::fgNormalizeEHCase2()
                                 fgReplaceJumpTarget(predBlock, newTryStart, insertBeforeBlk);
                             }
 
-                            if (predBlock->NextIs(newTryStart) && predBlock->bbFallsThrough())
+                            if (predBlock->bbFallsThrough() && predBlock->FallsInto(newTryStart))
                             {
                                 fgRemoveRefPred(insertBeforeBlk, predBlock);
                                 fgAddRefPred(newTryStart, predBlock);

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -888,9 +888,13 @@ void Compiler::fgExtendDbgLifetimes()
 
         switch (block->GetJumpKind())
         {
+            case BBJ_COND:
+                VarSetOps::UnionD(this, initVars, block->GetJumpDest()->bbScope);
+                FALLTHROUGH;
+
             case BBJ_NONE:
                 PREFIX_ASSUME(!block->IsLast());
-                VarSetOps::UnionD(this, initVars, block->Next()->bbScope);
+                VarSetOps::UnionD(this, initVars, block->GetFallThroughSucc()->bbScope);
                 break;
 
             case BBJ_ALWAYS:
@@ -904,14 +908,8 @@ void Compiler::fgExtendDbgLifetimes()
                 {
                     assert(block->isBBCallAlwaysPair());
                     PREFIX_ASSUME(!block->IsLast());
-                    VarSetOps::UnionD(this, initVars, block->Next()->bbScope);
+                    VarSetOps::UnionD(this, initVars, block->GetFallThroughSucc()->bbScope);
                 }
-                VarSetOps::UnionD(this, initVars, block->GetJumpDest()->bbScope);
-                break;
-
-            case BBJ_COND:
-                PREFIX_ASSUME(!block->IsLast());
-                VarSetOps::UnionD(this, initVars, block->Next()->bbScope);
                 VarSetOps::UnionD(this, initVars, block->GetJumpDest()->bbScope);
                 break;
 

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -2545,7 +2545,8 @@ BasicBlock* LinearScan::findPredBlockForLiveIn(BasicBlock* block,
                 if (predBlock->KindIs(BBJ_COND))
                 {
                     // Special handling to improve matching on backedges.
-                    BasicBlock* otherBlock = predBlock->NextIs(block) ? predBlock->GetJumpDest() : predBlock->Next();
+                    BasicBlock* otherBlock =
+                        predBlock->FallsInto(block) ? predBlock->GetJumpDest() : predBlock->GetFallThroughSucc();
                     noway_assert(otherBlock != nullptr);
                     if (isBlockVisited(otherBlock) && !blockInfo[otherBlock->bbNum].hasEHBoundaryIn)
                     {

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -935,7 +935,7 @@ void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DE
     {
         GenTreePhiArg* arg  = (GenTreePhiArg*)op;
         BasicBlock*    pred = arg->gtPredBB;
-        if (pred->bbFallsThrough() && pred->NextIs(block))
+        if (pred->bbFallsThrough() && pred->FallsInto(block))
         {
             assertions = pred->bbAssertionOut;
             JITDUMP("Merge assertions from pred " FMT_BB " edge: ", pred->bbNum);

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -94,9 +94,18 @@ bool IsConstantTestCondBlock(const BasicBlock* block,
                     return false;
                 }
 
-                *isReversed   = rootNode->gtGetOp1()->OperIs(GT_NE);
-                *blockIfTrue  = *isReversed ? block->Next() : block->GetJumpDest();
-                *blockIfFalse = *isReversed ? block->GetJumpDest() : block->Next();
+                *isReversed = rootNode->gtGetOp1()->OperIs(GT_NE);
+
+                if (*isReversed)
+                {
+                    *blockIfTrue  = block->GetFallThroughSucc();
+                    *blockIfFalse = block->GetJumpDest();
+                }
+                else
+                {
+                    *blockIfTrue  = block->GetJumpDest();
+                    *blockIfFalse = block->GetFallThroughSucc();
+                }
 
                 if (block->JumpsToNext() || block->HasJumpTo(block))
                 {


### PR DESCRIPTION
Next step for #93020. This change shouldn’t introduce any behavioral changes, as we don’t allow the fall-through successor to diverge from `bbNext` yet (that will be in a follow-up PR). Once we allow these to diverge (plus disallow BBJ_NONE until the block layout is set), we’ll theoretically no longer have to maintain an invariant of contiguous fall-through successors during block reordering, opening up more ordering possibilities.

Note that while BBJ_CALLFINALLY blocks can fall through, we don’t plan to allow their fall-through successors to diverge from `bbNext` yet. We will have to determine if there is any benefit in splitting up call-always pairs first. 