### PR TITLE
Optimize cancellation handling in Hosting

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -75,11 +75,15 @@ namespace Microsoft.Extensions.Hosting
             }
             finally
             {
+#if NET8_0_OR_GREATER
+                await _executeTask.WaitAsync(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+#else
                 // Wait until the task completes or the stop token triggers
                 var tcs = new TaskCompletionSource<object>();
                 using CancellationTokenRegistration registration = cancellationToken.Register(s => ((TaskCompletionSource<object>)s!).SetCanceled(), tcs);
                 // Do not await the _executeTask because cancelling it will throw an OperationCanceledException which we are explicitly ignoring
                 await Task.WhenAny(_executeTask, tcs.Task).ConfigureAwait(false);
+#endif
             }
 
         }

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostExtensions.cs
@@ -97,6 +97,9 @@ namespace Microsoft.Extensions.Hosting
             },
             applicationLifetime);
 
+#if NET8_0_OR_GREATER
+            await Task.Delay(Timeout.Infinite, applicationLifetime.ApplicationStopping).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+#else
             var waitForStop = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
             applicationLifetime.ApplicationStopping.Register(obj =>
             {
@@ -105,6 +108,7 @@ namespace Microsoft.Extensions.Hosting
             }, waitForStop);
 
             await waitForStop.Task.ConfigureAwait(false);
+#endif
 
             // Host will use its default ShutdownTimeout if none is specified.
             // The cancellation token may have been triggered to unblock waitForStop. Don't pass it here because that would trigger an abortive shutdown.

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Extensions.Hosting
         /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
         public static IHostBuilder ConfigureLogging(this IHostBuilder hostBuilder, Action<ILoggingBuilder> configureLogging)
         {
-            return hostBuilder.ConfigureServices((context, collection) => collection.AddLogging(builder => configureLogging(builder)));
+            return hostBuilder.ConfigureServices((context, collection) => collection.AddLogging(configureLogging));
         }
 
         /// <summary>
@@ -406,7 +406,7 @@ namespace Microsoft.Extensions.Hosting
         /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
         public static IHostBuilder ConfigureMetrics(this IHostBuilder hostBuilder, Action<IMetricsBuilder> configureMetrics)
         {
-            return hostBuilder.ConfigureServices((context, collection) => collection.AddMetrics(builder => configureMetrics(builder)));
+            return hostBuilder.ConfigureServices((context, collection) => collection.AddMetrics(configureMetrics));
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ApplicationLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/ApplicationLifetime.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             {
                 try
                 {
-                    ExecuteHandlers(_stoppingSource);
+                    _stoppingSource.Cancel();
                 }
                 catch (Exception ex)
                 {
@@ -81,7 +81,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         {
             try
             {
-                ExecuteHandlers(_startedSource);
+                _startedSource.Cancel();
             }
             catch (Exception ex)
             {
@@ -98,7 +98,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         {
             try
             {
-                ExecuteHandlers(_stoppedSource);
+                _stoppedSource.Cancel();
             }
             catch (Exception ex)
             {
@@ -106,18 +106,6 @@ namespace Microsoft.Extensions.Hosting.Internal
                                          "An error occurred stopping the application",
                                          ex);
             }
-        }
-
-        private static void ExecuteHandlers(CancellationTokenSource cancel)
-        {
-            // Noop if this is already cancelled
-            if (cancel.IsCancellationRequested)
-            {
-                return;
-            }
-
-            // Run the cancellation token callbacks
-            cancel.Cancel(throwOnFirstException: false);
         }
     }
 }


### PR DESCRIPTION
Avoid creating unnecessary `CancellationTokenSource` links and use `ConfigureAwaitOptions.SuppressThrowing` in a few places.