### PR TITLE
Haiku: Add Haiku support for CoreCLR/PAL

### DIFF
--- a/src/coreclr/ilasm/ilasmpch.h
+++ b/src/coreclr/ilasm/ilasmpch.h
@@ -25,4 +25,12 @@
 #include "mdfileformat.h"
 #include "stgpooli.h"
 
+#ifdef _EXPORT
+#undef _EXPORT
+#endif
+
+#ifdef _IMPORT
+#undef _IMPORT
+#endif
+
 #endif

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -2644,6 +2644,8 @@ PALIMPORT BOOL PALAPI PAL_GetUnwindInfoSize(SIZE_T baseAddress, ULONG64 ehFrameH
 #define PAL_CS_NATIVE_DATA_SIZE 96
 #elif defined(__linux__) && defined(__riscv) && __riscv_xlen == 64
 #define PAL_CS_NATIVE_DATA_SIZE 96
+#elif defined(__HAIKU__) && defined(__x86_64__)
+#define PAL_CS_NATIVE_DATA_SIZE 56
 #else
 #error  PAL_CS_NATIVE_DATA_SIZE is not defined for this architecture
 #endif
@@ -3952,7 +3954,9 @@ unsigned int __cdecl _rotr(unsigned int value, int shift)
 PALIMPORT DLLEXPORT char * __cdecl PAL_getenv(const char *);
 PALIMPORT DLLEXPORT int __cdecl _putenv(const char *);
 
+#ifndef ERANGE
 #define ERANGE          34
+#endif
 
 /****************PAL Perf functions for PInvoke*********************/
 #if PAL_PERF

--- a/src/coreclr/pal/inc/rt/safecrt.h
+++ b/src/coreclr/pal/inc/rt/safecrt.h
@@ -112,15 +112,6 @@ typedef int errno_t; /* standard */
 /* error codes */
 #if !defined(_SECURECRT_ERRCODE_VALUES_DEFINED)
 #define _SECURECRT_ERRCODE_VALUES_DEFINED
-#if !defined(EINVAL)
-#define EINVAL          22
-#endif
-#if !defined(ERANGE)
-#define ERANGE          34
-#endif
-#if !defined(EILSEQ)
-#define EILSEQ          42
-#endif
 #if !defined(STRUNCATE)
 #define STRUNCATE       80
 #endif

--- a/src/coreclr/pal/src/arch/amd64/signalhandlerhelper.cpp
+++ b/src/coreclr/pal/src/arch/amd64/signalhandlerhelper.cpp
@@ -8,7 +8,10 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT); // some headers have code with asserts, so do
 #include "pal/context.h"
 #include "pal/signal.hpp"
 #include "pal/utils.h"
+
+#if HAVE_SYS_UCONTEXT_H
 #include <sys/ucontext.h>
+#endif
 
 /*++
 Function :

--- a/src/coreclr/pal/src/config.h.in
+++ b/src/coreclr/pal/src/config.h.in
@@ -21,6 +21,8 @@
 #cmakedefine01 HAVE_PTHREAD_NP_H
 #cmakedefine01 HAVE_AUXV_HWCAP_H
 #cmakedefine01 HAVE_SYS_PTRACE_H
+#cmakedefine01 HAVE_SYS_UCONTEXT_H
+#cmakedefine01 HAVE_SYS_MOUNT_H
 #cmakedefine01 HAVE_UCONTEXT_H
 #cmakedefine01 HAVE_GETAUXVAL
 

--- a/src/coreclr/pal/src/configure.cmake
+++ b/src/coreclr/pal/src/configure.cmake
@@ -47,6 +47,8 @@ check_include_files(semaphore.h HAVE_SEMAPHORE_H)
 check_include_files(sys/prctl.h HAVE_PRCTL_H)
 check_include_files("sys/auxv.h;asm/hwcap.h" HAVE_AUXV_HWCAP_H)
 check_include_files("sys/ptrace.h" HAVE_SYS_PTRACE_H)
+check_include_files("sys/ucontext.h" HAVE_SYS_UCONTEXT_H)
+check_include_files("sys/mount.h" HAVE_SYS_MOUNT_H)
 check_include_files(ucontext.h HAVE_UCONTEXT_H)
 check_symbol_exists(getauxval sys/auxv.h HAVE_GETAUXVAL)
 

--- a/src/coreclr/pal/src/debug/debug.cpp
+++ b/src/coreclr/pal/src/debug/debug.cpp
@@ -45,7 +45,7 @@ SET_DEFAULT_DEBUG_CHANNEL(DEBUG); // some headers have code with asserts, so do 
 #include <unistd.h>
 #elif defined(HAVE_TTRACE) // HAVE_PROCFS_CTL
 #include <sys/ttrace.h>
-#else // defined(HAVE_TTRACE)
+#elif HAVE_SYS_PTRACE_H
 #include <sys/ptrace.h>
 #endif  // HAVE_PROCFS_CTL
 #if HAVE_VM_READ
@@ -635,7 +635,7 @@ Function:
   PAL_ReadProcessMemory
 
 Abstract
-  Reads process memory. 
+  Reads process memory.
 
 Parameter
   handle : from PAL_OpenProcessMemory
@@ -753,7 +753,7 @@ PAL_ProbeMemory(
 
     flags = fcntl(fds[0], F_GETFL, 0);
     fcntl(fds[0], F_SETFL, flags | O_NONBLOCK);
-    
+
     flags = fcntl(fds[1], F_GETFL, 0);
     fcntl(fds[1], F_SETFL, flags | O_NONBLOCK);
 

--- a/src/coreclr/pal/src/exception/seh.cpp
+++ b/src/coreclr/pal/src/exception/seh.cpp
@@ -305,7 +305,7 @@ PAL_ERROR SEHEnable(CPalThread *pthrCurrent)
 {
 #if HAVE_MACH_EXCEPTIONS
     return pthrCurrent->EnableMachExceptions();
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__sun)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__sun) || defined(__HAIKU__)
     return NO_ERROR;
 #else// HAVE_MACH_EXCEPTIONS
 #error not yet implemented
@@ -330,7 +330,7 @@ PAL_ERROR SEHDisable(CPalThread *pthrCurrent)
 {
 #if HAVE_MACH_EXCEPTIONS
     return pthrCurrent->DisableMachExceptions();
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__sun)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__sun) || defined(__HAIKU__)
     return NO_ERROR;
 #else // HAVE_MACH_EXCEPTIONS
 #error not yet implemented

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -44,11 +44,13 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT); // some headers have code with asserts, so do
 #include "pal/utils.h"
 
 #include <string.h>
-#include <sys/ucontext.h>
 #include <sys/utsname.h>
 #include <unistd.h>
 #include <sys/mman.h>
 
+#if HAVE_SYS_UCONTEXT_H
+#include <sys/ucontext.h>
+#endif // HAVE_SYS_UCONTEXT_H
 
 #endif // !HAVE_MACH_EXCEPTIONS
 #include "pal/context.h"

--- a/src/coreclr/pal/src/file/file.cpp
+++ b/src/coreclr/pal/src/file/file.cpp
@@ -32,10 +32,13 @@ SET_DEFAULT_DEBUG_CHANNEL(FILE); // some headers have code with asserts, so do t
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/param.h>
-#include <sys/mount.h>
 #include <errno.h>
 #include <limits.h>
 #include <fcntl.h>
+
+#if HAVE_SYS_MOUNT_H
+#include <sys/mount.h>
+#endif
 
 using namespace CorUnix;
 

--- a/src/coreclr/pal/src/include/pal/context.h
+++ b/src/coreclr/pal/src/include/pal/context.h
@@ -33,7 +33,9 @@ extern "C"
 /* A type to wrap the native context type, which is ucontext_t on some
  * platforms and another type elsewhere. */
 #if HAVE_UCONTEXT_T
+#if HAVE_UCONTEXT_H
 #include <ucontext.h>
+#endif // HAVE_UCONTEXT_H
 
 typedef ucontext_t native_context_t;
 #else   // HAVE_UCONTEXT_T
@@ -935,6 +937,41 @@ inline void *FPREG_Xstate_Hi16Zmm(const ucontext_t *uc, uint32_t *featureSize)
     *featureSize = sizeof(_STRUCT_ZMM_REG) * 16;
     return reinterpret_cast<void *>(&((_STRUCT_X86_AVX512_STATE64&)FPSTATE(uc)).__fpu_zmm16);
 }
+#elif defined(TARGET_HAIKU)
+
+#define MCREG_Rbp(mc)	    ((mc).rbp)
+#define MCREG_Rip(mc)	    ((mc).rip)
+#define MCREG_Rsp(mc)	    ((mc).rsp)
+#define MCREG_Rsi(mc)       ((mc).rsi)
+#define MCREG_Rdi(mc)	    ((mc).rdi)
+#define MCREG_Rbx(mc)	    ((mc).rbx)
+#define MCREG_Rdx(mc)	    ((mc).rdx)
+#define MCREG_Rcx(mc)	    ((mc).rcx)
+#define MCREG_Rax(mc)	    ((mc).rax)
+#define MCREG_R8(mc)	    ((mc).r8)
+#define MCREG_R9(mc)	    ((mc).r9)
+#define MCREG_R10(mc)	    ((mc).r10)
+#define MCREG_R11(mc)	    ((mc).r11)
+#define MCREG_R12(mc)	    ((mc).r12)
+#define MCREG_R13(mc)	    ((mc).r13)
+#define MCREG_R14(mc)	    ((mc).r14)
+#define MCREG_R15(mc)	    ((mc).r15)
+#define MCREG_EFlags(mc)    ((mc).rflags)
+// Haiku: missing SegCs
+
+#define FPSTATE(uc)             ((uc)->uc_mcontext.fpu)
+#define FPREG_ControlWord(uc)   FPSTATE(uc).fp_fxsave.control
+#define FPREG_StatusWord(uc)    FPSTATE(uc).fp_fxsave.status
+#define FPREG_TagWord(uc)       FPSTATE(uc).fp_fxsave.tag
+#define FPREG_MxCsr(uc)         FPSTATE(uc).fp_fxsave.mxcsr
+#define FPREG_MxCsr_Mask(uc)    FPSTATE(uc).fp_fxsave.mscsr_mask
+#define FPREG_ErrorOffset(uc)   *(DWORD*) &(FPSTATE(uc).fp_fxsave.rip)
+#define FPREG_ErrorSelector(uc) *((WORD*) &(FPSTATE(uc).fp_fxsave.rip) + 2)
+#define FPREG_DataOffset(uc)    *(DWORD*) &(FPSTATE(uc).fp_fxsave.rdp)
+#define FPREG_DataSelector(uc)  *((WORD*) &(FPSTATE(uc).fp_fxsave.rdp) + 2)
+
+#define FPREG_Xmm(uc, index)    *(M128A*) &(FPSTATE(uc).fp_fxsave.xmm[index])
+#define FPREG_St(uc, index)     *(M128A*) &(FPSTATE(uc).fp_fxsave.fp[index].value)
 #else //TARGET_OSX
 
     // For FreeBSD, as found in x86/ucontext.h

--- a/src/coreclr/pal/src/include/pal/palinternal.h
+++ b/src/coreclr/pal/src/include/pal/palinternal.h
@@ -193,8 +193,6 @@ function_name() to call the system's implementation
 #undef sigsetjmp
 #undef siglongjmp
 
-#undef _SIZE_T_DEFINED
-
 #define _DONT_USE_CTYPE_INLINE_
 #if HAVE_RUNETYPE_H
 #include <runetype.h>

--- a/src/coreclr/pal/src/include/pal/thread.hpp
+++ b/src/coreclr/pal/src/include/pal/thread.hpp
@@ -24,7 +24,6 @@ Abstract:
 #include "cs.hpp"
 
 #include <pthread.h>
-#include <sys/syscall.h>
 #if HAVE_MACH_EXCEPTIONS
 #include <mach/mach.h>
 #endif // HAVE_MACH_EXCEPTIONS

--- a/src/coreclr/pal/src/loader/module.cpp
+++ b/src/coreclr/pal/src/loader/module.cpp
@@ -497,6 +497,7 @@ LPCSTR FixLibCName(LPCSTR shortAsciiName)
     //   As a result, we have to use the full name (i.e. lib.so.6) that is defined by LIBC_SO.
     // * For macOS, use constant value absolute path "/usr/lib/libc.dylib".
     // * For FreeBSD, use constant value "libc.so.7".
+    // * For Haiku, use constant value "libroot.so".
     // * For rest of Unices, use constant value "libc.so".
     if (strcmp(shortAsciiName, LIBC_NAME_WITHOUT_EXTENSION) == 0)
     {
@@ -504,6 +505,8 @@ LPCSTR FixLibCName(LPCSTR shortAsciiName)
         return "/usr/lib/libc.dylib";
 #elif defined(__FreeBSD__)
         return "libc.so.7";
+#elif defined(__HAIKU__)
+        return "libroot.so";
 #elif defined(LIBC_SO)
         return LIBC_SO;
 #else

--- a/src/coreclr/pal/src/map/map.cpp
+++ b/src/coreclr/pal/src/map/map.cpp
@@ -108,6 +108,11 @@ MAPmmapAndRecord(
 #define MAP_ANON MAP_ANONYMOUS
 #endif
 
+/* Some platforms like Haiku does not provide MAP_FILE */
+#ifndef MAP_FILE
+#define MAP_FILE 0
+#endif
+
 void
 FileMappingCleanupRoutine(
     CPalThread *pThread,

--- a/src/coreclr/pal/src/map/map.cpp
+++ b/src/coreclr/pal/src/map/map.cpp
@@ -108,11 +108,6 @@ MAPmmapAndRecord(
 #define MAP_ANON MAP_ANONYMOUS
 #endif
 
-/* Some platforms like Haiku does not provide MAP_FILE */
-#ifndef MAP_FILE
-#define MAP_FILE 0
-#endif
-
 void
 FileMappingCleanupRoutine(
     CPalThread *pThread,
@@ -2115,7 +2110,7 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
 #endif
     SIZE_T reserveSize = 0;
     bool forceOveralign = false;
-    int readWriteFlags = MAP_FILE|MAP_PRIVATE|MAP_FIXED;
+    int readWriteFlags = MAP_PRIVATE|MAP_FIXED;
     int readOnlyFlags = readWriteFlags;
 
     ENTRY("MAPMapPEFile (hFile=%p offset=%zx)\n", hFile, offset);
@@ -2322,7 +2317,7 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
         // If PAL_MAP_READONLY_PE_HUGE_PAGE_AS_SHARED is set to 1. map the readonly sections as shared
         // which works well with the behavior of the hugetlbfs
         if (mapAsShared != NULL && (strcmp(mapAsShared, "1") == 0))
-            readOnlyFlags = MAP_FILE|MAP_SHARED|MAP_FIXED;
+            readOnlyFlags = MAP_SHARED|MAP_FIXED;
     }
 
     //we have now reserved memory (potentially we got rebased).  Walk the PE sections and map each part

--- a/src/coreclr/pal/src/map/virtual.cpp
+++ b/src/coreclr/pal/src/map/virtual.cpp
@@ -594,6 +594,10 @@ static LPVOID ReserveVirtualMemory(
     }
 #endif
 
+#ifdef __HAIKU__
+        mmapFlags |= MAP_NORESERVE;
+#endif
+
     LPVOID pRetVal = mmap((LPVOID) StartBoundary,
                           MemSize,
                           PROT_NONE,

--- a/src/coreclr/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/pal/src/misc/cgroup.cpp
@@ -23,7 +23,7 @@ SET_DEFAULT_DEBUG_CHANNEL(MISC);
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/param.h>
 #include <sys/mount.h>
-#else
+#elif !defined(__HAIKU__)
 #include <sys/vfs.h>
 #endif
 

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -65,6 +65,11 @@ Revision History:
 #include <mach/mach_host.h>
 #endif // defined(TARGET_OSX)
 
+#ifdef __HAIKU__
+#include <OS.h>
+#endif // __HAIKU__
+
+#ifdef __FreeBSD__
 // On some platforms sys/user.h ends up defining _DEBUG; if so
 // remove the definition before including the header and put
 // back our definition afterwards
@@ -78,6 +83,7 @@ Revision History:
 #define _DEBUG OLD_DEBUG
 #undef OLD_DEBUG
 #endif
+#endif // __FreeBSD__
 
 #include "pal/dbgmsg.h"
 #include "pal/process.h"
@@ -211,6 +217,8 @@ GetSystemInfo(
     lpSystemInfo->lpMaximumApplicationAddress = (PVOID) (1ull << 47);
 #elif defined(__sun)
     lpSystemInfo->lpMaximumApplicationAddress = (PVOID) 0xfffffd7fffe00000ul;
+#elif defined(__HAIKU__)
+    lpSystemInfo->lpMaximumApplicationAddress = (PVOID) 0x7fffffe00000ul;
 #elif defined(USERLIMIT)
     lpSystemInfo->lpMaximumApplicationAddress = (PVOID) USERLIMIT;
 #elif defined(HOST_64BIT)

--- a/src/coreclr/pal/src/thread/context.cpp
+++ b/src/coreclr/pal/src/thread/context.cpp
@@ -59,13 +59,22 @@ typedef int __ptrace_request;
 #endif // !HAVE_MACH_EXCEPTIONS
 
 #ifdef HOST_AMD64
+#ifdef __HAIKU__
 #define ASSIGN_CONTROL_REGS \
-    ASSIGN_REG(Rbp)     \
-    ASSIGN_REG(Rip)     \
-    ASSIGN_REG(SegCs)   \
-    ASSIGN_REG(EFlags)  \
-    ASSIGN_REG(Rsp)     \
+        ASSIGN_REG(Rbp)     \
+        ASSIGN_REG(Rip)     \
+        ASSIGN_REG(EFlags)  \
+        ASSIGN_REG(Rsp)     \
 
+#else // __HAIKU__
+#define ASSIGN_CONTROL_REGS \
+        ASSIGN_REG(Rbp)     \
+        ASSIGN_REG(Rip)     \
+        ASSIGN_REG(SegCs)   \
+        ASSIGN_REG(EFlags)  \
+        ASSIGN_REG(Rsp)     \
+
+#endif // __HAIKU__
 #define ASSIGN_INTEGER_REGS \
     ASSIGN_REG(Rdi)     \
     ASSIGN_REG(Rsi)     \

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -119,6 +119,11 @@ extern "C"
 #include <sys/user.h>
 #endif
 
+#ifdef __HAIKU__
+#include <image.h>
+#include <OS.h>
+#endif
+
 extern char *g_szCoreCLRPath;
 extern bool g_running_in_exe;
 
@@ -1397,7 +1402,7 @@ PALIMPORT
 VOID
 PALAPI
 PAL_SetCreateDumpCallback(
-    IN PCREATEDUMP_CALLBACK callback) 
+    IN PCREATEDUMP_CALLBACK callback)
 {
     _ASSERTE(g_createdumpCallback == nullptr);
     g_createdumpCallback = callback;
@@ -1679,6 +1684,23 @@ GetProcessIdDisambiguationKey(DWORD processId, UINT64 *disambiguationKey)
     *disambiguationKey = secondsSinceEpoch;
 
     return TRUE;
+
+#elif defined(__HAIKU__)
+
+    // On Haiku, we return the process start time expressed in microseconds since boot time.
+
+    team_info info;
+
+    if (get_team_info(processId, &info) == B_OK)
+    {
+        *disambiguationKey = info.start_time;
+        return TRUE;
+    }
+    else
+    {
+        WARN("Failed to get start time of a process.");
+        return FALSE;
+    }
 
 #elif HAVE_PROCFS_STAT
 

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -1388,6 +1388,7 @@ CorUnix::GetThreadTimesInternal(
 
     pTargetThread->Lock(pThread);
 
+#if HAVE_PTHREAD_GETCPUCLOCKID || HAVE_CLOCK_THREAD_CPUTIME
 #if HAVE_PTHREAD_GETCPUCLOCKID
     if (pthread_getcpuclockid(pTargetThread->GetPThreadSelf(), &cid) != 0)
     {
@@ -1396,6 +1397,9 @@ CorUnix::GetThreadTimesInternal(
         pTargetThread->Unlock(pThread);
         goto SetTimesToZero;
     }
+#else // HAVE_PTHREAD_GETCPUCLOCKID
+    cid = CLOCK_THREAD_CPUTIME_ID;
+#endif // HAVE_PTHREAD_GETCPUCLOCKID
 
     struct timespec ts;
     if (clock_gettime(cid, &ts) != 0)
@@ -1429,9 +1433,9 @@ CorUnix::GetThreadTimesInternal(
     close(fd);
 
     ts = status.pr_utime;
-#else // HAVE_PTHREAD_GETCPUCLOCKID
+#else // HAVE_PTHREAD_GETCPUCLOCKID || HAVE_CLOCK_THREAD_CPUTIME
 #error "Don't know how to obtain user cpu time on this platform."
-#endif // HAVE_PTHREAD_GETCPUCLOCKID
+#endif // HAVE_PTHREAD_GETCPUCLOCKID || HAVE_CLOCK_THREAD_CPUTIME
 
     pTargetThread->Unlock(pThread);
 

--- a/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
+++ b/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
@@ -15,9 +15,12 @@
 #include <stdio.h>
 #include <signal.h>
 #include <errno.h>
-#include <sys/ucontext.h>
 #include <sys/utsname.h>
 #include <unistd.h>
+
+#ifndef __HAIKU__
+#include <sys/ucontext.h>
+#endif
 
 enum
 {
@@ -59,7 +62,7 @@ void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
     {
         printf("ERROR: sigprocmask failed; error is %d\n", errno);
         _exit(FAIL);
-    } 
+    }
 
     printf("Signal chaining PASSED\n");
     _exit(PASS);

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/MapViewOfFile/test1/MapViewOfFile.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/MapViewOfFile/test1/MapViewOfFile.cpp
@@ -19,11 +19,14 @@
 // it is not possible to create file with FILE_FLAG_NO_BUFFERING.
 // So we explicitly use the /var/tmp that cannot be on tmpfs, since it it persistent over reboots.
 
-#ifndef __ANDROID__
-#define TEMP_DIRECTORY_PATH "/var/tmp/"
-#else
+#ifdef __ANDROID__
 // On Android, "/var/tmp/" doesn't exist; temporary files should go to /data/local/tmp/
 #define TEMP_DIRECTORY_PATH "/data/local/tmp/"
+#elif defined(__HAIKU__)
+// "/var/tmp/" also doesn't exist on Haiku.
+#define TEMP_DIRECTORY_PATH "/boot/system/cache/"
+#else
+#define TEMP_DIRECTORY_PATH "/var/tmp/"
 #endif
 
 PALTEST(filemapping_memmgt_MapViewOfFile_test1_paltest_mapviewoffile_test1, "filemapping_memmgt/MapViewOfFile/test1/paltest_mapviewoffile_test1")

--- a/src/native/minipal/debugger.c
+++ b/src/native/minipal/debugger.c
@@ -35,6 +35,8 @@
 #include <sys/proc.h>
 #include <sys/types.h>
 #include <sys/procfs.h>
+#elif defined(__HAIKU__)
+#include <OS.h>
 #endif
 
 bool minipal_is_native_debugger_present(void)
@@ -128,6 +130,14 @@ bool minipal_is_native_debugger_present(void)
     pid_t pid = getpid();
     getprocs64(&proc, sizeof(proc), NULL, 0, &pid, 1);
     return (proc.pi_flags & STRC) != 0; // SMPTRACE or SWTED might work too
+
+#elif defined(__HAIKU__)
+    team_info info;
+    if (get_team_info(B_CURRENT_TEAM, &info) == B_OK)
+    {
+        return info.debugger_nub_thread > 0;
+    }
+    return false;
 
 #else
     return false;

--- a/src/native/minipal/thread.h
+++ b/src/native/minipal/thread.h
@@ -67,6 +67,8 @@ static inline size_t minipal_get_current_thread_id(void)
         tid = (size_t)pthread_getthreadid_np();
 #elif defined(__NetBSD__)
         tid = (size_t)_lwp_self();
+#elif defined(__HAIKU__)
+        tid = (size_t)find_thread(NULL);
 #else
         tid = (size_t)(void*)pthread_self();
 #endif


### PR DESCRIPTION
This contains the code required to build this repo's native components and get `paltests` to pass on Haiku.

Most implementation details related to this commit are documented [here](https://www.haiku-os.org/blog/trungnt2910/2023-05-14_gsoc_2023_dotnet_port_progress_1/).

Part of https://github.com/dotnet/runtime/issues/55803.