### PR TITLE
Override InformationalVersion for NativeAOT corelib too

### DIFF
--- a/src/coreclr/nativeaot/Directory.Build.props
+++ b/src/coreclr/nativeaot/Directory.Build.props
@@ -25,6 +25,9 @@
     <!-- This prevents the default MsBuild targets from referencing System.Core.dll -->
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <RuntimeMetadataVersion>v4.0.30319</RuntimeMetadataVersion>
+     <!-- Override InformationalVersion during servicing as it's returned via public api. --> 
+    <InformationalVersion Condition="'$(PreReleaseVersionLabel)' == 'servicing'">$(ProductVersion)</InformationalVersion> 
+    <InformationalVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(ProductVersion)</InformationalVersion> 
     <NoWarn>$(NoWarn),0419,0649,CA2249,CA1830</NoWarn>
 
     <!-- Disable nullability-related warnings -->


### PR DESCRIPTION
We already do this for CoreCLR and Mono since https://github.com/dotnet/runtime/pull/60572 but we never did this for NativeAOT.
Without this the assembly has a version suffix in the AssemblyInformationalVersionAttribute when using stabilized package versions which caused the processinfo2 and processinfo3 tests to fail.