### PR TITLE
JIT: Fix encoding cross-jumps at JIT time

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -15858,8 +15858,8 @@ BYTE* emitter::emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i)
         }
         else
         {
-            // For non-cross jumps (usual case) or when splitting at JIT time
-            // we expect the displacement to be encodable in 32 bits.
+            // For all other cases the displacement should be encodable in 32
+            // bits.
             assert((distVal >= INT32_MIN) && (distVal <= INT32_MAX));
             encodedDisplacement = static_cast<int32_t>(distVal);
         }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -15847,12 +15847,13 @@ BYTE* emitter::emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i)
         bool crossJump = emitJumpCrossHotColdBoundary(srcOffs, dstOffs);
 
         int32_t encodedDisplacement;
-        if (crossJump && emitComp->opts.compReloc)
+        if ((crossJump || !relAddr) && emitComp->opts.compReloc)
         {
             // Cross jumps may not be encodable in a 32-bit displacement as the
             // hot/cold code buffers may be allocated arbitrarily far away from
-            // each other. We simply encode a 0 under the assumption that the
-            // relocations will take care of it.
+            // each other. Similarly, absolute addresses when cross compiling
+            // for 32-bit may also not be representable. We simply encode a 0
+            // under the assumption that the relocations will take care of it.
             encodedDisplacement = 0;
         }
         else

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -15847,7 +15847,7 @@ BYTE* emitter::emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i)
         bool crossJump = emitJumpCrossHotColdBoundary(srcOffs, dstOffs);
 
         int32_t encodedDisplacement;
-        if ((crossJump || !relAddr) && emitComp->opts.compReloc)
+        if (emitComp->opts.compReloc && (!relAddr || crossJump))
         {
             // Cross jumps may not be encodable in a 32-bit displacement as the
             // hot/cold code buffers may be allocated arbitrarily far away from

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -15844,25 +15844,37 @@ BYTE* emitter::emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i)
         // For forward jumps, record the address of the distance value
         id->idjTemp.idjAddr = (dstOffs > srcOffs) ? dst : nullptr;
 
-        // Cross jumps may not be encodable in a 32-bit displacement as the
-        // hot/cold code buffers may be allocated arbitrarily far away from
-        // each other. We simply encode a 0 under the assumption that the
-        // relocations will take care of it.
         bool crossJump = emitJumpCrossHotColdBoundary(srcOffs, dstOffs);
-        assert(!crossJump || emitComp->opts.compReloc);
 
-        dst += emitOutputLong(dst, crossJump ? 0 : distVal);
+        int32_t encodedDisplacement;
+        if (crossJump && emitComp->opts.compReloc)
+        {
+            // Cross jumps may not be encodable in a 32-bit displacement as the
+            // hot/cold code buffers may be allocated arbitrarily far away from
+            // each other. We simply encode a 0 under the assumption that the
+            // relocations will take care of it.
+            encodedDisplacement = 0;
+        }
+        else
+        {
+            // For non-cross jumps (usual case) or when splitting at JIT time
+            // we expect the displacement to be encodable in 32 bits.
+            assert((distVal >= INT32_MIN) && (distVal <= INT32_MAX));
+            encodedDisplacement = static_cast<int32_t>(distVal);
+        }
+
+        dst += emitOutputLong(dst, encodedDisplacement);
 
         if (emitComp->opts.compReloc)
         {
             if (!relAddr)
             {
-                emitRecordRelocation((void*)(dst - sizeof(INT32)), (void*)distVal, IMAGE_REL_BASED_HIGHLOW);
+                emitRecordRelocation((void*)(dst - sizeof(int32_t)), (void*)distVal, IMAGE_REL_BASED_HIGHLOW);
             }
             else if (crossJump)
             {
                 assert(id->idjKeepLong);
-                emitRecordRelocation((void*)(dst - sizeof(INT32)), dst + distVal, IMAGE_REL_BASED_REL32);
+                emitRecordRelocation((void*)(dst - sizeof(int32_t)), dst + distVal, IMAGE_REL_BASED_REL32);
             }
         }
     }


### PR DESCRIPTION
In 7db4f33f5b00ac9f5e65dd690b3f69969cb24e63 I made the assumption that cross-jumps only appear while prejitting (and thus while recording relocations). However, the fake splitting stress mode runs during JIT and thus will hit the assert. Make the logic handle JIT time splitting as well.

Fix #93848