### PR TITLE
remove extra assert from WinHttp handler

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -231,13 +231,12 @@ namespace System.Net.Http
         private static void OnRequestSendingRequest(WinHttpRequestState state)
         {
             Debug.Assert(state != null, "OnRequestSendingRequest: state is null");
-            Debug.Assert(state.RequestHandle != null, "OnRequestSendingRequest: state.RequestHandle is null");
             Debug.Assert(state.RequestMessage != null, "OnRequestSendingRequest: state.RequestMessage is null");
             Debug.Assert(state.RequestMessage.RequestUri != null, "OnRequestSendingRequest: state.RequestMessage.RequestUri is null");
 
-            if (state.RequestMessage.RequestUri.Scheme != UriScheme.Https)
+            if (state.RequestMessage.RequestUri.Scheme != UriScheme.Https || state.RequestHandle == null)
             {
-                // Not SSL/TLS.
+                // Not SSL/TLS or request already gone
                 return;
             }
 


### PR DESCRIPTION
it seems like the callback can be called multiple times - perhaps because of TLS 1.3.
With that, it is called and then it is set to null in `CreateResponseMessage`

https://github.com/dotnet/runtime/blob/9ad24aec018f8dbb4e5d5f67390f595930b5ea18/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs#L67

It seems like this is only problem with `Debug` build. All the methods inside `OnRequestSendingRequest`  can handle `null` `RequestHandle` without crashing. However the processing seems unnecessary so I simply removed the assert and return from the method under this condition. 


This was somewhat easy to reproduce on my Windows VM. After the change all tests are passing e.g. the Assert really seems unnecessary. 

fixes #93099


