### PR TITLE
Honor naming policy of JsonStringEnumConverter on dictionary key deserialization.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -271,17 +271,20 @@ namespace System.Text.Json.Serialization.Converters
         internal override T ReadAsPropertyNameCore(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
 #if NETCOREAPP
-            bool success = TryParseEnumCore(ref reader, out T value);
+            if (TryParseEnumCore(ref reader, out T value))
 #else
-            bool success = TryParseEnumCore(reader.GetString(), out T value);
+            string? enumString = reader.GetString();
+            if (TryParseEnumCore(reader.GetString(), out T value))
 #endif
-
-            if (!success)
             {
-                ThrowHelper.ThrowJsonException();
+                return value;
             }
 
-            return value;
+#if NETCOREAPP
+            return ReadEnumUsingNamingPolicy(reader.GetString());
+#else
+            return ReadEnumUsingNamingPolicy(enumString);
+#endif
         }
 
         internal override void WriteAsPropertyNameCore(Utf8JsonWriter writer, T value, JsonSerializerOptions options, bool isWritingExtensionDataProperty)

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -930,7 +930,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             var options1 = new JsonSerializerOptions
             {
-                PropertyNamingPolicy = new SimpleSnakeCasePolicy()
+                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
             };
 
             string json = @"{""x_VaLUE"":1,""Y_vALue"":2}";
@@ -942,7 +942,7 @@ namespace System.Text.Json.Serialization.Tests
 
             var options2 = new JsonSerializerOptions
             {
-                PropertyNamingPolicy = new SimpleSnakeCasePolicy(),
+                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
                 PropertyNameCaseInsensitive = true,
             };
 

--- a/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.NonPublicAccessors.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.NonPublicAccessors.cs
@@ -210,7 +210,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task HonorNamingPolicy()
         {
-            var options = new JsonSerializerOptions { PropertyNamingPolicy = new SimpleSnakeCasePolicy() };
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
 
             string json = @"{""my_string"":""Hello""}";
             Assert.Null((await Serializer.DeserializeWrapper<MyStruct_WithNonPublicAccessors_WithTypeAttribute>(json)).MyString);

--- a/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.cs
+++ b/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.cs
@@ -1905,14 +1905,6 @@ namespace System.Text.Json.Serialization.Tests
 #endif
     }
 
-    public class SimpleSnakeCasePolicy : JsonNamingPolicy
-    {
-        public override string ConvertName(string name)
-        {
-            return string.Concat(name.Select((x, i) => i > 0 && char.IsUpper(x) ? "_" + x.ToString() : x.ToString())).ToLower();
-        }
-    }
-
     public static class ReflectionExtensions
     {
 #if NET6_0_OR_GREATER

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonObjectTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonObjectTests.cs
@@ -291,7 +291,7 @@ namespace System.Text.Json.Nodes.Tests
             const string Json = "{\"myProperty\":42}";
 
             var options = new JsonSerializerOptions();
-            options.PropertyNamingPolicy = new SimpleSnakeCasePolicy();
+            options.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
 
             JsonObject obj = JsonSerializer.Deserialize<JsonObject>(Json, options);
             string json = obj.ToJsonString();

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Dynamic.Sample.Tests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Dynamic.Sample.Tests.cs
@@ -345,7 +345,7 @@ namespace System.Text.Json.Serialization.Tests
 
             var options = new JsonSerializerOptions();
             options.EnableDynamicTypes();
-            options.PropertyNamingPolicy = new SimpleSnakeCasePolicy();
+            options.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
 
             dynamic obj = JsonSerializer.Deserialize<dynamic>(Json, options);
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -1300,7 +1300,7 @@ namespace System.Text.Json.Serialization.Tests
                 else if (propertyType == typeof(JsonNamingPolicy))
                 {
                     options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-                    options.DictionaryKeyPolicy = new SimpleSnakeCasePolicy();
+                    options.DictionaryKeyPolicy = JsonNamingPolicy.SnakeCaseLower;
                 }
                 else if (propertyType == typeof(ReferenceHandler))
                 {


### PR DESCRIPTION
Fix #93765.