### PR TITLE
Keep using RO metadata after creating IMetaDataImporter for PDB reading

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -2113,7 +2113,7 @@ BOOL Module::IsInSameVersionBubble(Module *target)
 // Return Value:
 //      HRESULT indicating success or failure.
 //
-HRESULT Module::GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, bool swapForRWMDImport, LPVOID * ppvInterface)
+HRESULT Module::GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, bool openForWriting, LPVOID * ppvInterface)
 {
     CONTRACTL
     {
@@ -2137,7 +2137,7 @@ HRESULT Module::GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID rii
     // Normally, we just get an RWImporter to do the QI on, and we're on our way.
     EX_TRY
     {
-        pIUnk = GetRWImporter(swapForRWMDImport);
+        pIUnk = GetRWImporter(openForWriting);
     }
     EX_CATCH_HRESULT_NO_ERRORINFO(hr);
 
@@ -2316,7 +2316,7 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
             }
             if (SUCCEEDED(hr))
             {
-                hr = pBinder->GetReaderFromStream(GetRWImporter(/* swapForRWMDImport */ false), pIStream, &pReader);
+                hr = pBinder->GetReaderFromStream(GetRWImporter(/* openForWriting */ false), pIStream, &pReader);
             }
         }
         else
@@ -2328,7 +2328,7 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
             // trying to get a symbol reader. This has to be done once per
             // Assembly.
             ReleaseHolder<IUnknown> pUnk = NULL;
-            hr = GetReadablePublicMetaDataInterface(ofReadOnly, IID_IMetaDataImport, /* swapForRWMDImport */ false, &pUnk);
+            hr = GetReadablePublicMetaDataInterface(ofReadOnly, IID_IMetaDataImport, /* openForWriting */ false, &pUnk);
             if (SUCCEEDED(hr))
                 hr = pBinder->GetReaderForFile(pUnk, path, NULL, &pReader);
         }

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -2102,7 +2102,7 @@ BOOL Module::IsInSameVersionBubble(Module *target)
 
 //---------------------------------------------------------------------------------------
 //
-// Wrapper for Module::GetRWImporter + QI when writing is not needed.
+// Wrapper for Module::GetImporter + QI when writing is not needed.
 //
 // Arguments:
 //      * dwOpenFlags - Combo from CorOpenFlags. Better not contain ofWrite!
@@ -2113,7 +2113,7 @@ BOOL Module::IsInSameVersionBubble(Module *target)
 // Return Value:
 //      HRESULT indicating success or failure.
 //
-HRESULT Module::GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, LPVOID * ppvInterface)
+HRESULT Module::GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, bool swapForRWMDImport, LPVOID * ppvInterface)
 {
     CONTRACTL
     {
@@ -2137,7 +2137,7 @@ HRESULT Module::GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID rii
     // Normally, we just get an RWImporter to do the QI on, and we're on our way.
     EX_TRY
     {
-        pIUnk = GetRWImporter();
+        pIUnk = GetRWImporter(swapForRWMDImport);
     }
     EX_CATCH_HRESULT_NO_ERRORINFO(hr);
 
@@ -2316,7 +2316,7 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
             }
             if (SUCCEEDED(hr))
             {
-                hr = pBinder->GetReaderFromStream(GetRWImporter(), pIStream, &pReader);
+                hr = pBinder->GetReaderFromStream(GetRWImporter(/* swapForRWMDImport */ false), pIStream, &pReader);
             }
         }
         else
@@ -2328,7 +2328,7 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
             // trying to get a symbol reader. This has to be done once per
             // Assembly.
             ReleaseHolder<IUnknown> pUnk = NULL;
-            hr = GetReadablePublicMetaDataInterface(ofReadOnly, IID_IMetaDataImport, &pUnk);
+            hr = GetReadablePublicMetaDataInterface(ofReadOnly, IID_IMetaDataImport, /* swapForRWMDImport */ false, &pUnk);
             if (SUCCEEDED(hr))
                 hr = pBinder->GetReaderForFile(pUnk, path, NULL, &pReader);
         }

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1027,14 +1027,14 @@ public:
         return m_pPEAssembly->GetEmitter();
     }
 
-    IMetaDataImport2 *GetRWImporter(bool swapForRWMDImport = true)
+    IMetaDataImport2 *GetRWImporter(bool openForWriting=true)
     {
         WRAPPER_NO_CONTRACT;
 
-        return m_pPEAssembly->GetRWImporter(swapForRWMDImport);
+        return m_pPEAssembly->GetRWImporter(openForWriting);
     }
 
-    HRESULT GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, bool swapForRWMDImport, LPVOID * ppvInterface);
+    HRESULT GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, bool openForWriting, LPVOID * ppvInterface);
 #endif // !DACCESS_COMPILE
 
 #if defined(FEATURE_READYTORUN)

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1027,14 +1027,14 @@ public:
         return m_pPEAssembly->GetEmitter();
     }
 
-    IMetaDataImport2 *GetRWImporter()
+    IMetaDataImport2 *GetRWImporter(bool swapForRWMDImport = true)
     {
         WRAPPER_NO_CONTRACT;
 
-        return m_pPEAssembly->GetRWImporter();
+        return m_pPEAssembly->GetRWImporter(swapForRWMDImport);
     }
 
-    HRESULT GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, LPVOID * ppvInterface);
+    HRESULT GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, bool swapForRWMDImport, LPVOID * ppvInterface);
 #endif // !DACCESS_COMPILE
 
 #if defined(FEATURE_READYTORUN)

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -836,14 +836,6 @@ public:
         PREFIX_ASSUME(pModule != NULL);
         return pModule->GetEmitter();
     }
-
-    IMetaDataImport* GetRWImporter()
-    {
-        WRAPPER_NO_CONTRACT;
-        Module *pModule = GetModule();
-        PREFIX_ASSUME(pModule != NULL);
-        return pModule->GetRWImporter();
-    }
 #endif // !DACCESS_COMPILE
 
 #ifdef FEATURE_COMINTEROP

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -329,7 +329,6 @@ void PEAssembly::ConvertMDInternalToReadWrite(bool swapForRWMDImport)
 
     if (pConvertedImport != NULL)
     {
-        // TODO: Is this a good check if metadata is read write.
         if (swapForRWMDImport && pOld != pConvertedImport)
         {
             // We had converted the metadata before, now we are just requested
@@ -396,8 +395,6 @@ void PEAssembly::ConvertMDInternalToReadWrite(bool swapForRWMDImport)
         pNew = m_pConvertedMDImport;
     }
 
-    // TODO: this can still be torn? Struct with pointers and swapping might be the only good option.
-    //       need to see what pointers the struct should have.
     if (swapForRWMDImport)
     {
         if (InterlockedCompareExchangeT(&m_pMDImport, pNew, pOld) == pOld)

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -342,8 +342,13 @@ void PEAssembly::ConvertMDInternalToReadWrite(bool openForWriting)
                 //if the debugger queries, it will now see that we have RW metadata
                 m_MDImportIsRW_Debugger_Use_Only = TRUE;
 
-                m_pMDImport->AddRef();
-                HRESULT hr=m_pConvertedMDImport->SetUserContextData(pOld);
+                // Swapped -- get the metadata to hang onto the old Internal import.
+                // Additionally, now both m_pMDImport and m_pConvertedMDImport point to
+                // the same RW MDImport. Up the references such that both have to be freed
+                // before freeing the RW copy and the RO that hangs off it.
+                pConvertedImport->AddRef();
+                HRESULT hr = pConvertedImport->SetUserContextData(pOld);
+
                 _ASSERTE(SUCCEEDED(hr)||!"Leaking old MDImport");
                 IfFailThrow(hr);
             }
@@ -408,8 +413,12 @@ void PEAssembly::ConvertMDInternalToReadWrite(bool openForWriting)
             m_MDImportIsRW_Debugger_Use_Only = TRUE;
 
             // Swapped -- get the metadata to hang onto the old Internal import.
-            m_pMDImport->AddRef();
-            HRESULT hr=m_pMDImport->SetUserContextData(pOld);
+            // Additionally, now both m_pMDImport and m_pConvertedMDImport point to
+            // the RW MDImport. Up the references such that both have to be freed
+            // before freeing the RW copy and the RO that hangs off it.
+            pNew->AddRef();
+            HRESULT hr = pNew->SetUserContextData(pOld);
+
             _ASSERTE(SUCCEEDED(hr)||!"Leaking old MDImport");
             IfFailThrow(hr);
         }

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -324,14 +324,14 @@ void PEAssembly::ConvertMDInternalToReadWrite(bool swapForRWMDImport)
     //  or to an RW MDInternalXX.
     IMDInternalImport *pNew = NULL;                                 // New (RW) value of internal import.
     IMDInternalImport *pOld = m_pMDImport;                          // Old (current RO) value of internal import.
-    IMDInternalImport *pConvertedImport = m_pConvertedMDImport;     // Pointer to a RW interna metadata that might not be actively in use.
+    IMDInternalImport *pConvertedImport = m_pConvertedMDImport;     // Pointer to a RW internal metadata that might not be actively in use.
 
 
     if (pConvertedImport != NULL)
     {
         if (swapForRWMDImport && pOld != pConvertedImport)
         {
-            // We had converted the metadata before, now we are just requested
+            // We had converted the metadata before, now we are requesting
             // to replace the RO view we had with the converted one.
             if (InterlockedCompareExchangeT(&m_pMDImport, pConvertedImport, pOld) == pOld)
             {

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -161,12 +161,12 @@ public:
 
 #ifndef DACCESS_COMPILE
     IMetaDataEmit *GetEmitter();
-    IMetaDataImport2 *GetRWImporter();
+    IMetaDataImport2 *GetRWImporter(bool swapForRWMDImport = true);
 #else
     TADDR GetMDInternalRWAddress();
 #endif // DACCESS_COMPILE
 
-    void ConvertMDInternalToReadWrite();
+    void ConvertMDInternalToReadWrite(bool swapForRWMDImport = true);
 
     void GetMVID(GUID* pMvid);
     ULONG GetHashAlgId();
@@ -382,7 +382,7 @@ private:
 #endif
 
     void OpenMDImport();
-    void OpenImporter();
+    void OpenImporter(bool swapForRWMDImport = true);
     void OpenEmitter();
 
 private:
@@ -419,6 +419,8 @@ private:
         IMDInternalImport* m_pMDImport_UseAccessor;
 #endif
     };
+
+    IMDInternalImport* m_pConvertedMDImport;
 
     IMetaDataImport2* m_pImporter;
     IMetaDataEmit* m_pEmitter;

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -275,7 +275,7 @@ inline IMDInternalImport* PEAssembly::GetMDImport()
 
 #ifndef DACCESS_COMPILE
 
-inline IMetaDataImport2 *PEAssembly::GetRWImporter()
+inline IMetaDataImport2 *PEAssembly::GetRWImporter(bool swapForRWMDImport)
 {
     CONTRACT(IMetaDataImport2 *)
     {
@@ -288,7 +288,7 @@ inline IMetaDataImport2 *PEAssembly::GetRWImporter()
     CONTRACT_END;
 
     if (m_pImporter == NULL)
-        OpenImporter();
+        OpenImporter(swapForRWMDImport);
 
     RETURN m_pImporter;
 }

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -275,7 +275,7 @@ inline IMDInternalImport* PEAssembly::GetMDImport()
 
 #ifndef DACCESS_COMPILE
 
-inline IMetaDataImport2 *PEAssembly::GetRWImporter(bool swapForRWMDImport)
+inline IMetaDataImport2 *PEAssembly::GetRWImporter(bool openForWriting)
 {
     CONTRACT(IMetaDataImport2 *)
     {
@@ -288,7 +288,7 @@ inline IMetaDataImport2 *PEAssembly::GetRWImporter(bool swapForRWMDImport)
     CONTRACT_END;
 
     if (m_pImporter == NULL)
-        OpenImporter(swapForRWMDImport);
+        OpenImporter(openForWriting);
 
     RETURN m_pImporter;
 }

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -2172,7 +2172,7 @@ HRESULT ProfToEEInterfaceImpl::GetTokenAndMetaDataFromFunction(
     if (ppOut)
     {
         Module * pMod = pMD->GetModule();
-        hr = pMod->GetReadablePublicMetaDataInterface(ofRead, riid, /* swapForRWMDImport */ true, (LPVOID *) ppOut);
+        hr = pMod->GetReadablePublicMetaDataInterface(ofRead, riid, /* openForWriting */ true, (LPVOID *) ppOut);
     }
 
     return hr;
@@ -4254,7 +4254,7 @@ HRESULT ProfToEEInterfaceImpl::GetModuleMetaData(ModuleID    moduleId,
     if ((dwOpenFlags & ofWrite) == 0)
     {
         // Readable interface
-        return pModule->GetReadablePublicMetaDataInterface(dwOpenFlags, riid, /* swapForRWMDImport */ true, (LPVOID *) ppOut);
+        return pModule->GetReadablePublicMetaDataInterface(dwOpenFlags, riid, /* openForWriting */ true, (LPVOID *) ppOut);
     }
 
     // Writeable interface

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -2172,7 +2172,7 @@ HRESULT ProfToEEInterfaceImpl::GetTokenAndMetaDataFromFunction(
     if (ppOut)
     {
         Module * pMod = pMD->GetModule();
-        hr = pMod->GetReadablePublicMetaDataInterface(ofRead, riid, (LPVOID *) ppOut);
+        hr = pMod->GetReadablePublicMetaDataInterface(ofRead, riid, /* swapForRWMDImport */ true, (LPVOID *) ppOut);
     }
 
     return hr;
@@ -4254,7 +4254,7 @@ HRESULT ProfToEEInterfaceImpl::GetModuleMetaData(ModuleID    moduleId,
     if ((dwOpenFlags & ofWrite) == 0)
     {
         // Readable interface
-        return pModule->GetReadablePublicMetaDataInterface(dwOpenFlags, riid, (LPVOID *) ppOut);
+        return pModule->GetReadablePublicMetaDataInterface(dwOpenFlags, riid, /* swapForRWMDImport */ true, (LPVOID *) ppOut);
     }
 
     // Writeable interface


### PR DESCRIPTION
This change allows the runtime to keep using the read-only view of the metadata interfaces for internal use, even after a RW conversion of the metadata has been requested to back the classic PDB parser. Swapping of the cached RW converted view will be deferred until some other path (e.g. profiler, MD emit) requests a RW view of the metadata.

Main version of fix for https://github.com/dotnet/runtime/issues/90563