### PR TITLE
Add more data into MSTAT files

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FieldRvaDataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FieldRvaDataNode.cs
@@ -15,6 +15,8 @@ namespace ILCompiler.DependencyAnalysis
     {
         private readonly EcmaField _field;
 
+        public EcmaField Field => _field;
+
         public FieldRvaDataNode(EcmaField field)
         {
             Debug.Assert(field.HasRva);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ResourceDataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ResourceDataNode.cs
@@ -96,10 +96,9 @@ namespace ILCompiler.DependencyAnalysis
                             if (factory.MetadataManager.IsManifestResourceBlocked(factory, module, resourceName))
                                 continue;
 
-                            string assemblyName = module.GetName().FullName;
                             BlobReader reader = resourceDirectory.GetReader((int)resource.Offset, resourceDirectory.Length - (int)resource.Offset);
                             int length = (int)reader.ReadUInt32();
-                            ResourceIndexData indexData = new ResourceIndexData(assemblyName, resourceName, _totalLength, (int)resource.Offset + sizeof(int), module, length);
+                            ResourceIndexData indexData = new ResourceIndexData(module, resourceName, _totalLength, (int)resource.Offset + sizeof(int), module, length);
                             _indexData.Add(indexData);
                             _totalLength += length;
                         }
@@ -149,9 +148,9 @@ namespace ILCompiler.DependencyAnalysis
     /// </summary>
     internal sealed class ResourceIndexData
     {
-        public ResourceIndexData(string assemblyName, string resourceName, int nativeOffset, int ecmaOffset, EcmaModule ecmaModule, int length)
+        public ResourceIndexData(EcmaAssembly assembly, string resourceName, int nativeOffset, int ecmaOffset, EcmaModule ecmaModule, int length)
         {
-            AssemblyName = assemblyName;
+            Assembly = assembly;
             ResourceName = resourceName;
             NativeOffset = nativeOffset;
             EcmaOffset = ecmaOffset;
@@ -160,9 +159,9 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         /// <summary>
-        /// Full name of the assembly that contains the resource
+        /// Assembly that contains the resource
         /// </summary>
-        public string AssemblyName { get; }
+        public EcmaAssembly Assembly { get; }
 
         /// <summary>
         /// Name of the resource

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ResourceIndexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ResourceIndexNode.cs
@@ -74,7 +74,8 @@ namespace ILCompiler.DependencyAnalysis
 
             foreach (ResourceIndexData indexData in _resourceDataNode.GetOrCreateIndexData(factory))
             {
-                Vertex asmName = nativeWriter.GetStringConstant(indexData.AssemblyName);
+                string assemblyName = indexData.Assembly.GetName().FullName;
+                Vertex asmName = nativeWriter.GetStringConstant(assemblyName);
                 Vertex resourceName = nativeWriter.GetStringConstant(indexData.ResourceName);
                 Vertex offsetVertex = nativeWriter.GetUnsignedConstant((uint)indexData.NativeOffset);
                 Vertex lengthVertex = nativeWriter.GetUnsignedConstant((uint)indexData.Length);
@@ -83,7 +84,7 @@ namespace ILCompiler.DependencyAnalysis
                 indexVertex = nativeWriter.GetTuple(indexVertex, offsetVertex);
                 indexVertex = nativeWriter.GetTuple(indexVertex, lengthVertex);
 
-                int hashCode = TypeHashingAlgorithms.ComputeNameHashCode(indexData.AssemblyName);
+                int hashCode = TypeHashingAlgorithms.ComputeNameHashCode(assemblyName);
                 indexHashtable.Append((uint)hashCode, indexHashtableSection.Place(indexVertex));
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -1071,8 +1071,7 @@ namespace Internal.IL
 
         private void ImportLoadString(int token)
         {
-            // If we care, this can include allocating the frozen string node.
-            _dependencies.Add(_factory.SerializedStringObject(""), "ldstr");
+            _dependencies.Add(_factory.SerializedStringObject((string)_methodIL.GetObject(token)), "ldstr");
         }
 
         private void ImportBox(int token)


### PR DESCRIPTION
* Manifest resources are a large contributor to WinForms size, we better surface that.
* Frozen objects can get also pretty large
* And so does field RVA data (we have several 10+ kB large RVA static fields just in CoreLib).

Cc @dotnet/ilc-contrib 