### PR TITLE
[wasm] WBT: fix failing no-trimming test

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/NativeRefTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/NativeRefTests.cs
@@ -75,9 +75,12 @@ public class NativeTests : BlazorWasmTestBase
             <Error Text=""Stopping after AOT"" Condition=""'$(WasmBuildingForNestedPublish)' == 'true'"" />
         </Target>
         ";
+
+        // Use WasmDedup=false because aot-instances.dll for the no-trimming case ends
+        // up oom'ing.
         AddItemsPropertiesToProject(Path.Combine(_projectDir!, $"{id}.csproj"),
                                     extraItems: null,
-                                    extraProperties: null,
+                                    extraProperties: "<WasmDedup>false</WasmDedup>",
                                     atTheEnd: target);
 
         string publishLogPath = Path.Combine(s_buildEnv.LogRootPath, id, $"{id}.binlog");

--- a/src/mono/wasm/Wasm.Build.Tests/NativeBuildTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NativeBuildTests.cs
@@ -50,7 +50,9 @@ namespace Wasm.Build.Tests
 
             string projectName = $"mono_aot_cross_{buildArgs.Config}_{buildArgs.AOT}";
 
-            buildArgs = buildArgs with { ProjectName = projectName, ExtraBuildArgs = "-p:PublishTrimmed=false -v:n" };
+            // Use WasmDedup=false because aot-instances.dll for the no-trimming case ends
+            // up oom'ing.
+            buildArgs = buildArgs with { ProjectName = projectName, ExtraBuildArgs = "-p:PublishTrimmed=false -p:WasmDedup=false" };
             buildArgs = ExpandBuildArgs(buildArgs, extraProperties: "<WasmBuildNative>true</WasmBuildNative>", insertAtEnd: target);
 
             (_, string output) = BuildProject(


### PR DESCRIPTION
The test build gets terminated with:
`Precompiling failed for /root/helix/work/workitem/e/wbt/4hiqh2hp_nji/obj/Release/net8.0/browser-wasm/wasm/for-publish/aot-in/aot-instances.dll with exit code 137`

.. while compiling `aot-instances.dll`, with 190+ assemblies when not
trimming. Since, the particular tests terminate the build after this
step, and don't need the output, use `WasmDedup=false` to avoid using
`aot-instances.dll` at all.

Fixes https://github.com/dotnet/runtime/issues/93522
