### PR TITLE
Optimize "X == Y" to "(X ^ Y) == 0 for SIMD

### DIFF
--- a/src/coreclr/jit/importervectorization.cpp
+++ b/src/coreclr/jit/importervectorization.cpp
@@ -199,9 +199,12 @@ GenTree* Compiler::impExpandHalfConstEqualsSIMD(
 
     // Optimization: use a single load when byteLen equals simdSize.
     // For code simplicity we always create nodes for two vectors case.
-    const bool useSingleVector = simdSize == byteLen;
-    return gtNewSimdCmpOpAllNode(GT_EQ, TYP_UBYTE, useSingleVector ? xor1 : orr, gtNewZeroConNode(simdType), baseType,
-                                 simdSize);
+    if (simdSize == byteLen)
+    {
+        return gtNewSimdCmpOpAllNode(GT_EQ, TYP_UBYTE, vec1, cnsVec1, baseType, simdSize);
+    }
+
+    return gtNewSimdCmpOpAllNode(GT_EQ, TYP_UBYTE, orr, gtNewZeroConNode(simdType), baseType, simdSize);
 
     // Codegen example for byteLen=40 and OrdinalIgnoreCase mode with AVX:
     //

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -1791,8 +1791,7 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
             GenTree* xorVec  = comp->gtNewSimdBinOpNode(GT_XOR, simdType, op1, op2, simdBaseJitType, simdSize);
             node->Op(1)      = xorVec;
             node->Op(2)      = zeroVec;
-            BlockRange().InsertBefore(node, xorVec);
-            BlockRange().InsertBefore(node, zeroVec);
+            BlockRange().InsertBefore(node, xorVec, zeroVec);
 
             // We'll re-visit the comparison node again
             return xorVec;


### PR DESCRIPTION
Matches native compilers now https://godbolt.org/z/afaE18saG

Quick example:
```cs
bool Test(Vector256<byte> v1, Vector256<byte> v2) => v1 == v2;
```
```diff
; Method Test
       vzeroupper 
       vmovups  ymm0, ymmword ptr [rdx]
-      vpcmpeqb k1, ymm0, ymmword ptr [r8]
-      kortestd k1, k1
-      setb     al
+      vpxor    ymm0, ymm0, ymmword ptr [r8]
+      vptest   ymm0, ymm0
+      sete     al
       movzx    rax, al
       vzeroupper 
       ret      
-; Total bytes of code: 28
+; Total bytes of code: 27
```