### PR TITLE
[SuperPMI] nativeaot collections build fix

### DIFF
--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -561,7 +561,9 @@ def main(main_args):
 
         # Build nativeaot tests
         if coreclr_args.collection_type == "nativeaot":
+            build_file = "build.cmd" if is_windows else "build.sh"
             tests_build_file = "build.cmd" if is_windows else "build.sh"
+            run_command([os.path.join(source_directory, build_file), "Tools.ILLink", "-arch", arch, "-c", coreclr_args.build_type])
             run_command([os.path.join(tests_directory, tests_build_file), "nativeaot", arch, coreclr_args.build_type, "tree", "nativeaot/SmokeTests"], source_directory)
 
         # NOTE: we can't use the build machine ".dotnet" to run on all platforms. E.g., the Windows x86 build uses a


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/93845

`ILLink` need to be built before building the `smoke_tests` because `ILLink` isn't being restored via a NuGet package anymore, see change: https://github.com/dotnet/runtime/pull/91468

Pipeline results:
https://dev.azure.com/dnceng/internal/_build/results?buildId=2302293&view=results