### PR TITLE
[browser][Wasm.Build.Tests] Use trimmer friendly JSON serialization

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -267,6 +267,7 @@ jobs:
       - src/mono/wasi/*
       - src/mono/wasm/debugger/*
       - src/mono/wasm/host/*
+      - src/mono/wasm/testassets/*
       - src/mono/wasm/Wasm.Build.Tests/*
       - ${{ parameters._const_paths._wasm_pipelines }}
       - ${{ parameters._const_paths._always_exclude }}
@@ -286,6 +287,7 @@ jobs:
       - src/mono/mono/component/mini-wasm-debugger.c
       - src/mono/wasm/debugger/*
       - src/mono/wasm/host/*
+      - src/mono/wasm/testassets/*
       - src/mono/wasm/Wasm.Build.Tests/*
       - src/mono/nuget/Microsoft.NET.Runtime*
         src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/*

--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -226,6 +226,7 @@ jobs:
       - src/mono/wasm/host/*
       - src/mono/wasm/runtime/*
       - src/mono/wasm/templates/*
+      - src/mono/wasm/testassets/*
       - src/mono/wasm/Wasm.Build.Tests/*
       - ${{ parameters._const_paths._wasm_chrome }}
       - ${{ parameters._const_paths._wasm_src_native }}

--- a/src/mono/wasm/testassets/WasmBasicTestApp/LazyLoadingTest.cs
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/LazyLoadingTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Runtime.InteropServices.JavaScript;
 
 public partial class LazyLoadingTest
@@ -12,9 +13,14 @@ public partial class LazyLoadingTest
     {
         // System.Text.Json is marked as lazy loaded in the csproj ("BlazorWebAssemblyLazyLoad"), this method can be called only after the assembly is lazy loaded
         // In the test case it is done in the JS before call to this method
-        var text = JsonSerializer.Serialize(new Person("John", "Doe"));
+        var text = JsonSerializer.Serialize(new Person("John", "Doe"), PersonJsonSerializerContext.Default.Person);
         TestOutput.WriteLine(text);
     }
 
     public record Person(string FirstName, string LastName);
+
+    [JsonSerializable(typeof(Person))]
+    internal partial class PersonJsonSerializerContext : JsonSerializerContext
+    {
+    }
 }

--- a/src/mono/wasm/testassets/WasmBasicTestApp/WasmBasicTestApp.csproj
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/WasmBasicTestApp.csproj
@@ -4,7 +4,6 @@
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Use `JsonSerializer.Serialize` overload with `JsonSerializerContext`
- Remove `SuppressTrimAnalysisWarnings=true` from test project