### PR TITLE
Honor JsonSerializerOptions.PropertyNameCaseInsensitive in property name conflict resolution.

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -863,7 +863,7 @@ namespace System.Text.Json.SourceGeneration
             {
                 Location? typeLocation = typeToGenerate.Location;
                 List<PropertyGenerationSpec> properties = new();
-                PropertyHierarchyResolutionState state = new();
+                PropertyHierarchyResolutionState state = new(options);
                 hasExtensionDataProperty = false;
 
                 // Walk the type hierarchy starting from the current type up to the base type(s)
@@ -970,11 +970,10 @@ namespace System.Text.Json.SourceGeneration
                 }
             }
 
-            private ref struct PropertyHierarchyResolutionState
+            private ref struct PropertyHierarchyResolutionState(SourceGenerationOptionsSpec? options)
             {
-                public PropertyHierarchyResolutionState() { }
                 public readonly List<int> Properties = new();
-                public Dictionary<string, (PropertyGenerationSpec, ISymbol, int index)> AddedProperties = new();
+                public Dictionary<string, (PropertyGenerationSpec, ISymbol, int index)> AddedProperties = new(options?.PropertyNameCaseInsensitive == true ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
                 public Dictionary<string, ISymbol>? IgnoredMembers;
                 public bool IsPropertyOrderSpecified;
                 public bool HasInvalidConfigurationForFastPath;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Helpers.cs
@@ -88,7 +88,7 @@ namespace System.Text.Json.Serialization.Metadata
             bool constructorHasSetsRequiredMembersAttribute =
                 typeInfo.Converter.ConstructorInfo?.HasSetsRequiredMembersAttribute() ?? false;
 
-            JsonTypeInfo.PropertyHierarchyResolutionState state = new();
+            JsonTypeInfo.PropertyHierarchyResolutionState state = new(typeInfo.Options);
 
             // Walk the type hierarchy starting from the current type up to the base type(s)
             foreach (Type currentType in typeInfo.Type.GetSortedTypeHierarchy())

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Helpers.cs
@@ -137,7 +137,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             // Regardless of the source generator we need to re-run the naming conflict resolution algorithm
             // at run time since it is possible that the naming policy or other configs can be different then.
-            JsonTypeInfo.PropertyHierarchyResolutionState state = new();
+            JsonTypeInfo.PropertyHierarchyResolutionState state = new(typeInfo.Options);
 
             foreach (JsonPropertyInfo jsonPropertyInfo in properties)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -992,10 +992,9 @@ namespace System.Text.Json.Serialization.Metadata
         internal abstract ValueTask<object?> DeserializeAsObjectAsync(Stream utf8Json, CancellationToken cancellationToken);
         internal abstract object? DeserializeAsObject(Stream utf8Json);
 
-        internal ref struct PropertyHierarchyResolutionState
+        internal ref struct PropertyHierarchyResolutionState(JsonSerializerOptions options)
         {
-            public PropertyHierarchyResolutionState() { }
-            public Dictionary<string, (JsonPropertyInfo, int index)> AddedProperties = new();
+            public Dictionary<string, (JsonPropertyInfo, int index)> AddedProperties = new(options.PropertyNameCaseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
             public Dictionary<string, JsonPropertyInfo>? IgnoredProperties;
             public bool IsPropertyOrderSpecified;
         }

--- a/src/libraries/System.Text.Json/tests/Common/PropertyNameTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PropertyNameTests.cs
@@ -495,25 +495,28 @@ namespace System.Text.Json.Serialization.Tests
             public int YiIt_2 { get; set; }
         }
 
-        [Fact]
-        public async Task ClassWithIgnoredCaseSensitiveConflict_RespectsIgnoredMember()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ClassWithIgnoredCaseInsensitiveConflict_RespectsIgnoredMember(bool propertyNameCaseInsensitive)
         {
             // Regression test for https://github.com/dotnet/runtime/issues/93903
+            // specifically for propertyNameCaseInsensitive := true
 
             JsonSerializerOptions options = Serializer.CreateOptions(makeReadOnly: false);
-            options.PropertyNameCaseInsensitive = true;
+            options.PropertyNameCaseInsensitive = propertyNameCaseInsensitive;
 
-            var value = new ClassWithIgnoredCaseSensitiveConflict { name = "lowercase", Name = "uppercase" };
+            var value = new ClassWithIgnoredCaseInsensitiveConflict { name = "lowercase", Name = "uppercase" };
             string json = await Serializer.SerializeWrapper(value, options);
 
             Assert.Equal("""{"name":"lowercase"}""", json);
 
-            value = await Serializer.DeserializeWrapper<ClassWithIgnoredCaseSensitiveConflict>(json, options);
+            value = await Serializer.DeserializeWrapper<ClassWithIgnoredCaseInsensitiveConflict>(json, options);
             Assert.Equal("lowercase", value.name);
             Assert.Null(value.Name);
         }
 
-        public class ClassWithIgnoredCaseSensitiveConflict
+        public class ClassWithIgnoredCaseInsensitiveConflict
         {
             public string name { get; set; }
 

--- a/src/libraries/System.Text.Json/tests/Common/PropertyNameTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PropertyNameTests.cs
@@ -496,7 +496,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public async Task ClassWithIgnoredCaseSensitiveConflict_WorksAsExpected()
+        public async Task ClassWithIgnoredCaseSensitiveConflict_RespectsIgnoredMember()
         {
             // Regression test for https://github.com/dotnet/runtime/issues/93903
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PropertyNameTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PropertyNameTests.cs
@@ -28,6 +28,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(ObjectPropertyNamesDifferentByCaseOnly_TestClass))]
         [JsonSerializable(typeof(OverridePropertyNameDesignTime_TestClass))]
         [JsonSerializable(typeof(SimpleTestClass))]
+        [JsonSerializable(typeof(ClassWithIgnoredCaseSensitiveConflict))]
         internal sealed partial class PropertyNameTestsContext_Metadata : JsonSerializerContext
         {
         }
@@ -53,6 +54,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(ObjectPropertyNamesDifferentByCaseOnly_TestClass))]
         [JsonSerializable(typeof(OverridePropertyNameDesignTime_TestClass))]
         [JsonSerializable(typeof(SimpleTestClass))]
+        [JsonSerializable(typeof(ClassWithIgnoredCaseSensitiveConflict))]
         internal sealed partial class PropertyNameTestsContext_Default : JsonSerializerContext
         {
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PropertyNameTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PropertyNameTests.cs
@@ -28,7 +28,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(ObjectPropertyNamesDifferentByCaseOnly_TestClass))]
         [JsonSerializable(typeof(OverridePropertyNameDesignTime_TestClass))]
         [JsonSerializable(typeof(SimpleTestClass))]
-        [JsonSerializable(typeof(ClassWithIgnoredCaseSensitiveConflict))]
+        [JsonSerializable(typeof(ClassWithIgnoredCaseInsensitiveConflict))]
         internal sealed partial class PropertyNameTestsContext_Metadata : JsonSerializerContext
         {
         }
@@ -54,7 +54,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(ObjectPropertyNamesDifferentByCaseOnly_TestClass))]
         [JsonSerializable(typeof(OverridePropertyNameDesignTime_TestClass))]
         [JsonSerializable(typeof(SimpleTestClass))]
-        [JsonSerializable(typeof(ClassWithIgnoredCaseSensitiveConflict))]
+        [JsonSerializable(typeof(ClassWithIgnoredCaseInsensitiveConflict))]
         internal sealed partial class PropertyNameTestsContext_Default : JsonSerializerContext
         {
         }


### PR DESCRIPTION
The PR in https://github.com/dotnet/runtime/pull/81306 among other things consolidated the property name conflict resolution algorithm to a shared location in `JsonTypeInfo`, however the shared logic didn't account for the `JsonSerializerOptions.PropertyNameCaseInsensitive` setting. This PR rectifies the issue and adds a regression test.

Fix #93903.