### PR TITLE
Add support for UnsafeAccessorKind.FieldOffset (#45152)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/UnsafeAccessorAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/UnsafeAccessorAttribute.cs
@@ -31,7 +31,12 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Provide access to a static field.
         /// </summary>
-        StaticField
+        StaticField,
+
+        /// <summary>
+        /// Provide access to the offset of an instance field.
+        /// </summary>
+        FieldOffset
     };
 
     /// <summary>

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13304,7 +13304,8 @@ namespace System.Runtime.CompilerServices
         Method,
         StaticMethod,
         Field,
-        StaticField
+        StaticField,
+        FieldOffset
     };
     [System.AttributeUsageAttribute(System.AttributeTargets.Struct)]
     public sealed partial class UnsafeValueTypeAttribute : System.Attribute

--- a/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.cs
+++ b/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.cs
@@ -18,6 +18,7 @@ static unsafe class UnsafeAccessorsTests
     {
         public const string StaticFieldName = nameof(_F);
         public const string FieldName = nameof(_f);
+        public const string FieldSecondName = nameof(_i);
         public const string StaticMethodName = nameof(_M);
         public const string MethodName = nameof(_m);
         public const string StaticMethodVoidName = nameof(_MVV);
@@ -30,6 +31,7 @@ static unsafe class UnsafeAccessorsTests
 
         private static string _F = PrivateStatic;
         private string _f;
+        private int _i;
 
         public string Value => _f;
 
@@ -213,6 +215,18 @@ static unsafe class UnsafeAccessorsTests
 
         [UnsafeAccessor(UnsafeAccessorKind.Field, Name=UserDataClass.FieldName)]
         extern static ref string GetPrivateField(UserDataClass d);
+    }
+
+    [Fact]
+    public static void Verify_AccessFieldOffsetClass()
+    {
+        Console.WriteLine($"Running {nameof(Verify_AccessFieldOffsetClass)}");
+
+        // Offset = method table pointer + first string pointer
+        Assert.Equal(IntPtr.Size + IntPtr.Size, GetPrivateFieldOffset());
+
+        [UnsafeAccessor(UnsafeAccessorKind.FieldOffset, Name=UserDataClass.FieldSecondName)]
+        extern static nint GetPrivateFieldOffset(UserDataClass? d = null);
     }
 
     [Fact]


### PR DESCRIPTION
Draft PR to add support for `UnsafeAccessorKind.FieldOffset`.

This PR is for now just a proof of concept of the suggestion of implementing field offset computation via `UnsafeAccessorKind.FieldOffset` as suggested [here](https://github.com/dotnet/runtime/issues/45152#issuecomment-1777734470)
