### PR TITLE
Move JIT's clang-tidy flags into configuration files and add a root clang-tidy config that disables all checks.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+---
+Checks: '-*' # Disable all checks

--- a/src/coreclr/jit/.clang-tidy
+++ b/src/coreclr/jit/.clang-tidy
@@ -1,0 +1,3 @@
+---
+Checks: '-*,readability-braces*,modernize-use-nullptr'
+HeaderFilterRegex: 'jit/.*'


### PR DESCRIPTION
This helps us track our formatting rules next to the code.