### PR TITLE
Add runtime base address to Native AOT crash info JSON

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/CrashInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/CrashInfo.cs
@@ -103,10 +103,15 @@ namespace System
             if (!WriteValue("version"u8, "1.0.0"u8))
                 return false;
 
-            if (!WriteValue("runtime"u8, new ReadOnlySpan<byte>(RuntimeImports.RhGetRuntimeVersion(out int cbLength), cbLength)))
+            static void Dummy() { }
+
+            if (!WriteHexValue("runtime_base"u8, (ulong)RuntimeImports.RhGetOSModuleFromPointer((nint)(void*)(delegate*<void>)&Dummy)))
                 return false;
 
             if (!WriteIntValue("runtime_type"u8, (int)RuntimeType.NativeAOT))
+                return false;
+
+            if (!WriteValue("runtime_version"u8, new ReadOnlySpan<byte>(RuntimeImports.RhGetRuntimeVersion(out int cbLength), cbLength)))
                 return false;
 
             CrashReason crashReason = reason switch


### PR DESCRIPTION
# Customer Impact

The Native AOT Watson and SOS support needs to the module's base address containing the runtime for adequate performance. Add the module base address in the crash info as "runtime_base". Changed the "runtime" to the clearer "runtime_version" property.

# Testing

Verified the address in local testing. Modified the !crashinfo command in SOS to display this new base address.

# Risk

Very low. Native AOT unhandled exception crash info.