### PR TITLE
Use AVX512 intrinsics for numeric conversion in JIT

### DIFF
--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -1405,6 +1405,30 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
         case NI_Vector128_ConvertToDouble:
         case NI_Vector256_ConvertToDouble:
+        {
+            assert(sig->numArgs == 1);
+            assert(varTypeIsLong(simdBaseType));
+
+            if (!compOpportunisticallyDependsOn(InstructionSet_AVX512DQ_VL))
+            {
+                break;
+            }
+
+            switch (simdSize)
+            {
+                case 16:
+                    intrinsic = NI_AVX512DQ_VL_ConvertToVector128Double;
+                    break;
+                case 32:
+                    intrinsic = NI_AVX512DQ_VL_ConvertToVector256Double;
+                    break;
+                default:
+                    unreached();
+            }
+            op1     = impSIMDPopStack();
+            retNode = gtNewSimdHWIntrinsicNode(retType, op1, intrinsic, simdBaseJitType, simdSize);
+            break;
+        }
         case NI_Vector128_ConvertToInt64:
         case NI_Vector256_ConvertToInt64:
         case NI_Vector128_ConvertToUInt32:


### PR DESCRIPTION
Jit version of #89330

For `Vector128.ConvertToDouble`

### Before
```sh
G_M000_IG02:                ;; offset=0x0007
       call     [OthmarTesting.Testing:Src():long]
       vpbroadcastq  xmm0, rax
       vpblendd xmm1, xmm0, xmmword ptr [reloc @RWD00], 10
       vpsrlq   xmm0, xmm0, 32
       vpxorq   xmm0, xmm0, qword ptr [reloc @RWD16] {1to2}
       vsubpd   xmm0, xmm0, qword ptr [reloc @RWD24] {1to2}
       vaddpd   xmm0, xmm0, xmm1
       vmovups  xmmword ptr [rbx], xmm0
       mov      rax, rbx
```

### After
```sh
G_M000_IG02:                ;; offset=0x0007
       call     [OthmarTesting.Testing:Src():long]
       vpbroadcastq  xmm0, rax
       vcvtqq2pd xmm0, xmm0
       vmovups  xmmword ptr [rbx], xmm0
       mov      rax, rbx
```