### PR TITLE
Add common parent for frozen objects

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenObjectNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenObjectNode.cs
@@ -1,77 +1,54 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+
 using Internal.Text;
 using Internal.TypeSystem;
 
+using Debug = System.Diagnostics.Debug;
+
 namespace ILCompiler.DependencyAnalysis
 {
-    /// <summary>
-    /// Represents a frozen object that is statically preallocated within the data section
-    /// of the executable instead of on the GC heap.
-    /// </summary>
-    public sealed class FrozenObjectNode : EmbeddedObjectNode, ISymbolDefinitionNode
+    public abstract class FrozenObjectNode : EmbeddedObjectNode, ISymbolDefinitionNode
     {
-        private readonly MetadataType _owningType;
-        private readonly TypePreinit.ISerializableReference _data;
-        private readonly int _allocationSiteId;
-
-        public FrozenObjectNode(MetadataType owningType, int allocationSiteId, TypePreinit.ISerializableReference data)
-        {
-            _owningType = owningType;
-            _allocationSiteId = allocationSiteId;
-            _data = data;
-        }
-
-        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
-        {
-            sb.Append(nameMangler.CompilationUnitPrefix).Append("__FrozenObj_")
-                .Append(nameMangler.GetMangledTypeName(_owningType))
-                .Append(_allocationSiteId.ToStringInvariant());
-        }
-
-        public override bool StaticDependenciesAreComputed => true;
-
-        public TypeDesc ObjectType => _data.Type;
-
-        public bool IsKnownImmutable => _data.IsKnownImmutable;
-
-        public int GetArrayLength()
-        {
-            Debug.Assert(ObjectType.IsArray);
-            return _data.ArrayLength;
-        }
-
         int ISymbolNode.Offset => 0;
 
         int ISymbolDefinitionNode.Offset
         {
             get
             {
-                // The frozen object symbol points at the MethodTable portion of the object, skipping over the sync block
-                return OffsetFromBeginningOfArray + _owningType.Context.Target.PointerSize;
+                // The frozen symbol points at the MethodTable portion of the object, skipping over the sync block
+                return OffsetFromBeginningOfArray + ObjectType.Context.Target.PointerSize;
             }
         }
 
-        public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
-        {
-            // Sync Block
-            dataBuilder.EmitZeroPointer();
+        public abstract TypeDesc ObjectType { get; }
 
-            // byte contents
-            _data.WriteContent(ref dataBuilder, this, factory);
+        public abstract int? ArrayLength { get; }
+        public abstract bool IsKnownImmutable { get; }
+        public int Size => ObjectType.Context.Target.PointerSize + ContentSize; // SyncBlock + size of contents
+        protected abstract int ContentSize { get; }
+
+        public abstract void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb);
+
+        public sealed override bool StaticDependenciesAreComputed => true;
+
+        public sealed override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            dataBuilder.EmitZeroPointer(); // Sync block
+
+            int sizeBefore = dataBuilder.CountBytes;
+            EncodeContents(ref dataBuilder, factory, relocsOnly);
+            Debug.Assert(dataBuilder.CountBytes == sizeBefore + ContentSize);
         }
 
-        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
-
-        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
-            ObjectDataBuilder builder = new ObjectDataBuilder(factory, true);
-            EncodeData(ref builder, factory, true);
+            var builder = new ObjectDataBuilder(factory, relocsOnly: true);
+            EncodeData(ref builder, factory, relocsOnly: true);
             Relocation[] relocs = builder.ToObjectData().Relocs;
+
             DependencyList dependencies = null;
 
             if (relocs != null)
@@ -83,23 +60,15 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
-            _data.GetNonRelocationDependencies(ref dependencies, factory);
+            GetNonRelocationDependencies(ref dependencies, factory);
 
             return dependencies;
         }
 
-        public override int ClassCode => 1789429316;
-
-        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+        public virtual void GetNonRelocationDependencies(ref DependencyList dependencies, NodeFactory factory)
         {
-            var otherFrozenObjectNode = (FrozenObjectNode)other;
-            int result = comparer.Compare(otherFrozenObjectNode._owningType, _owningType);
-            if (result != 0)
-                return result;
-
-            return _allocationSiteId.CompareTo(otherFrozenObjectNode._allocationSiteId);
         }
 
-        public override string ToString() => $"Frozen {_data.Type.GetDisplayNameWithoutNamespace()} object";
+        public abstract void EncodeContents(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly);
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -360,12 +360,12 @@ namespace ILCompiler.DependencyAnalysis
 
             _frozenStringNodes = new NodeCache<string, FrozenStringNode>((string data) =>
             {
-                return new FrozenStringNode(data, Target);
+                return new FrozenStringNode(data, TypeSystemContext);
             });
 
-            _frozenObjectNodes = new NodeCache<SerializedFrozenObjectKey, FrozenObjectNode>(key =>
+            _frozenObjectNodes = new NodeCache<SerializedFrozenObjectKey, SerializedFrozenObjectNode>(key =>
             {
-                return new FrozenObjectNode(key.OwnerType, key.AllocationSiteId, key.SerializableObject);
+                return new SerializedFrozenObjectNode(key.OwnerType, key.AllocationSiteId, key.SerializableObject);
             });
 
             _interfaceDispatchCells = new NodeCache<DispatchCellKey, InterfaceDispatchCellNode>(callSiteCell =>
@@ -1220,9 +1220,9 @@ namespace ILCompiler.DependencyAnalysis
             return _frozenStringNodes.GetOrAdd(data);
         }
 
-        private NodeCache<SerializedFrozenObjectKey, FrozenObjectNode> _frozenObjectNodes;
+        private NodeCache<SerializedFrozenObjectKey, SerializedFrozenObjectNode> _frozenObjectNodes;
 
-        public FrozenObjectNode SerializedFrozenObject(MetadataType owningType, int allocationSiteId, TypePreinit.ISerializableReference data)
+        public SerializedFrozenObjectNode SerializedFrozenObject(MetadataType owningType, int allocationSiteId, TypePreinit.ISerializableReference data)
         {
             return _frozenObjectNodes.GetOrAdd(new SerializedFrozenObjectKey(owningType, allocationSiteId, data));
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SerializedFrozenObjectNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SerializedFrozenObjectNode.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a frozen object that is statically preallocated within the data section
+    /// of the executable instead of on the GC heap.
+    /// </summary>
+    public sealed class SerializedFrozenObjectNode : FrozenObjectNode
+    {
+        private readonly MetadataType _owningType;
+        private readonly TypePreinit.ISerializableReference _data;
+        private readonly int _allocationSiteId;
+
+        public MetadataType OwningType => _owningType;
+
+        public SerializedFrozenObjectNode(MetadataType owningType, int allocationSiteId, TypePreinit.ISerializableReference data)
+        {
+            _owningType = owningType;
+            _allocationSiteId = allocationSiteId;
+            _data = data;
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__FrozenObj_")
+                .Append(nameMangler.GetMangledTypeName(_owningType))
+                .Append(_allocationSiteId.ToStringInvariant());
+        }
+
+        public override TypeDesc ObjectType => _data.Type;
+
+        public override bool IsKnownImmutable => _data.IsKnownImmutable;
+
+        protected override int ContentSize
+            => _data.Type.IsArray
+            ? _data.Type.Context.Target.PointerSize * 2 + ((ArrayType)_data.Type).ElementType.GetElementSize().AsInt * _data.ArrayLength
+            : ((DefType)_data.Type).InstanceByteCount.AsInt + (_data.Type.IsValueType ? _data.Type.Context.Target.PointerSize : 0);
+
+        public override int? ArrayLength => _data.Type.IsArray ? _data.ArrayLength : null;
+
+        public override void EncodeContents(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
+        {
+            // byte contents
+            _data.WriteContent(ref dataBuilder, this, factory);
+        }
+
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
+        public override void GetNonRelocationDependencies(ref DependencyList dependencies, NodeFactory factory)
+        {
+            _data.GetNonRelocationDependencies(ref dependencies, factory);
+        }
+
+        public override int ClassCode => 1789429316;
+
+        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+        {
+            var otherFrozenObjectNode = (SerializedFrozenObjectNode)other;
+            int result = comparer.Compare(otherFrozenObjectNode._owningType, _owningType);
+            if (result != 0)
+                return result;
+
+            return _allocationSiteId.CompareTo(otherFrozenObjectNode._allocationSiteId);
+        }
+
+        public override string ToString() => $"Frozen {_data.Type.GetDisplayNameWithoutNamespace()} object";
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -57,7 +57,7 @@ namespace ILCompiler
         private readonly SortedSet<MethodDesc> _reflectableMethods = new SortedSet<MethodDesc>(TypeSystemComparer.Instance);
         private readonly SortedSet<GenericDictionaryNode> _genericDictionariesGenerated = new SortedSet<GenericDictionaryNode>(CompilerComparer.Instance);
         private readonly SortedSet<IMethodBodyNode> _methodBodiesGenerated = new SortedSet<IMethodBodyNode>(CompilerComparer.Instance);
-        private readonly SortedSet<EmbeddedObjectNode> _frozenObjects = new SortedSet<EmbeddedObjectNode>(CompilerComparer.Instance);
+        private readonly SortedSet<FrozenObjectNode> _frozenObjects = new SortedSet<FrozenObjectNode>(CompilerComparer.Instance);
         private readonly SortedSet<TypeGVMEntriesNode> _typeGVMEntries
             = new SortedSet<TypeGVMEntriesNode>(Comparer<TypeGVMEntriesNode>.Create((a, b) => TypeSystemComparer.Instance.Compare(a.AssociatedType, b.AssociatedType)));
         private readonly SortedSet<DefType> _typesWithDelegateMarshalling = new SortedSet<DefType>(TypeSystemComparer.Instance);
@@ -291,11 +291,6 @@ namespace ILCompiler
             if (obj is FrozenObjectNode frozenObj)
             {
                 _frozenObjects.Add(frozenObj);
-            }
-
-            if (obj is FrozenStringNode frozenStr)
-            {
-                _frozenObjects.Add(frozenStr);
             }
 
             if (obj is GenericStaticBaseInfoNode genericStaticBaseInfo)
@@ -751,7 +746,7 @@ namespace ILCompiler
             return _typeTemplates;
         }
 
-        public IEnumerable<EmbeddedObjectNode> GetFrozenObjects()
+        public IEnumerable<FrozenObjectNode> GetFrozenObjects()
         {
             return _frozenObjects;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -412,6 +412,7 @@
     <Compile Include="Compiler\DependencyAnalysis\DynamicDependencyAttributesOnEntityNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternSymbolsImportedNodeProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FieldRvaDataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\FrozenObjectNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FunctionPointerMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericMethodsHashtableEntryNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericStaticBaseInfoNode.cs" />
@@ -460,7 +461,7 @@
     <Compile Include="Compiler\InlinedThreadStatics.cs" />
     <Compile Include="Compiler\MstatObjectDumper.cs" />
     <Compile Include="Compiler\NoMetadataBlockingPolicy.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\FrozenObjectNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\SerializedFrozenObjectNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GCStaticsPreInitDataNode.cs" />
     <Compile Include="Compiler\MetadataBlockingPolicy.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MethodMetadataNode.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2261,7 +2261,7 @@ namespace Internal.JitInterface
                                 }
                                 return false;
 
-                            case FrozenObjectNode or FrozenStringNode:
+                            case FrozenObjectNode:
                                 Debug.Assert(valueOffset == 0);
                                 Debug.Assert(bufferSize == targetPtrSize);
 
@@ -2315,13 +2315,7 @@ namespace Internal.JitInterface
 
         private CORINFO_CLASS_STRUCT_* getObjectType(CORINFO_OBJECT_STRUCT_* objPtr)
         {
-            object obj = HandleToObject(objPtr);
-            return obj switch
-            {
-                FrozenStringNode => ObjectToHandle(_compilation.TypeSystemContext.GetWellKnownType(WellKnownType.String)),
-                FrozenObjectNode frozenObj => ObjectToHandle(frozenObj.ObjectType),
-                _ => throw new NotImplementedException($"Unexpected object in getObjectType: {obj}")
-            };
+            return ObjectToHandle(((FrozenObjectNode)HandleToObject(objPtr)).ObjectType);
         }
 
 #pragma warning disable CA1822 // Mark members as static
@@ -2334,13 +2328,7 @@ namespace Internal.JitInterface
 
         private bool isObjectImmutable(CORINFO_OBJECT_STRUCT_* objPtr)
         {
-            object obj = HandleToObject(objPtr);
-            return obj switch
-            {
-                FrozenStringNode => true,
-                FrozenObjectNode frozenObj => frozenObj.IsKnownImmutable,
-                _ => throw new NotImplementedException($"Unexpected object in isObjectImmutable: {obj}")
-            };
+            return ((FrozenObjectNode)HandleToObject(objPtr)).IsKnownImmutable;
         }
 
         private bool getStringChar(CORINFO_OBJECT_STRUCT_* strObj, int index, ushort* value)
@@ -2355,13 +2343,7 @@ namespace Internal.JitInterface
 
         private int getArrayOrStringLength(CORINFO_OBJECT_STRUCT_* objHnd)
         {
-            object obj = HandleToObject(objHnd);
-            return obj switch
-            {
-                FrozenStringNode frozenStr => frozenStr.Data.Length,
-                FrozenObjectNode frozenObj when frozenObj.ObjectType.IsArray => frozenObj.GetArrayLength(),
-                _ => -1
-            };
+            return ((FrozenObjectNode)HandleToObject(objHnd)).ArrayLength ?? -1;
         }
 
         private bool getIsClassInitedFlagAddress(CORINFO_CLASS_STRUCT_* cls, ref CORINFO_CONST_LOOKUP addr, ref int offset)


### PR DESCRIPTION
Frozen strings and frozen arbitrary objects were separate classes but giving them a common ancestors makes handling these easier.

Cc @dotnet/ilc-contrib 