### PR TITLE
Change OpenSslVersion to check for OpenSSL before attempting to determine openssl version

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -845,6 +845,7 @@
     <Compile Include="System\Security\Cryptography\RSAOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\RSAWrapper.cs" />
     <Compile Include="System\Security\Cryptography\SafeEvpPKeyHandle.OpenSsl.cs" />
+    <Compile Include="System\Security\Cryptography\SafeEvpPKeyHandle.OpenSsl.Unix.cs" />
     <Compile Include="System\Security\Cryptography\Shake128.NonWindows.cs" />
     <Compile Include="System\Security\Cryptography\Shake256.NonWindows.cs" />
     <Compile Include="System\Security\Cryptography\SP800108HmacCounterKdf.Managed.cs" />
@@ -1221,6 +1222,7 @@
     <Compile Include="System\Security\Cryptography\ECDiffieHellmanOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\RSAOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\SafeEvpPKeyHandle.OpenSsl.cs" />
+    <Compile Include="System\Security\Cryptography\SafeEvpPKeyHandle.OpenSsl.macOS.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\AppleCertificatePal.ImportExport.macOS.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\AppleCertificatePal.Keys.macOS.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\AppleCertificatePal.Pkcs12.macOS.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SafeEvpPKeyHandle.OpenSsl.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SafeEvpPKeyHandle.OpenSsl.Unix.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Versioning;
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class SafeEvpPKeyHandle
+    {
+        /// <summary>
+        /// The runtime version number for the loaded version of OpenSSL.
+        /// </summary>
+        /// <remarks>
+        /// For OpenSSL 1.1+ this is the result of <code>OpenSSL_version_num()</code>,
+        /// for OpenSSL 1.0.x this is the result of <code>SSLeay()</code>.
+        /// </remarks>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("browser")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("windows")]
+        public static long OpenSslVersion { get; } = Interop.OpenSsl.OpenSslVersionNumber();
+    }
+}

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SafeEvpPKeyHandle.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SafeEvpPKeyHandle.OpenSsl.cs
@@ -7,7 +7,7 @@ using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography
 {
-    public sealed class SafeEvpPKeyHandle : SafeHandle
+    public sealed partial class SafeEvpPKeyHandle : SafeHandle
     {
         internal static readonly SafeEvpPKeyHandle InvalidHandle = new SafeEvpPKeyHandle();
 
@@ -72,20 +72,6 @@ namespace System.Security.Cryptography
             safeHandle.SetHandle(handle);
             return safeHandle;
         }
-
-        /// <summary>
-        /// The runtime version number for the loaded version of OpenSSL.
-        /// </summary>
-        /// <remarks>
-        /// For OpenSSL 1.1+ this is the result of <code>OpenSSL_version_num()</code>,
-        /// for OpenSSL 1.0.x this is the result of <code>SSLeay()</code>.
-        /// </remarks>
-        [UnsupportedOSPlatform("android")]
-        [UnsupportedOSPlatform("browser")]
-        [UnsupportedOSPlatform("ios")]
-        [UnsupportedOSPlatform("tvos")]
-        [UnsupportedOSPlatform("windows")]
-        public static long OpenSslVersion { get; } = Interop.OpenSsl.OpenSslVersionNumber();
 
         /// <summary>
         ///   Open a named private key using a named OpenSSL <code>ENGINE</code>.

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SafeEvpPKeyHandle.OpenSsl.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SafeEvpPKeyHandle.OpenSsl.macOS.cs
@@ -8,7 +8,7 @@ namespace System.Security.Cryptography
 {
     public sealed partial class SafeEvpPKeyHandle
     {
-        private static long _openSslVersion;
+        private static readonly long _openSslVersion = !Interop.OpenSslNoInit.OpenSslIsAvailable ? 0 : Interop.OpenSsl.OpenSslVersionNumber();
 
         /// <summary>
         /// The runtime version number for the loaded version of OpenSSL.
@@ -26,17 +26,11 @@ namespace System.Security.Cryptography
         {
             get
             {
-                long version = Volatile.Read(ref _openSslVersion);
+                long version = _openSslVersion;
 
                 if (version == 0)
                 {
-                    if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
-                    {
-                        throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyOpenSSL);
-                    }
-
-                    version = Interop.OpenSsl.OpenSslVersionNumber();
-                    Volatile.Write(ref _openSslVersion, version);
+                    throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyOpenSSL);
                 }
 
                 return version;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SafeEvpPKeyHandle.OpenSsl.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SafeEvpPKeyHandle.OpenSsl.macOS.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Versioning;
+using System.Threading;
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class SafeEvpPKeyHandle
+    {
+        private static long _openSslVersion;
+
+        /// <summary>
+        /// The runtime version number for the loaded version of OpenSSL.
+        /// </summary>
+        /// <remarks>
+        /// For OpenSSL 1.1+ this is the result of <code>OpenSSL_version_num()</code>,
+        /// for OpenSSL 1.0.x this is the result of <code>SSLeay()</code>.
+        /// </remarks>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("browser")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("windows")]
+        public static long OpenSslVersion
+        {
+            get
+            {
+                long version = Volatile.Read(ref _openSslVersion);
+
+                if (version == 0)
+                {
+                    if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
+                    {
+                        throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyOpenSSL);
+                    }
+
+                    version = Interop.OpenSsl.OpenSslVersionNumber();
+                    Volatile.Write(ref _openSslVersion, version);
+                }
+
+                return version;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I decided to do a partial so the implementation remains unchanged on Unix. If someone took a dependency on this property being cheap, it stays so on Unix.

I don't like throwing an exception on a property read, but it's better than a process abort, and it seemed preferable to some sentinel "zero" return value.

Fixes #93883 