### PR TITLE
do not contain `LEA` if offset < 0`

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6176,7 +6176,7 @@ bool Lowering::TryCreateAddrMode(GenTree* addr, bool isContainable, GenTree* par
         return false;
     }
 
-    if (((scale | offset) > 0) && parent->OperIsHWIntrinsic())
+    if (((scale | offset) != 0) && parent->OperIsHWIntrinsic())
     {
         // For now we only support unscaled indices for SIMD loads
         return false;


### PR DESCRIPTION
This PR is needed to backport to `release/7.0-staging`. Once this is merged, I will merge https://github.com/dotnet/runtime/pull/93981 that totally reverts the special handling for LoadVector.

Details: https://github.com/dotnet/runtime/issues/93912#issuecomment-1778544956

Fixes: https://github.com/dotnet/runtime/issues/93912
Fixes: https://github.com/dotnet/runtime/issues/93047