### PR TITLE
[release/8.0-staging] Don't use File.OpenWrite when trying to overwrite a file in illink/wasm build tasks

### DIFF
--- a/src/tasks/MonoTargetsTasks/RuntimeConfigParser/RuntimeConfigParser.cs
+++ b/src/tasks/MonoTargetsTasks/RuntimeConfigParser/RuntimeConfigParser.cs
@@ -61,7 +61,7 @@ public class RuntimeConfigParserTask : Task
         ConvertDictionaryToBlob(configProperties, blobBuilder);
 
         Directory.CreateDirectory(Path.GetDirectoryName(OutputFile!)!);
-        using var stream = File.OpenWrite(OutputFile);
+        using var stream = new FileStream(OutputFile, FileMode.Create, FileAccess.Write, FileShare.None);
         blobBuilder.WriteContentTo(stream);
 
         return !Log.HasLoggedErrors;

--- a/src/tasks/WasmAppBuilder/WasmAppBuilderBaseTask.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilderBaseTask.cs
@@ -152,7 +152,7 @@ public abstract class WasmAppBuilderBaseTask : Task
         AddToRuntimeConfig(wasmHostProperties: wasmHostProperties, runtimeArgsArray: runtimeArgsArray, perHostConfigs: perHostConfigs);
 
         string dstPath = Path.Combine(AppDir!, Path.GetFileName(runtimeConfigPath));
-        using FileStream? fs = File.OpenWrite(dstPath);
+        using FileStream? fs = new FileStream(dstPath, FileMode.Create, FileAccess.Write, FileShare.None);
         using var writer = new Utf8JsonWriter(fs, new JsonWriterOptions { Indented = true });
         rootObject.WriteTo(writer);
         _fileWrites.Add(dstPath);

--- a/src/tools/illink/src/linker/Linker/DgmlDependencyRecorder.cs
+++ b/src/tools/illink/src/linker/Linker/DgmlDependencyRecorder.cs
@@ -38,7 +38,7 @@ namespace Mono.Linker
 				Directory.CreateDirectory (context.OutputDirectory);
 			}
 
-			var depsFile = File.OpenWrite (fileName);
+			var depsFile = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None);
 			stream = depsFile;
 
 			writer = XmlWriter.Create (stream, settings);

--- a/src/tools/illink/src/linker/Linker/XmlDependencyRecorder.cs
+++ b/src/tools/illink/src/linker/Linker/XmlDependencyRecorder.cs
@@ -61,7 +61,7 @@ namespace Mono.Linker
 				Directory.CreateDirectory (context.OutputDirectory);
 			}
 
-			var depsFile = File.OpenWrite (fileName);
+			var depsFile = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None);
 			stream = depsFile;
 
 			writer = XmlWriter.Create (stream, settings);


### PR DESCRIPTION
Backport of #93744

File.OpenWrite will open an existing file and not truncate existing data, this can lead to unexpected results if the new data is shorter than the existing data.

## Customer Impact

illink has a feature to dump a dependency analysis xml during the build and when you run another build after making a change that'd reduce dependencies the xml would get corrupted since it wrote less data than the existing file had.

The fix is to use the FileMode.Create option in cases where the intention is to create a new file or overwrite an existing one.

I noticed another instance of this in the Wasm build tasks so fixed it there as well.

## Testing

Verified an existing file gets overwritten as expected.

## Risk

Low