### PR TITLE
Arm64: Do not contain LEA if offset or scale is not zero

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5247,7 +5247,7 @@ bool Lowering::TryCreateAddrMode(GenTree* addr, bool isContainable, GenTree* par
         return false;
     }
 
-    if (((scale | offset) > 0) && parent->OperIsHWIntrinsic())
+    if (((scale | offset) != 0) && parent->OperIsHWIntrinsic())
     {
         // For now we only support unscaled indices for SIMD loads
         return false;


### PR DESCRIPTION
Do not mark `LEA` as contained if the `offset < 0`.
Details: https://github.com/dotnet/runtime/issues/93912#issuecomment-1778544956

Fixes: https://github.com/dotnet/runtime/issues/93912
Fixes: https://github.com/dotnet/runtime/issues/93047