### PR TITLE
Optimize Interlocked.CompareExchange use in Task

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
@@ -66,17 +66,6 @@ namespace System.Threading.Tasks
         // The value itself, if set.
         internal TResult? m_result;
 
-        // Extract rarely used helper for a static method in a separate type so that the Func<Task<Task>, Task<TResult>>
-        // generic instantiations don't contribute to all Task instantiations, but only those where WhenAny is used.
-        internal static class TaskWhenAnyCast
-        {
-            // Delegate used by:
-            //     public static Task<Task<TResult>> WhenAny<TResult>(IEnumerable<Task<TResult>> tasks);
-            //     public static Task<Task<TResult>> WhenAny<TResult>(params Task<TResult>[] tasks);
-            // Used to "cast" from Task<Task> to Task<Task<TResult>>.
-            internal static readonly Func<Task<Task>, Task<TResult>> Value = completed => (Task<TResult>)completed.Result;
-        }
-
         // Construct a promise-style task without any options.
         internal Task()
         {


### PR DESCRIPTION
Always use `Interlocked.CompareExchange` result when possible instead of re-reading the value.
Use `m_stateObject` for storing `WhenAllPromise` failed/canceled tasks.