### PR TITLE
Fix GitHub_93597 test build 

### DIFF
--- a/src/tests/Loader/classloader/regressions/GitHub_93597/GitHub_93597.cs
+++ b/src/tests/Loader/classloader/regressions/GitHub_93597/GitHub_93597.cs
@@ -3,9 +3,11 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Xunit;
 
 public class ReproGH93597 {
-        public static int Main() {
+        [Fact]
+        public static int TestEntryPoint() {
                 var expected = new int[] {5,4,3,2,1};
 
                 const int LowerBound = 5;

--- a/src/tests/Loader/classloader/regressions/GitHub_93597/GitHub_93597.csproj
+++ b/src/tests/Loader/classloader/regressions/GitHub_93597/GitHub_93597.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="GitHub_93597.cs" />
   </ItemGroup>


### PR DESCRIPTION
Build error (at least with `BuildAsStandalone=true`)
```sh
BuildAsStandalone=true ./src/tests/build.sh -Release portablebuild=false -x64 -priority1
```

```
/home/runtime/src/tests/Loader/classloader/regressions/GitHub_93597/GitHub_93597.cs(8,27): error XUW1001: Projects in merged tests group should not have entry points. Convert to Facts or Theories. [/home/runtime/src/tests/Loader/classloader/regressions/GitHub_93597/GitHub_93597.csproj] [/home/runtime/src/tests/build.proj]
```

Related to https://github.com/dotnet/runtime/pull/93616

cc @clamp03 @t-mustafin 