### PR TITLE
Fix double delims at the end of dirnames in tpa string when using corerun

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.hpp
+++ b/src/coreclr/hosts/corerun/corerun.hpp
@@ -552,9 +552,7 @@ namespace pal
             case DT_LNK:
             case DT_UNKNOWN:
                 {
-                    string_t full_filename;
-                    full_filename.append(directory);
-                    full_filename.append(1, pal::dir_delim);
+                    string_t full_filename{directory};
                     full_filename.append(entry->d_name);
                     if (!does_file_exist(full_filename.c_str()))
                         continue;

--- a/src/coreclr/hosts/corerun/corerun.hpp
+++ b/src/coreclr/hosts/corerun/corerun.hpp
@@ -572,7 +572,7 @@ namespace pal
             // Make sure if we have an assembly with multiple extensions present,
             // we insert only one version of it.
             if (should_add(entry->d_name))
-                file_list << directory << dir_delim << entry->d_name << env_path_delim;
+                file_list << directory << entry->d_name << env_path_delim;
         }
 
         closedir(dir);


### PR DESCRIPTION
### This issue is only on non windows platforms.

### A short story
In `System.Runtime.Extensions.Tests` method `System.Tests.AppDomainTests.GetAssemblies` tested loading an extra assembly to *tpa*. In result new assembly should be loaded minimum twice. So corect *tpa* will be for example:
```bash
# [...]
/runtime/artifacts/tests/corefx/coreroot/System.Net.Http.dll
# [...]
/runtime/artifacts/tests/corefx/coreroot/System.Net.Http.dll
```
but instead we got:
```bash
# [...]
/runtime/artifacts/tests/corefx/coreroot//System.Net.Http.dll
# [...]
/runtime/artifacts/tests/corefx/coreroot/System.Net.Http.dll
```
And technically those are correct paths, but in `System.Tests.AppDomainTests.GetAssemblies` method they are compared as normal strings:
```C#
a.Location == someType.Assembly.Location
```

### Solution explanation
`core_root` and `core_library` are paths, that must be ended with `/`:
```c++
// fragment of corerun.cpp file
assert(dir.back() == pal::dir_delim); // pal::dir_delim = W("/")
string_t tmp = pal::build_file_list(dir, ext, [&](const char_t* file)
```
 but `pal::build_file_list` is also adding `/` after each dirname before It will include filename to stringstream. So skipping one of `/` will solve the problem. 

--------
Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @JongHeonChoi @t-mustafin @gbalykov @clamp03 @tomeksowi @yurai007