### PR TITLE
Update APICompat settings under source build

### DIFF
--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -73,10 +73,11 @@
        That is necessary as APICompat is invoked twice, once for the ref <-> src comparision and then again
        for the package validation (which doesn't include reference assemblies). As both operations don't have
        all the inputs available, some suppressions might only apply to one or the other and hence unnecessary
-       suppressions can't be determined. -->
-  <PropertyGroup Condition="'$(IsPackable)' == 'true' and '$(IsRuntimeAndReferenceAssembly)' != 'true'">
-    <ApiCompatPreserveUnnecessarySuppressions Condition="'$(ApiCompatPreserveUnnecessarySuppressions)' == ''">true</ApiCompatPreserveUnnecessarySuppressions>
-    <ApiCompatPermitUnnecessarySuppressions Condition="'$(ApiCompatPermitUnnecessarySuppressions)' == ''">true</ApiCompatPermitUnnecessarySuppressions>
+       suppressions can't be determined.
+       Disable the validation under source build as that might use an out-of-date SDK and not the ApiCompat.Task package. -->
+  <PropertyGroup Condition="('$(IsPackable)' == 'true' and '$(IsRuntimeAndReferenceAssembly)' != 'true') or '$(DotNetBuildFromSource)' == 'true'">
+    <ApiCompatPreserveUnnecessarySuppressions>true</ApiCompatPreserveUnnecessarySuppressions>
+    <ApiCompatPermitUnnecessarySuppressions>true</ApiCompatPermitUnnecessarySuppressions>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsCrossTargetingBuild)' != 'true'">

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -75,8 +75,8 @@
        all the inputs available, some suppressions might only apply to one or the other and hence unnecessary
        suppressions can't be determined. -->
   <PropertyGroup Condition="'$(IsPackable)' == 'true' and '$(IsRuntimeAndReferenceAssembly)' != 'true'">
-    <ApiCompatPreserveUnnecessarySuppressions>true</ApiCompatPreserveUnnecessarySuppressions>
-    <ApiCompatPermitUnnecessarySuppressions>true</ApiCompatPermitUnnecessarySuppressions>
+    <ApiCompatPreserveUnnecessarySuppressions Condition="'$(ApiCompatPreserveUnnecessarySuppressions)' == ''">true</ApiCompatPreserveUnnecessarySuppressions>
+    <ApiCompatPermitUnnecessarySuppressions Condition="'$(ApiCompatPermitUnnecessarySuppressions)' == ''">true</ApiCompatPermitUnnecessarySuppressions>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsCrossTargetingBuild)' != 'true'">


### PR DESCRIPTION
Source build might use a toolset SDK that doesn't have the latest APICompat change: https://github.com/dotnet/sdk/commit/af245f28c8e07d57bb83c1712ecb8c2cf7cb7b1f

This should unblock https://github.com/dotnet/installer/pull/17187