### PR TITLE
Added the LOHThreshold public key to the GC Config.

### DIFF
--- a/src/coreclr/gc/gcconfig.h
+++ b/src/coreclr/gc/gcconfig.h
@@ -138,7 +138,7 @@ public:
     INT_CONFIG   (GCConserveMem,             "GCConserveMemory",          "System.GC.ConserveMemory",          0,                  "Specifies how hard GC should try to conserve memory - values 0-9")                       \
     INT_CONFIG   (GCWriteBarrier,            "GCWriteBarrier",            NULL,                                0,                  "Specifies whether GC should use more precise but slower write barrier")                  \
     STRING_CONFIG(GCName,                    "GCName",                    "System.GC.Name",                                        "Specifies the path of the standalone GC implementation.")                                \
-    INT_CONFIG   (GCSpinCountUnit,           "GCSpinCountUnit",           NULL,                                0,               "Specifies the spin count unit used by the GC.")                                             \
+    INT_CONFIG   (GCSpinCountUnit,           "GCSpinCountUnit",           NULL,                                0,                  "Specifies the spin count unit used by the GC.")                                          \
     INT_CONFIG   (GCDynamicAdaptationMode,   "GCDynamicAdaptationMode",   "System.GC.DynamicAdaptationMode",   0,                  "Enable the GC to dynamically adapt to application sizes.")
 // This class is responsible for retreiving configuration information
 // for how the GC should operate.

--- a/src/coreclr/gc/gcconfig.h
+++ b/src/coreclr/gc/gcconfig.h
@@ -79,7 +79,7 @@ public:
     BOOL_CONFIG  (GCLargePages,              "GCLargePages",              "System.GC.LargePages",              false,              "Enables using Large Pages in the GC")                                                     \
     INT_CONFIG   (HeapVerifyLevel,           "HeapVerify",                NULL,                                HEAPVERIFY_NONE,    "When set verifies the integrity of the managed heap on entry and exit of each GC")       \
     INT_CONFIG   (LOHCompactionMode,         "GCLOHCompact",              NULL,                                0,                  "Specifies the LOH compaction mode")                                                      \
-    INT_CONFIG   (LOHThreshold,              "GCLOHThreshold",            NULL,                                LARGE_OBJECT_SIZE,  "Specifies the size that will make objects go on LOH")                                     \
+    INT_CONFIG   (LOHThreshold,              "GCLOHThreshold",            "System.GC.LOHThreshold",            LARGE_OBJECT_SIZE,  "Specifies the size that will make objects go on LOH")                                    \
     INT_CONFIG   (BGCSpinCount,              "BGCSpinCount",              NULL,                                140,                "Specifies the bgc spin count")                                                           \
     INT_CONFIG   (BGCSpin,                   "BGCSpin",                   NULL,                                2,                  "Specifies the bgc spin time")                                                            \
     INT_CONFIG   (HeapCount,                 "GCHeapCount",               "System.GC.HeapCount",               0,                  "Specifies the number of server GC heaps")                                                 \
@@ -138,7 +138,7 @@ public:
     INT_CONFIG   (GCConserveMem,             "GCConserveMemory",          "System.GC.ConserveMemory",          0,                  "Specifies how hard GC should try to conserve memory - values 0-9")                       \
     INT_CONFIG   (GCWriteBarrier,            "GCWriteBarrier",            NULL,                                0,                  "Specifies whether GC should use more precise but slower write barrier")                  \
     STRING_CONFIG(GCName,                    "GCName",                    "System.GC.Name",                                        "Specifies the path of the standalone GC implementation.")                                \
-    INT_CONFIG   (GCSpinCountUnit,           "GCSpinCountUnit",           0,                                   0,                  "Specifies the spin count unit used by the GC.")                                          \
+    INT_CONFIG   (GCSpinCountUnit,           "GCSpinCountUnit",           NULL,                                0,               "Specifies the spin count unit used by the GC.")                                             \
     INT_CONFIG   (GCDynamicAdaptationMode,   "GCDynamicAdaptationMode",   "System.GC.DynamicAdaptationMode",   0,                  "Enable the GC to dynamically adapt to application sizes.")
 // This class is responsible for retreiving configuration information
 // for how the GC should operate.


### PR DESCRIPTION
 Fixes #93963. The GC Configuration API only displays the values for those configurations with public keys defined i.e., an assigned property for the runtime configuration json file. This PR adds the LOHThreshold public key that is mentioned in the documentation: https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#large-object-heap-threshold  but presumably forgotten to be added to the gcconfig.

## Testing

### Program

```csharp
    static void Main(string[] args)
    {
        var results = GC.GetConfigurationVariables();
        foreach (var result in results)
        {
            Console.WriteLine("{ " + $"{result.Key} : {result.Value?.ToString()}" + " }");
        }
    }
```

### Configuration

```json
{
  "runtimeOptions": {
    "tfm": "net7.0",
    "includedFrameworks": [
      {
        "name": "Microsoft.NETCore.App",
        "version": "7.0.12"
      }
    ],
    "configProperties": {
      "System.Reflection.Metadata.MetadataUpdater.IsSupported": false,
      __"System.GC.LOHThreshold": 850000__
    }
  }
}
```

### Confirmed Result

```
{ ServerGC : False }
{ ConcurrentGC : True }
{ RetainVM : False }
{ NoAffinitize : False }
{ GCCpuGroup : False }
{ GCLargePages : False }
**{ LOHThreshold : 850000 }**
{ HeapCount : 1 }
{ MaxHeapCount : 0 }
{ GCHeapAffinitizeMask : 0 }
{ GCHeapAffinitizeRanges :  }
{ GCHighMemPercent : 0 }
{ GCHeapHardLimit : 0 }
{ GCHeapHardLimitPercent : 0 }
{ GCHeapHardLimitSOH : 0 }
{ GCHeapHardLimitLOH : 0 }
{ GCHeapHardLimitPOH : 0 }
{ GCHeapHardLimitSOHPercent : 0 }
{ GCHeapHardLimitLOHPercent : 0 }
{ GCHeapHardLimitPOHPercent : 0 }
{ GCConserveMem : 0 }
{ GCName : clrgcexp.dll }
{ GCDynamicAdaptationMode : 0 }
```

Aso, tested with an environment variable > 85,000 KB. 

Minor clean up: changed the 0 in the SpinCount config registration to a NULL for consistency. 
