### PR TITLE
Lock that uses congestion detection for self-tuning

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
@@ -104,8 +104,8 @@ namespace System.Threading
         {
             // initialize essentials
             // this is safe to do as these do not need to take locks
-            s_maxSpinCount = DefaultMaxSpinCount;
-            s_minSpinCount = DefaultMinSpinCount;
+            s_maxSpinCount = DefaultMaxSpinCount << SpinCountScaleShift;
+            s_minSpinCount = DefaultMinSpinCount << SpinCountScaleShift;
 
             // we can now use the slow path of the lock.
             Volatile.Write(ref s_staticsInitializationStage, (int)StaticsInitializationStage.Usable);
@@ -132,8 +132,8 @@ namespace System.Threading
                 s_processorCount = RuntimeImports.RhGetProcessCpuCount();
                 if (s_processorCount > 1)
                 {
-                    s_minSpinCount = (short)(DetermineMinSpinCount());
-                    s_maxSpinCount = (short)(DetermineMaxSpinCount());
+                    s_minSpinCount = (short)(DetermineMinSpinCount() << SpinCountScaleShift);
+                    s_maxSpinCount = (short)(DetermineMaxSpinCount() << SpinCountScaleShift);
                 }
                 else
                 {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/ObjectHeader.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/ObjectHeader.cs
@@ -406,7 +406,7 @@ namespace System.Threading
                                     return -1;
                                 }
 
-                                // rare contention on owned lock,
+                                // rare contention on a lock that we own,
                                 // perhaps hashcode was installed or finalization bits were touched.
                                 // we still own the lock though and may be able to increment, try again
                                 continue;
@@ -423,12 +423,9 @@ namespace System.Threading
                     }
                 }
 
-                if (retries != 0)
-                {
-                    // spin a bit before retrying (1 spinwait is roughly 35 nsec)
-                    // the object is not pinned here
-                    Thread.SpinWaitInternal(i);
-                }
+                // spin a bit before retrying (1 spinwait is roughly 35 nsec)
+                // the object is not pinned here
+                Thread.SpinWaitInternal(i);
             }
 
             // owned by somebody else

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.NonNativeAot.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.NonNativeAot.cs
@@ -8,8 +8,8 @@ namespace System.Threading
 {
     public sealed partial class Lock
     {
-        private static readonly short s_maxSpinCount = DetermineMaxSpinCount();
-        private static readonly short s_minSpinCount = DetermineMinSpinCount();
+        private static readonly short s_maxSpinCount = (short)(IsSingleProcessor ? 0 :DetermineMaxSpinCount() << SpinCountScaleShift);
+        private static readonly short s_minSpinCount = (short)(IsSingleProcessor ? 0 :DetermineMinSpinCount() << SpinCountScaleShift);
 
         private static void LazyInit() { }
         private static bool StaticsInitComplete() => true;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.NonNativeAot.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.NonNativeAot.cs
@@ -11,12 +11,8 @@ namespace System.Threading
         private static readonly short s_maxSpinCount = DetermineMaxSpinCount();
         private static readonly short s_minSpinCount = DetermineMinSpinCount();
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Lock"/> class.
-        /// </summary>
-        public Lock() => _spinCount = s_maxSpinCount;
-
-        private static TryLockResult LazyInitializeOrEnter() => TryLockResult.Spin;
+        private static void LazyInit() { }
+        private static bool StaticsInitComplete() => true;
         private static bool IsSingleProcessor => Environment.IsSingleProcessor;
 
         internal partial struct ThreadId

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -681,19 +681,19 @@ namespace System.Threading
             double waitDurationNs =
                 (Stopwatch.GetTimestamp() - contentionTrackingStartedTicks) * 1_000_000_000.0 / Stopwatch.Frequency;
 
-            // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
-            if (NativeRuntimeEventSource.Log.IsEnabled())
+            try
             {
-                try
+                // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
+                if (NativeRuntimeEventSource.Log.IsEnabled())
                 {
                     NativeRuntimeEventSource.Log.ContentionStop(waitDurationNs);
                 }
-                catch
-                {
-                    // We are throwing. The acquire failed.
-                    this.Exit();
-                    throw;
-                }
+            }
+            catch
+            {
+                // We are throwing. The acquire failed and we should not leave the lock locked.
+                this.Exit();
+                throw;
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -19,12 +19,33 @@ namespace System.Threading
     [Runtime.Versioning.RequiresPreviewFeatures]
     public sealed partial class Lock
     {
+        private const short SpinCountNotInitialized = short.MinValue;
+        private const short SpinningDisabled = 0;
+
         private const short DefaultMaxSpinCount = 22;
-        private const short DefaultAdaptiveSpinPeriod = 100;
-        private const short SpinSleep0Threshold = 10;
-        private const ushort MaxDurationMsForPreemptingWaiters = 100;
+        private const short DefaultMinSpinCount = 1;
 
         private static long s_contentionCount;
+
+        //
+        // We will use exponential backoff in rare cases when we need to change state atomically and cannot
+        // make progress due to concurrent state changes by other threads.
+        // While we cannot know the ideal amount of wait needed before making a successfull attempt,
+        // the exponential backoff will generally be not more than 2X worse than the perfect guess and
+        // will do a lot less attempts than an simple retry. On multiprocessor machine fruitless attempts
+        // will cause unnecessary sharing of the contended state which may make modifying the state more expensive.
+        // To protect against degenerate cases we will cap the per-iteration wait to 1024 spinwaits.
+        //
+        private const uint MaxExponentialBackoffBits = 10;
+
+        //
+        // This lock is unfair and permits acquiring a contended lock by a nonwaiter in the presence of waiters.
+        // It is possible for one thread to keep holding the lock long enough that waiters go to sleep and
+        // then release and reacquire fast enough that waiters have no chance to get the lock.
+        // In extreme cases one thread could keep retaking the lock starving everybody else.
+        // If we see woken waiters not able to take the lock for too long we will ask nonwaiters to wait.
+        //
+        private const uint WaiterWatchdogTicks = 100;
 
         // The field's type is not ThreadId to try to retain the relative order of fields of intrinsic types. The type system
         // appears to place struct fields after fields of other types, in which case there can be a greater chance that
@@ -35,11 +56,34 @@ namespace System.Threading
         private uint _owningThreadId;
 #endif
 
-        private uint _state; // see State for layout
+        //
+        // m_state layout:
+        //
+        // bit 0: True if the lock is held, false otherwise.
+        //
+        // bit 1: True if we've set the event to wake a waiting thread.  The waiter resets this to false when it
+        //        wakes up.  This avoids the overhead of setting the event multiple times.
+        //
+        // bit 2: True if nonwaiters must not get ahead of waiters when acquiring a contended lock.
+        //
+        // everything else: A count of the number of threads waiting on the event.
+        //
+        private const uint Unlocked = 0;
+        private const uint Locked = 1;
+        private const uint WaiterWoken = 2;
+        private const uint YieldToWaiters = 4;
+        private const uint WaiterCountIncrement = 8;
+
+        private uint _state;
         private uint _recursionCount;
         private short _spinCount;
-        private ushort _waiterStartTimeMs;
+        private short _wakeWatchDog;
         private AutoResetEvent? _waitEvent;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Lock"/> class.
+        /// </summary>
+        public Lock() => _spinCount = SpinCountNotInitialized;
 
         /// <summary>
         /// Enters the lock. Once the method returns, the calling thread would be the only thread that holds the lock.
@@ -56,17 +100,8 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Enter()
         {
-            ThreadId currentThreadId = TryEnter_Inlined(timeoutMs: -1);
-            Debug.Assert(currentThreadId.IsInitialized);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private ThreadId EnterAndGetCurrentThreadId()
-        {
-            ThreadId currentThreadId = TryEnter_Inlined(timeoutMs: -1);
-            Debug.Assert(currentThreadId.IsInitialized);
-            Debug.Assert(currentThreadId.Id == _owningThreadId);
-            return currentThreadId;
+            bool success = TryEnter_Inlined(timeoutMs: -1);
+            Debug.Assert(success);
         }
 
         /// <summary>
@@ -89,7 +124,11 @@ namespace System.Threading
         /// enough that it would typically not be reached when the lock is used properly.
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Scope EnterScope() => new Scope(this, EnterAndGetCurrentThreadId());
+        public Scope EnterScope()
+        {
+            Enter();
+            return new Scope(this, new ThreadId(this._owningThreadId));
+        }
 
         /// <summary>
         /// A disposable structure that is returned by <see cref="EnterScope()"/>, which when disposed, exits the lock.
@@ -145,7 +184,7 @@ namespace System.Threading
         /// enough that it would typically not be reached when the lock is used properly.
         /// </exception>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public bool TryEnter() => TryEnter_Inlined(timeoutMs: 0).IsInitialized;
+        public bool TryEnter() => TryEnter_Inlined(timeoutMs: 0);
 
         /// <summary>
         /// Tries to enter the lock, waiting for roughly the specified duration. If the lock is entered, the calling thread
@@ -209,24 +248,44 @@ namespace System.Threading
         public bool TryEnter(TimeSpan timeout) => TryEnter_Outlined(WaitHandle.ToTimeoutMilliseconds(timeout));
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool TryEnter_Outlined(int timeoutMs) => TryEnter_Inlined(timeoutMs).IsInitialized;
+        private bool TryEnter_Outlined(int timeoutMs) => TryEnter_Inlined(timeoutMs);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private ThreadId TryEnter_Inlined(int timeoutMs)
+        private bool TryEnter_Inlined(int timeoutMs)
         {
             Debug.Assert(timeoutMs >= -1);
 
             ThreadId currentThreadId = ThreadId.Current_NoInitialize;
-            if (currentThreadId.IsInitialized && State.TryLock(this))
+            if (currentThreadId.IsInitialized && this.TryLock())
             {
                 Debug.Assert(!new ThreadId(_owningThreadId).IsInitialized);
                 Debug.Assert(_recursionCount == 0);
                 _owningThreadId = currentThreadId.Id;
-                return currentThreadId;
+                return true;
             }
 
             return TryEnterSlow(timeoutMs, currentThreadId);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryLock()
+        {
+            uint origState = _state;
+            if ((origState & (YieldToWaiters | Locked)) == 0)
+            {
+                uint newState = origState | Locked;
+                if (Interlocked.CompareExchange(ref _state, newState, origState) == origState)
+                {
+                    Debug.Assert(_owningThreadId == 0);
+                    Debug.Assert(_recursionCount == 0);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsLocked => (_state & Locked) != 0;
 
         /// <summary>
         /// Exits the lock.
@@ -269,28 +328,34 @@ namespace System.Threading
         {
             Debug.Assert(new ThreadId(_owningThreadId).IsInitialized);
             Debug.Assert(_owningThreadId == ThreadId.Current_NoInitialize.Id);
-            Debug.Assert(new State(this).IsLocked);
+            Debug.Assert(this.IsLocked);
 
             if (_recursionCount == 0)
             {
-                _owningThreadId = 0;
-
-                State state = State.Unlock(this);
-                if (state.HasAnyWaiters)
-                {
-                    SignalWaiterIfNecessary(state);
-                }
+                ReleaseCore();
+                return;
             }
-            else
+
+            _recursionCount--;
+        }
+
+        private static unsafe void ExponentialBackoff(uint iteration)
+        {
+            if (iteration > 0)
             {
-                _recursionCount--;
+                // no need for much randomness here, we will just hash the stack address + iteration.
+                uint rand = ((uint)&iteration + iteration) * 2654435769u;
+                // set the highmost bit to ensure minimum number of spins is exponentialy increasing
+                // that is in case some stack location results in a sequence of very low spin counts
+                // it basically gurantees that we spin at least 1, 2, 4, 8, 16, times, and so on
+                rand |= (1u << 31);
+                uint spins = rand >> (byte)(32 - Math.Min(iteration, MaxExponentialBackoffBits));
+                Thread.SpinWait((int)spins);
             }
         }
 
-        private static bool IsAdaptiveSpinEnabled(short minSpinCount) => minSpinCount <= 0;
-
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private ThreadId TryEnterSlow(int timeoutMs, ThreadId currentThreadId)
+        internal bool TryEnterSlow(int timeoutMs, ThreadId currentThreadId)
         {
             Debug.Assert(timeoutMs >= -1);
 
@@ -300,20 +365,23 @@ namespace System.Threading
                 // initializing the thread info, try the fast path first.
                 currentThreadId.InitializeForCurrentThread();
                 Debug.Assert(_owningThreadId != currentThreadId.Id);
-                if (State.TryLock(this))
+                if (this.TryLock())
                 {
-                    goto Locked;
+                    Debug.Assert(!new ThreadId(_owningThreadId).IsInitialized);
+                    Debug.Assert(_recursionCount == 0);
+                    _owningThreadId = currentThreadId.Id;
+                    return true;
                 }
             }
             else if (_owningThreadId == currentThreadId.Id)
             {
-                Debug.Assert(new State(this).IsLocked);
+                Debug.Assert(this.IsLocked);
 
                 uint newRecursionCount = _recursionCount + 1;
                 if (newRecursionCount != 0)
                 {
                     _recursionCount = newRecursionCount;
-                    return currentThreadId;
+                    return true;
                 }
 
                 throw new LockRecursionException(SR.Lock_Enter_LockRecursionException);
@@ -321,292 +389,355 @@ namespace System.Threading
 
             if (timeoutMs == 0)
             {
-                return new ThreadId(0);
+                return false;
             }
 
-            if (LazyInitializeOrEnter() == TryLockResult.Locked)
+            if (_spinCount == SpinCountNotInitialized)
             {
-                goto Locked;
+                LazyInit();
+                _spinCount = IsSingleProcessor ? SpinningDisabled : s_minSpinCount;
             }
 
-            bool isSingleProcessor = IsSingleProcessor;
-            short maxSpinCount = s_maxSpinCount;
-            if (maxSpinCount == 0)
+            bool hasWaited = false;
+            long contentionTrackingStartedTicks = 0;
+            // we will retry after waking up
+            while (true)
             {
-                goto Wait;
-            }
+                uint iteration = 1;
 
-            short minSpinCount = s_minSpinCount;
-            short spinCount = _spinCount;
-            if (spinCount < 0)
-            {
-                // When negative, the spin count serves as a counter for contentions such that a spin-wait can be attempted
-                // periodically to see if it would be beneficial. Increment the spin count and skip spin-waiting.
-                Debug.Assert(IsAdaptiveSpinEnabled(minSpinCount));
-                _spinCount = (short)(spinCount + 1);
-                goto Wait;
-            }
+                // We will count when we failed to change the state of the lock and increase pauses
+                // so that bursts of activity are better tolerated. This should not happen often.
+                uint collisions = 0;
 
-            // Try to acquire the lock, and check if non-waiters should stop preempting waiters. If this thread should not
-            // preempt waiters, skip spin-waiting. Upon contention, register a spinner.
-            TryLockResult tryLockResult = State.TryLockBeforeSpinLoop(this, spinCount, out bool isFirstSpinner);
-            if (tryLockResult != TryLockResult.Spin)
-            {
-                goto LockedOrWait;
-            }
+                // We will track the changes of ownership while we are trying to acquire the lock.
+                var oldOwner = _owningThreadId;
+                uint ownerChanged = 0;
 
-            // Lock was not acquired and a spinner was registered
-
-            if (isFirstSpinner)
-            {
-                // Whether a full-length spin-wait would be effective is determined by having the first spinner do a full-length
-                // spin-wait to see if it is effective. Shorter spin-waits would more often be ineffective just because they are
-                // shorter.
-                spinCount = maxSpinCount;
-            }
-
-            for (short spinIndex = 0; ;)
-            {
-                LowLevelSpinWaiter.Wait(spinIndex, SpinSleep0Threshold, isSingleProcessor);
-
-                if (++spinIndex >= spinCount)
+                int localSpinLimit = _spinCount;
+                // inner loop where we try acquiring the lock or registering as a waiter
+                while (true)
                 {
-                    // The last lock attempt for this spin will be done after the loop
-                    break;
-                }
+                    //
+                    // Try to grab the lock.  We may take the lock here even if there are existing waiters.  This creates the possibility
+                    // of starvation of waiters, but it also prevents lock convoys and preempted waiters from destroying perf.
+                    // However, if we do not see _wakeWatchDog cleared for long enough, we go into YieldToWaiters mode to ensure some
+                    // waiter progress.
+                    //
+                    uint oldState = _state;
+                    bool canAcquire = ((oldState & Locked) == Unlocked) &&
+                        (hasWaited || ((oldState & YieldToWaiters) == 0));
 
-                // Try to acquire the lock and unregister the spinner
-                tryLockResult = State.TryLockInsideSpinLoop(this);
-                if (tryLockResult == TryLockResult.Spin)
-                {
-                    continue;
-                }
-
-                if (tryLockResult == TryLockResult.Locked)
-                {
-                    if (isFirstSpinner && IsAdaptiveSpinEnabled(minSpinCount))
+                    if (canAcquire)
                     {
-                        // Since the first spinner does a full-length spin-wait, and to keep upward and downward changes to the
-                        // spin count more balanced, only the first spinner adjusts the spin count
-                        spinCount = _spinCount;
-                        if (spinCount < maxSpinCount)
+                        uint newState = oldState | Locked;
+                        if (hasWaited)
+                            newState = (newState - WaiterCountIncrement) & ~(WaiterWoken | YieldToWaiters);
+
+                        if (Interlocked.CompareExchange(ref _state, newState, oldState) == oldState)
                         {
-                            _spinCount = (short)(spinCount + 1);
+                            // GOT THE LOCK!!
+                            if (hasWaited)
+                                _wakeWatchDog = 0;
+
+                            // now we can estimate how busy the lock is and adjust spinning accordingly
+                            short spinLimit = _spinCount;
+                            if (ownerChanged != 0)
+                            {
+                                // The lock has changed ownership while we were trying to acquire it.
+                                // It is a signal that we might want to spin less next time.
+                                // Pursuing a lock that is being "stolen" by other threads is inefficient
+                                // due to cache misses and unnecessary sharing of state that keeps invalidating.
+                                if (spinLimit > s_minSpinCount)
+                                {
+                                    _spinCount = (short)(spinLimit - 1);
+                                }
+                            }
+                            else if (spinLimit < s_maxSpinCount && iteration >= spinLimit)
+                            {
+                                // we used all of allowed iterations, but the lock does not look very contested,
+                                // we can allow a bit more spinning.
+                                _spinCount = (short)(spinLimit + 1);
+                            }
+
+                            Debug.Assert((_state | Locked) != 0);
+                            Debug.Assert(_owningThreadId == 0);
+                            Debug.Assert(_recursionCount == 0);
+                            _owningThreadId = currentThreadId.Id;
+
+                            if (contentionTrackingStartedTicks != 0)
+                                LogContentionEnd(contentionTrackingStartedTicks);
+
+                            return true;
                         }
+
+                        collisions++;
                     }
 
-                    goto Locked;
+                    var newOwner = _owningThreadId;
+                    if (newOwner != 0 && newOwner != oldOwner)
+                    {
+                        if (oldOwner != 0)
+                            ownerChanged++;
+
+                        oldOwner = newOwner;
+                    }
+
+                    if (iteration < localSpinLimit)
+                    {
+                        iteration++;
+
+                        // We failed to acquire the lock and want to retry after a pause.
+                        // Ideally we will retry right when the lock becomes free, but we cannot know when that will happen.
+                        // We will use a pause that doubles up on every iteration. It will not be more than 2x worse
+                        // than the ideal guess, while minimizing the number of retries.
+                        // We will allow pauses up to 64~128 spinwaits, or more if there are collisions.
+                        ExponentialBackoff(Math.Min(iteration, 6) + collisions);
+                        continue;
+                    }
+                    else if (!canAcquire)
+                    {
+                        // make sure we have the event before committing to wait on it
+                        if (_waitEvent == null)
+                            CreateWaitEvent();
+
+                        //
+                        // We reached our spin limit, and need to wait.  Increment the waiter count.
+                        // Note that we do not do any overflow checking on this increment.  In order to overflow,
+                        // we'd need to have about 1 billion waiting threads, which is inconceivable anytime in the
+                        // forseeable future.
+                        //
+                        uint newState = oldState + WaiterCountIncrement;
+                        if (hasWaited)
+                            newState = (newState - WaiterCountIncrement) & ~WaiterWoken;
+
+                        if (Interlocked.CompareExchange(ref _state, newState, oldState) == oldState)
+                            break;
+
+                        collisions++;
+                    }
+
+                    ExponentialBackoff(collisions);
                 }
 
-                // The lock was not acquired and the spinner was not unregistered, stop spinning
-                Debug.Assert(tryLockResult == TryLockResult.Wait);
-                break;
+                //
+                // Now we wait.
+                //
+
+                TimeoutTracker timeoutTracker = TimeoutTracker.Start(timeoutMs);
+
+                // Lock was not acquired and a waiter was registered. All following paths need to unregister the waiter, including
+                // exceptional paths.
+                try
+                {
+                    Interlocked.Increment(ref s_contentionCount);
+
+                    if (contentionTrackingStartedTicks == 0)
+                        contentionTrackingStartedTicks = LogContentionStart();
+
+                    Debug.Assert(_state >= WaiterCountIncrement);
+                    bool waitSucceeded = _waitEvent!.WaitOne(timeoutMs);
+                    Debug.Assert(_state >= WaiterCountIncrement);
+
+                    if (!waitSucceeded)
+                        break;
+                }
+                catch
+                {
+                    // waiting failed
+                    UnregisterWaiter(contentionTrackingStartedTicks);
+                    throw;
+                }
+
+                // we did not time out and will try acquiring the lock again.
+                timeoutMs = timeoutTracker.Remaining;
+                hasWaited = true;
             }
 
-            // Unregister the spinner and try to acquire the lock
-            tryLockResult = State.TryLockAfterSpinLoop(this);
-            if (isFirstSpinner && IsAdaptiveSpinEnabled(minSpinCount))
+            // We timed out.  We're not going to wait again.
+            UnregisterWaiter(contentionTrackingStartedTicks);
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void UnregisterWaiter(long contentionTrackingStartedTicks)
+        {
+            uint iteration = 0;
+            while (true)
             {
-                // Since the first spinner does a full-length spin-wait, and to keep upward and downward changes to the
-                // spin count more balanced, only the first spinner adjusts the spin count
-                if (tryLockResult == TryLockResult.Locked)
+                uint oldState = _state;
+                Debug.Assert(oldState >= WaiterCountIncrement);
+
+                uint newState = oldState - WaiterCountIncrement;
+
+                // We could not have consumed a wake, or the wait would've succeeded.
+                // If we are the last waiter though, we will clear WaiterWoken and YieldToWaiters
+                // just so that lock would not look like contended.
+                if (newState < WaiterCountIncrement)
+                    newState = newState & ~WaiterWoken & ~YieldToWaiters;
+
+                if (Interlocked.CompareExchange(ref _state, newState, oldState) == oldState)
                 {
-                    spinCount = _spinCount;
-                    if (spinCount < maxSpinCount)
+                    if (contentionTrackingStartedTicks != 0)
+                        LogContentionEnd(contentionTrackingStartedTicks);
+
+                    return;
+                }
+
+                ExponentialBackoff(iteration++);
+            }
+        }
+
+        internal struct TimeoutTracker
+        {
+            private int _start;
+            private int _timeout;
+
+            public static TimeoutTracker Start(int timeout)
+            {
+                TimeoutTracker tracker = default;
+                tracker._timeout = timeout;
+                if (timeout != Timeout.Infinite)
+                    tracker._start = Environment.TickCount;
+                return tracker;
+            }
+
+            public int Remaining
+            {
+                get
+                {
+                    if (_timeout == Timeout.Infinite)
+                        return Timeout.Infinite;
+                    int elapsed = Environment.TickCount - _start;
+                    if (elapsed > _timeout)
+                        return 0;
+                    return _timeout - elapsed;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private unsafe void CreateWaitEvent()
+        {
+            Debug.Assert(!IsHeldByCurrentThread);
+
+            var newWaitEvent = new AutoResetEvent(false);
+            if (Interlocked.CompareExchange(ref _waitEvent, newWaitEvent, null) == null)
+            {
+                // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
+                if (StaticsInitComplete() && NativeRuntimeEventSource.Log.IsEnabled())
+                {
+                    if (NativeRuntimeEventSource.Log.IsEnabled(
+                                EventLevel.Informational,
+                                NativeRuntimeEventSource.Keywords.ContentionKeyword))
                     {
-                        _spinCount = (short)(spinCount + 1);
+                        NativeRuntimeEventSource.Log.ContentionLockCreated(this);
+                    }
+                }
+            }
+            else
+            {
+                newWaitEvent.Dispose();
+            }
+        }
+
+        private long LogContentionStart()
+        {
+            Debug.Assert(!IsHeldByCurrentThread);
+
+            // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
+            if (StaticsInitComplete() && NativeRuntimeEventSource.Log.IsEnabled())
+            {
+                if (NativeRuntimeEventSource.Log.IsEnabled(
+                            EventLevel.Informational,
+                            NativeRuntimeEventSource.Keywords.ContentionKeyword))
+                {
+                    NativeRuntimeEventSource.Log.ContentionStart(this);
+
+                    return Stopwatch.GetTimestamp();
+                }
+            }
+
+            return 0;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void LogContentionEnd(long contentionTrackingStartedTicks)
+        {
+            Debug.Assert(IsHeldByCurrentThread);
+
+            double waitDurationNs =
+                (Stopwatch.GetTimestamp() - contentionTrackingStartedTicks) * 1_000_000_000.0 / Stopwatch.Frequency;
+
+            // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
+            if (NativeRuntimeEventSource.Log.IsEnabled())
+            {
+                try
+                {
+                    NativeRuntimeEventSource.Log.ContentionStop(waitDurationNs);
+                }
+                catch
+                {
+                    // We are throwing. The acquire failed.
+                    this.Exit();
+                    throw;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ReleaseCore()
+        {
+            Debug.Assert(_recursionCount == 0);
+            _owningThreadId = 0;
+            uint origState = Interlocked.Decrement(ref _state);
+            if (origState < WaiterCountIncrement || (origState & WaiterWoken) != 0)
+            {
+                return;
+            }
+
+            //
+            // We have waiters; take the slow path.
+            //
+            AwakeWaiterIfNeeded();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void AwakeWaiterIfNeeded()
+        {
+            uint iteration = 0;
+            while (true)
+            {
+                uint oldState = _state;
+                if (oldState >= WaiterCountIncrement && (oldState & WaiterWoken) == 0)
+                {
+                    // there are waiters, and nobody has woken one.
+                    uint newState = oldState | WaiterWoken;
+
+                    short lastWakeTicks = _wakeWatchDog;
+                    if (lastWakeTicks != 0 && (short)Environment.TickCount - lastWakeTicks > WaiterWatchdogTicks)
+                    {
+                        newState |= YieldToWaiters;
+                    }
+
+                    if (Interlocked.CompareExchange(ref _state, newState, oldState) == oldState)
+                    {
+                        _waitEvent!.Set();
+                        if (lastWakeTicks == 0)
+                        {
+                            // nonzero timestamp of the last wake
+                            _wakeWatchDog = (short)(Environment.TickCount | 1);
+                        }
+
+                        return;
                     }
                 }
                 else
                 {
-                    // If the spin count is already zero, skip spin-waiting for a while, even for the first spinners. After a
-                    // number of contentions, the first spinner will attempt a spin-wait again to see if it is effective.
-                    Debug.Assert(tryLockResult == TryLockResult.Wait);
-                    spinCount = _spinCount;
-                    _spinCount = spinCount > 0 ? (short)(spinCount - 1) : minSpinCount;
-                }
-            }
-
-        LockedOrWait:
-            Debug.Assert(tryLockResult != TryLockResult.Spin);
-            if (tryLockResult == TryLockResult.Wait)
-            {
-                goto Wait;
-            }
-
-            Debug.Assert(tryLockResult == TryLockResult.Locked);
-
-        Locked:
-            Debug.Assert(!new ThreadId(_owningThreadId).IsInitialized);
-            Debug.Assert(_recursionCount == 0);
-            _owningThreadId = currentThreadId.Id;
-            return currentThreadId;
-
-        Wait:
-            bool areContentionEventsEnabled =
-                NativeRuntimeEventSource.Log.IsEnabled(
-                    EventLevel.Informational,
-                    NativeRuntimeEventSource.Keywords.ContentionKeyword);
-            AutoResetEvent waitEvent = _waitEvent ?? CreateWaitEvent(areContentionEventsEnabled);
-            if (State.TryLockBeforeWait(this))
-            {
-                // Lock was acquired and a waiter was not registered
-                goto Locked;
-            }
-
-            // Lock was not acquired and a waiter was registered. All following paths need to unregister the waiter, including
-            // exceptional paths.
-            try
-            {
-                Interlocked.Increment(ref s_contentionCount);
-
-                long waitStartTimeTicks = 0;
-                if (areContentionEventsEnabled)
-                {
-                    NativeRuntimeEventSource.Log.ContentionStart(this);
-                    waitStartTimeTicks = Stopwatch.GetTimestamp();
+                    // no need to wake a waiter.
+                    return;
                 }
 
-                bool acquiredLock = false;
-                int waitStartTimeMs = timeoutMs < 0 ? 0 : Environment.TickCount;
-                int remainingTimeoutMs = timeoutMs;
-                while (true)
-                {
-                    if (!waitEvent.WaitOne(remainingTimeoutMs))
-                    {
-                        break;
-                    }
-
-                    // Spin a bit while trying to acquire the lock. This has a few benefits:
-                    // - Spinning helps to reduce waiter starvation. Since other non-waiter threads can take the lock while
-                    //   there are waiters (see State.TryLock()), once a waiter wakes it will be able to better compete with
-                    //   other spinners for the lock.
-                    // - If there is another thread that is repeatedly acquiring and releasing the lock, spinning before waiting
-                    //   again helps to prevent a waiter from repeatedly context-switching in and out
-                    // - Further in the same situation above, waking up and waiting shortly thereafter deprioritizes this waiter
-                    //   because events release waiters in FIFO order. Spinning a bit helps a waiter to retain its priority at
-                    //   least for one spin duration before it gets deprioritized behind all other waiters.
-                    for (short spinIndex = 0; spinIndex < maxSpinCount; spinIndex++)
-                    {
-                        if (State.TryLockInsideWaiterSpinLoop(this))
-                        {
-                            acquiredLock = true;
-                            break;
-                        }
-
-                        LowLevelSpinWaiter.Wait(spinIndex, SpinSleep0Threshold, isSingleProcessor);
-                    }
-
-                    if (acquiredLock)
-                    {
-                        break;
-                    }
-
-                    if (State.TryLockAfterWaiterSpinLoop(this))
-                    {
-                        acquiredLock = true;
-                        break;
-                    }
-
-                    if (remainingTimeoutMs < 0)
-                    {
-                        continue;
-                    }
-
-                    uint waitDurationMs = (uint)(Environment.TickCount - waitStartTimeMs);
-                    if (waitDurationMs >= (uint)timeoutMs)
-                    {
-                        break;
-                    }
-
-                    remainingTimeoutMs = timeoutMs - (int)waitDurationMs;
-                }
-
-                if (acquiredLock)
-                {
-                    // In NativeAOT, ensure that class construction cycles do not occur after the lock is acquired but before
-                    // the state is fully updated. Update the state to fully reflect that this thread owns the lock before doing
-                    // other things.
-                    Debug.Assert(!new ThreadId(_owningThreadId).IsInitialized);
-                    Debug.Assert(_recursionCount == 0);
-                    _owningThreadId = currentThreadId.Id;
-
-                    if (areContentionEventsEnabled)
-                    {
-                        double waitDurationNs =
-                            (Stopwatch.GetTimestamp() - waitStartTimeTicks) * 1_000_000_000.0 / Stopwatch.Frequency;
-                        NativeRuntimeEventSource.Log.ContentionStop(waitDurationNs);
-                    }
-
-                    return currentThreadId;
-                }
-            }
-            catch // run this code before exception filters in callers
-            {
-                State.UnregisterWaiter(this);
-                throw;
-            }
-
-            State.UnregisterWaiter(this);
-            return new ThreadId(0);
-        }
-
-        private void ResetWaiterStartTime() => _waiterStartTimeMs = 0;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void RecordWaiterStartTime()
-        {
-            ushort currentTimeMs = (ushort)Environment.TickCount;
-            if (currentTimeMs == 0)
-            {
-                // Don't record zero, that value is reserved for indicating that a time is not recorded
-                currentTimeMs--;
-            }
-            _waiterStartTimeMs = currentTimeMs;
-        }
-
-        private bool ShouldStopPreemptingWaiters
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                // If the recorded time is zero, a time has not been recorded yet
-                ushort waiterStartTimeMs = _waiterStartTimeMs;
-                return
-                    waiterStartTimeMs != 0 &&
-                    (ushort)Environment.TickCount - waiterStartTimeMs >= MaxDurationMsForPreemptingWaiters;
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private unsafe AutoResetEvent CreateWaitEvent(bool areContentionEventsEnabled)
-        {
-            var newWaitEvent = new AutoResetEvent(false);
-            AutoResetEvent? waitEventBeforeUpdate = Interlocked.CompareExchange(ref _waitEvent, newWaitEvent, null);
-            if (waitEventBeforeUpdate == null)
-            {
-                // Also check NativeRuntimeEventSource.Log.IsEnabled() to enable trimming
-                if (areContentionEventsEnabled && NativeRuntimeEventSource.Log.IsEnabled())
-                {
-                    NativeRuntimeEventSource.Log.ContentionLockCreated(this);
-                }
-
-                return newWaitEvent;
-            }
-
-            newWaitEvent.Dispose();
-            return waitEventBeforeUpdate;
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void SignalWaiterIfNecessary(State state)
-        {
-            if (State.TrySetIsWaiterSignaledToWake(this, state))
-            {
-                // Signal a waiter to wake
-                Debug.Assert(_waitEvent != null);
-                bool signaled = _waitEvent.Set();
-                Debug.Assert(signaled);
+                ExponentialBackoff(iteration++);
             }
         }
 
@@ -619,7 +750,7 @@ namespace System.Threading
             {
                 var owningThreadId = new ThreadId(_owningThreadId);
                 bool isHeld = owningThreadId.IsInitialized && owningThreadId.Id == ThreadId.Current_NoInitialize.Id;
-                Debug.Assert(!isHeld || new State(this).IsLocked);
+                Debug.Assert(!isHeld || this.IsLocked);
                 return isHeld;
             }
         }
@@ -647,582 +778,20 @@ namespace System.Threading
 
         internal ulong OwningThreadId => _owningThreadId;
 
+        // Lock starts with MinSpinCount and may self-adjust up to the MaxSpinCount
+        // Setting MaxSpinCount <= MinSpinCount will effectively disable adaptive spin adjustment
         private static short DetermineMaxSpinCount() =>
             AppContextConfigHelper.GetInt16Config(
-                "System.Threading.Lock.SpinCount",
-                "DOTNET_Lock_SpinCount",
+                "System.Threading.Lock.MaxSpinCount",
+                "DOTNET_Lock_MaxSpinCount",
                 DefaultMaxSpinCount,
                 allowNegative: false);
 
-        private static short DetermineMinSpinCount()
-        {
-            // The config var can be set to -1 to disable adaptive spin
-            short adaptiveSpinPeriod =
-                AppContextConfigHelper.GetInt16Config(
-                    "System.Threading.Lock.AdaptiveSpinPeriod",
-                    "DOTNET_Lock_AdaptiveSpinPeriod",
-                    DefaultAdaptiveSpinPeriod,
-                    allowNegative: true);
-            if (adaptiveSpinPeriod < -1)
-            {
-                adaptiveSpinPeriod = DefaultAdaptiveSpinPeriod;
-            }
-
-            return (short)-adaptiveSpinPeriod;
-        }
-
-        private struct State : IEquatable<State>
-        {
-            // Layout constants for Lock._state
-            private const uint IsLockedMask = (uint)1 << 0; // bit 0
-            private const uint ShouldNotPreemptWaitersMask = (uint)1 << 1; // bit 1
-            private const uint SpinnerCountIncrement = (uint)1 << 2; // bits 2-4
-            private const uint SpinnerCountMask = (uint)0x7 << 2;
-            private const uint IsWaiterSignaledToWakeMask = (uint)1 << 5; // bit 5
-            private const byte WaiterCountShift = 6;
-            private const uint WaiterCountIncrement = (uint)1 << WaiterCountShift; // bits 6-31
-
-            private uint _state;
-
-            public State(Lock lockObj) : this(lockObj._state) { }
-            private State(uint state) => _state = state;
-
-            public static uint InitialStateValue => 0;
-            public static uint LockedStateValue => IsLockedMask;
-            private static uint Neg(uint state) => (uint)-(int)state;
-            public bool IsInitialState => this == default;
-            public bool IsLocked => (_state & IsLockedMask) != 0;
-
-            private void SetIsLocked()
-            {
-                Debug.Assert(!IsLocked);
-                _state += IsLockedMask;
-            }
-
-            private bool ShouldNotPreemptWaiters => (_state & ShouldNotPreemptWaitersMask) != 0;
-
-            private void SetShouldNotPreemptWaiters()
-            {
-                Debug.Assert(!ShouldNotPreemptWaiters);
-                Debug.Assert(HasAnyWaiters);
-
-                _state += ShouldNotPreemptWaitersMask;
-            }
-
-            private void ClearShouldNotPreemptWaiters()
-            {
-                Debug.Assert(ShouldNotPreemptWaiters);
-                _state -= ShouldNotPreemptWaitersMask;
-            }
-
-            private bool ShouldNonWaiterAttemptToAcquireLock
-            {
-                get
-                {
-                    Debug.Assert(HasAnyWaiters || !ShouldNotPreemptWaiters);
-                    return (_state & (IsLockedMask | ShouldNotPreemptWaitersMask)) == 0;
-                }
-            }
-
-            private bool HasAnySpinners => (_state & SpinnerCountMask) != 0;
-
-            private bool TryIncrementSpinnerCount()
-            {
-                uint newState = _state + SpinnerCountIncrement;
-                if (new State(newState).HasAnySpinners) // overflow check
-                {
-                    _state = newState;
-                    return true;
-                }
-                return false;
-            }
-
-            private void DecrementSpinnerCount()
-            {
-                Debug.Assert(HasAnySpinners);
-                _state -= SpinnerCountIncrement;
-            }
-
-            private bool IsWaiterSignaledToWake => (_state & IsWaiterSignaledToWakeMask) != 0;
-
-            private void SetIsWaiterSignaledToWake()
-            {
-                Debug.Assert(HasAnyWaiters);
-                Debug.Assert(NeedToSignalWaiter);
-
-                _state += IsWaiterSignaledToWakeMask;
-            }
-
-            private void ClearIsWaiterSignaledToWake()
-            {
-                Debug.Assert(IsWaiterSignaledToWake);
-                _state -= IsWaiterSignaledToWakeMask;
-            }
-
-            public bool HasAnyWaiters => _state >= WaiterCountIncrement;
-
-            private bool TryIncrementWaiterCount()
-            {
-                uint newState = _state + WaiterCountIncrement;
-                if (new State(newState).HasAnyWaiters) // overflow check
-                {
-                    _state = newState;
-                    return true;
-                }
-                return false;
-            }
-
-            private void DecrementWaiterCount()
-            {
-                Debug.Assert(HasAnyWaiters);
-                _state -= WaiterCountIncrement;
-            }
-
-            public bool NeedToSignalWaiter
-            {
-                get
-                {
-                    Debug.Assert(HasAnyWaiters);
-                    return (_state & (SpinnerCountMask | IsWaiterSignaledToWakeMask)) == 0;
-                }
-            }
-
-            public static bool operator ==(State state1, State state2) => state1._state == state2._state;
-            public static bool operator !=(State state1, State state2) => !(state1 == state2);
-
-            bool IEquatable<State>.Equals(State other) => this == other;
-            public override bool Equals(object? obj) => obj is State other && this == other;
-            public override int GetHashCode() => (int)_state;
-
-            private static State CompareExchange(Lock lockObj, State toState, State fromState) =>
-                new State(Interlocked.CompareExchange(ref lockObj._state, toState._state, fromState._state));
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool TryLock(Lock lockObj)
-            {
-                // The lock is mostly fair to release waiters in a typically FIFO order (though the order is not guaranteed).
-                // However, it allows non-waiters to acquire the lock if it's available to avoid lock convoys.
-                //
-                // Lock convoys can be detrimental to performance in scenarios where work is being done on multiple threads and
-                // the work involves periodically taking a particular lock for a short time to access shared resources. With a
-                // lock convoy, once there is a waiter for the lock (which is not uncommon in such scenarios), a worker thread
-                // would be forced to context-switch on the subsequent attempt to acquire the lock, often long before the worker
-                // thread exhausts its time slice. This process repeats as long as the lock has a waiter, forcing every worker
-                // to context-switch on each attempt to acquire the lock, killing performance and creating a positive feedback
-                // loop that makes it more likely for the lock to have waiters. To avoid the lock convoy, each worker needs to
-                // be allowed to acquire the lock multiple times in sequence despite there being a waiter for the lock in order
-                // to have the worker continue working efficiently during its time slice as long as the lock is not contended.
-                //
-                // This scheme has the possibility to starve waiters. Waiter starvation is mitigated by other means, see
-                // TryLockBeforeSpinLoop() and references to ShouldNotPreemptWaiters.
-
-                var state = new State(lockObj);
-                if (!state.ShouldNonWaiterAttemptToAcquireLock)
-                {
-                    return false;
-                }
-
-                State newState = state;
-                newState.SetIsLocked();
-
-                return CompareExchange(lockObj, newState, state) == state;
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static State Unlock(Lock lockObj)
-            {
-                Debug.Assert(IsLockedMask == 1);
-
-                var state = new State(Interlocked.Decrement(ref lockObj._state));
-                Debug.Assert(!state.IsLocked);
-                return state;
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static TryLockResult TryLockBeforeSpinLoop(Lock lockObj, short spinCount, out bool isFirstSpinner)
-            {
-                // Normally, threads are allowed to preempt waiters to acquire the lock in order to avoid creating lock convoys,
-                // see TryLock(). There can be cases where waiters can be easily starved as a result. For example, a thread that
-                // holds a lock for a significant amount of time (much longer than the time it takes to do a context switch),
-                // then releases and reacquires the lock in quick succession, and repeats. Though a waiter would be woken upon
-                // lock release, usually it will not have enough time to context-switch-in and take the lock, and can be starved
-                // for an unreasonably long duration.
-                //
-                // In order to prevent such starvation and force a bit of fair forward progress, it is sometimes necessary to
-                // change the normal policy and disallow threads from preempting waiters. ShouldNotPreemptWaiters() indicates
-                // the current state of the policy and this method determines whether the policy should be changed to disallow
-                // non-waiters from preempting waiters.
-                //   - When the first waiter begins waiting, it records the current time as a "waiter starvation start time".
-                //     That is a point in time after which no forward progress has occurred for waiters. When a waiter acquires
-                //     the lock, the time is updated to the current time.
-                //   - This method checks whether the starvation duration has crossed a threshold and if so, sets
-                //     ShouldNotPreemptWaitersMask
-                //
-                // When unreasonable starvation is occurring, the lock will be released occasionally and if caused by spinners,
-                // those threads may start to spin again.
-                //   - Before starting to spin this method is called. If ShouldNotPreemptWaitersMask is set, the spinner will
-                //     skip spinning and wait instead. Spinners that are already registered at the time
-                //     ShouldNotPreemptWaitersMask is set will stop spinning as necessary. Eventually, all spinners will drain
-                //     and no new ones will be registered.
-                //   - Upon releasing a lock, if there are no spinners, a waiter will be signaled to wake. On that path,
-                //     TrySetIsWaiterSignaledToWake() is called.
-                //   - Eventually, after spinners have drained, only a waiter will be able to acquire the lock. When a waiter
-                //     acquires the lock, or when the last waiter unregisters itself, ShouldNotPreemptWaitersMask is cleared to
-                //     restore the normal policy.
-
-                Debug.Assert(spinCount >= 0);
-
-                isFirstSpinner = false;
-                var state = new State(lockObj);
-                while (true)
-                {
-                    State newState = state;
-                    TryLockResult result = TryLockResult.Spin;
-                    if (newState.HasAnyWaiters)
-                    {
-                        if (newState.ShouldNotPreemptWaiters)
-                        {
-                            return TryLockResult.Wait;
-                        }
-                        if (lockObj.ShouldStopPreemptingWaiters)
-                        {
-                            newState.SetShouldNotPreemptWaiters();
-                            result = TryLockResult.Wait;
-                        }
-                    }
-                    if (result == TryLockResult.Spin)
-                    {
-                        Debug.Assert(!newState.ShouldNotPreemptWaiters);
-                        if (!newState.IsLocked)
-                        {
-                            newState.SetIsLocked();
-                            result = TryLockResult.Locked;
-                        }
-                        else if ((newState.HasAnySpinners && spinCount == 0) || !newState.TryIncrementSpinnerCount())
-                        {
-                            return TryLockResult.Wait;
-                        }
-                    }
-
-                    State stateBeforeUpdate = CompareExchange(lockObj, newState, state);
-                    if (stateBeforeUpdate == state)
-                    {
-                        if (result == TryLockResult.Spin && !state.HasAnySpinners)
-                        {
-                            isFirstSpinner = true;
-                        }
-                        return result;
-                    }
-
-                    state = stateBeforeUpdate;
-                }
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static TryLockResult TryLockInsideSpinLoop(Lock lockObj)
-            {
-                // This method is called from inside a spin loop, it must unregister the spinner if the lock is acquired
-
-                var state = new State(lockObj);
-                while (true)
-                {
-                    Debug.Assert(state.HasAnySpinners);
-                    if (!state.ShouldNonWaiterAttemptToAcquireLock)
-                    {
-                        return state.ShouldNotPreemptWaiters ? TryLockResult.Wait : TryLockResult.Spin;
-                    }
-
-                    State newState = state;
-                    newState.SetIsLocked();
-                    newState.DecrementSpinnerCount();
-
-                    State stateBeforeUpdate = CompareExchange(lockObj, newState, state);
-                    if (stateBeforeUpdate == state)
-                    {
-                        return TryLockResult.Locked;
-                    }
-
-                    state = stateBeforeUpdate;
-                }
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static TryLockResult TryLockAfterSpinLoop(Lock lockObj)
-            {
-                // This method is called at the end of a spin loop, it must unregister the spinner always and acquire the lock
-                // if it's available. If the lock is available, a spinner must acquire the lock along with unregistering itself,
-                // because a lock releaser does not wake a waiter when there is a spinner registered.
-
-                var state = new State(Interlocked.Add(ref lockObj._state, Neg(SpinnerCountIncrement)));
-                Debug.Assert(new State(state._state + SpinnerCountIncrement).HasAnySpinners);
-
-                while (true)
-                {
-                    Debug.Assert(state.HasAnyWaiters || !state.ShouldNotPreemptWaiters);
-                    if (state.IsLocked)
-                    {
-                        return TryLockResult.Wait;
-                    }
-
-                    State newState = state;
-                    newState.SetIsLocked();
-
-                    State stateBeforeUpdate = CompareExchange(lockObj, newState, state);
-                    if (stateBeforeUpdate == state)
-                    {
-                        return TryLockResult.Locked;
-                    }
-
-                    state = stateBeforeUpdate;
-                }
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool TryLockBeforeWait(Lock lockObj)
-            {
-                // This method is called before waiting. It must either acquire the lock or register a waiter. It also keeps
-                // track of the waiter starvation start time.
-
-                var state = new State(lockObj);
-                bool waiterStartTimeWasReset = false;
-                while (true)
-                {
-                    State newState = state;
-                    if (newState.ShouldNonWaiterAttemptToAcquireLock)
-                    {
-                        newState.SetIsLocked();
-                    }
-                    else
-                    {
-                        if (!newState.TryIncrementWaiterCount())
-                        {
-                            ThrowHelper.ThrowOutOfMemoryException_LockEnter_WaiterCountOverflow();
-                        }
-
-                        if (!state.HasAnyWaiters && !waiterStartTimeWasReset)
-                        {
-                            // This would be the first waiter. Once the waiter is registered, another thread may check the
-                            // waiter starvation start time and the previously recorded value may be stale, causing
-                            // ShouldNotPreemptWaitersMask to be set unnecessarily. Reset the start time before registering the
-                            // waiter.
-                            waiterStartTimeWasReset = true;
-                            lockObj.ResetWaiterStartTime();
-                        }
-                    }
-
-                    State stateBeforeUpdate = CompareExchange(lockObj, newState, state);
-                    if (stateBeforeUpdate == state)
-                    {
-                        if (state.ShouldNonWaiterAttemptToAcquireLock)
-                        {
-                            return true;
-                        }
-
-                        Debug.Assert(state.HasAnyWaiters || waiterStartTimeWasReset);
-                        if (!state.HasAnyWaiters || waiterStartTimeWasReset)
-                        {
-                            // This was the first waiter or the waiter start time was reset, record the waiter start time
-                            lockObj.RecordWaiterStartTime();
-                        }
-                        return false;
-                    }
-
-                    state = stateBeforeUpdate;
-                }
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool TryLockInsideWaiterSpinLoop(Lock lockObj)
-            {
-                // This method is called from inside the waiter's spin loop and should observe the wake signal only if the lock
-                // is taken, to prevent a lock releaser from waking another waiter while one is already spinning to acquire the
-                // lock
-
-                bool waiterStartTimeWasRecorded = false;
-                var state = new State(lockObj);
-                while (true)
-                {
-                    Debug.Assert(state.HasAnyWaiters);
-                    Debug.Assert(state.IsWaiterSignaledToWake);
-
-                    if (state.IsLocked)
-                    {
-                        return false;
-                    }
-
-                    State newState = state;
-                    newState.SetIsLocked();
-                    newState.ClearIsWaiterSignaledToWake();
-                    newState.DecrementWaiterCount();
-                    if (newState.ShouldNotPreemptWaiters)
-                    {
-                        newState.ClearShouldNotPreemptWaiters();
-
-                        if (newState.HasAnyWaiters && !waiterStartTimeWasRecorded)
-                        {
-                            // Update the waiter starvation start time. The time must be recorded before
-                            // ShouldNotPreemptWaitersMask is cleared, as once that is cleared, another thread may check the
-                            // waiter starvation start time and the previously recorded value may be stale, causing
-                            // ShouldNotPreemptWaitersMask to be set again unnecessarily.
-                            waiterStartTimeWasRecorded = true;
-                            lockObj.RecordWaiterStartTime();
-                        }
-                    }
-
-                    State stateBeforeUpdate = CompareExchange(lockObj, newState, state);
-                    if (stateBeforeUpdate == state)
-                    {
-                        if (newState.HasAnyWaiters)
-                        {
-                            Debug.Assert(!state.ShouldNotPreemptWaiters || waiterStartTimeWasRecorded);
-                            if (!waiterStartTimeWasRecorded)
-                            {
-                                // Since the lock was acquired successfully by a waiter, update the waiter starvation start time
-                                lockObj.RecordWaiterStartTime();
-                            }
-                        }
-                        return true;
-                    }
-
-                    state = stateBeforeUpdate;
-                }
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool TryLockAfterWaiterSpinLoop(Lock lockObj)
-            {
-                // This method is called at the end of the waiter's spin loop. It must observe the wake signal always, and if
-                // the lock is available, it must acquire the lock and unregister the waiter. If the lock is available, a waiter
-                // must acquire the lock along with observing the wake signal, because a lock releaser does not wake a waiter
-                // when a waiter was signaled but the wake signal has not been observed. If the lock is acquired, the waiter
-                // starvation start time is also updated.
-
-                var state = new State(Interlocked.Add(ref lockObj._state, Neg(IsWaiterSignaledToWakeMask)));
-                Debug.Assert(new State(state._state + IsWaiterSignaledToWakeMask).IsWaiterSignaledToWake);
-
-                bool waiterStartTimeWasRecorded = false;
-                while (true)
-                {
-                    Debug.Assert(state.HasAnyWaiters);
-
-                    if (state.IsLocked)
-                    {
-                        return false;
-                    }
-
-                    State newState = state;
-                    newState.SetIsLocked();
-                    newState.DecrementWaiterCount();
-                    if (newState.ShouldNotPreemptWaiters)
-                    {
-                        newState.ClearShouldNotPreemptWaiters();
-
-                        if (newState.HasAnyWaiters && !waiterStartTimeWasRecorded)
-                        {
-                            // Update the waiter starvation start time. The time must be recorded before
-                            // ShouldNotPreemptWaitersMask is cleared, as once that is cleared, another thread may check the
-                            // waiter starvation start time and the previously recorded value may be stale, causing
-                            // ShouldNotPreemptWaitersMask to be set again unnecessarily.
-                            waiterStartTimeWasRecorded = true;
-                            lockObj.RecordWaiterStartTime();
-                        }
-                    }
-
-                    State stateBeforeUpdate = CompareExchange(lockObj, newState, state);
-                    if (stateBeforeUpdate == state)
-                    {
-                        if (newState.HasAnyWaiters)
-                        {
-                            Debug.Assert(!state.ShouldNotPreemptWaiters || waiterStartTimeWasRecorded);
-                            if (!waiterStartTimeWasRecorded)
-                            {
-                                // Since the lock was acquired successfully by a waiter, update the waiter starvation start time
-                                lockObj.RecordWaiterStartTime();
-                            }
-                        }
-                        return true;
-                    }
-
-                    state = stateBeforeUpdate;
-                }
-            }
-
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            public static void UnregisterWaiter(Lock lockObj)
-            {
-                // This method is called upon an exception while waiting, or when a wait has timed out. It must unregister the
-                // waiter, and if it's the last waiter, clear ShouldNotPreemptWaitersMask to allow other threads to acquire the
-                // lock.
-
-                var state = new State(lockObj);
-                while (true)
-                {
-                    Debug.Assert(state.HasAnyWaiters);
-
-                    State newState = state;
-                    newState.DecrementWaiterCount();
-                    if (newState.ShouldNotPreemptWaiters && !newState.HasAnyWaiters)
-                    {
-                        newState.ClearShouldNotPreemptWaiters();
-                    }
-
-                    State stateBeforeUpdate = CompareExchange(lockObj, newState, state);
-                    if (stateBeforeUpdate == state)
-                    {
-                        return;
-                    }
-
-                    state = stateBeforeUpdate;
-                }
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool TrySetIsWaiterSignaledToWake(Lock lockObj, State state)
-            {
-                // Determine whether we must signal a waiter to wake. Keep track of whether a thread has been signaled to wake
-                // but has not yet woken from the wait. IsWaiterSignaledToWakeMask is cleared when a signaled thread wakes up by
-                // observing a signal. Since threads can preempt waiting threads and acquire the lock (see TryLock()), it allows
-                // for example, one thread to acquire and release the lock multiple times while there are multiple waiting
-                // threads. In such a case, we don't want that thread to signal a waiter every time it releases the lock, as
-                // that will cause unnecessary context switches with more and more signaled threads waking up, finding that the
-                // lock is still locked, and going back into a wait state. So, signal only one waiting thread at a time.
-
-                Debug.Assert(state.HasAnyWaiters);
-
-                while (true)
-                {
-                    if (!state.NeedToSignalWaiter)
-                    {
-                        return false;
-                    }
-
-                    State newState = state;
-                    newState.SetIsWaiterSignaledToWake();
-                    if (!newState.ShouldNotPreemptWaiters && lockObj.ShouldStopPreemptingWaiters)
-                    {
-                        newState.SetShouldNotPreemptWaiters();
-                    }
-
-                    State stateBeforeUpdate = CompareExchange(lockObj, newState, state);
-                    if (stateBeforeUpdate == state)
-                    {
-                        return true;
-                    }
-                    if (!stateBeforeUpdate.HasAnyWaiters)
-                    {
-                        return false;
-                    }
-
-                    state = stateBeforeUpdate;
-                }
-            }
-        }
-
-        private enum TryLockResult
-        {
-            Locked,
-            Spin,
-            Wait
-        }
+        private static short DetermineMinSpinCount() =>
+            AppContextConfigHelper.GetInt16Config(
+                "System.Threading.Lock.MinSpinCount",
+                "DOTNET_Lock_MinSpinCount",
+                DefaultMinSpinCount,
+                allowNegative: false);
     }
 }


### PR DESCRIPTION
This is basically the same as https://github.com/dotnet/runtime/pull/87672  with some additions

The main difference is that `TryEnterSlow` uses the same algorithm as in NativeAOT lock, so that congestion detection could be used for self-tuning.

The essence of the algorithm is:
- when we try to acquire the lock on the slow path loop, we also observe whether the lock is changing its ownership. 
- if, while we were trying to acquire, the lock was owned by 2 other threads, we consider that as a signal that there is too much competition and dial down the spin limit. 
- shorter spin limit makes unsuccessful spinners to sleep earlier, which statistically reduces the overall number of concurrent spinners and decreases competition.
- conversely, if successful spinning gets close to the limit _and no congestion is seen_, the limit is increased.
- every thread that acquires the lock via the slow path gets to cast a vote on how the acquiring went (too crowded, could allow more spin, nothing special)

The goal of this scheme is to scale better in cases of heavy concurrent use of the lock (i.e. > 4-8 threads).