### PR TITLE
Fix the perf issue in TensorPrimitives.MinMaxCore

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.cs
@@ -169,20 +169,8 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static float CosineSimilarity(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
-        {
-            if (x.IsEmpty)
-            {
-                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
-            }
-
-            if (x.Length != y.Length)
-            {
-                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
-            }
-
-            return CosineSimilarityCore(x, y);
-        }
+        public static float CosineSimilarity(ReadOnlySpan<float> x, ReadOnlySpan<float> y) =>
+            CosineSimilarityCore(x, y);
 
         /// <summary>Computes the distance between two points, specified as non-empty, equal-length tensors of single-precision floating-point numbers, in Euclidean space.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -314,15 +302,8 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static int IndexOfMax(ReadOnlySpan<float> x)
-        {
-            if (x.IsEmpty)
-            {
-                return -1;
-            }
-
-            return IndexOfMinMaxCore<IndexOfMaxOperator>(x);
-        }
+        public static int IndexOfMax(ReadOnlySpan<float> x) =>
+            IndexOfMinMaxCore<IndexOfMaxOperator>(x);
 
         /// <summary>Searches for the index of the single-precision floating-point number with the largest magnitude in the specified tensor.</summary>
         /// <param name="x">The tensor, represented as a span.</param>
@@ -338,15 +319,8 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static int IndexOfMaxMagnitude(ReadOnlySpan<float> x)
-        {
-            if (x.IsEmpty)
-            {
-                return -1;
-            }
-
-            return IndexOfMinMaxCore<IndexOfMaxMagnitudeOperator>(x);
-        }
+        public static int IndexOfMaxMagnitude(ReadOnlySpan<float> x) =>
+            IndexOfMinMaxCore<IndexOfMaxMagnitudeOperator>(x);
 
         /// <summary>Searches for the index of the smallest single-precision floating-point number in the specified tensor.</summary>
         /// <param name="x">The tensor, represented as a span.</param>
@@ -361,15 +335,8 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static int IndexOfMin(ReadOnlySpan<float> x)
-        {
-            if (x.IsEmpty)
-            {
-                return -1;
-            }
-
-            return IndexOfMinMaxCore<IndexOfMinOperator>(x);
-        }
+        public static int IndexOfMin(ReadOnlySpan<float> x) =>
+            IndexOfMinMaxCore<IndexOfMinOperator>(x);
 
         /// <summary>Searches for the index of the single-precision floating-point number with the smallest magnitude in the specified tensor.</summary>
         /// <param name="x">The tensor, represented as a span.</param>
@@ -385,15 +352,8 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static int IndexOfMinMagnitude(ReadOnlySpan<float> x)
-        {
-            if (x.IsEmpty)
-            {
-                return -1;
-            }
-
-            return IndexOfMinMaxCore<IndexOfMinMagnitudeOperator>(x);
-        }
+        public static int IndexOfMinMagnitude(ReadOnlySpan<float> x) =>
+            IndexOfMinMaxCore<IndexOfMinMagnitudeOperator>(x);
 
         /// <summary>Computes the element-wise natural (base <c>e</c>) logarithm of single-precision floating-point numbers in the specified tensor.</summary>
         /// <param name="x">The tensor, represented as a span.</param>
@@ -455,15 +415,8 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static float Max(ReadOnlySpan<float> x)
-        {
-            if (x.IsEmpty)
-            {
-                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
-            }
-
-            return MinMaxCore<MaxOperator>(x);
-        }
+        public static float Max(ReadOnlySpan<float> x) =>
+            MinMaxCore<MaxOperator>(x);
 
         /// <summary>Computes the element-wise maximum of the single-precision floating-point numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -504,15 +457,8 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static float MaxMagnitude(ReadOnlySpan<float> x)
-        {
-            if (x.IsEmpty)
-            {
-                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
-            }
-
-            return MinMaxCore<MaxMagnitudeOperator>(x);
-        }
+        public static float MaxMagnitude(ReadOnlySpan<float> x) =>
+            MinMaxCore<MaxMagnitudeOperator>(x);
 
         /// <summary>Computes the element-wise single-precision floating-point number with the largest magnitude in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -546,15 +492,8 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static float Min(ReadOnlySpan<float> x)
-        {
-            if (x.IsEmpty)
-            {
-                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
-            }
-
-            return MinMaxCore<MinOperator>(x);
-        }
+        public static float Min(ReadOnlySpan<float> x) =>
+            MinMaxCore<MinOperator>(x);
 
         /// <summary>Computes the element-wise minimum of the single-precision floating-point numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -595,15 +534,8 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static float MinMagnitude(ReadOnlySpan<float> x)
-        {
-            if (x.IsEmpty)
-            {
-                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
-            }
-
-            return MinMaxCore<MinMagnitudeOperator>(x);
-        }
+        public static float MinMagnitude(ReadOnlySpan<float> x) =>
+            MinMaxCore<MinMagnitudeOperator>(x);
 
         /// <summary>Computes the element-wise single-precision floating-point number with the smallest magnitude in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.cs
@@ -455,8 +455,15 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static float Max(ReadOnlySpan<float> x) =>
-            MinMaxCore<MaxOperator>(x);
+        public static float Max(ReadOnlySpan<float> x)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            return MinMaxCore<MaxOperator>(x);
+        }
 
         /// <summary>Computes the element-wise maximum of the single-precision floating-point numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -497,8 +504,15 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static float MaxMagnitude(ReadOnlySpan<float> x) =>
-            MinMaxCore<MaxMagnitudeOperator>(x);
+        public static float MaxMagnitude(ReadOnlySpan<float> x)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            return MinMaxCore<MaxMagnitudeOperator>(x);
+        }
 
         /// <summary>Computes the element-wise single-precision floating-point number with the largest magnitude in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -532,8 +546,15 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static float Min(ReadOnlySpan<float> x) =>
-            MinMaxCore<MinOperator>(x);
+        public static float Min(ReadOnlySpan<float> x)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            return MinMaxCore<MinOperator>(x);
+        }
 
         /// <summary>Computes the element-wise minimum of the single-precision floating-point numbers in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>
@@ -574,8 +595,15 @@ namespace System.Numerics.Tensors
         /// operating systems or architectures.
         /// </para>
         /// </remarks>
-        public static float MinMagnitude(ReadOnlySpan<float> x) =>
-            MinMaxCore<MinMagnitudeOperator>(x);
+        public static float MinMagnitude(ReadOnlySpan<float> x)
+        {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            return MinMaxCore<MinMagnitudeOperator>(x);
+        }
 
         /// <summary>Computes the element-wise single-precision floating-point number with the smallest magnitude in the specified tensors.</summary>
         /// <param name="x">The first tensor, represented as a span.</param>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
@@ -2513,8 +2513,8 @@ namespace System.Numerics.Tensors
                 Vector512<float> result = Vector512.LoadUnsafe(ref xRef, 0);
                 Vector512<float> current;
 
-                Vector512<float> nanMask = Vector512.Equals(result, result);
-                if (nanMask != Vector512<float>.AllBitsSet)
+                Vector512<float> nanMask = ~Vector512.Equals(result, result);
+                if (nanMask != Vector512<float>.Zero)
                 {
                     return result.GetElement(IndexOfFirstMatch(nanMask));
                 }
@@ -2528,8 +2528,8 @@ namespace System.Numerics.Tensors
                     // Load the next vector, and early exit on NaN.
                     current = Vector512.LoadUnsafe(ref xRef, (uint)i);
 
-                    nanMask = Vector512.Equals(current, current);
-                    if (nanMask != Vector512<float>.AllBitsSet)
+                    nanMask = ~Vector512.Equals(current, current);
+                    if (nanMask != Vector512<float>.Zero)
                     {
                         return current.GetElement(i + IndexOfFirstMatch(nanMask));
                     }
@@ -2543,8 +2543,8 @@ namespace System.Numerics.Tensors
                 {
                     current = Vector512.LoadUnsafe(ref xRef, (uint)(x.Length - Vector512<float>.Count));
 
-                    nanMask = Vector512.Equals(current, current);
-                    if (nanMask != Vector512<float>.AllBitsSet)
+                    nanMask = ~Vector512.Equals(current, current);
+                    if (nanMask != Vector512<float>.Zero)
                     {
                         return current.GetElement(IndexOfFirstMatch(nanMask));
                     }
@@ -2570,8 +2570,8 @@ namespace System.Numerics.Tensors
                 Vector256<float> result = Vector256.LoadUnsafe(ref xRef, 0);
                 Vector256<float> current;
 
-                Vector256<float> nanMask = Vector256.Equals(result, result);
-                if (nanMask != Vector256<float>.AllBitsSet)
+                Vector256<float> nanMask = ~Vector256.Equals(result, result);
+                if (nanMask != Vector256<float>.Zero)
                 {
                     return result.GetElement(IndexOfFirstMatch(nanMask));
                 }
@@ -2585,8 +2585,8 @@ namespace System.Numerics.Tensors
                     // Load the next vector, and early exit on NaN.
                     current = Vector256.LoadUnsafe(ref xRef, (uint)i);
 
-                    nanMask = Vector256.Equals(current, current);
-                    if (nanMask != Vector256<float>.AllBitsSet)
+                    nanMask = ~Vector256.Equals(current, current);
+                    if (nanMask != Vector256<float>.Zero)
                     {
                         return current.GetElement(i + IndexOfFirstMatch(nanMask));
                     }
@@ -2600,8 +2600,8 @@ namespace System.Numerics.Tensors
                 {
                     current = Vector256.LoadUnsafe(ref xRef, (uint)(x.Length - Vector256<float>.Count));
 
-                    nanMask = Vector256.Equals(current, current);
-                    if (nanMask != Vector256<float>.AllBitsSet)
+                    nanMask = ~Vector256.Equals(current, current);
+                    if (nanMask != Vector256<float>.Zero)
                     {
                         return current.GetElement(IndexOfFirstMatch(nanMask));
                     }
@@ -2626,8 +2626,8 @@ namespace System.Numerics.Tensors
                 Vector128<float> result = Vector128.LoadUnsafe(ref xRef, 0);
                 Vector128<float> current;
 
-                Vector128<float> nanMask = Vector128.Equals(result, result);
-                if (nanMask != Vector128<float>.AllBitsSet)
+                Vector128<float> nanMask = ~Vector128.Equals(result, result);
+                if (nanMask != Vector128<float>.Zero)
                 {
                     return result.GetElement(IndexOfFirstMatch(nanMask));
                 }
@@ -2641,8 +2641,8 @@ namespace System.Numerics.Tensors
                     // Load the next vector, and early exit on NaN.
                     current = Vector128.LoadUnsafe(ref xRef, (uint)i);
 
-                    nanMask = Vector128.Equals(current, current);
-                    if (nanMask != Vector128<float>.AllBitsSet)
+                    nanMask = ~Vector128.Equals(current, current);
+                    if (nanMask != Vector128<float>.Zero)
                     {
                         return current.GetElement(i + IndexOfFirstMatch(nanMask));
                     }
@@ -2656,8 +2656,8 @@ namespace System.Numerics.Tensors
                 {
                     current = Vector128.LoadUnsafe(ref xRef, (uint)(x.Length - Vector128<float>.Count));
 
-                    nanMask = Vector128.Equals(current, current);
-                    if (nanMask != Vector128<float>.AllBitsSet)
+                    nanMask = ~Vector128.Equals(current, current);
+                    if (nanMask != Vector128<float>.Zero)
                     {
                         return current.GetElement(IndexOfFirstMatch(nanMask));
                     }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
@@ -2498,11 +2498,6 @@ namespace System.Numerics.Tensors
         private static float MinMaxCore<TMinMaxOperator>(ReadOnlySpan<float> x)
             where TMinMaxOperator : struct, IAggregationOperator
         {
-            if (x.IsEmpty)
-            {
-                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
-            }
-
             // This matches the IEEE 754:2019 `maximum`/`minimum` functions.
             // It propagates NaN inputs back to the caller and
             // otherwise returns the greater of the inputs.
@@ -2512,12 +2507,16 @@ namespace System.Numerics.Tensors
             if (Vector512.IsHardwareAccelerated && x.Length >= Vector512<float>.Count)
             {
                 ref float xRef = ref MemoryMarshal.GetReference(x);
+
                 // Load the first vector as the initial set of results, and bail immediately
                 // to scalar handling if it contains any NaNs (which don't compare equally to themselves).
-                Vector512<float> result = Vector512.LoadUnsafe(ref xRef, 0), current;
-                if (!Vector512.EqualsAll(result, result))
+                Vector512<float> result = Vector512.LoadUnsafe(ref xRef, 0);
+                Vector512<float> current;
+
+                Vector512<float> nanMask = Vector512.Equals(result, result);
+                if (nanMask != Vector512<float>.AllBitsSet)
                 {
-                    return GetFirstNaN(result);
+                    return result.GetElement(IndexOfFirstMatch(nanMask));
                 }
 
                 int oneVectorFromEnd = x.Length - Vector512<float>.Count;
@@ -2528,9 +2527,11 @@ namespace System.Numerics.Tensors
                 {
                     // Load the next vector, and early exit on NaN.
                     current = Vector512.LoadUnsafe(ref xRef, (uint)i);
-                    if (!Vector512.EqualsAll(current, current))
+
+                    nanMask = Vector512.Equals(current, current);
+                    if (nanMask != Vector512<float>.AllBitsSet)
                     {
-                        return GetFirstNaN(current);
+                        return current.GetElement(i + IndexOfFirstMatch(nanMask));
                     }
 
                     result = TMinMaxOperator.Invoke(result, current);
@@ -2541,15 +2542,18 @@ namespace System.Numerics.Tensors
                 if (i != x.Length)
                 {
                     current = Vector512.LoadUnsafe(ref xRef, (uint)(x.Length - Vector512<float>.Count));
-                    if (!Vector512.EqualsAll(current, current))
+
+                    nanMask = Vector512.Equals(current, current);
+                    if (nanMask != Vector512<float>.AllBitsSet)
                     {
-                        return GetFirstNaN(current);
+                        return current.GetElement(IndexOfFirstMatch(nanMask));
                     }
 
-                    result = Vector512.ConditionalSelect(
-                        Vector512.Equals(CreateRemainderMaskSingleVector512(x.Length - i), Vector512<float>.Zero),
+                    result = ElementWiseSelect(
+                        CreateRemainderMaskSingleVector512(x.Length - i),
                         result,
-                        TMinMaxOperator.Invoke(result, current));
+                        TMinMaxOperator.Invoke(result, current)
+                    );
                 }
 
                 // Aggregate the lanes in the vector to create the final scalar result.
@@ -2563,10 +2567,13 @@ namespace System.Numerics.Tensors
 
                 // Load the first vector as the initial set of results, and bail immediately
                 // to scalar handling if it contains any NaNs (which don't compare equally to themselves).
-                Vector256<float> result = Vector256.LoadUnsafe(ref xRef, 0), current;
-                if (!Vector256.EqualsAll(result, result))
+                Vector256<float> result = Vector256.LoadUnsafe(ref xRef, 0);
+                Vector256<float> current;
+
+                Vector256<float> nanMask = Vector256.Equals(result, result);
+                if (nanMask != Vector256<float>.AllBitsSet)
                 {
-                    return GetFirstNaN(result);
+                    return result.GetElement(IndexOfFirstMatch(nanMask));
                 }
 
                 int oneVectorFromEnd = x.Length - Vector256<float>.Count;
@@ -2577,9 +2584,11 @@ namespace System.Numerics.Tensors
                 {
                     // Load the next vector, and early exit on NaN.
                     current = Vector256.LoadUnsafe(ref xRef, (uint)i);
-                    if (!Vector256.EqualsAll(current, current))
+
+                    nanMask = Vector256.Equals(current, current);
+                    if (nanMask != Vector256<float>.AllBitsSet)
                     {
-                        return GetFirstNaN(current);
+                        return current.GetElement(i + IndexOfFirstMatch(nanMask));
                     }
 
                     result = TMinMaxOperator.Invoke(result, current);
@@ -2590,15 +2599,18 @@ namespace System.Numerics.Tensors
                 if (i != x.Length)
                 {
                     current = Vector256.LoadUnsafe(ref xRef, (uint)(x.Length - Vector256<float>.Count));
-                    if (!Vector256.EqualsAll(current, current))
+
+                    nanMask = Vector256.Equals(current, current);
+                    if (nanMask != Vector256<float>.AllBitsSet)
                     {
-                        return GetFirstNaN(current);
+                        return current.GetElement(IndexOfFirstMatch(nanMask));
                     }
 
-                    result = Vector256.ConditionalSelect(
-                        Vector256.Equals(CreateRemainderMaskSingleVector256(x.Length - i), Vector256<float>.Zero),
+                    result = ElementWiseSelect(
+                        CreateRemainderMaskSingleVector256(x.Length - i),
                         result,
-                        TMinMaxOperator.Invoke(result, current));
+                        TMinMaxOperator.Invoke(result, current)
+                    );
                 }
 
                 // Aggregate the lanes in the vector to create the final scalar result.
@@ -2611,10 +2623,13 @@ namespace System.Numerics.Tensors
 
                 // Load the first vector as the initial set of results, and bail immediately
                 // to scalar handling if it contains any NaNs (which don't compare equally to themselves).
-                Vector128<float> result = Vector128.LoadUnsafe(ref xRef, 0), current;
-                if (!Vector128.EqualsAll(result, result))
+                Vector128<float> result = Vector128.LoadUnsafe(ref xRef, 0);
+                Vector128<float> current;
+
+                Vector128<float> nanMask = Vector128.Equals(result, result);
+                if (nanMask != Vector128<float>.AllBitsSet)
                 {
-                    return GetFirstNaN(result);
+                    return result.GetElement(IndexOfFirstMatch(nanMask));
                 }
 
                 int oneVectorFromEnd = x.Length - Vector128<float>.Count;
@@ -2625,9 +2640,11 @@ namespace System.Numerics.Tensors
                 {
                     // Load the next vector, and early exit on NaN.
                     current = Vector128.LoadUnsafe(ref xRef, (uint)i);
-                    if (!Vector128.EqualsAll(current, current))
+
+                    nanMask = Vector128.Equals(current, current);
+                    if (nanMask != Vector128<float>.AllBitsSet)
                     {
-                        return GetFirstNaN(current);
+                        return current.GetElement(i + IndexOfFirstMatch(nanMask));
                     }
 
                     result = TMinMaxOperator.Invoke(result, current);
@@ -2638,15 +2655,18 @@ namespace System.Numerics.Tensors
                 if (i != x.Length)
                 {
                     current = Vector128.LoadUnsafe(ref xRef, (uint)(x.Length - Vector128<float>.Count));
-                    if (!Vector128.EqualsAll(current, current))
+
+                    nanMask = Vector128.Equals(current, current);
+                    if (nanMask != Vector128<float>.AllBitsSet)
                     {
-                        return GetFirstNaN(current);
+                        return current.GetElement(IndexOfFirstMatch(nanMask));
                     }
 
-                    result = Vector128.ConditionalSelect(
-                        Vector128.Equals(CreateRemainderMaskSingleVector128(x.Length - i), Vector128<float>.Zero),
+                    result = ElementWiseSelect(
+                        CreateRemainderMaskSingleVector128(x.Length - i),
                         result,
-                        TMinMaxOperator.Invoke(result, current));
+                        TMinMaxOperator.Invoke(result, current)
+                    );
                 }
 
                 // Aggregate the lanes in the vector to create the final scalar result.
@@ -2654,26 +2674,24 @@ namespace System.Numerics.Tensors
             }
 
             // Scalar path used when either vectorization is not supported or the input is too small to vectorize.
+            float curResult = x[0];
+            if (float.IsNaN(curResult))
             {
-                float result = x[0];
-                if (float.IsNaN(result))
-                {
-                    return result;
-                }
-
-                for (int i = 1; i < x.Length; i++)
-                {
-                    float current = x[i];
-                    if (float.IsNaN(current))
-                    {
-                        return current;
-                    }
-
-                    result = TMinMaxOperator.Invoke(result, current);
-                }
-
-                return result;
+                return curResult;
             }
+
+            for (int i = 1; i < x.Length; i++)
+            {
+                float current = x[i];
+                if (float.IsNaN(current))
+                {
+                    return current;
+                }
+
+                curResult = TMinMaxOperator.Invoke(curResult, current);
+            }
+
+            return curResult;
         }
 
         private static int IndexOfMinMaxCore<TIndexOfMinMax>(ReadOnlySpan<float> x) where TIndexOfMinMax : struct, IIndexOfOperator
@@ -9324,56 +9342,6 @@ namespace System.Numerics.Tensors
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector512<float> IsPositive(Vector512<float> vector) =>
             Vector512.GreaterThan(vector.AsInt32(), Vector512<int>.AllBitsSet).AsSingle();
-#endif
-
-        /// <summary>Finds and returns the first NaN value in <paramref name="vector"/>.</summary>
-        /// <remarks>The vector must have already been validated to contain a NaN.</remarks>
-        private static float GetFirstNaN(Vector128<float> vector)
-        {
-            Debug.Assert(!Vector128.EqualsAll(vector, vector), "Expected vector to contain a NaN");
-            return vector.GetElement(BitOperations.TrailingZeroCount((~Vector128.Equals(vector, vector)).ExtractMostSignificantBits()));
-        }
-
-        /// <summary>Finds and returns the first NaN index value in <paramref name="vector"/>.</summary>
-        /// <remarks>The vector must have already been validated to contain a NaN.</remarks>
-        private static int GetFirstNaNIndex(Vector128<float> vector, Vector128<int> index)
-        {
-            Debug.Assert(!Vector128.EqualsAll(vector, vector), "Expected vector to contain a NaN");
-            return index.GetElement(BitOperations.TrailingZeroCount((~Vector128.Equals(vector, vector)).ExtractMostSignificantBits()));
-        }
-
-        /// <summary>Finds and returns the first NaN value in <paramref name="vector"/>.</summary>
-        /// <remarks>The vector must have already been validated to contain a NaN.</remarks>
-        private static float GetFirstNaN(Vector256<float> vector)
-        {
-            Debug.Assert(!Vector256.EqualsAll(vector, vector), "Expected vector to contain a NaN");
-            return vector.GetElement(BitOperations.TrailingZeroCount((~Vector256.Equals(vector, vector)).ExtractMostSignificantBits()));
-        }
-
-        /// <summary>Finds and returns the first NaN index value in <paramref name="vector"/>.</summary>
-        /// <remarks>The vector must have already been validated to contain a NaN.</remarks>
-        private static int GetFirstNaNIndex(Vector256<float> vector, Vector256<int> index)
-        {
-            Debug.Assert(!Vector256.EqualsAll(vector, vector), "Expected vector to contain a NaN");
-            return index.GetElement(BitOperations.TrailingZeroCount((~Vector256.Equals(vector, vector)).ExtractMostSignificantBits()));
-        }
-
-#if NET8_0_OR_GREATER
-        /// <summary>Finds and returns the first NaN value in <paramref name="vector"/>.</summary>
-        /// <remarks>The vector must have already been validated to contain a NaN.</remarks>
-        private static float GetFirstNaN(Vector512<float> vector)
-        {
-            Debug.Assert(!Vector512.EqualsAll(vector, vector), "Expected vector to contain a NaN");
-            return vector.GetElement(BitOperations.TrailingZeroCount((~Vector512.Equals(vector, vector)).ExtractMostSignificantBits()));
-        }
-
-        /// <summary>Finds and returns the first NaN value in <paramref name="vector"/>.</summary>
-        /// <remarks>The vector must have already been validated to contain a NaN.</remarks>
-        private static int GetFirstNaNIndex(Vector512<float> vector, Vector512<int> index)
-        {
-            Debug.Assert(!Vector512.EqualsAll(vector, vector), "Expected vector to contain a NaN");
-            return index.GetElement(BitOperations.TrailingZeroCount((~Vector512.Equals(vector, vector)).ExtractMostSignificantBits()));
-        }
 #endif
 
         /// <summary>Gets the base 2 logarithm of <paramref name="x"/>.</summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
@@ -625,6 +625,16 @@ namespace System.Numerics.Tensors
         /// <remarks>Assumes arguments have already been validated to be non-empty and equal length.</remarks>
         private static float CosineSimilarityCore(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
         {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            if (x.Length != y.Length)
+            {
+                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+            }
+
             // Compute the same as:
             // TensorPrimitives.Dot(x, y) / (Math.Sqrt(TensorPrimitives.SumOfSquares(x)) * Math.Sqrt(TensorPrimitives.SumOfSquares(y)))
             // but only looping over each span once.
@@ -2498,6 +2508,11 @@ namespace System.Numerics.Tensors
         private static float MinMaxCore<TMinMaxOperator>(ReadOnlySpan<float> x)
             where TMinMaxOperator : struct, IAggregationOperator
         {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
             // This matches the IEEE 754:2019 `maximum`/`minimum` functions.
             // It propagates NaN inputs back to the caller and
             // otherwise returns the greater of the inputs.
@@ -2696,6 +2711,11 @@ namespace System.Numerics.Tensors
 
         private static int IndexOfMinMaxCore<TIndexOfMinMax>(ReadOnlySpan<float> x) where TIndexOfMinMax : struct, IIndexOfOperator
         {
+            if (x.IsEmpty)
+            {
+                return -1;
+            }
+
             // This matches the IEEE 754:2019 `maximum`/`minimum` functions.
             // It propagates NaN inputs back to the caller and
             // otherwise returns the index of the greater of the inputs.

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netcore.cs
@@ -2546,7 +2546,7 @@ namespace System.Numerics.Tensors
                     nanMask = ~Vector512.Equals(current, current);
                     if (nanMask != Vector512<float>.Zero)
                     {
-                        return current.GetElement(i + IndexOfFirstMatch(nanMask));
+                        return current.GetElement(IndexOfFirstMatch(nanMask));
                     }
 
                     result = TMinMaxOperator.Invoke(result, current);
@@ -2564,11 +2564,7 @@ namespace System.Numerics.Tensors
                         return current.GetElement(IndexOfFirstMatch(nanMask));
                     }
 
-                    result = ElementWiseSelect(
-                        CreateRemainderMaskSingleVector512(x.Length - i),
-                        result,
-                        TMinMaxOperator.Invoke(result, current)
-                    );
+                    result = TMinMaxOperator.Invoke(result, current);
                 }
 
                 // Aggregate the lanes in the vector to create the final scalar result.
@@ -2603,7 +2599,7 @@ namespace System.Numerics.Tensors
                     nanMask = ~Vector256.Equals(current, current);
                     if (nanMask != Vector256<float>.Zero)
                     {
-                        return current.GetElement(i + IndexOfFirstMatch(nanMask));
+                        return current.GetElement(IndexOfFirstMatch(nanMask));
                     }
 
                     result = TMinMaxOperator.Invoke(result, current);
@@ -2621,11 +2617,7 @@ namespace System.Numerics.Tensors
                         return current.GetElement(IndexOfFirstMatch(nanMask));
                     }
 
-                    result = ElementWiseSelect(
-                        CreateRemainderMaskSingleVector256(x.Length - i),
-                        result,
-                        TMinMaxOperator.Invoke(result, current)
-                    );
+                    result = TMinMaxOperator.Invoke(result, current);
                 }
 
                 // Aggregate the lanes in the vector to create the final scalar result.
@@ -2659,7 +2651,7 @@ namespace System.Numerics.Tensors
                     nanMask = ~Vector128.Equals(current, current);
                     if (nanMask != Vector128<float>.Zero)
                     {
-                        return current.GetElement(i + IndexOfFirstMatch(nanMask));
+                        return current.GetElement(IndexOfFirstMatch(nanMask));
                     }
 
                     result = TMinMaxOperator.Invoke(result, current);
@@ -2677,11 +2669,7 @@ namespace System.Numerics.Tensors
                         return current.GetElement(IndexOfFirstMatch(nanMask));
                     }
 
-                    result = ElementWiseSelect(
-                        CreateRemainderMaskSingleVector128(x.Length - i),
-                        result,
-                        TMinMaxOperator.Invoke(result, current)
-                    );
+                    result = TMinMaxOperator.Invoke(result, current);
                 }
 
                 // Aggregate the lanes in the vector to create the final scalar result.

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netstandard.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netstandard.cs
@@ -717,11 +717,6 @@ namespace System.Numerics.Tensors
         private static float MinMaxCore<TMinMaxOperator>(ReadOnlySpan<float> x, TMinMaxOperator op = default)
             where TMinMaxOperator : struct, IBinaryOperator
         {
-            if (x.IsEmpty)
-            {
-                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
-            }
-
             // This matches the IEEE 754:2019 `maximum`/`minimum` functions.
             // It propagates NaN inputs back to the caller and
             // otherwise returns the greater of the inputs.

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netstandard.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.netstandard.cs
@@ -13,6 +13,16 @@ namespace System.Numerics.Tensors
         /// <remarks>Assumes arguments have already been validated to be non-empty and equal length.</remarks>
         private static float CosineSimilarityCore(ReadOnlySpan<float> x, ReadOnlySpan<float> y)
         {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
+            if (x.Length != y.Length)
+            {
+                ThrowHelper.ThrowArgument_SpansMustHaveSameLength();
+            }
+
             // Compute the same as:
             // TensorPrimitives.Dot(x, y) / (Math.Sqrt(TensorPrimitives.SumOfSquares(x)) * Math.Sqrt(TensorPrimitives.SumOfSquares(y)))
             // but only looping over each span once.
@@ -717,6 +727,11 @@ namespace System.Numerics.Tensors
         private static float MinMaxCore<TMinMaxOperator>(ReadOnlySpan<float> x, TMinMaxOperator op = default)
             where TMinMaxOperator : struct, IBinaryOperator
         {
+            if (x.IsEmpty)
+            {
+                ThrowHelper.ThrowArgument_SpansMustBeNonEmpty();
+            }
+
             // This matches the IEEE 754:2019 `maximum`/`minimum` functions.
             // It propagates NaN inputs back to the caller and
             // otherwise returns the greater of the inputs.
@@ -796,6 +811,11 @@ namespace System.Numerics.Tensors
         private static int IndexOfMinMaxCore<TIndexOfMinMaxOperator>(ReadOnlySpan<float> x, TIndexOfMinMaxOperator op = default)
             where TIndexOfMinMaxOperator : struct, IIndexOfOperator
         {
+            if (x.IsEmpty)
+            {
+                return -1;
+            }
+
             // This matches the IEEE 754:2019 `maximum`/`minimum` functions.
             // It propagates NaN inputs back to the caller and
             // otherwise returns the index of the greater of the inputs.


### PR DESCRIPTION
This resolves a performance issue caused by `GetFirstNaN` and it not being inlined. The perf is now on par or better than `IndexOfMax`, as expected.

| Method            | TensorLength | Mean          | Error       | StdDev      | Median        |
|------------------ |------------- |--------------:|------------:|------------:|--------------:|
| Max (main)        | 1            |      2.478 ns |   0.0672 ns |   0.0800 ns |      2.416 ns |
| Max (pr)          | 1            |      1.636 ns |   0.0199 ns |   0.0166 ns |      1.638 ns |
| Max (main)        | 2            |      2.994 ns |   0.0353 ns |   0.0330 ns |      2.986 ns |
| Max (pr)          | 2            |      2.203 ns |   0.0472 ns |   0.0442 ns |      2.196 ns |
| Max (main)        | 3            |      3.524 ns |   0.0446 ns |   0.0417 ns |      3.513 ns |
| Max (pr)          | 3            |      2.576 ns |   0.0526 ns |   0.0492 ns |      2.538 ns |
| Max (main)        | 4            |      3.451 ns |   0.0579 ns |   0.0541 ns |      3.451 ns |
| Max (pr)          | 4            |      2.220 ns |   0.0547 ns |   0.0512 ns |      2.208 ns |
| Max (main)        | 5            |      5.034 ns |   0.0723 ns |   0.0676 ns |      4.989 ns |
| Max (pr)          | 5            |      2.940 ns |   0.0521 ns |   0.0487 ns |      2.921 ns |
| Max (main)        | 6            |      5.069 ns |   0.0896 ns |   0.0795 ns |      5.066 ns |
| Max (pr)          | 6            |      2.962 ns |   0.0544 ns |   0.0509 ns |      2.959 ns |
| Max (main)        | 7            |      5.122 ns |   0.0851 ns |   0.0754 ns |      5.134 ns |
| Max (pr)          | 7            |      2.929 ns |   0.0278 ns |   0.0232 ns |      2.931 ns |
| Max (main)        | 8            |      4.162 ns |   0.0568 ns |   0.0532 ns |      4.164 ns |
| Max (pr)          | 8            |      2.386 ns |   0.0546 ns |   0.0511 ns |      2.372 ns |
| Max (main)        | 9            |      6.131 ns |   0.0758 ns |   0.0709 ns |      6.135 ns |
| Max (pr)          | 9            |      3.166 ns |   0.0697 ns |   0.0652 ns |      3.150 ns |
| Max (main)        | 10           |      6.098 ns |   0.0670 ns |   0.0626 ns |      6.093 ns |
| Max (pr)          | 10           |      3.165 ns |   0.0499 ns |   0.0467 ns |      3.179 ns |
| Max (main)        | 11           |      5.720 ns |   0.0635 ns |   0.0594 ns |      5.690 ns |
| Max (pr)          | 11           |      3.104 ns |   0.0320 ns |   0.0284 ns |      3.087 ns |
| Max (main)        | 12           |      5.692 ns |   0.0633 ns |   0.0592 ns |      5.687 ns |
| Max (pr)          | 12           |      3.147 ns |   0.0698 ns |   0.0653 ns |      3.147 ns |
| Max (main)        | 13           |      5.643 ns |   0.0249 ns |   0.0194 ns |      5.639 ns |
| Max (pr)          | 13           |      3.171 ns |   0.0798 ns |   0.0747 ns |      3.144 ns |
| Max (main)        | 14           |      5.694 ns |   0.0933 ns |   0.0827 ns |      5.672 ns |
| Max (pr)          | 14           |      3.111 ns |   0.0465 ns |   0.0412 ns |      3.085 ns |
| Max (main)        | 15           |      6.223 ns |   0.0762 ns |   0.0713 ns |      6.232 ns |
| Max (pr)          | 15           |      3.102 ns |   0.0401 ns |   0.0355 ns |      3.085 ns |
| Max (main)        | 16           |      4.541 ns |   0.0671 ns |   0.0627 ns |      4.553 ns |
| Max (pr)          | 16           |      2.584 ns |   0.0625 ns |   0.0584 ns |      2.579 ns |
| Max (main)        | 32           |      7.656 ns |   0.1455 ns |   0.1361 ns |      7.682 ns |
| Max (pr)          | 32           |      3.725 ns |   0.0708 ns |   0.0662 ns |      3.730 ns |
| Max (main)        | 64           |     39.188 ns |   0.4249 ns |   0.3975 ns |     38.957 ns |
| Max (pr)          | 64           |      7.028 ns |   0.1278 ns |   0.1196 ns |      6.992 ns |
| Max (main)        | 128          |     26.486 ns |   0.4680 ns |   0.4378 ns |     26.348 ns |
| Max (pr)          | 128          |     15.763 ns |   0.2658 ns |   0.2486 ns |     15.842 ns |
| Max (main)        | 256          |    131.064 ns |   1.6986 ns |   1.5889 ns |    130.746 ns |
| Max (pr)          | 256          |     31.814 ns |   0.5802 ns |   0.5427 ns |     31.491 ns |
| Max (main)        | 512          |    261.370 ns |   3.2722 ns |   3.0608 ns |    261.329 ns |
| Max (pr)          | 512          |     71.107 ns |   1.3994 ns |   1.3090 ns |     70.427 ns |
| Max (main)        | 1024         |    510.065 ns |   5.4908 ns |   5.1361 ns |    509.669 ns |
| Max (pr)          | 1024         |    150.685 ns |   2.8876 ns |   3.2096 ns |    148.938 ns |
| Max (main)        | 2048         |    993.753 ns |  11.4559 ns |  10.7159 ns |    992.964 ns |
| Max (pr)          | 2048         |    304.270 ns |   5.4914 ns |   5.1366 ns |    300.003 ns |
| Max (main)        | 4096         |  1,118.725 ns |   6.5303 ns |   5.4531 ns |  1,117.834 ns |
| Max (pr)          | 4096         |    607.103 ns |  11.9408 ns |  11.1694 ns |    600.681 ns |
| Max (main)        | 65536        | 31,133.123 ns | 452.4921 ns | 423.2614 ns | 31,015.117 ns |
| Max (pr)          | 65536        |  9,775.156 ns | 170.3118 ns | 159.3097 ns |  9,666.399 ns |
| Max (main)        | 131072       | 62,373.737 ns | 934.9628 ns | 874.5648 ns | 62,199.103 ns |
| Max (pr)          | 131072       | 19,485.664 ns | 372.0646 ns | 382.0830 ns | 19,188.719 ns |
