### PR TITLE
Disabling two socket tests

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -124,7 +124,6 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/93737", TestPlatforms.Linux)]
         [OuterLoop("Connects to external server")]
         [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.MacCatalyst | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.FreeBSD, "Not supported on BSD like OSes.")]
         [Theory]
@@ -138,6 +137,12 @@ namespace System.Net.Sockets.Tests
         [InlineData("[::ffff:1.1.1.1]", true, false)]
         public async Task ConnectGetsCanceledByDispose(string addressString, bool useDns, bool owning)
         {
+            if (UsesSync && !PlatformDetection.IsWindows)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
+                return;
+            }
+
             // Aborting sync operations for non-owning handles is not supported on Unix.
             if (!owning && UsesSync && !PlatformDetection.IsWindows)
             {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -163,7 +163,7 @@ namespace System.Net.Sockets.Tests
                 // Wait a little so the operation is started.
                 await Task.Delay(Math.Min(msDelay, 1000));
                 msDelay *= 2;
-                Task disposeTask = Task.Run(() => client.Close());
+                Task disposeTask = Task.Run(() => client.Dispose());
 
                 await Task.WhenAny(disposeTask, connectTask).WaitAsync(TimeSpan.FromSeconds(30));
                 await disposeTask;

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -124,6 +124,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/93737", TestPlatforms.Linux)]
         [OuterLoop("Connects to external server")]
         [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.MacCatalyst | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.FreeBSD, "Not supported on BSD like OSes.")]
         [Theory]
@@ -162,7 +163,7 @@ namespace System.Net.Sockets.Tests
                 // Wait a little so the operation is started.
                 await Task.Delay(Math.Min(msDelay, 1000));
                 msDelay *= 2;
-                Task disposeTask = Task.Run(() => client.Dispose());
+                Task disposeTask = Task.Run(() => client.Close());
 
                 await Task.WhenAny(disposeTask, connectTask).WaitAsync(TimeSpan.FromSeconds(30));
                 await disposeTask;

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -187,7 +187,7 @@ namespace System.Net.Sockets.Tests
             }, connectMethod, useDnsEndPoint.ToString()).Dispose();
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/93735", TestPlatforms.Linux)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
         [OuterLoop]
         [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.FreeBSD, "Same as Connect.ConnectGetsCanceledByDispose")]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -187,6 +187,7 @@ namespace System.Net.Sockets.Tests
             }, connectMethod, useDnsEndPoint.ToString()).Dispose();
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/93735", TestPlatforms.Linux)]
         [OuterLoop]
         [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.FreeBSD, "Same as Connect.ConnectGetsCanceledByDispose")]


### PR DESCRIPTION
Disables #93737 and #93735 until regression in Linux kernel has been fixed.
Tracking issue: #94149 

/cc @tmds @wfurt @antonfirsov 