### PR TITLE
Add RuntimeInformation.FrameworkDescription test to validate version

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -186,7 +186,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             var frameworkDescription = RuntimeInformation.FrameworkDescription;
             var version = frameworkDescription.Substring(".NET".Length).Trim(); // remove ".NET" prefix
 
-            if (String.IsNullOrEmpty(version))
+            if (string.IsNullOrEmpty(version))
                 return;
 
             Assert.DoesNotContain("+", version); // no git hash

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -181,6 +181,29 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         }
 
         [Fact]
+        public void VerifyFrameworkDescriptionContainsCorrectVersion()
+        {
+            var frameworkDescription = RuntimeInformation.FrameworkDescription;
+            var version = frameworkDescription.Substring(".NET".Length).Trim(); // remove ".NET" prefix
+
+            if (String.IsNullOrEmpty(version))
+                return;
+
+            Assert.DoesNotContain("+", version); // no git hash
+
+#if STABILIZE_PACKAGE_VERSION
+            // a stabilized version looks like 8.0.0
+            Assert.DoesNotContain("-", version);
+            Assert.True(Version.TryParse(version, out Version _));
+#else
+            // a non-stabilized version looks like 8.0.0-preview.5.23280.8 or 8.0.0-dev
+            Assert.Contains("-", version);
+            var versionNumber = version.Substring(0, version.IndexOf("-"));
+            Assert.True(Version.TryParse(versionNumber, out Version _));
+#endif
+        }
+
+        [Fact]
         public void VerifyOSDescription()
         {
             Assert.NotNull(RuntimeInformation.OSDescription);

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/System.Runtime.InteropServices.RuntimeInformation.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/System.Runtime.InteropServices.RuntimeInformation.Tests.csproj
@@ -4,6 +4,9 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-unix;$(NetCoreAppCurrent)-browser</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup>
+    <DefineConstants Condition="'$(StabilizePackageVersion)' == 'true'">$(DefineConstants);STABILIZE_PACKAGE_VERSION</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="CheckArchitectureTests.cs" />


### PR DESCRIPTION
We need to make sure the string contains only the stabilized version in servicing, or a non-stabilized one otherwise. This prevents issues like https://github.com/dotnet/runtime/issues/45812 and what we hit in https://github.com/dotnet/runtime/pull/93807.

Closes https://github.com/dotnet/runtime/issues/45812