### PR TITLE
JIT: fix bug introduced by recent throw helper block changes

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3538,9 +3538,15 @@ const char* sckName(SpecialCodeKind codeKind)
 //
 void Compiler::fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind)
 {
+    // Record that the code will call a THROW_HELPER
+    // so on Windows Amd64 we can allocate the 4 outgoing
+    // arg slots on the stack frame if there are no other calls.
+    //
+    compUsesThrowHelper = true;
+
     if (!fgUseThrowHelperBlocks() && (kind != SCK_FAIL_FAST))
     {
-        // FailFast will still use a thrwo helper, even in debuggable modes.
+        // FailFast will still use a common throw helper, even in debuggable modes.
         //
         return;
     }
@@ -3548,11 +3554,6 @@ void Compiler::fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind)
     JITDUMP(FMT_BB " requires throw helper block for %s\n", srcBlk->bbNum, sckName(kind));
 
     unsigned const refData = (kind == SCK_FAIL_FAST) ? 0 : bbThrowIndex(srcBlk);
-
-    // Record that the code will call a THROW_HELPER
-    // so on Windows Amd64 we can allocate the 4 outgoing
-    // arg slots on the stack frame if there are no other calls.
-    compUsesThrowHelper = true;
 
     // Look for an existing entry that matches what we're looking for
     //


### PR DESCRIPTION
`compUsesThrowHelper` indicates codegen will likely need to create a call to a helper, whether or not such calls are shared.

In #93371 I didn't appreciate this, and so the JIT was failing to set `compUsesThrowHelper` in cases where a throw helper was going to be needed but throw helper calls were not going to be shared.

Fixes #93710.